### PR TITLE
feat(config): ordered model preference chain with CLI and runtime failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Action `model` input and explicit chain selection no longer lose to
+  `MERGECRAFT_MODEL`; missing agent binaries are skipped when walking the chain;
+  retryable chain advancement is wired through the Action entrypoint (#14)
 - Always post the `mergecraft-approval` status check on PR runs when status checks
   are enabled; use `neutral` when the review did not complete so a failed run no
   longer leaves a missing check that branch protection can misread as pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.mergecraft/config.yaml` accepts an ordered `models` list and optional
+  `modelFallbacks` map for per-slug backup chains; the legacy scalar `model` key
+  still works unchanged (#14)
 - Reviewers can list GitHub check suites for a commit via `list_check_runs` and fetch
   one suite by id via `get_check_suite`, then pass the id to `get_check_suite_logs`
   (#8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.mergecraft/config.yaml` accepts an ordered `models` list and optional
   `modelFallbacks` map for per-slug backup chains; the legacy scalar `model` key
   still works unchanged (#14)
+- `mergecraft models list`, `models set`, and `models show` CLI commands for
+  inspecting the curated catalog, writing an ordered preference list, and
+  previewing which slug would run (#14)
 - Reviewers can list GitHub check suites for a commit via `list_check_runs` and fetch
   one suite by id via `get_check_suite`, then pass the id to `get_check_suite_logs`
   (#8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mergecraft models list`, `models set`, and `models show` CLI commands for
   inspecting the curated catalog, writing an ordered preference list, and
   previewing which slug would run (#14)
+- Runtime model chain resolution: skip entries without credentials, advance on
+  retryable provider failures, and log selected/skipped slugs at Action-visible
+  levels (#14)
 - Reviewers can list GitHub check suites for a commit via `list_check_runs` and fetch
   one suite by id via `get_check_suite`, then pass the id to `get_check_suite_logs`
   (#8)

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ signedCommits: false
 ```
 
 **Ordered preference list** — try each entry in order; optional per-slug backups via
-`modelFallbacks` (runtime chain resolution lands in a later release):
+`modelFallbacks`; runtime skips entries without credentials and advances on retryable
+provider failures:
 
 ```yaml
 models:

--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ Learnings live in `.mergecraft/learnings.md` and are seeded/persisted across run
 | `mergecraft auth codex` | Save a ChatGPT subscription credential (`CODEX_AUTH_JSON`) via `gh secret set` |
 | `mergecraft auth gemini` | Save a Gemini API key (`GEMINI_API_KEY`) via `gh secret set` |
 | `mergecraft auth cursor` | Save a Cursor Cloud API key (`CURSOR_API_KEY`) via `gh secret set` |
+| `mergecraft models list` | List curated model slugs and whether local credentials are detected |
+| `mergecraft models set <slug> [<slug>…]` | Write an ordered `models:` preference list to `.mergecraft/config.yaml` |
+| `mergecraft models show` | Show effective model order (config + `MERGECRAFT_MODEL`) and which slug would win now |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
 | `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting) |
 | `mergecraft gha` | Action runtime entry (used by Docker Action) |

--- a/README.md
+++ b/README.md
@@ -244,8 +244,27 @@ PR checkout.
 
 Create `.mergecraft/config.yaml` (see [`examples/config.yaml`](examples/config.yaml)):
 
+**Single model (legacy scalar):**
+
 ```yaml
 model: anthropic/claude-sonnet
+push: restricted
+shell: restricted
+prApproveEnabled: false
+signedCommits: false
+```
+
+**Ordered preference list** — try each entry in order; optional per-slug backups via
+`modelFallbacks` (runtime chain resolution lands in a later release):
+
+```yaml
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+modelFallbacks:
+  anthropic/claude-sonnet:
+    - anthropic/claude-opus
 push: restricted
 shell: restricted
 prApproveEnabled: false

--- a/docs/test-plans/open-issues-sweep-batch-e.md
+++ b/docs/test-plans/open-issues-sweep-batch-e.md
@@ -1,0 +1,42 @@
+# Open issues sweep — Batch E test plan (W16 RED)
+
+Wave plan: `.ignorelocal/waves/open-issues-sweep-wave-plan.md`
+Worktree: `mergecraft-issues-e-model-routing` @ `wave/issues-e-model-routing`
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W17** | `tests/config/test_model_preference_config.py::test_load_repo_settings_parses_models_ordered_list` | `green after W17: models list parses into RepoSettings (#14)` |
+| **W17** | `tests/config/test_model_preference_config.py::test_load_repo_settings_scalar_model_unchanged_without_models_list` | `green after W17: scalar model back-compat unchanged (#14)` |
+| **W18** | `tests/cli/test_models_cmd.py::test_models_show_prints_config_order_with_env_override` | `green after W18: mergecraft models show prints effective order (#14)` |
+| **W19** | `tests/utils/test_model_chain_resolve.py::test_model_chain_skips_slugs_without_credentials` | `green after W19: chain skips entries without required credentials (#14)` |
+| **W19** | `tests/utils/test_model_chain_resolve.py::test_model_chain_advances_on_retryable_provider_failure` | `green after W19: chain advances on retryable provider failure (#14)` |
+| **W19** | `tests/utils/test_model_chain_resolve.py::test_model_chain_caps_attempts_at_max_depth` | `green after W19: chain caps total attempts at max depth (#14)` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#14** | D13 — additive `models:` list; scalar `model:` unchanged | Unit | Happy path — ordered `models:` YAML → `RepoSettings.models` | `test_model_preference_config.py::test_load_repo_settings_parses_models_ordered_list` |
+| **#14** | D13 | Unit | Back-compat — scalar `model:` only, no `models` key | `test_model_preference_config.py::test_load_repo_settings_scalar_model_unchanged_without_models_list` |
+| **#14** | W18 CLI contract | Functional | Happy path — `models show` lists config order + `MERGECRAFT_MODEL` override | `test_models_cmd.py::test_models_show_prints_config_order_with_env_override` |
+| **#14** | W19 runtime chain | Unit | Edge — skip slug when required secret absent | `test_model_chain_resolve.py::test_model_chain_skips_slugs_without_credentials` |
+| **#14** | W19 | Integration | Error handling — retryable provider failure advances chain | `test_model_chain_resolve.py::test_model_chain_advances_on_retryable_provider_failure` |
+| **#14** | W19 | Unit | Edge — cap total attempts at `_MAX_FALLBACK_DEPTH` | `test_model_chain_resolve.py::test_model_chain_caps_attempts_at_max_depth` |
+
+## Pinned module surface (for impl waves)
+
+| Module | Expected symbols |
+|--------|------------------|
+| `mergecraft.config.settings.RepoSettings` | `models: list[str] \| None`, optional `model_fallbacks: dict[str, list[str]] \| None` (`modelFallbacks` alias); scalar `model` unchanged |
+| `mergecraft.cli.models_cmd` | Typer app with `list`, `set`, `show`; registered on root `app` as `models` |
+| `mergecraft.utils.agent_resolve` | `select_runnable_model_slug(settings=…)` — first chain entry with credentials; `run_with_model_chain(settings=…, run_once=…, max_attempts=…)` — walk chain, skip missing creds, advance when `AgentResult.metadata["retryable"]` is true, cap attempts |
+
+## Implementation notes for impl waves
+
+- **W17:** Add `models` / `modelFallbacks` to `RepoSettings`; un-xfail both config parse tests.
+- **W18:** Add `cli/models_cmd.py` + register on `app`; `show` prints effective order (config + `MERGECRAFT_MODEL`); un-xfail CLI test.
+- **W19:** Implement chain resolution in `agent_resolve.py`; retryable failures use `AgentResult.metadata["retryable"] = True`; un-xfail all three chain tests.

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -6,7 +6,15 @@ import typer
 from rich.console import Console
 
 from mergecraft import __version__
-from mergecraft.cli import analyzers_cmd, auth_cmd, diff_review_cmd, gha_cmd, init_cmd, watch_cmd
+from mergecraft.cli import (
+    analyzers_cmd,
+    auth_cmd,
+    diff_review_cmd,
+    gha_cmd,
+    init_cmd,
+    models_cmd,
+    watch_cmd,
+)
 
 app = typer.Typer(
     name="mergecraft",
@@ -18,6 +26,7 @@ app = typer.Typer(
 console = Console(stderr=True)
 
 app.add_typer(auth_cmd.app, name="auth")
+app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")
 app.command("init")(init_cmd.run)
 app.command("watch")(watch_cmd.run)

--- a/src/mergecraft/cli/models_cmd.py
+++ b/src/mergecraft/cli/models_cmd.py
@@ -13,8 +13,12 @@ from rich.table import Table
 
 from mergecraft.config import load_repo_settings
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL
-from mergecraft.models import MODEL_ALIASES, get_model_provider
-from mergecraft.utils.agent_resolve import resolve_model
+from mergecraft.models import MODEL_ALIASES
+from mergecraft.utils.agent_resolve import (
+    effective_model_slugs,
+    has_credentials_for_slug,
+    resolve_model,
+)
 
 if TYPE_CHECKING:
     from mergecraft.config.settings import RepoSettings
@@ -31,70 +35,12 @@ def _bail(msg: str) -> NoReturn:
     raise typer.Exit(1)
 
 
-def _has_env(name: str) -> bool:
-    val = os.environ.get(name)
-    return isinstance(val, str) and bool(val.strip())
-
-
-def _has_claude_code_auth() -> bool:
-    return _has_env("CLAUDE_CODE_OAUTH_TOKEN") or _has_env("ANTHROPIC_API_KEY")
-
-
-def _has_codex_subscription_auth() -> bool:
-    raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
-    if not raw:
-        return False
-    from mergecraft.agents.codex import _codex_subscription_auth_usable
-
-    return _codex_subscription_auth_usable(raw)
-
-
-def _has_openai_api_key_auth() -> bool:
-    return _has_env("OPENAI_API_KEY")
-
-
-def _has_gemini_auth() -> bool:
-    return _has_env("GEMINI_API_KEY") or _has_env("GOOGLE_GENERATIVE_AI_API_KEY")
-
-
-def _has_cursor_auth() -> bool:
-    return _has_env("CURSOR_API_KEY")
-
-
-def has_credentials_for_slug(slug: str) -> bool:
-    """Return whether the current environment has credentials for ``slug``."""
-    try:
-        provider = get_model_provider(slug)
-    except ValueError:
-        return False
-
-    if provider == "anthropic":
-        return _has_claude_code_auth()
-    if provider == "openai":
-        return _has_codex_subscription_auth() or _has_openai_api_key_auth()
-    if provider == "google":
-        return _has_gemini_auth()
-    if provider == "cursor":
-        return _has_cursor_auth()
-    return False
-
-
 def _configured_model_slugs(settings: RepoSettings) -> list[str]:
     if settings.models:
         return list(settings.models)
     if settings.model:
         return [settings.model]
     return []
-
-
-def effective_model_slugs(settings: RepoSettings) -> list[str]:
-    """Config order with ``MERGECRAFT_MODEL`` promoted to the front when set."""
-    base = _configured_model_slugs(settings)
-    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
-    if not env_model:
-        return base
-    rest = [slug for slug in base if slug != env_model]
-    return [env_model, *rest]
 
 
 def _winning_slug(settings: RepoSettings) -> str | None:

--- a/src/mergecraft/cli/models_cmd.py
+++ b/src/mergecraft/cli/models_cmd.py
@@ -1,0 +1,228 @@
+"""``mergecraft models`` — inspect and configure ordered model preference (#14)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from mergecraft.config import load_repo_settings
+from mergecraft.config.settings import _DEFAULT_CONFIG_REL
+from mergecraft.models import MODEL_ALIASES, get_model_provider
+from mergecraft.utils.agent_resolve import resolve_model
+
+if TYPE_CHECKING:
+    from mergecraft.config.settings import RepoSettings
+
+app = typer.Typer(
+    help="Inspect and configure ordered model preferences.",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+def _bail(msg: str) -> NoReturn:
+    console.print(f"[red]{msg}[/red]")
+    raise typer.Exit(1)
+
+
+def _has_env(name: str) -> bool:
+    val = os.environ.get(name)
+    return isinstance(val, str) and bool(val.strip())
+
+
+def _has_claude_code_auth() -> bool:
+    return _has_env("CLAUDE_CODE_OAUTH_TOKEN") or _has_env("ANTHROPIC_API_KEY")
+
+
+def _has_codex_subscription_auth() -> bool:
+    raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
+    if not raw:
+        return False
+    from mergecraft.agents.codex import _codex_subscription_auth_usable
+
+    return _codex_subscription_auth_usable(raw)
+
+
+def _has_openai_api_key_auth() -> bool:
+    return _has_env("OPENAI_API_KEY")
+
+
+def _has_gemini_auth() -> bool:
+    return _has_env("GEMINI_API_KEY") or _has_env("GOOGLE_GENERATIVE_AI_API_KEY")
+
+
+def _has_cursor_auth() -> bool:
+    return _has_env("CURSOR_API_KEY")
+
+
+def has_credentials_for_slug(slug: str) -> bool:
+    """Return whether the current environment has credentials for ``slug``."""
+    try:
+        provider = get_model_provider(slug)
+    except ValueError:
+        return False
+
+    if provider == "anthropic":
+        return _has_claude_code_auth()
+    if provider == "openai":
+        return _has_codex_subscription_auth() or _has_openai_api_key_auth()
+    if provider == "google":
+        return _has_gemini_auth()
+    if provider == "cursor":
+        return _has_cursor_auth()
+    return False
+
+
+def _configured_model_slugs(settings: RepoSettings) -> list[str]:
+    if settings.models:
+        return list(settings.models)
+    if settings.model:
+        return [settings.model]
+    return []
+
+
+def effective_model_slugs(settings: RepoSettings) -> list[str]:
+    """Config order with ``MERGECRAFT_MODEL`` promoted to the front when set."""
+    base = _configured_model_slugs(settings)
+    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
+    if not env_model:
+        return base
+    rest = [slug for slug in base if slug != env_model]
+    return [env_model, *rest]
+
+
+def _winning_slug(settings: RepoSettings) -> str | None:
+    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
+    if env_model:
+        return env_model
+
+    for slug in _configured_model_slugs(settings):
+        if has_credentials_for_slug(slug):
+            return slug
+
+    configured = _configured_model_slugs(settings)
+    if configured:
+        return configured[0]
+
+    return resolve_model(slug=settings.model)
+
+
+def _config_path(cwd: Path) -> Path:
+    return (cwd / _DEFAULT_CONFIG_REL).resolve()
+
+
+def _load_config_dict(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        _bail(f"config must be a mapping: {path}")
+    return loaded
+
+
+def _write_models_config(*, cwd: Path, slugs: list[str]) -> Path:
+    config_path = _config_path(cwd)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    data = _load_config_dict(config_path)
+    data["models"] = slugs
+    config_path.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+@app.command("list")
+def list_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """List curated model slugs and whether credentials are detected locally."""
+    repo_root = cwd.resolve()
+    table = Table(title="Model catalog")
+    table.add_column("slug")
+    table.add_column("provider")
+    table.add_column("display")
+    table.add_column("credentials")
+
+    for alias in sorted(MODEL_ALIASES, key=lambda entry: entry.slug):
+        if alias.hidden:
+            continue
+        creds = "yes" if has_credentials_for_slug(alias.slug) else "no"
+        table.add_row(alias.slug, alias.provider, alias.display_name, creds)
+
+    console.print(table)
+    settings = load_repo_settings(root=repo_root, load_learnings_files=False)
+    configured = _configured_model_slugs(settings)
+    if configured:
+        console.print(
+            f"\nconfigured order in [cyan]{_DEFAULT_CONFIG_REL}[/cyan]: " + ", ".join(configured)
+        )
+
+
+@app.command("set")
+def set_cmd(
+    slugs: list[str] = typer.Argument(
+        ...,
+        help="Ordered model slugs written to the models: list in config.",
+    ),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Write an ordered ``models:`` list to ``.mergecraft/config.yaml``."""
+    if not slugs:
+        _bail("provide at least one model slug")
+
+    cleaned = [slug.strip() for slug in slugs if slug.strip()]
+    if not cleaned:
+        _bail("provide at least one non-empty model slug")
+
+    repo_root = cwd.resolve()
+    config_path = _write_models_config(cwd=repo_root, slugs=cleaned)
+    console.print(
+        f"wrote [green]{config_path.relative_to(repo_root)}[/green] models: " + ", ".join(cleaned)
+    )
+
+
+@app.command("show")
+def show_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Show effective model order, env override, and the slug that would win now."""
+    repo_root = cwd.resolve()
+    settings = load_repo_settings(root=repo_root, load_learnings_files=False)
+    order = effective_model_slugs(settings)
+    env_override = os.environ.get("MERGECRAFT_MODEL", "").strip()
+    winner = _winning_slug(settings)
+
+    if env_override:
+        console.print(f"env override [cyan]MERGECRAFT_MODEL[/cyan]: {env_override}")
+    else:
+        console.print("[dim]env override MERGECRAFT_MODEL: (unset)[/dim]")
+
+    if not order:
+        console.print("[yellow]no models configured[/yellow]")
+        if winner:
+            console.print(f"would win now: {winner}")
+        return
+
+    console.print("effective order:")
+    for index, slug in enumerate(order, start=1):
+        markers: list[str] = []
+        if env_override and slug == env_override:
+            markers.append("env")
+        if winner and slug == winner:
+            markers.append("win")
+        creds = "yes" if has_credentials_for_slug(slug) else "no"
+        suffix = f" ({', '.join(markers)})" if markers else ""
+        line = f"  {index}. {slug} [credentials: {creds}]{suffix}"
+        console.print(line)
+
+    if winner:
+        console.print(f"\nwould win now: [bold]{winner}[/bold]")

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -87,6 +87,8 @@ class RepoSettings(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     model: str | None = None
+    models: list[str] | None = None
+    model_fallbacks: dict[str, list[str]] | None = Field(default=None, alias="modelFallbacks")
     modes: list[ModeDefinition] = Field(default_factory=list)
     setup_script: str | None = Field(default=None, alias="setupScript")
     post_checkout_script: str | None = Field(default=None, alias="postCheckoutScript")
@@ -156,6 +158,8 @@ def default_settings() -> RepoSettings:
     return RepoSettings.model_validate(
         {
             "model": None,
+            "models": None,
+            "model_fallbacks": None,
             "modes": [],
             "setup_script": None,
             "post_checkout_script": None,

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -25,7 +25,12 @@ from mergecraft.mcp.server import start_mcp_http_server
 from mergecraft.mcp.tool_state import ProgressComment, init_tool_state
 from mergecraft.modes import Mode, compute_modes
 from mergecraft.review_checks import StaticCheckConfig
-from mergecraft.utils.agent_resolve import resolve_model, resolve_runtime_agent
+from mergecraft.utils.agent_resolve import (
+    effective_model_chain,
+    resolve_model,
+    resolve_runtime_agent,
+    select_runnable_model_slug,
+)
 from mergecraft.utils.git_setup import create_temp_directory, setup_git, wipe_runner_leak_surface
 from mergecraft.utils.github import GitHubClient, resolve_run_context_data
 from mergecraft.utils.instructions import resolve_instructions
@@ -146,7 +151,11 @@ async def main() -> MainResult:
         if cwd and os.getcwd() != cwd:
             os.chdir(cwd)
 
-        resolved_model = resolve_model(slug=payload.get("model"))
+        if effective_model_chain(settings):
+            selected_slug = select_runnable_model_slug(settings=settings)
+            resolved_model = resolve_model(slug=selected_slug)
+        else:
+            resolved_model = resolve_model(slug=payload.get("model"))
         agent = resolve_runtime_agent(model=resolved_model)
         agent_id = agent.name
         tool_state.model = payload.get("proxyModel") or resolved_model or payload.get("model")

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -29,6 +29,7 @@ from mergecraft.utils.agent_resolve import (
     effective_model_chain,
     resolve_model,
     resolve_runtime_agent,
+    run_with_model_chain,
     select_runnable_model_slug,
 )
 from mergecraft.utils.git_setup import create_temp_directory, setup_git, wipe_runner_leak_surface
@@ -151,11 +152,20 @@ async def main() -> MainResult:
         if cwd and os.getcwd() != cwd:
             os.chdir(cwd)
 
-        if effective_model_chain(settings):
+        payload_model = payload.get("model")
+        model_explicit = bool(payload.get("modelExplicit"))
+        use_model_chain = bool(effective_model_chain(settings)) and not model_explicit
+        selected_slug: str | None
+
+        if use_model_chain:
             selected_slug = select_runnable_model_slug(settings=settings)
-            resolved_model = resolve_model(slug=selected_slug)
+            resolved_model = resolve_model(slug=selected_slug, respect_env_override=False)
         else:
-            resolved_model = resolve_model(slug=payload.get("model"))
+            resolved_model = resolve_model(
+                slug=payload_model if isinstance(payload_model, str) else None,
+                respect_env_override=not model_explicit,
+            )
+            selected_slug = payload_model if isinstance(payload_model, str) else None
         agent = resolve_runtime_agent(model=resolved_model)
         agent_id = agent.name
         tool_state.model = payload.get("proxyModel") or resolved_model or payload.get("model")
@@ -310,10 +320,66 @@ async def main() -> MainResult:
         )
 
         timeout_raw = payload.get("timeout")
-        agent_task = asyncio.create_task(agent.run(run_ctx))
+
+        async def _run_agent_once(slug: str) -> AgentResult:
+            attempt_model = resolve_model(slug=slug, respect_env_override=False)
+            attempt_agent = resolve_runtime_agent(model=attempt_model)
+            attempt_agent_id = attempt_agent.name
+
+            if attempt_agent_id == agent_id:
+                attempt_ctx = replace(run_ctx, resolved_model=attempt_model)
+            else:
+                attempt_modes = [
+                    *compute_modes(attempt_agent_id, settings.signed_commits),
+                    *_custom_modes(settings.modes),
+                ]
+                attempt_instructions = resolve_instructions(
+                    payload=payload,
+                    repo=run_context.repo,
+                    modes=attempt_modes,
+                    agent_id=attempt_agent_id,
+                    output_schema=output_schema,
+                    signed_commits=settings.signed_commits,
+                    learnings_file_path=tool_state.learnings_file_path,
+                    learnings_headings=settings.learnings_headings,
+                    setup_hook_failure="",
+                    xrepo_brief=settings.xrepo_brief,
+                    xrepo_learnings_file_path=tool_state.xrepo_learnings_file_path,
+                    xrepo_learnings_headings=settings.xrepo_learnings_headings,
+                )
+                attempt_denied = subagent_denied_tool_names(
+                    replace(tool_context, agent_id=attempt_agent_id),
+                    output_schema,
+                )
+                attempt_ctx = replace(
+                    run_ctx,
+                    resolved_model=attempt_model,
+                    instructions=attempt_instructions,
+                    subagent_denied_tools=attempt_denied,
+                )
+                tool_context.agent_id = attempt_agent_id
+                tool_context.modes = attempt_modes
+                tool_context.resolved_model = attempt_model
+                logger.info(
+                    "» model chain advanced to agent={} model={}",
+                    attempt_agent_id,
+                    attempt_model or "(auto)",
+                )
+            return await attempt_agent.run(attempt_ctx)
+
+        async def _execute_agent() -> tuple[str | None, AgentResult]:
+            if use_model_chain:
+                winning_slug, chain_result = await run_with_model_chain(
+                    settings=settings,
+                    run_once=_run_agent_once,
+                )
+                return winning_slug, chain_result
+            return selected_slug, await agent.run(run_ctx)
+
+        agent_task = asyncio.create_task(_execute_agent())
 
         if timeout_raw == TIMEOUT_DISABLED:
-            result: AgentResult = await agent_task
+            winning_slug, result = await agent_task
         else:
             usable = resolve_timeout_ms(timeout_raw)
             if timeout_raw and usable is None:
@@ -322,11 +388,18 @@ async def main() -> MainResult:
                 )
             timeout_ms = usable if usable is not None else 3_600_000
             try:
-                result = await asyncio.wait_for(agent_task, timeout=timeout_ms / 1000.0)
+                winning_slug, result = await asyncio.wait_for(
+                    agent_task, timeout=timeout_ms / 1000.0
+                )
             except TimeoutError:
                 agent_task.cancel()
                 msg = f"agent run timed out after {timeout_raw or '1h'}"
                 raise RuntimeError(msg) from None
+
+        if winning_slug:
+            resolved_model = resolve_model(slug=winning_slug, respect_env_override=False)
+            tool_state.model = payload.get("proxyModel") or resolved_model or payload_model
+            tool_context.resolved_model = resolved_model
 
         if result.usage:
             tool_state.usage_entries.append(result.usage)

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import os
+import shutil
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from mergecraft.agents import agents, resolve_agent
 from mergecraft.models import (
+    _MAX_FALLBACK_DEPTH,
     BEDROCK_MODEL_ID_ENV,
+    MODEL_ALIASES,
     VERTEX_MODEL_ID_ENV,
+    ModelAlias,
     get_model_provider,
     is_bedrock_anthropic_id,
     is_vertex_anthropic_id,
@@ -19,7 +24,10 @@ from mergecraft.models import (
 )
 
 if TYPE_CHECKING:
-    from mergecraft.agents.shared import Agent
+    from collections.abc import Awaitable, Callable
+
+    from mergecraft.agents.shared import Agent, AgentResult
+    from mergecraft.config.settings import RepoSettings
 
 
 def _has_env(name: str) -> bool:
@@ -60,6 +68,255 @@ def _has_gemini_auth() -> bool:
 
 def _has_cursor_auth() -> bool:
     return _has_env("CURSOR_API_KEY")
+
+
+def has_credentials_for_slug(slug: str) -> bool:
+    """Return whether the current environment has credentials for ``slug``."""
+    try:
+        provider = get_model_provider(slug)
+    except ValueError:
+        return False
+
+    if provider == "anthropic":
+        return _has_claude_code_auth()
+    if provider == "openai":
+        return _has_codex_subscription_auth() or _has_openai_api_key_auth()
+    if provider == "google":
+        return _has_gemini_auth()
+    if provider == "cursor":
+        return _has_cursor_auth()
+    return False
+
+
+def _ctx_tmpdir_fallback() -> str:
+    return os.environ.get("MERGECRAFT_TEMP_DIR") or "/tmp"
+
+
+def _local_agent_binary(name: str) -> Path:
+    return Path(_ctx_tmpdir_fallback()) / "node_modules" / ".bin" / name
+
+
+def _agent_binary_available(slug: str) -> bool:
+    try:
+        provider = get_model_provider(slug)
+    except ValueError:
+        return False
+
+    binary_by_provider = {
+        "anthropic": "claude",
+        "openai": "codex",
+        "google": "gemini",
+        "cursor": "cursor",
+    }
+    binary = binary_by_provider.get(provider)
+    if binary is None:
+        return True
+    if shutil.which(binary):
+        return True
+    return _local_agent_binary(binary).exists()
+
+
+def is_runnable_model_slug(slug: str) -> bool:
+    """Return whether ``slug`` has credentials and an agent CLI available."""
+    if not has_credentials_for_slug(slug):
+        return False
+    return _agent_binary_available(slug)
+
+
+def _configured_model_slugs(settings: RepoSettings) -> list[str]:
+    if settings.models:
+        return list(settings.models)
+    if settings.model:
+        return [settings.model]
+    return []
+
+
+def effective_model_slugs(settings: RepoSettings) -> list[str]:
+    """Config order with ``MERGECRAFT_MODEL`` promoted to the front when set."""
+    base = _configured_model_slugs(settings)
+    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
+    if not env_model:
+        return base
+    rest = [slug for slug in base if slug != env_model]
+    return [env_model, *rest]
+
+
+def _alias_for_slug(slug: str) -> ModelAlias | None:
+    return next(
+        (alias for alias in MODEL_ALIASES if alias.slug == slug or alias.resolve == slug), None
+    )
+
+
+def _catalog_fallback_tail(slug: str) -> list[str]:
+    tail: list[str] = []
+    current = slug
+    visited: set[str] = set()
+    for _ in range(_MAX_FALLBACK_DEPTH):
+        alias = _alias_for_slug(current)
+        if alias is None or not alias.fallback:
+            break
+        nxt = alias.fallback
+        if nxt in visited:
+            break
+        visited.add(nxt)
+        tail.append(nxt)
+        current = nxt
+    return tail
+
+
+def _expand_slug_with_fallbacks(slug: str, settings: RepoSettings) -> list[str]:
+    entries = [slug]
+    configured = (settings.model_fallbacks or {}).get(slug, [])
+    for fallback in configured:
+        if fallback not in entries:
+            entries.append(fallback)
+    for fallback in _catalog_fallback_tail(slug):
+        if fallback not in entries:
+            entries.append(fallback)
+    return entries
+
+
+def effective_model_chain(settings: RepoSettings) -> list[str]:
+    """Ordered chain: config ``models``/``modelFallbacks``, env override, catalog ``fallback:``."""
+    configured = _configured_model_slugs(settings)
+    explicit_chain = len(configured) > 1 or bool(settings.model_fallbacks)
+
+    chain: list[str] = []
+    for slug in configured:
+        if explicit_chain:
+            entries = [slug]
+            for fallback in (settings.model_fallbacks or {}).get(slug, []):
+                if fallback not in entries:
+                    entries.append(fallback)
+        else:
+            entries = _expand_slug_with_fallbacks(slug, settings)
+        for entry in entries:
+            if entry not in chain:
+                chain.append(entry)
+
+    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
+    if env_model:
+        if explicit_chain:
+            expanded = [env_model]
+            for fallback in (settings.model_fallbacks or {}).get(env_model, []):
+                if fallback not in expanded:
+                    expanded.append(fallback)
+        else:
+            expanded = _expand_slug_with_fallbacks(env_model, settings)
+        chain = expanded + [entry for entry in chain if entry not in expanded]
+
+    return chain[:_MAX_FALLBACK_DEPTH]
+
+
+def select_runnable_model_slug(*, settings: RepoSettings) -> str:
+    """Pick the first chain entry with credentials and an available agent binary."""
+    chain = effective_model_chain(settings)
+    if not chain:
+        msg = "no model chain configured — set models: or model: in .mergecraft/config.yaml"
+        raise RuntimeError(msg)
+
+    skipped: list[str] = []
+    for slug in chain:
+        if not has_credentials_for_slug(slug):
+            skipped.append(f"{slug} (missing credentials)")
+            continue
+        if skipped:
+            logger.warning("» model chain skipped backups: {}", ", ".join(skipped))
+        if _agent_binary_available(slug):
+            logger.info("» model chain selected slug={}", slug)
+        else:
+            logger.warning(
+                "» model chain selected slug={} (credentials present; agent binary missing)",
+                slug,
+            )
+        return slug
+
+    if skipped:
+        logger.warning("» model chain skipped backups: {}", ", ".join(skipped))
+    msg = "no runnable model slug in chain — configure credentials for at least one entry"
+    raise RuntimeError(msg)
+
+
+def _is_retryable_failure(result: AgentResult) -> bool:
+    metadata = result.metadata or {}
+    retryable = metadata.get("retryable")
+    return retryable is True
+
+
+async def run_with_model_chain(
+    *,
+    settings: RepoSettings,
+    run_once: Callable[[str], Awaitable[AgentResult]],
+    max_attempts: int = _MAX_FALLBACK_DEPTH,
+) -> tuple[str, AgentResult]:
+    """Walk the model chain, skipping unrunnable entries and advancing on retryable failures."""
+    chain = effective_model_chain(settings)
+    if not chain:
+        msg = "no model chain configured"
+        raise RuntimeError(msg)
+
+    runnable: list[str] = []
+    skipped: list[str] = []
+    for slug in chain:
+        if not has_credentials_for_slug(slug):
+            skipped.append(f"{slug} (missing credentials)")
+            continue
+        if not _agent_binary_available(slug):
+            logger.warning(
+                "» model chain slug={} has credentials but agent binary missing — still eligible",
+                slug,
+            )
+        runnable.append(slug)
+
+    if skipped:
+        logger.warning("» model chain skipped backups: {}", ", ".join(skipped))
+
+    if not runnable:
+        msg = "no runnable model slug in chain"
+        raise RuntimeError(msg)
+
+    chain_index = 0
+    attempts = 0
+
+    while attempts < max_attempts:
+        slug = runnable[chain_index]
+        attempts += 1
+        logger.info("» model chain attempt {}/{} slug={}", attempts, max_attempts, slug)
+        result = await run_once(slug)
+
+        if result.success:
+            logger.info("» model chain succeeded slug={}", slug)
+            return slug, result
+
+        if not _is_retryable_failure(result):
+            logger.warning(
+                "» model chain slug={} failed (non-retryable): {}",
+                slug,
+                result.error or "unknown error",
+            )
+            return slug, result
+
+        if chain_index < len(runnable) - 1:
+            nxt = runnable[chain_index + 1]
+            logger.warning(
+                "» model chain slug={} failed (retryable): {} — advancing to {}",
+                slug,
+                result.error or "unknown error",
+                nxt,
+            )
+            chain_index += 1
+            continue
+
+        logger.warning(
+            "» model chain slug={} failed (retryable): {} — retrying ({}/{})",
+            slug,
+            result.error or "unknown error",
+            attempts,
+            max_attempts,
+        )
+
+    msg = f"model chain exhausted after {max_attempts} attempts (cap reached)"
+    raise RuntimeError(msg) from None
 
 
 def _fail_loud_for_openai(*, model: str) -> None:
@@ -176,4 +433,13 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
     return agents["opencode"]
 
 
-__all__ = ["resolve_model", "resolve_runtime_agent"]
+__all__ = [
+    "effective_model_chain",
+    "effective_model_slugs",
+    "has_credentials_for_slug",
+    "is_runnable_model_slug",
+    "resolve_model",
+    "resolve_runtime_agent",
+    "run_with_model_chain",
+    "select_runnable_model_slug",
+]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -85,6 +85,10 @@ def has_credentials_for_slug(slug: str) -> bool:
         return _has_gemini_auth()
     if provider == "cursor":
         return _has_cursor_auth()
+    if provider == "bedrock":
+        return _has_bedrock_auth() and bool(os.environ.get(BEDROCK_MODEL_ID_ENV, "").strip())
+    if provider == "vertex":
+        return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
     return False
 
 
@@ -220,15 +224,12 @@ def select_runnable_model_slug(*, settings: RepoSettings) -> str:
         if not has_credentials_for_slug(slug):
             skipped.append(f"{slug} (missing credentials)")
             continue
+        if not _agent_binary_available(slug):
+            skipped.append(f"{slug} (agent binary missing)")
+            continue
         if skipped:
             logger.warning("» model chain skipped backups: {}", ", ".join(skipped))
-        if _agent_binary_available(slug):
-            logger.info("» model chain selected slug={}", slug)
-        else:
-            logger.warning(
-                "» model chain selected slug={} (credentials present; agent binary missing)",
-                slug,
-            )
+        logger.info("» model chain selected slug={}", slug)
         return slug
 
     if skipped:
@@ -262,10 +263,8 @@ async def run_with_model_chain(
             skipped.append(f"{slug} (missing credentials)")
             continue
         if not _agent_binary_available(slug):
-            logger.warning(
-                "» model chain slug={} has credentials but agent binary missing — still eligible",
-                slug,
-            )
+            skipped.append(f"{slug} (agent binary missing)")
+            continue
         runnable.append(slug)
 
     if skipped:
@@ -369,11 +368,12 @@ def _resolve_slug(slug: str) -> str | None:
     return resolve_cli_model(slug)
 
 
-def resolve_model(*, slug: str | None = None) -> str | None:
+def resolve_model(*, slug: str | None = None, respect_env_override: bool = True) -> str | None:
     """Resolve the effective model string for this run."""
-    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
-    if env_model:
-        return _resolve_slug(env_model) or env_model
+    if respect_env_override:
+        env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
+        if env_model:
+            return _resolve_slug(env_model) or env_model
 
     cleaned = (slug or "").strip()
     if cleaned:

--- a/src/mergecraft/utils/payload.py
+++ b/src/mergecraft/utils/payload.py
@@ -423,7 +423,9 @@ def resolve_payload(
         "~mergecraft": True,
         "version": (json_payload.version if json_payload else None) or _package_version(),
         "model": model,
-        "modelExplicit": (json_payload.model_explicit if json_payload else None) or False,
+        "modelExplicit": bool(
+            (json_payload.model_explicit if json_payload else None) or inputs.model
+        ),
         "prompt": prompt,
         "triggerer": triggerer,
         "baseInstructions": json_payload.base_instructions if json_payload else None,

--- a/tests/cli/test_models_cmd.py
+++ b/tests/cli/test_models_cmd.py
@@ -1,0 +1,59 @@
+"""RED tests for ``mergecraft models show`` (issue #14 / W18)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_ORDERED_MODELS = (
+    "anthropic/claude-sonnet",
+    "openai/gpt-5.3-codex",
+    "google/gemini-3.1-pro-preview",
+)
+
+
+def _write_models_config(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(
+        """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W18: mergecraft models show prints effective order (#14)",
+    strict=False,
+)
+def test_models_show_prints_config_order_with_env_override(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _write_models_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGECRAFT_MODEL", "openai/gpt-5.3-codex")
+
+    result = runner.invoke(app, ["models", "show"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    output = result.stdout
+    for slug in _ORDERED_MODELS:
+        assert slug in output
+    assert "openai/gpt-5.3-codex" in output
+    assert output.index("openai/gpt-5.3-codex") < output.index("google/gemini-3.1-pro-preview")

--- a/tests/cli/test_models_cmd.py
+++ b/tests/cli/test_models_cmd.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
@@ -37,10 +36,6 @@ models:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W18: mergecraft models show prints effective order (#14)",
-    strict=False,
-)
 def test_models_show_prints_config_order_with_env_override(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/config/test_model_preference_config.py
+++ b/tests/config/test_model_preference_config.py
@@ -1,0 +1,68 @@
+"""RED tests for ordered ``models:`` config parsing (issue #14 / W16, D13)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config import load_repo_settings
+from mergecraft.config.settings import RepoSettings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+_ORDERED_MODELS = (
+    "anthropic/claude-sonnet",
+    "openai/gpt-5.3-codex",
+    "google/gemini-3.1-pro-preview",
+)
+
+
+@pytest.mark.xfail(
+    reason="green after W17: models list parses into RepoSettings (#14)", strict=False
+)
+def test_load_repo_settings_parses_models_ordered_list(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(
+        """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+""",
+        encoding="utf-8",
+    )
+
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+
+    assert "models" in RepoSettings.model_fields
+    assert settings.models == list(_ORDERED_MODELS)
+
+
+@pytest.mark.xfail(reason="green after W17: scalar model back-compat unchanged (#14)", strict=False)
+def test_load_repo_settings_scalar_model_unchanged_without_models_list(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(
+        "model: anthropic/claude-sonnet\n",
+        encoding="utf-8",
+    )
+
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+
+    assert settings.model == "anthropic/claude-sonnet"
+    assert "models" in RepoSettings.model_fields
+    assert settings.models is None

--- a/tests/config/test_model_preference_config.py
+++ b/tests/config/test_model_preference_config.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mergecraft.config import load_repo_settings
 from mergecraft.config.settings import RepoSettings
 
@@ -22,9 +20,6 @@ _ORDERED_MODELS = (
 )
 
 
-@pytest.mark.xfail(
-    reason="green after W17: models list parses into RepoSettings (#14)", strict=False
-)
 def test_load_repo_settings_parses_models_ordered_list(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -48,7 +43,6 @@ models:
     assert settings.models == list(_ORDERED_MODELS)
 
 
-@pytest.mark.xfail(reason="green after W17: scalar model back-compat unchanged (#14)", strict=False)
 def test_load_repo_settings_scalar_model_unchanged_without_models_list(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/utils/test_model_chain_resolve.py
+++ b/tests/utils/test_model_chain_resolve.py
@@ -1,0 +1,152 @@
+"""RED tests for ordered model chain resolution at runtime (issue #14 / W19)."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from mergecraft.agents.shared import AgentResult
+from mergecraft.config.settings import RepoSettings
+from mergecraft.models import _MAX_FALLBACK_DEPTH
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+_PROVIDER_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CODEX_AUTH_JSON",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "CURSOR_API_KEY",
+    "MERGECRAFT_AGENT",
+    "MERGECRAFT_MODEL",
+)
+
+
+def _clear_provider_env(monkeypatch: MonkeyPatch) -> None:
+    for key in _PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _import_chain_symbol(name: str) -> object:
+    module = importlib.import_module("mergecraft.utils.agent_resolve")
+    try:
+        return getattr(module, name)
+    except AttributeError as exc:
+        pytest.fail(f"mergecraft.utils.agent_resolve.{name} not implemented: {exc}")
+
+
+def _chain_settings(slugs: list[str]) -> RepoSettings:
+    return RepoSettings.model_validate({"models": slugs})
+
+
+@pytest.mark.xfail(
+    reason="green after W19: chain skips entries without required credentials (#14)",
+    strict=False,
+)
+def test_model_chain_skips_slugs_without_credentials(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+    select_runnable_model_slug = cast(
+        "Callable[..., str]",
+        _import_chain_symbol("select_runnable_model_slug"),
+    )
+    settings = _chain_settings(
+        [
+            "anthropic/claude-sonnet",
+            "openai/gpt-5.3-codex",
+            "google/gemini-3.1-pro-preview",
+        ]
+    )
+
+    selected = select_runnable_model_slug(settings=settings)
+
+    assert selected == "google/gemini-3.1-pro-preview"
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="green after W19: chain advances on retryable provider failure (#14)",
+    strict=False,
+)
+async def test_model_chain_advances_on_retryable_provider_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+    run_with_model_chain = cast(
+        "Callable[..., Awaitable[tuple[str, AgentResult]]]",
+        _import_chain_symbol("run_with_model_chain"),
+    )
+    settings = _chain_settings(
+        [
+            "openai/gpt-5.3-codex",
+            "google/gemini-3.1-pro-preview",
+        ]
+    )
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        if slug == "openai/gpt-5.3-codex":
+            return AgentResult(
+                success=False,
+                error="provider rate limited",
+                metadata={"retryable": True},
+            )
+        return AgentResult(success=True, output="review complete")
+
+    selected_slug, result = await run_with_model_chain(
+        settings=settings,
+        run_once=run_once,
+    )
+
+    assert attempts == ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]
+    assert selected_slug == "google/gemini-3.1-pro-preview"
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="green after W19: chain caps total attempts at max depth (#14)",
+    strict=False,
+)
+async def test_model_chain_caps_attempts_at_max_depth(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+    run_with_model_chain = cast(
+        "Callable[..., Awaitable[tuple[str, AgentResult]]]",
+        _import_chain_symbol("run_with_model_chain"),
+    )
+    settings = _chain_settings(["openai/gpt-5.3-codex"])
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        return AgentResult(
+            success=False,
+            error="transient provider failure",
+            metadata={"retryable": True},
+        )
+
+    with pytest.raises(RuntimeError, match=r"max|cap|attempt"):
+        await run_with_model_chain(
+            settings=settings,
+            run_once=run_once,
+            max_attempts=_MAX_FALLBACK_DEPTH,
+        )
+
+    assert len(attempts) == _MAX_FALLBACK_DEPTH

--- a/tests/utils/test_model_chain_resolve.py
+++ b/tests/utils/test_model_chain_resolve.py
@@ -45,10 +45,6 @@ def _chain_settings(slugs: list[str]) -> RepoSettings:
     return RepoSettings.model_validate({"models": slugs})
 
 
-@pytest.mark.xfail(
-    reason="green after W19: chain skips entries without required credentials (#14)",
-    strict=False,
-)
 def test_model_chain_skips_slugs_without_credentials(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -73,10 +69,6 @@ def test_model_chain_skips_slugs_without_credentials(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W19: chain advances on retryable provider failure (#14)",
-    strict=False,
-)
 async def test_model_chain_advances_on_retryable_provider_failure(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -117,10 +109,6 @@ async def test_model_chain_advances_on_retryable_provider_failure(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W19: chain caps total attempts at max depth (#14)",
-    strict=False,
-)
 async def test_model_chain_caps_attempts_at_max_depth(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/utils/test_model_chain_resolve.py
+++ b/tests/utils/test_model_chain_resolve.py
@@ -50,6 +50,10 @@ def test_model_chain_skips_slugs_without_credentials(
 ) -> None:
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
 
     select_runnable_model_slug = cast(
         "Callable[..., str]",
@@ -75,6 +79,10 @@ async def test_model_chain_advances_on_retryable_provider_failure(
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
     monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
 
     run_with_model_chain = cast(
         "Callable[..., Awaitable[tuple[str, AgentResult]]]",
@@ -114,6 +122,10 @@ async def test_model_chain_caps_attempts_at_max_depth(
 ) -> None:
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
 
     run_with_model_chain = cast(
         "Callable[..., Awaitable[tuple[str, AgentResult]]]",


### PR DESCRIPTION
## Summary

- Add ordered `models` / `modelFallbacks` config with backward-compatible scalar `model:` shorthand (#14)
- Add `mergecraft models list`, `set`, and `show` CLI for inspecting and writing preference order
- Resolve the effective chain at Action startup, skip entries without credentials or agent binaries, and advance on retryable provider failures with Action-visible logging
- Final fixup wires chain execution through the Action entrypoint: honors Action `model` override over `MERGECRAFT_MODEL`, re-resolves agent instructions/MCP context on cross-provider failover

Closes #14

## Test plan

- [x] `make ci` green (565 passed)
- [x] Bugbot review gate clean above `low` (after fixup `2583f2f`)
- [x] RED suite `tests/config/test_model_chain.py` + `tests/utils/test_model_chain_resolve.py` green
- [x] CLI contract tests in `tests/cli/test_models_cmd.py` green
