### PR TITLE
fix(codex): pre-approve mergecraft MCP tools so CI reviews can call them

### DIFF
--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -187,6 +187,16 @@ def _append_mcp_server_lines(lines: list[str], ctx: AgentRunContext) -> None:
             "",
             f"[mcp_servers.{MERGECRAFT_MCP_NAME}]",
             f"url = {_toml_string(ctx.mcp_server_url)}",
+            # Without this, every tool call is auto-cancelled in CI. Codex
+            # auto-approves an MCP call only when the permission profile grants
+            # full disk write access (codex_mcp::mcp_permission_prompt_is_auto_approved),
+            # and the read-only review profile does not. `approval_policy =
+            # "never"` then means the elicitation is never answered, so the call
+            # resolves to "user cancelled MCP tool call" — with no interactive
+            # user anywhere in the pipeline. The server is ours and the action
+            # already runs with push/shell disabled, so approving its tools up
+            # front is the intended posture.
+            'default_tools_approval_mode = "approve"',
         ]
     )
     if disabled_tools:

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -131,6 +131,26 @@ def test_write_mcp_config_omits_permission_profiles_without_mcp_url(tmp_path: Pa
     assert "[mcp_servers.mergecraft]" not in text
 
 
+def test_write_mcp_config_auto_approves_mergecraft_tools(tmp_path: Path) -> None:
+    """Read-only reviews must not need an approver for their own MCP tools.
+
+    Codex only auto-approves an MCP tool call when the permission profile grants
+    full disk write access, which the review profile deliberately does not. With
+    ``approval_policy = "never"`` and nobody to answer the elicitation, every
+    call resolves to "user cancelled MCP tool call" unless the server declares
+    its tools pre-approved.
+    """
+    codex_module = _load_codex_module()
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+    ctx.payload.shell = "disabled"
+
+    config_path = Path(codex_module.write_mcp_config(ctx))
+    text = config_path.read_text(encoding="utf-8")
+
+    server_block = text.split("[mcp_servers.mergecraft]", 1)[1]
+    assert 'default_tools_approval_mode = "approve"' in server_block
+
+
 def test_write_mcp_config_enables_network_in_workspace_write_sandbox(tmp_path: Path) -> None:
     codex_module = _load_codex_module()
     ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")


### PR DESCRIPTION
## Summary

Every Codex MCP tool call in CI resolves to `user cancelled MCP tool call`, so reviews finish with no verdict and post `mergecraft-approval=neutral`. #78 made the MCP server reachable; this is the next gate on the same path.

Codex auto-approves an MCP tool call only when both conditions hold (`codex_mcp::mcp_permission_prompt_is_auto_approved`): `approval_policy` is `Never`, AND the permission profile is `Disabled`/`External`, or a `Managed` profile whose file system has full disk write access.

Read-only PR reviews use the `mergecraft-review` managed profile (`extends = ":read-only"`), which by design has no full disk write access. So the call falls through to an approval elicitation — and with `approval_policy = "never"` nothing ever answers it, so the decision resolves to `Cancel`. The pipeline has no interactive user by construction, so this is unanswerable, not merely unanswered.

The fix declares the server's tools pre-approved, which short-circuits the check at its first branch (`tool_approval_mode == Some(Approve)`).

## Why this is not a capability widening

The MCP server is mergeCraft's own, spawned by the action, and the action already runs with `push: disabled` and `shell: disabled`. Nothing new becomes reachable — the elicitation was only ever a prompt with no one to answer it. The sandbox and network posture are untouched.

## Test plan

- [x] `tests/agents/test_codex.py::test_write_mcp_config_auto_approves_mergecraft_tools`
- [x] `uv run pytest tests/agents` — 38 passed
- [x] `make lint`, `make typecheck` (150 source files, no issues)
- [x] End-to-end against the real Codex 0.146 CLI and the real mergeCraft MCP app. Config generated by `write_mcp_config()`, model served by a stub Responses provider that forces one `checkout_pr` call:
  - with this change: `"status":"completed"`, tool executes (`checked out`), server logs the `tools/call` POST
  - without it (same config, this key removed): `user cancelled MCP tool call`, `"status":"failed"` — the CI failure reproduced verbatim

## Follow-up

sevn's workflow pin needs bumping to the merge SHA before its Codex reviews pass.

Refs #40.
