### PR TITLE
feat(cli): structured findings output for diff-review (Batch A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mergecraft diff-review --json PATH` writes structured findings validated against
+  the `Finding` schema for offline benchmark/scoring workflows (#30)
 - `.mergecraft/config.yaml` accepts an ordered `models` list and optional
   `modelFallbacks` map for per-slug backup chains; the legacy scalar `model` key
   still works unchanged (#14)

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Learnings live in `.mergecraft/learnings.md` and are seeded/persisted across run
 | `mergecraft models set <slug> [<slug>…]` | Write an ordered `models:` preference list to `.mergecraft/config.yaml` |
 | `mergecraft models show` | Show effective model order (config + `MERGECRAFT_MODEL`) and which slug would win now |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
-| `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting) |
+| `mergecraft diff-review` | Offline local git/patch review (no GitHub PR posting); optional `--json` for structured findings |
 | `mergecraft gha` | Action runtime entry (used by Docker Action) |
 | `mergecraft gha token [--post]` | Installation token mint / post write-back |
 
@@ -321,10 +321,14 @@ uv run mergecraft diff-review --base origin/main --model anthropic/claude-sonnet
 
 # Review an existing patch without git
 uv run mergecraft diff-review --diff changes.patch --dry-run
+
+# Structured findings JSON (machine-readable Finding[] for benchmarks/scoring)
+uv run mergecraft diff-review --diff changes.patch --json findings.json
 ```
 
 `--dry-run` materializes the unified diff and prints the Review prompt without
-invoking an agent (no LLM keys required).
+invoking an agent (no LLM keys required). With `--json`, `--dry-run` does not
+create the JSON file.
 
 ## Action inputs
 

--- a/docs/test-plans/issue-30-reviewbench.md
+++ b/docs/test-plans/issue-30-reviewbench.md
@@ -1,0 +1,48 @@
+# Issue #30 ReviewBench — Batch A test plan (W1 RED)
+
+Wave plan: `.ignorelocal/waves/issue-30-reviewbench-wave-plan.md`
+Worktree: `mergecraft-issue-30-reviewbench` @ `wave/issue-30-reviewbench`
+
+## Locked decisions exercised
+
+| ID | Decision | Tests |
+|----|----------|-------|
+| **D3** | Schema derived from `Finding.model_json_schema()` wrapped in `{"findings": [...]}` | `test_findings_output_schema_is_valid_json_schema` |
+| **D4** | CLI flag name `--json PATH` | `test_cli_diff_review_help_lists_json`, CLI invoke paths in json tests |
+| **D5** | Dual output (`--json` + `-o`) | Deferred to W3 impl / optional follow-on — not RED-scoped in W1 |
+| **D6** | `--json` requires structured `set_output`; validate each item as `Finding`; fail if missing output | `test_cli_diff_review_json_validates_findings`, prompt requirement test |
+| **D7** | `--dry-run --json` writes nothing; exit 0 | `test_cli_diff_review_json_dry_run_does_not_write_file` |
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W2** | `tests/cli/test_diff_review_json.py::test_findings_output_schema_is_valid_json_schema` | `green after W2: findings_output_schema helper` |
+| **W3** | `test_build_offline_review_prompt_requires_set_output_when_json_mode` | `green after W3: json_mode prompt requirement` |
+| **W3** | `test_cli_diff_review_json_dry_run_does_not_write_file` | `green after W3: --json dry-run wiring` |
+| **W3** | `test_cli_diff_review_json_validates_findings[valid_finding]` | `green after W3: --json validation wiring` |
+| **W3** | `test_cli_diff_review_json_validates_findings[invalid_finding]` | `green after W3: --json validation wiring` |
+| **W3** | `test_cli_diff_review_help_lists_json` | `green after W3: --json in help` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Contract | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| D3 — derived JSON Schema | Unit | Happy — `properties.findings` array of `Finding` fields; `required: ["findings"]` | `test_findings_output_schema_is_valid_json_schema` |
+| D6 — prompt requires `set_output` when JSON mode | Unit | Happy — step 4 says required, not “if available” | `test_build_offline_review_prompt_requires_set_output_when_json_mode` |
+| D7 — dry-run + JSON | Functional | Happy — exit 0, JSON path not created | `test_cli_diff_review_json_dry_run_does_not_write_file` |
+| D6 — validate findings on write | Integration | Happy — monkeypatched agent output → file round-trips `Finding.model_validate` | `test_cli_diff_review_json_validates_findings[valid_finding]` |
+| D6 — invalid finding rejected | Integration | Error — malformed finding → non-zero exit | `test_cli_diff_review_json_validates_findings[invalid_finding]` |
+| D4 — CLI surface documented | Functional | Happy — `--help` lists `--json` | `test_cli_diff_review_help_lists_json` |
+
+## Implementation notes for impl waves
+
+- **W2:** Add `findings_output_schema()` in `offline_review.py` or `utils/payload.py`; un-xfail schema test only.
+- **W3:** Wire `--json`, `json_mode` on `build_offline_review_prompt`, MCP `output_schema`, post-run validation/write; un-xfail all W3 rows.
+- **Existing suite:** `tests/cli/test_diff_review.py` must remain green unchanged (markdown default, dry-run without `--json`).
+
+## Monkeypatch contract (W1.4)
+
+`test_cli_diff_review_json_validates_findings` patches `mergecraft.offline_review._run_agent_review` to return JSON `{"findings": [...]}` without invoking a live agent. W3 should validate and write from structured agent output (`tool_state.output` or equivalent) before exit.

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import json
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
@@ -12,6 +13,13 @@ from mergecraft.review_taxonomy import (
     FINDING_SEVERITIES,
     FindingSource,
     finding_fingerprint,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+STRUCTURED_OUTPUT_REQUIRED_MSG = (
+    "output_schema was provided but agent did not call set_output — structured output is required"
 )
 
 IntroducedByPr = Literal["true", "false", "unknown"]
@@ -119,9 +127,59 @@ def make_finding(
         raise FindingValidationError(str(exc)) from exc
 
 
+class FindingsPayload(BaseModel):
+    """Structured ``set_output`` envelope for benchmark/scoring workflows."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    findings: list[Finding]
+
+
+def findings_output_schema() -> dict[str, Any]:
+    """JSON Schema for structured findings output derived from ``Finding``."""
+    item_schema = Finding.model_json_schema()
+    properties = item_schema.get("properties")
+    if isinstance(properties, dict):
+        properties["category"] = {"type": "string", "enum": list(FINDING_CATEGORIES)}
+        properties["severity"] = {"type": "string", "enum": list(FINDING_SEVERITIES)}
+        properties["confidence"] = {"type": "string", "enum": list(FINDING_CONFIDENCES)}
+    return {
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": item_schema,
+            }
+        },
+        "required": ["findings"],
+    }
+
+
+def parse_findings_payload(raw: str) -> list[dict[str, Any]]:
+    """Parse structured output JSON and validate each finding."""
+    try:
+        payload = FindingsPayload.model_validate_json(raw)
+    except ValidationError as exc:
+        msg = f"set_output does not conform to findings schema: {exc}"
+        raise ValueError(msg) from exc
+    return [finding.model_dump() for finding in payload.findings]
+
+
+def write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None:
+    """Write validated findings to a pretty-printed JSON file."""
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"findings": findings}, indent=2, ensure_ascii=False)
+    json_path.write_text(f"{payload}\n", encoding="utf-8")
+
+
 __all__ = [
+    "STRUCTURED_OUTPUT_REQUIRED_MSG",
     "Finding",
     "FindingValidationError",
+    "FindingsPayload",
     "IntroducedByPr",
+    "findings_output_schema",
     "make_finding",
+    "parse_findings_payload",
+    "write_findings_json",
 ]

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -54,6 +54,11 @@ def run(
         "-o",
         help="Write the review markdown (or dry-run prompt) to this file.",
     ),
+    json_output: Path | None = typer.Option(
+        None,
+        "--json",
+        help="Write structured findings JSON to this file.",
+    ),
     prompt: str | None = typer.Option(
         None,
         "--prompt",
@@ -85,6 +90,7 @@ def run(
             model=model,
             prompt_extra=prompt,
             dry_run=dry_run,
+            json_path=json_output,
         )
     )
 
@@ -100,8 +106,11 @@ def run(
     if output is not None:
         output.write_text(text, encoding="utf-8")
         console.print(f"[green]wrote[/green] {output}")
-    else:
+    elif json_output is None:
         console.print(text)
+
+    if json_output is not None and result.success and not dry_run:
+        console.print(f"[green]wrote[/green] {json_output}")
 
     if result.empty_diff:
         raise typer.Exit(0)

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import tempfile
 from dataclasses import dataclass
@@ -11,12 +10,17 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-from pydantic import ValidationError
 
 from mergecraft.agents.gates import subagent_denied_tool_names
 from mergecraft.agents.shared import AgentRunContext
-from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.finding import (
+    STRUCTURED_OUTPUT_REQUIRED_MSG,
+    findings_output_schema,
+    parse_findings_payload,
+    write_findings_json,
+)
 from mergecraft.config import load_repo_settings
+from mergecraft.config.settings import RepoInfo
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.server import start_mcp_http_server
 from mergecraft.mcp.tool_state import init_tool_state
@@ -24,7 +28,7 @@ from mergecraft.modes import compute_modes
 from mergecraft.review_checks import StaticCheckConfig
 from mergecraft.utils.agent_resolve import resolve_model, resolve_runtime_agent
 from mergecraft.utils.github import GitHubClient
-from mergecraft.utils.instructions import ResolvedInstructions
+from mergecraft.utils.instructions import resolve_instructions
 from mergecraft.utils.offline_diff import DiffMaterialization, materialize_diff, summarize_diff
 from mergecraft.utils.skills import install_bundled_skills
 
@@ -37,20 +41,6 @@ class OfflineReviewResult:
     diff_path: str | None = None
     empty_diff: bool = False
     structured_output: str | None = None
-
-
-def findings_output_schema() -> dict[str, Any]:
-    """JSON Schema for structured findings output derived from ``Finding``."""
-    return {
-        "type": "object",
-        "properties": {
-            "findings": {
-                "type": "array",
-                "items": Finding.model_json_schema(),
-            }
-        },
-        "required": ["findings"],
-    }
 
 
 def build_offline_review_prompt(
@@ -102,34 +92,41 @@ def build_offline_review_prompt(
     )
 
 
-def _parse_and_validate_findings(raw: str) -> list[dict[str, Any]]:
-    """Parse structured output JSON and validate each finding."""
+def _finalize_structured_findings(
+    result: OfflineReviewResult,
+    json_path: Path,
+) -> OfflineReviewResult:
+    """Validate agent structured output and write findings JSON."""
+    if not result.success:
+        return result
+
+    structured_raw = result.structured_output
+    if not structured_raw:
+        return OfflineReviewResult(
+            success=False,
+            error=STRUCTURED_OUTPUT_REQUIRED_MSG,
+            diff_path=result.diff_path,
+        )
+
     try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        msg = f"invalid JSON in set_output: {exc}"
-        raise ValueError(msg) from exc
-    if not isinstance(data, dict):
-        msg = "set_output must be a JSON object with a findings array"
-        raise ValueError(msg)
-    findings_raw = data.get("findings")
-    if not isinstance(findings_raw, list):
-        msg = "set_output must contain a findings array"
-        raise ValueError(msg)
-    validated: list[dict[str, Any]] = []
-    for index, item in enumerate(findings_raw):
-        try:
-            validated.append(Finding.model_validate(item).model_dump())
-        except ValidationError as exc:
-            msg = f"finding[{index}] does not conform to Finding schema: {exc}"
-            raise ValueError(msg) from exc
-    return validated
+        findings = parse_findings_payload(structured_raw)
+    except ValueError as exc:
+        return OfflineReviewResult(
+            success=False,
+            error=str(exc),
+            diff_path=result.diff_path,
+        )
 
+    try:
+        write_findings_json(json_path, findings)
+    except OSError as exc:
+        return OfflineReviewResult(
+            success=False,
+            error=f"failed to write findings JSON: {exc}",
+            diff_path=result.diff_path,
+        )
 
-def _write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None:
-    json_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps({"findings": findings}, indent=2, ensure_ascii=False)
-    json_path.write_text(f"{payload}\n", encoding="utf-8")
+    return result
 
 
 async def run_offline_diff_review(
@@ -157,6 +154,14 @@ async def run_offline_diff_review(
         return OfflineReviewResult(success=False, error=str(exc))
 
     if materialization.empty:
+        if json_path is not None:
+            try:
+                write_findings_json(json_path, [])
+            except OSError as exc:
+                return OfflineReviewResult(
+                    success=False,
+                    error=f"failed to write findings JSON: {exc}",
+                )
         return OfflineReviewResult(
             success=True,
             output="no changes to review (empty diff).",
@@ -164,12 +169,12 @@ async def run_offline_diff_review(
             empty_diff=True,
         )
 
-    json_mode = json_path is not None
+    output_schema = findings_output_schema() if json_path is not None else None
     prompt = build_offline_review_prompt(
         diff_path=materialization.path,
         base_ref=materialization.base_ref,
         extra=prompt_extra,
-        json_mode=json_mode,
+        json_mode=output_schema is not None,
     )
 
     if dry_run:
@@ -186,41 +191,12 @@ async def run_offline_diff_review(
         prompt=prompt,
         model=model,
         tmpdir=out_dir,
-        json_mode=json_mode,
+        output_schema=output_schema,
     )
-    if not result.success or json_path is None:
+    if json_path is None:
         return result
 
-    structured_raw = result.structured_output or result.output
-    if not structured_raw:
-        return OfflineReviewResult(
-            success=False,
-            error=(
-                "output_schema was provided but agent did not call set_output — "
-                "structured output is required"
-            ),
-            diff_path=result.diff_path,
-        )
-
-    try:
-        findings = _parse_and_validate_findings(structured_raw)
-    except ValueError as exc:
-        return OfflineReviewResult(
-            success=False,
-            error=str(exc),
-            diff_path=result.diff_path,
-        )
-
-    try:
-        _write_findings_json(json_path, findings)
-    except OSError as exc:
-        return OfflineReviewResult(
-            success=False,
-            error=f"failed to write findings JSON: {exc}",
-            diff_path=result.diff_path,
-        )
-
-    return result
+    return _finalize_structured_findings(result, json_path)
 
 
 async def _run_agent_review(
@@ -230,7 +206,7 @@ async def _run_agent_review(
     prompt: str,
     model: str | None,
     tmpdir: Path,
-    json_mode: bool = False,
+    output_schema: dict[str, Any] | None = None,
 ) -> OfflineReviewResult:
     stop_mcp = None
     github: GitHubClient | None = None
@@ -284,17 +260,23 @@ async def _run_agent_review(
             analyzers_settings_enabled=settings.analyzers.enabled,
         )
 
-        output_schema = findings_output_schema() if json_mode else None
         mcp_url, stop_mcp = start_mcp_http_server(tool_context, output_schema=output_schema)
         tool_context.mcp_server_url = mcp_url
         skills_home = str(tmpdir / "home")
         Path(skills_home).mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(install_bundled_skills, home=skills_home)
 
-        instructions = ResolvedInstructions(
-            full=prompt,
-            system="Offline mergecraft diff-review. Read-only. Do not post GitHub reviews or push.",
-            user=prompt,
+        instructions = resolve_instructions(
+            payload={
+                "event": {"trigger": "unknown", "title": "offline diff-review"},
+                "shell": "disabled",
+                "push": "disabled",
+                "prompt": prompt,
+            },
+            repo=RepoInfo(owner="local", name=cwd.name),
+            modes=modes,
+            agent_id=agent.name,
+            output_schema=output_schema,
         )
         run_ctx = AgentRunContext(
             payload=payload,
@@ -312,32 +294,18 @@ async def _run_agent_review(
         result = await agent.run(run_ctx)
         structured_output = tool_state.output
         markdown_output = result.output
-        if json_mode and not structured_output:
-            return OfflineReviewResult(
-                success=False,
-                error=(
-                    "output_schema was provided but agent did not call set_output — "
-                    "structured output is required"
-                ),
-                diff_path=str(materialization.path),
-            )
         if not result.success:
             return OfflineReviewResult(
                 success=False,
-                output=markdown_output or structured_output,
-                error=result.error or "agent failed",
-                diff_path=str(materialization.path),
-            )
-        if json_mode:
-            return OfflineReviewResult(
-                success=True,
                 output=markdown_output,
                 structured_output=structured_output,
+                error=result.error or "agent failed",
                 diff_path=str(materialization.path),
             )
         return OfflineReviewResult(
             success=True,
-            output=markdown_output or structured_output,
+            output=markdown_output,
+            structured_output=structured_output,
             diff_path=str(materialization.path),
         )
     except Exception as exc:

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import tempfile
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+from pydantic import ValidationError
 
 from mergecraft.agents.gates import subagent_denied_tool_names
 from mergecraft.agents.shared import AgentRunContext
@@ -34,6 +36,7 @@ class OfflineReviewResult:
     error: str | None = None
     diff_path: str | None = None
     empty_diff: bool = False
+    structured_output: str | None = None
 
 
 def findings_output_schema() -> dict[str, Any]:
@@ -55,6 +58,7 @@ def build_offline_review_prompt(
     diff_path: Path,
     base_ref: str | None,
     extra: str | None = None,
+    json_mode: bool = False,
 ) -> str:
     """Build the user prompt for an offline Review-mode run."""
     summary = summarize_diff(diff_path.read_text(encoding="utf-8"))
@@ -62,6 +66,20 @@ def build_offline_review_prompt(
     extra_block = (
         f"\n## Additional instructions\n\n{extra.strip()}\n" if extra and extra.strip() else ""
     )
+    if json_mode:
+        step_four = (
+            "4. Call `set_output` with structured findings — **required**. Each item must "
+            "conform to the schema exposed by the set_output tool. You may also put a "
+            "complete markdown review in your final response (preamble + cross-cutting "
+            "sections + optional nitpicks).\n"
+        )
+    else:
+        step_four = (
+            "4. Produce a complete review body using the Review mode format "
+            "(preamble + cross-cutting sections + optional nitpicks). "
+            "Put the full markdown review in your final response and, if available, "
+            "`set_output` with key `review`.\n"
+        )
     return (
         "You are running an **offline** local diff review (mergecraft diff-review).\n"
         "There is no GitHub pull request. Do **not** call `checkout_pr`, "
@@ -75,16 +93,43 @@ def build_offline_review_prompt(
         "   When `run_analyzers` is available, call it with the diff's changed paths and "
         f"`diff_path: {diff_path}` before drafting findings; use `analyzer_findings` for "
         "placement and dispatch `mergecraft-verifier` for Critical/Major analyzer hits.\n"
-        "4. Produce a complete review body using the Review mode format "
-        "(preamble + cross-cutting sections + optional nitpicks). "
-        "Put the full markdown review in your final response and, if available, "
-        "`set_output` with key `review`.\n"
+        f"{step_four}"
         "5. Do not modify files, commit, or push.\n\n"
         f"{base_line}"
         f"Diff path: `{diff_path}`\n\n"
         f"## Diff summary\n\n{summary}\n"
         f"{extra_block}"
     )
+
+
+def _parse_and_validate_findings(raw: str) -> list[dict[str, Any]]:
+    """Parse structured output JSON and validate each finding."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"invalid JSON in set_output: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(data, dict):
+        msg = "set_output must be a JSON object with a findings array"
+        raise ValueError(msg)
+    findings_raw = data.get("findings")
+    if not isinstance(findings_raw, list):
+        msg = "set_output must contain a findings array"
+        raise ValueError(msg)
+    validated: list[dict[str, Any]] = []
+    for index, item in enumerate(findings_raw):
+        try:
+            validated.append(Finding.model_validate(item).model_dump())
+        except ValidationError as exc:
+            msg = f"finding[{index}] does not conform to Finding schema: {exc}"
+            raise ValueError(msg) from exc
+    return validated
+
+
+def _write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"findings": findings}, indent=2, ensure_ascii=False)
+    json_path.write_text(f"{payload}\n", encoding="utf-8")
 
 
 async def run_offline_diff_review(
@@ -95,6 +140,7 @@ async def run_offline_diff_review(
     model: str | None = None,
     prompt_extra: str | None = None,
     dry_run: bool = False,
+    json_path: Path | None = None,
 ) -> OfflineReviewResult:
     """Materialize a local diff and optionally run the Review agent against it."""
     cwd = cwd.resolve()
@@ -118,10 +164,12 @@ async def run_offline_diff_review(
             empty_diff=True,
         )
 
+    json_mode = json_path is not None
     prompt = build_offline_review_prompt(
         diff_path=materialization.path,
         base_ref=materialization.base_ref,
         extra=prompt_extra,
+        json_mode=json_mode,
     )
 
     if dry_run:
@@ -132,13 +180,47 @@ async def run_offline_diff_review(
             empty_diff=False,
         )
 
-    return await _run_agent_review(
+    result = await _run_agent_review(
         cwd=cwd,
         materialization=materialization,
         prompt=prompt,
         model=model,
         tmpdir=out_dir,
+        json_mode=json_mode,
     )
+    if not result.success or json_path is None:
+        return result
+
+    structured_raw = result.structured_output or result.output
+    if not structured_raw:
+        return OfflineReviewResult(
+            success=False,
+            error=(
+                "output_schema was provided but agent did not call set_output — "
+                "structured output is required"
+            ),
+            diff_path=result.diff_path,
+        )
+
+    try:
+        findings = _parse_and_validate_findings(structured_raw)
+    except ValueError as exc:
+        return OfflineReviewResult(
+            success=False,
+            error=str(exc),
+            diff_path=result.diff_path,
+        )
+
+    try:
+        _write_findings_json(json_path, findings)
+    except OSError as exc:
+        return OfflineReviewResult(
+            success=False,
+            error=f"failed to write findings JSON: {exc}",
+            diff_path=result.diff_path,
+        )
+
+    return result
 
 
 async def _run_agent_review(
@@ -148,6 +230,7 @@ async def _run_agent_review(
     prompt: str,
     model: str | None,
     tmpdir: Path,
+    json_mode: bool = False,
 ) -> OfflineReviewResult:
     stop_mcp = None
     github: GitHubClient | None = None
@@ -201,7 +284,8 @@ async def _run_agent_review(
             analyzers_settings_enabled=settings.analyzers.enabled,
         )
 
-        mcp_url, stop_mcp = start_mcp_http_server(tool_context)
+        output_schema = findings_output_schema() if json_mode else None
+        mcp_url, stop_mcp = start_mcp_http_server(tool_context, output_schema=output_schema)
         tool_context.mcp_server_url = mcp_url
         skills_home = str(tmpdir / "home")
         Path(skills_home).mkdir(parents=True, exist_ok=True)
@@ -216,7 +300,7 @@ async def _run_agent_review(
             payload=payload,
             mcp_server_url=mcp_url,
             tmpdir=str(tmpdir),
-            subagent_denied_tools=subagent_denied_tool_names(tool_context),
+            subagent_denied_tools=subagent_denied_tool_names(tool_context, output_schema),
             instructions=instructions,
             tool_state=tool_state,
             api_token="",
@@ -226,17 +310,34 @@ async def _run_agent_review(
         logger.info("» offline diff-review via agent={}", agent.name)
         await agent.install()
         result = await agent.run(run_ctx)
-        output = result.output or tool_state.output
+        structured_output = tool_state.output
+        markdown_output = result.output
+        if json_mode and not structured_output:
+            return OfflineReviewResult(
+                success=False,
+                error=(
+                    "output_schema was provided but agent did not call set_output — "
+                    "structured output is required"
+                ),
+                diff_path=str(materialization.path),
+            )
         if not result.success:
             return OfflineReviewResult(
                 success=False,
-                output=output,
+                output=markdown_output or structured_output,
                 error=result.error or "agent failed",
+                diff_path=str(materialization.path),
+            )
+        if json_mode:
+            return OfflineReviewResult(
+                success=True,
+                output=markdown_output,
+                structured_output=structured_output,
                 diff_path=str(materialization.path),
             )
         return OfflineReviewResult(
             success=True,
-            output=output,
+            output=markdown_output or structured_output,
             diff_path=str(materialization.path),
         )
     except Exception as exc:

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -7,11 +7,13 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
 
 from mergecraft.agents.gates import subagent_denied_tool_names
 from mergecraft.agents.shared import AgentRunContext
+from mergecraft.analyzers.finding import Finding
 from mergecraft.config import load_repo_settings
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.server import start_mcp_http_server
@@ -32,6 +34,20 @@ class OfflineReviewResult:
     error: str | None = None
     diff_path: str | None = None
     empty_diff: bool = False
+
+
+def findings_output_schema() -> dict[str, Any]:
+    """JSON Schema for structured findings output derived from ``Finding``."""
+    return {
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": Finding.model_json_schema(),
+            }
+        },
+        "required": ["findings"],
+    }
 
 
 def build_offline_review_prompt(

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -100,7 +100,6 @@ def test_findings_output_schema_is_valid_json_schema() -> None:
     assert schema.get("required") == ["findings"]
 
 
-@pytest.mark.xfail(reason="green after W3: json_mode prompt requirement", strict=False)
 def test_build_offline_review_prompt_requires_set_output_when_json_mode(
     tmp_path: Path,
 ) -> None:
@@ -119,7 +118,6 @@ def test_build_offline_review_prompt_requires_set_output_when_json_mode(
     assert "if available" not in step_four
 
 
-@pytest.mark.xfail(reason="green after W3: --json dry-run wiring", strict=False)
 def test_cli_diff_review_json_dry_run_does_not_write_file(tmp_path: Path) -> None:
     patch = tmp_path / "change.diff"
     patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
@@ -178,7 +176,6 @@ def _install_fake_agent_review(
     ],
     ids=["valid_finding", "invalid_finding"],
 )
-@pytest.mark.xfail(reason="green after W3: --json validation wiring", strict=False)
 def test_cli_diff_review_json_validates_findings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -221,7 +218,6 @@ def test_cli_diff_review_json_validates_findings(
         ), combined
 
 
-@pytest.mark.xfail(reason="green after W3: --json in help", strict=False)
 def test_cli_diff_review_help_lists_json() -> None:
     result = runner.invoke(app, ["diff-review", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
     assert result.exit_code == 0

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -4,40 +4,18 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import pytest
 from tests.analyzers.support import import_module as import_analyzer_module
 from typer.testing import CliRunner
 
+from mergecraft.analyzers.finding import Finding, findings_output_schema
 from mergecraft.cli.app import app
 from mergecraft.offline_review import OfflineReviewResult, build_offline_review_prompt
 
 runner = CliRunner()
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
-
-_FINDING_FIELDS = frozenset(
-    {
-        "tool",
-        "rule_id",
-        "category",
-        "severity",
-        "confidence",
-        "message",
-        "path",
-        "start_line",
-        "end_line",
-        "fingerprint",
-        "evidence",
-        "remediation",
-        "autofix",
-        "introduced_by_pr",
-        "source",
-        "cluster_id",
-    }
-)
 
 _SAMPLE_PATCH = (
     "diff --git a/demo.py b/demo.py\n--- a/demo.py\n+++ b/demo.py\n@@ -0,0 +1 @@\n+print(1)\n"
@@ -66,14 +44,6 @@ def _sample_finding_dict() -> dict[str, object]:
     return finding.model_dump()
 
 
-def _import_findings_output_schema() -> Callable[[], dict[str, Any]]:
-    try:
-        from mergecraft.offline_review import findings_output_schema
-    except ImportError:
-        from mergecraft.utils.payload import findings_output_schema
-    return findings_output_schema
-
-
 def _step_four_block(prompt: str) -> str:
     match = re.search(r"4\. (.+?)\n5\.", prompt, flags=re.DOTALL)
     assert match is not None, "expected numbered step 4 in offline review prompt"
@@ -81,8 +51,7 @@ def _step_four_block(prompt: str) -> str:
 
 
 def test_findings_output_schema_is_valid_json_schema() -> None:
-    schema_fn = _import_findings_output_schema()
-    schema = schema_fn()
+    schema = findings_output_schema()
 
     assert schema.get("type") == "object"
     properties = schema.get("properties")
@@ -96,8 +65,12 @@ def test_findings_output_schema_is_valid_json_schema() -> None:
 
     item_properties = items.get("properties")
     assert isinstance(item_properties, dict)
-    assert frozenset(item_properties) >= _FINDING_FIELDS
+    assert frozenset(item_properties) >= frozenset(Finding.model_json_schema()["properties"])
     assert schema.get("required") == ["findings"]
+
+    severity = item_properties.get("severity")
+    assert isinstance(severity, dict)
+    assert "enum" in severity
 
 
 def test_build_offline_review_prompt_requires_set_output_when_json_mode(
@@ -142,6 +115,33 @@ def test_cli_diff_review_json_dry_run_does_not_write_file(tmp_path: Path) -> Non
     assert not json_out.exists()
 
 
+def test_cli_diff_review_json_empty_diff_writes_empty_findings(tmp_path: Path) -> None:
+    patch = tmp_path / "empty.diff"
+    patch.write_text("\n", encoding="utf-8")
+    json_out = tmp_path / "findings.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "diff-review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+            "--json",
+            str(json_out),
+        ],
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 0, combined
+    assert json_out.is_file(), combined
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload == {"findings": []}
+    assert "wrote" in combined.lower()
+
+
 def _install_fake_agent_review(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -161,7 +161,8 @@ def _install_fake_agent_review(
             )
         return OfflineReviewResult(
             success=True,
-            output=payload,
+            output="# Review\n\nLooks good.",
+            structured_output=payload,
             diff_path=str(materialization.path),
         )
 

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -80,7 +80,6 @@ def _step_four_block(prompt: str) -> str:
     return match.group(1)
 
 
-@pytest.mark.xfail(reason="green after W2: findings_output_schema helper", strict=False)
 def test_findings_output_schema_is_valid_json_schema() -> None:
     schema_fn = _import_findings_output_schema()
     schema = schema_fn()

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -1,0 +1,229 @@
+"""RED tests for ``mergecraft diff-review --json`` structured findings (issue #30, Batch A W1)."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.analyzers.support import import_module as import_analyzer_module
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.offline_review import OfflineReviewResult, build_offline_review_prompt
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+_FINDING_FIELDS = frozenset(
+    {
+        "tool",
+        "rule_id",
+        "category",
+        "severity",
+        "confidence",
+        "message",
+        "path",
+        "start_line",
+        "end_line",
+        "fingerprint",
+        "evidence",
+        "remediation",
+        "autofix",
+        "introduced_by_pr",
+        "source",
+        "cluster_id",
+    }
+)
+
+_SAMPLE_PATCH = (
+    "diff --git a/demo.py b/demo.py\n--- a/demo.py\n+++ b/demo.py\n@@ -0,0 +1 @@\n+print(1)\n"
+)
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _sample_finding_dict() -> dict[str, object]:
+    finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import",
+        path="demo.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        introduced_by_pr="unknown",
+    )
+    return finding.model_dump()
+
+
+def _import_findings_output_schema() -> Callable[[], dict[str, Any]]:
+    try:
+        from mergecraft.offline_review import findings_output_schema
+    except ImportError:
+        from mergecraft.utils.payload import findings_output_schema
+    return findings_output_schema
+
+
+def _step_four_block(prompt: str) -> str:
+    match = re.search(r"4\. (.+?)\n5\.", prompt, flags=re.DOTALL)
+    assert match is not None, "expected numbered step 4 in offline review prompt"
+    return match.group(1)
+
+
+@pytest.mark.xfail(reason="green after W2: findings_output_schema helper", strict=False)
+def test_findings_output_schema_is_valid_json_schema() -> None:
+    schema_fn = _import_findings_output_schema()
+    schema = schema_fn()
+
+    assert schema.get("type") == "object"
+    properties = schema.get("properties")
+    assert isinstance(properties, dict)
+    assert "findings" in properties
+
+    findings_prop = properties["findings"]
+    assert findings_prop.get("type") == "array"
+    items = findings_prop.get("items")
+    assert isinstance(items, dict)
+
+    item_properties = items.get("properties")
+    assert isinstance(item_properties, dict)
+    assert frozenset(item_properties) >= _FINDING_FIELDS
+    assert schema.get("required") == ["findings"]
+
+
+@pytest.mark.xfail(reason="green after W3: json_mode prompt requirement", strict=False)
+def test_build_offline_review_prompt_requires_set_output_when_json_mode(
+    tmp_path: Path,
+) -> None:
+    diff_path = tmp_path / "review.diff"
+    diff_path.write_text("diff --git a/x b/x\n+1\n", encoding="utf-8")
+
+    prompt = build_offline_review_prompt(
+        diff_path=diff_path,
+        base_ref="origin/main",
+        json_mode=True,
+    )
+    step_four = _step_four_block(prompt).lower()
+
+    assert "set_output" in step_four
+    assert "required" in step_four
+    assert "if available" not in step_four
+
+
+@pytest.mark.xfail(reason="green after W3: --json dry-run wiring", strict=False)
+def test_cli_diff_review_json_dry_run_does_not_write_file(tmp_path: Path) -> None:
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    json_out = tmp_path / "structured.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "diff-review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+            "--dry-run",
+            "--json",
+            str(json_out),
+        ],
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert not json_out.exists()
+
+
+def _install_fake_agent_review(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    findings: list[dict[str, object]],
+    success: bool = True,
+) -> None:
+    import mergecraft.offline_review as offline_mod
+
+    async def fake_run_agent_review(**kwargs: object) -> OfflineReviewResult:
+        materialization = kwargs["materialization"]
+        payload = json.dumps({"findings": findings})
+        if not success:
+            return OfflineReviewResult(
+                success=False,
+                error="agent failed",
+                diff_path=str(materialization.path),
+            )
+        return OfflineReviewResult(
+            success=True,
+            output=payload,
+            diff_path=str(materialization.path),
+        )
+
+    monkeypatch.setattr(offline_mod, "_run_agent_review", fake_run_agent_review)
+
+
+@pytest.mark.parametrize(
+    ("findings", "expect_ok"),
+    [
+        ([_sample_finding_dict()], True),
+        ([{"tool": "broken", "severity": "NotReal"}], False),
+    ],
+    ids=["valid_finding", "invalid_finding"],
+)
+@pytest.mark.xfail(reason="green after W3: --json validation wiring", strict=False)
+def test_cli_diff_review_json_validates_findings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    findings: list[dict[str, object]],
+    expect_ok: bool,
+) -> None:
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    json_out = tmp_path / "findings.json"
+    _install_fake_agent_review(monkeypatch, findings=findings)
+
+    result = runner.invoke(
+        app,
+        [
+            "diff-review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+            "--json",
+            str(json_out),
+        ],
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+
+    combined = _plain(result.stdout + result.stderr)
+    if expect_ok:
+        assert result.exit_code == 0, combined
+        assert json_out.is_file(), combined
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert isinstance(payload.get("findings"), list)
+        finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
+        for item in payload["findings"]:
+            finding_mod.Finding.model_validate(item)
+    else:
+        assert result.exit_code != 0, combined
+        assert not json_out.exists(), combined
+        assert any(
+            token in combined.lower() for token in ("valid", "finding", "validation", "conform")
+        ), combined
+
+
+@pytest.mark.xfail(reason="green after W3: --json in help", strict=False)
+def test_cli_diff_review_help_lists_json() -> None:
+    result = runner.invoke(app, ["diff-review", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
+    assert result.exit_code == 0
+    assert "--json" in _plain(result.stdout)


### PR DESCRIPTION
## Summary

Batch A of #30 (ReviewBench eval infrastructure): adds `--json PATH` to `mergecraft diff-review` for machine-readable structured findings output.

- **`--json` flag** — writes validated `Finding[]` JSON to the given path; markdown default unchanged
- **Schema derived from `Finding`** — `findings_output_schema()` built via Pydantic (`Finding.model_json_schema()`), not hand-written
- **Enforcement** — when `--json` is set, MCP `output_schema` is registered, prompt requires `set_output`, and missing structured output fails like the Action path
- **`--dry-run` safe** — no agent invocation, no JSON file written
- **Tests** — RED→GREEN suite in `tests/cli/test_diff_review_json.py` (6 cases)
- **Docs** — README CLI table + example; CHANGELOG `## [Unreleased]` entry

Thermos clean above `low`; `make ci` green (576 passed).

Partially addresses #30. Harbor agent skeleton (`mergecraft[harbor]`), `make bench-review`, and full verifier/scoring remain in Batch B and blocked on [tripll#64](https://github.com/sevn-bot/tripll/issues/64) for the frozen task corpus.

## Test plan

- [x] `make ci` — all 9 steps passed (576 tests)
- [x] Thermos review + code-quality subagents — clean above `low`
- [x] `tests/cli/test_diff_review_json.py` — 6/6 green

## Related issues

Partially closes #30

Depends on: none (base `pre-0.0.1`)

Follow-up: Batch B (`wave/issue-30-harbor`) — Harbor agent + `make bench-review` stub; corpus in tripll#64
