### PR TITLE
docs(workflows): hardened examples and default-branch guidance (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Hardened reference workflow at `examples/workflows/mergecraft-hardened.yml`
+  (same-repo secret guard, PR-number concurrency, wait-for-CI, base-ref fetch,
+  full-SHA pin, approval-check enforcement) plus a template renderer with
+  `make example-workflows-check` wired into `make ci-static`.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ci-static: lockcheck lint typecheck pyright catalog-check build example-workflow
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check build security test
+CI_STEPS := lockcheck lint typecheck pyright catalog-check build example-workflows-check security test
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ PIP_AUDIT_CACHE ?= $(CURDIR)/.cache/pip-audit
 PRE_COMMIT ?= $(UV) run pre-commit
 
 .PHONY: help setup install lockcheck lint format typecheck pyright test security \
-	precommit build ci ci-static ci-steps ci-resume ci-reset catalog-check docker-build clean
+	precommit build ci ci-static ci-steps ci-resume ci-reset catalog-check docker-build clean \
+	examples example-workflows-check
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -79,7 +80,13 @@ precommit: ## Run pre-commit on all files
 build: ## Build wheel/sdist
 	$(UV) build
 
-ci-static: lockcheck lint typecheck pyright catalog-check build ## Static/build tier
+examples: ## Render example workflow YAML from templates
+	$(UV) run python scripts/render_example_workflows.py
+
+example-workflows-check: ## Fail when committed example workflows drift from templates
+	$(UV) run python scripts/render_example_workflows.py --check
+
+ci-static: lockcheck lint typecheck pyright catalog-check build example-workflows-check ## Static/build tier
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ jobs:
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # or API key
 ```
 
+Ready-made workflow files live under [`examples/workflows/`](examples/workflows/):
+
+- [`mergecraft.yml`](examples/workflows/mergecraft.yml) — minimal getting-started
+  example (`pull_request`, comment triggers).
+- [`mergecraft-hardened.yml`](examples/workflows/mergecraft-hardened.yml) — use
+  this one when the review is a **required check** (`pull_request_target`,
+  wait-for-CI, approval enforcement).
+
+Both are rendered from templates in `scripts/example_workflows/` (`make examples`
+to regenerate; CI fails on drift).
+
 ### Where the workflow must live (`pull_request_target`)
 
 Under GitHub's Nov 2025 policy (**effective 2025-12-08**), a

--- a/README.md
+++ b/README.md
@@ -98,6 +98,70 @@ jobs:
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # or API key
 ```
 
+### Where the workflow must live (`pull_request_target`)
+
+Under GitHub's Nov 2025 policy (**effective 2025-12-08**), a
+`pull_request_target` workflow is resolved from the repository's **default
+branch** — not from the PR's base branch. Three consequences:
+
+- The **default-branch copy runs for every PR**, whatever base branch the PR
+  targets.
+- A PR that **edits the workflow cannot review itself** with its own changes;
+  updates take effect on the **next** PR after merge.
+- If your **trunk is not the default branch**, a copy of the workflow on the
+  trunk is **inert**. It never runs, must be hand-mirrored onto the default
+  branch forever, and the two copies drift.
+
+This matters when `main` is a stub (for example, only `LICENSE`) while real work
+lands on another branch such as `pre-0.0.1`: keep
+`.github/workflows/mergecraft.yml` on **`main`** (or whichever branch GitHub
+lists as default), not only on the trunk. mergeCraft itself is an example —
+there is no workflow under `.github/workflows/` yet, and the default branch does
+not match the development trunk.
+
+### `pull_request` vs `pull_request_target`
+
+| Trigger | When to use | Trade-off |
+|---------|-------------|-----------|
+| `pull_request` | The review job is **not** a required check | Simpler and safer — no repository secrets in scope for fork PRs |
+| `pull_request_target` | The review job **is** a required check | Runs with secrets; must never execute PR-authored code |
+
+GitHub **skips** `pull_request` workflows when `refs/pull/N/merge` cannot be
+built — i.e. whenever the PR has a **merge conflict**. If the review job is a
+required check, that leaves the check permanently missing and the PR
+unmergeable even after the conflict is fixed. `pull_request_target` still fires
+on `synchronize` in that state.
+
+The cost of `pull_request_target` is that it runs with repository secrets in
+scope, so the workflow must not execute PR-authored scripts or checkout untrusted
+code. Use same-repo guards, `push: disabled`, and `shell: disabled` in
+mergeCraft config. **If the review is not a required check, prefer plain
+`pull_request`.**
+
+### Pin parity across copies
+
+Many repos pin the action SHA in more than one place — the workflow, a Makefile
+variable for local `mergecraft diff-review`, a devcontainer, or docs. Gate those
+copies against each other in CI. The non-obvious part:
+
+> Read the workflow side from the **default branch**, not from the working tree:
+>
+> ```bash
+> git show origin/main:.github/workflows/mergecraft.yml
+> ```
+
+Comparing a working-tree copy that never executes against a local pin verifies
+two values that do not matter, while the pin that actually runs goes unchecked.
+A SHA bumped only on the default branch stays invisible to a gate that reads the
+PR checkout.
+
+- **Bump order: default branch first, local pin second.** The gate compares
+  against the default branch, so reversing the order fails until the default
+  branch catches up.
+- The gate should **skip with a warning** when the default-branch ref is
+  unreachable (offline local runs) and **hard-fail under `CI`** — otherwise a
+  network hiccup turns the check into a decorative no-op.
+
 ### Local config
 
 Create `.mergecraft/config.yaml` (see [`examples/config.yaml`](examples/config.yaml)):

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ This matters when `main` is a stub (for example, only `LICENSE`) while real work
 lands on another branch such as `pre-0.0.1`: keep
 `.github/workflows/mergecraft.yml` on **`main`** (or whichever branch GitHub
 lists as default), not only on the trunk. mergeCraft itself is an example —
-there is no workflow under `.github/workflows/` yet, and the default branch does
-not match the development trunk.
+there is no **mergeCraft review** workflow under `.github/workflows/` yet (CI,
+release, Docker, and CodeQL workflows exist; only `mergecraft.yml` is missing),
+and the default branch does not match the development trunk.
 
 ### `pull_request` vs `pull_request_target`
 

--- a/docs/artifacts/dogfood-main-landing.md
+++ b/docs/artifacts/dogfood-main-landing.md
@@ -1,0 +1,45 @@
+# Operator action: land mergeCraft dogfood workflow on `main` (D6)
+
+**Status:** Blocked on operator — W10 does **not** push this to `main`.
+
+## Why a separate step
+
+GitHub resolves `pull_request_target` workflows from the repository **default branch** (`main`), not from `pre-0.0.1`. Today `main` holds only `LICENSE`; Batch C worktrees target `pre-0.0.1`. Landing `.github/workflows/mergecraft.yml` on `main` is the first real content on the production default branch and must be an explicit operator decision (plan D6).
+
+## Review artifact (Batch C PR)
+
+| Item | Path |
+|------|------|
+| Rendered hardened workflow | [`dogfood-mergecraft.yml`](dogfood-mergecraft.yml) |
+| Template source | `scripts/example_workflows/hardened.yml.tpl` + `scripts/render_example_workflows.py` |
+
+Dogfood overrides baked into the artifact:
+
+- **`branches`:** `[pre-0.0.1]` — PRs targeting the real trunk (see `.github/workflows/ci.yml`).
+- **`CI_JOB_PREFIX`:** `"Verify ("` — matches CI job names: `Verify (toolchain)`, `Verify (tests N/2)`, `Verify (static + build)`, `Verify (security audit)`.
+- **Action pin:** full SHA `f98aeb0063b387a51960503a758351608d377002` (`origin/pre-0.0.1` at sweep baseline). **Bump to the release SHA** you intend to run before merging to `main`.
+
+## Operator checklist (separate PR → `main`)
+
+1. **Branch:** Create a short-lived branch from `main` (e.g. `dogfood/mergecraft-workflow`).
+2. **Copy workflow:** Move [`dogfood-mergecraft.yml`](dogfood-mergecraft.yml) to `.github/workflows/mergecraft.yml` on that branch (strip the review-only header comments if desired).
+3. **Pin parity:** Update `action_pin_hardened` / the `uses:` SHA to the commit you want consumers (and this repo) to run; align with any Makefile or docs pins per README § Pin parity.
+4. **Secrets:** Configure repository secrets on `alexhawat/mergeCraft`:
+   - `CLAUDE_CODE_OAUTH_TOKEN` and/or `ANTHROPIC_API_KEY` (see README Authentication table).
+5. **Optional ruleset:** If `mergeCraft review` is a required check, add a branch ruleset on `pre-0.0.1` requiring job `mergeCraft review` (and understand `neutral` / fail-open semantics from README).
+6. **Open PR targeting `main`**, review, merge. The workflow takes effect on the **next** PR after merge (not the PR that introduces the file).
+7. **Issue #9:** After merge, comment on #9 that dogfooding is live (or leave open if secrets/ruleset are still pending). Batch C Final (C.4) closes #9 only when this step is done.
+
+## Regenerate after template changes
+
+```bash
+MERGECRAFT_EXAMPLE_BASE_BRANCHES='[pre-0.0.1]' \
+MERGECRAFT_EXAMPLE_CI_JOB_PREFIX='Verify (' \
+MERGECRAFT_EXAMPLE_ACTION_PIN_HARDENED='<full-commit-sha>' \
+uv run python scripts/render_example_workflows.py --variant hardened
+# Copy stdout or examples/workflows/mergecraft-hardened.yml with overrides applied to docs/artifacts/dogfood-mergecraft.yml
+```
+
+## Explicit non-actions (W10)
+
+- Do **not** commit `.github/workflows/mergecraft.yml` on `pre-0.0.1` from the batch worktree unless the operator decides this repo should also run mergeCraft from the staging branch (inert under current default-branch policy).

--- a/docs/artifacts/dogfood-mergecraft.yml
+++ b/docs/artifacts/dogfood-mergecraft.yml
@@ -1,0 +1,346 @@
+# DO NOT commit this path to .github/workflows/ on pre-0.0.1 (D6).
+# Review artifact for mergeCraft dogfooding — land on main via operator PR (see dogfood-main-landing.md).
+# Render: MERGECRAFT_EXAMPLE_BASE_BRANCHES='[pre-0.0.1]' MERGECRAFT_EXAMPLE_CI_JOB_PREFIX='Verify (' #   MERGECRAFT_EXAMPLE_ACTION_PIN_HARDENED=<full-sha> uv run python scripts/render_example_workflows.py --variant hardened
+# (then copy output; this file is the pre-rendered result.)
+
+# mergeCraft PR review — hardened reference workflow.
+#
+# Auto-reviews PRs on open / ready / new commits, posting inline comments plus a
+# summary, and (with `status_checks: enabled`) the `mergecraft` and
+# `mergecraft-approval` check-runs. The final step fails the job when
+# `mergecraft-approval` concluded "would not approve", so a branch ruleset can
+# require this job and block merges with outstanding review feedback.
+#
+# It ALWAYS fails open when the review cannot run — fork PR without secrets,
+# provider session limit, no approval posted. A required check that can go
+# permanently missing is a permanent merge block, which is worse than no gate.
+#
+# ---------------------------------------------------------------------------
+# Trigger choice: pull_request_target vs pull_request
+# ---------------------------------------------------------------------------
+# This template uses `pull_request_target`. GitHub SKIPS `pull_request` workflows
+# when `refs/pull/N/merge` cannot be built — i.e. whenever the PR has a merge
+# conflict — which leaves a required check permanently missing and the PR
+# unmergeable even after the conflict is fixed. `pull_request_target` still fires
+# on `synchronize` in that state.
+#
+# The cost is that `pull_request_target` runs with repository secrets in scope, so
+# it MUST NOT execute PR-authored code. This workflow does not: the same-repo
+# guard below withholds secrets from fork PRs, and mergeCraft runs with
+# `push: disabled` / `shell: disabled` and reaches PR content through its own
+# `checkout_pr` + API layer.
+#
+# If your review job is NOT a required check, plain `pull_request` is simpler and
+# safer — use it.
+#
+# ---------------------------------------------------------------------------
+# WHERE THIS FILE MUST LIVE
+# ---------------------------------------------------------------------------
+# Under GitHub's Nov 2025 policy (effective 2025-12-08), `pull_request_target`
+# definitions are resolved from the repository's DEFAULT BRANCH — not from the
+# PR's base branch. Consequences:
+#
+#   * The default-branch copy runs for every PR, whatever base it targets.
+#   * A PR that edits this file cannot review itself with its own changes; they
+#     take effect on the next PR after merge.
+#   * If your trunk is NOT the default branch (e.g. `main` is a stub and real
+#     work lands on a staging branch), keep this file ONLY on the default branch.
+#     A second copy on the trunk is inert, has to be hand-mirrored forever, and
+#     invites the two copies to drift.
+#
+# If you also pin the action SHA somewhere else — a Makefile variable for local
+# review runs, a devcontainer, docs — gate the two against each other in CI, and
+# read the workflow side from the DEFAULT BRANCH (`git show origin/main:<path>`),
+# not from the working tree. Comparing a working-tree copy that never executes
+# against your Makefile checks two values that do not matter while the pin that
+# actually runs goes unverified. Bump order is then: default branch first, local
+# pin second — the gate compares against the default branch, so the reverse order
+# fails.
+# ---------------------------------------------------------------------------
+
+name: mergeCraft
+
+on:
+  pull_request_target:
+    # Add every base branch that should be auto-reviewed. Globs work:
+    # branches: [main, develop, "release-*"]
+    branches: [pre-0.0.1]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent (workflow_dispatch only)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  # Post the inline PR review + comments.
+  pull-requests: write
+  issues: write
+  # Post the mergecraft / mergecraft-approval check-runs.
+  checks: write
+  statuses: write
+  # Only needed if mergeCraft mints short-lived tokens via OIDC.
+  id-token: write
+
+concurrency:
+  # pull_request_target resolves github.ref to the default branch, so keying on
+  # github.ref would collapse every open PR into one group and they would cancel
+  # each other. Key on the PR number.
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Hold the review until your own CI has finished on the PR head SHA, so the
+  # reviewer reads real lint/type/test outcomes instead of speculating about them.
+  # `needs:` cannot reference another workflow file, so this polls the check-runs
+  # API for the jobs named by CI_JOB_PREFIX.
+  #
+  # Delete this job (and the `needs:` below) if you do not want reviews to wait.
+  #
+  # ALWAYS fails open (`exit 0` on every path): if the review job is required, a
+  # wait that could fail would turn a slow or absent CI run into a permanent merge
+  # block. Timing out just means the review proceeds without CI context.
+  wait-for-ci:
+    name: mergeCraft wait for CI
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      # complete | timeout | absent | skipped
+      state: ${{ steps.wait.outputs.state || 'skipped' }}
+      failed_count: ${{ steps.wait.outputs.failed_count || '0' }}
+      failed_names: ${{ steps.wait.outputs.failed_names || '' }}
+      check_suite_id: ${{ steps.wait.outputs.check_suite_id || '' }}
+    steps:
+      - name: Wait for CI checks on the PR head SHA
+        id: wait
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Name prefix of YOUR CI jobs. Set this to whatever your CI workflow
+          # calls its jobs, e.g. "build (" or "test (".
+          CI_JOB_PREFIX: "Verify ("
+          # Total budget. Set a little above your CI's usual wall time; keep it
+          # below this job's timeout-minutes.
+          WAIT_BUDGET_SECONDS: "1200"
+          # If no matching job has appeared by then, assume CI is not running for
+          # this PR and stop waiting.
+          APPEAR_BUDGET_SECONDS: "300"
+        run: |
+          set -uo pipefail
+          jq_verify="[.check_runs[]? | select(.name | startswith(\"${CI_JOB_PREFIX}\"))]"
+          started="$(date +%s)"
+          state="timeout"
+          failed_count=0
+          failed_names=""
+          check_suite_id=""
+
+          while :; do
+            now="$(date +%s)"
+            elapsed=$(( now - started ))
+
+            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+              total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
+              pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
+
+              if [ "${total}" -gt 0 ] && [ "${pending}" -eq 0 ]; then
+                state="complete"
+                failed_count="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\")) | length")"
+                failed_names="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .name) | join(\", \")")"
+                # Any failing job carries the check_suite id the reviewer needs
+                # for get_check_suite_logs().
+                check_suite_id="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .check_suite.id) | first // \"\"")"
+                break
+              fi
+
+              if [ "${total}" -eq 0 ] && [ "${elapsed}" -ge "${APPEAR_BUDGET_SECONDS}" ]; then
+                state="absent"
+                break
+              fi
+            else
+              echo "check-runs query failed (elapsed ${elapsed}s) — retrying" >&2
+            fi
+
+            if [ "${elapsed}" -ge "${WAIT_BUDGET_SECONDS}" ]; then
+              state="timeout"
+              break
+            fi
+            sleep 20
+          done
+
+          {
+            echo "state=${state}"
+            echo "failed_count=${failed_count}"
+            echo "failed_names=${failed_names}"
+            echo "check_suite_id=${check_suite_id}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "CI wait finished: state=${state} failed=${failed_count} suite=${check_suite_id:-none}"
+          case "${state}" in
+            timeout) echo "::notice title=mergeCraft CI wait::CI did not finish within ${WAIT_BUDGET_SECONDS}s — reviewing without CI context." ;;
+            absent)  echo "::notice title=mergeCraft CI wait::No matching CI checks appeared for ${HEAD_SHA} — reviewing without CI context." ;;
+          esac
+          exit 0
+
+  review:
+    name: mergeCraft review
+    needs: wait-for-ci
+    # `always()` keeps the required check reporting even if the (fail-open) wait
+    # job errors out on a runner fault; a skipped wait job still skips the review,
+    # because the draft/dispatch condition below is the same one it uses.
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Same-repo guard: fork PRs must never receive repository secrets under
+      # pull_request_target.
+      IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+      HAS_AUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Persist the checkout token so mergeCraft's own git layer
+          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
+          # fail and the action marks its `mergecraft` self-status red even though
+          # the review completes via the API. Read-only escalation only: the
+          # action runs with push/shell disabled, so a persisted token cannot be
+          # used to push.
+          persist-credentials: true
+
+      - name: Ensure PR base ref exists locally
+        if: github.event_name == 'pull_request_target'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags origin "${base}:refs/remotes/origin/${base}"
+          # pull_request_target checks out the DEFAULT branch. When the PR targets
+          # that same branch, `git branch -f` fails because it is the active
+          # worktree — and origin/<base> is already fetched above.
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${base}" ]; then
+            git branch -f "${base}" "origin/${base}"
+          fi
+
+      - name: Skip when provider auth is not configured
+        if: env.HAS_AUTH != 'true'
+        run: |
+          if [ "${{ env.IS_SAME_REPO }}" != "true" ]; then
+            echo "::notice title=mergeCraft skipped::Fork PR — secrets are withheld, review skipped."
+          else
+            echo "::notice title=mergeCraft skipped::Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to enable reviews."
+          fi
+
+      # Composed in a step rather than inline in `with:` so the CI-context clause
+      # stays readable. Every interpolated value is repo-controlled (PR number,
+      # base ref, our own wait-job outputs) — no PR-authored free text reaches the
+      # prompt.
+      - name: Compose review prompt
+        id: prompt
+        if: env.HAS_AUTH == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PROMPT: ${{ inputs.prompt }}
+          CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
+          CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
+          CI_FAILED_NAMES: ${{ needs.wait-for-ci.outputs.failed_names }}
+          CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
+            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          else
+            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            # The action runs with `shell: disabled`, so the reviewer cannot run
+            # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
+            # check_suite id, because no MCP tool can discover one.
+            case "${CI_STATE}" in
+              complete)
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                else
+                  text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
+                fi
+                ;;
+              *)
+                text="${text} CI results are NOT available for this head commit (wait state: ${CI_STATE}), so no lint/typecheck/test signal informs this review. Do not assert that the change passes or fails those gates."
+                ;;
+            esac
+          fi
+          {
+            echo "text<<MERGECRAFT_PROMPT_EOF"
+            echo "${text}"
+            echo "MERGECRAFT_PROMPT_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review
+        if: env.HAS_AUTH == 'true'
+        id: mergecraft
+        continue-on-error: true
+        # Pin to a full-length commit SHA. Many orgs enforce Actions SHA pinning,
+        # which rejects a branch ref at action-resolution time — before the step
+        # runs. Keep this SHA equal to any other place you pin mergeCraft.
+        uses: alexhawat/mergeCraft@f98aeb0063b387a51960503a758351608d377002
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
+          # first, the action never posts its `mergecraft` completion check and
+          # the only diagnostic is lost. 5 minutes of headroom lets it exit
+          # cleanly and report failure instead.
+          timeout: 25m
+          model: anthropic/claude-sonnet
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: mergeCraft review incomplete (non-fatal)
+        if: env.HAS_AUTH == 'true' && steps.mergecraft.outcome != 'success'
+        run: |
+          echo "::notice title=mergeCraft incomplete::Review step did not finish successfully (see its log). Approval enforcement skipped."
+
+      # Gate on the approval check-run rather than on the review step's exit code,
+      # so agent infrastructure failures do not read as "changes requested".
+      - name: Fail when mergeCraft would not approve
+        if: github.event_name == 'pull_request_target' && env.HAS_AUTH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          conclusion=""; queried=""
+          for attempt in $(seq 1 5); do
+            if conclusion="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+                      | sort_by(.completed_at // .started_at) | last | .conclusion // ""')"; then
+              queried="yes"; break
+            fi
+            echo "check-runs query failed (attempt ${attempt}/5); retrying in 5s…" >&2
+            sleep 5
+          done
+          if [ -z "${queried}" ]; then
+            echo "::warning title=mergeCraft approval unknown::Could not query check-runs for ${HEAD_SHA} after retries. Failing open."
+            exit 0
+          fi
+          case "${conclusion}" in
+            failure)
+              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — address the review feedback on this PR."
+              exit 1
+              ;;
+            success)
+              echo "mergeCraft approval: no outstanding review feedback."
+              ;;
+            *)
+              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking."
+              ;;
+          esac

