### PR TITLE
docs: rewrite README with easy setup + Claude subscription auth; add OSS governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every path requires review from the owner before merge.
+# The ruleset "protect-main" enforces code-owner review on the default branch.
+* @alexhawat

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a problem
+title: ''
+labels: bug
+---
+
+## Summary
+
+<!-- A clear, one-paragraph description of the problem. -->
+
+## Current behavior
+
+<!-- What actually happens. Include error messages or logs if available. -->
+
+## Expected behavior
+
+<!-- What you expected to happen instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OS:
+- Python version:
+- Install method:
+
+## Notes
+
+<!-- Anything else that might help — screenshots, related issues, workarounds. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/alexhawat/mergeCraft/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an enhancement
+title: ''
+labels: enhancement
+---
+
+## Summary
+
+<!-- A clear, one-paragraph description of the enhancement. -->
+
+## Current behavior
+
+<!-- What happens today, and why it falls short. -->
+
+## Desired behavior
+
+<!-- What you would like to happen instead. -->
+
+## Benefit
+
+<!-- Who benefits and how — the value this adds. -->
+
+## Notes
+
+<!-- Anything else that might help — alternatives considered, related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What?
+
+<!-- What does this change do? Keep it short and concrete. -->
+
+## Why?
+
+<!-- Why is this needed? Link any related issues. -->
+
+## Test plan
+
+- [ ] `make ci` green locally
+- [ ] Added or updated tests where it makes sense
+
+> Note: code changes under `src/mergecraft/**` or `scripts/**` require a matching
+> `## [Unreleased]` entry in [`CHANGELOG.md`](../CHANGELOG.md) — see
+> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- Rewrite README with a 3-step quickstart and a dedicated Authentication section
+  documenting Claude/Codex subscription auth (`mergecraft auth claude` /
+  `auth codex`, `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_AUTH_JSON`) alongside API keys.
+- Add OSS governance files for parity with sevn-bot/sevn: `SECURITY.md`,
+  `CODE_OF_CONDUCT.md`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`,
+  and `.github/ISSUE_TEMPLATE/` (bug report, feature request, security contact link).
+
 ### Fixed
 
 - Wire D7 sandbox planning into adapter execution; fail-closed trust tier when the GitHub

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement — the project
+maintainer @alexhawat — privately via a GitHub Security Advisory at
+https://github.com/alexhawat/mergeCraft/security/advisories/new. All complaints
+will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -4,24 +4,64 @@ Standalone **BYOK** GitHub Action for AI-powered PR review — inspired by prior
 work including [pullfrog](https://github.com/pullfrog/pullfrog) and CodeRabbit.
 
 No proprietary SaaS account is required. Settings, learnings, and secrets
-come from your repo and GitHub Actions secrets.
+come from your repo and GitHub Actions secrets — **you bring your own
+Claude subscription, API key, or other provider credential.**
 
 ## Requirements
 
 - Python **3.14+**
 - [uv](https://docs.astral.sh/uv/)
-- Provider API keys (Anthropic, OpenAI/Codex, Gemini, OpenRouter, …) as needed
+- [GitHub CLI (`gh`)](https://cli.github.com), authenticated (`gh auth login`) — used by `mergecraft auth` and `mergecraft init`
+- A credential for at least one provider — see [Authentication](#authentication) below
 
-## Quick start
+## Get started in 3 steps
 
-```bash
-# Install locally
-uv sync --extra dev
-uv run mergecraft --help
+1. **Install and scaffold** in the repo you want reviewed (not yet published to
+   PyPI, so install straight from git):
 
-# Scaffold config + example workflow into a consumer repo
-uv run mergecraft init
-```
+   ```bash
+   uv tool install "git+https://github.com/alexhawat/mergeCraft@pre-0.0.1"
+   mergecraft init   # writes .mergecraft/config.yaml + .github/workflows/mergecraft.yml
+   ```
+
+   Working on mergeCraft itself instead? Clone it and run
+   `uv sync --extra dev && uv run mergecraft --help`.
+
+2. **Authenticate** — pick one:
+
+   ```bash
+   mergecraft auth claude   # use your Claude Pro/Max subscription (no per-token API billing)
+   # or
+   mergecraft auth codex    # use your ChatGPT subscription (ChatGPT Plus/Pro/Team/Enterprise)
+   ```
+
+   Either command saves the credential as a GitHub Actions secret in the current repo via `gh secret set`. No API key required.
+
+3. **Commit and push** the scaffolded workflow, then trigger it by opening a PR, commenting `@mergecraft ...`, or running it manually from the Actions tab.
+
+That's it — no server, dashboard, or account to sign up for.
+
+## Authentication
+
+mergeCraft is BYOK: it never talks to a proprietary backend, only directly to
+the provider you configure. You can authenticate either with a **subscription**
+(no metered API billing) or a traditional **API key**.
+
+| Provider | Subscription (recommended) | API key |
+|----------|-----------------------------|---------|
+| Anthropic Claude | `mergecraft auth claude` → saves `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` (Claude Pro/Max) | `ANTHROPIC_API_KEY` secret |
+| OpenAI Codex | `mergecraft auth codex` → saves `CODEX_AUTH_JSON` from `codex login --device-auth` (ChatGPT Plus/Pro/Team/Enterprise) | `OPENAI_API_KEY` secret |
+
+Using a subscription means the GitHub Action authenticates as *you* through the
+official `claude` / `codex` CLIs — the same credential your local coding agent
+already uses — instead of paying per-token via a separate API key. Run the
+relevant `mergecraft auth ...` command from the repo you want reviewed; it
+detects the `origin` remote and stores the secret with `gh secret set`
+automatically (or prints the manual `Settings → Secrets` steps if `gh` isn't
+authenticated).
+
+Only set the env var(s) for the provider(s) you actually use — see the
+workflow example below, where the unused lines are commented out.
 
 ### Consumer workflow
 
@@ -50,8 +90,12 @@ jobs:
         with:
           prompt: ${{ inputs.prompt }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Claude — pick one:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # subscription (mergecraft auth claude)
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}           # or API key
+          # Codex / OpenAI — pick one:
+          # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}               # subscription (mergecraft auth codex)
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # or API key
 ```
 
 ### Local config
