### PR TITLE
fix(status-checks): structural approval gate derived from typed findings (Batch D — #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add OSS governance files for parity with sevn-bot/sevn: `SECURITY.md`,
   `CODE_OF_CONDUCT.md`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`,
   and `.github/ISSUE_TEMPLATE/` (bug report, feature request, security contact link).
+- Document the structural approval gate next to `status_checks: enabled`: the
+  `mergecraft-approval` conclusion is now a pure function of the typed `Finding`
+  list, the run's completion state, and the trust tier — narrative
+  (`ApprovalRecord.would_approve`) is recorded as an advisory input only, never
+  the sole positive input. The pre-W8 "neutral is non-blocking" framing is
+  removed; the hardened example workflow ships a `neutral` ⇒ blocking enforce
+  step (#75).
+
+### Changed (BREAKING)
+
+- **`mergecraft-approval` is now structural (D13 — fail closed on incomplete
+  runs).** A crashed / timed-out / no-findings run posts `neutral` regardless of
+  any recorded `ApprovalRecord.would_approve`. The hardened example workflow's
+  enforce step treats `neutral` as blocking; GitHub branch protection must wire
+  that step into the merge rule if it relied on the previous "neutral is
+  non-blocking" behaviour. `report_status_checks()` consults
+  `mergecraft.agents.gates.decide_approval(findings, run_succeeded, tier)`
+  instead of `approval.would_approve` (#75).
+- **`prApproveEnabled` is inert for `untrusted` tier runs (D14 — no self-
+  approval on fork PRs).** `create_pull_request_review` does not send
+  `event="APPROVE"` to GitHub when `ctx.trust_tier == "untrusted"` even with
+  `pr_approve_enabled=true` and the agent's `approved=true` argument. The
+  advisory `ApprovalRecord(would_approve=True, sha=...)` is still recorded so
+  the trajectory / merge-evidence work (#41) reads it after the fact. Trusted
+  in-repo PRs are unchanged (#75).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -364,13 +364,29 @@ workflows can trigger on `pull_request` (e.g. auto-review on open/sync),
 `issue_comment`, or `pull_request_review_comment` events and the agent gets PR
 context (number, branch, `is_pr`) automatically — no hand-built `~mergecraft` JSON
 payload required. With `status_checks: enabled`, PR runs always post the `mergecraft`
-and `mergecraft-approval` commit-status checks. The approval check has three
-outcomes: `success` when mergeCraft would approve, `failure` when it would not,
-and `neutral` when the review did not complete (agent crash, timeout, or no
-approval recorded). GitHub branch protection treats `neutral` as non-blocking by
-default — gate on `success`/`failure` explicitly in your enforce step if you
-require a completed review. An explicit `~mergecraft` payload event still takes
-precedence when provided.
+and `mergecraft-approval` commit-status checks.
+
+The approval check is **structural**: its conclusion is a pure function of the
+typed `Finding` list, the run's completion state, and the trust tier. Narrative
+(`create_pull_request_review(approved=true|false)`) is recorded as an advisory
+input only — it is never the sole positive input. The wire-shape has three
+outcomes:
+
+- `success` — run completed, trust tier is trusted, no `Critical` or `Major`
+  finding in the list, and at least one finding attests the review ran.
+- `failure` — at least one `Critical` or `Major` finding. The agent's
+  `approved=true` cannot outvote a blocker.
+- `neutral` — run crashed / timed out / produced no findings, **or** trust tier
+  is `untrusted` (fork PR / `pull_request_target`).
+
+GitHub branch protection treats `neutral` as non-blocking by default. The
+hardened example workflow ships an enforce step (`Fail when mergeCraft would
+not approve`) that flips `neutral` to blocking — wire it into your branch
+protection rule if you want the gate to require a clean structural conclusion,
+not just a missing check. The pre-W8 "neutral is non-blocking" framing is
+removed: a crashed / injected / fork-suppressed review must not pass the gate
+silently. An explicit `~mergecraft` payload event still takes precedence when
+provided.
 
 ## Development
 

--- a/docs/test-plans/security-structural-approval.md
+++ b/docs/test-plans/security-structural-approval.md
@@ -1,40 +1,32 @@
-# Security — structural approval gate (#75) — test plan (W7 RED)
+# Security — structural approval gate (#75) — test plan (W7 RED → W8 GREEN)
 
 Wave plan: `.ignorelocal/waves/issues-security-trust-boundary-wave-plan.md`
 Worktree: `mergecraft-sec-d-structural-gate` @ `wave/sec-d-structural-gate`
 
 ## xfail schedule
 
-| Wave | Test | Marker reason |
-|------|------|---------------|
-| **W8** | `tests/status_checks/test_decide_approval.py::test_narrative_approval_with_blocker_finding_yields_failure` | `green after W8: derive approval from typed findings, not narrative (#75)` |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-approve]` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-block]` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-unrecorded]` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_agent_approved_flag_is_advisory_only_with_empty_findings` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_agent_approved_flag_is_advisory_only_with_blocking_findings` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_record_remains_an_advisory_input` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_no_second_finding_model_introduced` | same |
-| **W8** | `tests/status_checks/test_decide_approval.py::test_finding_source_is_preserved_for_evidence_audit` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_crashed_run_does_not_leave_permissive_gate` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_timed_out_run_with_findings_yields_failure` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_report_status_checks_surfaces_neutral_for_crashed_run` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_fork_pr_cannot_self_approve_at_decision_layer` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_fork_pr_cannot_self_approve_at_tool_layer` | same |
-| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_in_repo_pr_with_pr_approve_enabled_can_self_approve` | same |
+All W7 xfail markers were removed at W8. The 15 tests in
+`tests/status_checks/` now pass on the structural-approval gate (`make
+ci` green, 623 passed; the status_checks subtree is 15 / 15).
 
-All cross-wave markers use `strict=False`. The in-repo regression guard
-`test_in_repo_pr_with_pr_approve_enabled_can_self_approve` already passes
-pre-W8 (the current code does send `event="APPROVE"` for trusted runs); it
-is marked xfail only to keep the W7 cycle consistent. W8 un-xfails it
-alongside the rest.
+The in-repo regression guard
+`test_in_repo_pr_with_pr_approve_enabled_can_self_approve` already passed
+pre-W8 (the prior code did send `event="APPROVE"` for trusted runs); it
+was marked xfail only to keep the W7 cycle consistent and is now plain.
+
+The pre-W8
+`tests/utils/test_status_checks.py::test_report_status_checks_preserves_approval_when_run_fails_later`
+was renamed to `test_report_status_checks_neutral_for_crashed_run_with_recorded_approval`
+and rewritten to assert the W8 / D13 contract: a recorded
+`ApprovalRecord(would_approve=False)` does not flip a crashed run to
+`failure` — the conclusion is `neutral` regardless, and the reviewed
+commit SHA is preserved in the summary so operators can audit the run.
 
 No non-xfail collection tests guard this suite. The conftest does a
 `import mergecraft.analyzers.finding` and
 `import mergecraft.utils.status_checks` at module load so a missing
 module is a hard collection failure rather than a deferred runtime
-error — the existing fixtures in `tests/utils/test_status_checks.py`
-already exercise the same surface.
+error.
 
 ## Contract matrix
 
@@ -69,7 +61,7 @@ The conftest also imports `mergecraft.analyzers.finding.Finding` and
 module load so a missing import is a hard collection failure rather
 than a deferred test fixture error.
 
-## What W8 must satisfy (D12, D13, D14)
+## What W8 satisfies (D12, D13, D14)
 
 The decision function lands in `src/mergecraft/agents/gates.py` (W8.1)
 with this contract:
@@ -91,19 +83,27 @@ def decide_approval(
 - `tier="untrusted"` ⇒ never `"success"` and never `"neutral"` with
   blocker prerequisites; the gate is inert for fork PRs and
   `pull_request_target` regardless of `pr_approve_enabled` (D14).
-- `tier="trusted"` + no blockers + `run_succeeded=True` ⇒ `"success"`.
+- `tier="trusted"` + no blockers + `run_succeeded=True` + at least one
+  non-blocker finding ⇒ `"success"`.
 
-`report_status_checks()` (W8.2) must call `decide_approval()` instead
+`report_status_checks()` (W8.2) calls `decide_approval()` instead
 of reading `approval.would_approve` directly. The agent's boolean stays
 in `ApprovalRecord.would_approve` (W8.3) as an advisory input the
 trajectory/evidence work in the merge-evidence plan reads after the
 fact (#41).
 
-`create_pull_request_review` (W8.5) must not send `event="APPROVE"` to
+`create_pull_request_review` (W8.5) does not send `event="APPROVE"` to
 GitHub when `ctx.trust_tier == "untrusted"`, even with
 `pr_approve_enabled=True` and `approved=True`. The advisory record
 (`ApprovalRecord(would_approve=True, sha=...)`) is still stored — the
 guard is at the wire-call layer, not the storage layer.
+
+W8.6 emits the decision inputs (findings count, severities present,
+`run_succeeded`, `tier`, `has_blocker`) into the check-run summary so
+the conclusion is reconstructible from the stored findings alone (#75
+proposal item 4). The full durable artifact lives in the merge-evidence
+plan's `MergeEvidencePacket` (#47); W8 does not introduce a second
+packet format.
 
 ## Cross-file pins
 
@@ -121,11 +121,11 @@ read-only for this plan. The analyze-evidence plan owns the signature.
 not modified. W7.6's structural guard fails if W8 introduces a
 parallel model.
 
-## Out of scope for W7
+## Out of scope for W8
 
-- W8 implementation. W7 pins the contract; W8 makes it green.
-- The `examples/workflows/mergecraft-hardened.yml` enforce step (W8.4).
-- `README.md` semantics update (W8.7).
-- `CHANGELOG.md` BREAKING bullets (W8.9).
+- The merge-evidence plan's W2/W9 (they rebase onto this branch).
+- The `examples/workflows/mergecraft.yml` minimal template (unchanged
+  by W8; only the hardened template's enforce step moved).
+- The merge-evidence plan's `MergeEvidencePacket` durable artifact.
 - Any change to `derive_trust_tier()` itself (analyzer plan owns it).
 - Any extension of `Finding` (merge-evidence plan owns it, additively).

--- a/docs/test-plans/security-structural-approval.md
+++ b/docs/test-plans/security-structural-approval.md
@@ -1,0 +1,131 @@
+# Security — structural approval gate (#75) — test plan (W7 RED)
+
+Wave plan: `.ignorelocal/waves/issues-security-trust-boundary-wave-plan.md`
+Worktree: `mergecraft-sec-d-structural-gate` @ `wave/sec-d-structural-gate`
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W8** | `tests/status_checks/test_decide_approval.py::test_narrative_approval_with_blocker_finding_yields_failure` | `green after W8: derive approval from typed findings, not narrative (#75)` |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-approve]` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-block]` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_conclusion_is_pure_function_of_findings[narrative-unrecorded]` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_agent_approved_flag_is_advisory_only_with_empty_findings` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_agent_approved_flag_is_advisory_only_with_blocking_findings` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_approval_record_remains_an_advisory_input` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_no_second_finding_model_introduced` | same |
+| **W8** | `tests/status_checks/test_decide_approval.py::test_finding_source_is_preserved_for_evidence_audit` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_crashed_run_does_not_leave_permissive_gate` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_timed_out_run_with_findings_yields_failure` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_report_status_checks_surfaces_neutral_for_crashed_run` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_fork_pr_cannot_self_approve_at_decision_layer` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_fork_pr_cannot_self_approve_at_tool_layer` | same |
+| **W8** | `tests/status_checks/test_status_checks_enforce.py::test_in_repo_pr_with_pr_approve_enabled_can_self_approve` | same |
+
+All cross-wave markers use `strict=False`. The in-repo regression guard
+`test_in_repo_pr_with_pr_approve_enabled_can_self_approve` already passes
+pre-W8 (the current code does send `event="APPROVE"` for trusted runs); it
+is marked xfail only to keep the W7 cycle consistent. W8 un-xfails it
+alongside the rest.
+
+No non-xfail collection tests guard this suite. The conftest does a
+`import mergecraft.analyzers.finding` and
+`import mergecraft.utils.status_checks` at module load so a missing
+module is a hard collection failure rather than a deferred runtime
+error — the existing fixtures in `tests/utils/test_status_checks.py`
+already exercise the same surface.
+
+## Contract matrix
+
+Per D12, D13, D14 of the wave plan. The test names below map to W7.1–W7.6
+in the plan.
+
+| Plan W | Decision | Layer | Scenario | Primary test |
+|--------|----------|-------|----------|--------------|
+| **W7.1** | D12 — conclusion is a pure function of `Finding` severities, never narrative | Decision | Headline acceptance: narrative says "approved" + blocker finding ⇒ `failure` | `test_narrative_approval_with_blocker_finding_yields_failure` |
+| **W7.2** | D12 — same findings, three different narratives ⇒ identical conclusion | Decision | Purity / no-I/O | `test_approval_conclusion_is_pure_function_of_findings` (parametrized: approve / block / unrecorded) |
+| **W7.3** | D13 — fail closed on incomplete runs; `neutral` is the wire-shape the hardened enforce step blocks on | Enforce | `run_succeeded=False` ⇒ non-`success`; crashed-run through `report_status_checks` ⇒ `neutral` | `test_crashed_run_does_not_leave_permissive_gate`, `test_timed_out_run_with_findings_yields_failure`, `test_report_status_checks_surfaces_neutral_for_crashed_run` |
+| **W7.4** | D14 — untrusted (fork / `pull_request_target`) runs cannot self-approve | Decision + tool | `derive_trust_tier()` returns `"untrusted"` ⇒ decision is non-`success`; `create_pull_request_review` does not send `event="APPROVE"` even with `pr_approve_enabled=True` and `approved=True`. Regression guard: in-repo PR still approves. | `test_fork_pr_cannot_self_approve_at_decision_layer`, `test_fork_pr_cannot_self_approve_at_tool_layer`, `test_in_repo_pr_with_pr_approve_enabled_can_self_approve` |
+| **W7.5** | D12 — agent's `approved` boolean is advisory only | Decision | `create_pull_request_review(approved=True)` with no findings ⇒ `neutral` (not `success`); with a blocker ⇒ `failure`; `ApprovalRecord.would_approve=True` does not by itself produce `success` | `test_agent_approved_flag_is_advisory_only_with_empty_findings`, `test_agent_approved_flag_is_advisory_only_with_blocking_findings`, `test_approval_record_remains_an_advisory_input` |
+| **W7.6** | D12 — no parallel finding model | Structural | The decision function imports `Finding` from `analyzers/finding.py`; no class with `Finding` suffix lives in `mergecraft.agents.gates`; `decide_approval`'s `findings` argument is annotated `list[Finding]`; `Finding.source` is preserved across the call (merge-evidence plan #41/#46 reconstruct the conclusion from stored findings) | `test_no_second_finding_model_introduced`, `test_finding_source_is_preserved_for_evidence_audit` |
+
+## Fixture model
+
+The conftest in `tests/status_checks/conftest.py` exposes typed findings
+at three severity tiers — `blocker_finding` (Major), `critical_finding`
+(Critical), `trivial_finding` (Trivial) — plus three composed lists
+(`sample_findings`, `blocker_only_findings`, `clean_findings`,
+`clean_findings_with_trivial`). All findings use
+`FindingSource = "agent"` so the structural-guard test (W7.6) sees a
+single source across the suite.
+
+`blocked_pr_event` and `trusted_pr_event` are raw GitHub event
+dicts shaped the way `derive_trust_tier()` expects — a fork PR (head
+repo `fork: True`) and an in-repo PR (head repo `fork: False`).
+
+The conftest also imports `mergecraft.analyzers.finding.Finding` and
+`mergecraft.utils.status_checks.{Conclusion, report_status_checks}` at
+module load so a missing import is a hard collection failure rather
+than a deferred test fixture error.
+
+## What W8 must satisfy (D12, D13, D14)
+
+The decision function lands in `src/mergecraft/agents/gates.py` (W8.1)
+with this contract:
+
+```python
+def decide_approval(
+    findings: list[Finding],
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> Conclusion: ...
+```
+
+- `Findings = []` + `run_succeeded=True` + `tier="trusted"` ⇒ `"neutral"`
+  (the hardened enforce step blocks on `neutral` — D13).
+- `Findings = []` + `run_succeeded=False` ⇒ `"neutral"` (D13).
+- Any `Critical` or `Major` finding ⇒ `"failure"` regardless of run
+  state (D12).
+- `tier="untrusted"` ⇒ never `"success"` and never `"neutral"` with
+  blocker prerequisites; the gate is inert for fork PRs and
+  `pull_request_target` regardless of `pr_approve_enabled` (D14).
+- `tier="trusted"` + no blockers + `run_succeeded=True` ⇒ `"success"`.
+
+`report_status_checks()` (W8.2) must call `decide_approval()` instead
+of reading `approval.would_approve` directly. The agent's boolean stays
+in `ApprovalRecord.would_approve` (W8.3) as an advisory input the
+trajectory/evidence work in the merge-evidence plan reads after the
+fact (#41).
+
+`create_pull_request_review` (W8.5) must not send `event="APPROVE"` to
+GitHub when `ctx.trust_tier == "untrusted"`, even with
+`pr_approve_enabled=True` and `approved=True`. The advisory record
+(`ApprovalRecord(would_approve=True, sha=...)`) is still stored — the
+guard is at the wire-call layer, not the storage layer.
+
+## Cross-file pins
+
+This plan is the **first** of the merge-evidence-gating plan's
+Batch-D sibling plan to land `decide_approval()`. The merge-evidence
+plan's W2 (#41 evidence-not-confidence) and W9 (#46 gate→action map)
+both consume `decide_approval()` rather than reimplementing it. W8 owns
+the function and the `report_status_checks()` rewire; both downstream
+plans rebase.
+
+`derive_trust_tier()` (`src/mergecraft/analyzers/trust.py:30-58`) is
+read-only for this plan. The analyze-evidence plan owns the signature.
+
+`Finding` (`src/mergecraft/analyzers/finding.py:32-53`) is consumed,
+not modified. W7.6's structural guard fails if W8 introduces a
+parallel model.
+
+## Out of scope for W7
+
+- W8 implementation. W7 pins the contract; W8 makes it green.
+- The `examples/workflows/mergecraft-hardened.yml` enforce step (W8.4).
+- `README.md` semantics update (W8.7).
+- `CHANGELOG.md` BREAKING bullets (W8.9).
+- Any change to `derive_trust_tier()` itself (analyzer plan owns it).
+- Any extension of `Finding` (merge-evidence plan owns it, additively).

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -309,6 +309,23 @@ jobs:
 
       # Gate on the approval check-run rather than on the review step's exit code,
       # so agent infrastructure failures do not read as "changes requested".
+      #
+      # W8.4 (D13): the approval conclusion is computed structurally from the
+      # typed `Finding` list + run state + trust tier — narrative ("approved",
+      # "not approved") never enters the decision. The hardened enforce step
+      # treats anything other than `success` as blocking:
+      #
+      # - `failure` ⇒ review surfaced a blocker (Critical/Major finding) — block.
+      # - `neutral` ⇒ the run crashed / timed out / produced no findings, or
+      #   the trust tier is `untrusted` (fork PR / pull_request_target) — block.
+      #   `neutral` is the wire-shape that means "no permissive gate"; an
+      #   injected PR that suppresses its findings still surfaces `neutral`
+      #   because the structural decision reads the typed finding list.
+      # - `success` ⇒ review completed, no blockers, at least one finding — pass.
+      # - absent (no `mergecraft-approval` check posted at all, e.g. the
+      #   review step never ran) ⇒ still fail open. The required check
+      #   pattern relies on a posted check; if no check exists, the GitHub
+      #   branch-protection rule itself blocks the merge, not this step.
       - name: Fail when mergeCraft would not approve
         if: github.event_name == 'pull_request_target' && env.HAS_AUTH == 'true'
         env:
@@ -332,14 +349,18 @@ jobs:
             exit 0
           fi
           case "${conclusion}" in
+            success)
+              echo "mergeCraft approval: structural gate passed (no blockers in the typed Finding list)."
+              ;;
             failure)
-              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — address the review feedback on this PR."
+              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — the typed Finding list contains a Critical or Major finding."
               exit 1
               ;;
-            success)
-              echo "mergeCraft approval: no outstanding review feedback."
+            neutral)
+              echo "::error title=mergeCraft review incomplete::mergecraft-approval is 'neutral' — the run crashed, timed out, produced no findings, or ran on an untrusted tier. This is treated as blocking by W8 (D13)."
+              exit 1
               ;;
             *)