--- a/docs/artifacts/dogfood-mergecraft.yml
+++ b/docs/artifacts/dogfood-mergecraft.yml
@@ -1,8 +1,5 @@
-# DO NOT commit this path to .github/workflows/ on pre-0.0.1 (D6).
 # Review artifact for mergeCraft dogfooding — land on main via operator PR (see dogfood-main-landing.md).
-# Render: MERGECRAFT_EXAMPLE_BASE_BRANCHES='[pre-0.0.1]' MERGECRAFT_EXAMPLE_CI_JOB_PREFIX='Verify (' #   MERGECRAFT_EXAMPLE_ACTION_PIN_HARDENED=<full-sha> uv run python scripts/render_example_workflows.py --variant hardened
-# (then copy output; this file is the pre-rendered result.)
-
+# Do NOT commit this path to .github/workflows/ on pre-0.0.1 from Batch C (plan D6).
 # mergeCraft PR review — hardened reference workflow.
 #
 # Auto-reviews PRs on open / ready / new commits, posting inline comments plus a
@@ -143,7 +140,7 @@ jobs:
             now="$(date +%s)"
             elapsed=$(( now - started ))
 
-            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+            if runs="$(gh api --paginate "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs: [.[].check_runs[]?]}')" ; then
               total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
               pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
 
