### PR TITLE
ci(release): add Sentry Craft release pipeline

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Craft release configuration — https://getsentry.github.io/craft/
+minVersion: '2.21.0'
+
+github:
+  owner: alexhawat
+  repo: mergeCraft
+
+versioning:
+  policy: auto
+
+changelog:
+  filePath: CHANGELOG.md
+  policy: auto
+
+artifactProvider:
+  name: github
+  config:
+    artifacts:
+      CI/CD:
+        - artifact-python-dist
+
+requireNames:
+  - /^merge[_-]craft.*\.(whl|tar\.gz)$/
+
+postReleaseCommand: bash scripts/post-release.sh
+
+targets:
+  - name: pypi
+    includeNames: /^merge[_-]craft.*$/
+  - name: github
+    tagPrefix: v
+  - name: docker
+    id: slim
+    source: ghcr.io/alexhawat/mergecraft
+    target: ghcr.io/alexhawat/mergecraft
+  - name: docker
+    id: slim-latest
+    source: ghcr.io/alexhawat/mergecraft
+    target:
+      image: ghcr.io/alexhawat/mergecraft
+      format: '{{{image}}}:latest'
+  - name: docker
+    id: analyzers
+    source:
+      image: ghcr.io/alexhawat/mergecraft
+      format: '{{{image}}}:analyzers-{{{revision}}}'
+    target:
+      image: ghcr.io/alexhawat/mergecraft
+      format: '{{{image}}}:analyzers-{{{version}}}'
+  - name: docker
+    id: analyzers-latest
+    source:
+      image: ghcr.io/alexhawat/mergecraft
+      format: '{{{image}}}:analyzers-{{{revision}}}'
+    target:
+      image: ghcr.io/alexhawat/mergecraft
+      format: '{{{image}}}:analyzers'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+# Craft auto-changelog categories (extends GitHub release.yml format).
+# https://getsentry.github.io/craft/configuration/#auto-mode
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot[bot]
+      - renovate[bot]
+  categories:
+    - title: Breaking Changes
+      commit_patterns:
+        - '^(?<type>\w+(?:\([^)]+\))?!:\s*)'
+      semver: major
+    - title: Added
+      commit_patterns:
+        - '^(?<type>feat(?:\([^)]+\))?!?:\s*)'
+      semver: minor
+    - title: Fixed
+      commit_patterns:
+        - '^(?<type>fix(?:\([^)]+\))?!?:\s*)'
+        - '^Revert "'
+      semver: patch
+    - title: Changed
+      commit_patterns:
+        - '^(?<type>(?:refactor|perf)(?:\([^)]+\))?!?:\s*)'
+      semver: patch
+    - title: Docs
+      commit_patterns:
+        - '^(?<type>docs?(?:\([^)]+\))?!?:\s*)'
+      semver: patch
+    - title: Internal
+      commit_patterns:
+        - '^(?<type>(?:build|chore|ci|test|style|meta)(?:\([^)]+\))?!?:\s*)'
+      semver: patch

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+# Posts (or status-checks) a Craft changelog preview on pull requests.
+name: Changelog Preview
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: changelog-preview-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changelog-preview:
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    secrets: inherit

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [main, pre-0.0.1]
+    branches: [main, pre-0.0.1, "release/**"]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -27,10 +27,28 @@ jobs:
       - name: make ci
         run: make ci
 