-              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking."
+              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking (fail-open for missing check — branch protection handles the missing required check)."
               ;;
           esac

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -309,6 +309,23 @@ jobs:
 
       # Gate on the approval check-run rather than on the review step's exit code,
       # so agent infrastructure failures do not read as "changes requested".
+      #
+      # W8.4 (D13): the approval conclusion is computed structurally from the
+      # typed `Finding` list + run state + trust tier — narrative ("approved",
+      # "not approved") never enters the decision. The hardened enforce step
+      # treats anything other than `success` as blocking:
+      #
+      # - `failure` ⇒ review surfaced a blocker (Critical/Major finding) — block.
+      # - `neutral` ⇒ the run crashed / timed out / produced no findings, or
+      #   the trust tier is `untrusted` (fork PR / pull_request_target) — block.
+      #   `neutral` is the wire-shape that means "no permissive gate"; an
+      #   injected PR that suppresses its findings still surfaces `neutral`
+      #   because the structural decision reads the typed finding list.
+      # - `success` ⇒ review completed, no blockers, at least one finding — pass.
+      # - absent (no `mergecraft-approval` check posted at all, e.g. the
+      #   review step never ran) ⇒ still fail open. The required check
+      #   pattern relies on a posted check; if no check exists, the GitHub
+      #   branch-protection rule itself blocks the merge, not this step.
       - name: Fail when mergeCraft would not approve
         if: github.event_name == 'pull_request_target' && env.HAS_AUTH == 'true'
         env:
@@ -332,14 +349,18 @@ jobs:
             exit 0
           fi
           case "${conclusion}" in
+            success)
+              echo "mergeCraft approval: structural gate passed (no blockers in the typed Finding list)."
+              ;;
             failure)
-              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — address the review feedback on this PR."
+              echo "::error title=mergeCraft requested changes::mergecraft-approval failed — the typed Finding list contains a Critical or Major finding."
               exit 1
               ;;
-            success)
-              echo "mergeCraft approval: no outstanding review feedback."
+            neutral)
+              echo "::error title=mergeCraft review incomplete::mergecraft-approval is 'neutral' — the run crashed, timed out, produced no findings, or ran on an untrusted tier. This is treated as blocking by W8 (D13)."
+              exit 1
               ;;
             *)
-              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking."
+              echo "::notice title=mergeCraft approval not posted::No mergecraft-approval check on ${HEAD_SHA}. Not blocking (fail-open for missing check — branch protection handles the missing required check)."
               ;;
           esac

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
+
+from loguru import logger
 
 from mergecraft.mcp.server import build_orchestrator_tools
 
 if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
+    from mergecraft.analyzers.manifest import TrustTier
     from mergecraft.mcp.context import ToolContext
     from mergecraft.mcp.shared import JsonSchema
+    from mergecraft.utils.status_checks import Conclusion
 
 # OpenCode Wildcard dialect write denies for the entire .git tree
 GIT_NATIVE_WRITE_DENY_OPENCODE: dict[str, str] = {
@@ -32,6 +37,13 @@ GIT_NATIVE_WRITE_DENY_CLAUDE: list[str] = [
 ]
 
 GIT_NATIVE_READ_DENY_CLAUDE: list[str] = [f"{tool}(.git/config)" for tool in CLAUDE_READ_TOOLS]
+
+
+# Severities that block the approval gate. Anything below (Minor, Trivial) is
+# advisory only — the gate treats the run as approved. Centralized here so the
+# merge-evidence plan's W2 (D12) and the analyzer plan's blocker taxonomy share
+# one source of truth.
+BLOCKING_SEVERITIES: Final[frozenset[str]] = frozenset({"Critical", "Major"})
 
 
 def subagent_denied_tool_names(
@@ -64,3 +76,130 @@ def build_opencode_native_fs_permission() -> dict[str, object]:
         "edit": {"*": "allow", **GIT_NATIVE_WRITE_DENY_OPENCODE},
         "read": {"*": "allow", **GIT_NATIVE_READ_DENY_OPENCODE},
     }
+
+
+def _has_blocker(findings: list[Finding]) -> bool:
+    """True iff any finding carries a severity the gate treats as blocking."""
+    return any(f.severity in BLOCKING_SEVERITIES for f in findings)
+
+
+def decide_approval(
+    findings: list[Finding],
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> Conclusion:
+    """Pure structural approval conclusion (D12, D13, D14).
+
+    The approval gate's wire-shape (``success`` / ``failure`` / ``neutral``) is a
+    pure function of the typed finding list, the run's completion state, and the
+    trust tier. Narrative (``ApprovalRecord.would_approve``, ``result.output``,
+    any model prose) is never an input — the agent's ``approved`` boolean is
+    recorded separately (W8.3) and consumed by the trajectory/evidence work in
+    the merge-evidence plan (#41) after the fact.
+
+    The decision is monotone in blockers:
+
+    - Any ``Critical`` or ``Major`` finding ⇒ ``"failure"`` regardless of run
+      state or tier. The narrative cannot outvote a blocker.
+    - ``run_succeeded=False`` ⇒ ``"neutral"``. A crashed / timed-out run must
+      not propagate a permissive outcome; the hardened enforce step blocks on
+      ``neutral`` (W8.4 / D13).
+    - ``tier="untrusted"`` ⇒ never ``"success"``. The gate is inert for fork PRs
+      and ``pull_request_target`` regardless of ``prApproveEnabled`` and the
+      agent's ``approved=True`` (D14). With no blockers the conclusion is
+      ``"neutral"``; with a blocker the prior rule wins and yields ``"failure"``.
+    - Otherwise (``tier="trusted"`` + ``run_succeeded=True`` + no blockers):
+      ``"success"`` when the finding list contains at least one finding
+      (attested structural evidence the review ran), ``"neutral"`` when the
+      list is empty (the run completed without findings to attest to).
+
+    The function is pure: no I/O, no logging, no module state. The merge-evidence
+    plan's W2 (D12) and W9 (#46) call this function without re-shaping; the
+    signature is the contract.
+    """
+    if _has_blocker(findings):
+        return "failure"
+    if not run_succeeded:
+        return "neutral"
+    if tier == "untrusted":
+        return "neutral"
+    if not findings:
+        return "neutral"
+    return "success"
+
+
+def approval_decision_inputs(
+    findings: list[Finding],
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> dict[str, object]:
+    """Return the decision inputs so the check-run summary is reconstructible (#75 proposal item 4).
+
+    Lightweight, dict-only payload — the full evidence packet lives in
+    ``src/mergecraft/evidence/packet.py`` (merge-evidence plan's W1). This
+    helper exists so the check-run summary lists severities / count / run state /
+    tier alongside the conclusion, and a downstream consumer can reproduce the
+    ``decide_approval`` decision from the stored summary without re-running the
+    analysis path.
+    """
+    severities = sorted({f.severity for f in findings})
+    return {
+        "findings_count": len(findings),
+        "severities": severities,
+        "has_blocker": _has_blocker(findings),
+        "run_succeeded": run_succeeded,
+        "tier": tier,
+    }
+
+
+def decision_summary_lines(inputs: dict[str, object]) -> list[str]:
+    """Render ``approval_decision_inputs`` as human-readable check-run summary lines (W8.6)."""
+    findings_count_raw = inputs.get("findings_count", 0)
+    findings_count = int(findings_count_raw) if isinstance(findings_count_raw, (int, float)) else 0
+    severities_raw = inputs.get("severities") or []
+    severities = [str(item) for item in severities_raw] if isinstance(severities_raw, list) else []
+    tier_raw = inputs.get("tier", "trusted")
+    tier = str(tier_raw) if tier_raw is not None else "trusted"
+    run_succeeded = bool(inputs.get("run_succeeded"))
+    has_blocker = bool(inputs.get("has_blocker"))
+    severities_text = ", ".join(severities) if severities else "(none)"
+    return [
+        f"- Findings: {findings_count} (severities: {severities_text})",
+        f"- Run succeeded: {run_succeeded}",
+        f"- Trust tier: {tier}",
+        f"- Has blocker: {has_blocker}",
+    ]
+
+
+def log_decision(
+    findings: list[Finding],
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+    conclusion: Conclusion,
+) -> None:
+    """Log the structural approval decision at info level. Kept separate from
+    ``decide_approval`` so the pure function stays side-effect-free."""
+    inputs = approval_decision_inputs(findings, run_succeeded=run_succeeded, tier=tier)
+    logger.info(
+        "approval decision: {} (findings={}, severities={}, run_succeeded={}, tier={})",
+        conclusion,
+        inputs["findings_count"],
+        inputs["severities"],
+        run_succeeded,
+        tier,
+    )
+
+
+__all__ = [
+    "BLOCKING_SEVERITIES",
+    "approval_decision_inputs",
+    "build_claude_native_fs_denies",
+    "build_opencode_native_fs_permission",
+    "decide_approval",
+    "decision_summary_lines",
+    "log_decision",
+    "subagent_denied_tool_names",
+]

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -75,7 +75,12 @@ def create_pull_request_review_tool(ctx: ToolContext):
                 }
 
         event = "COMMENT"
-        if approved and ctx.pr_approve_enabled:
+        if approved and ctx.pr_approve_enabled and ctx.trust_tier == "trusted":
+            # D14 — prApproveEnabled is inert for untrusted runs (fork PR /
+            # pull_request_target). One config knob, one inert path. The
+            # advisory ApprovalRecord is still written below (W8.3), so the
+            # trajectory/evidence work in the merge-evidence plan (#41) reads
+            # the agent's stored boolean after the fact.
             event = "APPROVE"
         elif request_changes:
             event = "REQUEST_CHANGES"

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -79,6 +79,23 @@ class ReviewRecord:
 
 @dataclass(slots=True)
 class ApprovalRecord:
+    """Advisory record of what the agent asked ``create_pull_request_review``
+    to do.
+
+    ``would_approve`` is the agent's *self-assessment*, captured as a side
+    effect of the ``create_pull_request_review`` tool call. It is **never the
+    sole positive input** to the approval gate — that gate is computed
+    structurally by ``mergecraft.agents.gates.decide_approval`` from the typed
+    ``Finding`` list, the run's completion state, and the trust tier (D12).
+
+    The field exists for the trajectory / merge-evidence plan (#41) so the
+    recorded "self-assessment" can be compared against the structural
+    conclusion after the fact. It is not consulted by ``report_status_checks``
+    or ``create_pull_request_review``'s wire-call layer — both are pinned to
+    structural inputs by W7.3 / W7.4 / W7.5 of the security-trust-boundary
+    plan (#75).
+    """
+
     would_approve: bool
     sha: str | None
 

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -1,4 +1,21 @@
-"""Opt-in commit-status check-runs (``mergecraft`` / ``mergecraft-approval``)."""
+"""Opt-in commit-status check-runs (``mergecraft`` / ``mergecraft-approval``).
+
+The approval check-run is computed structurally (W8): the conclusion is a pure
+function of the typed ``Finding`` list, the run's completion state, and the
+trust tier. Narrative (``ApprovalRecord.would_approve``, ``result.output``,
+anything the model wrote) is recorded separately as an advisory input and is
+never the sole positive input — see ``decide_approval`` in
+``mergecraft.agents.gates`` for the full contract (D12, D13, D14).
+
+Wire-shape semantics:
+
+- ``success`` — run completed, trust tier is trusted, no blockers in the finding
+  list, and at least one finding attests the review ran.
+- ``failure`` — at least one ``Critical`` or ``Major`` finding; the agent's
+  narrative cannot outvote a blocker.
+- ``neutral`` — run crashed / timed out / produced no findings / untrusted tier;
+  the hardened enforce step treats this as blocking (#75, D13).
+"""
 
 from __future__ import annotations
 
@@ -12,6 +29,35 @@ if TYPE_CHECKING:
 COMPLETION_CHECK = "mergecraft"
 APPROVAL_CHECK = "mergecraft-approval"
 Conclusion = Literal["success", "failure", "neutral"]
+
+
+def _load_structural_findings(ctx: ToolContext) -> list[Any]:
+    """Return the typed ``Finding`` objects the approval gate reads.
+
+    Reads ``ctx.tool_state.analyzer_run.findings`` (stored as dicts by the
+    analyzer pipeline) and validates them against ``analyzers.finding.Finding``.
+    Validation errors are logged at debug level and skipped — a malformed
+    analyzer row must not crash the run; it just drops from the structural set.
+    The merge-evidence plan's W1 owns the durable store; this loader is the
+    minimal hook the approval gate needs today.
+    """
+    run_state = getattr(ctx.tool_state, "analyzer_run", None)
+    if run_state is None:
+        return []
+    raw = list(getattr(run_state, "findings", []) or [])
+    if not raw:
+        return []
+    from mergecraft.analyzers.finding import Finding, FindingValidationError
+
+    typed: list[Any] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        try:
+            typed.append(Finding.model_validate(row))
+        except FindingValidationError as err:
+            logger.debug("status checks: dropping malformed finding row: {}", err)
+    return typed
 
 
 async def _create_check_run(
@@ -94,19 +140,46 @@ async def report_status_checks(
     except Exception as err:
         logger.debug("status checks: {} post failed: {}", COMPLETION_CHECK, err)
 
+    # --- Approval gate (W8.2): structural conclusion, not narrative. ---------
+    # The agent's boolean is still in ApprovalRecord.would_approve (W8.3) as an
+    # advisory input the merge-evidence plan reads; the conclusion is computed
+    # from typed findings + run state + tier only.
+    from mergecraft.agents.gates import (
+        approval_decision_inputs,
+        decide_approval,
+        decision_summary_lines,
+        log_decision,
+    )
+
+    findings = _load_structural_findings(ctx)
+    tier = getattr(ctx, "trust_tier", "trusted")
+    approval_conclusion: Conclusion = decide_approval(
+        findings,
+        run_succeeded=run_succeeded,
+        tier=tier,  # type: ignore[arg-type]
+    )
+    decision_inputs = approval_decision_inputs(
+        findings,
+        run_succeeded=run_succeeded,
+        tier=tier,  # type: ignore[arg-type]
+    )
+    log_decision(
+        findings,
+        run_succeeded=run_succeeded,
+        tier=tier,  # type: ignore[arg-type]
+        conclusion=approval_conclusion,
+    )
+
     approval = ctx.tool_state.approval
-    if approval and approval.would_approve:
-        approval_conclusion: Conclusion = "success"
+    if approval_conclusion == "success":
         approval_title = "mergeCraft would approve"
         approval_summary = "mergeCraft has no outstanding review feedback on this PR."
-    elif approval and not approval.would_approve:
-        approval_conclusion = "failure"
+    elif approval_conclusion == "failure":
         approval_title = "mergeCraft would not approve"
         approval_summary = (
             "mergeCraft has outstanding review feedback or requested changes on this PR."
         )
     else:
-        approval_conclusion = "neutral"
         approval_title = "mergeCraft review did not complete"
         approval_summary = (
             "The mergeCraft review did not complete, so no approval decision was recorded."
@@ -114,6 +187,9 @@ async def report_status_checks(
 
     if approval and approval.sha:
         approval_summary = f"{approval_summary} Reviewed commit: {approval.sha}."
+    approval_summary = f"{approval_summary}\nDecision inputs:\n" + "\n".join(
+        decision_summary_lines(decision_inputs)
+    )
 
     try:
         await _create_check_run(

--- a/tests/status_checks/__init__.py
+++ b/tests/status_checks/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest package marker for `mergecraft-approval` structural-gate tests (W7)."""

--- a/tests/status_checks/conftest.py
+++ b/tests/status_checks/conftest.py
@@ -1,0 +1,184 @@
+"""Shared fixtures for the W7 RED suite (#75 structural approval gate).
+
+W7 is the test-creator wave for Batch D. It pins the acceptance contract that
+W8 (executor) must satisfy:
+
+- The approval conclusion is a pure function of findings + run state + trust
+  tier (D12). Narrative never enters the decision.
+- A crashed / timed-out / no-findings run never leaves a permissive gate (D13).
+- Untrusted (fork / ``pull_request_target``) runs cannot self-approve even
+  with ``prApproveEnabled=True`` (D14).
+- The agent's ``approved`` boolean is advisory only — never the sole positive
+  input (D12).
+- The approval path reuses ``Finding`` from ``analyzers/finding.py`` and
+  defines no parallel model (D12).
+
+Each test is decorated with ``@pytest.mark.xfail(reason="green after W8",
+strict=False)`` on the test functions themselves so they collect even though
+the decision function does not exist yet.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.analyzers.finding import make_finding
+from mergecraft.review_taxonomy import FindingSource
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
+
+
+@pytest.fixture
+def blocker_finding() -> Finding:
+    """One Major-severity finding — the smallest input that must trip the gate."""
+    return make_finding(
+        tool="structural-approval-fixture",
+        rule_id="W7-BLOCKER",
+        category="Security & Privacy",
+        severity="Major",
+        confidence="certain",
+        message="Fence module imported but never used.",
+        path="src/mergecraft/utils/fence.py",
+        start_line=1,
+        end_line=10,
+        source="agent",
+        evidence=["fence is imported but never referenced"],
+        remediation="Use the fence for every untrusted-field interpolation.",
+        fingerprint="w7-blocker-mjr",
+    )
+
+
+@pytest.fixture
+def critical_finding() -> Finding:
+    """One Critical-severity finding — also blocking."""
+    return make_finding(
+        tool="structural-approval-fixture",
+        rule_id="W7-CRITICAL",
+        category="Security & Privacy",
+        severity="Critical",
+        confidence="certain",
+        message="Approval decision reads from agent prose.",
+        path="src/mergecraft/utils/status_checks.py",
+        start_line=46,
+        end_line=120,
+        source="agent",
+        evidence=["report_status_checks() branches on approval.would_approve"],
+        remediation="Route through decide_approval() with typed findings.",
+        fingerprint="w7-critical-cr",
+    )
+
+
+@pytest.fixture
+def trivial_finding() -> Finding:
+    """One Trivial-severity finding — never trips the gate on its own."""
+    return make_finding(
+        tool="structural-approval-fixture",
+        rule_id="W7-NIT",
+        category="Maintainability & Code Quality",
+        severity="Trivial",
+        confidence="possible",
+        message="Docstring missing a trailing period.",
+        path="src/mergecraft/utils/status_checks.py",
+        start_line=1,
+        end_line=1,
+        source="ci",
+        evidence=["line 1: ''"],
+        remediation="Add a period.",
+        fingerprint="w7-trivial-tr",
+    )
+
+
+@pytest.fixture
+def sample_findings(
+    blocker_finding: Finding,
+    critical_finding: Finding,
+    trivial_finding: Finding,
+) -> list[Finding]:
+    """Mixed-severity finding list — one of each kind."""
+    return [critical_finding, blocker_finding, trivial_finding]
+
+
+@pytest.fixture
+def blocker_only_findings(blocker_finding: Finding) -> list[Finding]:
+    """A focused list containing only one blocker."""
+    return [blocker_finding]
+
+
+@pytest.fixture
+def clean_findings() -> list[Finding]:
+    """An empty list — nothing to flag, but the run still has to be considered."""
+    return []
+
+
+@pytest.fixture
+def clean_findings_with_trivial(trivial_finding: Finding) -> list[Finding]:
+    """A non-empty list with only Trivial findings — must not block the gate."""
+    return [trivial_finding]
+
+
+@pytest.fixture
+def blocked_pr_event() -> dict:
+    """A fork PR event payload — what ``derive_trust_tier`` would resolve to ``untrusted``."""
+    return {
+        "pull_request": {
+            "head": {
+                "repo": {
+                    "fork": True,
+                    "full_name": "attacker/evil-fork",
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def trusted_pr_event() -> dict:
+    """An in-repo PR event — ``derive_trust_tier`` would resolve to ``trusted``."""
+    return {
+        "pull_request": {
+            "head": {
+                "repo": {
+                    "fork": False,
+                    "full_name": "acme/widgets",
+                }
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module-availability guards — the W7 suite pins the *contract* that W8 must
+# satisfy. The decision function (``decide_approval``) and trust-tier inert
+# flag (``prApproveEnabled``) do not yet exist on this branch — W8 adds them.
+# The fixtures above are the only "real" Finding objects; the decision helpers
+# the tests call are imported lazily inside each test so an unresolved import
+# is reported as a collection failure rather than a global hard fail.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_finding_module_available() -> None:
+    """``Finding`` must be importable for the suite to collect at all."""
+    from mergecraft.analyzers.finding import Finding  # noqa: F401
+
+
+def _ensure_status_checks_module_available() -> None:
+    """`report_status_checks` and `Conclusion` must exist for the enforce tests."""
+    from mergecraft.utils.status_checks import (
+        Conclusion,  # noqa: F401
+        report_status_checks,  # noqa: F401
+    )
+
+
+_ensure_finding_module_available()
+_ensure_status_checks_module_available()
+
+
+# Source-finding helper, used implicitly by ``FindingSource`` and made explicit
+# for the structural-guard test (W7.6) so the import-coupling is asserted at
+# the literal level rather than via a transitive attribute.
+def _source_for_approval_path() -> FindingSource:
+    """Source used by every W7 finding — keeps the suite self-consistent."""
+    return "agent"

--- a/tests/status_checks/test_decide_approval.py
+++ b/tests/status_checks/test_decide_approval.py
@@ -1,0 +1,354 @@
+"""W7 RED suite for #75 structural approval gate — pure decision function.
+
+These tests pin the contract W8 must implement in
+``src/mergecraft/agents/gates.py`` (or a sibling module under
+``src/mergecraft/agents/``). Every test is marked
+``@pytest.mark.xfail(reason="green after W8", strict=False)`` because the
+function ``decide_approval(findings, *, run_succeeded, tier) -> Conclusion``
+does not yet exist on this branch — W8 will add it.
+
+The contract under test (D12, D13):
+
+- ``decide_approval`` is a *pure function* of the finding list, the run
+  completion state, and the trust tier. Narrative (``ApprovalRecord``,
+  ``result.output``, anything the model wrote) is never one of its inputs.
+- Any blocker (Critical or Major) finding ⇒ ``"failure"``.
+- A crashed / timed-out / no-findings run on a trusted tier with no blockers
+  resolves to ``"neutral"`` (the wire-shape that the hardened enforce step
+  treats as blocking — D13).
+- An untrusted tier cannot self-approve regardless of the agent's
+  ``approved`` signal — the gate is inert for ``tier == "untrusted"`` (D14).
+- The agent's ``approved=True`` argument is recorded as an advisory input
+  (the unsigned boolean remains in ``ApprovalRecord.would_approve``) but
+  is *not* the sole positive input. A ``decided`` success requires
+  ``run_succeeded == True`` and no blockers (W7.5).
+- The decision function imports ``Finding`` from ``analyzers/finding.py``
+  and does not define a parallel model anywhere (W7.6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.finding import Finding
+from mergecraft.review_taxonomy import FindingSource
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Module-availability guard for the future decision function. W8 will land
+# ``decide_approval`` in `src/mergecraft/agents/gates.py` (or a sibling
+# module); the import is inside a helper so the failure mode is a clear
+# AttributeError / ImportError on the test rather than a top-level collection
+# crash that hides the actual assertion.
+# ---------------------------------------------------------------------------
+
+
+def _decide_approval() -> Callable[..., Any]:
+    """Return ``decide_approval`` from the W8 module it lands in.
+
+    W8's outline (from the plan, W8.1): a pure function
+    ``decide_approval(findings: list[Finding], *, run_succeeded: bool,
+    tier: TrustTier) -> Conclusion`` in `src/mergecraft/agents/gates.py`.
+    The module may add it as a sibling helper rather than renaming the file.
+    """
+    from mergecraft.agents import gates as _gates
+
+    fn = getattr(_gates, "decide_approval", None)
+    if fn is None:  # pragma: no cover - W7 expects this until W8 lands
+        msg = (
+            "decide_approval is not yet defined in mergecraft.agents.gates "
+            "(W8 deliverable — W7.1–W7.6 are xfail until it lands)"
+        )
+        raise AttributeError(msg)
+    return fn
+
+
+def _approval_conclusion_module() -> Any:
+    """Return the module that defines ``Conclusion`` (per W8.1 it reuses
+    ``utils/status_checks.Conclusion``)."""
+    from mergecraft.utils import status_checks as _sc
+
+    return _sc
+
+
+# ---------------------------------------------------------------------------
+# W7.1 — narrative "approved" + blocker finding ⇒ failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_narrative_approval_with_blocker_finding_yields_failure(
+    blocker_finding: Finding,
+) -> None:
+    """The issue's headline acceptance criterion (#75).
+
+    Drive a run whose narrative says "approved" (the agent's boolean lives
+    in ``ApprovalRecord.would_approve``) while the typed finding list
+    contains a blocker. The structural approval gate must post ``failure``
+    regardless of the narrative.
+    """
+    decide = _decide_approval()
+    sc = _approval_conclusion_module()
+
+    # Narrative says "approved" — model passed approved=True.
+    narrative_says_approved = True
+    assert narrative_says_approved is True  # guard: the test is about the conflict
+
+    conclusion = decide(
+        [blocker_finding],
+        run_succeeded=True,
+        tier="trusted",
+    )
+
+    assert conclusion == sc.Conclusion  # type: ignore[attr-defined]
+    assert conclusion == "failure", (
+        "approval gate must be derived from findings, not narrative — "
+        "a blocker must yield 'failure' even when the agent said 'approved'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# W7.2 — pure function of findings: same findings, different narratives,
+# identical conclusion.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+@pytest.mark.parametrize(
+    "narrative_would_approve",
+    [True, False, None],
+    ids=["narrative-approve", "narrative-block", "narrative-unrecorded"],
+)
+def test_approval_conclusion_is_pure_function_of_findings(
+    sample_findings: list[Finding],
+    narrative_would_approve: bool | None,
+) -> None:
+    """Same finding list, three different narratives → identical conclusion.
+
+    The decision function's signature must not accept an
+    ``ApprovalRecord.would_approve`` value. The agent's boolean is recorded
+    separately by W8.3; the conclusion is computed from findings + run
+    state + tier only.
+    """
+    decide = _decide_approval()
+
+    # The narrative lives in tool_state.approval.would_approve — it is
+    # never an input to decide_approval. The test asserts that the same
+    # finding list + run state + tier produces the same conclusion across
+    # three different recorded narratives.
+    decisions = [
+        decide(
+            sample_findings,
+            run_succeeded=True,
+            tier="trusted",
+        )
+        for _ in range(3)
+    ]
+    assert len({id(d) for d in decisions}) == 1, (
+        "decide_approval must return a single value — it has no I/O and no internal state"
+    )
+    # Same value, same conclusion.
+    assert decisions[0] == decisions[1] == decisions[2]
+
+    # Same finding list (blockers present) ⇒ failure. The narrative is
+    # not part of the call: narrative_would_approve is parametrized only
+    # so the test name documents the matrix.
+    assert decisions[0] == "failure", (
+        "a finding list containing blockers must yield 'failure' "
+        "regardless of the agent's recorded narrative"
+    )
+
+    # Sanity: the parametrized axis is not silently consumed by the function.
+    _ = narrative_would_approve
+
+
+# ---------------------------------------------------------------------------
+# W7.5 — the agent's approved flag is advisory only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_agent_approved_flag_is_advisory_only_with_empty_findings(
+    clean_findings: list[Finding],
+) -> None:
+    """``create_pull_request_review(approved=True)`` with no findings must
+    not by itself produce ``success``.
+
+    W8.3 demotes the agent's boolean to advisory. With *no* findings on
+    the structural side, the gate is ``neutral`` (the wire-shape the
+    hardened enforce step treats as blocking — D13), not ``success``.
+    """
+    decide = _decide_approval()
+
+    # Simulate the agent calling create_pull_request_review(approved=True).
+    # The ApprovalRecord is recorded separately; the decision is computed
+    # from findings + run state + tier only.
+    conclusion = decide(
+        clean_findings,
+        run_succeeded=True,
+        tier="trusted",
+    )
+
+    # "neutral" is the only honest shape here: the run completed, no
+    # blockers, but there are also no findings to attest to. The hardened
+    # enforce step (W8.4) treats neutral as blocking.
+    assert conclusion == "neutral", (
+        "the agent's approved=True must not by itself produce 'success' "
+        "when the structural finding list is empty — the conclusion is "
+        "a pure function of findings, not narrative"
+    )
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_agent_approved_flag_is_advisory_only_with_blocking_findings(
+    blocker_finding: Finding,
+) -> None:
+    """Mirror of W7.5: the agent's ``approved=True`` cannot override a blocker.
+
+    Even with the agent's boolean set, the gate must remain ``failure``
+    because the finding list contains a blocker.
+    """
+    decide = _decide_approval()
+
+    conclusion = decide(
+        [blocker_finding],
+        run_succeeded=True,
+        tier="trusted",
+    )
+
+    assert conclusion == "failure", (
+        "advisory 'approved' from the agent must not flip a blocker "
+        "into 'success' — findings are the structural input"
+    )
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_approval_record_remains_an_advisory_input(
+    tmp_path: Path,
+) -> None:
+    """W8.3 keeps ``ApprovalRecord.would_approve`` recorded but never
+    consulted as the sole positive input.
+
+    This is a structural test: an ``ApprovalRecord`` with ``would_approve=True``
+    is constructed in ``tool_state`` (the same way ``create_pull_request_review``
+    would record it today), and the decision function is invoked *without*
+    passing the ``ApprovalRecord`` as an argument. The conclusion is computed
+    from findings + run state + tier only.
+    """
+    from mergecraft.mcp.tool_state import ApprovalRecord, init_tool_state
+
+    decide = _decide_approval()
+
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    # Simulate the agent having called create_pull_request_review(approved=True).
+    tool_state.approval = ApprovalRecord(would_approve=True, sha="abc123")
+
+    # No findings, run succeeded, trusted tier.
+    conclusion = decide(
+        [],
+        run_succeeded=True,
+        tier="trusted",
+    )
+
+    # The agent's stored boolean is irrelevant to the decision function.
+    assert conclusion == "neutral", (
+        "the decision function must not read ApprovalRecord.would_approve; "
+        "an approval with no findings must not produce 'success'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# W7.6 — structural guard: no parallel finding model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_no_second_finding_model_introduced() -> None:
+    """D12: the approval path imports ``Finding`` from
+    ``analyzers/finding.py`` and defines no parallel model.
+
+    Asserted by inspecting the module W8 will add the decision function
+    to (``src/mergecraft/agents/gates.py``) and the ``analyzers``
+    package for parallel models.
+    """
+    import mergecraft.agents.gates as gates
+    from mergecraft.analyzers import finding as finding_mod
+
+    # The decision function (W8) lives in this module.
+    assert hasattr(gates, "decide_approval"), (
+        "W8 must add decide_approval to mergecraft.agents.gates"
+    )
+
+    # The approval path's Finding is the canonical one from finding.py.
+    decision_finding = gates.decide_approval.__annotations__["findings"]
+    # The annotation must be ``list[Finding]`` (or equivalent) — not a
+    # parallel model defined in gates.py.
+    assert str(decision_finding) == "list[Finding]", (
+        "decide_approval's findings argument must be annotated as "
+        "list[Finding] — D12 forbids a parallel model"
+    )
+
+    # No parallel finding class in the gates module.
+    for name in vars(gates):
+        obj = getattr(gates, name)
+        if isinstance(obj, type) and obj is not Finding and obj.__name__.endswith("Finding"):
+            msg = f"mergecraft.agents.gates must not define a parallel finding model: {obj}"
+            raise AssertionError(msg)
+
+    # The canonical Finding is still re-exported from analyzers.finding.
+    assert finding_mod.Finding is Finding
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_finding_source_is_preserved_for_evidence_audit() -> None:
+    """Findings carry a ``source`` field (analyzer / agent / ci) that the
+    approval conclusion must respect when distinguishing "agent claims
+    versus structural evidence".
+
+    The decision is *not* a function of the sources themselves
+    (severity is the gating axis), but the decision must not strip or
+    rewrite ``source`` — that breaks the merge-evidence plan's
+    reconstruction requirement (#75 proposal item 4).
+    """
+    decide = _decide_approval()
+
+    findings: list[Finding] = [
+        _make_finding_with_source("agent"),
+        _make_finding_with_source("ci"),
+    ]
+    before = [f.source for f in findings]
+    decide(
+        findings,
+        run_succeeded=True,
+        tier="trusted",
+    )
+    after = [f.source for f in findings]
+    assert before == after, (
+        "decide_approval must not mutate findings — the merge-evidence "
+        "plan reconstructs the conclusion from stored findings"
+    )
+
+
+def _make_finding_with_source(source: FindingSource) -> Finding:
+    """Constructor helper for the no-mutation assertion."""
+    from mergecraft.analyzers.finding import make_finding
+
+    return make_finding(
+        tool="w7-fixture",
+        rule_id="W7-SRC",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="possible",
+        message="source-preservation probe",
+        path="src/mergecraft/utils/status_checks.py",
+        start_line=1,
+        end_line=1,
+        source=source,
+        fingerprint=f"w7-src-{source}",
+    )

--- a/tests/status_checks/test_decide_approval.py
+++ b/tests/status_checks/test_decide_approval.py
@@ -1,13 +1,7 @@
-"""W7 RED suite for #75 structural approval gate — pure decision function.
+"""W8 GREEN suite for #75 structural approval gate — pure decision function.
 
-These tests pin the contract W8 must implement in
-``src/mergecraft/agents/gates.py`` (or a sibling module under
-``src/mergecraft/agents/``). Every test is marked
-``@pytest.mark.xfail(reason="green after W8", strict=False)`` because the
-function ``decide_approval(findings, *, run_succeeded, tier) -> Conclusion``
-does not yet exist on this branch — W8 will add it.
-
-The contract under test (D12, D13):
+These tests pin the contract ``decide_approval`` satisfies in W8
+(``src/mergecraft/agents/gates.py``):
 
 - ``decide_approval`` is a *pure function* of the finding list, the run
   completion state, and the trust tier. Narrative (``ApprovalRecord``,
@@ -41,37 +35,29 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Module-availability guard for the future decision function. W8 will land
-# ``decide_approval`` in `src/mergecraft/agents/gates.py` (or a sibling
-# module); the import is inside a helper so the failure mode is a clear
-# AttributeError / ImportError on the test rather than a top-level collection
-# crash that hides the actual assertion.
+# Module-availability helper — W8 added ``decide_approval`` to
+# ``mergecraft.agents.gates``. The import is inside a helper so the failure
+# mode is a clear AttributeError on the test rather than a top-level
+# collection crash that hides the actual assertion.
 # ---------------------------------------------------------------------------
 
 
 def _decide_approval() -> Callable[..., Any]:
-    """Return ``decide_approval`` from the W8 module it lands in.
-
-    W8's outline (from the plan, W8.1): a pure function
-    ``decide_approval(findings: list[Finding], *, run_succeeded: bool,
-    tier: TrustTier) -> Conclusion`` in `src/mergecraft/agents/gates.py`.
-    The module may add it as a sibling helper rather than renaming the file.
-    """
+    """Return ``decide_approval`` from the W8 module it lives in."""
     from mergecraft.agents import gates as _gates
 
     fn = getattr(_gates, "decide_approval", None)
-    if fn is None:  # pragma: no cover - W7 expects this until W8 lands
+    if fn is None:  # pragma: no cover - W8 ships this
         msg = (
-            "decide_approval is not yet defined in mergecraft.agents.gates "
-            "(W8 deliverable — W7.1–W7.6 are xfail until it lands)"
+            "decide_approval is not defined in mergecraft.agents.gates "
+            "(W8 deliverable — this fixture requires it)"
         )
         raise AttributeError(msg)
     return fn
 
 
 def _approval_conclusion_module() -> Any:
-    """Return the module that defines ``Conclusion`` (per W8.1 it reuses
-    ``utils/status_checks.Conclusion``)."""
+    """Return the module that defines ``Conclusion``."""
     from mergecraft.utils import status_checks as _sc
 
     return _sc
@@ -82,7 +68,6 @@ def _approval_conclusion_module() -> Any:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_narrative_approval_with_blocker_finding_yields_failure(
     blocker_finding: Finding,
 ) -> None:
@@ -106,7 +91,10 @@ def test_narrative_approval_with_blocker_finding_yields_failure(
         tier="trusted",
     )
 
-    assert conclusion == sc.Conclusion  # type: ignore[attr-defined]
+    # The conclusion must be one of the wire-shape literals the Conclusion
+    # type alias advertises — i.e. a typed string, not a parallel model.
+    assert conclusion in ("success", "failure", "neutral")
+    assert hasattr(sc, "Conclusion")  # the literal type alias is exported
     assert conclusion == "failure", (
         "approval gate must be derived from findings, not narrative — "
         "a blocker must yield 'failure' even when the agent said 'approved'"
@@ -119,7 +107,6 @@ def test_narrative_approval_with_blocker_finding_yields_failure(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 @pytest.mark.parametrize(
     "narrative_would_approve",
     [True, False, None],
@@ -173,7 +160,6 @@ def test_approval_conclusion_is_pure_function_of_findings(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_agent_approved_flag_is_advisory_only_with_empty_findings(
     clean_findings: list[Finding],
 ) -> None:
@@ -205,7 +191,6 @@ def test_agent_approved_flag_is_advisory_only_with_empty_findings(
     )
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_agent_approved_flag_is_advisory_only_with_blocking_findings(
     blocker_finding: Finding,
 ) -> None:
@@ -228,7 +213,6 @@ def test_agent_approved_flag_is_advisory_only_with_blocking_findings(
     )
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_approval_record_remains_an_advisory_input(
     tmp_path: Path,
 ) -> None:
@@ -268,12 +252,11 @@ def test_approval_record_remains_an_advisory_input(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_no_second_finding_model_introduced() -> None:
     """D12: the approval path imports ``Finding`` from
     ``analyzers/finding.py`` and defines no parallel model.
 
-    Asserted by inspecting the module W8 will add the decision function
+    Asserted by inspecting the module W8 added the decision function
     to (``src/mergecraft/agents/gates.py``) and the ``analyzers``
     package for parallel models.
     """
@@ -305,7 +288,6 @@ def test_no_second_finding_model_introduced() -> None:
     assert finding_mod.Finding is Finding
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_finding_source_is_preserved_for_evidence_audit() -> None:
     """Findings carry a ``source`` field (analyzer / agent / ci) that the
     approval conclusion must respect when distinguishing "agent claims

--- a/tests/status_checks/test_status_checks_enforce.py
+++ b/tests/status_checks/test_status_checks_enforce.py
@@ -1,6 +1,6 @@
-"""W7 RED suite for #75 — enforce-path tests (D13, D14).
+"""W8 GREEN suite for #75 — enforce-path tests (D13, D14).
 
-These tests pin the *enforce* contract W8 must satisfy:
+These tests pin the *enforce* contract W8 satisfies:
 
 - W7.3 (D13): a crashed / timed-out / no-findings run yields an
   ``mergecraft-approval`` conclusion that the hardened enforce step
@@ -17,18 +17,12 @@ These tests pin the *enforce* contract W8 must satisfy:
   2. The MCP tool ``create_pull_request_review`` — untrusted tier
      never sends ``event="APPROVE"`` to GitHub regardless of
      ``pr_approve_enabled`` and the agent's boolean.
-
-Both tests are decorated with ``@pytest.mark.xfail(reason="green after
-W8", strict=False)`` because the inert behaviour does not yet exist on
-this branch — W8 will add it.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
-
-import pytest
 
 from mergecraft.analyzers.finding import Finding
 from mergecraft.analyzers.trust import derive_trust_tier
@@ -43,14 +37,14 @@ if TYPE_CHECKING:
 
 
 def _decide_approval() -> Callable[..., Any]:
-    """Return ``decide_approval`` from the W8 module it lands in."""
+    """Return ``decide_approval`` from the W8 module it lives in."""
     from mergecraft.agents import gates as _gates
 
     fn = getattr(_gates, "decide_approval", None)
-    if fn is None:  # pragma: no cover - W7 expects this until W8 lands
+    if fn is None:  # pragma: no cover - W8 ships this
         msg = (
-            "decide_approval is not yet defined in mergecraft.agents.gates "
-            "(W8 deliverable — W7.3/W7.4 are xfail until it lands)"
+            "decide_approval is not defined in mergecraft.agents.gates "
+            "(W8 deliverable — this fixture requires it)"
         )
         raise AttributeError(msg)
     return fn
@@ -87,7 +81,6 @@ def _context_factory() -> Any:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_crashed_run_does_not_leave_permissive_gate() -> None:
     """A run that raises or times out yields a conclusion the hardened
     enforce step treats as blocking (D13).
@@ -115,7 +108,6 @@ def test_crashed_run_does_not_leave_permissive_gate() -> None:
     assert conclusion is not None
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_timed_out_run_with_findings_yields_failure() -> None:
     """A timed-out run that *did* record a blocker before timing out must
     still surface ``failure``. The decision is the monotone-OR of run
@@ -152,7 +144,6 @@ def test_timed_out_run_with_findings_yields_failure() -> None:
     assert conclusion == "failure", "a timed-out run with a blocker finding must surface 'failure'"
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 async def test_report_status_checks_surfaces_neutral_for_crashed_run(
     tmp_path: Path,
 ) -> None:
@@ -238,7 +229,6 @@ async def test_report_status_checks_surfaces_neutral_for_crashed_run(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 def test_fork_pr_cannot_self_approve_at_decision_layer(
     blocked_pr_event: dict,
 ) -> None:
@@ -271,7 +261,6 @@ def test_fork_pr_cannot_self_approve_at_decision_layer(
     assert conclusion in ("failure", "neutral")
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 async def test_fork_pr_cannot_self_approve_at_tool_layer(
     tmp_path: Path,
 ) -> None:
@@ -341,7 +330,6 @@ async def test_fork_pr_cannot_self_approve_at_tool_layer(
     _ = httpx.__name__
 
 
-@pytest.mark.xfail(reason="green after W8", strict=False)
 async def test_in_repo_pr_with_pr_approve_enabled_can_self_approve(
     tmp_path: Path,
 ) -> None:

--- a/tests/status_checks/test_status_checks_enforce.py
+++ b/tests/status_checks/test_status_checks_enforce.py
@@ -1,0 +1,402 @@
+"""W7 RED suite for #75 — enforce-path tests (D13, D14).
+
+These tests pin the *enforce* contract W8 must satisfy:
+
+- W7.3 (D13): a crashed / timed-out / no-findings run yields an
+  ``mergecraft-approval`` conclusion that the hardened enforce step
+  treats as blocking. The wire-shape is ``"neutral"`` — the W8 README
+  copy replaces the current "neutral is non-blocking" framing.
+
+- W7.4 (D14): a fork PR with ``prApproveEnabled=True`` cannot produce
+  an ``APPROVE`` review event. The inert behaviour is asserted at
+  *two* layers because the gate has two enforcement points:
+
+  1. The decision function (``decide_approval``) — untrusted tier
+     produces ``"failure"`` (or another non-``success`` shape) even
+     when the agent's approval boolean is True.
+  2. The MCP tool ``create_pull_request_review`` — untrusted tier
+     never sends ``event="APPROVE"`` to GitHub regardless of
+     ``pr_approve_enabled`` and the agent's boolean.
+
+Both tests are decorated with ``@pytest.mark.xfail(reason="green after
+W8", strict=False)`` because the inert behaviour does not yet exist on
+this branch — W8 will add it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.trust import derive_trust_tier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Module-availability helpers — same pattern as test_decide_approval.py.
+# ---------------------------------------------------------------------------
+
+
+def _decide_approval() -> Callable[..., Any]:
+    """Return ``decide_approval`` from the W8 module it lands in."""
+    from mergecraft.agents import gates as _gates
+
+    fn = getattr(_gates, "decide_approval", None)
+    if fn is None:  # pragma: no cover - W7 expects this until W8 lands
+        msg = (
+            "decide_approval is not yet defined in mergecraft.agents.gates "
+            "(W8 deliverable — W7.3/W7.4 are xfail until it lands)"
+        )
+        raise AttributeError(msg)
+    return fn
+
+
+def _status_checks_module() -> Any:
+    """Return ``mergecraft.utils.status_checks`` for the enforce tests."""
+    from mergecraft.utils import status_checks as _sc
+
+    return _sc
+
+
+def _context_class() -> Any:
+    """Return ``ToolContext`` (lazy to keep collection lenient)."""
+    from mergecraft.mcp.context import ToolContext
+
+    return ToolContext
+
+
+def _context_factory() -> Any:
+    """Return the ``ToolContext`` constructor and event/payload types."""
+    from mergecraft.mcp.context import (
+        PayloadEvent,
+        RepoIdentity,
+        ResolvedPayload,
+        ToolContext,
+    )
+
+    return ToolContext, PayloadEvent, RepoIdentity, ResolvedPayload
+
+
+# ---------------------------------------------------------------------------
+# W7.3 — crashed / timed-out run does not leave a permissive gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_crashed_run_does_not_leave_permissive_gate() -> None:
+    """A run that raises or times out yields a conclusion the hardened
+    enforce step treats as blocking (D13).
+
+    The decision function is invoked with ``run_succeeded=False`` and
+    no findings. The result must be ``"neutral"`` — the wire-shape the
+    enforced step (W8.4) treats as blocking. It must not be
+    ``"success"`` because the run never completed.
+    """
+    decide = _decide_approval()
+    _ = _status_checks_module()  # ensures the module is importable
+
+    conclusion = decide(
+        [],
+        run_succeeded=False,
+        tier="trusted",
+    )
+
+    assert conclusion == "neutral", (
+        "a crashed run must not produce 'success' — the hardened enforce "
+        "step treats 'neutral' as blocking (D13)"
+    )
+    # The conftest imports ensure this is in scope.
+    assert conclusion in ("success", "failure", "neutral")
+    assert conclusion is not None
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_timed_out_run_with_findings_yields_failure() -> None:
+    """A timed-out run that *did* record a blocker before timing out must
+    still surface ``failure``. The decision is the monotone-OR of run
+    state and findings: a failed run with blockers is ``failure``."""
+    decide = _decide_approval()
+
+    blocker = Finding.model_validate(
+        {
+            "tool": "w7-fixture",
+            "rule_id": "W7-TIMEOUT",
+            "category": "Security & Privacy",
+            "severity": "Major",
+            "confidence": "certain",
+            "message": "Auth bypass present.",
+            "path": "src/foo.py",
+            "start_line": 1,
+            "end_line": 10,
+            "fingerprint": "w7-timeout-mjr",
+            "evidence": ["line 1: ..."],
+            "remediation": "Add the auth check.",
+            "autofix": None,
+            "introduced_by_pr": "true",
+            "source": "agent",
+            "cluster_id": None,
+        }
+    )
+
+    conclusion = decide(
+        [blocker],
+        run_succeeded=False,
+        tier="trusted",
+    )
+
+    assert conclusion == "failure", "a timed-out run with a blocker finding must surface 'failure'"
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+async def test_report_status_checks_surfaces_neutral_for_crashed_run(
+    tmp_path: Path,
+) -> None:
+    """Wired through ``report_status_checks``: the approve check posts
+    ``"neutral"`` when the run did not succeed, even if the agent
+    previously recorded ``ApprovalRecord(would_approve=True)``.
+
+    The hardened enforce step (W8.4) treats ``"neutral"`` as blocking.
+    """
+    import httpx
+
+    from mergecraft.mcp.tool_state import ApprovalRecord, init_tool_state
+    from mergecraft.modes import compute_modes
+    from mergecraft.utils.github import GitHubClient
+
+    sc = _status_checks_module()
+
+    class _RecordingGitHub(GitHubClient):
+        def __init__(self) -> None:
+            super().__init__(token="test-token")
+            self.check_runs: list[dict[str, Any]] = []
+            self.review_payload: dict[str, Any] = {}
+
+        async def get_pull(self, owner: str, repo: str, pull_number: int) -> dict[str, Any]:
+            return {"head": {"sha": "deadbeef" * 5}}
+
+        async def post(self, path: str, **kwargs: Any) -> Any:
+            if path.endswith("/check-runs"):
+                body = kwargs.get("json")
+                if isinstance(body, dict):
+                    self.check_runs.append(body)
+            return {}
+
+        async def create_review(
+            self, owner: str, repo: str, pull_number: int, **payload: Any
+        ) -> dict[str, Any]:
+            self.review_payload = payload
+            return {"id": 1, "node_id": "n1", "html_url": "https://x/1", "state": "COMMENTED"}
+
+    ToolContext, PayloadEvent, RepoIdentity, ResolvedPayload = _context_factory()
+
+    github = _RecordingGitHub()
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    # Simulate the agent having called create_pull_request_review(approved=True)
+    # before the run was killed.
+    tool_state.approval = ApprovalRecord(would_approve=True, sha="deadbeef")
+    ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=42, is_pr=True),
+            status_checks=True,
+        ),
+        github=github,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+    # Even though the agent's stored boolean says "approved", the run
+    # crashed — the post-W8 rewire must consult the decision function
+    # and surface ``"neutral"`` for the mergecraft-approval check.
+    await sc.report_status_checks(ctx, run_succeeded=False)
+
+    approve_checks = [run for run in github.check_runs if run.get("name") == sc.APPROVAL_CHECK]
+    assert len(approve_checks) == 1
+    assert approve_checks[0]["conclusion"] == "neutral", (
+        "a crashed run must not propagate ApprovalRecord.would_approve "
+        "into a 'success' check — the structural gate is the source of "
+        "truth (D13, D12)"
+    )
+
+    # Drop the unused import hint so ruff does not flag it.
+    _ = httpx.__name__
+
+
+# ---------------------------------------------------------------------------
+# W7.4 — fork PR cannot self-approve (D14)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+def test_fork_pr_cannot_self_approve_at_decision_layer(
+    blocked_pr_event: dict,
+) -> None:
+    """``derive_trust_tier()`` returns ``"untrusted"`` for a fork PR, and
+    ``prApproveEnabled=true`` ⇒ no approval, regardless of config (D14).
+
+    The decision function is the structural source of truth. With
+    ``tier="untrusted"`` and a clean (no-blocker) finding list, the
+    conclusion must not be ``"success"`` — it must be ``"failure"`` or
+    ``"neutral"`` (the exact shape is W8's call; the contract is *not*
+    success).
+    """
+    tier = derive_trust_tier(blocked_pr_event)
+    assert tier == "untrusted", (
+        "sanity: a fork PR event must be tier='untrusted' before we assert the inert path"
+    )
+
+    decide = _decide_approval()
+    conclusion = decide(
+        [],
+        run_succeeded=True,
+        tier=tier,
+    )
+
+    assert conclusion != "success", (
+        "an untrusted tier must never produce 'success' — even with "
+        "no blockers and a successful run, the gate is inert for "
+        "fork PRs and pull_request_target (D14)"
+    )
+    assert conclusion in ("failure", "neutral")
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+async def test_fork_pr_cannot_self_approve_at_tool_layer(
+    tmp_path: Path,
+) -> None:
+    """Mirror of the above at the create_pull_request_review tool layer.
+
+    With ``pr_approve_enabled=True`` *and* the agent's
+    ``approved=True`` argument, the tool must NOT send
+    ``event="APPROVE"`` to GitHub when the trust tier is ``untrusted``.
+    The current behaviour (W7 source) sends ``event="APPROVE"`` —
+    W8.5 makes the flag inert for untrusted runs.
+    """
+    import httpx
+
+    from mergecraft.mcp.review import create_pull_request_review_tool
+    from mergecraft.mcp.tool_state import init_tool_state
+    from mergecraft.modes import compute_modes
+    from mergecraft.utils.github import GitHubClient
+
+    ToolContext, PayloadEvent, RepoIdentity, ResolvedPayload = _context_factory()
+
+    class _RecordingGitHub(GitHubClient):
+        def __init__(self) -> None:
+            super().__init__(token="test-token")
+            self.review_payloads: list[dict[str, Any]] = []
+
+        async def create_review(
+            self, owner: str, repo: str, pull_number: int, **payload: Any
+        ) -> dict[str, Any]:
+            self.review_payloads.append(payload)
+            return {"id": 1, "node_id": "n1", "html_url": "https://x/1", "state": "COMMENTED"}
+
+    github = _RecordingGitHub()
+    ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=7, is_pr=True)
+        ),
+        github=github,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+        trust_tier="untrusted",
+    )
+
+    spec = create_pull_request_review_tool(ctx)
+    await spec.execute(
+        {"pull_number": 7, "body": "Looks good.", "approved": True},
+    )
+
+    sent_events = [p.get("event") for p in github.review_payloads]
+    assert "APPROVE" not in sent_events, (
+        "create_pull_request_review must not send event='APPROVE' on "
+        "untrusted runs, even with pr_approve_enabled=True and "
+        "approved=True — D14 enforces one config knob, one inert path"
+    )
+
+    # The advisory input is still recorded (W8.3).
+    assert ctx.tool_state.approval is not None
+    assert ctx.tool_state.approval.would_approve is True
+
+    _ = httpx.__name__
+
+
+@pytest.mark.xfail(reason="green after W8", strict=False)
+async def test_in_repo_pr_with_pr_approve_enabled_can_self_approve(
+    tmp_path: Path,
+) -> None:
+    """Regression guard for D14: the inert path applies to *untrusted*
+    only. An in-repo PR with ``pr_approve_enabled=True`` and
+    ``approved=True`` must still send ``event="APPROVE"``.
+
+    This is the pin-side of the test: D14 is "make untrusted inert",
+    not "remove approval entirely".
+    """
+    from mergecraft.mcp.review import create_pull_request_review_tool
+    from mergecraft.mcp.tool_state import init_tool_state
+    from mergecraft.modes import compute_modes
+    from mergecraft.utils.github import GitHubClient
+
+    ToolContext, PayloadEvent, RepoIdentity, ResolvedPayload = _context_factory()
+
+    class _RecordingGitHub(GitHubClient):
+        def __init__(self) -> None:
+            super().__init__(token="test-token")
+            self.review_payloads: list[dict[str, Any]] = []
+
+        async def create_review(
+            self, owner: str, repo: str, pull_number: int, **payload: Any
+        ) -> dict[str, Any]:
+            self.review_payloads.append(payload)
+            return {"id": 1, "node_id": "n1", "html_url": "https://x/1", "state": "COMMENTED"}
+
+    github = _RecordingGitHub()
+    ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=7, is_pr=True)
+        ),
+        github=github,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+        trust_tier="trusted",
+    )
+
+    spec = create_pull_request_review_tool(ctx)
+    await spec.execute(
+        {"pull_number": 7, "body": "Looks good.", "approved": True},
+    )
+
+    sent_events = [p.get("event") for p in github.review_payloads]
+    assert sent_events == ["APPROVE"], (
+        "regression guard: a trusted in-repo PR with pr_approve_enabled "
+        "and approved=True must still post event='APPROVE' — D14 only "
+        "inert on untrusted tier"
+    )

--- a/tests/utils/test_status_checks.py
+++ b/tests/utils/test_status_checks.py
@@ -1,4 +1,14 @@
-"""Regression tests for opt-in commit status checks (issues #5, #6)."""
+"""Regression tests for opt-in commit status checks (issues #5, #6, #75).
+
+The approval check conclusion is computed structurally by ``decide_approval``
+(``mergecraft.agents.gates``) from the typed ``Finding`` list, the run's
+completion state, and the trust tier (D12). Narrative (``ApprovalRecord``) is
+never the sole positive input. The pre-W8 "preserve approval when run fails
+later" expectation is replaced by the W8 #75 structural contract: a crashed
+run yields ``neutral`` (the wire-shape the hardened enforce step blocks on —
+D13), regardless of any recorded ``ApprovalRecord.would_approve``. The new
+tests below pin that contract.
+"""
 
 from __future__ import annotations
 
@@ -96,10 +106,20 @@ async def test_report_status_checks_posts_neutral_approval_when_review_incomplet
 
 
 @pytest.mark.asyncio
-async def test_report_status_checks_preserves_approval_when_run_fails_later(
+async def test_report_status_checks_neutral_for_crashed_run_with_recorded_approval(
     tmp_path: Path,
 ) -> None:
-    """Approval recorded before a later run failure must not be masked as neutral."""
+    """A recorded ``ApprovalRecord(would_approve=...)`` must not flip a crashed
+    run to ``success`` or ``failure`` — D13 fail-closed.
+
+    Replaces the pre-W8 "preserve approval when run fails later" expectation:
+    the structural approval gate consults ``decide_approval(findings,
+    run_succeeded=False, tier)`` and yields ``"neutral"`` regardless of what
+    the agent's boolean recorded. The ``ApprovalRecord`` survives in
+    ``tool_state.approval`` as an advisory input for the trajectory / merge-
+    evidence work (#41); the reviewed commit SHA is included in the summary
+    so operators can audit the run.
+    """
     github = _RecordingGitHub()
     ctx = _ctx(
         tmp_path,
@@ -112,12 +132,13 @@ async def test_report_status_checks_preserves_approval_when_run_fails_later(
     approval_checks = _approval_checks(github)
     assert len(approval_checks) == 1
     check = approval_checks[0]
-    assert check["conclusion"] == "failure"
-    summary = check["output"]["summary"]
-    assert (
-        "would not approve" in check["output"]["title"].lower() or "not approve" in summary.lower()
+    assert check["conclusion"] == "neutral", (
+        "W8 / D13 — a crashed run must surface 'neutral' regardless of any "
+        "recorded ApprovalRecord; the hardened enforce step blocks on 'neutral'"
     )
-    assert REVIEWED_SHA in summary or REVIEWED_SHA[:7] in summary
+    assert (
+        REVIEWED_SHA in check["output"]["summary"] or REVIEWED_SHA[:7] in check["output"]["summary"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #75.

## What

`mergecraft-approval` is no longer derived from the agent's `approved` boolean or any narrative field. The conclusion is a pure function of the typed `Finding` list, the run's completion state, and the trust tier — `decide_approval(findings, *, run_succeeded, tier)` in `src/mergecraft/agents/gates.py`. `mcp/review.py::create_pull_request_review` still records the agent's `ApprovalRecord(would_approve=...)` as an advisory self-assessment, but the wire-call gate that emits the check conclusion no longer reads it as a decision driver.

## Semantics (D12–D14, batched into a single, public-facing flip)

- Any `Critical` or `Major` finding ⇒ `failure`, regardless of narrative, run state, or tier. **Findings, not confidence.**
- `run_succeeded=False` ⇒ `neutral`. The hardened example workflow now ships a `neutral`-as-blocking enforce step (D13).
- `tier="untrusted"` (fork head, or `pull_request_target`) ⇒ never `success`; the wire-call `event="APPROVE"` path is gated on `ctx.trust_tier == "trusted"`, so `prApproveEnabled` is inert for untrusted runs (D14).
- `tier="trusted"` + succeeded + no blocker + non-empty findings ⇒ `success`; with empty findings ⇒ `neutral` (attested structural evidence the review ran).

`ApprovalRecord.would_approve` is retained as the agent's advisory self-assessment — the merge-evidence plan (#41) reads it as trajectory, separately from the evidence-driven conclusion. No parallel `Finding` model is introduced; the gate imports `Finding` from `analyzers/finding.py`.

## ⚠️ Breaking changes — see the `Changed (BREAKING)` section in `CHANGELOG.md`

Both flips are consumer-visible and are recorded verbatim under `## [Unreleased]` → `### Changed (BREAKING)`:

1. **`mergecraft-approval` is now structural — `neutral` becomes blocking (D13).**
   A crashed / timed-out / no-findings run posts `neutral` regardless of any recorded `ApprovalRecord.would_approve`. The hardened example workflow's enforce step treats `neutral` as **blocking**. Anyone who relied on the previous "neutral is non-blocking by default" framing must adopt the hardened workflow's enforce step (or an equivalent branch-protection rule). `report_status_checks()` now consults `decide_approval(findings, run_succeeded, tier)` instead of `approval.would_approve`.

2. **`prApproveEnabled` goes inert for `untrusted` tier runs (D14) — no self-approval on fork PRs.**
   `create_pull_request_review` does not send `event="APPROVE"` to GitHub when `ctx.trust_tier == "untrusted"`, even with `pr_approve_enabled=true` and the agent passing `approved=true`. The advisory `ApprovalRecord(would_approve=True, sha=...)` is still recorded so the trajectory / merge-evidence work (#41) can read it after the fact. Trusted in-repo PRs are unchanged.

`README.md` is updated next to `status_checks: enabled` to state the new semantics; the pre-W8 "neutral is non-blocking" framing is removed.

## Why

#75 names two paths to a permissive `mergecraft-approval`: direct (prose says approve) and indirect (findings suppressed so the check passes honestly on dishonest input). Both are closed by deriving the conclusion from a typed structure the agent cannot author into. The hardened workflow's enforce step is the consumer-facing flip that turns `neutral` into a blocking check.

## Out of scope (per the plan)

- Adversarial prompt-injection test suites / susceptibility scoring — D9, security Batch B.
- A "second signal" / two-person-rule approval mechanism — D14.
- `decide_approval()` remains a pure function; the merge-evidence plan (#41, #46) reuses it without re-shaping.

## Verification (D Final, re-run after rebase onto `origin/pre-0.0.1`)

The branch was rebased onto `origin/pre-0.0.1` (which now carries merged security Batches A, B, and C) and the whole gate was re-run on the rebased tree:

- `make ci-resume` — **✅ all 9 steps passed** (equivalent to `make ci`: `lockcheck lint typecheck pyright catalog-check build example-workflows-check security test`). Tests: **637 passed, 1 skipped, 3 xfailed, 8 xpassed**. The 3 xfails are the documented pre-existing Batch B deferrals (`test_offline_review_fence.py` ×2, `test_fence.py::test_forged_close_does_not_escape_fence`); the 8 xpasses are Batch C learnings-provenance tests that now pass on mainline. No new xfails, no W7 leftovers.
- Security-review gate (D3) on the batch diff vs `origin/pre-0.0.1` — **clean above `low`**. Bandit reports 0 medium/high. The approval path fails closed at every branch: a missing `analyzer_run`, an unparsable finding row, a crashed run, or an untrusted tier all resolve to `neutral`, never `success`.
- `graphify update .` — graph rebuilt (3300 nodes / 5158 edges / 284 communities).

## Merge order (cross-plan)

**This PR should merge before `wave/evi-a-packet` (#47 / #41).** `decide_approval()` is the contract that plan's W2 consumes; `wave/evi-a-packet` currently carries patch-identical copies of this branch's two commits so it can build and test, and it extends `decide_approval()` with a packet overload rather than forking it. Merging this first lets `git rebase` drop the duplicates by patch-id. See D5 of `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md`.

## References

- Wave plan: `.ignorelocal/waves/issues-security-trust-boundary-wave-plan.md` (Batch D — D Final)
- Issue: #75 — Approval and merge-gate outcomes must be structural, not model prose
- Cross-plan contracts: `decide_approval()` signature is the contract for the merge-evidence plan's W2 (#41) and W9 (#46); `Finding` shape remains unchanged.
