### PR TITLE
fix(agents): stop Codex from requesting a GitHub plugin for checkout_pr

### DIFF
--- a/docs/artifacts/dogfood-mergecraft.yml
+++ b/docs/artifacts/dogfood-mergecraft.yml
@@ -254,7 +254,7 @@ jobs:
           if [ "${EVENT_NAME}" != "pull_request_target" ]; then
             text="${DISPATCH_PROMPT:-Review the current pull request.}"
           else
-            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
             # The action runs with `shell: disabled`, so the reviewer cannot run
             # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
             # check_suite id, because no MCP tool can discover one.
@@ -262,7 +262,7 @@ jobs:
               complete)
                 if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
                   if [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call mergecraft_get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
                   else
                     text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
                   fi

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -252,7 +252,7 @@ jobs:
           if [ "${EVENT_NAME}" != "pull_request_target" ]; then
             text="${DISPATCH_PROMPT:-Review the current pull request.}"
           else
-            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
             # The action runs with `shell: disabled`, so the reviewer cannot run
             # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
             # check_suite id, because no MCP tool can discover one.
@@ -260,7 +260,7 @@ jobs:
               complete)
                 if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
                   if [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call mergecraft_get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
                   else
                     text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
                   fi

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -252,7 +252,7 @@ jobs:
           if [ "${EVENT_NAME}" != "pull_request_target" ]; then
             text="${DISPATCH_PROMPT:-Review the current pull request.}"
           else
-            text="Review pull request #${PR_NUMBER}. Call checkout_pr first. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
             # The action runs with `shell: disabled`, so the reviewer cannot run
             # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
             # check_suite id, because no MCP tool can discover one.
@@ -260,7 +260,7 @@ jobs:
               complete)
                 if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null; then
                   if [ -n "${CI_CHECK_SUITE_ID}" ]; then
-                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                    text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call mergecraft_get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
                   else
                     text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). get_check_suite_logs is unavailable (check_suite id unknown); still treat these mechanical failures as blocking and note the limitation."
                   fi

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -125,6 +125,30 @@ def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
 
 
+def _codex_mcp_tool_preamble() -> str:
+    """Steer Codex away from the interactive GitHub *plugin* install path.
+
+    Codex 0.14x treats a bare ``checkout_pr`` mention as a request for the
+    optional GitHub plugin. That plugin is not installed in the Action image,
+    so the agent aborts and mergeCraft posts ``mergecraft-approval: neutral``
+    (issue #40). Tools already live on the localhost ``mergecraft`` MCP server
+    and are presented as ``mergecraft_<tool>``.
+    """
+    return (
+        "## mergeCraft MCP tools (Codex)\n\n"
+        "GitHub/PR operations use the localhost **mergecraft** MCP server "
+        f"(config key `[mcp_servers.{MERGECRAFT_MCP_NAME}]`). Tool names are "
+        f"prefixed: e.g. `{MERGECRAFT_MCP_NAME}_checkout_pr`, "
+        f"`{MERGECRAFT_MCP_NAME}_create_pull_request_review`, "
+        f"`{MERGECRAFT_MCP_NAME}_get_check_suite_logs`.\n\n"
+        "Do **not** install, request, enable, or wait for any GitHub plugin / "
+        "GitHub integration — those are unrelated to mergeCraft and will never "
+        "become available in this non-interactive CI session. If a user prompt "
+        "says bare `checkout_pr`, call "
+        f"`{MERGECRAFT_MCP_NAME}_checkout_pr` instead."
+    )
+
+
 def _build_subagent_instructions() -> str:
     return "\n\n".join(
         [
@@ -197,6 +221,8 @@ def write_mcp_config(ctx: AgentRunContext) -> str:
     codex_home = _codex_home(ctx)
     codex_home.mkdir(parents=True, exist_ok=True)
     instructions_parts: list[str] = []
+    if ctx.mcp_server_url:
+        instructions_parts.append(_codex_mcp_tool_preamble())
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
     instructions_parts.append(_build_subagent_instructions())

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -99,6 +99,22 @@ def test_write_mcp_config_uses_permission_profiles_for_read_only_mcp(tmp_path: P
     assert "[sandbox_read_only]" not in text
     assert "[mcp_servers.mergecraft]" in text
 
+    instructions = (tmp_path / ".codex" / "mergecraft-instructions.md").read_text(encoding="utf-8")
+    assert "Do **not** install, request, enable, or wait for any GitHub plugin" in instructions
+    assert "mergecraft_checkout_pr" in instructions
+
+
+def test_write_mcp_config_omits_github_plugin_preamble_without_mcp_url(tmp_path: Path) -> None:
+    codex_module = _load_codex_module()
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+    ctx.mcp_server_url = ""
+    ctx.payload.shell = "disabled"
+
+    codex_module.write_mcp_config(ctx)
+    instructions = (tmp_path / ".codex" / "mergecraft-instructions.md").read_text(encoding="utf-8")
+    assert "GitHub plugin" not in instructions
+    assert "mergecraft_checkout_pr" not in instructions
+
 
 def test_write_mcp_config_omits_permission_profiles_without_mcp_url(tmp_path: Path) -> None:
     codex_module = _load_codex_module()


### PR DESCRIPTION
## Summary
- Fixes [#40](https://github.com/alexhawat/mergeCraft/issues/40): Codex aborts PR reviews requesting a GitHub plugin when prompts say bare `checkout_pr`.
- Inject a Codex instructions preamble: use `mergecraft_*` MCP tools; never install/wait for a GitHub plugin.
- Align example/dogfood workflow prompts with the same naming.

## Test plan
- [x] `uv run pytest tests/agents/test_codex.py` (6 passed)
- [ ] After merge, bump `alexhawat/mergeCraft@…` pin in consumer workflows (e.g. sevn-bot/sevn `main`) for defense-in-depth; sevn prompt-only fix can land independently

Closes #40


Made with [Cursor](https://cursor.com)