### PR TITLE
fix(review): honest learnings persistence and static-check visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ coverage.xml
 *.swp
 .DS_Store
 
+# Graphify knowledge graph (built on demand with `graphify update .`)
+graphify-out/
+
 # Local operator
 .ignorelocal/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permissions flag, CI env) at warning level on non-zero exit; propagate the
   diagnosable error into Action failure output and the `mergecraft` check-run
   summary ([#15](https://github.com/alexhawat/mergeCraft/issues/15)).
+- Learnings updates on ephemeral Action runners now log a warning instead of a false
+  success and include the before→after delta in the posted review or progress comment
+  so operators can commit `.mergecraft/learnings.md` deliberately ([#7](https://github.com/alexhawat/mergeCraft/issues/7)).
 - Wire K3 CI intelligence to the `analyze_ci_failures` MCP tool — fetches check-suite logs,
   clusters failures, and returns review-ready `section`, `preMergeSummary`, `comments`, and
   `stats`; Review/IncrementalReview prompts call the tool instead of manual log clustering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Reviewers can list GitHub check suites for a commit via `list_check_runs` and fetch
+  one suite by id via `get_check_suite`, then pass the id to `get_check_suite_logs`
+  (#8)
+- Configured `staticChecks` now report a `declared-but-cannot-run` row when the gate
+  cannot execute in this environment (for example `shell: disabled`), instead of
+  disappearing silently (#8)
+
 ### Docs
 
 - Rewrite README with a 3-step quickstart and a dedicated Authentication section

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -69,7 +69,7 @@ Your repo's own gate — unchanged from prior mergeCraft behavior:
 - **Discovered gates** — with nothing declared, mergecraft looks for `lint`, `format-check`, `typecheck`, and `ci-static` Makefile targets. Skipped when `make` is not installed.
 - **Nothing found** → skipped. mergecraft will **not** substitute a linter of its own (`except A, B:` is legal on Python 3.14 and a syntax error on 3.13 — version mismatch manufactures false positives).
 
-Each gate returns one of four statuses; only **`failed`** is a finding:
+Each gate returns one of five statuses; only **`failed`** is a finding:
 
 | Status | Meaning |
 |---|---|
@@ -77,6 +77,9 @@ Each gate returns one of four statuses; only **`failed`** is a finding:
 | `failed` | ran, non-zero exit — a finding |
 | `timed_out` | exceeded the per-gate timeout |
 | `unavailable` | executable not installed — judged nothing |
+| `declared-but-cannot-run` | gate is declared in config but this environment cannot execute it (for example `shell: disabled` on a pull-request event) — judged nothing, but the gate is visible instead of silently omitted |
+
+When `staticChecks` are configured but every gate is `unavailable` or `declared-but-cannot-run`, `run_static_checks` returns `ran: false` with an explicit reason and one row per configured gate so the **Mechanical gates** pre-merge row can report skipped instead of implying the repo has no gates.
 
 ### Catalog analyzers (`run_analyzers`)
 
@@ -109,6 +112,8 @@ Offline inspection: `mergecraft analyzers list|detect|run|explain|export --sarif
 
 When CI failed on the PR head, mergeCraft calls `analyze_ci_failures`, which wraps `get_check_suite_logs` and normalizes failures behind `GitHubActionsProvider`.
 
+To discover a `check_suite_id` for a commit, call `list_check_runs` with the PR head SHA (or `get_check_suite` when you already have an id). Then pass that id to `get_check_suite_logs` or `analyze_ci_failures`.
+
 **What is read**
 
 - Failed workflow job/step names, exit codes, and redacted log excerpts
@@ -131,7 +136,7 @@ When CI failed on the PR head, mergeCraft calls `analyze_ci_failures`, which wra
 
 The review publishes `### 🚨 CI failures` with clustered root causes, flaky/blame verdicts, and redacted excerpts. The pre-merge **CI** row reports failure count, cluster count, flaky count, PR-attributed count, and whether truncation occurred. Inline CI comments may carry a one-click `suggestion` when the fix is a contained single-hunk edit; pushing a fix commit stays behind the existing `push` permission.
 
-Implementation: [`src/mergecraft/ci/intelligence.py`](src/mergecraft/ci/intelligence.py), [`src/mergecraft/ci/review.py`](src/mergecraft/ci/review.py), [`src/mergecraft/ci/cluster.py`](src/mergecraft/ci/cluster.py), [`src/mergecraft/mcp/ci_intelligence.py`](src/mergecraft/mcp/ci_intelligence.py), [`src/mergecraft/mcp/check_suite.py`](src/mergecraft/mcp/check_suite.py).
+Implementation: [`src/mergecraft/ci/intelligence.py`](src/mergecraft/ci/intelligence.py), [`src/mergecraft/ci/review.py`](src/mergecraft/ci/review.py), [`src/mergecraft/ci/cluster.py`](src/mergecraft/ci/cluster.py), [`src/mergecraft/mcp/ci_intelligence.py`](src/mergecraft/mcp/ci_intelligence.py), [`src/mergecraft/mcp/check_suite.py`](src/mergecraft/mcp/check_suite.py), [`src/mergecraft/mcp/check_runs.py`](src/mergecraft/mcp/check_runs.py).
 
 ## 3. Pull request hygiene
 

--- a/docs/test-plans/open-issues-sweep-batch-b.md
+++ b/docs/test-plans/open-issues-sweep-batch-b.md
@@ -1,0 +1,32 @@
+# Open issues sweep — Batch B test plan (W5 RED)
+
+Wave plan: `.ignorelocal/waves/open-issues-sweep-wave-plan.md`
+Worktree: `mergecraft-issues-b-review-signal` @ `wave/issues-b-review-signal`
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W6** | `tests/utils/test_learnings_persist.py::test_persist_learnings_warns_ephemeral_and_surfaces_delta` | `green after W6: ephemeral learnings warning + review delta (#7)` |
+| **W7** | `tests/mcp/test_check_runs.py::test_list_check_runs_returns_check_suite_data_for_ref` | `green after W7: list_check_runs MCP tool (#8)` |
+| **W7** | `tests/mcp/test_check_runs.py::test_get_check_suite_tool_returns_suite_detail` | `green after W7: get_check_suite MCP tool detail path (#8)` |
+| **W7** | `tests/mcp/test_static_checks.py::test_static_checks_declared_but_cannot_run_when_shell_disabled` | `green after W7: declared-but-cannot-run when shell disabled (#8)` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#7** | D7 — warn loudly + PR-comment delta; no Contents-API auto-commit | Unit | Happy path N/A (ephemeral runner is the defect path) | — |
+| **#7** | D7 | Unit | Edge — `GITHUB_WORKSPACE` temp dir, learnings changed from seed | `test_learnings_persist.py::test_persist_learnings_warns_ephemeral_and_surfaces_delta` |
+| **#7** | D7 | Unit | Error — no `logger.info` success for ephemeral write | same |
+| **#7** | D7 | Integration | Functional — `tool_state.learnings_review_delta` carries before→after delta for review/PR comment path | same |
+| **#8** | D8 — affordable substitute only | Integration | Happy path — `list_check_runs` for a ref returns suite rows via `list_check_suites_for_ref` | `test_check_runs.py::test_list_check_runs_returns_check_suite_data_for_ref` |
+| **#8** | D8 | Integration | Happy path — optional `get_check_suite` detail by id | `test_check_runs.py::test_get_check_suite_tool_returns_suite_detail` |
+| **#8** | D8 | Integration | Error — `staticChecks` configured, `shell == "disabled"` → explicit `"declared but cannot run"` (not silent omission) | `test_static_checks.py::test_static_checks_declared_but_cannot_run_when_shell_disabled` |
+
+## Implementation notes for impl waves
+
+- **W6:** Replace info-level persist success with warning about ephemeral runner; set `tool_state.learnings_review_delta` (or equivalent) when only workspace-local path exists; un-xfail `test_learnings_persist.py` only.
+- **W7:** Add `mergecraft.mcp.check_runs` with `list_check_runs_tool` (and `get_check_suite_tool` if split); wire into `build_common_tools`; teach `run_static_checks` / `plan_checks` to emit explicit declared-but-cannot-run rows when shell is disabled; un-xfail all `#8` tests only.

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 CHECK_TIMEOUT_S = 300
 MAX_OUTPUT_CHARS = 8_000
 
-CheckStatus = Literal["passed", "failed", "timed_out", "unavailable"]
+CheckStatus = Literal["passed", "failed", "timed_out", "unavailable", "declared-but-cannot-run"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,7 +42,7 @@ class AnalyzerOutcome:
 
     @property
     def ran(self) -> bool:
-        return self.status != "unavailable"
+        return self.status not in {"unavailable", "declared-but-cannot-run"}
 
 
 def _run_tmpdir(plan: AnalyzerPlan) -> Path:

--- a/src/mergecraft/mcp/check_runs.py
+++ b/src/mergecraft/mcp/check_runs.py
@@ -1,0 +1,62 @@
+"""list_check_runs and get_check_suite tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.mcp.shared import execute, tool
+
+if TYPE_CHECKING:
+    from mergecraft.mcp.context import ToolContext
+
+
+def list_check_runs_tool(ctx: ToolContext):
+    async def _run(params: dict[str, Any]):
+        ref = str(params["ref"])
+        data = await ctx.github.list_check_suites_for_ref(ctx.repo.owner, ctx.repo.name, ref)
+        return {
+            "ref": ref,
+            "total_count": data.get("total_count"),
+            "check_suites": data.get("check_suites") or [],
+        }
+
+    return tool(
+        name="list_check_runs",
+        description=(
+            "List GitHub check suites for a commit ref. Returns check suite ids, "
+            "status, and conclusions so you can pick a check_suite_id for "
+            "get_check_suite_logs."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"ref": {"type": "string", "description": "Commit SHA or ref."}},
+            "required": ["ref"],
+            "additionalProperties": False,
+        },
+        execute=execute(_run, "list_check_runs"),
+    )
+
+
+def get_check_suite_tool(ctx: ToolContext):
+    async def _run(params: dict[str, Any]):
+        check_suite_id = int(params["check_suite_id"])
+        return await ctx.github.get_check_suite(
+            ctx.repo.owner,
+            ctx.repo.name,
+            check_suite_id,
+        )
+
+    return tool(
+        name="get_check_suite",
+        description="Fetch one GitHub check suite by id (status, conclusion, head SHA).",
+        input_schema={
+            "type": "object",
+            "properties": {"check_suite_id": {"type": "number"}},
+            "required": ["check_suite_id"],
+            "additionalProperties": False,
+        },
+        execute=execute(_run, "get_check_suite"),
+    )
+
+
+__all__ = ["get_check_suite_tool", "list_check_runs_tool"]

--- a/src/mergecraft/mcp/comment.py
+++ b/src/mergecraft/mcp/comment.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import ProgressComment, ReviewReplyRecord, primary_repo_state
+from mergecraft.utils.learnings import merge_learnings_delta_into_review_body
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -192,7 +193,8 @@ def report_progress_tool(ctx: ToolContext):
                 ),
             }
 
-        body_with_footer = add_footer(ctx, body)
+        body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, body)
+        body_with_footer = add_footer(ctx, body_with_delta)
 
         if target_plan and ctx.tool_state.existing_plan_comment_id:
             result = await ctx.github.update_issue_comment(

--- a/src/mergecraft/mcp/comment.py
+++ b/src/mergecraft/mcp/comment.py
@@ -8,7 +8,10 @@ from loguru import logger
 
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import ProgressComment, ReviewReplyRecord, primary_repo_state
-from mergecraft.utils.learnings import merge_learnings_delta_into_review_body
+from mergecraft.utils.learnings import (
+    ensure_learnings_review_delta,
+    merge_learnings_delta_into_review_body,
+)
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -193,6 +196,7 @@ def report_progress_tool(ctx: ToolContext):
                 ),
             }
 
+        await ensure_learnings_review_delta(ctx.tool_state)
         body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, body)
         body_with_footer = add_footer(ctx, body_with_delta)
 

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -11,7 +11,10 @@ from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import ApprovalRecord, ReviewRecord, primary_repo_state
 from mergecraft.review_taxonomy import stamp_finding_fingerprint
-from mergecraft.utils.learnings import merge_learnings_delta_into_review_body
+from mergecraft.utils.learnings import (
+    ensure_learnings_review_delta,
+    merge_learnings_delta_into_review_body,
+)
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -79,6 +82,7 @@ def create_pull_request_review_tool(ctx: ToolContext):
 
         payload: dict[str, Any] = {"event": event}
         if body:
+            await ensure_learnings_review_delta(ctx.tool_state)
             body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, str(body))
             payload["body"] = add_footer(ctx, body_with_delta)
         if params.get("commit_id"):

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -11,6 +11,7 @@ from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import ApprovalRecord, ReviewRecord, primary_repo_state
 from mergecraft.review_taxonomy import stamp_finding_fingerprint
+from mergecraft.utils.learnings import merge_learnings_delta_into_review_body
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -78,7 +79,8 @@ def create_pull_request_review_tool(ctx: ToolContext):
 
         payload: dict[str, Any] = {"event": event}
         if body:
-            payload["body"] = add_footer(ctx, str(body))
+            body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, str(body))
+            payload["body"] = add_footer(ctx, body_with_delta)
         if params.get("commit_id"):
             payload["commit_id"] = params["commit_id"]
         elif primary.checkout_sha:

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -17,6 +17,7 @@ from starlette.responses import JSONResponse
 
 from mergecraft.analyzers.trust import analyzers_enabled
 from mergecraft.mcp.analyzers import analyzer_findings_tool, run_analyzers_tool
+from mergecraft.mcp.check_runs import get_check_suite_tool, list_check_runs_tool
 from mergecraft.mcp.check_suite import get_check_suite_logs_tool
 from mergecraft.mcp.checkout import checkout_pr_tool
 from mergecraft.mcp.ci_intelligence import analyze_ci_failures_tool
@@ -97,6 +98,8 @@ def build_common_tools(ctx: ToolContext, output_schema: JsonSchema | None = None
         list_pull_request_reviews_tool(ctx),
         resolve_review_thread_tool(ctx),
         get_check_suite_logs_tool(ctx),
+        list_check_runs_tool(ctx),
+        get_check_suite_tool(ctx),
         analyze_ci_failures_tool(ctx),
         add_labels_tool(ctx),
         remove_labels_tool(ctx),

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -49,7 +49,7 @@ def run_static_checks_tool(ctx: ToolContext):
                 "checks": [],
             }
 
-        if ctx.payload.shell == "disabled" and ctx.static_checks:
+        if ctx.payload.shell == "disabled" and ctx.static_checks and ctx.trust_tier != "trusted":
             reason = (
                 "staticChecks are configured but cannot run in this environment — "
                 "shell is disabled on pull-request events"

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import primary_repo_state
-from mergecraft.review_checks import plan_checks, run_checks
+from mergecraft.review_checks import declared_cannot_run_outcomes, plan_checks, run_checks
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -49,6 +49,18 @@ def run_static_checks_tool(ctx: ToolContext):
                 "checks": [],
             }
 
+        if ctx.payload.shell == "disabled" and ctx.static_checks:
+            reason = (
+                "staticChecks are configured but cannot run in this environment — "
+                "shell is disabled on pull-request events"
+            )
+            outcomes = declared_cannot_run_outcomes(checks, reason=reason)
+            return {
+                "ran": False,
+                "reason": reason,
+                "checks": [_serialize(o) for o in outcomes],
+            }
+
         outcomes = run_checks(checks, root=root)
         executed = [o for o in outcomes if o.ran]
         logger.info(
@@ -86,8 +98,8 @@ def run_static_checks_tool(ctx: ToolContext):
             "when none of its gates are installed in this environment; either way "
             "report the check as skipped rather than running a linter or interpreter "
             "of your own, whose version may not match the repo's. Per-gate status is "
-            "passed, failed, timed_out, or unavailable — only `failed` says anything "
-            "about the diff."
+            "passed, failed, timed_out, unavailable, or declared-but-cannot-run — "
+            "only `failed` says anything about the diff."
         ),
         input_schema={
             "type": "object",

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -143,6 +143,7 @@ class ToolState:
     learnings_file_path: str | None = None
     learnings_seed: str | None = None
     learnings_persist_attempted: bool = False
+    learnings_review_delta: str | None = None
     xrepo_learnings_file_path: str | None = None
     xrepo_learnings_seed: str | None = None
     xrepo_learnings_persist_attempted: bool = False

--- a/src/mergecraft/review_checks.py
+++ b/src/mergecraft/review_checks.py
@@ -133,6 +133,23 @@ def run_checks(checks: list[StaticCheck], *, root: Path) -> list[StaticCheckOutc
     return run_plans(plans)
 
 
+def declared_cannot_run_outcomes(
+    checks: list[StaticCheck],
+    *,
+    reason: str,
+) -> list[StaticCheckOutcome]:
+    """Return explicit rows when configured gates cannot execute in this environment."""
+    return [
+        StaticCheckOutcome(
+            name=check.name,
+            command=check.command,
+            status="declared-but-cannot-run",
+            output=reason,
+        )
+        for check in checks
+    ]
+
+
 __all__ = [
     "CHECK_TIMEOUT_S",
     "DISCOVERABLE_TARGETS",
@@ -142,6 +159,7 @@ __all__ = [
     "StaticCheck",
     "StaticCheckConfig",
     "StaticCheckOutcome",
+    "declared_cannot_run_outcomes",
     "discover_makefile_targets",
     "plan_checks",
     "run_checks",

--- a/src/mergecraft/utils/learnings.py
+++ b/src/mergecraft/utils/learnings.py
@@ -99,14 +99,39 @@ def build_learnings_review_delta(*, before: str, after: str) -> str:
     )
 
 
+async def ensure_learnings_review_delta(tool_state: ToolState) -> None:
+    """Populate review delta from the agent tmpfile when learnings changed mid-run."""
+    if not persist_is_ephemeral():
+        tool_state.learnings_review_delta = None
+        return
+    file_path = tool_state.learnings_file_path
+    if not file_path:
+        tool_state.learnings_review_delta = None
+        return
+    current = await read_learnings_file(file_path)
+    if current is None:
+        tool_state.learnings_review_delta = None
+        return
+    seed = (tool_state.learnings_seed or "").strip()
+    if current == seed:
+        tool_state.learnings_review_delta = None
+        return
+    tool_state.learnings_review_delta = build_learnings_review_delta(
+        before=seed,
+        after=current,
+    )
+
+
 def merge_learnings_delta_into_review_body(tool_state: ToolState, body: str) -> str:
     """Append ephemeral learnings delta to review or PR-comment bodies."""
     delta = tool_state.learnings_review_delta
     if not delta or not delta.strip():
         return body
     cleaned = body.rstrip()
-    if "### Learnings delta" in cleaned:
-        return cleaned
+    marker = "### Learnings delta"
+    if marker in cleaned:
+        prefix = cleaned.split(marker, 1)[0].rstrip()
+        return f"{prefix}\n\n{delta.rstrip()}" if prefix else delta.rstrip()
     return f"{cleaned}\n\n{delta.rstrip()}"
 
 
@@ -132,10 +157,7 @@ async def persist_learnings(ctx: ToolContext) -> None:
         )
         if persist_is_ephemeral():
             logger.warning(_EPHEMERAL_LEARNINGS_WARNING, dest)
-            ctx.tool_state.learnings_review_delta = build_learnings_review_delta(
-                before=seed,
-                after=current,
-            )
+            await ensure_learnings_review_delta(ctx.tool_state)
         else:
             logger.info("» learnings updated at {}", dest)
     except OSError as exc:
@@ -172,6 +194,7 @@ __all__ = [
     "MAX_LEARNINGS_LENGTH",
     "XREPO_LEARNINGS_FILE_NAME",
     "build_learnings_review_delta",
+    "ensure_learnings_review_delta",
     "learnings_file_path",
     "merge_learnings_delta_into_review_body",
     "persist_is_ephemeral",

--- a/src/mergecraft/utils/learnings.py
+++ b/src/mergecraft/utils/learnings.py
@@ -9,10 +9,20 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
+    from mergecraft.mcp.tool_state import ToolState
 
 LEARNINGS_FILE_NAME = "mergecraft-learnings.md"
 XREPO_LEARNINGS_FILE_NAME = "mergecraft-xrepo-learnings.md"
 MAX_LEARNINGS_LENGTH = 100_000
+
+_EPHEMERAL_LEARNINGS_WARNING = (
+    "learnings written to checkout workspace at {} — this will not survive an "
+    "ephemeral CI runner unless the repo commits `.mergecraft/learnings.md`"
+)
+_EPHEMERAL_XREPO_LEARNINGS_WARNING = (
+    "xrepo learnings written to checkout workspace at {} — this will not survive an "
+    "ephemeral CI runner unless the repo commits `.mergecraft/xrepo-learnings.md`"
+)
 
 
 def truncate_at_line_boundary(text: str, max_length: int = MAX_LEARNINGS_LENGTH) -> str:
@@ -55,7 +65,17 @@ async def read_learnings_file(path: str) -> str | None:
     return truncate_at_line_boundary(raw.strip(), MAX_LEARNINGS_LENGTH)
 
 
-def _local_persist_path(*, owner: str, name: str, kind: str = "learnings") -> Path:
+def _has_durable_persist_path() -> bool:
+    """Contents-API auto-commit path (D7 — deferred)."""
+    return False
+
+
+def persist_is_ephemeral() -> bool:
+    """True when only workspace-local persist is available (e.g. Action checkout)."""
+    return not _has_durable_persist_path()
+
+
+def _local_persist_path(*, kind: str = "learnings") -> Path:
     workspace = Path(os_environ_workspace())
     if kind == "xrepo":
         return workspace / ".mergecraft" / "xrepo-learnings.md"
@@ -66,6 +86,28 @@ def os_environ_workspace() -> str:
     import os
 
     return os.environ.get("GITHUB_WORKSPACE") or os.getcwd()
+
+
+def build_learnings_review_delta(*, before: str, after: str) -> str:
+    """Before→after block for PR/review output when persistence is ephemeral."""
+    return (
+        "### Learnings delta\n\n"
+        "Copy the **After** block into `.mergecraft/learnings.md` "
+        "(this run could not persist durably):\n\n"
+        f"**Before:**\n\n{before.rstrip()}\n\n"
+        f"**After:**\n\n{after.rstrip()}"
+    )
+
+
+def merge_learnings_delta_into_review_body(tool_state: ToolState, body: str) -> str:
+    """Append ephemeral learnings delta to review or PR-comment bodies."""
+    delta = tool_state.learnings_review_delta
+    if not delta or not delta.strip():
+        return body
+    cleaned = body.rstrip()
+    if "### Learnings delta" in cleaned:
+        return cleaned
+    return f"{cleaned}\n\n{delta.rstrip()}"
 
 
 async def persist_learnings(ctx: ToolContext) -> None:
@@ -82,13 +124,20 @@ async def persist_learnings(ctx: ToolContext) -> None:
     if current == seed:
         logger.debug("learnings tmpfile unchanged from seed — skipping persist")
         return
-    dest = _local_persist_path(owner=ctx.repo.owner, name=ctx.repo.name)
+    dest = _local_persist_path()
     try:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(
             current + ("\n" if current and not current.endswith("\n") else ""), encoding="utf-8"
         )
-        logger.info("» learnings updated at {}", dest)
+        if persist_is_ephemeral():
+            logger.warning(_EPHEMERAL_LEARNINGS_WARNING, dest)
+            ctx.tool_state.learnings_review_delta = build_learnings_review_delta(
+                before=seed,
+                after=current,
+            )
+        else:
+            logger.info("» learnings updated at {}", dest)
     except OSError as exc:
         logger.warning("learnings persist failed: {}", exc)
 
@@ -104,13 +153,16 @@ async def persist_xrepo_learnings(ctx: ToolContext) -> None:
     seed = (ctx.tool_state.xrepo_learnings_seed or "").strip()
     if current == seed:
         return
-    dest = _local_persist_path(owner=ctx.repo.owner, name=ctx.repo.name, kind="xrepo")
+    dest = _local_persist_path(kind="xrepo")
     try:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(
             current + ("\n" if current and not current.endswith("\n") else ""), encoding="utf-8"
         )
-        logger.info("» xrepo learnings updated at {}", dest)
+        if persist_is_ephemeral():
+            logger.warning(_EPHEMERAL_XREPO_LEARNINGS_WARNING, dest)
+        else:
+            logger.info("» xrepo learnings updated at {}", dest)
     except OSError as exc:
         logger.warning("xrepo learnings persist failed: {}", exc)
 
@@ -119,7 +171,10 @@ __all__ = [
     "LEARNINGS_FILE_NAME",
     "MAX_LEARNINGS_LENGTH",
     "XREPO_LEARNINGS_FILE_NAME",
+    "build_learnings_review_delta",
     "learnings_file_path",
+    "merge_learnings_delta_into_review_body",
+    "persist_is_ephemeral",
     "persist_learnings",
     "persist_xrepo_learnings",
     "read_learnings_file",

--- a/tests/mcp/test_check_runs.py
+++ b/tests/mcp/test_check_runs.py
@@ -1,0 +1,126 @@
+"""Regression tests for check-suite discovery MCP tool (issue #8 / D8)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.server import build_common_tools
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+REF_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+SUITE_ID = 4242
+
+
+class _RecordingGitHub(GitHubClient):
+    """Records check-suite API calls made by the MCP tool under test."""
+
+    def __init__(self) -> None:
+        super().__init__(token="test-token")
+        self.list_calls: list[tuple[str, str, str]] = []
+        self.get_calls: list[int] = []
+
+    async def list_check_suites_for_ref(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.list_calls.append((owner, repo, ref))
+        return {
+            "total_count": 1,
+            "check_suites": [
+                {
+                    "id": SUITE_ID,
+                    "head_sha": ref,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"name": "GitHub Actions"},
+                }
+            ],
+        }
+
+    async def get_check_suite(
+        self,
+        owner: str,
+        repo: str,
+        check_suite_id: int,
+    ) -> dict[str, Any]:
+        self.get_calls.append(check_suite_id)
+        return {
+            "id": check_suite_id,
+            "head_sha": REF_SHA,
+            "status": "completed",
+            "conclusion": "success",
+        }
+
+
+def _ctx(tmp_path: Path, *, github: GitHubClient | None = None) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request", is_pr=True)),
+        github=github or GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="green after W7: list_check_runs MCP tool (#8)", strict=False)
+async def test_list_check_runs_returns_check_suite_data_for_ref(tmp_path: Path) -> None:
+    """New MCP tool must expose check suites for a ref via GitHubClient list/get helpers."""
+    check_runs = importlib.import_module("mergecraft.mcp.check_runs")
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+
+    tool = check_runs.list_check_runs_tool(ctx)
+    entry = tool.list_entry()
+    assert entry["name"] == "list_check_runs"
+
+    names = {t.name for t in build_common_tools(ctx)}
+    assert "list_check_runs" in names
+
+    payload = json.loads((await tool.execute({"ref": REF_SHA})).content[0]["text"])
+    assert payload["ref"] == REF_SHA
+    suites = payload.get("check_suites") or payload.get("checkSuites")
+    assert isinstance(suites, list)
+    assert suites
+    assert suites[0]["id"] == SUITE_ID
+
+    assert github.list_calls == [("acme", "demo", REF_SHA)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="green after W7: get_check_suite MCP tool detail path (#8)",
+    strict=False,
+)
+async def test_get_check_suite_tool_returns_suite_detail(tmp_path: Path) -> None:
+    """Companion tool must fetch one suite by id (GitHubClient.get_check_suite)."""
+    check_runs = importlib.import_module("mergecraft.mcp.check_runs")
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+
+    get_tool = getattr(check_runs, "get_check_suite_tool", None)
+    assert get_tool is not None, "W7 must expose get_check_suite alongside list_check_runs"
+
+    tool = get_tool(ctx)
+    payload = json.loads((await tool.execute({"check_suite_id": SUITE_ID})).content[0]["text"])
+    assert payload["id"] == SUITE_ID
+    assert github.get_calls == [SUITE_ID]

--- a/tests/mcp/test_check_runs.py
+++ b/tests/mcp/test_check_runs.py
@@ -82,7 +82,6 @@ def _ctx(tmp_path: Path, *, github: GitHubClient | None = None) -> ToolContext:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W7: list_check_runs MCP tool (#8)", strict=False)
 async def test_list_check_runs_returns_check_suite_data_for_ref(tmp_path: Path) -> None:
     """New MCP tool must expose check suites for a ref via GitHubClient list/get helpers."""
     check_runs = importlib.import_module("mergecraft.mcp.check_runs")
@@ -107,10 +106,6 @@ async def test_list_check_runs_returns_check_suite_data_for_ref(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W7: get_check_suite MCP tool detail path (#8)",
-    strict=False,
-)
 async def test_get_check_suite_tool_returns_suite_detail(tmp_path: Path) -> None:
     """Companion tool must fetch one suite by id (GitHubClient.get_check_suite)."""
     check_runs = importlib.import_module("mergecraft.mcp.check_runs")

--- a/tests/mcp/test_registry.py
+++ b/tests/mcp/test_registry.py
@@ -42,6 +42,8 @@ EXPECTED_CORE_TOOLS = {
     "list_pull_request_reviews",
     "resolve_review_thread",
     "get_check_suite_logs",
+    "list_check_runs",
+    "get_check_suite",
     "analyze_ci_failures",
     "add_labels",
     "remove_labels",

--- a/tests/mcp/test_static_checks.py
+++ b/tests/mcp/test_static_checks.py
@@ -124,6 +124,7 @@ async def test_static_checks_declared_but_cannot_run_when_shell_disabled(
         static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
         enabled=True,
     )
+    ctx.trust_tier = "untrusted"
     payload = await _run(ctx)
     assert payload["ran"] is False
     reason = str(payload.get("reason", "")).lower()
@@ -131,3 +132,21 @@ async def test_static_checks_declared_but_cannot_run_when_shell_disabled(
     status_values = {str(check.get("status", "")).lower() for check in checks}
     assert "declared but cannot run" in reason or "declared-but-cannot-run" in status_values
     assert checks, "configured gates must appear as explicit unavailable rows"
+
+
+@pytest.mark.asyncio
+async def test_static_checks_run_when_shell_disabled_but_trusted_offline(
+    tmp_path: Path,
+) -> None:
+    """Offline diff-review keeps shell disabled for security but still runs declared gates."""
+    ctx = _ctx(
+        tmp_path,
+        shell="disabled",
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+        enabled=True,
+    )
+    ctx.trust_tier = "trusted"
+    payload = await _run(ctx)
+    assert payload["ran"] is True
+    assert payload["allPassed"] is True
+    assert payload["checks"][0]["status"] == "passed"

--- a/tests/mcp/test_static_checks.py
+++ b/tests/mcp/test_static_checks.py
@@ -111,3 +111,27 @@ def test_tool_is_withheld_when_static_checks_disabled(tmp_path: Path) -> None:
     assert "run_static_checks" not in names
     names = {t.name for t in build_common_tools(_ctx(tmp_path, enabled=True))}
     assert "run_static_checks" in names
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="green after W7: declared-but-cannot-run when shell disabled (#8)",
+    strict=False,
+)
+async def test_static_checks_declared_but_cannot_run_when_shell_disabled(
+    tmp_path: Path,
+) -> None:
+    """Configured staticChecks with shell disabled must report explicitly, not omit silently."""
+    ctx = _ctx(
+        tmp_path,
+        shell="disabled",
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+        enabled=True,
+    )
+    payload = await _run(ctx)
+    assert payload["ran"] is False
+    reason = str(payload.get("reason", "")).lower()
+    checks = payload.get("checks") or []
+    status_values = {str(check.get("status", "")).lower() for check in checks}
+    assert "declared but cannot run" in reason or "declared-but-cannot-run" in status_values
+    assert checks, "configured gates must appear as explicit unavailable rows"

--- a/tests/mcp/test_static_checks.py
+++ b/tests/mcp/test_static_checks.py
@@ -114,10 +114,6 @@ def test_tool_is_withheld_when_static_checks_disabled(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W7: declared-but-cannot-run when shell disabled (#8)",
-    strict=False,
-)
 async def test_static_checks_declared_but_cannot_run_when_shell_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/utils/test_learnings_persist.py
+++ b/tests/utils/test_learnings_persist.py
@@ -44,9 +44,6 @@ def _ctx(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W6: ephemeral learnings warning + review delta (#7)", strict=False
-)
 async def test_persist_learnings_warns_ephemeral_and_surfaces_delta(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/utils/test_learnings_persist.py
+++ b/tests/utils/test_learnings_persist.py
@@ -1,0 +1,93 @@
+"""Regression tests for learnings persistence honesty (issue #7 / D7)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from loguru import logger
+
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from mergecraft.utils.learnings import persist_learnings, seed_learnings_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    learnings_file_path: str,
+    learnings_seed: str,
+) -> ToolContext:
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    tool_state.learnings_file_path = learnings_file_path
+    tool_state.learnings_seed = learnings_seed
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request", is_pr=True)),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="green after W6: ephemeral learnings warning + review delta (#7)", strict=False
+)
+async def test_persist_learnings_warns_ephemeral_and_surfaces_delta(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Ephemeral GITHUB_WORKSPACE persist must warn (not info-success) and expose the delta."""
+    workspace = tmp_path / "runner-workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    seed = "# Learnings\n\n## Build\n- keep this\n"
+    delta_line = "- reviewer added this during the run\n"
+    updated = seed + f"\n## Review memory\n{delta_line}"
+
+    learnings_path = await seed_learnings_file(tmpdir=str(tmp_path / "agent-tmp"), current=updated)
+    ctx = _ctx(tmp_path, learnings_file_path=learnings_path, learnings_seed=seed)
+
+    log_records: list[tuple[str, str]] = []
+
+    def _capture(record: object) -> None:
+        entry = record.record  # type: ignore[attr-defined]
+        log_records.append((entry["level"].name, entry["message"]))
+
+    sink_id = logger.add(_capture, level="DEBUG")
+    try:
+        await persist_learnings(ctx)
+    finally:
+        logger.remove(sink_id)
+
+    info_success = [
+        message
+        for level, message in log_records
+        if level == "INFO" and "learnings updated" in message.lower()
+    ]
+    assert not info_success, "ephemeral persist must not log info-level success"
+
+    warnings = [message for level, message in log_records if level == "WARNING"]
+    assert warnings
+    joined = " ".join(warnings).lower()
+    assert "ephemeral" in joined or "will not survive" in joined or "not survive" in joined
+
+    delta = getattr(ctx.tool_state, "learnings_review_delta", None)
+    assert delta is not None
+    assert delta.strip()
+    assert delta_line.strip() in delta or "## Review memory" in delta

--- a/tests/utils/test_learnings_persist.py
+++ b/tests/utils/test_learnings_persist.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,11 +13,14 @@ from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, 
 from mergecraft.mcp.tool_state import init_tool_state
 from mergecraft.modes import compute_modes
 from mergecraft.utils.github import GitHubClient
-from mergecraft.utils.learnings import persist_learnings, seed_learnings_file
+from mergecraft.utils.learnings import (
+    ensure_learnings_review_delta,
+    merge_learnings_delta_into_review_body,
+    persist_learnings,
+    seed_learnings_file,
+)
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from _pytest.monkeypatch import MonkeyPatch
 
 
@@ -88,3 +93,62 @@ async def test_persist_learnings_warns_ephemeral_and_surfaces_delta(
     assert delta is not None
     assert delta.strip()
     assert delta_line.strip() in delta or "## Review memory" in delta
+
+
+@pytest.mark.asyncio
+async def test_ensure_learnings_review_delta_before_persist(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Review/comment paths can surface the delta before post-run persist_learnings."""
+    workspace = tmp_path / "runner-workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    seed = "# Learnings\n\n## Build\n- keep this\n"
+    delta_line = "- reviewer added this during the run\n"
+    updated = seed + f"\n## Review memory\n{delta_line}"
+
+    learnings_path = await seed_learnings_file(tmpdir=str(tmp_path / "agent-tmp"), current=updated)
+    ctx = _ctx(tmp_path, learnings_file_path=learnings_path, learnings_seed=seed)
+
+    await ensure_learnings_review_delta(ctx.tool_state)
+    body = merge_learnings_delta_into_review_body(ctx.tool_state, "## Review\n\nLooks good.")
+    assert "### Learnings delta" in body
+    assert delta_line.strip() in body
+    assert ctx.tool_state.learnings_review_delta is not None
+
+
+@pytest.mark.asyncio
+async def test_ensure_learnings_review_delta_refreshes_after_later_edits(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Progress and final review must reflect the latest learnings tmpfile contents."""
+    workspace = tmp_path / "runner-workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    seed = "# Learnings\n\n## Build\n- keep this\n"
+    first_edit = seed + "\n## Review memory\n- first edit\n"
+    second_edit = first_edit + "\n- second edit\n"
+
+    learnings_path = await seed_learnings_file(
+        tmpdir=str(tmp_path / "agent-tmp"), current=first_edit
+    )
+    ctx = _ctx(tmp_path, learnings_file_path=learnings_path, learnings_seed=seed)
+
+    await ensure_learnings_review_delta(ctx.tool_state)
+    first_body = merge_learnings_delta_into_review_body(ctx.tool_state, "progress")
+    assert "- first edit" in first_body
+    assert "- second edit" not in first_body
+
+    await asyncio.to_thread(Path(learnings_path).write_text, second_edit, encoding="utf-8")
+    await ensure_learnings_review_delta(ctx.tool_state)
+    second_body = merge_learnings_delta_into_review_body(ctx.tool_state, "review")
+    assert "- second edit" in second_body
+
+    stale_progress = merge_learnings_delta_into_review_body(ctx.tool_state, first_body)
+    assert "- second edit" in stale_progress
+    after_section = stale_progress.split("**After:**", 1)[1]
+    assert "- second edit" in after_section


### PR DESCRIPTION
## Summary

- **#7:** Warn loudly when learnings persistence is ephemeral and surface the learnings delta in review output so operators know when writes did not stick.
- **#8:** Add MCP tools `list_check_runs` / check-suite visibility and honest `staticChecks` status when analyzers are declared but cannot run in the current environment.
- Review-checks doc updates and RED tests for #7/#8.
- **Scope limits (D7/D8):** This batch does not implement full CI log ingestion or every static-check runner path—only honest signaling and MCP exposure for what the Action can observe today.

## Test plan

- [x] `make ci`
- [x] Unit tests: `tests/utils/test_learnings_persist.py`, `tests/mcp/test_check_runs.py`, `tests/mcp/test_static_checks.py`
- [x] Bugbot / review gate on branch

## Related issues

Closes #7
Closes #8

Made with [Cursor](https://cursor.com)