@@ -90,7 +134,8 @@ Learnings live in `.mergecraft/learnings.md` and are seeded/persisted across run
 | Command | Purpose |
 |---------|---------|
 | `mergecraft init` | Scaffold `.mergecraft/config.yaml` + example workflow |
-| `mergecraft auth codex` / `auth claude` | Store credentials via `gh secret set` |
+| `mergecraft auth claude` | Save a Claude Pro/Max subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) via `gh secret set` |
+| `mergecraft auth codex` | Save a ChatGPT subscription credential (`CODEX_AUTH_JSON`) via `gh secret set` |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
 | `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting) |
 | `mergecraft gha` | Action runtime entry (used by Docker Action) |
@@ -144,7 +189,15 @@ Coding style and CI patterns are adapted from
 (Python 3.14, uv, loguru, Makefile-gated Ruff/mypy/pytest). This repo does
 **not** include a workflow that invokes `mergecraft/mergecraft`.
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
+
+## Security
+
+BYOK by design: your provider credentials and repo contents never leave
+GitHub Actions / your machine and this repo's own code. See
+[SECURITY.md](SECURITY.md) to report a vulnerability, and
+[REVIEW-CHECKS.md](REVIEW-CHECKS.md) for what a review does (and never does).
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report privately via [GitHub Security Advisories](https://github.com/alexhawat/mergeCraft/security/advisories/new).
+You will receive an acknowledgement as soon as possible.
+
+## Supported Versions
+
+This project is under active early development; only the latest `main` /
+`pre-0.0.1` branch is supported.
+
+## Security model
+
+mergeCraft is BYOK (bring-your-own-key/subscription): it talks directly to
+the provider you configure (Anthropic, OpenAI, etc.) and never routes your
+code, prompts, or credentials through a third-party SaaS backend.
+
+- Provider credentials (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`,
+  `OPENAI_API_KEY`, `CODEX_AUTH_JSON`, …) live only in your repo's GitHub
+  Actions secrets and the ephemeral Action container's environment.
+- `src/mergecraft/utils/secrets.py` filters sensitive env vars before they
+  reach any shell/MCP tool the agent can call; see `tests/test_security_parity.py`
+  and `tests/utils/test_secrets.py` for the enforced behavior.
+- `mergecraft auth claude` / `mergecraft auth codex` write secrets straight
+  to `gh secret set` in the target repo — the token is never printed, logged,
+  or transmitted anywhere else.
+- Analyzer and static-check tooling (`actionlint`, `zizmor`, `ShellCheck`,
+  `Hadolint`) run locally inside the Action container; see
+  [REVIEW-CHECKS.md](REVIEW-CHECKS.md) for the full list of what a review
+  checks and what it deliberately never reports.


### PR DESCRIPTION
## What?
- Rewrites README.md with a 3-step quickstart and a dedicated **Authentication** section documenting Claude/Codex *subscription* auth (`mergecraft auth claude` / `auth codex` → `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_AUTH_JSON`) alongside API keys. Also fixes the install instructions (`uv tool install merge-craft` doesn't work — package isn't published to PyPI yet).
- Adds missing OSS governance files for parity with sevn-bot/sevn@pre-0.0.1: `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*`.
- CHANGELOG entry under `[Unreleased] / Docs`.

## Why?
Verified the CLI already fully supports subscription-based Claude auth end-to-end (`agent_resolve.py`, `models.py`, `claude.py`, Dockerfile) — the gap was purely documentation. Also closed OSS-readiness gaps found comparing live GitHub settings against sevn-bot/sevn (see below, applied separately via API, not in this diff): Dependabot alerts/security updates, a `protect-main` branch-protection ruleset, private vulnerability reporting, and repo description/topics/delete-branch-on-merge.

## Test plan
- [x] `uv run mergecraft --help` / `mergecraft auth --help` sanity-checked, no code changes
- [x] Docs-only change; no `src/mergecraft/**` touched, so no additional tests required