@@ -263,8 +260,12 @@ jobs:
             # check_suite id, because no MCP tool can discover one.
             case "${CI_STATE}" in
               complete)
-                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
+                  if [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                  else
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
+                  fi
                 else
                   text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
                 fi

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -138,7 +138,7 @@ jobs:
             now="$(date +%s)"
             elapsed=$(( now - started ))
 
-            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+            if runs="$(gh api --paginate "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs: [.[].check_runs[]?]}')" ; then
               total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
               pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
 
@@ -258,8 +258,12 @@ jobs:
             # check_suite id, because no MCP tool can discover one.
             case "${CI_STATE}" in
               complete)
-                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
+                  if [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                  else
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
+                  fi
                 else
                   text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
                 fi

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -1,0 +1,341 @@
+# mergeCraft PR review — hardened reference workflow.
+#
+# Auto-reviews PRs on open / ready / new commits, posting inline comments plus a
+# summary, and (with `status_checks: enabled`) the `mergecraft` and
+# `mergecraft-approval` check-runs. The final step fails the job when
+# `mergecraft-approval` concluded "would not approve", so a branch ruleset can
+# require this job and block merges with outstanding review feedback.
+#
+# It ALWAYS fails open when the review cannot run — fork PR without secrets,
+# provider session limit, no approval posted. A required check that can go
+# permanently missing is a permanent merge block, which is worse than no gate.
+#
+# ---------------------------------------------------------------------------
+# Trigger choice: pull_request_target vs pull_request
+# ---------------------------------------------------------------------------
+# This template uses `pull_request_target`. GitHub SKIPS `pull_request` workflows
+# when `refs/pull/N/merge` cannot be built — i.e. whenever the PR has a merge
+# conflict — which leaves a required check permanently missing and the PR
+# unmergeable even after the conflict is fixed. `pull_request_target` still fires
+# on `synchronize` in that state.
+#
+# The cost is that `pull_request_target` runs with repository secrets in scope, so
+# it MUST NOT execute PR-authored code. This workflow does not: the same-repo
+# guard below withholds secrets from fork PRs, and mergeCraft runs with
+# `push: disabled` / `shell: disabled` and reaches PR content through its own
+# `checkout_pr` + API layer.
+#
+# If your review job is NOT a required check, plain `pull_request` is simpler and
+# safer — use it.
+#
+# ---------------------------------------------------------------------------
+# WHERE THIS FILE MUST LIVE
+# ---------------------------------------------------------------------------
+# Under GitHub's Nov 2025 policy (effective 2025-12-08), `pull_request_target`
+# definitions are resolved from the repository's DEFAULT BRANCH — not from the
+# PR's base branch. Consequences:
+#
+#   * The default-branch copy runs for every PR, whatever base it targets.
+#   * A PR that edits this file cannot review itself with its own changes; they
+#     take effect on the next PR after merge.
+#   * If your trunk is NOT the default branch (e.g. `main` is a stub and real
+#     work lands on a staging branch), keep this file ONLY on the default branch.
+#     A second copy on the trunk is inert, has to be hand-mirrored forever, and
+#     invites the two copies to drift.
+#
+# If you also pin the action SHA somewhere else — a Makefile variable for local
+# review runs, a devcontainer, docs — gate the two against each other in CI, and
+# read the workflow side from the DEFAULT BRANCH (`git show origin/main:<path>`),
+# not from the working tree. Comparing a working-tree copy that never executes
+# against your Makefile checks two values that do not matter while the pin that
+# actually runs goes unverified. Bump order is then: default branch first, local
+# pin second — the gate compares against the default branch, so the reverse order
+# fails.
+# ---------------------------------------------------------------------------
+
+name: mergeCraft
+
+on:
+  pull_request_target:
+    # Add every base branch that should be auto-reviewed. Globs work:
+    # branches: [main, develop, "release-*"]
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent (workflow_dispatch only)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  # Post the inline PR review + comments.
+  pull-requests: write
+  issues: write
+  # Post the mergecraft / mergecraft-approval check-runs.
+  checks: write
+  statuses: write
+  # Only needed if mergeCraft mints short-lived tokens via OIDC.
+  id-token: write
+
+concurrency:
+  # pull_request_target resolves github.ref to the default branch, so keying on
+  # github.ref would collapse every open PR into one group and they would cancel
+  # each other. Key on the PR number.
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Hold the review until your own CI has finished on the PR head SHA, so the
+  # reviewer reads real lint/type/test outcomes instead of speculating about them.
+  # `needs:` cannot reference another workflow file, so this polls the check-runs
+  # API for the jobs named by CI_JOB_PREFIX.
+  #
+  # Delete this job (and the `needs:` below) if you do not want reviews to wait.
+  #
+  # ALWAYS fails open (`exit 0` on every path): if the review job is required, a
+  # wait that could fail would turn a slow or absent CI run into a permanent merge
+  # block. Timing out just means the review proceeds without CI context.
+  wait-for-ci:
+    name: mergeCraft wait for CI
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      # complete | timeout | absent | skipped
+      state: ${{ steps.wait.outputs.state || 'skipped' }}
+      failed_count: ${{ steps.wait.outputs.failed_count || '0' }}
+      failed_names: ${{ steps.wait.outputs.failed_names || '' }}
+      check_suite_id: ${{ steps.wait.outputs.check_suite_id || '' }}
+    steps:
+      - name: Wait for CI checks on the PR head SHA
+        id: wait
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Name prefix of YOUR CI jobs. Set this to whatever your CI workflow
+          # calls its jobs, e.g. "build (" or "test (".
+          CI_JOB_PREFIX: "Verify ("
+          # Total budget. Set a little above your CI's usual wall time; keep it
+          # below this job's timeout-minutes.
+          WAIT_BUDGET_SECONDS: "1200"
+          # If no matching job has appeared by then, assume CI is not running for
+          # this PR and stop waiting.
+          APPEAR_BUDGET_SECONDS: "300"
+        run: |
+          set -uo pipefail
+          jq_verify="[.check_runs[]? | select(.name | startswith(\"${CI_JOB_PREFIX}\"))]"
+          started="$(date +%s)"
+          state="timeout"
+          failed_count=0
+          failed_names=""
+          check_suite_id=""
+
+          while :; do
+            now="$(date +%s)"
+            elapsed=$(( now - started ))
+
+            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+              total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
+              pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
+
+              if [ "${total}" -gt 0 ] && [ "${pending}" -eq 0 ]; then
+                state="complete"
+                failed_count="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\")) | length")"
+                failed_names="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .name) | join(\", \")")"
+                # Any failing job carries the check_suite id the reviewer needs
+                # for get_check_suite_logs().
+                check_suite_id="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .check_suite.id) | first // \"\"")"
+                break
+              fi
+
+              if [ "${total}" -eq 0 ] && [ "${elapsed}" -ge "${APPEAR_BUDGET_SECONDS}" ]; then
+                state="absent"
+                break
+              fi
+            else
+              echo "check-runs query failed (elapsed ${elapsed}s) — retrying" >&2
+            fi
+
+            if [ "${elapsed}" -ge "${WAIT_BUDGET_SECONDS}" ]; then
+              state="timeout"
+              break
+            fi
+            sleep 20
+          done
+
+          {
+            echo "state=${state}"
+            echo "failed_count=${failed_count}"
+            echo "failed_names=${failed_names}"
+            echo "check_suite_id=${check_suite_id}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "CI wait finished: state=${state} failed=${failed_count} suite=${check_suite_id:-none}"
+          case "${state}" in
+            timeout) echo "::notice title=mergeCraft CI wait::CI did not finish within ${WAIT_BUDGET_SECONDS}s — reviewing without CI context." ;;
+            absent)  echo "::notice title=mergeCraft CI wait::No matching CI checks appeared for ${HEAD_SHA} — reviewing without CI context." ;;
+          esac
+          exit 0
+
+  review:
+    name: mergeCraft review
+    needs: wait-for-ci
+    # `always()` keeps the required check reporting even if the (fail-open) wait
+    # job errors out on a runner fault; a skipped wait job still skips the review,
+    # because the draft/dispatch condition below is the same one it uses.
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Same-repo guard: fork PRs must never receive repository secrets under
+      # pull_request_target.
+      IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+      HAS_AUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Persist the checkout token so mergeCraft's own git layer
+          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
+          # fail and the action marks its `mergecraft` self-status red even though
+          # the review completes via the API. Read-only escalation only: the
+          # action runs with push/shell disabled, so a persisted token cannot be
+          # used to push.
+          persist-credentials: true
+
+      - name: Ensure PR base ref exists locally
+        if: github.event_name == 'pull_request_target'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags origin "${base}:refs/remotes/origin/${base}"
+          # pull_request_target checks out the DEFAULT branch. When the PR targets
+          # that same branch, `git branch -f` fails because it is the active
+          # worktree — and origin/<base> is already fetched above.
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${base}" ]; then
+            git branch -f "${base}" "origin/${base}"
+          fi
+
+      - name: Skip when provider auth is not configured
+        if: env.HAS_AUTH != 'true'
+        run: |
+          if [ "${{ env.IS_SAME_REPO }}" != "true" ]; then
+            echo "::notice title=mergeCraft skipped::Fork PR — secrets are withheld, review skipped."
+          else
+            echo "::notice title=mergeCraft skipped::Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to enable reviews."
+          fi
+
+      # Composed in a step rather than inline in `with:` so the CI-context clause
+      # stays readable. Every interpolated value is repo-controlled (PR number,
+      # base ref, our own wait-job outputs) — no PR-authored free text reaches the
+      # prompt.
+      - name: Compose review prompt
+        id: prompt
+        if: env.HAS_AUTH == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PROMPT: ${{ inputs.prompt }}
+          CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
+          CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
+          CI_FAILED_NAMES: ${{ needs.wait-for-ci.outputs.failed_names }}
+          CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
+            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          else
+            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            # The action runs with `shell: disabled`, so the reviewer cannot run
+            # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
+            # check_suite id, because no MCP tool can discover one.
+            case "${CI_STATE}" in
+              complete)
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                else
+                  text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
+                fi
+                ;;
+              *)
+                text="${text} CI results are NOT available for this head commit (wait state: ${CI_STATE}), so no lint/typecheck/test signal informs this review. Do not assert that the change passes or fails those gates."
+                ;;
+            esac
+          fi
+          {
+            echo "text<<MERGECRAFT_PROMPT_EOF"
+            echo "${text}"
+            echo "MERGECRAFT_PROMPT_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review
+        if: env.HAS_AUTH == 'true'
+        id: mergecraft
+        continue-on-error: true
+        # Pin to a full-length commit SHA. Many orgs enforce Actions SHA pinning,
+        # which rejects a branch ref at action-resolution time — before the step
+        # runs. Keep this SHA equal to any other place you pin mergeCraft.
+        uses: alexhawat/mergeCraft@REPLACE_WITH_FULL_COMMIT_SHA
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
+          # first, the action never posts its `mergecraft` completion check and
+          # the only diagnostic is lost. 5 minutes of headroom lets it exit
+          # cleanly and report failure instead.
+          timeout: 25m
+          model: anthropic/claude-sonnet
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: mergeCraft review incomplete (non-fatal)
+        if: env.HAS_AUTH == 'true' && steps.mergecraft.outcome != 'success'
+        run: |
+          echo "::notice title=mergeCraft incomplete::Review step did not finish successfully (see its log). Approval enforcement skipped."
+
+      # Gate on the approval check-run rather than on the review step's exit code,
+      # so agent infrastructure failures do not read as "changes requested".
+      - name: Fail when mergeCraft would not approve
+        if: github.event_name == 'pull_request_target' && env.HAS_AUTH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          conclusion=""; queried=""
+          for attempt in $(seq 1 5); do
+            if conclusion="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+                      | sort_by(.completed_at // .started_at) | last | .conclusion // ""')"; then
+              queried="yes"; break
+            fi
+            echo "check-runs query failed (attempt ${attempt}/5); retrying in 5s…" >&2
+            sleep 5
+          done
+          if [ -z "${queried}" ]; then
+            echo "::warning title=mergeCraft approval unknown::Could not query check-runs for ${HEAD_SHA} after retries. Failing open."
+            exit 0
+          fi
+          case "${conclusion}" in
+            failure)
+              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — address the review feedback on this PR."
+              exit 1
+              ;;
+            success)
+              echo "mergeCraft approval: no outstanding review feedback."
+              ;;
+            *)
+              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking."
+              ;;
+          esac

