### PR TITLE
fix(status-checks,agents): reliability defects #15/#5/#6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Anchor the `mergecraft-approval` check to the PR head SHA and name the
   actually-reviewed commit in the check summary so stale reviews are visible
   ([#6](https://github.com/alexhawat/mergeCraft/issues/6)).
+- Preserve a recorded approval conclusion when the overall run fails after the
+  review step (e.g. schema enforcement), instead of masking it as `neutral`
+  ([#5](https://github.com/alexhawat/mergeCraft/issues/5)).
 - Surface `claude` CLI stdout/stderr, exit code, and attempt context (model,
   permissions flag, CI env) at warning level on non-zero exit; propagate the
   diagnosable error into Action failure output and the `mergecraft` check-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are enabled; use `neutral` when the review did not complete so a failed run no
   longer leaves a missing check that branch protection can misread as pass
   ([#5](https://github.com/alexhawat/mergeCraft/issues/5)).
+- Anchor the `mergecraft-approval` check to the PR head SHA and name the
+  actually-reviewed commit in the check summary so stale reviews are visible
+  ([#6](https://github.com/alexhawat/mergeCraft/issues/6)).
 - Surface `claude` CLI stdout/stderr, exit code, and attempt context (model,
   permissions flag, CI env) at warning level on non-zero exit; propagate the
   diagnosable error into Action failure output and the `mergecraft` check-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Always post the `mergecraft-approval` status check on PR runs when status checks
+  are enabled; use `neutral` when the review did not complete so a failed run no
+  longer leaves a missing check that branch protection can misread as pass
+  ([#5](https://github.com/alexhawat/mergeCraft/issues/5)).
 - Surface `claude` CLI stdout/stderr, exit code, and attempt context (model,
   permissions flag, CI env) at warning level on non-zero exit; propagate the
   diagnosable error into Action failure output and the `mergecraft` check-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surface `claude` CLI stdout/stderr, exit code, and attempt context (model,
+  permissions flag, CI env) at warning level on non-zero exit; propagate the
+  diagnosable error into Action failure output and the `mergecraft` check-run
+  summary ([#15](https://github.com/alexhawat/mergeCraft/issues/15)).
 - Wire K3 CI intelligence to the `analyze_ci_failures` MCP tool — fetches check-suite logs,
   clusters failures, and returns review-ready `section`, `preMergeSummary`, `comments`, and
   `stats`; Review/IncrementalReview prompts call the tool instead of manual log clustering.

--- a/README.md
+++ b/README.md
@@ -170,9 +170,14 @@ The Action reads the native `GITHUB_EVENT_PATH` / `GITHUB_EVENT_NAME`, so
 workflows can trigger on `pull_request` (e.g. auto-review on open/sync),
 `issue_comment`, or `pull_request_review_comment` events and the agent gets PR
 context (number, branch, `is_pr`) automatically — no hand-built `~mergecraft` JSON
-payload required. With `status_checks: enabled`, PR runs post the `mergecraft` and
-`mergecraft-approval` commit-status checks (gate on the latter). An explicit
-`~mergecraft` payload event still takes precedence when provided.
+payload required. With `status_checks: enabled`, PR runs always post the `mergecraft`
+and `mergecraft-approval` commit-status checks. The approval check has three
+outcomes: `success` when mergeCraft would approve, `failure` when it would not,
+and `neutral` when the review did not complete (agent crash, timeout, or no
+approval recorded). GitHub branch protection treats `neutral` as non-blocking by
+default — gate on `success`/`failure` explicitly in your enforce step if you
+require a completed review. An explicit `~mergecraft` payload event still takes
+precedence when provided.
 
 ## Development
 

--- a/docs/test-plans/open-issues-sweep-batch-a.md
+++ b/docs/test-plans/open-issues-sweep-batch-a.md
@@ -1,0 +1,33 @@
+# Open issues sweep — Batch A test plan (W1 RED)
+
+Wave plan: `.ignorelocal/waves/open-issues-sweep-wave-plan.md`
+Worktree: `mergecraft-issues-a-reliability` @ `wave/issues-a-reliability`
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W2** | `tests/agents/test_claude.py::test_claude_exit_with_empty_streams_surfaces_diagnosable_error` | `green after W2: diagnosable claude CLI exit (#15)` |
+| **W3** | `tests/utils/test_status_checks.py::test_report_status_checks_posts_neutral_approval_when_review_incomplete` | `green after W3: neutral approval when review incomplete (#5)` |
+| **W4** | `tests/utils/test_status_checks.py::test_report_status_checks_anchors_approval_to_pr_head_sha` | `green after W4: anchor approval check to PR head SHA (#6)` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#15** | D5 — diagnosability, not guessed CLI fix | Unit | Happy path N/A | — |
+| **#15** | D5 | Unit | Edge — exit 1, empty stdout/stderr | `test_claude.py::test_claude_exit_with_empty_streams_surfaces_diagnosable_error` |
+| **#15** | D5 | Unit | Error — `AgentResult.error` names exit code + attempt context (model, CI / skip-permissions), not bare `claude exited N` | same |
+| **#15** | D5 | Unit | Error — failure logged at WARNING/ERROR, not DEBUG-only | same |
+| **#5** | W3 contract | Integration | Edge — `run_succeeded=False`, no approval | `test_status_checks.py::test_report_status_checks_posts_neutral_approval_when_review_incomplete[run_failed]` |
+| **#5** | W3 contract | Integration | Edge — `run_succeeded=True`, no approval recorded | `test_status_checks.py::test_report_status_checks_posts_neutral_approval_when_review_incomplete[run_ok_no_approval]` |
+| **#6** | W4 contract | Integration | Edge — `approval.sha` differs from PR head SHA | `test_status_checks.py::test_report_status_checks_anchors_approval_to_pr_head_sha` |
+| **#6** | W4 contract | Integration | Functional — check summary names actually-reviewed SHA | same |
+
+## Implementation notes for impl waves
+
+- **W2:** Un-xfail `test_claude.py` only; leave status-check xfails until W3/W4.
+- **W3:** Extend `Conclusion` with `"neutral"`; un-xfail #5 test only.
+- **W4:** Un-xfail #6 test only.

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -93,6 +93,35 @@ def ctx_tmpdir_fallback() -> str:
     return os.environ.get("MERGECRAFT_TEMP_DIR") or "/tmp"
 
 
+_STDERR_TAIL_LINES = 20
+
+
+def _claude_attempt_context(*, model: str | None, skip_permissions: bool) -> str:
+    parts = [f"model={model or 'default'}"]
+    if skip_permissions:
+        parts.append("--dangerously-skip-permissions")
+    if os.environ.get("CI") == "true":
+        parts.append("CI=true")
+    return ", ".join(parts)
+
+
+def _build_claude_failure_error(
+    *,
+    returncode: int,
+    stderr: str,
+    model: str | None,
+    skip_permissions: bool,
+) -> str:
+    context = _claude_attempt_context(model=model, skip_permissions=skip_permissions)
+    stderr_lines = [line for line in (stderr or "").strip().splitlines() if line.strip()]
+    if stderr_lines:
+        tail = stderr_lines[-_STDERR_TAIL_LINES:]
+        stderr_part = "; stderr tail: " + " | ".join(tail)
+    else:
+        stderr_part = " (no stderr output)"
+    return f"claude exited {returncode} ({context}){stderr_part}"
+
+
 def _build_env(ctx: AgentRunContext) -> dict[str, str]:
     env = dict(os.environ)
     # Agent process keeps full env (needs LLM keys). Secrets are filtered at MCP shell.
@@ -137,7 +166,8 @@ def _run_claude_once(
     if continue_session:
         cmd.append("--continue")
     # Permission mode: skip interactive prompts in CI
-    if os.environ.get("CI") == "true":
+    skip_permissions = os.environ.get("CI") == "true"
+    if skip_permissions:
         cmd.append("--dangerously-skip-permissions")
 
     system = ctx.instructions.system
@@ -164,8 +194,8 @@ def _run_claude_once(
 
     stdout = completed.stdout or ""
     stderr = completed.stderr or ""
-    if stderr.strip():
-        for line in stderr.strip().splitlines()[-20:]:
+    if completed.returncode == 0 and stderr.strip():
+        for line in stderr.strip().splitlines()[-_STDERR_TAIL_LINES:]:
             logger.debug("[claude] {}", line)
 
     usage: AgentUsage | None = None
@@ -213,10 +243,23 @@ def _run_claude_once(
         pass
 
     if completed.returncode != 0:
+        context = _claude_attempt_context(model=model, skip_permissions=skip_permissions)
+        logger.warning(
+            "claude CLI failed (exit={}, {}); stdout={!r}; stderr={!r}",
+            completed.returncode,
+            context,
+            stdout,
+            stderr,
+        )
         return AgentResult(
             success=False,
             output=output or None,
-            error=stderr.strip() or f"claude exited {completed.returncode}",
+            error=_build_claude_failure_error(
+                returncode=completed.returncode,
+                stderr=stderr,
+                model=model,
+                skip_permissions=skip_permissions,
+            ),
             usage=usage,
         )
     return AgentResult(success=True, output=output or None, usage=usage)

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -336,7 +336,11 @@ async def main() -> MainResult:
 
         if tool_context:
             await persist_learnings(tool_context)
-            await report_status_checks(tool_context, run_succeeded=result.success)
+            await report_status_checks(
+                tool_context,
+                run_succeeded=result.success,
+                failure_reason=result.error if not result.success else None,
+            )
 
         if not result.success:
             return MainResult(success=False, error=result.error or "agent execution failed")
@@ -350,7 +354,11 @@ async def main() -> MainResult:
         if tool_context:
             try:
                 await persist_learnings(tool_context)
-                await report_status_checks(tool_context, run_succeeded=False)
+                await report_status_checks(
+                    tool_context,
+                    run_succeeded=False,
+                    failure_reason=error_message,
+                )
             except Exception:
                 pass
         return MainResult(success=False, error=error_message)

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -43,7 +43,12 @@ async def _create_check_run(
     )
 
 
-async def report_status_checks(ctx: ToolContext, *, run_succeeded: bool) -> None:
+async def report_status_checks(
+    ctx: ToolContext,
+    *,
+    run_succeeded: bool,
+    failure_reason: str | None = None,
+) -> None:
     """Post opt-in status checks. Best-effort; never raises into the run outcome."""
     payload = ctx.payload
     status_enabled = getattr(payload, "status_checks", False) or (
@@ -80,7 +85,10 @@ async def report_status_checks(ctx: ToolContext, *, run_succeeded: bool) -> None
             summary=(
                 "The mergeCraft run finished successfully."
                 if run_succeeded
-                else "The mergeCraft run failed or timed out. See the run logs for details."
+                else (
+                    failure_reason
+                    or "The mergeCraft run failed or timed out. See the run logs for details."
+                )
             ),
         )
     except Exception as err:

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 COMPLETION_CHECK = "mergecraft"
 APPROVAL_CHECK = "mergecraft-approval"
-Conclusion = Literal["success", "failure"]
+Conclusion = Literal["success", "failure", "neutral"]
 
 
 async def _create_check_run(
@@ -95,26 +95,34 @@ async def report_status_checks(
         logger.debug("status checks: {} post failed: {}", COMPLETION_CHECK, err)
 
     approval = ctx.tool_state.approval
-    if run_succeeded and approval:
-        try:
-            await _create_check_run(
-                ctx,
-                name=APPROVAL_CHECK,
-                head_sha=approval.sha or head_sha,
-                conclusion="success" if approval.would_approve else "failure",
-                title=(
-                    "mergeCraft would approve"
-                    if approval.would_approve
-                    else "mergeCraft would not approve"
-                ),
-                summary=(
-                    "mergeCraft has no outstanding review feedback on this PR."
-                    if approval.would_approve
-                    else "mergeCraft has outstanding review feedback or requested changes on this PR."
-                ),
-            )
-        except Exception as err:
-            logger.debug("status checks: {} post failed: {}", APPROVAL_CHECK, err)
+    if run_succeeded and approval and approval.would_approve:
+        approval_conclusion: Conclusion = "success"
+        approval_title = "mergeCraft would approve"
+        approval_summary = "mergeCraft has no outstanding review feedback on this PR."
+    elif run_succeeded and approval and not approval.would_approve:
+        approval_conclusion = "failure"
+        approval_title = "mergeCraft would not approve"
+        approval_summary = (
+            "mergeCraft has outstanding review feedback or requested changes on this PR."
+        )
+    else:
+        approval_conclusion = "neutral"
+        approval_title = "mergeCraft review did not complete"
+        approval_summary = (
+            "The mergeCraft review did not complete, so no approval decision was recorded."
+        )
+
+    try:
+        await _create_check_run(
+            ctx,
+            name=APPROVAL_CHECK,
+            head_sha=approval.sha or head_sha if approval else head_sha,
+            conclusion=approval_conclusion,
+            title=approval_title,
+            summary=approval_summary,
+        )
+    except Exception as err:
+        logger.debug("status checks: {} post failed: {}", APPROVAL_CHECK, err)
 
 
 __all__ = ["APPROVAL_CHECK", "COMPLETION_CHECK", "report_status_checks"]

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -112,11 +112,14 @@ async def report_status_checks(
             "The mergeCraft review did not complete, so no approval decision was recorded."
         )
 
+    if approval and approval.sha:
+        approval_summary = f"{approval_summary} Reviewed commit: {approval.sha}."
+
     try:
         await _create_check_run(
             ctx,
             name=APPROVAL_CHECK,
-            head_sha=approval.sha or head_sha if approval else head_sha,
+            head_sha=head_sha,
             conclusion=approval_conclusion,
             title=approval_title,
             summary=approval_summary,

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -95,11 +95,11 @@ async def report_status_checks(
         logger.debug("status checks: {} post failed: {}", COMPLETION_CHECK, err)
 
     approval = ctx.tool_state.approval
-    if run_succeeded and approval and approval.would_approve:
+    if approval and approval.would_approve:
         approval_conclusion: Conclusion = "success"
         approval_title = "mergeCraft would approve"
         approval_summary = "mergeCraft has no outstanding review feedback on this PR."
-    elif run_succeeded and approval and not approval.would_approve:
+    elif approval and not approval.would_approve:
         approval_conclusion = "failure"
         approval_title = "mergeCraft would not approve"
         approval_summary = (

--- a/tests/agents/test_claude.py
+++ b/tests/agents/test_claude.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import subprocess
 from typing import TYPE_CHECKING
 
-import pytest
 from loguru import logger
 
 from mergecraft.agents.claude import _run_claude_once
@@ -15,6 +15,8 @@ from mergecraft.mcp.tool_state import init_tool_state
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 
 def _run_ctx(
@@ -31,7 +33,6 @@ def _run_ctx(
     )
 
 
-@pytest.mark.xfail(reason="green after W2: diagnosable claude CLI exit (#15)", strict=False)
 def test_claude_exit_with_empty_streams_surfaces_diagnosable_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -45,7 +46,8 @@ def test_claude_exit_with_empty_streams_surfaces_diagnosable_error(
     ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="")
 
-    monkeypatch.setattr("mergecraft.agents.claude.subprocess.run", _fake_run)
+    claude_module = importlib.import_module("mergecraft.agents.claude")
+    monkeypatch.setattr(claude_module.subprocess, "run", _fake_run)
 
     log_records: list[tuple[str, str]] = []
 

--- a/tests/agents/test_claude.py
+++ b/tests/agents/test_claude.py
@@ -1,0 +1,78 @@
+"""Regression tests for the Claude Code agent harness (issue #15 / D5)."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from loguru import logger
+
+from mergecraft.agents.claude import _run_claude_once
+from mergecraft.agents.shared import AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import PayloadEvent, ResolvedPayload
+from mergecraft.mcp.tool_state import init_tool_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run_ctx(
+    tmp_path: Path, *, resolved_model: str | None = "anthropic/claude-sonnet-5"
+) -> AgentRunContext:
+    return AgentRunContext(
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request")),
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(user="review this diff"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        resolved_model=resolved_model,
+    )
+
+
+@pytest.mark.xfail(reason="green after W2: diagnosable claude CLI exit (#15)", strict=False)
+def test_claude_exit_with_empty_streams_surfaces_diagnosable_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-zero ``claude`` exit with empty stdout/stderr must name exit code + attempt context."""
+    monkeypatch.setenv("CI", "true")
+
+    def _fake_run(
+        cmd: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr("mergecraft.agents.claude.subprocess.run", _fake_run)
+
+    log_records: list[tuple[str, str]] = []
+
+    def _capture(record: object) -> None:
+        entry = record.record  # type: ignore[attr-defined]
+        log_records.append((entry["level"].name, entry["message"]))
+
+    sink_id = logger.add(_capture, level="DEBUG")
+    try:
+        result = _run_claude_once(
+            cli="/usr/bin/claude",
+            prompt="review this diff",
+            ctx=_run_ctx(tmp_path),
+            mcp_config=str(tmp_path / "mcp.json"),
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "1" in result.error
+    assert result.error != "claude exited 1"
+
+    lowered = result.error.lower()
+    assert "model" in lowered or "claude-sonnet" in lowered
+    assert "ci" in lowered or "skip-permissions" in lowered or "dangerously" in lowered
+
+    visible = [message for level, message in log_records if level in {"WARNING", "ERROR"}]
+    assert visible
+    assert any("1" in message or "exit" in message.lower() for message in visible)

--- a/tests/utils/test_status_checks.py
+++ b/tests/utils/test_status_checks.py
@@ -96,6 +96,31 @@ async def test_report_status_checks_posts_neutral_approval_when_review_incomplet
 
 
 @pytest.mark.asyncio
+async def test_report_status_checks_preserves_approval_when_run_fails_later(
+    tmp_path: Path,
+) -> None:
+    """Approval recorded before a later run failure must not be masked as neutral."""
+    github = _RecordingGitHub()
+    ctx = _ctx(
+        tmp_path,
+        github=github,
+        approval=ApprovalRecord(would_approve=False, sha=REVIEWED_SHA),
+    )
+
+    await report_status_checks(ctx, run_succeeded=False)
+
+    approval_checks = _approval_checks(github)
+    assert len(approval_checks) == 1
+    check = approval_checks[0]
+    assert check["conclusion"] == "failure"
+    summary = check["output"]["summary"]
+    assert (
+        "would not approve" in check["output"]["title"].lower() or "not approve" in summary.lower()
+    )
+    assert REVIEWED_SHA in summary or REVIEWED_SHA[:7] in summary
+
+
+@pytest.mark.asyncio
 async def test_report_status_checks_anchors_approval_to_pr_head_sha(
     tmp_path: Path,
 ) -> None:

--- a/tests/utils/test_status_checks.py
+++ b/tests/utils/test_status_checks.py
@@ -77,9 +77,6 @@ def _approval_checks(github: _RecordingGitHub) -> list[dict[str, Any]]:
     ],
     ids=["run_failed", "run_ok_no_approval"],
 )
-@pytest.mark.xfail(
-    reason="green after W3: neutral approval when review incomplete (#5)", strict=False
-)
 @pytest.mark.asyncio
 async def test_report_status_checks_posts_neutral_approval_when_review_incomplete(
     tmp_path: Path,

--- a/tests/utils/test_status_checks.py
+++ b/tests/utils/test_status_checks.py
@@ -1,0 +1,120 @@
+"""Regression tests for opt-in commit status checks (issues #5, #6)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import ApprovalRecord, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from mergecraft.utils.status_checks import APPROVAL_CHECK, report_status_checks
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PR_HEAD_SHA = "aaa1111111111111111111111111111111111111111"
+REVIEWED_SHA = "bbb2222222222222222222222222222222222222222"
+
+
+class _RecordingGitHub(GitHubClient):
+    """Captures check-run POST bodies instead of calling the REST API."""
+
+    def __init__(self, *, pr_head_sha: str = PR_HEAD_SHA) -> None:
+        super().__init__(token="test-token")
+        self.pr_head_sha = pr_head_sha
+        self.check_runs: list[dict[str, Any]] = []
+
+    async def get_pull(self, owner: str, repo: str, pull_number: int) -> dict[str, Any]:
+        return {"head": {"sha": self.pr_head_sha}}
+
+    async def post(self, path: str, **kwargs: Any) -> Any:
+        if path.endswith("/check-runs"):
+            body = kwargs.get("json")
+            if isinstance(body, dict):
+                self.check_runs.append(body)
+        return {}
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    github: _RecordingGitHub | None = None,
+    approval: ApprovalRecord | None = None,
+) -> ToolContext:
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    tool_state.approval = approval
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=42, is_pr=True),
+            status_checks=True,
+            shell="restricted",
+        ),
+        github=github or _RecordingGitHub(),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def _approval_checks(github: _RecordingGitHub) -> list[dict[str, Any]]:
+    return [run for run in github.check_runs if run.get("name") == APPROVAL_CHECK]
+
+
+@pytest.mark.parametrize(
+    ("run_succeeded", "approval"),
+    [
+        (False, None),
+        (True, None),
+    ],
+    ids=["run_failed", "run_ok_no_approval"],
+)
+@pytest.mark.xfail(
+    reason="green after W3: neutral approval when review incomplete (#5)", strict=False
+)
+@pytest.mark.asyncio
+async def test_report_status_checks_posts_neutral_approval_when_review_incomplete(
+    tmp_path: Path,
+    run_succeeded: bool,
+    approval: ApprovalRecord | None,
+) -> None:
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, approval=approval)
+
+    await report_status_checks(ctx, run_succeeded=run_succeeded)
+
+    approval_checks = _approval_checks(github)
+    assert len(approval_checks) == 1
+    assert approval_checks[0]["conclusion"] == "neutral"
+    summary = approval_checks[0]["output"]["summary"]
+    assert "did not complete" in summary.lower() or "not complete" in summary.lower()
+
+
+@pytest.mark.xfail(reason="green after W4: anchor approval check to PR head SHA (#6)", strict=False)
+@pytest.mark.asyncio
+async def test_report_status_checks_anchors_approval_to_pr_head_sha(
+    tmp_path: Path,
+) -> None:
+    github = _RecordingGitHub(pr_head_sha=PR_HEAD_SHA)
+    ctx = _ctx(
+        tmp_path,
+        github=github,
+        approval=ApprovalRecord(would_approve=True, sha=REVIEWED_SHA),
+    )
+
+    await report_status_checks(ctx, run_succeeded=True)
+
+    approval_checks = _approval_checks(github)
+    assert len(approval_checks) == 1
+    check = approval_checks[0]
+    assert check["head_sha"] == PR_HEAD_SHA
+    summary = check["output"]["summary"]
+    assert REVIEWED_SHA in summary or REVIEWED_SHA[:7] in summary

--- a/tests/utils/test_status_checks.py
+++ b/tests/utils/test_status_checks.py
@@ -95,7 +95,6 @@ async def test_report_status_checks_posts_neutral_approval_when_review_incomplet
     assert "did not complete" in summary.lower() or "not complete" in summary.lower()
 
 
-@pytest.mark.xfail(reason="green after W4: anchor approval check to PR head SHA (#6)", strict=False)
 @pytest.mark.asyncio
 async def test_report_status_checks_anchors_approval_to_pr_head_sha(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- **#15:** Surface Claude CLI stderr and exit reason so failed agent runs are diagnosable instead of opaque failures.
- **#5 / #6:** Post mergecraft-approval unconditionally (neutral/success/failure paths) and anchor the approval check to the PR head SHA so stale or missing checks do not block merges incorrectly.
- RED regression suite for #15/#5/#6; wave baseline commit included.
- `make ci` and Bugbot clean on this branch.

## Test plan

- [x] `make ci`
- [x] Unit tests: `tests/agents/test_claude.py`, `tests/utils/test_status_checks.py`
- [x] Bugbot / review gate on branch

## Related issues

Closes #15
Closes #5
Closes #6

Made with [Cursor](https://cursor.com)