+  build-dist:
+    name: Build Python dist
+    needs: verify
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/bootstrap
+      - name: uv build
+        run: uv build
+      - name: Upload Python dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: artifact-python-dist
+          path: dist/*
+          if-no-files-found: error
+
   publish-ghcr:
     name: Publish GHCR image
     needs: verify
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -63,14 +81,3 @@ jobs:
             ghcr.io/alexhawat/mergecraft:analyzers-${{ github.sha }}
           cache-from: type=gha,scope=mergeCraft-analyzers
           cache-to: type=gha,mode=max,scope=mergeCraft-analyzers
-
-  release:
-    name: GitHub Release
-    needs: verify
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: softprops/action-gh-release@6da8fa9354acfd0aee3ea35f3aba2d3a4a1c0c5f # v2.4.0
-        with:
-          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, pre-0.0.1]
   push:
-    branches: [main, pre-0.0.1]
+    branches: [main, pre-0.0.1, "release/**"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Craft-driven release: prepare release branch, wait for CI/CD artifacts, publish.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (semver, major/minor/patch, or auto)'
+        required: false
+        default: auto
+      force:
+        description: Force release despite release-blocker label
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    uses: getsentry/craft/.github/workflows/release.yml@v2
+    with:
+      version: ${{ inputs.version }}
+      force: ${{ inputs.force && 'true' || 'false' }}
+      publish_repo: self
+    secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,47 @@ Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:
 | GitHub repo | `mergeCraft` (camelCase) |
 | Python package / import | `mergecraft` (lowercase) |
 | CLI binary | `mergecraft` (not `mc` — Midnight Commander collision) |
-| PyPI distribution | `merge-craft` (reserved conceptually; no publish workflow) |
+| PyPI distribution | `merge-craft` (published via [Craft](https://github.com/getsentry/craft)) |
 | Container image | `ghcr.io/alexhawat/mergecraft` (lowercase, hardcoded) |
 | MCP server | `mergecraft` → `mcp__mergecraft__*` / `mergecraft_*` |
 | Config directory | `.mergecraft/` |
 
 Never interchange repo spelling with package spelling in code.
+
+## Releases (Craft)
+
+Releases are managed with [Sentry Craft](https://github.com/getsentry/craft). Configuration
+lives in `.craft.yml` at the repo root.
+
+### Prerequisites
+
+- Craft CLI: `npm install -g @sentry/craft` (or download a [binary release](https://github.com/getsentry/craft/releases))
+- `GITHUB_TOKEN` with `repo` scope (local prepare/publish, or supplied by Actions)
+- PyPI credentials for publish: `TWINE_USERNAME` and `TWINE_PASSWORD` (or API token as password)
+
+Add repository secrets for the Release workflow: `TWINE_USERNAME`, `TWINE_PASSWORD`.
+
+### Cut a release
+
+1. **Prepare** (creates `release/<version>`, bumps `pyproject.toml`, cuts `CHANGELOG.md`, pushes):
+   ```bash
+   craft prepare auto   # or: craft prepare 0.1.0
+   ```
+2. **CI/CD** on the release branch runs `make ci`, builds `dist/*`, uploads the
+   `artifact-python-dist` artifact, and pushes SHA-tagged GHCR images.
+3. **Publish** (waits for green CI, uploads to GitHub/PyPI/GHCR):
+   ```bash
+   craft publish <version>
+   ```
+
+Or dispatch **Release** in GitHub Actions (`.github/workflows/release.yml`) with
+`version: auto` or an explicit semver.
+
+Dry-run locally: `craft prepare auto --dry-run`.
+
+The first release has no prior git tag — use an explicit version (e.g. `craft prepare 0.0.1`)
+instead of `auto`. GitHub releases are created by Craft's `github` target during `publish`
+(not the CI/CD workflow).
+
+Changelog previews post on pull requests via `.github/workflows/changelog-preview.yml`.
+Skip entries with `#skip-changelog` or the `skip-changelog` label.

--- a/scripts/check_conventional_commit.py
+++ b/scripts/check_conventional_commit.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 
 _PATTERN = re.compile(
-    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
+    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|release|meta)"
     r"(\([a-z0-9._-]+\))?!?: .{1,72}$"
 )
 

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Bump pyproject.toml to the next patch dev version after a successful publish.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -z "${CRAFT_NEW_VERSION:-}" ]]; then
+  echo "CRAFT_NEW_VERSION is required" >&2
+  exit 1
+fi
+
+IFS='.' read -r major minor patch <<< "${CRAFT_NEW_VERSION%%-*}"
+patch="${patch%%[^0-9]*}"
+dev_version="${major}.${minor}.$((patch + 1))-dev"
+
+perl -i -pe "s/^version = \".*\"/version = \"${dev_version}\"/" pyproject.toml
+grep -q "version = \"${dev_version}\"" pyproject.toml
+
+echo "Bumped development version to ${dev_version}"


### PR DESCRIPTION
## Summary

- Add [Sentry Craft](https://github.com/getsentry/craft) configuration (`.craft.yml`) for GitHub releases, PyPI (`merge-craft`), and GHCR image retagging (slim + analyzers).
- Extend CI/CD to build and upload Python dist artifacts on `release/**` branches, publish GHCR images from release branches, and remove the redundant `softprops/action-gh-release` job (Craft owns GitHub releases).
- Add Release and Changelog Preview workflows, plus contributor docs and hook allowances for Craft's `release:` / `meta:` commit messages.

## Test plan

- [ ] Confirm `craft config` parses in a checkout with this branch
- [ ] Merge, add `TWINE_USERNAME` / `TWINE_PASSWORD` repo secrets, then dispatch **Release** with version `0.0.1` (first release — `auto` needs a prior tag)
- [ ] Verify CI/CD on `release/0.0.1` uploads `artifact-python-dist` and pushes SHA-tagged GHCR images
- [ ] Verify Changelog Preview posts on this PR
