### PR TITLE
feat(agents): add Codex, Gemini, and Cursor Cloud provider harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cursor Cloud Agent harness (`agents/cursor.py`, Phase A / D9): launches a
   remote cloud agent via the Cursor API (`CURSOR_API_KEY`); polls to terminal
   status and surfaces the dashboard URL in agent metadata; local Cursor CLI
-  detection remains deferred; `mergecraft auth cursor` saves the API key via
+  detection remains deferred (Phase B); `mergecraft auth cursor` saves the API key via
   `gh secret set`.
+- Batch D Final gate hardening: httpx-based `auth gemini`/`auth cursor` key
+  validation (Bandit-clean), usable-only `CODEX_AUTH_JSON` resolution, Gemini
+  system-prompt delivery, Cursor loopback MCP omission for cloud runs, and
+  dict-payload shell/branch reads for Action runs.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GOOGLE_GENERATIVE_AI_API_KEY` is set for `google/*` models; Docker image
   installs `@google/gemini-cli`; `mergecraft auth gemini` saves the API key via
   `gh secret set`.
+- Cursor Cloud Agent harness (`agents/cursor.py`, Phase A / D9): launches a
+  remote cloud agent via the Cursor API (`CURSOR_API_KEY`); polls to terminal
+  status and surfaces the dashboard URL in agent metadata; local Cursor CLI
+  detection remains deferred; `mergecraft auth cursor` saves the API key via
+  `gh secret set`.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI API key path on the Codex harness: `OPENAI_API_KEY`-only runs resolve
   to the same `codex` agent for any `openai/*` model; fail-loud when neither
   `OPENAI_API_KEY` nor `CODEX_AUTH_JSON` is configured.
+- Gemini agent harness (`agents/gemini.py`): invokes the official `gemini` CLI
+  with mergeCraft MCP settings; resolves when `GEMINI_API_KEY` or
+  `GOOGLE_GENERATIVE_AI_API_KEY` is set for `google/*` models; Docker image
+  installs `@google/gemini-cli`; `mergecraft auth gemini` saves the API key via
+  `gh secret set`.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (same-repo secret guard, PR-number concurrency, wait-for-CI, base-ref fetch,
   full-SHA pin, approval-check enforcement) plus a template renderer with
   `make example-workflows-check` wired into `make ci-static`.
+- Codex subscription agent harness (`agents/codex.py`): invokes the official
+  `codex exec` CLI with mergeCraft MCP config, reviewer/verifier instructions,
+  and the same push/shell permission gates as Claude Code; resolves when
+  `CODEX_AUTH_JSON` is set; Docker image installs `@openai/codex`.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `codex exec` CLI with mergeCraft MCP config, reviewer/verifier instructions,
   and the same push/shell permission gates as Claude Code; resolves when
   `CODEX_AUTH_JSON` is set; Docker image installs `@openai/codex`.
+- OpenAI API key path on the Codex harness: `OPENAI_API_KEY`-only runs resolve
+  to the same `codex` agent for any `openai/*` model; fail-loud when neither
+  `OPENAI_API_KEY` nor `CODEX_AUTH_JSON` is configured.
 - CI pipeline intelligence (K1): ``PipelineProvider`` protocol with ``GitHubActionsProvider``
   (delegates ``get_check_suite_logs`` behind the provider), honest CircleCI/GitLab/Azure stubs,
   normalized failure shape with stable fingerprints, and ingest-time log redaction via

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,11 @@ RUN apt-get update -qq \
 # Claude Code CLI — required by the `claude` agent (BYOK auth via
 # CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY). Installed globally so it is on
 # PATH for the unprivileged `mergecraft` runtime user.
-RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli \
     && npm cache clean --force \
     && claude --version \
-    && codex --version
+    && codex --version \
+    && gemini --version
 
 WORKDIR /opt/mergecraft
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,10 @@ RUN apt-get update -qq \
 # Claude Code CLI — required by the `claude` agent (BYOK auth via
 # CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY). Installed globally so it is on
 # PATH for the unprivileged `mergecraft` runtime user.
-RUN npm install -g @anthropic-ai/claude-code \
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
     && npm cache clean --force \
-    && claude --version
+    && claude --version \
+    && codex --version
 
 WORKDIR /opt/mergecraft
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ env:
   CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
 ```
 
+**OpenAI API key example** — set `OPENAI_API_KEY` and point the repo at any
+`openai/*` model (same Codex CLI harness as the subscription path):
+
+```yaml
+# .mergecraft/config.yaml
+model: openai/gpt
+```
+
+```yaml
+# workflow env (API key path)
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
 ### Consumer workflow
 
 ```yaml
@@ -107,9 +121,9 @@ jobs:
           # Claude — pick one:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # subscription (mergecraft auth claude)
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}           # or API key
-          # Codex / OpenAI — pick one:
+          # Codex / OpenAI — pick one (see Authentication above):
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}               # subscription (mergecraft auth codex)
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # or API key
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # API key + model: openai/gpt
 ```
 
 Ready-made workflow files live under [`examples/workflows/`](examples/workflows/):

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ the provider you configure. You can authenticate either with a **subscription**
 |----------|-----------------------------|---------|
 | Anthropic Claude | `mergecraft auth claude` → saves `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` (Claude Pro/Max) | `ANTHROPIC_API_KEY` secret |
 | OpenAI Codex | `mergecraft auth codex` → saves `CODEX_AUTH_JSON` from `codex login --device-auth` (ChatGPT Plus/Pro/Team/Enterprise) | `OPENAI_API_KEY` secret |
+| Google Gemini | `mergecraft auth gemini` → saves `GEMINI_API_KEY` from a pasted AI Studio key | `GEMINI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` secret |
 
 Using a subscription means the GitHub Action authenticates as *you* through the
 official `claude` / `codex` CLIs — the same credential your local coding agent
-already uses — instead of paying per-token via a separate API key. Run the
+already uses — instead of paying per-token via a separate API key. Gemini uses
+the official `gemini` CLI with an API key from Google AI Studio. Run the
 relevant `mergecraft auth ...` command from the repo you want reviewed; it
 detects the `origin` remote and stores the secret with `gh secret set`
 automatically (or prints the manual `Settings → Secrets` steps if `gh` isn't
@@ -91,6 +93,21 @@ env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+**Gemini API key example** — set `GEMINI_API_KEY` and point the repo at a
+curated `google/*` slug (`gemini-pro` → `google/gemini-3.1-pro-preview`,
+`gemini-flash` → `google/gemini-3.5-flash`):
+
+```yaml
+# .mergecraft/config.yaml
+model: google/gemini-3.1-pro-preview
+```
+
+```yaml
+# workflow env (API key path)
+env:
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+```
+
 ### Consumer workflow
 
 ```yaml
@@ -124,6 +141,8 @@ jobs:
           # Codex / OpenAI — pick one (see Authentication above):
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}               # subscription (mergecraft auth codex)
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # API key + model: openai/gpt
+          # Gemini — API key (mergecraft auth gemini):
+          # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}                 # + model: google/gemini-3.1-pro-preview
 ```
 
 Ready-made workflow files live under [`examples/workflows/`](examples/workflows/):
@@ -240,6 +259,7 @@ Learnings live in `.mergecraft/learnings.md` and are seeded/persisted across run
 | `mergecraft init` | Scaffold `.mergecraft/config.yaml` + example workflow |
 | `mergecraft auth claude` | Save a Claude Pro/Max subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) via `gh secret set` |
 | `mergecraft auth codex` | Save a ChatGPT subscription credential (`CODEX_AUTH_JSON`) via `gh secret set` |
+| `mergecraft auth gemini` | Save a Gemini API key (`GEMINI_API_KEY`) via `gh secret set` |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
 | `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting) |
 | `mergecraft gha` | Action runtime entry (used by Docker Action) |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ authenticated).
 Only set the env var(s) for the provider(s) you actually use — see the
 workflow example below, where the unused lines are commented out.
 
+**Codex subscription example** — set `CODEX_AUTH_JSON` and point the repo at a
+Codex-family model:
+
+```yaml
+# .mergecraft/config.yaml
+model: openai/gpt-codex
+```
+
+```yaml
+# workflow env (subscription path)
+env:
+  CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+```
+
 ### Consumer workflow
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -52,11 +52,14 @@ the provider you configure. You can authenticate either with a **subscription**
 | Anthropic Claude | `mergecraft auth claude` → saves `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` (Claude Pro/Max) | `ANTHROPIC_API_KEY` secret |
 | OpenAI Codex | `mergecraft auth codex` → saves `CODEX_AUTH_JSON` from `codex login --device-auth` (ChatGPT Plus/Pro/Team/Enterprise) | `OPENAI_API_KEY` secret |
 | Google Gemini | `mergecraft auth gemini` → saves `GEMINI_API_KEY` from a pasted AI Studio key | `GEMINI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` secret |
+| Cursor Cloud | `mergecraft auth cursor` → saves `CURSOR_API_KEY` from a pasted Cursor API key | `CURSOR_API_KEY` secret |
 
 Using a subscription means the GitHub Action authenticates as *you* through the
 official `claude` / `codex` CLIs — the same credential your local coding agent
 already uses — instead of paying per-token via a separate API key. Gemini uses
-the official `gemini` CLI with an API key from Google AI Studio. Run the
+the official `gemini` CLI with an API key from Google AI Studio. **Cursor Cloud**
+(issue #13 Phase A) runs a remote cloud agent via the Cursor API — there is no
+local `cursor` CLI harness in mergeCraft yet (Phase B deferred). Run the
 relevant `mergecraft auth ...` command from the repo you want reviewed; it
 detects the `origin` remote and stores the secret with `gh secret set`
 automatically (or prints the manual `Settings → Secrets` steps if `gh` isn't
@@ -108,6 +111,20 @@ env:
   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 ```
 
+**Cursor Cloud example** — set `CURSOR_API_KEY` and point the repo at
+`cursor/cloud-agent` (remote cloud agent; local Cursor CLI deferred):
+
+```yaml
+# .mergecraft/config.yaml
+model: cursor/cloud-agent
+```
+
+```yaml
+# workflow env (Cloud Agent API path)
+env:
+  CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+```
+
 ### Consumer workflow
 
 ```yaml
@@ -143,6 +160,8 @@ jobs:
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}                 # API key + model: openai/gpt
           # Gemini — API key (mergecraft auth gemini):
           # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}                 # + model: google/gemini-3.1-pro-preview
+          # Cursor Cloud — API key (mergecraft auth cursor; local CLI deferred):
+          # CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}                 # + model: cursor/cloud-agent
 ```
 
 Ready-made workflow files live under [`examples/workflows/`](examples/workflows/):
@@ -260,6 +279,7 @@ Learnings live in `.mergecraft/learnings.md` and are seeded/persisted across run
 | `mergecraft auth claude` | Save a Claude Pro/Max subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) via `gh secret set` |
 | `mergecraft auth codex` | Save a ChatGPT subscription credential (`CODEX_AUTH_JSON`) via `gh secret set` |
 | `mergecraft auth gemini` | Save a Gemini API key (`GEMINI_API_KEY`) via `gh secret set` |
+| `mergecraft auth cursor` | Save a Cursor Cloud API key (`CURSOR_API_KEY`) via `gh secret set` |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
 | `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting) |
 | `mergecraft gha` | Action runtime entry (used by Docker Action) |

--- a/docs/test-plans/open-issues-sweep-batch-d.md
+++ b/docs/test-plans/open-issues-sweep-batch-d.md
@@ -1,0 +1,50 @@
+# Open issues sweep — Batch D test plan (W11 RED)
+
+Wave plan: `.ignorelocal/waves/open-issues-sweep-wave-plan.md`
+Worktree: `mergecraft-issues-d-providers` @ `wave/issues-d-providers`
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W12–W15** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_fail_loud_without_credentials[...]` (×4) | `green after W12-W15: D12 fail-loud resolve_runtime_agent` |
+| **W12–W15** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_never_returns_opencode_for_provider_models[...]` (×4) | same |
+| **W12** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_codex_with_codex_auth_json` | `green after W12: codex subscription resolve (#10)` |
+| **W13** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_codex_with_openai_api_key_only` | `green after W13: OPENAI_API_KEY resolve (#11)` |
+| **W14** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_gemini_with_gemini_api_key` | `green after W14: Gemini resolve (#12)` |
+| **W15** | `tests/agents/test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_cursor_with_cursor_api_key` | `green after W15: Cursor Cloud resolve (#13)` |
+| **W12** | `tests/agents/test_codex.py::test_codex_harness_invokes_cli_and_parses_agent_result` | `green after W12: codex harness contract (#10)` |
+| **W14** | `tests/agents/test_gemini.py::test_gemini_harness_invokes_cli_and_parses_agent_result` | `green after W14: Gemini harness contract (#12)` |
+| **W15** | `tests/agents/test_cursor.py::test_cursor_harness_launches_cloud_agent_and_parses_agent_result` | `green after W15: Cursor Cloud harness contract (#13)` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#10–#13** | D12 — fail loud, never fall through to `opencode` | Unit | Error — `codex/*`/`openai/*`/`google/*`/`cursor/*` slug without required credential | `test_agent_resolve_providers.py::test_resolve_runtime_agent_fail_loud_without_credentials` |
+| **#10–#13** | D12 | Unit | Error — must not return `opencode` agent silently | `test_agent_resolve_providers.py::test_resolve_runtime_agent_never_returns_opencode_for_provider_models` |
+| **#10** | D10 — Codex subscription harness | Unit | Happy path — `CODEX_AUTH_JSON` resolves to `codex` agent | `test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_codex_with_codex_auth_json` |
+| **#10** | D10 | Integration | Happy path — fake `codex` CLI + env → argv + `AgentResult` | `test_codex.py::test_codex_harness_invokes_cli_and_parses_agent_result` |
+| **#11** | D10 — reuse Codex harness for API key | Unit | Happy path — `OPENAI_API_KEY` only resolves to `codex` | `test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_codex_with_openai_api_key_only` |
+| **#12** | D11 — dedicated Gemini harness | Unit | Happy path — `GEMINI_API_KEY` resolves to `gemini` | `test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_gemini_with_gemini_api_key` |
+| **#12** | D11 | Integration | Happy path — fake Gemini CLI + env → argv + `AgentResult` | `test_gemini.py::test_gemini_harness_invokes_cli_and_parses_agent_result` |
+| **#13** | D9 — Cursor Cloud Phase A only | Unit | Happy path — `CURSOR_API_KEY` resolves to `cursor` | `test_agent_resolve_providers.py::test_resolve_runtime_agent_selects_cursor_with_cursor_api_key` |
+| **#13** | D9 | Integration | Happy path — mocked Cloud API → terminal run + dashboard metadata | `test_cursor.py::test_cursor_harness_launches_cloud_agent_and_parses_agent_result` |
+
+## Pinned module surface (for impl waves)
+
+| Module | Expected symbols |
+|--------|------------------|
+| `mergecraft.agents.codex` | `_run_codex_once`, `agent(name="codex", …)` |
+| `mergecraft.agents.gemini` | `_run_gemini_once`, `agent(name="gemini", …)` |
+| `mergecraft.agents.cursor` | `_run_cursor_once`, `CursorCloudClient`, `agent(name="cursor", …)` |
+| `mergecraft.utils.agent_resolve` | D12 errors naming missing env vars; registry entries for `codex`, `gemini`, `cursor` |
+
+## Implementation notes for impl waves
+
+- **W12:** Add `agents/codex.py`, register in `agents/__init__.py`, wire `resolve_runtime_agent` for `CODEX_AUTH_JSON`; un-xfail codex resolve + codex harness tests; keep shared D12 xfails until W13–W15 land their provider portions.
+- **W13:** Extend codex harness for `OPENAI_API_KEY`-only; un-xfail OpenAI API resolve test.
+- **W14:** Add `agents/gemini.py`; un-xfail Gemini resolve + harness tests.
+- **W15:** Add `agents/cursor.py` with Cloud client (`create_cloud_agent`, `get_run`, `list_artifacts`); un-xfail Cursor resolve + harness tests; remove remaining D12 xfails when all four providers are wired.

--- a/examples/workflows/mergecraft.yml
+++ b/examples/workflows/mergecraft.yml
@@ -57,5 +57,5 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}   # subscription + model: openai/gpt-codex
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}     # API key + model: openai/gpt

--- a/examples/workflows/mergecraft.yml
+++ b/examples/workflows/mergecraft.yml
@@ -57,5 +57,5 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}   # subscription + model: openai/gpt-codex
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}     # API key + model: openai/gpt
+          # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/src/mergecraft/agents/__init__.py
+++ b/src/mergecraft/agents/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from mergecraft.agents.claude import claude
 from mergecraft.agents.codex import codex
+from mergecraft.agents.gemini import gemini
 from mergecraft.agents.opencode import opencode
 from mergecraft.agents.shared import Agent, AgentImpl, AgentResult, AgentRunContext, AgentUsage
 
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 agents: dict[str, AgentImpl] = {
     "claude": claude,
     "codex": codex,
+    "gemini": gemini,
     "opencode": opencode,
 }
 
@@ -37,6 +39,7 @@ __all__ = [
     "agents",
     "claude",
     "codex",
+    "gemini",
     "opencode",
     "resolve_agent",
 ]

--- a/src/mergecraft/agents/__init__.py
+++ b/src/mergecraft/agents/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from mergecraft.agents.claude import claude
 from mergecraft.agents.codex import codex
+from mergecraft.agents.cursor import cursor
 from mergecraft.agents.gemini import gemini
 from mergecraft.agents.opencode import opencode
 from mergecraft.agents.shared import Agent, AgentImpl, AgentResult, AgentRunContext, AgentUsage
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 agents: dict[str, AgentImpl] = {
     "claude": claude,
     "codex": codex,
+    "cursor": cursor,
     "gemini": gemini,
     "opencode": opencode,
 }
@@ -39,6 +41,7 @@ __all__ = [
     "agents",
     "claude",
     "codex",
+    "cursor",
     "gemini",
     "opencode",
     "resolve_agent",

--- a/src/mergecraft/agents/__init__.py
+++ b/src/mergecraft/agents/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mergecraft.agents.claude import claude
+from mergecraft.agents.codex import codex
 from mergecraft.agents.opencode import opencode
 from mergecraft.agents.shared import Agent, AgentImpl, AgentResult, AgentRunContext, AgentUsage
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 
 agents: dict[str, AgentImpl] = {
     "claude": claude,
+    "codex": codex,
     "opencode": opencode,
 }
 
@@ -34,6 +36,7 @@ __all__ = [
     "AgentUsage",
     "agents",
     "claude",
+    "codex",
     "opencode",
     "resolve_agent",
 ]

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -24,6 +24,7 @@ from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROM
 from mergecraft.types import MERGECRAFT_MCP_NAME
 
 CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 
 
 def _strip_provider_prefix(specifier: str) -> str:
@@ -78,14 +79,20 @@ def _save_codex_writeback_state(*, auth_path: Path, auth_json: str) -> None:
     os.environ["STATE_codex_writeback"] = payload  # noqa: SIM112 — matches action/post.py _get_state("codex_writeback")
 
 
+def _has_openai_api_key() -> bool:
+    return bool(os.environ.get(OPENAI_API_KEY_ENV, "").strip())
+
+
 def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
     raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
-    if not raw:
+    if raw:
+        codex_home.mkdir(parents=True, exist_ok=True)
+        auth_path = codex_home / "auth.json"
+        auth_path.write_text(raw, encoding="utf-8")
+        _save_codex_writeback_state(auth_path=auth_path, auth_json=raw)
         return
-    codex_home.mkdir(parents=True, exist_ok=True)
-    auth_path = codex_home / "auth.json"
-    auth_path.write_text(raw, encoding="utf-8")
-    _save_codex_writeback_state(auth_path=auth_path, auth_json=raw)
+    if _has_openai_api_key():
+        logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
 
 
 def _build_subagent_instructions() -> str:

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -19,6 +19,7 @@ from mergecraft.agents.shared import (
     AgentUsage,
     agent,
     log_token_table,
+    payload_shell_mode,
 )
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
 from mergecraft.types import MERGECRAFT_MCP_NAME
@@ -83,14 +84,42 @@ def _has_openai_api_key() -> bool:
     return bool(os.environ.get(OPENAI_API_KEY_ENV, "").strip())
 
 
+def _codex_subscription_auth_usable(raw: str) -> bool:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    if _extract_refresh_token(raw):
+        return True
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict):
+        for key in ("access_token", "access", "refresh_token", "refresh"):
+            val = tokens.get(key)
+            if isinstance(val, str) and val.strip():
+                return True
+    for key in ("access_token", "access"):
+        val = data.get(key)
+        if isinstance(val, str) and val.strip():
+            return True
+    return False
+
+
 def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
     raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
-    if raw:
+    if raw and _codex_subscription_auth_usable(raw):
         codex_home.mkdir(parents=True, exist_ok=True)
         auth_path = codex_home / "auth.json"
         auth_path.write_text(raw, encoding="utf-8")
         _save_codex_writeback_state(auth_path=auth_path, auth_json=raw)
         return
+    if raw:
+        logger.warning(
+            "{} is set but not usable subscription JSON — falling back to {} when present",
+            CODEX_AUTH_ENV,
+            OPENAI_API_KEY_ENV,
+        )
     if _has_openai_api_key():
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
 
@@ -108,7 +137,7 @@ def _build_subagent_instructions() -> str:
 
 
 def _sandbox_mode(ctx: AgentRunContext) -> str:
-    shell = str(getattr(ctx.payload, "shell", None) or "restricted")
+    shell = payload_shell_mode(ctx)
     if shell == "enabled":
         return "workspace-write"
     return "read-only"
@@ -264,8 +293,6 @@ def _run_codex_once(
     if model:
         cmd.extend(["--model", model])
     cmd.extend(["--sandbox", _sandbox_mode(ctx)])
-    if os.environ.get("CI") == "true":
-        cmd.append("--dangerously-bypass-approvals-and-sandbox")
     if continue_session:
         cmd.extend(["resume", "--last"])
     cmd.append(prompt or ctx.instructions.user)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -1,0 +1,327 @@
+"""Codex CLI agent harness — invokes ``codex exec`` with MCP config."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
+from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.shared import (
+    AgentResult,
+    AgentRunContext,
+    AgentUsage,
+    agent,
+    log_token_table,
+)
+from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.types import MERGECRAFT_MCP_NAME
+
+CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
+
+
+def _strip_provider_prefix(specifier: str) -> str:
+    slash = specifier.find("/")
+    return specifier[slash + 1 :] if slash > 0 else specifier
+
+
+def _codex_home(ctx: AgentRunContext) -> Path:
+    return Path(ctx.tmpdir) / ".codex"
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _toml_string_list(values: list[str]) -> str:
+    inner = ", ".join(_toml_string(item) for item in values)
+    return f"[{inner}]"
+
+
+def _extract_refresh_token(auth_json: str) -> str | None:
+    try:
+        data = json.loads(auth_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else data
+    if isinstance(tokens, dict):
+        refresh = tokens.get("refresh_token") or tokens.get("refresh")
+        if isinstance(refresh, str) and refresh:
+            return refresh
+    refresh = data.get("refresh_token") or data.get("refresh")
+    return refresh if isinstance(refresh, str) and refresh else None
+
+
+def _save_codex_writeback_state(*, auth_path: Path, auth_json: str) -> None:
+    refresh = _extract_refresh_token(auth_json)
+    if not refresh:
+        return
+    payload = json.dumps(
+        {
+            "authPath": str(auth_path),
+            "originalRefresh": refresh,
+        }
+    )
+    state_file = os.environ.get("GITHUB_STATE")
+    if state_file:
+        with open(state_file, "a", encoding="utf-8") as fh:
+            fh.write(f"codex_writeback={payload}\n")
+    os.environ["STATE_codex_writeback"] = payload  # noqa: SIM112 — matches action/post.py _get_state("codex_writeback")
+
+
+def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
+    raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
+    if not raw:
+        return
+    codex_home.mkdir(parents=True, exist_ok=True)
+    auth_path = codex_home / "auth.json"
+    auth_path.write_text(raw, encoding="utf-8")
+    _save_codex_writeback_state(auth_path=auth_path, auth_json=raw)
+
+
+def _build_subagent_instructions() -> str:
+    return "\n\n".join(
+        [
+            "Registered read-only subagents (spawn via Codex subagent tooling when needed):",
+            f"## {REVIEWER_AGENT_NAME}",
+            REVIEWER_SYSTEM_PROMPT,
+            f"## {VERIFIER_AGENT_NAME}",
+            VERIFIER_SYSTEM_PROMPT,
+        ]
+    )
+
+
+def _sandbox_mode(ctx: AgentRunContext) -> str:
+    shell = str(getattr(ctx.payload, "shell", None) or "restricted")
+    if shell == "enabled":
+        return "workspace-write"
+    return "read-only"
+
+
+def write_mcp_config(ctx: AgentRunContext) -> str:
+    """Write Codex ``config.toml`` under ``$CODEX_HOME`` and return its path."""
+    codex_home = _codex_home(ctx)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    instructions_parts: list[str] = []
+    if ctx.instructions.system:
+        instructions_parts.append(ctx.instructions.system)
+    instructions_parts.append(_build_subagent_instructions())
+    instructions_path = codex_home / "mergecraft-instructions.md"
+    instructions_path.write_text("\n\n".join(instructions_parts), encoding="utf-8")
+
+    disabled_tools = [str(name) for name in ctx.subagent_denied_tools]
+    sandbox_mode = _sandbox_mode(ctx)
+    lines = [
+        f"approval_policy = {_toml_string('never' if os.environ.get('CI') == 'true' else 'on-request')}",
+        f"sandbox_mode = {_toml_string(sandbox_mode)}",
+        f"experimental_instructions_file = {_toml_string(str(instructions_path))}",
+        f"model_reasoning_effort = {_toml_string('high')}",
+        "",
+        f"[mcp_servers.{MERGECRAFT_MCP_NAME}]",
+        f"url = {_toml_string(ctx.mcp_server_url)}",
+    ]
+    if disabled_tools:
+        lines.append(f"disabled_tools = {_toml_string_list(disabled_tools)}")
+    if sandbox_mode == "workspace-write":
+        lines.extend(
+            [
+                "",
+                "[sandbox_workspace_write]",
+                "network_access = true",
+            ]
+        )
+
+    config_path = codex_home / "config.toml"
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(config_path)
+
+
+async def _install(_token: str | None = None) -> str:
+    path = shutil.which("codex")
+    if path:
+        return path
+    local = Path(ctx_tmpdir_fallback()) / "node_modules" / ".bin" / "codex"
+    if local.exists():
+        return str(local)
+    msg = "codex CLI not found on PATH. Install @openai/codex or ensure `codex` is available."
+    raise FileNotFoundError(msg)
+
+
+def ctx_tmpdir_fallback() -> str:
+    return os.environ.get("MERGECRAFT_TEMP_DIR") or "/tmp"
+
+
+def _build_env(ctx: AgentRunContext) -> dict[str, str]:
+    env = dict(os.environ)
+    codex_home = _codex_home(ctx)
+    env["CODEX_HOME"] = str(codex_home)
+    _setup_codex_auth(ctx, codex_home=codex_home)
+    return env
+
+
+def _parse_codex_payload(data: dict[str, Any]) -> tuple[str, AgentUsage | None]:
+    output = str(data.get("result") or data.get("output") or data.get("message") or "")
+    usage_raw = data.get("usage") or {}
+    usage: AgentUsage | None = None
+    if usage_raw or data.get("total_cost_usd") is not None:
+        input_tokens = int(usage_raw.get("input_tokens") or usage_raw.get("inputTokens") or 0)
+        output_tokens = int(usage_raw.get("output_tokens") or usage_raw.get("outputTokens") or 0)
+        cache_read = int(
+            usage_raw.get("cache_read_input_tokens") or usage_raw.get("cacheReadTokens") or 0
+        )
+        cache_write = int(
+            usage_raw.get("cache_creation_input_tokens") or usage_raw.get("cacheWriteTokens") or 0
+        )
+        cost = data.get("total_cost_usd")
+        usage = AgentUsage(
+            agent="codex",
+            input_tokens=input_tokens + cache_read + cache_write,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read or None,
+            cache_write_tokens=cache_write or None,
+            cost_usd=float(cost) if cost is not None else None,
+        )
+        log_token_table(
+            input_tokens=input_tokens,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            output=output_tokens,
+            cost_usd=usage.cost_usd,
+        )
+    return output, usage
+
+
+def _parse_codex_stdout(stdout: str) -> tuple[str, AgentUsage | None]:
+    text = stdout.strip()
+    if not text:
+        return "", None
+
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return _parse_codex_payload(data)
+    except json.JSONDecodeError:
+        pass
+
+    usage: AgentUsage | None = None
+    output = text
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "message" and isinstance(event.get("content"), str):
+            output = str(event["content"])
+        parsed_output, parsed_usage = _parse_codex_payload(event)
+        if parsed_output:
+            output = parsed_output
+        if parsed_usage is not None:
+            usage = parsed_usage
+        if event.get("type") in {"turn.completed", "agent-turn-complete", "result"}:
+            break
+    return output, usage
+
+
+def _run_codex_once(
+    *,
+    cli: str,
+    prompt: str,
+    ctx: AgentRunContext,
+    mcp_config: str,
+    continue_session: bool = False,
+) -> AgentResult:
+    del mcp_config  # config lives in $CODEX_HOME/config.toml written by write_mcp_config()
+    model = None
+    if ctx.resolved_model:
+        model = _strip_provider_prefix(ctx.resolved_model)
+
+    cmd = [
+        cli,
+        "exec",
+        "--json",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.extend(["--sandbox", _sandbox_mode(ctx)])
+    if os.environ.get("CI") == "true":
+        cmd.append("--dangerously-bypass-approvals-and-sandbox")
+    if continue_session:
+        cmd.extend(["resume", "--last"])
+    cmd.append(prompt or ctx.instructions.user)
+
+    logger.info("invoking codex CLI (model={})", model or "default")
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=os.getcwd(),
+            env=_build_env(ctx),
+            capture_output=True,
+            text=True,
+            timeout=int(os.environ.get("MERGECRAFT_AGENT_TIMEOUT", "3600")),
+            check=False,
+        )
+    except FileNotFoundError as err:
+        return AgentResult(success=False, error=str(err))
+    except subprocess.TimeoutExpired:
+        return AgentResult(success=False, error="codex CLI timed out")
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    if stderr.strip():
+        for line in stderr.strip().splitlines()[-20:]:
+            logger.debug("[codex] {}", line)
+
+    output, usage = _parse_codex_stdout(stdout)
+
+    if completed.returncode != 0:
+        return AgentResult(
+            success=False,
+            output=output or None,
+            error=stderr.strip() or f"codex exited {completed.returncode}",
+            usage=usage,
+        )
+    return AgentResult(success=True, output=output or None, usage=usage)
+
+
+async def _run(ctx: AgentRunContext) -> AgentResult:
+    try:
+        cli = await _install(None)
+    except FileNotFoundError as err:
+        return AgentResult(success=False, error=str(err))
+
+    mcp_config = write_mcp_config(ctx)
+    initial = _run_codex_once(
+        cli=cli,
+        prompt=ctx.instructions.user,
+        ctx=ctx,
+        mcp_config=mcp_config,
+    )
+
+    async def resume(prompt: str) -> AgentResult:
+        return _run_codex_once(
+            cli=cli,
+            prompt=prompt,
+            ctx=ctx,
+            mcp_config=mcp_config,
+            continue_session=True,
+        )
+
+    result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
+    return await finalize_agent_result(ctx, result)
+
+
+codex = agent(name="codex", install=_install, run=_run)

--- a/src/mergecraft/agents/cursor.py
+++ b/src/mergecraft/agents/cursor.py
@@ -1,0 +1,266 @@
+"""Cursor Cloud Agent harness — launches a cloud agent via the Cursor API."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from loguru import logger
+
+from mergecraft.agents.post_run import finalize_agent_result
+from mergecraft.agents.shared import (
+    AgentResult,
+    AgentRunContext,
+    AgentUsage,
+    agent,
+    log_token_table,
+)
+from mergecraft.integrations.cursor_cloud.client import (
+    CURSOR_API_KEY_ENV,
+    CursorCloudClient,
+    resolve_cursor_api_key,
+)
+from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.types import MERGECRAFT_MCP_NAME
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        "completed",
+        "complete",
+        "finished",
+        "failed",
+        "failure",
+        "cancelled",
+        "canceled",
+        "error",
+        "COMPLETED",
+        "FINISHED",
+        "FAILED",
+        "CANCELLED",
+        "ERROR",
+    }
+)
+_POLL_INTERVAL_S = 5.0
+_DEFAULT_CLOUD_MODEL = "composer-2"
+
+
+def _strip_provider_prefix(specifier: str) -> str:
+    slash = specifier.find("/")
+    return specifier[slash + 1 :] if slash > 0 else specifier
+
+
+def _resolve_cloud_model_id(ctx: AgentRunContext) -> str:
+    if not ctx.resolved_model:
+        return _DEFAULT_CLOUD_MODEL
+    slug = _strip_provider_prefix(ctx.resolved_model)
+    if slug in {"", "cloud-agent", "default"}:
+        return _DEFAULT_CLOUD_MODEL
+    return slug
+
+
+def _repo_url_from_ctx(ctx: AgentRunContext) -> str:
+    repo = primary_repo_state(ctx.tool_state)
+    return f"https://github.com/{repo.owner}/{repo.name}"
+
+
+def _starting_ref_from_ctx(ctx: AgentRunContext) -> str:
+    event = getattr(ctx.payload, "event", None)
+    branch = getattr(event, "branch", None) if event is not None else None
+    if isinstance(branch, str) and branch.strip():
+        return branch.strip()
+    repo = primary_repo_state(ctx.tool_state)
+    if repo.default_branch:
+        return repo.default_branch
+    if repo.initial_head and repo.initial_head.kind == "branch":
+        return repo.initial_head.name
+    return "main"
+
+
+def _build_review_prompt(ctx: AgentRunContext) -> str:
+    parts: list[str] = []
+    system = getattr(ctx.instructions, "system", "")
+    if isinstance(system, str) and system.strip():
+        parts.append(system.strip())
+    user = getattr(ctx.instructions, "user", "")
+    if isinstance(user, str) and user.strip():
+        parts.append(user.strip())
+    return "\n\n".join(parts) if parts else "Review this pull request."
+
+
+def _build_mcp_servers(ctx: AgentRunContext) -> list[dict[str, Any]]:
+    if not ctx.mcp_server_url:
+        return []
+    return [
+        {
+            "name": MERGECRAFT_MCP_NAME,
+            "type": "sse",
+            "url": ctx.mcp_server_url,
+        }
+    ]
+
+
+def _is_terminal_status(status: str) -> bool:
+    return status.strip() in _TERMINAL_STATUSES
+
+
+def _parse_usage(run: dict[str, object]) -> AgentUsage | None:
+    usage_raw = run.get("usage")
+    if not isinstance(usage_raw, dict):
+        return None
+    input_tokens = int(usage_raw.get("input_tokens") or usage_raw.get("inputTokens") or 0)
+    output_tokens = int(usage_raw.get("output_tokens") or usage_raw.get("outputTokens") or 0)
+    if input_tokens == 0 and output_tokens == 0:
+        return None
+    log_token_table(
+        input_tokens=input_tokens,
+        cache_read=0,
+        cache_write=0,
+        output=output_tokens,
+    )
+    return AgentUsage(agent="cursor", input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+def _result_text_from_run(run: dict[str, object]) -> str:
+    result = run.get("result")
+    if isinstance(result, str) and result.strip():
+        return result.strip()
+    summary = run.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+    return ""
+
+
+async def _poll_run_to_terminal(
+    client: CursorCloudClient,
+    *,
+    run_id: str,
+) -> dict[str, object]:
+    timeout_s = float(os.environ.get("MERGECRAFT_AGENT_TIMEOUT", "3600"))
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    last: dict[str, object] = {}
+
+    while asyncio.get_running_loop().time() < deadline:
+        last = await client.get_run(run_id)
+        status = str(last.get("status") or "")
+        if _is_terminal_status(status):
+            return last
+        await asyncio.sleep(_POLL_INTERVAL_S)
+
+    msg = (
+        f"cursor cloud agent run {run_id!r} did not reach a terminal status within {timeout_s:.0f}s"
+    )
+    raise TimeoutError(msg)
+
+
+async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
+    api_key = resolve_cursor_api_key()
+    if not api_key:
+        return AgentResult(
+            success=False,
+            error=(
+                f"{CURSOR_API_KEY_ENV} is not set. Configure a Cursor API key secret "
+                "or run `mergecraft auth cursor`."
+            ),
+        )
+
+    client = CursorCloudClient(api_key=api_key)
+    prompt = _build_review_prompt(ctx)
+    repo_url = _repo_url_from_ctx(ctx)
+    starting_ref = _starting_ref_from_ctx(ctx)
+    model_id = _resolve_cloud_model_id(ctx)
+
+    logger.info(
+        "launching Cursor Cloud agent (repo={}, ref={}, model={})",
+        repo_url,
+        starting_ref,
+        model_id,
+    )
+
+    try:
+        created = await client.create_cloud_agent(
+            prompt=prompt,
+            repo_url=repo_url,
+            starting_ref=starting_ref,
+            model=model_id,
+            auto_create_pr=False,
+            mcp_servers=_build_mcp_servers(ctx),
+        )
+    except (RuntimeError, ValueError) as exc:
+        return AgentResult(success=False, error=str(exc))
+
+    run_id = str(created.get("run_id") or created.get("id") or "")
+    dashboard_url = str(created.get("dashboard_url") or "")
+    if dashboard_url:
+        logger.info("cursor cloud dashboard: {}", dashboard_url)
+
+    if not run_id:
+        return AgentResult(
+            success=False,
+            error="cursor cloud agent create response missing run id",
+            metadata={"dashboard_url": dashboard_url} if dashboard_url else {},
+        )
+
+    try:
+        run = await _poll_run_to_terminal(client, run_id=run_id)
+    except TimeoutError as exc:
+        return AgentResult(
+            success=False,
+            error=str(exc),
+            metadata={"dashboard_url": dashboard_url} if dashboard_url else {},
+        )
+    except RuntimeError as exc:
+        return AgentResult(
+            success=False,
+            error=str(exc),
+            metadata={"dashboard_url": dashboard_url} if dashboard_url else {},
+        )
+
+    await client.list_artifacts(run_id)
+
+    status = str(run.get("status") or "")
+    output = _result_text_from_run(run)
+    usage = _parse_usage(run)
+    metadata: dict[str, Any] = {}
+    if dashboard_url:
+        metadata["dashboard_url"] = dashboard_url
+
+    if status.upper() in {"FAILED", "FAILURE", "ERROR", "CANCELLED", "CANCELED"}:
+        detail = str(run.get("error") or run.get("message") or status)
+        return AgentResult(
+            success=False,
+            output=output or None,
+            error=f"cursor cloud agent failed: {detail}",
+            metadata=metadata,
+            usage=usage,
+        )
+
+    return AgentResult(
+        success=True,
+        output=output or None,
+        metadata=metadata,
+        usage=usage,
+    )
+
+
+async def _install(_token: str | None = None) -> str:
+    if resolve_cursor_api_key():
+        return "cursor-cloud"
+    msg = (
+        f"{CURSOR_API_KEY_ENV} is not set. Configure a Cursor API key secret "
+        "or run `mergecraft auth cursor`."
+    )
+    raise FileNotFoundError(msg)
+
+
+async def _run(ctx: AgentRunContext) -> AgentResult:
+    try:
+        await _install(None)
+    except FileNotFoundError as err:
+        return AgentResult(success=False, error=str(err))
+
+    result = await _run_cursor_once(ctx=ctx)
+    return await finalize_agent_result(ctx, result)
+
+
+cursor = agent(name="cursor", install=_install, run=_run)

--- a/src/mergecraft/agents/cursor.py
+++ b/src/mergecraft/agents/cursor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 from loguru import logger
 
@@ -15,6 +16,7 @@ from mergecraft.agents.shared import (
     AgentUsage,
     agent,
     log_token_table,
+    payload_event_branch,
 )
 from mergecraft.integrations.cursor_cloud.client import (
     CURSOR_API_KEY_ENV,
@@ -39,6 +41,8 @@ _TERMINAL_STATUSES = frozenset(
         "FAILED",
         "CANCELLED",
         "ERROR",
+        "EXPIRED",
+        "expired",
     }
 )
 _POLL_INTERVAL_S = 5.0
@@ -65,15 +69,17 @@ def _repo_url_from_ctx(ctx: AgentRunContext) -> str:
 
 
 def _starting_ref_from_ctx(ctx: AgentRunContext) -> str:
-    event = getattr(ctx.payload, "event", None)
-    branch = getattr(event, "branch", None) if event is not None else None
-    if isinstance(branch, str) and branch.strip():
-        return branch.strip()
+    branch = payload_event_branch(ctx)
+    if branch:
+        return branch
     repo = primary_repo_state(ctx.tool_state)
-    if repo.default_branch:
-        return repo.default_branch
+    push_dest = repo.push_dest
+    if push_dest is not None and push_dest.remote_branch.strip():
+        return push_dest.remote_branch.strip()
     if repo.initial_head and repo.initial_head.kind == "branch":
         return repo.initial_head.name
+    if repo.default_branch:
+        return repo.default_branch
     return "main"
 
 
@@ -88,8 +94,20 @@ def _build_review_prompt(ctx: AgentRunContext) -> str:
     return "\n\n".join(parts) if parts else "Review this pull request."
 
 
+def _mcp_url_unreachable_from_cloud(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in {"127.0.0.1", "localhost", "::1"} or host.startswith("127.")
+
+
 def _build_mcp_servers(ctx: AgentRunContext) -> list[dict[str, Any]]:
     if not ctx.mcp_server_url:
+        return []
+    if _mcp_url_unreachable_from_cloud(ctx.mcp_server_url):
+        logger.warning(
+            "cursor cloud agent cannot reach mergeCraft MCP at {} — "
+            "MCP tools are omitted; the cloud run uses the review prompt only",
+            ctx.mcp_server_url,
+        )
         return []
     return [
         {
@@ -216,7 +234,10 @@ async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
             metadata={"dashboard_url": dashboard_url} if dashboard_url else {},
         )
 
-    await client.list_artifacts(run_id)
+    try:
+        await client.list_artifacts(run_id)
+    except RuntimeError as exc:
+        logger.warning("cursor cloud artifact listing failed (run already terminal): {}", exc)
 
     status = str(run.get("status") or "")
     output = _result_text_from_run(run)
@@ -225,7 +246,7 @@ async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
     if dashboard_url:
         metadata["dashboard_url"] = dashboard_url
 
-    if status.upper() in {"FAILED", "FAILURE", "ERROR", "CANCELLED", "CANCELED"}:
+    if status.upper() in {"FAILED", "FAILURE", "ERROR", "CANCELLED", "CANCELED", "EXPIRED"}:
         detail = str(run.get("error") or run.get("message") or status)
         return AgentResult(
             success=False,

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -48,25 +48,44 @@ def _build_subagent_instructions() -> str:
     )
 
 
-def write_mcp_config(ctx: AgentRunContext) -> str:
-    """Write Gemini ``settings.json`` under the run temp dir and return its path."""
-    gemini_home = _gemini_home(ctx)
-    gemini_home.mkdir(parents=True, exist_ok=True)
+def _build_instruction_text(ctx: AgentRunContext) -> str:
     instructions_parts: list[str] = []
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
     instructions_parts.append(_build_subagent_instructions())
-    instructions_path = gemini_home / "mergecraft-instructions.md"
-    instructions_path.write_text("\n\n".join(instructions_parts), encoding="utf-8")
+    return "\n\n".join(instructions_parts)
+
+
+def _build_gemini_prompt(ctx: AgentRunContext, prompt: str) -> str:
+    sections = [_build_instruction_text(ctx)]
+    user = (prompt or ctx.instructions.user or "").strip()
+    if user:
+        sections.append(user)
+    return "\n\n".join(sections)
+
+
+def write_mcp_config(ctx: AgentRunContext) -> str:
+    """Write Gemini ``settings.json`` under the run temp dir and return its path."""
+    gemini_home = _gemini_home(ctx)
+    gemini_home.mkdir(parents=True, exist_ok=True)
+    instructions_path = gemini_home / "GEMINI.md"
+    instructions_path.write_text(_build_instruction_text(ctx), encoding="utf-8")
+
+    server_config: dict[str, object] = {
+        "httpUrl": ctx.mcp_server_url,
+        "trust": True,
+    }
+    excluded_tools = [str(name) for name in ctx.subagent_denied_tools]
+    if excluded_tools:
+        server_config["excludeTools"] = excluded_tools
 
     settings = {
         "mcpServers": {
-            MERGECRAFT_MCP_NAME: {
-                "httpUrl": ctx.mcp_server_url,
-                "trust": True,
-            }
+            MERGECRAFT_MCP_NAME: server_config,
         },
-        "contextFileName": str(instructions_path.name),
+        "context": {
+            "fileName": "GEMINI.md",
+        },
     }
     config_path = gemini_home / "settings.json"
     config_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
@@ -185,7 +204,7 @@ def _run_gemini_once(
     if ctx.resolved_model:
         model = _strip_provider_prefix(ctx.resolved_model)
 
-    user_prompt = prompt or ctx.instructions.user
+    user_prompt = _build_gemini_prompt(ctx, prompt)
     cmd = [
         cli,
         "-p",

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -1,0 +1,264 @@
+"""Gemini CLI agent harness — invokes ``gemini`` with MCP settings."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
+from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.shared import (
+    AgentResult,
+    AgentRunContext,
+    AgentUsage,
+    agent,
+    log_token_table,
+)
+from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.types import MERGECRAFT_MCP_NAME
+
+GEMINI_API_KEY_ENV = "GEMINI_API_KEY"
+GOOGLE_GENERATIVE_AI_API_KEY_ENV = "GOOGLE_GENERATIVE_AI_API_KEY"
+
+
+def _strip_provider_prefix(specifier: str) -> str:
+    slash = specifier.find("/")
+    return specifier[slash + 1 :] if slash > 0 else specifier
+
+
+def _gemini_home(ctx: AgentRunContext) -> Path:
+    return Path(ctx.tmpdir) / ".gemini"
+
+
+def _build_subagent_instructions() -> str:
+    return "\n\n".join(
+        [
+            "Registered read-only subagents (spawn when needed):",
+            f"## {REVIEWER_AGENT_NAME}",
+            REVIEWER_SYSTEM_PROMPT,
+            f"## {VERIFIER_AGENT_NAME}",
+            VERIFIER_SYSTEM_PROMPT,
+        ]
+    )
+
+
+def write_mcp_config(ctx: AgentRunContext) -> str:
+    """Write Gemini ``settings.json`` under the run temp dir and return its path."""
+    gemini_home = _gemini_home(ctx)
+    gemini_home.mkdir(parents=True, exist_ok=True)
+    instructions_parts: list[str] = []
+    if ctx.instructions.system:
+        instructions_parts.append(ctx.instructions.system)
+    instructions_parts.append(_build_subagent_instructions())
+    instructions_path = gemini_home / "mergecraft-instructions.md"
+    instructions_path.write_text("\n\n".join(instructions_parts), encoding="utf-8")
+
+    settings = {
+        "mcpServers": {
+            MERGECRAFT_MCP_NAME: {
+                "httpUrl": ctx.mcp_server_url,
+                "trust": True,
+            }
+        },
+        "contextFileName": str(instructions_path.name),
+    }
+    config_path = gemini_home / "settings.json"
+    config_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    return str(config_path)
+
+
+async def _install(_token: str | None = None) -> str:
+    path = shutil.which("gemini")
+    if path:
+        return path
+    local = Path(ctx_tmpdir_fallback()) / "node_modules" / ".bin" / "gemini"
+    if local.exists():
+        return str(local)
+    msg = (
+        "gemini CLI not found on PATH. Install @google/gemini-cli or ensure `gemini` is available."
+    )
+    raise FileNotFoundError(msg)
+
+
+def ctx_tmpdir_fallback() -> str:
+    return os.environ.get("MERGECRAFT_TEMP_DIR") or "/tmp"
+
+
+def _normalize_gemini_api_key(env: dict[str, str]) -> None:
+    if env.get(GEMINI_API_KEY_ENV, "").strip():
+        return
+    alt = env.get(GOOGLE_GENERATIVE_AI_API_KEY_ENV, "").strip()
+    if alt:
+        env[GEMINI_API_KEY_ENV] = alt
+
+
+def _build_env(ctx: AgentRunContext) -> dict[str, str]:
+    env = dict(os.environ)
+    _normalize_gemini_api_key(env)
+    # Isolate Gemini user config to the run temp dir (~/.gemini/settings.json).
+    env["HOME"] = str(Path(ctx.tmpdir))
+    return env
+
+
+def _parse_gemini_payload(data: dict[str, Any]) -> tuple[str, AgentUsage | None]:
+    output = str(data.get("result") or data.get("output") or data.get("response") or "")
+    usage_raw = data.get("usage") or {}
+    usage: AgentUsage | None = None
+    if usage_raw or data.get("total_cost_usd") is not None:
+        input_tokens = int(usage_raw.get("input_tokens") or usage_raw.get("inputTokens") or 0)
+        output_tokens = int(usage_raw.get("output_tokens") or usage_raw.get("outputTokens") or 0)
+        cache_read = int(
+            usage_raw.get("cache_read_input_tokens") or usage_raw.get("cacheReadTokens") or 0
+        )
+        cache_write = int(
+            usage_raw.get("cache_creation_input_tokens") or usage_raw.get("cacheWriteTokens") or 0
+        )
+        cost = data.get("total_cost_usd")
+        usage = AgentUsage(
+            agent="gemini",
+            input_tokens=input_tokens + cache_read + cache_write,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read or None,
+            cache_write_tokens=cache_write or None,
+            cost_usd=float(cost) if cost is not None else None,
+        )
+        log_token_table(
+            input_tokens=input_tokens,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            output=output_tokens,
+            cost_usd=usage.cost_usd,
+        )
+    return output, usage
+
+
+def _parse_gemini_stdout(stdout: str) -> tuple[str, AgentUsage | None]:
+    text = stdout.strip()
+    if not text:
+        return "", None
+
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return _parse_gemini_payload(data)
+    except json.JSONDecodeError:
+        pass
+
+    usage: AgentUsage | None = None
+    output = text
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        parsed_output, parsed_usage = _parse_gemini_payload(event)
+        if parsed_output:
+            output = parsed_output
+        if parsed_usage is not None:
+            usage = parsed_usage
+        if event.get("type") in {"result", "turn.completed", "agent-turn-complete"}:
+            break
+    return output, usage
+
+
+def _run_gemini_once(
+    *,
+    cli: str,
+    prompt: str,
+    ctx: AgentRunContext,
+    mcp_config: str,
+    continue_session: bool = False,
+) -> AgentResult:
+    del mcp_config  # MCP lives in $HOME/.gemini/settings.json from write_mcp_config()
+    model = None
+    if ctx.resolved_model:
+        model = _strip_provider_prefix(ctx.resolved_model)
+
+    user_prompt = prompt or ctx.instructions.user
+    cmd = [
+        cli,
+        "-p",
+        user_prompt,
+        "--output-format",
+        "json",
+    ]
+    if model:
+        cmd.extend(["-m", model])
+    if continue_session:
+        cmd.extend(["--resume", "latest"])
+    if os.environ.get("CI") == "true":
+        cmd.append("-y")
+
+    logger.info("invoking gemini CLI (model={})", model or "default")
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=os.getcwd(),
+            env=_build_env(ctx),
+            capture_output=True,
+            text=True,
+            timeout=int(os.environ.get("MERGECRAFT_AGENT_TIMEOUT", "3600")),
+            check=False,
+        )
+    except FileNotFoundError as err:
+        return AgentResult(success=False, error=str(err))
+    except subprocess.TimeoutExpired:
+        return AgentResult(success=False, error="gemini CLI timed out")
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    if stderr.strip():
+        for line in stderr.strip().splitlines()[-20:]:
+            logger.debug("[gemini] {}", line)
+
+    output, usage = _parse_gemini_stdout(stdout)
+
+    if completed.returncode != 0:
+        return AgentResult(
+            success=False,
+            output=output or None,
+            error=stderr.strip() or f"gemini exited {completed.returncode}",
+            usage=usage,
+        )
+    return AgentResult(success=True, output=output or None, usage=usage)
+
+
+async def _run(ctx: AgentRunContext) -> AgentResult:
+    try:
+        cli = await _install(None)
+    except FileNotFoundError as err:
+        return AgentResult(success=False, error=str(err))
+
+    write_mcp_config(ctx)
+    initial = _run_gemini_once(
+        cli=cli,
+        prompt=ctx.instructions.user,
+        ctx=ctx,
+        mcp_config="",
+    )
+
+    async def resume(prompt: str) -> AgentResult:
+        return _run_gemini_once(
+            cli=cli,
+            prompt=prompt,
+            ctx=ctx,
+            mcp_config="",
+            continue_session=True,
+        )
+
+    result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
+    return await finalize_agent_result(ctx, result)
+
+
+gemini = agent(name="gemini", install=_install, run=_run)

--- a/src/mergecraft/agents/shared.py
+++ b/src/mergecraft/agents/shared.py
@@ -126,6 +126,28 @@ class AgentRunContext:
     on_tool_use: Callable[[AgentToolUseEvent], None] | None = None
 
 
+def payload_shell_mode(ctx: AgentRunContext) -> str:
+    """Read ``shell`` from dict or dataclass payloads (Action uses a dict)."""
+    payload = ctx.payload
+    shell = payload.get("shell") if isinstance(payload, dict) else getattr(payload, "shell", None)
+    return str(shell or "restricted")
+
+
+def payload_event_branch(ctx: AgentRunContext) -> str | None:
+    """Read PR head branch from dict or dataclass event payloads."""
+    payload = ctx.payload
+    event = payload.get("event") if isinstance(payload, dict) else getattr(payload, "event", None)
+    if isinstance(event, dict):
+        branch = event.get("branch")
+    elif event is not None:
+        branch = getattr(event, "branch", None)
+    else:
+        branch = None
+    if isinstance(branch, str) and branch.strip():
+        return branch.strip()
+    return None
+
+
 class Agent(Protocol):
     name: AgentId
 

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -22,6 +22,7 @@ console = Console()
 
 CODEX_AUTH_SECRET = "CODEX_AUTH_JSON"
 CLAUDE_OAUTH_SECRET = "CLAUDE_CODE_OAUTH_TOKEN"
+GEMINI_API_SECRET = "GEMINI_API_KEY"
 CLAUDE_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 
 
@@ -145,3 +146,51 @@ def auth_claude() -> None:
             f"  https://github.com/{repo_slug}/settings/secrets/actions"
         )
     console.print(f"[green]saved {CLAUDE_OAUTH_SECRET}[/green] to GitHub Actions secrets")
+
+
+def _validate_gemini_api_key(api_key: str) -> bool:
+    try:
+        import urllib.error
+        import urllib.request
+
+        url = f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}&pageSize=1"
+        with urllib.request.urlopen(url, timeout=15) as response:
+            return bool(response.status == 200)
+    except urllib.error.HTTPError as exc:
+        if exc.code in {401, 403}:
+            return False
+        logger.warning("gemini key validation returned HTTP {} — saving anyway", exc.code)
+        return True
+    except OSError as exc:
+        logger.warning("gemini key validation skipped (network): {}", exc)
+        return True
+
+
+@app.command("gemini")
+def auth_gemini() -> None:
+    """Save a Gemini API key as GEMINI_API_KEY."""
+    _get_gh_token()
+    owner, repo = _parse_git_remote()
+    repo_slug = f"{owner}/{repo}"
+    console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+    console.print(
+        "create an API key at [cyan]https://aistudio.google.com/apikey[/cyan], then paste it below."
+    )
+    try:
+        api_key = getpass.getpass("Gemini API key (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not api_key:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    if not _validate_gemini_api_key(api_key):
+        _bail("Gemini API key validation failed (401/403). Check the key and retry.")
+
+    console.print(f"saving [cyan]{GEMINI_API_SECRET}[/cyan] via gh secret set...")
+    if not _set_gh_secret(name=GEMINI_API_SECRET, value=api_key, repo_slug=repo_slug):
+        _bail(
+            f"could not set secret — set it manually at:\n"
+            f"  https://github.com/{repo_slug}/settings/secrets/actions"
+        )
+    console.print(f"[green]saved {GEMINI_API_SECRET}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -23,6 +23,7 @@ console = Console()
 CODEX_AUTH_SECRET = "CODEX_AUTH_JSON"
 CLAUDE_OAUTH_SECRET = "CLAUDE_CODE_OAUTH_TOKEN"
 GEMINI_API_SECRET = "GEMINI_API_KEY"
+CURSOR_API_SECRET = "CURSOR_API_KEY"
 CLAUDE_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 
 
@@ -194,3 +195,61 @@ def auth_gemini() -> None:
             f"  https://github.com/{repo_slug}/settings/secrets/actions"
         )
     console.print(f"[green]saved {GEMINI_API_SECRET}[/green] to GitHub Actions secrets")
+
+
+def _validate_cursor_api_key(api_key: str) -> bool:
+    try:
+        import base64
+        import urllib.error
+        import urllib.request
+
+        token = base64.b64encode(f"{api_key}:".encode()).decode("ascii")
+        request = urllib.request.Request(
+            "https://api.cursor.com/v1/agents?limit=1",
+            headers={
+                "Authorization": f"Basic {token}",
+                "Accept": "application/json",
+            },
+            method="GET",
+        )
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return bool(response.status == 200)
+    except urllib.error.HTTPError as exc:
+        if exc.code in {401, 403}:
+            return False
+        logger.warning("cursor key validation returned HTTP {} — saving anyway", exc.code)
+        return True
+    except OSError as exc:
+        logger.warning("cursor key validation skipped (network): {}", exc)
+        return True
+
+
+@app.command("cursor")
+def auth_cursor() -> None:
+    """Save a Cursor API key as CURSOR_API_KEY."""
+    _get_gh_token()
+    owner, repo = _parse_git_remote()
+    repo_slug = f"{owner}/{repo}"
+    console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+    console.print(
+        "create an API key in the Cursor dashboard, then paste it below "
+        "(Cloud Agent API — Phase A; local Cursor CLI is not wired yet)."
+    )
+    try:
+        api_key = getpass.getpass("Cursor API key (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not api_key:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    if not _validate_cursor_api_key(api_key):
+        _bail("Cursor API key validation failed (401/403). Check the key and retry.")
+
+    console.print(f"saving [cyan]{CURSOR_API_SECRET}[/cyan] via gh secret set...")
+    if not _set_gh_secret(name=CURSOR_API_SECRET, value=api_key, repo_slug=repo_slug):
+        _bail(
+            f"could not set secret — set it manually at:\n"
+            f"  https://github.com/{repo_slug}/settings/secrets/actions"
+        )
+    console.print(f"[green]saved {CURSOR_API_SECRET}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import NoReturn
 
+import httpx
 import typer
 from loguru import logger
 from rich.console import Console
@@ -151,18 +152,20 @@ def auth_claude() -> None:
 
 def _validate_gemini_api_key(api_key: str) -> bool:
     try:
-        import urllib.error
-        import urllib.request
-
-        url = f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}&pageSize=1"
-        with urllib.request.urlopen(url, timeout=15) as response:
-            return bool(response.status == 200)
-    except urllib.error.HTTPError as exc:
-        if exc.code in {401, 403}:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                params={"key": api_key, "pageSize": 1},
+            )
+        if response.status_code == 200:
+            return True
+        if response.status_code in {401, 403}:
             return False
-        logger.warning("gemini key validation returned HTTP {} — saving anyway", exc.code)
+        logger.warning(
+            "gemini key validation returned HTTP {} — saving anyway", response.status_code
+        )
         return True
-    except OSError as exc:
+    except httpx.HTTPError as exc:
         logger.warning("gemini key validation skipped (network): {}", exc)
         return True
 
@@ -200,26 +203,26 @@ def auth_gemini() -> None:
 def _validate_cursor_api_key(api_key: str) -> bool:
     try:
         import base64
-        import urllib.error
-        import urllib.request
 
         token = base64.b64encode(f"{api_key}:".encode()).decode("ascii")
-        request = urllib.request.Request(
-            "https://api.cursor.com/v1/agents?limit=1",
-            headers={
-                "Authorization": f"Basic {token}",
-                "Accept": "application/json",
-            },
-            method="GET",
-        )
-        with urllib.request.urlopen(request, timeout=15) as response:
-            return bool(response.status == 200)
-    except urllib.error.HTTPError as exc:
-        if exc.code in {401, 403}:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.get(
+                "https://api.cursor.com/v1/agents",
+                params={"limit": 1},
+                headers={
+                    "Authorization": f"Basic {token}",
+                    "Accept": "application/json",
+                },
+            )
+        if response.status_code == 200:
+            return True
+        if response.status_code in {401, 403}:
             return False
-        logger.warning("cursor key validation returned HTTP {} — saving anyway", exc.code)
+        logger.warning(
+            "cursor key validation returned HTTP {} — saving anyway", response.status_code
+        )
         return True
-    except OSError as exc:
+    except httpx.HTTPError as exc:
         logger.warning("cursor key validation skipped (network): {}", exc)
         return True
 

--- a/src/mergecraft/integrations/cursor_cloud/__init__.py
+++ b/src/mergecraft/integrations/cursor_cloud/__init__.py
@@ -1,0 +1,7 @@
+"""Cursor Cloud Agents API client (adapted from sevn ``integrations/cursor_cloud``)."""
+
+from __future__ import annotations
+
+from mergecraft.integrations.cursor_cloud.client import CursorCloudClient
+
+__all__ = ["CursorCloudClient"]

--- a/src/mergecraft/integrations/cursor_cloud/client.py
+++ b/src/mergecraft/integrations/cursor_cloud/client.py
@@ -1,0 +1,147 @@
+"""Minimal Cursor Cloud Agents API v1 client for mergeCraft."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any
+
+import httpx
+
+CURSOR_API_KEY_ENV = "CURSOR_API_KEY"
+_CURSOR_BASE_URL = "https://api.cursor.com"
+_DEFAULT_TIMEOUT_S = 120.0
+_DEFAULT_MODEL_ID = "composer-2"
+
+
+def _basic_auth_header(api_key: str) -> dict[str, str]:
+    token = base64.b64encode(f"{api_key}:".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def _extract_agent_from_create(payload: dict[str, Any]) -> dict[str, Any]:
+    agent = payload.get("agent")
+    if isinstance(agent, dict) and agent.get("id"):
+        return agent
+    if payload.get("id"):
+        return payload
+    msg = "cursor agents.create response missing agent id"
+    raise ValueError(msg)
+
+
+class CursorCloudClient:
+    """Async client for Cursor Cloud Agents (``create_cloud_agent``, ``get_run``, ``list_artifacts``)."""
+
+    def __init__(self, *, api_key: str, **kwargs: object) -> None:
+        _ = kwargs
+        self._api_key = api_key.strip()
+        self._agent_id: str | None = None
+        self._run_id: str | None = None
+
+    async def _request(
+        self,
+        *,
+        method: str,
+        path: str,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{_CURSOR_BASE_URL}{path}"
+        headers = {
+            **_basic_auth_header(self._api_key),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT_S) as client:
+                response = await client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=json_body,
+                    params=params,
+                )
+        except httpx.HTTPError as exc:
+            msg = f"cursor upstream failed: {exc}"
+            raise RuntimeError(msg) from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            msg = f"cursor returned non-JSON (status {response.status_code})"
+            raise RuntimeError(msg) from exc
+
+        if not isinstance(data, dict):
+            msg = "cursor returned non-object JSON"
+            raise RuntimeError(msg)
+
+        if response.status_code >= 400:
+            detail = str(data.get("detail") or data.get("message") or data)
+            msg = f"cursor API error {response.status_code}: {detail}"
+            raise RuntimeError(msg)
+
+        return data
+
+    async def create_cloud_agent(self, **payload: object) -> dict[str, str]:
+        """Launch a cloud agent; returns ``id``, ``run_id``, and ``dashboard_url``."""
+        prompt = str(payload.get("prompt") or payload.get("prompt_text") or "").strip()
+        repo_url = str(payload.get("repo_url") or "").strip()
+        starting_ref = str(payload.get("starting_ref") or payload.get("ref") or "main").strip()
+        model_raw = payload.get("model")
+        model_id = (
+            str(model_raw).strip()
+            if isinstance(model_raw, str) and model_raw.strip()
+            else _DEFAULT_MODEL_ID
+        )
+        auto_create_pr = bool(payload.get("auto_create_pr", False))
+        mcp_servers = payload.get("mcp_servers")
+
+        body: dict[str, Any] = {
+            "prompt": {"text": prompt},
+            "repos": [{"url": repo_url, "startingRef": starting_ref}],
+            "model": {"id": model_id},
+            "autoCreatePR": auto_create_pr,
+        }
+        if isinstance(mcp_servers, list) and mcp_servers:
+            body["mcpServers"] = mcp_servers
+
+        data = await self._request(method="POST", path="/v1/agents", json_body=body)
+        agent = _extract_agent_from_create(data)
+        agent_id = str(agent["id"])
+        run = data.get("run")
+        run_id = str(run["id"]) if isinstance(run, dict) and run.get("id") else agent_id
+        dashboard_url = str(agent.get("url") or f"https://cursor.com/agents/{agent_id}")
+
+        self._agent_id = agent_id
+        self._run_id = run_id
+        return {
+            "id": run_id,
+            "agent_id": agent_id,
+            "run_id": run_id,
+            "dashboard_url": dashboard_url,
+        }
+
+    async def get_run(self, run_id: str) -> dict[str, object]:
+        """Fetch run status for the agent created by ``create_cloud_agent``."""
+        agent_id = self._agent_id or run_id
+        path = f"/v1/agents/{agent_id}/runs/{run_id}"
+        return await self._request(method="GET", path=path)
+
+    async def list_artifacts(self, run_id: str) -> list[dict[str, str]]:
+        """List artifacts for the agent created by ``create_cloud_agent``."""
+        agent_id = self._agent_id or run_id
+        path = f"/v1/agents/{agent_id}/artifacts"
+        data = await self._request(method="GET", path=path)
+        items = data.get("items")
+        if not isinstance(items, list):
+            return []
+        return [item for item in items if isinstance(item, dict)]
+
+
+def resolve_cursor_api_key() -> str | None:
+    """Return ``CURSOR_API_KEY`` when set."""
+    raw = os.environ.get(CURSOR_API_KEY_ENV, "").strip()
+    return raw or None
+
+
+__all__ = ["CURSOR_API_KEY_ENV", "CursorCloudClient", "resolve_cursor_api_key"]

--- a/src/mergecraft/types.py
+++ b/src/mergecraft/types.py
@@ -26,10 +26,10 @@ def format_mcp_tool_ref(agent_id: AgentId, tool_name: str) -> str:
     match agent_id:
         case "claude":
             return f"mcp__{MERGECRAFT_MCP_NAME}__{tool_name}"
-        case "opencode" | "codex":
+        case "opencode" | "codex" | "cursor":
             return f"{MERGECRAFT_MCP_NAME}_{tool_name}"
         case "gemini":
-            return f"@{MERGECRAFT_MCP_NAME}/{tool_name}"
+            return f"mcp_{MERGECRAFT_MCP_NAME}_{tool_name}"
         case _:
             raise ValueError(f"unknown agent id: {agent_id!r}")
 

--- a/src/mergecraft/types.py
+++ b/src/mergecraft/types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # ── agent / MCP ───────────────────────────────────────────────────────────────
 
-AgentId = Literal["claude", "opencode"]
+AgentId = Literal["claude", "codex", "opencode"]
 
 MERGECRAFT_MCP_NAME = "mergecraft"
 # Back-compat alias matching the TS export name style in prompts/docs.

--- a/src/mergecraft/types.py
+++ b/src/mergecraft/types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # ── agent / MCP ───────────────────────────────────────────────────────────────
 
-AgentId = Literal["claude", "codex", "opencode"]
+AgentId = Literal["claude", "codex", "gemini", "opencode"]
 
 MERGECRAFT_MCP_NAME = "mergecraft"
 # Back-compat alias matching the TS export name style in prompts/docs.
@@ -26,8 +26,10 @@ def format_mcp_tool_ref(agent_id: AgentId, tool_name: str) -> str:
     match agent_id:
         case "claude":
             return f"mcp__{MERGECRAFT_MCP_NAME}__{tool_name}"
-        case "opencode":
+        case "opencode" | "codex":
             return f"{MERGECRAFT_MCP_NAME}_{tool_name}"
+        case "gemini":
+            return f"@{MERGECRAFT_MCP_NAME}/{tool_name}"
         case _:
             raise ValueError(f"unknown agent id: {agent_id!r}")
 

--- a/src/mergecraft/types.py
+++ b/src/mergecraft/types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # ── agent / MCP ───────────────────────────────────────────────────────────────
 
-AgentId = Literal["claude", "codex", "gemini", "opencode"]
+AgentId = Literal["claude", "codex", "cursor", "gemini", "opencode"]
 
 MERGECRAFT_MCP_NAME = "mergecraft"
 # Back-compat alias matching the TS export name style in prompts/docs.

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -11,7 +11,6 @@ from mergecraft.agents import agents, resolve_agent
 from mergecraft.models import (
     BEDROCK_MODEL_ID_ENV,
     VERTEX_MODEL_ID_ENV,
-    get_model_managed_credentials,
     get_model_provider,
     is_bedrock_anthropic_id,
     is_vertex_anthropic_id,
@@ -46,17 +45,17 @@ def _has_codex_subscription_auth() -> bool:
     return _has_env("CODEX_AUTH_JSON")
 
 
-def _is_codex_family_model(model: str) -> bool:
-    _, model_id = model.split("/", 1) if "/" in model else ("", model)
-    return "codex" in model_id.lower()
+def _has_openai_api_key_auth() -> bool:
+    return _has_env("OPENAI_API_KEY")
 
 
-def _fail_loud_for_openai_codex(*, model: str) -> None:
-    hints = get_model_managed_credentials(model) or ["CODEX_AUTH_JSON"]
+def _fail_loud_for_openai(*, model: str) -> None:
+    hints = ("CODEX_AUTH_JSON", "OPENAI_API_KEY")
     env_list = ", ".join(hints)
     msg = (
-        f"OpenAI Codex model {model!r} selected but no subscription credential is configured. "
-        f"Set {env_list} (e.g. `mergecraft auth codex`) or choose a different model."
+        f"OpenAI model {model!r} selected but no credential is configured. "
+        f"Set {env_list} (subscription via `mergecraft auth codex`, or an API key secret) "
+        "or choose a different model."
     )
     raise ValueError(msg)
 
@@ -122,10 +121,9 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
             provider = None
 
         if provider == "openai":
-            if _has_codex_subscription_auth():
+            if _has_codex_subscription_auth() or _has_openai_api_key_auth():
                 return agents["codex"]
-            if _is_codex_family_model(model):
-                _fail_loud_for_openai_codex(model=model)
+            _fail_loud_for_openai(model=model)
 
         if provider == "anthropic" and _has_claude_code_auth():
             return agents["claude"]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -11,6 +11,7 @@ from mergecraft.agents import agents, resolve_agent
 from mergecraft.models import (
     BEDROCK_MODEL_ID_ENV,
     VERTEX_MODEL_ID_ENV,
+    get_model_managed_credentials,
     get_model_provider,
     is_bedrock_anthropic_id,
     is_vertex_anthropic_id,
@@ -39,6 +40,25 @@ def _has_bedrock_auth() -> bool:
 
 def _has_vertex_auth() -> bool:
     return _has_env("GOOGLE_APPLICATION_CREDENTIALS") or _has_env("VERTEX_SERVICE_ACCOUNT_JSON")
+
+
+def _has_codex_subscription_auth() -> bool:
+    return _has_env("CODEX_AUTH_JSON")
+
+
+def _is_codex_family_model(model: str) -> bool:
+    _, model_id = model.split("/", 1) if "/" in model else ("", model)
+    return "codex" in model_id.lower()
+
+
+def _fail_loud_for_openai_codex(*, model: str) -> None:
+    hints = get_model_managed_credentials(model) or ["CODEX_AUTH_JSON"]
+    env_list = ", ".join(hints)
+    msg = (
+        f"OpenAI Codex model {model!r} selected but no subscription credential is configured. "
+        f"Set {env_list} (e.g. `mergecraft auth codex`) or choose a different model."
+    )
+    raise ValueError(msg)
 
 
 def _resolve_slug(slug: str) -> str | None:
@@ -98,10 +118,17 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
     if model:
         try:
             provider = get_model_provider(model)
-            if provider == "anthropic" and _has_claude_code_auth():
-                return agents["claude"]
-        except Exception:
-            pass
+        except ValueError:
+            provider = None
+
+        if provider == "openai":
+            if _has_codex_subscription_auth():
+                return agents["codex"]
+            if _is_codex_family_model(model):
+                _fail_loud_for_openai_codex(model=model)
+
+        if provider == "anthropic" and _has_claude_code_auth():
+            return agents["claude"]
 
     return agents["opencode"]
 

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -49,12 +49,27 @@ def _has_openai_api_key_auth() -> bool:
     return _has_env("OPENAI_API_KEY")
 
 
+def _has_gemini_auth() -> bool:
+    return _has_env("GEMINI_API_KEY") or _has_env("GOOGLE_GENERATIVE_AI_API_KEY")
+
+
 def _fail_loud_for_openai(*, model: str) -> None:
     hints = ("CODEX_AUTH_JSON", "OPENAI_API_KEY")
     env_list = ", ".join(hints)
     msg = (
         f"OpenAI model {model!r} selected but no credential is configured. "
         f"Set {env_list} (subscription via `mergecraft auth codex`, or an API key secret) "
+        "or choose a different model."
+    )
+    raise ValueError(msg)
+
+
+def _fail_loud_for_google(*, model: str) -> None:
+    hints = ("GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY")
+    env_list = ", ".join(hints)
+    msg = (
+        f"Google model {model!r} selected but no credential is configured. "
+        f"Set {env_list} (via `mergecraft auth gemini` or a GitHub Actions secret) "
         "or choose a different model."
     )
     raise ValueError(msg)
@@ -124,6 +139,11 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
             if _has_codex_subscription_auth() or _has_openai_api_key_auth():
                 return agents["codex"]
             _fail_loud_for_openai(model=model)
+
+        if provider == "google":
+            if _has_gemini_auth():
+                return agents["gemini"]
+            _fail_loud_for_google(model=model)
 
         if provider == "anthropic" and _has_claude_code_auth():
             return agents["claude"]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -53,6 +53,10 @@ def _has_gemini_auth() -> bool:
     return _has_env("GEMINI_API_KEY") or _has_env("GOOGLE_GENERATIVE_AI_API_KEY")
 
 
+def _has_cursor_auth() -> bool:
+    return _has_env("CURSOR_API_KEY")
+
+
 def _fail_loud_for_openai(*, model: str) -> None:
     hints = ("CODEX_AUTH_JSON", "OPENAI_API_KEY")
     env_list = ", ".join(hints)
@@ -70,6 +74,17 @@ def _fail_loud_for_google(*, model: str) -> None:
     msg = (
         f"Google model {model!r} selected but no credential is configured. "
         f"Set {env_list} (via `mergecraft auth gemini` or a GitHub Actions secret) "
+        "or choose a different model."
+    )
+    raise ValueError(msg)
+
+
+def _fail_loud_for_cursor(*, model: str) -> None:
+    hints = ("CURSOR_API_KEY",)
+    env_list = ", ".join(hints)
+    msg = (
+        f"Cursor model {model!r} selected but no credential is configured. "
+        f"Set {env_list} (via `mergecraft auth cursor` or a GitHub Actions secret) "
         "or choose a different model."
     )
     raise ValueError(msg)
@@ -144,6 +159,11 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
             if _has_gemini_auth():
                 return agents["gemini"]
             _fail_loud_for_google(model=model)
+
+        if provider == "cursor":
+            if _has_cursor_auth():
+                return agents["cursor"]
+            _fail_loud_for_cursor(model=model)
 
         if provider == "anthropic" and _has_claude_code_auth():
             return agents["claude"]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 def _has_env(name: str) -> bool:
     val = os.environ.get(name)
-    return isinstance(val, str) and len(val) > 0
+    return isinstance(val, str) and bool(val.strip())
 
 
 def _has_claude_code_auth() -> bool:
@@ -42,7 +42,12 @@ def _has_vertex_auth() -> bool:
 
 
 def _has_codex_subscription_auth() -> bool:
-    return _has_env("CODEX_AUTH_JSON")
+    raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
+    if not raw:
+        return False
+    from mergecraft.agents.codex import _codex_subscription_auth_usable
+
+    return _codex_subscription_auth_usable(raw)
 
 
 def _has_openai_api_key_auth() -> bool:

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for agent harness contract tests (Batch D / W11)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mergecraft.agents.shared import AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import PayloadEvent, ResolvedPayload
+from mergecraft.mcp.tool_state import init_tool_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def make_agent_run_context(
+    tmp_path: Path,
+    *,
+    resolved_model: str | None,
+) -> AgentRunContext:
+    """Build a minimal ``AgentRunContext`` for harness contract tests."""
+    return AgentRunContext(
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request")),
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(user="review this diff"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        resolved_model=resolved_model,
+    )

--- a/tests/agents/test_agent_resolve_providers.py
+++ b/tests/agents/test_agent_resolve_providers.py
@@ -1,0 +1,150 @@
+"""D12 fail-loud tests for ``resolve_runtime_agent`` (Batch D / W11, issues #10-#13)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents import agents
+from mergecraft.utils.agent_resolve import resolve_runtime_agent
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+_PROVIDER_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CODEX_AUTH_JSON",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "CURSOR_API_KEY",
+    "MERGECRAFT_AGENT",
+)
+
+
+def _clear_provider_env(monkeypatch: MonkeyPatch) -> None:
+    for key in _PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+_FAIL_LOUD_CASES = (
+    pytest.param(
+        "openai/gpt-5.3-codex",
+        ("CODEX_AUTH_JSON", "OPENAI_API_KEY"),
+        id="codex-subscription-slug",
+    ),
+    pytest.param(
+        "openai/gpt-5.6-sol",
+        ("OPENAI_API_KEY", "CODEX_AUTH_JSON"),
+        id="openai-api-slug",
+    ),
+    pytest.param(
+        "google/gemini-3.1-pro-preview",
+        ("GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"),
+        id="google-gemini-slug",
+    ),
+    pytest.param(
+        "cursor/cloud-agent",
+        ("CURSOR_API_KEY",),
+        id="cursor-cloud-slug",
+    ),
+)
+
+
+@pytest.mark.parametrize(("model", "credential_env_hints"), _FAIL_LOUD_CASES)
+@pytest.mark.xfail(
+    reason="green after W12-W15: D12 fail-loud resolve_runtime_agent",
+    strict=False,
+)
+def test_resolve_runtime_agent_fail_loud_without_credentials(
+    model: str,
+    credential_env_hints: tuple[str, ...],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Non-Anthropic models must not silently fall through to ``opencode`` without creds."""
+    _clear_provider_env(monkeypatch)
+
+    with pytest.raises((ValueError, RuntimeError)) as exc_info:
+        resolve_runtime_agent(model=model)
+
+    message = str(exc_info.value)
+    lowered = message.lower()
+    assert "opencode" not in lowered
+    assert any(env.lower() in lowered for env in credential_env_hints), (
+        f"expected one of {credential_env_hints} in error message, got: {message!r}"
+    )
+
+
+@pytest.mark.parametrize("model", [case.values[0] for case in _FAIL_LOUD_CASES])
+@pytest.mark.xfail(
+    reason="green after W12-W15: D12 fail-loud resolve_runtime_agent",
+    strict=False,
+)
+def test_resolve_runtime_agent_never_returns_opencode_for_provider_models(
+    model: str,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Document the anti-pattern: missing creds must not resolve to the ``opencode`` agent."""
+    _clear_provider_env(monkeypatch)
+
+    try:
+        agent = resolve_runtime_agent(model=model)
+    except ValueError, RuntimeError:
+        return
+
+    assert agent.name != "opencode", (
+        f"resolve_runtime_agent({model!r}) silently fell through to opencode"
+    )
+
+
+@pytest.mark.xfail(reason="green after W12: codex subscription resolve (#10)", strict=False)
+def test_resolve_runtime_agent_selects_codex_with_codex_auth_json(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+
+    agent = resolve_runtime_agent(model="openai/gpt-5.3-codex")
+
+    assert agent.name == "codex"
+    assert "codex" in agents
+
+
+@pytest.mark.xfail(reason="green after W13: OPENAI_API_KEY resolve (#11)", strict=False)
+def test_resolve_runtime_agent_selects_codex_with_openai_api_key_only(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+    agent = resolve_runtime_agent(model="openai/gpt-5.6-sol")
+
+    assert agent.name == "codex"
+
+
+@pytest.mark.xfail(reason="green after W14: Gemini resolve (#12)", strict=False)
+def test_resolve_runtime_agent_selects_gemini_with_gemini_api_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+    agent = resolve_runtime_agent(model="google/gemini-3.1-pro-preview")
+
+    assert agent.name == "gemini"
+    assert "gemini" in agents
+
+
+@pytest.mark.xfail(reason="green after W15: Cursor Cloud resolve (#13)", strict=False)
+def test_resolve_runtime_agent_selects_cursor_with_cursor_api_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "cursor-test-key")
+
+    agent = resolve_runtime_agent(model="cursor/cloud-agent")
+
+    assert agent.name == "cursor"
+    assert "cursor" in agents

--- a/tests/agents/test_agent_resolve_providers.py
+++ b/tests/agents/test_agent_resolve_providers.py
@@ -39,25 +39,33 @@ _FAIL_LOUD_CASES = (
         "openai/gpt-5.6-sol",
         ("OPENAI_API_KEY", "CODEX_AUTH_JSON"),
         id="openai-api-slug",
+        marks=pytest.mark.xfail(
+            reason="green after W13: OPENAI_API_KEY resolve (#11)",
+            strict=False,
+        ),
     ),
     pytest.param(
         "google/gemini-3.1-pro-preview",
         ("GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"),
         id="google-gemini-slug",
+        marks=pytest.mark.xfail(
+            reason="green after W14: Gemini resolve (#12)",
+            strict=False,
+        ),
     ),
     pytest.param(
         "cursor/cloud-agent",
         ("CURSOR_API_KEY",),
         id="cursor-cloud-slug",
+        marks=pytest.mark.xfail(
+            reason="green after W15: Cursor Cloud resolve (#13)",
+            strict=False,
+        ),
     ),
 )
 
 
 @pytest.mark.parametrize(("model", "credential_env_hints"), _FAIL_LOUD_CASES)
-@pytest.mark.xfail(
-    reason="green after W12-W15: D12 fail-loud resolve_runtime_agent",
-    strict=False,
-)
 def test_resolve_runtime_agent_fail_loud_without_credentials(
     model: str,
     credential_env_hints: tuple[str, ...],
@@ -77,10 +85,38 @@ def test_resolve_runtime_agent_fail_loud_without_credentials(
     )
 
 
-@pytest.mark.parametrize("model", [case.values[0] for case in _FAIL_LOUD_CASES])
-@pytest.mark.xfail(
-    reason="green after W12-W15: D12 fail-loud resolve_runtime_agent",
-    strict=False,
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(
+            "openai/gpt-5.3-codex",
+            id="codex-subscription-slug",
+        ),
+        pytest.param(
+            "openai/gpt-5.6-sol",
+            id="openai-api-slug",
+            marks=pytest.mark.xfail(
+                reason="green after W13: OPENAI_API_KEY resolve (#11)",
+                strict=False,
+            ),
+        ),
+        pytest.param(
+            "google/gemini-3.1-pro-preview",
+            id="google-gemini-slug",
+            marks=pytest.mark.xfail(
+                reason="green after W14: Gemini resolve (#12)",
+                strict=False,
+            ),
+        ),
+        pytest.param(
+            "cursor/cloud-agent",
+            id="cursor-cloud-slug",
+            marks=pytest.mark.xfail(
+                reason="green after W15: Cursor Cloud resolve (#13)",
+                strict=False,
+            ),
+        ),
+    ],
 )
 def test_resolve_runtime_agent_never_returns_opencode_for_provider_models(
     model: str,
@@ -99,7 +135,6 @@ def test_resolve_runtime_agent_never_returns_opencode_for_provider_models(
     )
 
 
-@pytest.mark.xfail(reason="green after W12: codex subscription resolve (#10)", strict=False)
 def test_resolve_runtime_agent_selects_codex_with_codex_auth_json(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_agent_resolve_providers.py
+++ b/tests/agents/test_agent_resolve_providers.py
@@ -49,10 +49,6 @@ _FAIL_LOUD_CASES = (
         "cursor/cloud-agent",
         ("CURSOR_API_KEY",),
         id="cursor-cloud-slug",
-        marks=pytest.mark.xfail(
-            reason="green after W15: Cursor Cloud resolve (#13)",
-            strict=False,
-        ),
     ),
 )
 
@@ -95,10 +91,6 @@ def test_resolve_runtime_agent_fail_loud_without_credentials(
         pytest.param(
             "cursor/cloud-agent",
             id="cursor-cloud-slug",
-            marks=pytest.mark.xfail(
-                reason="green after W15: Cursor Cloud resolve (#13)",
-                strict=False,
-            ),
         ),
     ],
 )
@@ -154,7 +146,6 @@ def test_resolve_runtime_agent_selects_gemini_with_gemini_api_key(
     assert "gemini" in agents
 
 
-@pytest.mark.xfail(reason="green after W15: Cursor Cloud resolve (#13)", strict=False)
 def test_resolve_runtime_agent_selects_cursor_with_cursor_api_key(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_agent_resolve_providers.py
+++ b/tests/agents/test_agent_resolve_providers.py
@@ -39,10 +39,6 @@ _FAIL_LOUD_CASES = (
         "openai/gpt-5.6-sol",
         ("OPENAI_API_KEY", "CODEX_AUTH_JSON"),
         id="openai-api-slug",
-        marks=pytest.mark.xfail(
-            reason="green after W13: OPENAI_API_KEY resolve (#11)",
-            strict=False,
-        ),
     ),
     pytest.param(
         "google/gemini-3.1-pro-preview",
@@ -95,10 +91,6 @@ def test_resolve_runtime_agent_fail_loud_without_credentials(
         pytest.param(
             "openai/gpt-5.6-sol",
             id="openai-api-slug",
-            marks=pytest.mark.xfail(
-                reason="green after W13: OPENAI_API_KEY resolve (#11)",
-                strict=False,
-            ),
         ),
         pytest.param(
             "google/gemini-3.1-pro-preview",
@@ -147,7 +139,6 @@ def test_resolve_runtime_agent_selects_codex_with_codex_auth_json(
     assert "codex" in agents
 
 
-@pytest.mark.xfail(reason="green after W13: OPENAI_API_KEY resolve (#11)", strict=False)
 def test_resolve_runtime_agent_selects_codex_with_openai_api_key_only(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_agent_resolve_providers.py
+++ b/tests/agents/test_agent_resolve_providers.py
@@ -44,10 +44,6 @@ _FAIL_LOUD_CASES = (
         "google/gemini-3.1-pro-preview",
         ("GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"),
         id="google-gemini-slug",
-        marks=pytest.mark.xfail(
-            reason="green after W14: Gemini resolve (#12)",
-            strict=False,
-        ),
     ),
     pytest.param(
         "cursor/cloud-agent",
@@ -95,10 +91,6 @@ def test_resolve_runtime_agent_fail_loud_without_credentials(
         pytest.param(
             "google/gemini-3.1-pro-preview",
             id="google-gemini-slug",
-            marks=pytest.mark.xfail(
-                reason="green after W14: Gemini resolve (#12)",
-                strict=False,
-            ),
         ),
         pytest.param(
             "cursor/cloud-agent",
@@ -150,7 +142,6 @@ def test_resolve_runtime_agent_selects_codex_with_openai_api_key_only(
     assert agent.name == "codex"
 
 
-@pytest.mark.xfail(reason="green after W14: Gemini resolve (#12)", strict=False)
 def test_resolve_runtime_agent_selects_gemini_with_gemini_api_key(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -23,7 +23,6 @@ def _load_codex_module():
         pytest.fail(f"mergecraft.agents.codex not implemented: {exc}")
 
 
-@pytest.mark.xfail(reason="green after W12: codex harness contract (#10)", strict=False)
 def test_codex_harness_invokes_cli_and_parses_agent_result(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -1,0 +1,83 @@
+"""Contract tests for the Codex/OpenAI agent harness (issue #10/#11 / D10)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _load_codex_module():
+    try:
+        return importlib.import_module("mergecraft.agents.codex")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.codex not implemented: {exc}")
+
+
+@pytest.mark.xfail(reason="green after W12: codex harness contract (#10)", strict=False)
+def test_codex_harness_invokes_cli_and_parses_agent_result(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Fake ``codex`` on PATH + ``CODEX_AUTH_JSON`` → expected argv + ``AgentResult`` shape."""
+    codex_module = _load_codex_module()
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("CI", "true")
+
+    captured: list[list[str]] = []
+
+    def _fake_run(
+        cmd: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        captured.append(list(cmd))
+        payload = {
+            "result": "review complete",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+            },
+            "total_cost_usd": 0.01,
+        }
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    monkeypatch.setattr(codex_module.subprocess, "run", _fake_run)
+
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+    mcp_config = str(tmp_path / "mcp.json")
+    (tmp_path / "mcp.json").write_text("{}", encoding="utf-8")
+
+    result = codex_module._run_codex_once(
+        cli="/usr/bin/codex",
+        prompt="review this diff",
+        ctx=ctx,
+        mcp_config=mcp_config,
+    )
+
+    assert captured, "expected codex harness to invoke subprocess.run"
+    cmd = captured[0]
+    assert cmd[0] == "/usr/bin/codex"
+    assert "review this diff" in cmd
+    assert any("--model" in arg or "gpt-5.3-codex" in arg for arg in cmd)
+
+    assert result.success is True
+    assert result.output is not None
+    assert "review complete" in result.output
+    assert result.usage is not None
+    assert result.usage.agent == "codex"
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0

--- a/tests/agents/test_cursor.py
+++ b/tests/agents/test_cursor.py
@@ -22,7 +22,6 @@ def _load_cursor_module():
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W15: Cursor Cloud harness contract (#13)", strict=False)
 async def test_cursor_harness_launches_cloud_agent_and_parses_agent_result(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_cursor.py
+++ b/tests/agents/test_cursor.py
@@ -1,0 +1,71 @@
+"""Contract tests for the Cursor Cloud agent harness (issue #13 / D9 Phase A)."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _load_cursor_module():
+    try:
+        return importlib.import_module("mergecraft.agents.cursor")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.cursor not implemented: {exc}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="green after W15: Cursor Cloud harness contract (#13)", strict=False)
+async def test_cursor_harness_launches_cloud_agent_and_parses_agent_result(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Mocked Cursor Cloud API + ``CURSOR_API_KEY`` → ``AgentResult`` with dashboard URL."""
+    cursor_module = _load_cursor_module()
+    monkeypatch.setenv("CURSOR_API_KEY", "cursor-test-key")
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _FakeCloudClient:
+        def __init__(self, *, api_key: str, **kwargs: object) -> None:
+            calls.append(("init", {"api_key": api_key}))
+
+        async def create_cloud_agent(self, **payload: object) -> dict[str, str]:
+            calls.append(("create_cloud_agent", dict(payload)))
+            return {"id": "run-123", "dashboard_url": "https://cursor.example/agents/run-123"}
+
+        async def get_run(self, run_id: str) -> dict[str, object]:
+            calls.append(("get_run", {"run_id": run_id}))
+            return {
+                "id": run_id,
+                "status": "completed",
+                "result": "cursor cloud review complete",
+                "usage": {"input_tokens": 60, "output_tokens": 30},
+            }
+
+        async def list_artifacts(self, run_id: str) -> list[dict[str, str]]:
+            calls.append(("list_artifacts", {"run_id": run_id}))
+            return []
+
+    monkeypatch.setattr(cursor_module, "CursorCloudClient", _FakeCloudClient)
+
+    ctx = make_agent_run_context(tmp_path, resolved_model="cursor/cloud-agent")
+
+    result = await cursor_module._run_cursor_once(ctx=ctx)
+
+    assert any(call[0] == "create_cloud_agent" for call in calls)
+    assert result.success is True
+    assert result.output is not None
+    assert "cursor cloud review complete" in result.output
+    assert result.usage is not None
+    assert result.usage.agent == "cursor"
+    dashboard = result.metadata.get("dashboard_url") or result.metadata.get("dashboardUrl")
+    assert dashboard is not None
+    assert "run-123" in str(dashboard)

--- a/tests/agents/test_gemini.py
+++ b/tests/agents/test_gemini.py
@@ -69,7 +69,9 @@ def test_gemini_harness_invokes_cli_and_parses_agent_result(
     assert captured, "expected gemini harness to invoke subprocess.run"
     cmd = captured[0]
     assert cmd[0] == "/usr/bin/gemini"
-    assert "review this diff" in cmd
+    prompt_arg = cmd[cmd.index("-p") + 1]
+    assert "review this diff" in prompt_arg
+    assert "mergecraft-reviewer" in prompt_arg
 
     assert result.success is True
     assert result.output is not None

--- a/tests/agents/test_gemini.py
+++ b/tests/agents/test_gemini.py
@@ -1,0 +1,81 @@
+"""Contract tests for the Gemini agent harness (issue #12 / D11)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _load_gemini_module():
+    try:
+        return importlib.import_module("mergecraft.agents.gemini")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.gemini not implemented: {exc}")
+
+
+@pytest.mark.xfail(reason="green after W14: Gemini harness contract (#12)", strict=False)
+def test_gemini_harness_invokes_cli_and_parses_agent_result(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Fake Gemini CLI on PATH + ``GEMINI_API_KEY`` → expected argv + ``AgentResult`` shape."""
+    gemini_module = _load_gemini_module()
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setenv("CI", "true")
+
+    captured: list[list[str]] = []
+
+    def _fake_run(
+        cmd: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        captured.append(list(cmd))
+        payload = {
+            "result": "gemini review complete",
+            "usage": {
+                "input_tokens": 80,
+                "output_tokens": 40,
+            },
+        }
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    monkeypatch.setattr(gemini_module.subprocess, "run", _fake_run)
+
+    ctx = make_agent_run_context(tmp_path, resolved_model="google/gemini-3.1-pro-preview")
+    mcp_config = str(tmp_path / "mcp.json")
+    (tmp_path / "mcp.json").write_text("{}", encoding="utf-8")
+
+    result = gemini_module._run_gemini_once(
+        cli="/usr/bin/gemini",
+        prompt="review this diff",
+        ctx=ctx,
+        mcp_config=mcp_config,
+    )
+
+    assert captured, "expected gemini harness to invoke subprocess.run"
+    cmd = captured[0]
+    assert cmd[0] == "/usr/bin/gemini"
+    assert "review this diff" in cmd
+
+    assert result.success is True
+    assert result.output is not None
+    assert "gemini review complete" in result.output
+    assert result.usage is not None
+    assert result.usage.agent == "gemini"
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0

--- a/tests/agents/test_gemini.py
+++ b/tests/agents/test_gemini.py
@@ -23,7 +23,6 @@ def _load_gemini_module():
         pytest.fail(f"mergecraft.agents.gemini not implemented: {exc}")
 
 
-@pytest.mark.xfail(reason="green after W14: Gemini harness contract (#12)", strict=False)
 def test_gemini_harness_invokes_cli_and_parses_agent_result(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_resolve.py
+++ b/tests/agents/test_resolve.py
@@ -26,19 +26,21 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_resolve_agent_claude_opencode_and_codex() -> None:
+def test_resolve_agent_claude_opencode_codex_and_gemini() -> None:
     claude = resolve_agent("claude")
     opencode = resolve_agent("opencode")
     codex_agent = resolve_agent("codex")
+    gemini_agent = resolve_agent("gemini")
     assert claude.name == "claude"
     assert opencode.name == "opencode"
     assert codex_agent.name == "codex"
-    assert set(agents) == {"claude", "codex", "opencode"}
+    assert gemini_agent.name == "gemini"
+    assert set(agents) == {"claude", "codex", "gemini", "opencode"}
 
 
 def test_resolve_agent_unknown_raises() -> None:
     with pytest.raises(ValueError, match="unknown agent"):
-        resolve_agent("gemini")
+        resolve_agent("cursor")
 
 
 def test_subagent_denied_tools_derived_from_mutates(tmp_path: Path) -> None:

--- a/tests/agents/test_resolve.py
+++ b/tests/agents/test_resolve.py
@@ -26,17 +26,19 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_resolve_agent_claude_and_opencode() -> None:
+def test_resolve_agent_claude_opencode_and_codex() -> None:
     claude = resolve_agent("claude")
     opencode = resolve_agent("opencode")
+    codex_agent = resolve_agent("codex")
     assert claude.name == "claude"
     assert opencode.name == "opencode"
-    assert set(agents) == {"claude", "opencode"}
+    assert codex_agent.name == "codex"
+    assert set(agents) == {"claude", "codex", "opencode"}
 
 
 def test_resolve_agent_unknown_raises() -> None:
     with pytest.raises(ValueError, match="unknown agent"):
-        resolve_agent("codex")
+        resolve_agent("gemini")
 
 
 def test_subagent_denied_tools_derived_from_mutates(tmp_path: Path) -> None:

--- a/tests/agents/test_resolve.py
+++ b/tests/agents/test_resolve.py
@@ -26,21 +26,23 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_resolve_agent_claude_opencode_codex_and_gemini() -> None:
+def test_resolve_agent_claude_opencode_codex_gemini_and_cursor() -> None:
     claude = resolve_agent("claude")
     opencode = resolve_agent("opencode")
     codex_agent = resolve_agent("codex")
     gemini_agent = resolve_agent("gemini")
+    cursor_agent = resolve_agent("cursor")
     assert claude.name == "claude"
     assert opencode.name == "opencode"
     assert codex_agent.name == "codex"
     assert gemini_agent.name == "gemini"
-    assert set(agents) == {"claude", "codex", "gemini", "opencode"}
+    assert cursor_agent.name == "cursor"
+    assert set(agents) == {"claude", "codex", "cursor", "gemini", "opencode"}
 
 
 def test_resolve_agent_unknown_raises() -> None:
     with pytest.raises(ValueError, match="unknown agent"):
-        resolve_agent("cursor")
+        resolve_agent("not-a-real-agent")
 
 
 def test_subagent_denied_tools_derived_from_mutates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **#10:** Codex subscription harness plus `OPENAI_API_KEY` auth path.
- **#11:** Gemini agent harness.
- **#12:** Fail-loud `resolve_runtime_agent` when configuration is invalid or unsupported.
- **#13 (Phase A only):** Cursor Cloud Agent harness with mocked Cloud smoke tests; local Cursor IDE integration deferred to a later phase.
- CLI auth helpers, integration client under `integrations/cursor_cloud/`, Dockerfile/README updates, RED + provider test suite.
- `make ci` (547 tests passed on branch) and Bugbot clean.

## Test plan

- [x] `make ci`
- [x] Unit tests: `tests/agents/test_codex.py`, `test_gemini.py`, `test_cursor.py`, `test_agent_resolve_providers.py`
- [x] Bugbot / review gate on branch

## Related issues

Closes #10
Closes #11
Closes #12
Closes #13 (Phase A — Cursor Cloud harness; local Cursor deferred)

Made with [Cursor](https://cursor.com)