### PR TITLE
fix(codex): keep CODEX_HOME outside /tmp for PATH aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep mergeCraft run temp / ``CODEX_HOME`` outside ``/tmp`` (prefer
+  ``RUNNER_TEMP`` or ``~/.cache/mergecraft``) so Codex can install PATH-alias
+  helper binaries; Codex 0.14x refuses helpers under world-writable temp and
+  exits non-zero, leaving ``mergecraft-approval`` neutral until a fallback
+  reviewer completes
 - Action `model` input and explicit chain selection no longer lose to
   `MERGECRAFT_MODEL`; missing agent binaries are skipped when walking the chain;
   retryable chain advancement is wired through the Action entrypoint (#14)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -28,14 +28,60 @@ CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
 OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 CODEX_REVIEW_PERMISSION_PROFILE = "mergecraft-review"
 
+# Mirrors mergecraft.utils.git_setup — Codex refuses PATH aliases under these.
+_FORBIDDEN_TEMP_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/usr/tmp")
+
 
 def _strip_provider_prefix(specifier: str) -> str:
     slash = specifier.find("/")
     return specifier[slash + 1 :] if slash > 0 else specifier
 
 
+def _is_under_forbidden_temp(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for root in _FORBIDDEN_TEMP_ROOTS:
+        try:
+            resolved.relative_to(Path(root).resolve())
+        except ValueError, OSError:
+            continue
+        else:
+            return True
+    return False
+
+
+def _safe_codex_home_parent(ctx: AgentRunContext) -> Path:
+    """Parent for ``CODEX_HOME`` that Codex will accept for PATH aliases."""
+    tmp = Path(ctx.tmpdir)
+    if not _is_under_forbidden_temp(tmp):
+        return tmp
+    for key in ("MERGECRAFT_CODEX_HOME_PARENT", "RUNNER_TEMP", "GITHUB_WORKSPACE"):
+        raw = os.environ.get(key, "").strip()
+        if not raw:
+            continue
+        candidate = Path(raw)
+        if _is_under_forbidden_temp(candidate):
+            continue
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        return candidate / tmp.name
+    cache = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "mergecraft"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache / tmp.name
+
+
 def _codex_home(ctx: AgentRunContext) -> Path:
-    return Path(ctx.tmpdir) / ".codex"
+    """Return ``$CODEX_HOME`` for this run.
+
+    Codex 0.14x refuses to install PATH-alias helper binaries when home is under
+    ``/tmp`` (world-writable temp). Prefer the run tmpdir when it is safe;
+    otherwise relocate under ``RUNNER_TEMP`` / workspace / cache.
+    """
+    return _safe_codex_home_parent(ctx) / ".codex"
 
 
 def _toml_string(value: str) -> str:

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -19,11 +19,58 @@ ShellPerm = Literal["disabled", "restricted", "enabled"]
 MERGECRAFT_BOT_EMAIL = "226033991+mergecraft[bot]@users.noreply.github.com"
 MERGECRAFT_BOT_NAME = "mergecraft[bot]"
 
+# Codex refuses PATH-alias helper binaries when CODEX_HOME is under these roots
+# ("Refusing to create helper binaries under temporary dir /tmp"). Keep the
+# mergeCraft run temp (and thus $CODEX_HOME) outside them.
+_FORBIDDEN_TEMP_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/usr/tmp")
+
+
+def _is_under_forbidden_temp(path: Path) -> bool:
+    """Return True when ``path`` resolves under a Codex-forbidden temp root."""
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for root in _FORBIDDEN_TEMP_ROOTS:
+        try:
+            resolved.relative_to(Path(root).resolve())
+        except ValueError, OSError:
+            continue
+        else:
+            return True
+    return False
+
+
+def _safe_temp_parent() -> Path | None:
+    """Prefer a parent Codex accepts for PATH aliases (not world-writable /tmp)."""
+    for key in ("MERGECRAFT_TEMP_PARENT", "RUNNER_TEMP"):
+        raw = os.environ.get(key, "").strip()
+        if not raw:
+            continue
+        candidate = Path(raw)
+        if candidate.is_dir() and not _is_under_forbidden_temp(candidate):
+            return candidate
+    cache = (
+        Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "mergecraft" / "tmp"
+    )
+    try:
+        cache.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    if _is_under_forbidden_temp(cache):
+        return None
+    return cache
+
 
 def create_temp_directory() -> str:
     import tempfile
 
-    shared = tempfile.mkdtemp(prefix="mergecraft-")
+    parent = _safe_temp_parent()
+    shared = (
+        tempfile.mkdtemp(prefix="mergecraft-", dir=str(parent))
+        if parent is not None
+        else tempfile.mkdtemp(prefix="mergecraft-")
+    )
     os.environ["MERGECRAFT_TEMP_DIR"] = shared
     logger.info("» created temp dir at {}", shared)
     return shared

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -99,7 +99,9 @@ def test_write_mcp_config_uses_permission_profiles_for_read_only_mcp(tmp_path: P
     assert "[sandbox_read_only]" not in text
     assert "[mcp_servers.mergecraft]" in text
 
-    instructions = (tmp_path / ".codex" / "mergecraft-instructions.md").read_text(encoding="utf-8")
+    instructions = (codex_module._codex_home(ctx) / "mergecraft-instructions.md").read_text(
+        encoding="utf-8"
+    )
     assert "Do **not** install, request, enable, or wait for any GitHub plugin" in instructions
     assert "mergecraft_checkout_pr" in instructions
 
@@ -111,7 +113,9 @@ def test_write_mcp_config_omits_github_plugin_preamble_without_mcp_url(tmp_path:
     ctx.payload.shell = "disabled"
 
     codex_module.write_mcp_config(ctx)
-    instructions = (tmp_path / ".codex" / "mergecraft-instructions.md").read_text(encoding="utf-8")
+    instructions = (codex_module._codex_home(ctx) / "mergecraft-instructions.md").read_text(
+        encoding="utf-8"
+    )
     assert "GitHub plugin" not in instructions
     assert "mergecraft_checkout_pr" not in instructions
 
@@ -223,3 +227,32 @@ def test_run_codex_once_omits_sandbox_flag_for_permission_profiles(
 
     cmd = captured[0]
     assert "--sandbox" not in cmd
+
+
+def test_codex_home_relocates_off_tmp(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """CODEX_HOME must not sit under /tmp (Codex PATH-alias refusal)."""
+    codex_module = _load_codex_module()
+    forbidden = tmp_path / "fake-tmp" / "mergecraft-run"
+    forbidden.mkdir(parents=True)
+    safe = tmp_path / "runner-temp"
+    safe.mkdir()
+
+    monkeypatch.setattr(
+        codex_module,
+        "_is_under_forbidden_temp",
+        lambda path: (
+            Path(path).resolve() == forbidden.resolve()
+            or str(Path(path).resolve()).startswith(str(forbidden.resolve()))
+        ),
+    )
+    monkeypatch.setenv("RUNNER_TEMP", str(safe))
+    monkeypatch.delenv("MERGECRAFT_CODEX_HOME_PARENT", raising=False)
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+
+    ctx = make_agent_run_context(forbidden, resolved_model="openai/gpt-5.3-codex")
+    home = codex_module._codex_home(ctx)
+    assert str(home).startswith(str(safe))
+    assert home.name == ".codex"

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -58,14 +58,13 @@ def test_create_temp_directory_prefers_runner_temp_over_tmp(
     runner.mkdir()
     monkeypatch.setenv("RUNNER_TEMP", str(runner))
     monkeypatch.delenv("MERGECRAFT_TEMP_PARENT", raising=False)
-    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    # Do not monkeypatch MERGECRAFT_TEMP_DIR: create_temp_directory writes
+    # os.environ directly, and a later setenv undo would re-leak the value.
+    os.environ.pop("MERGECRAFT_TEMP_DIR", None)
 
     try:
         created = create_temp_directory()
-        # create_temp_directory writes os.environ directly; re-bind via
-        # monkeypatch so xdist siblings do not inherit MERGECRAFT_TEMP_DIR.
-        monkeypatch.setenv("MERGECRAFT_TEMP_DIR", created)
         assert created.startswith(str(runner))
         assert not _is_under_forbidden_temp(Path(created))
         assert os.environ["MERGECRAFT_TEMP_DIR"] == created
@@ -87,11 +86,10 @@ def test_create_temp_directory_skips_forbidden_runner_temp(
     monkeypatch.setenv("RUNNER_TEMP", str(runner))
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
     monkeypatch.delenv("MERGECRAFT_TEMP_PARENT", raising=False)
-    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    os.environ.pop("MERGECRAFT_TEMP_DIR", None)
 
     try:
         created = create_temp_directory()
-        monkeypatch.setenv("MERGECRAFT_TEMP_DIR", created)
         assert created.startswith(str(cache_home / "mergecraft" / "tmp"))
         assert not created.startswith(str(runner))
         assert not _is_under_forbidden_temp(Path(created))

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -63,10 +63,14 @@ def test_create_temp_directory_prefers_runner_temp_over_tmp(
 
     try:
         created = create_temp_directory()
+        # create_temp_directory writes os.environ directly; re-bind via
+        # monkeypatch so xdist siblings do not inherit MERGECRAFT_TEMP_DIR.
+        monkeypatch.setenv("MERGECRAFT_TEMP_DIR", created)
         assert created.startswith(str(runner))
         assert not _is_under_forbidden_temp(Path(created))
         assert os.environ["MERGECRAFT_TEMP_DIR"] == created
     finally:
+        os.environ.pop("MERGECRAFT_TEMP_DIR", None)
         shutil.rmtree(staging, ignore_errors=True)
 
 
@@ -87,10 +91,12 @@ def test_create_temp_directory_skips_forbidden_runner_temp(
 
     try:
         created = create_temp_directory()
+        monkeypatch.setenv("MERGECRAFT_TEMP_DIR", created)
         assert created.startswith(str(cache_home / "mergecraft" / "tmp"))
         assert not created.startswith(str(runner))
         assert not _is_under_forbidden_temp(Path(created))
         assert os.environ["MERGECRAFT_TEMP_DIR"] == created
     finally:
+        os.environ.pop("MERGECRAFT_TEMP_DIR", None)
         shutil.rmtree(forbidden_root, ignore_errors=True)
         shutil.rmtree(cache_home, ignore_errors=True)

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from mergecraft.utils.git_setup import write_askpass_script
+from mergecraft.utils.git_setup import (
+    _is_under_forbidden_temp,
+    create_temp_directory,
+    write_askpass_script,
+)
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from _pytest.monkeypatch import MonkeyPatch
 
 
 def test_askpass_returns_x_access_token_for_username(tmp_path: Path) -> None:
@@ -33,3 +39,21 @@ def test_askpass_returns_x_access_token_for_username(tmp_path: Path) -> None:
     # The token must never be emitted for the username prompt (the old bug that
     # produced https://<token>:<token>@ and intermittent "invalid credentials").
     assert "ghs_secrettoken" not in user.stdout
+
+
+def test_create_temp_directory_prefers_runner_temp_over_tmp(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Codex PATH aliases need CODEX_HOME outside /tmp — prefer RUNNER_TEMP."""
+    runner = tmp_path / "runner-temp"
+    runner.mkdir()
+    monkeypatch.setenv("RUNNER_TEMP", str(runner))
+    monkeypatch.delenv("MERGECRAFT_TEMP_PARENT", raising=False)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+    created = create_temp_directory()
+    assert created.startswith(str(runner))
+    assert not _is_under_forbidden_temp(Path(created))
+    assert os.environ["MERGECRAFT_TEMP_DIR"] == created

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -41,19 +42,55 @@ def test_askpass_returns_x_access_token_for_username(tmp_path: Path) -> None:
     assert "ghs_secrettoken" not in user.stdout
 
 
+def _safe_staging_root(label: str) -> Path:
+    """Stage outside pytest's /tmp tree so Codex-forbidden-root checks apply."""
+    root = Path.home() / ".cache" / "mergecraft-test" / f"{label}-{os.getpid()}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
 def test_create_temp_directory_prefers_runner_temp_over_tmp(
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Codex PATH aliases need CODEX_HOME outside /tmp — prefer RUNNER_TEMP."""
-    runner = tmp_path / "runner-temp"
+    staging = _safe_staging_root("runner")
+    runner = staging / "runner-temp"
     runner.mkdir()
     monkeypatch.setenv("RUNNER_TEMP", str(runner))
     monkeypatch.delenv("MERGECRAFT_TEMP_PARENT", raising=False)
     monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
 
-    created = create_temp_directory()
-    assert created.startswith(str(runner))
-    assert not _is_under_forbidden_temp(Path(created))
-    assert os.environ["MERGECRAFT_TEMP_DIR"] == created
+    try:
+        created = create_temp_directory()
+        assert created.startswith(str(runner))
+        assert not _is_under_forbidden_temp(Path(created))
+        assert os.environ["MERGECRAFT_TEMP_DIR"] == created
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def test_create_temp_directory_skips_forbidden_runner_temp(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """RUNNER_TEMP under /tmp is rejected; fall back to XDG cache."""
+    # Stage under a real forbidden root (pytest's tmp_path may be /var/folders).
+    forbidden_root = Path("/tmp") / f"mergecraft-test-forbidden-{os.getpid()}"
+    runner = forbidden_root / "runner-temp"
+    runner.mkdir(parents=True)
+    assert _is_under_forbidden_temp(runner)
+    cache_home = _safe_staging_root("xdg")
+    monkeypatch.setenv("RUNNER_TEMP", str(runner))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+    monkeypatch.delenv("MERGECRAFT_TEMP_PARENT", raising=False)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+
+    try:
+        created = create_temp_directory()
+        assert created.startswith(str(cache_home / "mergecraft" / "tmp"))
+        assert not created.startswith(str(runner))
+        assert not _is_under_forbidden_temp(Path(created))
+        assert os.environ["MERGECRAFT_TEMP_DIR"] == created
+    finally:
+        shutil.rmtree(forbidden_root, ignore_errors=True)
+        shutil.rmtree(cache_home, ignore_errors=True)


### PR DESCRIPTION
## Summary
- Codex 0.14x refuses PATH-alias helper binaries when `CODEX_HOME` is under `/tmp` / `/var/tmp` / `/usr/tmp`, exiting non-zero with `WARNING: proceeding, even though we could not create PATH aliases…`
- Prefer `RUNNER_TEMP` (or `~/.cache/mergecraft`) for the mergeCraft run temp, and relocate `CODEX_HOME` when the tmpdir is still under a forbidden root
- Without this, Codex reviews post `mergecraft-approval: neutral` (no verdict) until a fallback reviewer completes

## Test plan
- [x] `uv run pytest tests/utils/test_git_setup.py tests/agents/test_codex.py`
- [ ] After merge to `pre-0.0.1`, bump sevn `main` workflow pin `alexhawat/mergeCraft@e7b922d…` (admin), then trunk `MERGECRAFT_REF`
- [ ] Re-run mergeCraft on sevn #237 and confirm Codex completes without `/tmp` PATH-alias failure


Made with [Cursor](https://cursor.com)