--- a/scripts/example_workflows/defaults.yaml
+++ b/scripts/example_workflows/defaults.yaml
@@ -1,0 +1,11 @@
+# Shared placeholders for rendered example workflows.
+# Edit here (or override via env) then run: make examples
+action_repo: alexhawat/mergeCraft
+# Branch ref is fine for the minimal getting-started example.
+action_pin_minimal: pre-0.0.1
+# Hardened workflow must pin a full commit SHA for org SHA-pinning policies.
+action_pin_hardened: REPLACE_WITH_FULL_COMMIT_SHA
+# Prefix of YOUR CI job names (see .github/workflows/ci.yml in this repo).
+ci_job_prefix: "Verify ("
+# Base branches auto-reviewed under pull_request_target.
+base_branches: "[main]"

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -138,7 +138,7 @@ jobs:
             now="$(date +%s)"
             elapsed=$(( now - started ))
 
-            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+            if runs="$(gh api --paginate "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs: [.[].check_runs[]?]}')" ; then
               total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
               pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
 
@@ -258,8 +258,12 @@ jobs:
             # check_suite id, because no MCP tool can discover one.
             case "${CI_STATE}" in
               complete)
-                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
+                  if [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                  else
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
+                  fi
                 else
                   text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
                 fi

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -1,0 +1,341 @@
+# mergeCraft PR review — hardened reference workflow.
+#
+# Auto-reviews PRs on open / ready / new commits, posting inline comments plus a
+# summary, and (with `status_checks: enabled`) the `mergecraft` and
+# `mergecraft-approval` check-runs. The final step fails the job when
+# `mergecraft-approval` concluded "would not approve", so a branch ruleset can
+# require this job and block merges with outstanding review feedback.
+#
+# It ALWAYS fails open when the review cannot run — fork PR without secrets,
+# provider session limit, no approval posted. A required check that can go
+# permanently missing is a permanent merge block, which is worse than no gate.
+#
+# ---------------------------------------------------------------------------
+# Trigger choice: pull_request_target vs pull_request
+# ---------------------------------------------------------------------------
+# This template uses `pull_request_target`. GitHub SKIPS `pull_request` workflows
+# when `refs/pull/N/merge` cannot be built — i.e. whenever the PR has a merge
+# conflict — which leaves a required check permanently missing and the PR
+# unmergeable even after the conflict is fixed. `pull_request_target` still fires
+# on `synchronize` in that state.
+#
+# The cost is that `pull_request_target` runs with repository secrets in scope, so
+# it MUST NOT execute PR-authored code. This workflow does not: the same-repo
+# guard below withholds secrets from fork PRs, and mergeCraft runs with
+# `push: disabled` / `shell: disabled` and reaches PR content through its own
+# `checkout_pr` + API layer.
+#
+# If your review job is NOT a required check, plain `pull_request` is simpler and
+# safer — use it.
+#
+# ---------------------------------------------------------------------------
+# WHERE THIS FILE MUST LIVE
+# ---------------------------------------------------------------------------
+# Under GitHub's Nov 2025 policy (effective 2025-12-08), `pull_request_target`
+# definitions are resolved from the repository's DEFAULT BRANCH — not from the
+# PR's base branch. Consequences:
+#
+#   * The default-branch copy runs for every PR, whatever base it targets.
+#   * A PR that edits this file cannot review itself with its own changes; they
+#     take effect on the next PR after merge.
+#   * If your trunk is NOT the default branch (e.g. `main` is a stub and real
+#     work lands on a staging branch), keep this file ONLY on the default branch.
+#     A second copy on the trunk is inert, has to be hand-mirrored forever, and
+#     invites the two copies to drift.
+#
+# If you also pin the action SHA somewhere else — a Makefile variable for local
+# review runs, a devcontainer, docs — gate the two against each other in CI, and
+# read the workflow side from the DEFAULT BRANCH (`git show origin/main:<path>`),
+# not from the working tree. Comparing a working-tree copy that never executes
+# against your Makefile checks two values that do not matter while the pin that
+# actually runs goes unverified. Bump order is then: default branch first, local
+# pin second — the gate compares against the default branch, so the reverse order
+# fails.
+# ---------------------------------------------------------------------------
+
+name: mergeCraft
+
+on:
+  pull_request_target:
+    # Add every base branch that should be auto-reviewed. Globs work:
+    # branches: [main, develop, "release-*"]
+    branches: __BASE_BRANCHES__
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent (workflow_dispatch only)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  # Post the inline PR review + comments.
+  pull-requests: write
+  issues: write
+  # Post the mergecraft / mergecraft-approval check-runs.
+  checks: write
+  statuses: write
+  # Only needed if mergeCraft mints short-lived tokens via OIDC.
+  id-token: write
+
+concurrency:
+  # pull_request_target resolves github.ref to the default branch, so keying on
+  # github.ref would collapse every open PR into one group and they would cancel
+  # each other. Key on the PR number.
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Hold the review until your own CI has finished on the PR head SHA, so the
+  # reviewer reads real lint/type/test outcomes instead of speculating about them.
+  # `needs:` cannot reference another workflow file, so this polls the check-runs
+  # API for the jobs named by CI_JOB_PREFIX.
+  #
+  # Delete this job (and the `needs:` below) if you do not want reviews to wait.
+  #
+  # ALWAYS fails open (`exit 0` on every path): if the review job is required, a
+  # wait that could fail would turn a slow or absent CI run into a permanent merge
+  # block. Timing out just means the review proceeds without CI context.
+  wait-for-ci:
+    name: mergeCraft wait for CI
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      # complete | timeout | absent | skipped
+      state: ${{ steps.wait.outputs.state || 'skipped' }}
+      failed_count: ${{ steps.wait.outputs.failed_count || '0' }}
+      failed_names: ${{ steps.wait.outputs.failed_names || '' }}
+      check_suite_id: ${{ steps.wait.outputs.check_suite_id || '' }}
+    steps:
+      - name: Wait for CI checks on the PR head SHA
+        id: wait
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Name prefix of YOUR CI jobs. Set this to whatever your CI workflow
+          # calls its jobs, e.g. "build (" or "test (".
+          CI_JOB_PREFIX: __CI_JOB_PREFIX__
+          # Total budget. Set a little above your CI's usual wall time; keep it
+          # below this job's timeout-minutes.
+          WAIT_BUDGET_SECONDS: "1200"
+          # If no matching job has appeared by then, assume CI is not running for
+          # this PR and stop waiting.
+          APPEAR_BUDGET_SECONDS: "300"
+        run: |
+          set -uo pipefail
+          jq_verify="[.check_runs[]? | select(.name | startswith(\"${CI_JOB_PREFIX}\"))]"
+          started="$(date +%s)"
+          state="timeout"
+          failed_count=0
+          failed_names=""
+          check_suite_id=""
+
+          while :; do
+            now="$(date +%s)"
+            elapsed=$(( now - started ))
+
+            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+              total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
+              pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
+
+              if [ "${total}" -gt 0 ] && [ "${pending}" -eq 0 ]; then
+                state="complete"
+                failed_count="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\")) | length")"
+                failed_names="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .name) | join(\", \")")"
+                # Any failing job carries the check_suite id the reviewer needs
+                # for get_check_suite_logs().
+                check_suite_id="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .check_suite.id) | first // \"\"")"
+                break
+              fi
+
+              if [ "${total}" -eq 0 ] && [ "${elapsed}" -ge "${APPEAR_BUDGET_SECONDS}" ]; then
+                state="absent"
+                break
+              fi
+            else
+              echo "check-runs query failed (elapsed ${elapsed}s) — retrying" >&2
+            fi
+
+            if [ "${elapsed}" -ge "${WAIT_BUDGET_SECONDS}" ]; then
+              state="timeout"
+              break
+            fi
+            sleep 20
+          done
+
+          {
+            echo "state=${state}"
+            echo "failed_count=${failed_count}"
+            echo "failed_names=${failed_names}"
+            echo "check_suite_id=${check_suite_id}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "CI wait finished: state=${state} failed=${failed_count} suite=${check_suite_id:-none}"
+          case "${state}" in
+            timeout) echo "::notice title=mergeCraft CI wait::CI did not finish within ${WAIT_BUDGET_SECONDS}s — reviewing without CI context." ;;
+            absent)  echo "::notice title=mergeCraft CI wait::No matching CI checks appeared for ${HEAD_SHA} — reviewing without CI context." ;;
+          esac
+          exit 0
+
+  review:
+    name: mergeCraft review
+    needs: wait-for-ci
+    # `always()` keeps the required check reporting even if the (fail-open) wait
+    # job errors out on a runner fault; a skipped wait job still skips the review,
+    # because the draft/dispatch condition below is the same one it uses.
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Same-repo guard: fork PRs must never receive repository secrets under
+      # pull_request_target.
+      IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+      HAS_AUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Persist the checkout token so mergeCraft's own git layer
+          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
+          # fail and the action marks its `mergecraft` self-status red even though
+          # the review completes via the API. Read-only escalation only: the
+          # action runs with push/shell disabled, so a persisted token cannot be
+          # used to push.
+          persist-credentials: true
+
+      - name: Ensure PR base ref exists locally
+        if: github.event_name == 'pull_request_target'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags origin "${base}:refs/remotes/origin/${base}"
+          # pull_request_target checks out the DEFAULT branch. When the PR targets
+          # that same branch, `git branch -f` fails because it is the active
+          # worktree — and origin/<base> is already fetched above.
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${base}" ]; then
+            git branch -f "${base}" "origin/${base}"
+          fi
+
+      - name: Skip when provider auth is not configured
+        if: env.HAS_AUTH != 'true'
+        run: |
+          if [ "${{ env.IS_SAME_REPO }}" != "true" ]; then
+            echo "::notice title=mergeCraft skipped::Fork PR — secrets are withheld, review skipped."
+          else
+            echo "::notice title=mergeCraft skipped::Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to enable reviews."
+          fi
+
+      # Composed in a step rather than inline in `with:` so the CI-context clause
+      # stays readable. Every interpolated value is repo-controlled (PR number,
+      # base ref, our own wait-job outputs) — no PR-authored free text reaches the
+      # prompt.
+      - name: Compose review prompt
+        id: prompt
+        if: env.HAS_AUTH == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PROMPT: ${{ inputs.prompt }}
+          CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
+          CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
+          CI_FAILED_NAMES: ${{ needs.wait-for-ci.outputs.failed_names }}
+          CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
+            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          else
+            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            # The action runs with `shell: disabled`, so the reviewer cannot run
+            # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
+            # check_suite id, because no MCP tool can discover one.
+            case "${CI_STATE}" in
+              complete)
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                else
+                  text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
+                fi
+                ;;
+              *)
+                text="${text} CI results are NOT available for this head commit (wait state: ${CI_STATE}), so no lint/typecheck/test signal informs this review. Do not assert that the change passes or fails those gates."
+                ;;
+            esac
+          fi
+          {
+            echo "text<<MERGECRAFT_PROMPT_EOF"
+            echo "${text}"
+            echo "MERGECRAFT_PROMPT_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review
+        if: env.HAS_AUTH == 'true'
+        id: mergecraft
+        continue-on-error: true
+        # Pin to a full-length commit SHA. Many orgs enforce Actions SHA pinning,
+        # which rejects a branch ref at action-resolution time — before the step
+        # runs. Keep this SHA equal to any other place you pin mergeCraft.
+        uses: __ACTION_REPO__@__ACTION_PIN__
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
+          # first, the action never posts its `mergecraft` completion check and
+          # the only diagnostic is lost. 5 minutes of headroom lets it exit
+          # cleanly and report failure instead.
+          timeout: 25m
+          model: anthropic/claude-sonnet
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: mergeCraft review incomplete (non-fatal)
+        if: env.HAS_AUTH == 'true' && steps.mergecraft.outcome != 'success'
+        run: |
+          echo "::notice title=mergeCraft incomplete::Review step did not finish successfully (see its log). Approval enforcement skipped."
+
+      # Gate on the approval check-run rather than on the review step's exit code,
+      # so agent infrastructure failures do not read as "changes requested".
+      - name: Fail when mergeCraft would not approve
+        if: github.event_name == 'pull_request_target' && env.HAS_AUTH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          conclusion=""; queried=""
+          for attempt in $(seq 1 5); do
+            if conclusion="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+                      | sort_by(.completed_at // .started_at) | last | .conclusion // ""')"; then
+              queried="yes"; break
+            fi
+            echo "check-runs query failed (attempt ${attempt}/5); retrying in 5s…" >&2
+            sleep 5
+          done
+          if [ -z "${queried}" ]; then
+            echo "::warning title=mergeCraft approval unknown::Could not query check-runs for ${HEAD_SHA} after retries. Failing open."
+            exit 0
+          fi
+          case "${conclusion}" in
+            failure)
+              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — address the review feedback on this PR."
+              exit 1
+              ;;
+            success)
+              echo "mergeCraft approval: no outstanding review feedback."
+              ;;
+            *)
+              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking."
+              ;;
+          esac

