### PR TITLE
fix(codex): stop hiding mutating MCP tools from the main reviewer

### DIFF
--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -43,11 +43,6 @@ def _toml_string(value: str) -> str:
     return f'"{escaped}"'
 
 
-def _toml_string_list(values: list[str]) -> str:
-    inner = ", ".join(_toml_string(item) for item in values)
-    return f"[{inner}]"
-
-
 def _extract_refresh_token(auth_json: str) -> str | None:
     try:
         data = json.loads(auth_json)
@@ -181,7 +176,6 @@ def _codex_use_permission_profiles(ctx: AgentRunContext) -> bool:
 
 
 def _append_mcp_server_lines(lines: list[str], ctx: AgentRunContext) -> None:
-    disabled_tools = [str(name) for name in ctx.subagent_denied_tools]
     lines.extend(
         [
             "",
@@ -199,8 +193,14 @@ def _append_mcp_server_lines(lines: list[str], ctx: AgentRunContext) -> None:
             'default_tools_approval_mode = "approve"',
         ]
     )
-    if disabled_tools:
-        lines.append(f"disabled_tools = {_toml_string_list(disabled_tools)}")
+    # Do NOT put ctx.subagent_denied_tools into ``disabled_tools``. That list is
+    # every mutates=True MCP tool (checkout_pr, create_pull_request_review, …)
+    # and exists to keep *subagents* read-only. Wiring it onto the main session's
+    # MCP server hides those tools from the reviewer itself, so Codex can inspect
+    # a PR but can never check it out or submit a review — mergecraft-approval
+    # stays neutral forever. Subagent read-only posture stays in the instructions
+    # preamble (_build_subagent_instructions); Claude's harness never disabled
+    # these tools for the primary agent either.
 
 
 def _append_read_only_mcp_network_lines(lines: list[str]) -> None:

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -151,6 +151,30 @@ def test_write_mcp_config_auto_approves_mergecraft_tools(tmp_path: Path) -> None
     assert 'default_tools_approval_mode = "approve"' in server_block
 
 
+def test_write_mcp_config_keeps_mutating_tools_for_the_main_session(
+    tmp_path: Path,
+) -> None:
+    """Subagent deny list must not hide checkout/review tools from Codex itself.
+
+    ``subagent_denied_tools`` is every mutates=True MCP tool. Putting that list
+    into Codex's ``disabled_tools`` made the primary reviewer unable to call
+    ``checkout_pr`` or ``create_pull_request_review``, so every review posted
+    ``mergecraft-approval=neutral`` even when Codex wanted to approve.
+    """
+    codex_module = _load_codex_module()
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+    ctx.payload.shell = "disabled"
+    ctx.subagent_denied_tools = ("checkout_pr", "create_pull_request_review", "push_branch")
+
+    config_path = Path(codex_module.write_mcp_config(ctx))
+    text = config_path.read_text(encoding="utf-8")
+
+    server_block = text.split("[mcp_servers.mergecraft]", 1)[1]
+    assert "disabled_tools" not in server_block
+    assert "checkout_pr" not in server_block
+    assert "create_pull_request_review" not in server_block
+
+
 def test_write_mcp_config_enables_network_in_workspace_write_sandbox(tmp_path: Path) -> None:
     codex_module = _load_codex_module()
     ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")


### PR DESCRIPTION
## Summary

The Codex harness was writing `subagent_denied_tools` into the main session's `[mcp_servers.mergecraft].disabled_tools`. That list is every `mutates=True` MCP tool — including `checkout_pr` and `create_pull_request_review` — and exists to keep **subagents** read-only. Applying it to the primary reviewer meant Codex could inspect a PR but could never check it out or submit a review.

Observed on [sevn-bot/sevn#233](https://github.com/sevn-bot/sevn/pull/233) against pin `72a415dc` (post #78/#80): MCP handshake and tool approval both worked, Codex concluded `approved: true`, then reported "checkout/submission endpoints were not exposed" and mergeCraft posted `mergecraft-approval=neutral`. The enforce step fail-closed.

Claude's harness never disabled these tools for the primary agent. Drop the `disabled_tools` wiring; subagent read-only posture stays in the instructions preamble (`_build_subagent_instructions`).

## Test plan

- [x] `tests/agents/test_codex.py::test_write_mcp_config_keeps_mutating_tools_for_the_main_session` — config with a populated deny list must not emit `disabled_tools`
- [x] Existing auto-approve / permission-profile tests still pass (8 total)
- [x] `make lint`, `make typecheck`

## Follow-up

sevn needs another pin bump to this merge SHA before Codex reviews can post a real `mergecraft-approval=success`.