--- a/scripts/example_workflows/minimal.yml.tpl
+++ b/scripts/example_workflows/minimal.yml.tpl
@@ -44,7 +44,7 @@ jobs:
       #     GITHUB_APP_PRIVATE_KEY: ${{ secrets.MERGECRAFT_APP_PRIVATE_KEY }}
 
       - name: Run mergeCraft
-        uses: alexhawat/mergeCraft@pre-0.0.1
+        uses: __ACTION_REPO__@__ACTION_PIN__
         with:
           prompt: >
             ${{ github.event_name == 'pull_request'

--- a/scripts/render_example_workflows.py
+++ b/scripts/render_example_workflows.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Render committed example workflow YAML from shared templates.
+
+Module: scripts.render_example_workflows
+Depends: argparse, pathlib, sys, yaml
+
+Exports:
+    main — render or --check example workflows under examples/workflows/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+TEMPLATE_DIR = Path(__file__).resolve().parent / "example_workflows"
+DEFAULTS_PATH = TEMPLATE_DIR / "defaults.yaml"
+OUTPUTS: Final[dict[str, Path]] = {
+    "minimal": REPO / "examples" / "workflows" / "mergecraft.yml",
+    "hardened": REPO / "examples" / "workflows" / "mergecraft-hardened.yml",
+}
+TEMPLATES: Final[dict[str, Path]] = {
+    "minimal": TEMPLATE_DIR / "minimal.yml.tpl",
+    "hardened": TEMPLATE_DIR / "hardened.yml.tpl",
+}
+
+
+def _load_defaults() -> dict[str, str]:
+    """Load shared placeholder values from defaults.yaml and env overrides."""
+    raw = yaml.safe_load(DEFAULTS_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"expected mapping in {DEFAULTS_PATH}"
+        raise TypeError(msg)
+    defaults: dict[str, str] = {str(key): str(value) for key, value in raw.items()}
+    env_map = {
+        "action_repo": "MERGECRAFT_EXAMPLE_ACTION_REPO",
+        "action_pin_minimal": "MERGECRAFT_EXAMPLE_ACTION_PIN_MINIMAL",
+        "action_pin_hardened": "MERGECRAFT_EXAMPLE_ACTION_PIN_HARDENED",
+        "ci_job_prefix": "MERGECRAFT_EXAMPLE_CI_JOB_PREFIX",
+        "base_branches": "MERGECRAFT_EXAMPLE_BASE_BRANCHES",
+    }
+    for key, env_name in env_map.items():
+        if env_name in os.environ:
+            defaults[key] = os.environ[env_name]
+    return defaults
+
+
+def _substitute(template_text: str, *, variant: str, defaults: dict[str, str]) -> str:
+    """Apply shared placeholders to a template body."""
+    pin_key = "action_pin_hardened" if variant == "hardened" else "action_pin_minimal"
+    replacements = {
+        "__ACTION_REPO__": defaults["action_repo"],
+        "__ACTION_PIN__": defaults[pin_key],
+        "__CI_JOB_PREFIX__": json.dumps(defaults["ci_job_prefix"]),
+        "__BASE_BRANCHES__": defaults["base_branches"],
+    }
+    rendered = template_text
+    for token, value in replacements.items():
+        rendered = rendered.replace(token, value)
+    missing = [token for token in replacements if token in rendered]
+    if missing:
+        msg = f"{TEMPLATES[variant]}: unresolved placeholders: {', '.join(missing)}"
+        raise ValueError(msg)
+    if not rendered.endswith("\n"):
+        rendered += "\n"
+    return rendered
+
+
+def render_all(defaults: dict[str, str] | None = None) -> dict[str, str]:
+    """Render every example workflow variant."""
+    values = defaults if defaults is not None else _load_defaults()
+    rendered: dict[str, str] = {}
+    for variant, template_path in TEMPLATES.items():
+        body = _substitute(
+            template_path.read_text(encoding="utf-8"), variant=variant, defaults=values
+        )
+        rendered[variant] = body
+    return rendered
+
+
+def _write(rendered: dict[str, str]) -> None:
+    """Write rendered workflows to examples/workflows/."""
+    for variant, out_path in OUTPUTS.items():
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered[variant], encoding="utf-8")
+        rel = out_path.relative_to(REPO)
+        print(f"wrote {rel}")
+
+
+def main() -> int:
+    """CLI: render example workflows or verify committed copies."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero when committed files differ from rendered output.",
+    )
+    parser.add_argument(
+        "--variant",
+        choices=sorted(TEMPLATES),
+        help="Render only one variant (default: all).",
+    )
+    args = parser.parse_args()
+    rendered = render_all()
+    check_variants = [args.variant] if args.variant else list(OUTPUTS)
+
+    if args.check:
+        drift: list[str] = []
+        for variant in check_variants:
+            out_path = OUTPUTS[variant]
+            expected = rendered[variant]
+            if not out_path.is_file():
+                drift.append(f"missing {out_path.relative_to(REPO)}")
+                continue
+            actual = out_path.read_text(encoding="utf-8")
+            if actual != expected:
+                drift.append(f"drift {out_path.relative_to(REPO)} (run: make examples)")
+        if drift:
+            print("example workflow template drift:", file=sys.stderr)
+            for line in drift:
+                print(f"  {line}", file=sys.stderr)
+            return 1
+        print("example workflows OK")
+        return 0
+
+    if args.variant is not None:
+        out_path = OUTPUTS[args.variant]
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered[args.variant], encoding="utf-8")
+        print(f"wrote {out_path.relative_to(REPO)}")
+        return 0
+
+    _write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Hardened reference workflow (`examples/workflows/mergecraft-hardened.yml`) with drift-checked template rendering via `scripts/render_example_workflows.py` and Makefile integration.
- README guidance for `pull_request_target` default-branch resolution and pin parity with shipped examples.
- **#9 (partial):** Dogfood workflow artifact at `docs/artifacts/dogfood-mergecraft.yml` plus operator checklist `docs/artifacts/dogfood-main-landing.md` for landing mergeCraft on the repo default branch. Main-branch dogfood (wave D6) is still pending—this PR does not complete full #9 closure.

## Test plan

- [x] `make ci`
- [x] Workflow template render / drift checks via Makefile targets
- [x] Bugbot / review gate on branch

## Related issues

Partially addresses #9 — follow-up: merge dogfood workflow to `main` per `docs/artifacts/dogfood-main-landing.md` (Batch E / D6).

Made with [Cursor](https://cursor.com)