### PR TITLE
feat(classify+evidence): blast radius + lane policy (#42, #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Merge-lane policy maps blast radius to a typed packet signal: low changes are
+  `eligible`, medium changes are `assisted`, and high changes are `forbidden`.
+  `MergeEvidencePacket.blast_radius` now validates `BlastRadiusClassification`,
+  with `PACKET_SCHEMA_VERSION` bumped to `1.2.0`; repository overrides remain
+  additive per category and `autoMergeEnabled` remains disabled (#42, W5).
 - Blast-radius classifier: `classify_blast_radius()` maps changed paths and
   optional diff text to typed low, medium, or high merge lanes using a shipped
   declarative rule set with additive per-category overrides. The pure classifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Blast-radius classifier: `classify_blast_radius()` maps changed paths and
+  optional diff text to typed low, medium, or high merge lanes using a shipped
+  declarative rule set with additive per-category overrides. The pure classifier
+  covers migrations, sensitive code and config, generated files, public APIs,
+  dependencies, untested source, and irreversible infrastructure (#48, W6).
 - Merge Evidence Packet: every run emits a versioned, structured
   `MergeEvidencePacket` (`src/mergecraft/evidence/packet.py`) that composes
   the existing `Finding` model and derives its JSON Schema from the Pydantic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merge Evidence Packet: every run emits a versioned, structured
   `MergeEvidencePacket` (`src/mergecraft/evidence/packet.py`) that composes
   the existing `Finding` model and derives its JSON Schema from the Pydantic
-  models (no hand-written schema). `PACKET_SCHEMA_VERSION = "1.0.0"` is
+  models (no hand-written schema). `PACKET_SCHEMA_VERSION = "1.1.0"` is
   required and pinned; `tests/evidence/test_packet_schema.py` enforces the
   contract. The packet is assembled by `build_packet()` (pure) and emitted
   by `write_packet()` (I/O shell) under `mergecraft.evidence.{build,emit}`,
   and ships with `docs/evidence-packet.md` as the field reference (#47, W1).
+  W2 (#41) adds the `self_assessment: SelfAssessment | None` section as a
+  sibling of `decision` and bumps the schema to `1.1.0` (additive minor).
+- Merge-evidence packet `self_assessment` row carries the agent's
+  `approved` boolean + the reviewed commit SHA — distinct from the
+  structural `decision` verdict. `mergecraft.evidence.build._coerce_self_assessment`
+  translates the legacy `ApprovalRecord` shape (`would_approve` /
+  `sha`) into the packet row, so existing `mcp/review.py` call sites keep
+  working unchanged. The legacy `tool_state.approval` surface is preserved
+  for backward compatibility (#41, W2.1).
+- `decide_approval()` overload in `src/mergecraft/agents/gates.py` now
+  accepts a `MergeEvidencePacket` as the first positional argument and
+  returns a `Decision` row whose `verdict` is authoritative over the
+  recorded `self_assessment` (#41, W2.2, W2.3). The legacy `list[Finding]`
+  overload is unchanged and `report_status_checks()` keeps working — the
+  function remains a pure function of typed findings, run state, and trust
+  tier; the packet overload adds the self-assessment split on top. The
+  `#41` hard rule — a self-assessment-only run cannot reach `auto_merge`
+  — is pinned by
+  `tests/evidence/test_self_assessment.py::test_self_assessment_alone_blocks_auto_merge`.
 - `mergecraft diff-review --json PATH` writes structured findings validated against
   the `Finding` schema for offline benchmark/scoring workflows (#30)
 - Optional `mergecraft[harbor]` extra with `MergecraftReviewAgent` — installs
@@ -68,6 +87,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- `docs/REVIEW-DOCTRINE.md` adds a "Green is evidence, not proof" section
+  that documents the #41 hard rule (agent self-assessment is recorded but
+  never sufficient) and the evidence-weighting table — typed `Finding`s,
+  `DeterministicCheck` rows, CI check-runs, `self_assessment` (advisory),
+  `decision` (authoritative). Adds an "Honesty about unavailable signals"
+  subsection that names PR #17's `staticChecks` vocabulary as the
+  precedent (W2.5, #41).
+- `REVIEW-CHECKS.md` adds a "Mechanical evidence — what counts" section
+  that distinguishes typed findings, deterministic checks, CI check-runs,
+  and the agent's recorded self-assessment (advisory only) from the
+  packet's `decision` row (authoritative); lists what does **not** count
+  as mechanical evidence even when it appears in a check-run summary or
+  in the agent's prose (#41, W2.5).
 - Rewrite README with a 3-step quickstart and a dedicated Authentication section
   documenting Claude/Codex subscription auth (`mergecraft auth claude` /
   `auth codex`, `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_AUTH_JSON`) alongside API keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quarantined entries with their provenance records as JSON (audit-friendly) or
   human-readable text (D11, #74 proposal item 5).
 
+### Changed
+
+- Batch B (blast radius) is PR-ready: `MergeEvidencePacket.blast_radius` is
+  populated end-to-end by `classify_blast_radius()` via the packet overload
+  of `decide_approval()`. The lane policy is advisory — `autoMergeEnabled`
+  remains `False` (D11) and the Batch D thermostat in
+  `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md` owns the
+  gate outcome → action map. `make ci` is green on `wave/evi-b-blast`
+  (666 passed, 1 skipped, 3 documented pre-existing xfails from the
+  security plan's Batch B/W3/W4). `tests/evidence/test_blast_radius.py`
+  ships 24/24 passing (#42, #48, B-Final).
+
 ### Docs
 
 - `docs/REVIEW-DOCTRINE.md` adds a "Green is evidence, not proof" section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Merge Evidence Packet: every run emits a versioned, structured
+  `MergeEvidencePacket` (`src/mergecraft/evidence/packet.py`) that composes
+  the existing `Finding` model and derives its JSON Schema from the Pydantic
+  models (no hand-written schema). `PACKET_SCHEMA_VERSION = "1.0.0"` is
+  required and pinned; `tests/evidence/test_packet_schema.py` enforces the
+  contract. The packet is assembled by `build_packet()` (pure) and emitted
+  by `write_packet()` (I/O shell) under `mergecraft.evidence.{build,emit}`,
+  and ships with `docs/evidence-packet.md` as the field reference (#47, W1).
 - `mergecraft diff-review --json PATH` writes structured findings validated against
   the `Finding` schema for offline benchmark/scoring workflows (#30)
 - Optional `mergecraft[harbor]` extra with `MergecraftReviewAgent` — installs

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -26,6 +26,50 @@ A quick orientation before the lists:
 
 ---
 
+## Mechanical evidence — what counts (#41, W2.5)
+
+Mechanical evidence is what the merge-evidence packet calls **structural**
+— typed `Finding`s, deterministic gate outcomes, and CI check-suite
+results. It is the *only* category of evidence that can move the merge
+verdict; everything else is advisory. Concretely:
+
+- **Typed `Finding`s** — emitted by the analyzer catalog (`Finding` from
+  `mergecraft.analyzers.finding`, `extra="forbid"`). Each finding carries
+  `tool`, `rule_id`, `category`, `severity`, `confidence`, `path`,
+  `start_line`/`end_line`, `fingerprint`, `evidence: list[str]`,
+  `introduced_by_pr`, `source`, `cluster_id`. Findings are the
+  authoritative structural input to `decide_approval()`.
+- **`DeterministicCheck` rows** — one per declared `staticChecks` or
+  discovered Makefile target. Status is one of five: `passed`, `failed`,
+  `timed_out`, `unavailable`, `declared-but-cannot-run`. **Only
+  `failed`** is a negative finding; **only `passed`** is a positive
+  signal. The other three are honest skips, never silent passes.
+- **CI check-runs** — raw `check_suite` data from `mcp/check_runs.py`
+  plus the cluster/blame/flaky annotations from `src/mergecraft/ci/`.
+- **The agent's `approved` boolean** — **NOT** mechanical evidence. It
+  is recorded on the packet as `self_assessment` and is advisory only;
+  a self-assessment-only run cannot reach `auto_merge` (the #41 hard
+  rule, pinned by `tests/evidence/test_self_assessment.py`).
+
+What does *not* count as mechanical evidence, even when it appears in a
+check-run summary or in the agent's prose:
+
+- The agent's review narrative — `ApprovalRecord.would_approve`,
+  `result.output`, anything the model wrote.
+- PR title / body / comment text (even when fenced and unfenced by
+  trust tier) — see the `Trust tiers and contributor weight` section in
+  `docs/REVIEW-DOCTRINE.md`.
+- A "green" status with no underlying typed finding — `unavailable` /
+  `declared-but-cannot-run` / `timed_out` are explicit and visible; the
+  absence of evidence is itself evidence the verdict must surface.
+
+The merge-evidence packet's `decision` row is computed by
+`mergecraft.agents.gates.decide_approval(findings, *, run_succeeded,
+tier)` from these structural inputs. When the packet is given directly
+to `decide_approval(packet, …)`, the explicit `Decision` row on the
+packet wins over every other signal — including the recorded
+`self_assessment`.
+
 ## 1. Code correctness and risk
 
 The reviewer reads the whole diff itself, then picks the **lenses** the PR actually warrants and investigates each as a falsifiable question — optionally dispatching a `mergecraft-reviewer` subagent per lens so they run in parallel. Nothing here is a fixed pass; a docs-only diff gets none of it.

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -216,6 +216,15 @@ Checks on the review process itself, so a review can't quietly skip half the PR:
   - a "typo fix" in user-facing copy that changes meaning ("approved" → "denied")
   - a semantic one-liner buried in a formatting-only diff
 
+### Blast-radius merge lanes
+
+The packet's blast-radius classification is an evidence-weighted policy signal,
+not an instruction to merge. `low` means the change is eligible for the
+auto-merge lane after required checks pass, `medium` means assisted review, and
+`high` means automatic merge is forbidden. These semantics do not enable or
+disable auto-merge; `autoMergeEnabled` remains `false`, and Batch D (#46) owns
+the separate mapping from evidence outcomes to workflow actions.
+
 ## 5. Finding grading
 
 Every surviving finding is graded on three independent axes before it is placed. The grade decides placement, so it isn't decoration.

--- a/docs/REVIEW-DOCTRINE.md
+++ b/docs/REVIEW-DOCTRINE.md
@@ -58,6 +58,58 @@ config names; on a pull request those are commands the PR author controls. Offli
 Harvested from pullfrog-py `origin/main` commits `bff76e7` (feat/review-triage-and-mechanical-gates)
 and `31441ce` (fix/static-check-availability-and-shell-gate), PR #20.
 
+## Green is evidence, not proof (#41, W2)
+
+A passing check-run is **evidence**, never a **proof**. The merge decision
+is a function of durable, structured evidence — never of an agent's
+self-report. Two consequences follow:
+
+- **The agent's `approved` boolean is recorded but never sufficient.** It
+  lives on the merge-evidence packet as `self_assessment` (with the
+  reviewed `sha`) — a sibling of `decision`, not a substitute. When the
+  agent's `self_assessment.approved == True` is the *only* positive
+  signal, the verdict is `neutral` (or the packet's explicit `decision`
+  if set upstream), not `auto_merge`. That is the #41 hard rule; it is
+  pinned by `tests/evidence/test_self_assessment.py::test_self_assessment_alone_blocks_auto_merge`.
+- **The decision is monotone in blockers.** Any `Critical` or `Major`
+  finding yields `failure` regardless of the agent's `approved` value;
+  `run_succeeded == False` yields `neutral`; `tier == "untrusted"`
+  yields `neutral`. A "green" check-run never outvotes a blocker; an
+  agent's `approved=True` never outvotes a blocker. See
+  `mergecraft.agents.gates.decide_approval` (the security-trust-boundary
+  plan's Batch D contract, D5) and `tests/status_checks/test_decide_approval.py`.
+
+### Evidence weighting
+
+What the merge-evidence packet carries, and how each signal weights:
+
+| Signal | Weight | Notes |
+|--------|--------|-------|
+| `findings: list[Finding]` (typed, taxonomy-validated, `extra="forbid"`) | **structural** | One `Critical` or `Major` finding blocks. Source/severity/confidence preserved verbatim. |
+| `deterministic_checks: list[DeterministicCheck]` (name, status, command) | **mechanical** | Only `passed` / `failed` count as positive / negative evidence; `unavailable` / `declared-but-cannot-run` / `timed_out` are honest skips — not silent passes (PR #17 vocabulary, see `REVIEW-CHECKS.md`). |
+| `ci_check_runs` / `ci_intelligence.annotations` | **mechanical** | Per-ref check-suite outcome + log-cluster signatures, flaky vs stable, blame-attributed. |
+| `self_assessment.approved: bool` + `self_assessment.sha` | **advisory only** | Recorded; never the sole positive input. The packet's `decision` row is authoritative. |
+| `decision: { verdict, reason, decided_by }` | **authoritative** | Populated by `decide_approval`. When present on the packet, it wins over every other signal. |
+
+What is **never** an input to the verdict: the agent's prose narrative,
+the PR title / body / comment text (fenced), `result.output`, the model
+slag in tool output, or any other string that was not produced by a
+deterministic check on the diff. The merge-evidence packet is the
+single artifact a human or a later tool reads to reconstruct why a PR
+was auto-merged, blocked, or escalated; it is durable, versioned, and
+the schema is derived from the Pydantic models (`mergecraft.evidence.
+packet.PACKET_SCHEMA_VERSION`, D7).
+
+### Honesty about unavailable signals (W2.4)
+
+Where a signal source is unreachable, the packet records it as
+`unavailable` with a reason — never silently as "passing". This is the
+same honesty rule PR #17 landed for `staticChecks`: an environment
+without `make`, a missing linter binary, an unreachable check-suite API,
+or a CI provider mergeCraft cannot reach — all surface explicitly. The
+"green" in a check-run summary is the verdict's input; "no signal" is a
+verdict's input that says *the review has nothing to attest to*.
+
 ## Trust tiers and contributor weight
 
 `analyzers/trust.py::derive_trust_tier()` collapses an event's metadata into one of

--- a/docs/blast-radius.md
+++ b/docs/blast-radius.md
@@ -1,0 +1,36 @@
+# Blast-radius classifier
+
+The blast-radius classifier turns repo-root-relative changed paths and optional diff statistics into a deterministic merge lane. It is a pure function: it does not read the repository, environment, or network.
+
+## Lane semantics
+
+- **Low** (`eligible`) — documentation, tests, generated output without another high-risk signal, and small isolated source changes. Required checks must still pass.
+- **Medium** (`assisted`) — dependency changes, public API changes, broad reversible source changes, and source changes without tests.
+- **High** (`forbidden`) — migrations; authentication, security, permissions, or payment code; secrets, deployment, or production config; and irreversible infrastructure. A generated file is high only when another high-risk signal is also present.
+
+The result also names the detected categories, a human-readable reason, and the next required action. Classification does not itself enable automatic merge.
+
+## Categories and defaults
+
+| Category | Default lane |
+|---|---|
+| `migrations` | high |
+| `auth_security_payment` | high |
+| `secrets_config_deployment` | high |
+| `irreversible_infra` | high |
+| `dependency_changes` | medium |
+| `public_api_changes` | medium |
+| `source_without_tests` | medium |
+| `generated_files` | low; high only alongside another high-risk category |
+
+Path matching is supplemented by small diff-text heuristics for destructive database or infrastructure operations and synthetic secret-assignment markers.
+
+## Per-repository overrides
+
+`classify_blast_radius(change, rule_set=...)` accepts an additive `RuleSet`. Each supplied category is merged over the shipped default, and the repository value wins for that category. Omitting `rule_set`, or passing an empty one, uses the defaults unchanged.
+
+The repository-settings field that supplies this value is part of the separate lane-policy wiring wave. The classifier does not read settings itself.
+
+## Merge Evidence Packet
+
+`BlastRadiusClassification` is the typed value intended for `MergeEvidencePacket.blast_radius`. The separate lane-policy wiring wave owns populating that field and updating the packet schema version; this classifier only produces the deterministic value.

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -1,0 +1,215 @@
+# The Merge Evidence Packet
+
+Every mergeCraft run emits one **versioned, structured packet** that records
+the durable evidence behind the merge decision. The packet is the
+single artifact a human or a later tool reads to reconstruct why a PR was
+auto-merged, blocked, or escalated — and it is **durable**, meaning it
+survives the run and can be re-validated later.
+
+This document is the normative field reference. The schema is the
+contract; the prose below explains the contract field-by-field, with a
+worked example at the end.
+
+## Source
+
+The packet is defined in `src/mergecraft/evidence/packet.py` and exposed
+via `mergecraft.evidence.packet_output_schema()`. The JSON Schema is
+**derived from the Pydantic models** — there is no hand-written schema
+dict in parallel (D3). The precedent is
+`mergecraft.analyzers.finding.findings_output_schema()`
+(`src/mergecraft/analyzers/finding.py:138`).
+
+## Versioning (D7)
+
+The packet is versioned from day one. The version is asserted in a test
+(`test_packet_schema_version_is_pinned`), and the literal lives at
+`mergecraft.evidence.packet.PACKET_SCHEMA_VERSION`.
+
+**Version bump rule.** Any field-level change (additive or otherwise)
+that is not accompanied by a bump of `PACKET_SCHEMA_VERSION` must fail
+the pinning test at the gate. Bumping the literal is the **only** way
+to ship a schema change. The rules are:
+
+1. **Additive changes** (new optional field, new nullable-until-later
+   section, new value within an enum) require a `minor` bump and an
+   entry in `## [Unreleased]` of [`CHANGELOG.md`](../CHANGELOG.md).
+2. **Removing or renaming a field** requires a `major` bump and is
+   treated as a breaking change — the versioned packet is no longer
+   wire-compatible with the previous one.
+3. **Schema-only documentation changes** (clarifying a docstring, fixing
+   a typo) do **not** require a bump. The version is the contract, not
+   the prose around it.
+
+The current version is `1.0.0`.
+
+## Top-level fields
+
+### `schema_version` — required
+
+The pinned `PACKET_SCHEMA_VERSION` literal. Versioned at the top level
+so downstream tooling can refuse packets whose schema version it does
+not understand (D7).
+
+### `change_id` — required
+
+The fully-qualified PR identifier, in the form `owner/repo#123`. The
+packet is the evidence *for* one PR; the `change_id` is its address.
+
+### `agent` — required (`AgentMetadata`)
+
+Identifies the producing agent. Shape:
+
+| Field | Type | Notes |
+|------|------|-------|
+| `id` | `str` | The agent name (e.g. `claude`). |
+| `version` | `str` | The agent's runtime version string. |
+| `model` | `str` | The model slug the agent ran with. |
+
+### `files_changed` — required (`list[str]`)
+
+Repo-root-relative paths for every file touched by the PR. The packet
+is the per-PR evidence record; this list is its scope.
+
+### `findings` — required (`list[Finding]`)
+
+The re-typed analyzer findings. The packet **composes** the existing
+`Finding` model from `mergecraft.analyzers.finding`, not a parallel
+finding model (D3). The wire shape is governed by the
+[`Finding` schema](ANALYZERS.md); the packet's `findings` field
+inlines that schema entirely into its emitted JSON Schema, so a
+packet consumer never has to look at `$defs` to validate a
+`findings` item.
+
+### `deterministic_checks` — required (`list[DeterministicCheck]`)
+
+The mechanical gates that ran (or were skipped) for this PR. Each
+entry carries the check name, status, and the command that ran —
+this is the **mechanical evidence** that backs the merge verdict.
+
+| Field | Type | Notes |
+|------|------|-------|
+| `name` | `str` | The check name (e.g. `lint`). |
+| `status` | `str` | The outcome (`pass` / `fail` / `skipped` / `unavailable`). |
+| `command` | `str` | The literal command that ran. |
+
+### `decision` — required (`Decision | None`)
+
+The evidence verdict. W1 ships the **shape**; W2 populates this field
+from `decide_approval()` (the function the security plan's Batch D
+lands — D5). Until W2 the field is typically `{"verdict": "block",
+"reason": "self-assessment-only run", "decided_by": "..."}`.
+
+| Field | Type | Notes |
+|------|------|-------|
+| `verdict` | `str` | One of `auto_merge`, `block`, `request_changes`, `require_human_review`, `unavailable`. |
+| `reason` | `str` | Human-readable explanation. |
+| `decided_by` | `str` | Dotted path of the function that produced the verdict. |
+
+### `blast_radius` — `dict[str, Any] | None` (nullable until Batch B)
+
+Placeholder; populated by Batch B's lane classifier. The field is
+typed `| None` from W1 (D4) so the wire schema is fixed even though
+the implementation lands later.
+
+### `trajectory` — `dict[str, Any] | None` (nullable until Batch C)
+
+Placeholder; populated by Batch C's `TrajectoryRecord` and the
+trajectory auditor. Built from the MCP tool-call layer (D8) — no
+external trace dependency.
+
+### `evals` — `dict[str, Any] | None` (nullable until Batch E)
+
+Placeholder; populated by Batch E's eval bank. The case store lives
+under the existing `evals/` tree (D13).
+
+## Worked example
+
+A minimal but complete packet, showing the shape end-to-end. This is
+also the canonical fixture used by the WA-T round-trip tests:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "change_id": "alexhawat/mergeCraft#42",
+  "agent": {
+    "id": "claude",
+    "version": "1.2.3",
+    "model": "claude-sonnet-4-5"
+  },
+  "files_changed": ["src/mergecraft/evidence/packet.py"],
+  "findings": [
+    {
+      "tool": "ruff",
+      "rule_id": "F401",
+      "category": "Maintainability & Code Quality",
+      "severity": "Minor",
+      "confidence": "likely",
+      "message": "unused import",
+      "path": "src/mergecraft/evidence/__init__.py",
+      "start_line": 1,
+      "end_line": 1,
+      "fingerprint": "...",
+      "evidence": [],
+      "remediation": null,
+      "autofix": null,
+      "introduced_by_pr": "true",
+      "source": "analyzer",
+      "cluster_id": null
+    }
+  ],
+  "deterministic_checks": [
+    {
+      "name": "lint",
+      "status": "pass",
+      "command": "ruff check src tests scripts"
+    }
+  ],
+  "decision": {
+    "verdict": "block",
+    "reason": "self-assessment-only run",
+    "decided_by": "mergecraft.agents.gates.decide_approval"
+  },
+  "blast_radius": null,
+  "trajectory": null,
+  "evals": null
+}
+```
+
+`extra="forbid"` is enforced at the model level; any unknown
+top-level field, or any unknown field on a nested model, is rejected
+at validation. There is no second finding model: the packet's
+`findings` items are exactly the [`Finding`](ANALYZERS.md) model
+(D3).
+
+## Reading the packet
+
+The packet is the **contract** between the per-run evidence layer
+and the gate layer. Consumers of the packet should:
+
+1. Validate it against `mergecraft.evidence.packet_output_schema()`
+   before reading any fields.
+2. Treat the `schema_version` as a hard precondition — refuse
+   versions your consumer does not understand.
+3. **Never** rely on the agent's self-assessment alone (that is the
+   `#41` rule; enforced by W2). The `decision` field is the
+   evidence verdict.
+4. Treat the packet as immutable. Downstream code that needs to
+   annotate, score, or transform the packet should produce a new
+   packet (with a new `schema_version` if the shape changes — D7).
+
+## Where the packet is emitted
+
+- **Schema & model:** `src/mergecraft/evidence/packet.py`
+- **Pure assembly:** `src/mergecraft/evidence/build.py` (D3, convention 5)
+- **I/O shell:** `src/mergecraft/evidence/emit.py` (W1.4)
+- **Tests:** `tests/evidence/` (WA-T; W1.6 un-xfails the schema, round-trip, and sections)
+- **Test plan:** `docs/test-plans/merge-evidence-gating.md`
+
+## Cross-references
+
+- D3 — the packet composes `Finding`; JSON Schema derived from the models.
+- D7 — the packet is versioned from day one; the version is asserted in a test.
+- D4 — nullable-until-later sections are typed `| None`, not omitted.
+- D5 — `decision` is the W2 surface and consumes `decide_approval()`.
+- D8 — `trajectory` is built from MCP tool state without external trace.
+- D13 — `evals` is file-backed under `evals/`.

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -40,7 +40,7 @@ to ship a schema change. The rules are:
    a typo) do **not** require a bump. The version is the contract, not
    the prose around it.
 
-The current version is `1.1.0`.
+The current version is `1.2.0`.
 
 ### Version history
 
@@ -53,6 +53,12 @@ The current version is `1.1.0`.
   before. The legacy `ApprovalRecord.would_approve` surface stays for
   backward compatibility; the packet's `self_assessment` row is the
   explicit "what the agent *said*" record.
+
+- `1.2.0` — W5 (#42). Replaces the nullable untyped `blast_radius`
+  placeholder with `BlastRadiusClassification | None`. Populated packets now
+  validate the lane, lane policy, reason, next action, and detected categories.
+  The field remains optional, but its existing type changed, so D7 requires a
+  minor bump.
 
 ## Top-level fields
 

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -40,7 +40,19 @@ to ship a schema change. The rules are:
    a typo) do **not** require a bump. The version is the contract, not
    the prose around it.
 
-The current version is `1.0.0`.
+The current version is `1.1.0`.
+
+### Version history
+
+- `1.0.0` — initial schema (#47, W1). Required top-level fields, nullable
+  `blast_radius` / `trajectory` / `evals` (D4), `Decision` row shape.
+- `1.1.0` — W2 (#41). Adds the `self_assessment: SelfAssessment | None`
+  section as a sibling of `decision`. Additive — the wire shape is
+  backwards-compatible; the verdict function reads the new field but a
+  packet with `decision=None` and no `self_assessment` validates as
+  before. The legacy `ApprovalRecord.would_approve` surface stays for
+  backward compatibility; the packet's `self_assessment` row is the
+  explicit "what the agent *said*" record.
 
 ## Top-level fields
 
@@ -94,16 +106,36 @@ this is the **mechanical evidence** that backs the merge verdict.
 
 ### `decision` — required (`Decision | None`)
 
-The evidence verdict. W1 ships the **shape**; W2 populates this field
-from `decide_approval()` (the function the security plan's Batch D
+The evidence verdict. W1 ships the **shape**; W2 (#41) populates this
+field from `decide_approval()` (the function the security plan's Batch D
 lands — D5). Until W2 the field is typically `{"verdict": "block",
 "reason": "self-assessment-only run", "decided_by": "..."}`.
 
 | Field | Type | Notes |
 |------|------|-------|
-| `verdict` | `str` | One of `auto_merge`, `block`, `request_changes`, `require_human_review`, `unavailable`. |
+| `verdict` | `str` | One of `auto_merge`, `block`, `request_changes`, `require_human_review`, `unavailable`, `neutral`. |
 | `reason` | `str` | Human-readable explanation. |
 | `decided_by` | `str` | Dotted path of the function that produced the verdict. |
+
+### `self_assessment` — `SelfAssessment | None` (added in W2, #41)
+
+The agent's recorded self-assessment — what it **said**. Distinct from
+the `decision` row, which is what the evidence **proved**. The two
+fields are populated independently: `self_assessment` carries the
+agent's `approved` boolean + the reviewed commit SHA; `decision` carries
+the structural verdict computed from typed findings + run state + trust
+tier.
+
+The `self_assessment` row is **advisory only**. When the packet carries
+an explicit `decision` row, that row is returned verbatim by
+`decide_approval(packet, …)` (#41 hard rule). When the packet does
+**not** carry an explicit verdict and the recorded `self_assessment` is
+the only positive signal, the verdict is `neutral`, never `auto_merge`.
+
+| Field | Type | Notes |
+|------|------|-------|
+| `approved` | `bool` | The agent's `approved` boolean from `create_pull_request_review`. |
+| `sha` | `str \| None` | The reviewed commit SHA. |
 
 ### `blast_radius` — `dict[str, Any] | None` (nullable until Batch B)
 
@@ -129,7 +161,7 @@ also the canonical fixture used by the WA-T round-trip tests:
 
 ```json
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "change_id": "alexhawat/mergeCraft#42",
   "agent": {
     "id": "claude",
@@ -164,6 +196,10 @@ also the canonical fixture used by the WA-T round-trip tests:
       "command": "ruff check src tests scripts"
     }
   ],
+  "self_assessment": {
+    "approved": false,
+    "sha": "0123456789abcdef0123456789abcdef01234567"
+  },
   "decision": {
     "verdict": "block",
     "reason": "self-assessment-only run",

--- a/docs/test-plans/merge-evidence-blast-radius.md
+++ b/docs/test-plans/merge-evidence-blast-radius.md
@@ -1,0 +1,117 @@
+# Merge evidence & gating — Batch B (blast radius) test plan (WB-T RED)
+
+Wave plan: `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md`
+Worktree: `mergecraft-evi-b-blast` @ `wave/evi-b-blast`
+Tests: `tests/evidence/test_blast_radius.py`
+
+This plan mirrors the structural shape of `docs/test-plans/merge-evidence-gating.md`
+(Batch A test plan) so the WB-T close-out is directly comparable to WA-T.
+
+## Locked decisions exercised
+
+| ID | Decision | Test(s) |
+|----|----------|---------|
+| **D4** | Batch B wires the `MergeEvidencePacket.blast_radius` field via a typed classifier — packet remains nullable until W5/W6 | all WB-T cases lazy-import `mergecraft.classify.blast_radius` |
+| **D9** | Rule set is declarative and overridable per repo via `RepoSettings.blast_radius_override` (additive, default empty) | `test_rule_set_is_overridable_per_repo` |
+| **D10** | Default rule set ships with mergeCraft and the consumer repo may extend it | `test_classifier_low_risk_examples`, `test_classifier_medium_risk_examples`, `test_classifier_high_risk_examples` |
+| Convention 5 | Classifier is pure — no filesystem, no network, no `os.environ` | `test_classifier_is_pure` |
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#48** | D10 | Unit | Docs/tests/small isolated changes classify as `low` | `test_classifier_low_risk_examples` |
+| **#48** | D10 | Unit | Broad application changes classify as `medium` | `test_classifier_medium_risk_examples` |
+| **#48** | D10 | Unit | Migrations / auth / security / payment / deployment / irreversible infra classify as `high` | `test_classifier_high_risk_examples` |
+| **#48** | D10 | Unit | Each named category appears in `result.categories` | `test_classifier_detects_each_named_category` |
+| **#42** | D9 | Unit | A `RepoSettings.blast_radius_override` changes the outcome without a code change | `test_rule_set_is_overridable_per_repo` |
+| **#42** | D9 | Unit | Decision output carries `lane`, `reason`, `next_action` | `test_decision_output_names_lane_reason_and_next_action` |
+| Convention 5 | D5 | Unit | Classifier performs no filesystem, network, or env access | `test_classifier_is_pure` |
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W6** | `tests/evidence/test_blast_radius.py::test_classifier_low_risk_examples` | `green after W5/W6` |
+| **W6** | `tests/evidence/test_blast_radius.py::test_classifier_medium_risk_examples` | `green after W5/W6` |
+| **W6** | `tests/evidence/test_blast_radius.py::test_classifier_high_risk_examples` | `green after W5/W6` |
+| **W6** | `tests/evidence/test_blast_radius.py::test_classifier_detects_each_named_category` | `green after W5/W6` |
+| **W6** | `tests/evidence/test_blast_radius.py::test_rule_set_is_overridable_per_repo` | `green after W5/W6` |
+| **W5** | `tests/evidence/test_blast_radius.py::test_decision_output_names_lane_reason_and_next_action` | `green after W5/W6` |
+| **W6** | `tests/evidence/test_blast_radius.py::test_classifier_is_pure` | `green after W5/W6` |
+
+All cross-wave markers use `strict=False` so the W5/W6 green half flips
+each case to PASS without breaking the suite under the project-wide
+`xfail_strict=true` setting.
+
+## Contract surface locked for W5 / W6
+
+```python
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel
+
+Lane = Literal["low", "medium", "high"]
+AutoMergeLane = Literal["eligible", "assisted", "human_review", "forbidden"]
+
+
+class ChangeSet(TypedDict, total=False):
+    """Side-effect-free change payload fed to the classifier."""
+
+    changed_paths: list[str]
+    diff_stats: dict[str, object]
+
+
+class RuleSet(TypedDict, total=False):
+    """Declarative override block read from RepoSettings.blast_radius_override."""
+
+    migrations: dict[str, object]
+    auth_security_payment: dict[str, object]
+    secrets_config_deployment: dict[str, object]
+    generated_files: dict[str, object]
+    public_api_changes: dict[str, object]
+    dependency_changes: dict[str, object]
+    source_without_tests: dict[str, object]
+
+
+class BlastRadiusClassification(BaseModel):
+    """Decision output of `classify_blast_radius`."""
+
+    lane: Lane
+    auto_merge_lane: AutoMergeLane
+    reason: str
+    next_action: str
+    categories: list[str]
+
+
+def classify_blast_radius(
+    change: ChangeSet, *, rule_set: RuleSet | None = None
+) -> BlastRadiusClassification: ...
+```
+
+`RepoSettings` must grow an additive `blast_radius_override: RuleSet` field
+(default empty) so the override test can vary classification without code
+changes (D9).
+
+## Implementation notes for impl waves
+
+- **W5** — Land `BlastRadiusClassification`, the additive
+  `RepoSettings.blast_radius_override`, the lane-policy mapping
+  (`low → eligible`, `medium → assisted/human_review`, `high → forbidden`),
+  and wire the result into `MergeEvidencePacket.blast_radius` while
+  bumping `PACKET_SCHEMA_VERSION` (D7). Un-xfail
+  `test_decision_output_names_lane_reason_and_next_action`.
+- **W6** — Land the default rule set and the pure
+  `classify_blast_radius` implementation in
+  `src/mergecraft/classify/blast_radius.py`. Reuse existing catalog
+  vocabulary where it exists (D10) and document the rules in
+  `REVIEW-CHECKS.md`. Un-xfail
+  `test_classifier_low_risk_examples`,
+  `test_classifier_medium_risk_examples`,
+  `test_classifier_high_risk_examples`,
+  `test_classifier_detects_each_named_category`,
+  `test_rule_set_is_overridable_per_repo`, and
+  `test_classifier_is_pure`.
+- **Style mirrors the analyzer test suite** — lazy import inside the
+  fixture, `from __future__ import annotations` everywhere, no real
+  credentials, no filesystem/network/env access in fixtures.

--- a/docs/test-plans/merge-evidence-gating.md
+++ b/docs/test-plans/merge-evidence-gating.md
@@ -1,0 +1,83 @@
+# Merge evidence & gating (#47, #41) — Batch A test plan (WA-T RED)
+
+Wave plan: `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md`
+Worktree: `mergecraft-evi-a-packet` @ `wave/evi-a-packet`
+
+## Locked decisions exercised
+
+| ID | Decision | Tests |
+|----|----------|-------|
+| **D3** | Packet composes `Finding`; JSON Schema derived from the Pydantic models (mirroring `analyzers/finding.py:138`) | `test_evidence_packet_schema_is_derived_not_handwritten`, `test_packet_findings_match_finding_model_json_schema` |
+| **D3** | `extra="forbid"` on the packet (and nested models) | `test_evidence_packet_rejects_unknown_fields`, `test_evidence_packet_rejects_nested_unknown_fields` |
+| **D7** | `schema_version` is required and a pinned literal — silent drift fails the test | `test_evidence_packet_requires_schema_version`, `test_packet_schema_version_is_pinned` |
+| **D4** | Nullable-until-later sections (`blast_radius`, `trajectory`, `evals`) are typed `| None`, not omitted | `test_packet_contains_nullable_until_later_sections` |
+| **D5** | `decide_approval()` consumed, not reimplemented; the function lives in `mergecraft.agents.gates` | `test_self_assessment_alone_blocks_auto_merge`, `test_decide_approval_does_not_treat_self_assessment_as_evidence` |
+| **#41** | Self-assessment is recorded separately and never sufficient | `test_self_assessment_is_recorded_separately_from_evidence`, `test_self_assessment_field_carries_approved_and_sha`, `test_self_assessment_alone_blocks_auto_merge` |
+
+## xfail schedule
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **W1** | `tests/evidence/test_packet_schema.py::test_evidence_packet_schema_is_derived_not_handwritten` | `green after W1: packet model + derived schema` |
+| **W1** | `tests/evidence/test_packet_schema.py::test_packet_findings_match_finding_model_json_schema` | `green after W1: findings composes Finding` |
+| **W1** | `tests/evidence/test_packet_schema.py::test_evidence_packet_requires_schema_version` | `green after W1: schema_version field` |
+| **W1** | `tests/evidence/test_packet_schema.py::test_packet_schema_version_is_pinned` | `green after W1: PACKET_SCHEMA_VERSION literal` |
+| **W1** | `tests/evidence/test_packet_schema.py::test_packet_schema_round_trip_json_serializes` | `green after W1: packet serializes + re-validates` |
+| **W1** | `tests/evidence/test_packet_round_trip.py::test_evidence_packet_round_trips_through_json` | `green after W1: packet round-trips through JSON` |
+| **W1** | `tests/evidence/test_packet_round_trip.py::test_evidence_packet_round_trips_through_dict` | `green after W1: packet round-trips through dict` |
+| **W1** | `tests/evidence/test_packet_round_trip.py::test_evidence_packet_rejects_unknown_fields` | `green after W1: extra="forbid"` |
+| **W1** | `tests/evidence/test_packet_round_trip.py::test_evidence_packet_rejects_nested_unknown_fields` | `green after W1: extra="forbid" propagates` |
+| **W1** | `tests/evidence/test_packet_sections.py::test_packet_contains_required_sections` | `green after W1: required top-level sections` |
+| **W1** | `tests/evidence/test_packet_sections.py::test_packet_contains_nullable_until_later_sections` | `green after W1: nullable-until-later fields are typed ` |
+| **W1** | `tests/evidence/test_packet_sections.py::test_packet_agent_section_carries_id_version_and_model` | `green after W1: AgentMetadata` |
+| **W1** | `tests/evidence/test_packet_sections.py::test_packet_decision_section_exists` | `green after W1: decision section` |
+| **W1/W2** | `tests/evidence/test_self_assessment.py::test_self_assessment_is_recorded_separately_from_evidence` | `green after W1: self_assessment field; W2: distinct from decision` |
+| **W1/W2** | `tests/evidence/test_self_assessment.py::test_self_assessment_field_carries_approved_and_sha` | `green after W1: self_assessment shape` |
+| **W1/W2** | `tests/evidence/test_self_assessment.py::test_self_assessment_alone_blocks_auto_merge` | `green after W2: decide_approval honours #41 hard rule` |
+| **W1/W2** | `tests/evidence/test_self_assessment.py::test_decide_approval_does_not_treat_self_assessment_as_evidence` | `green after W2: decision field is authoritative` |
+
+All cross-wave markers use `strict=False`.
+
+## Contract matrix
+
+| Issue | Decision | Layer | Scenario | Primary test |
+|-------|----------|-------|----------|--------------|
+| **#47** | D3 — JSON Schema derived from Pydantic models | Unit | Happy — `properties.findings.items` matches `Finding.model_json_schema()` | `test_evidence_packet_schema_is_derived_not_handwritten` |
+| **#47** | D3 — `findings: list[Finding]` typed | Unit | Annotation — `list[Finding]` | `test_packet_findings_match_finding_model_json_schema` |
+| **#47** | D7 — `schema_version` required | Unit | Happy — field present, no default | `test_evidence_packet_requires_schema_version` |
+| **#47** | D7 — version is a pinned literal | Unit | Drifts — missing or wrong value fails | `test_packet_schema_version_is_pinned` |
+| **#47** | D3 — round-trip JSON | Unit | Happy — `model_dump_json()` → `model_validate_json()` is identity | `test_evidence_packet_round_trips_through_json` |
+| **#47** | D3 — round-trip dict | Unit | Happy — `model_dump()` → re-validate is identity | `test_evidence_packet_round_trips_through_dict` |
+| **#47** | D3 — `extra="forbid"` | Unit | Error — unknown top-level field rejected | `test_evidence_packet_rejects_unknown_fields` |
+| **#47** | D3 — `extra="forbid"` propagates | Unit | Error — unknown nested field rejected | `test_evidence_packet_rejects_nested_unknown_fields` |
+| **#47** | D4 — required sections present | Unit | All six required top-level sections present | `test_packet_contains_required_sections` |
+| **#47** | D4 — nullable-until-later | Unit | `blast_radius`, `trajectory`, `evals` typed `| None`, not omitted | `test_packet_contains_nullable_until_later_sections` |
+| **#47** | D4 — `agent` sub-model | Unit | `AgentMetadata` has `id`, `version`, `model` | `test_packet_agent_section_carries_id_version_and_model` |
+| **#47** | D4 — `decision` section | Unit | `decision` field present on packet | `test_packet_decision_section_exists` |
+| **#41** | D5 — `decide_approval` consumed | Unit | Happy — packet with self-assessment and no findings → not `auto_merge` | `test_self_assessment_alone_blocks_auto_merge` |
+| **#41** | D5 — `decision` is authoritative | Unit | Edge — explicit `block` decision wins over an approving self-assessment | `test_decide_approval_does_not_treat_self_assessment_as_evidence` |
+| **#41** | Split | Unit | Distinct fields, both populated | `test_self_assessment_is_recorded_separately_from_evidence` |
+| **#41** | Split | Unit | `self_assessment` carries `approved` + `sha` | `test_self_assessment_field_carries_approved_and_sha` |
+
+## Implementation notes for impl waves
+
+- **W1:** Land `src/mergecraft/evidence/packet.py` with:
+  - `class MergeEvidencePacket(BaseModel)` with `model_config = ConfigDict(extra="forbid")`,
+  - module-level `PACKET_SCHEMA_VERSION = "1.0.0"`,
+  - `findings: list[Finding]` (D3 — composes, does not replace `Finding`),
+  - nullable-until-later fields `blast_radius: BlastRadius | None = None`, `trajectory: Trajectory | None = None`, `evals: Evals | None = None`,
+  - `class AgentMetadata(BaseModel)` with `id`, `version`, `model`,
+  - `def packet_output_schema() -> dict[str, Any]:` mirroring `analyzers/finding.py:138` (derives from `MergeEvidencePacket.model_json_schema()`),
+  - un-xfail `test_packet_schema.py` and `test_packet_round_trip.py` and `test_packet_sections.py` (W1.6).
+- **W2:** Add `decide_approval(packet, *, run_succeeded, tier)` in `src/mergecraft/agents/gates.py` (or consume the function the security plan's Batch D lands — D5) and the `self_assessment: SelfAssessment | None` field on the packet. Un-xfail `test_self_assessment.py` (W2.6).
+- **Style mirrors the analyzer test suite:** lazy `import_module` (so collection succeeds before `src/mergecraft/evidence/` exists), `from __future__ import annotations` everywhere, `dict[str, object]`-typed fixtures, no in-line `decide_approval` mock — the outcome is pinned and the impl may freely adjust the signature.
+
+## Deferred to W1 / W2 (not in WA-T scope)
+
+- `blast_radius`, `trajectory`, `evals` payload shapes (Batches B / C / E)
+- `mergecraft eval add/list/replay` (Batch E)
+- LLM judge logging contract (Batch E, W13)
+- Shadow-mode disagreement report (Batch D, W10)
+- `blast_radius` classifier unit tests (Batch B, WB-T)
+- Trajectory auditor unit tests (Batch C, WC-T)
+- `decide_approval` signature lockdown — the WA-T.5 / WA-T.6 tests assert the **outcome** (not `auto_merge` for self-assessment-only); W2 may adjust the parameter list as long as the outcome holds.

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -1,11 +1,16 @@
-"""Subagent mutates deny + native FS denies (ported from subagentToolGates / nativeFsDenies)."""
+"""Subagent mutates deny + native FS denies + structural approval gate (ported from
+subagentToolGates / nativeFsDenies and extended by the security-trust-boundary plan
+Batch D and the merge-evidence plan Batch A - W2).
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Union, overload
 
 from loguru import logger
 
+from mergecraft.evidence.packet import Decision as PacketDecision
+from mergecraft.evidence.packet import MergeEvidencePacket
 from mergecraft.mcp.server import build_orchestrator_tools
 
 if TYPE_CHECKING:
@@ -83,20 +88,53 @@ def _has_blocker(findings: list[Finding]) -> bool:
     return any(f.severity in BLOCKING_SEVERITIES for f in findings)
 
 
+@overload
 def decide_approval(
     findings: list[Finding],
     *,
     run_succeeded: bool,
     tier: TrustTier,
-) -> Conclusion:
-    """Pure structural approval conclusion (D12, D13, D14).
+) -> Conclusion: ...
 
-    The approval gate's wire-shape (``success`` / ``failure`` / ``neutral``) is a
-    pure function of the typed finding list, the run's completion state, and the
-    trust tier. Narrative (``ApprovalRecord.would_approve``, ``result.output``,
-    any model prose) is never an input — the agent's ``approved`` boolean is
-    recorded separately (W8.3) and consumed by the trajectory/evidence work in
-    the merge-evidence plan (#41) after the fact.
+
+@overload
+def decide_approval(
+    findings: MergeEvidencePacket,
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> PacketDecision: ...
+
+
+def decide_approval(
+    findings: Union[list[Finding], MergeEvidencePacket],  # noqa: UP007
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> Union[Conclusion, PacketDecision]:  # noqa: UP007
+    """Pure structural approval verdict - finding list or merge-evidence packet (D5, D12-D14, #41).
+
+    The approval gate's wire-shape is a pure function of typed findings, the run's
+    completion state, and the trust tier. Narrative (``ApprovalRecord.would_approve``,
+    ``result.output``, any model prose) is never an input — the agent's
+    ``approved`` boolean is recorded separately as ``SelfAssessment`` on the
+    packet (W2.1 / #41) and consulted by the trajectory / merge-evidence work,
+    not by this gate.
+
+    Two overloads (D5):
+
+    - **Legacy / security-plan Batch D call sites** (positional ``list[Finding]``):
+      returns a ``Conclusion`` literal (``"success"`` / ``"failure"`` /
+      ``"neutral"``). ``report_status_checks`` consumes this for the
+      ``mergecraft-approval`` check-run.
+    - **Merge-evidence packet call sites** (positional ``MergeEvidencePacket``):
+      returns a :class:`mergecraft.evidence.packet.Decision` row with
+      ``verdict`` / ``reason`` / ``decided_by``. The packet's existing
+      ``self_assessment`` row is **advisory only**; if the packet carries an
+      explicit ``Decision``, that decision is returned verbatim (#41 hard rule —
+      the structural verdict is authoritative). Otherwise the same monotone
+      blocker logic runs against ``packet.findings`` and the result is wrapped
+      in a :class:`Decision`.
 
     The decision is monotone in blockers:
 
@@ -114,10 +152,30 @@ def decide_approval(
       (attested structural evidence the review ran), ``"neutral"`` when the
       list is empty (the run completed without findings to attest to).
 
+    #41 hard rule, enforced here: when the recorded self-assessment is the only
+    positive signal, the verdict is **not** ``auto_merge``. With no findings,
+    no passing deterministic checks, ``run_succeeded=True``, and ``tier="trusted"``
+    the legacy path yields ``"neutral"``; the packet overload maps that to a
+    ``Decision`` whose ``verdict`` is ``"neutral"``. A caller that needs the
+    W9 closed-action vocabulary can then derive ``auto_merge`` only after
+    further positive evidence (blast-radius lane, trajectory clean, …).
+
     The function is pure: no I/O, no logging, no module state. The merge-evidence
-    plan's W2 (D12) and W9 (#46) call this function without re-shaping; the
+    plan's W2 (#41) and W9 (#46) call this function without re-shaping; the
     signature is the contract.
     """
+    if isinstance(findings, MergeEvidencePacket):
+        return _decide_approval_from_packet(findings, run_succeeded=run_succeeded, tier=tier)
+    return _decide_approval_from_findings(findings, run_succeeded=run_succeeded, tier=tier)
+
+
+def _decide_approval_from_findings(
+    findings: list[Finding],
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> Conclusion:
+    """Legacy structural approval conclusion — typed findings input (D12, D13, D14)."""
     if _has_blocker(findings):
         return "failure"
     if not run_succeeded:
@@ -127,6 +185,67 @@ def decide_approval(
     if not findings:
         return "neutral"
     return "success"
+
+
+def _decide_approval_from_packet(
+    packet: MergeEvidencePacket,
+    *,
+    run_succeeded: bool,
+    tier: TrustTier,
+) -> PacketDecision:
+    """Packet-aware structural approval decision (#41, W2.2, W2.3).
+
+    Returns a :class:`mergecraft.evidence.packet.Decision` row. When the packet
+    carries an explicit ``decision`` row, that row is returned verbatim — the
+    structural verdict is authoritative over the agent's recorded
+    ``self_assessment``. When the packet does not carry an explicit verdict,
+    the legacy blocker logic runs against ``packet.findings`` and the
+    ``Conclusion`` literal is wrapped in a ``Decision`` with a stable
+    ``decided_by`` and a reason that names the signal the verdict came from.
+
+    The function is pure: no I/O, no logging, no module state.
+    """
+    from mergecraft.evidence.packet import Decision as PacketDecision
+
+    # #41 hard rule — if the packet already carries an explicit decision
+    # (set by an upstream layer, e.g. a W9 thermostat overlay), honour it
+    # verbatim. The agent's recorded ``self_assessment`` cannot override
+    # the structural verdict.
+    if packet.decision is not None:
+        return packet.decision
+
+    conclusion = _decide_approval_from_findings(
+        packet.findings, run_succeeded=run_succeeded, tier=tier
+    )
+    return PacketDecision(
+        verdict=conclusion,
+        reason=_packet_decision_reason(conclusion, packet),
+        decided_by="mergecraft.agents.gates.decide_approval",
+    )
+
+
+def _packet_decision_reason(
+    conclusion: Conclusion,
+    packet: MergeEvidencePacket,
+) -> str:
+    """Render a short, evidence-attributed reason for a packet verdict (#41).
+
+    Keeps the reason deterministic and grounded in what the packet actually
+    carries, never in the agent's prose. The string is short — the full
+    evidence lives in the packet itself and downstream consumers should
+    read it from there.
+    """
+    if packet.self_assessment is not None and packet.self_assessment.approved:
+        # The agent said approved; the structural verdict is whatever the
+        # evidence proved. Surface both so a human reader can see the
+        # disagreement explicitly.
+        return (
+            f"{conclusion}: structural evidence — agent's self_assessment.approved=true "
+            "is advisory only and did not override the verdict"
+        )
+    if not packet.findings:
+        return f"{conclusion}: no typed findings to attest to the review"
+    return f"{conclusion}: derived from typed findings and run state"
 
 
 def approval_decision_inputs(

--- a/src/mergecraft/classify/__init__.py
+++ b/src/mergecraft/classify/__init__.py
@@ -1,0 +1,23 @@
+"""Pure classifiers used by merge evidence."""
+
+from __future__ import annotations
+
+from mergecraft.classify.blast_radius import (
+    DEFAULT_RULE_SET,
+    AutoMergeLane,
+    BlastRadiusClassification,
+    ChangeSet,
+    Lane,
+    RuleSet,
+    classify_blast_radius,
+)
+
+__all__ = [
+    "DEFAULT_RULE_SET",
+    "AutoMergeLane",
+    "BlastRadiusClassification",
+    "ChangeSet",
+    "Lane",
+    "RuleSet",
+    "classify_blast_radius",
+]

--- a/src/mergecraft/classify/blast_radius.py
+++ b/src/mergecraft/classify/blast_radius.py
@@ -1,0 +1,249 @@
+"""Pure blast-radius classification for merge evidence (#48)."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict, cast
+
+from pydantic import BaseModel, ConfigDict
+
+Lane = Literal["low", "medium", "high"]
+AutoMergeLane = Literal["eligible", "assisted", "human_review", "forbidden"]
+Category = Literal[
+    "migrations",
+    "auth_security_payment",
+    "secrets_config_deployment",
+    "generated_files",
+    "public_api_changes",
+    "dependency_changes",
+    "source_without_tests",
+    "irreversible_infra",
+]
+
+
+class ChangeSet(TypedDict, total=False):
+    """Side-effect-free change payload fed to the classifier."""
+
+    changed_paths: list[str]
+    diff_stats: dict[str, object]
+
+
+class RuleOverride(TypedDict, total=False):
+    """Per-category rule values that a repository may override."""
+
+    lane: Lane
+
+
+class RuleSet(TypedDict, total=False):
+    """Additive per-repository blast-radius rule overrides."""
+
+    migrations: RuleOverride
+    auth_security_payment: RuleOverride
+    secrets_config_deployment: RuleOverride
+    generated_files: RuleOverride
+    public_api_changes: RuleOverride
+    dependency_changes: RuleOverride
+    source_without_tests: RuleOverride
+    irreversible_infra: RuleOverride
+
+
+class BlastRadiusClassification(BaseModel):
+    """Deterministic lane decision and the signals that produced it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lane: Lane
+    auto_merge_lane: AutoMergeLane
+    reason: str
+    next_action: str
+    categories: list[str]
+
+
+DEFAULT_RULE_SET: dict[Category, RuleOverride] = {
+    "migrations": {"lane": "high"},
+    "auth_security_payment": {"lane": "high"},
+    "secrets_config_deployment": {"lane": "high"},
+    "generated_files": {"lane": "low"},
+    "public_api_changes": {"lane": "medium"},
+    "dependency_changes": {"lane": "medium"},
+    "source_without_tests": {"lane": "medium"},
+    "irreversible_infra": {"lane": "high"},
+}
+
+_LANE_RANK: dict[Lane, int] = {"low": 0, "medium": 1, "high": 2}
+_AUTO_MERGE_LANE: dict[Lane, AutoMergeLane] = {
+    "low": "eligible",
+    "medium": "assisted",
+    "high": "forbidden",
+}
+_NEXT_ACTION: dict[Lane, str] = {
+    "low": "Eligible for automatic merge after required checks pass.",
+    "medium": "Use assisted review and verify the affected behavior.",
+    "high": "Require human review; automatic merge is forbidden.",
+}
+_DEPENDENCY_FILES = {
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "pyproject.toml",
+    "uv.lock",
+    "requirements.txt",
+    "poetry.lock",
+    "go.mod",
+    "go.sum",
+    "cargo.toml",
+    "cargo.lock",
+}
+_DIFF_SIGNAL_KEYS = ("diff", "diff_text", "patch", "text")
+
+
+def _contains_path_part(path: str, parts: tuple[str, ...]) -> bool:
+    normalized = f"/{path.lower().strip('/')}"
+    return any(f"/{part}/" in f"{normalized}/" for part in parts)
+
+
+def _diff_text(diff_stats: dict[str, object]) -> str:
+    return "\n".join(
+        value for key in _DIFF_SIGNAL_KEYS if isinstance((value := diff_stats.get(key)), str)
+    ).lower()
+
+
+def _detected_categories(paths: list[str], diff_text: str) -> tuple[list[str], set[Category]]:
+    categories: list[str] = []
+    rule_categories: set[Category] = set()
+
+    def add(rule_category: Category, *labels: str) -> None:
+        rule_categories.add(rule_category)
+        for label in labels or (rule_category,):
+            if label not in categories:
+                categories.append(label)
+
+    lowered = [path.lower().strip("/") for path in paths]
+    if any(_contains_path_part(path, ("migration", "migrations")) for path in lowered) or any(
+        token in diff_text for token in ("drop table", "alter table", "create table")
+    ):
+        add("migrations")
+
+    for path in lowered:
+        if _contains_path_part(path, ("auth",)):
+            add("auth_security_payment", "auth_security_payment", "auth")
+        if _contains_path_part(path, ("security",)):
+            add("auth_security_payment", "auth_security_payment", "security")
+        if _contains_path_part(path, ("payment", "payments", "billing")):
+            add("auth_security_payment", "auth_security_payment", "payment")
+        if _contains_path_part(path, ("permission", "permissions")):
+            add("auth_security_payment", "auth_security_payment", "permissions")
+
+    secret_diff = any(
+        token in diff_text
+        for token in ("password =", "aws_secret_access_key", "secret_key =", "private_key =")
+    )
+    config_path = any(
+        path == ".env.example" or path.startswith(("config/", ".github/workflows/"))
+        for path in lowered
+    )
+    if secret_diff or config_path:
+        labels = ["secrets_config_deployment"]
+        if any(path.startswith(".github/workflows/") for path in lowered):
+            labels.append("deployment")
+        if any(path.startswith("config/") or path == ".env.example" for path in lowered):
+            labels.append("secrets_config")
+        add("secrets_config_deployment", *labels)
+
+    if any(_contains_path_part(path, ("generated",)) for path in lowered):
+        add("generated_files")
+
+    if any(path.endswith("/__init__.py") for path in lowered):
+        add("public_api_changes")
+
+    if any(path.rsplit("/", 1)[-1] in _DEPENDENCY_FILES for path in lowered):
+        add("dependency_changes")
+
+    source_paths = [path for path in lowered if path.startswith("src/")]
+    test_paths = [path for path in lowered if path.startswith("tests/") or "/test_" in path]
+    generated_source = any(_contains_path_part(path, ("generated",)) for path in source_paths)
+    if source_paths and not test_paths and not generated_source:
+        add("source_without_tests")
+
+    irreversible_diff = any(token in diff_text for token in ("rm -rf", "terraform destroy"))
+    if any(path.startswith("infra/terraform/") for path in lowered) or irreversible_diff:
+        add("irreversible_infra")
+
+    return categories, rule_categories
+
+
+def _merged_rules(rule_set: RuleSet | None) -> dict[Category, dict[str, object]]:
+    merged: dict[Category, dict[str, object]] = {
+        category: dict(values) for category, values in DEFAULT_RULE_SET.items()
+    }
+    if rule_set:
+        overrides = cast("dict[str, RuleOverride]", rule_set)
+        for raw_category, override in overrides.items():
+            if raw_category not in DEFAULT_RULE_SET:
+                continue
+            category = raw_category
+            current = merged[category]
+            current.update(override)
+    return merged
+
+
+def _is_small_isolated_source(paths: list[str], diff_stats: dict[str, object]) -> bool:
+    if len(paths) != 1 or not paths[0].lower().startswith("src/"):
+        return False
+    added = diff_stats.get("lines_added")
+    deleted = diff_stats.get("lines_deleted")
+    return isinstance(added, int) and isinstance(deleted, int) and added + deleted <= 5
+
+
+def classify_blast_radius(
+    change: ChangeSet, *, rule_set: RuleSet | None = None
+) -> BlastRadiusClassification:
+    """Classify typed change data without filesystem, network, or environment access."""
+    paths = change.get("changed_paths", [])
+    diff_stats = change.get("diff_stats", {})
+    categories, rule_categories = _detected_categories(paths, _diff_text(diff_stats))
+    rules = _merged_rules(rule_set)
+
+    lanes: list[Lane] = [
+        cast("Lane", rules[category]["lane"])
+        for category in rule_categories
+        if "lane" in rules[category]
+    ]
+    lane: Lane = "low"
+    for candidate in lanes:
+        if _LANE_RANK[candidate] > _LANE_RANK[lane]:
+            lane = candidate
+    has_source = any(path.lower().startswith("src/") for path in paths)
+    if lane == "low" and has_source and "generated_files" not in rule_categories:
+        lane = "medium"
+
+    source_override = rule_set is not None and "source_without_tests" in rule_set
+    if lane == "medium" and _is_small_isolated_source(paths, diff_stats) and not source_override:
+        lane = "low"
+
+    if "generated_files" in rule_categories and lane == "high":
+        lane = "high"
+
+    reason = (
+        f"Detected blast-radius categories: {', '.join(categories)}."
+        if categories
+        else "No elevated blast-radius category was detected."
+    )
+    return BlastRadiusClassification(
+        lane=lane,
+        auto_merge_lane=_AUTO_MERGE_LANE[lane],
+        reason=reason,
+        next_action=_NEXT_ACTION[lane],
+        categories=categories,
+    )
+
+
+__all__ = [
+    "DEFAULT_RULE_SET",
+    "AutoMergeLane",
+    "BlastRadiusClassification",
+    "ChangeSet",
+    "Lane",
+    "RuleSet",
+    "classify_blast_radius",
+]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -11,6 +11,7 @@ import yaml
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from mergecraft.classify import RuleSet
 from mergecraft.types import PushPermission, ShellPermission  # noqa: TC001
 
 AccountPlan = Literal["none", "payg"]
@@ -98,6 +99,7 @@ class RepoSettings(BaseModel):
     shell: ShellPermission = "restricted"
     pr_approve_enabled: bool = Field(default=False, alias="prApproveEnabled")
     auto_merge_enabled: bool = Field(default=False, alias="autoMergeEnabled")
+    blast_radius_override: RuleSet = Field(default_factory=RuleSet, alias="blastRadiusOverride")
     signed_commits: bool = Field(default=False, alias="signedCommits")
     mode_instructions: dict[str, str] = Field(default_factory=dict, alias="modeInstructions")
     static_checks: list[StaticCheckDefinition] = Field(default_factory=list, alias="staticChecks")
@@ -182,6 +184,7 @@ def default_settings() -> RepoSettings:
             "shell": "restricted",
             "pr_approve_enabled": False,
             "auto_merge_enabled": False,
+            "blast_radius_override": {},
             "signed_commits": False,
             "mode_instructions": {},
             "static_checks": [],

--- a/src/mergecraft/evidence/__init__.py
+++ b/src/mergecraft/evidence/__init__.py
@@ -8,6 +8,7 @@ from mergecraft.evidence.packet import (
     Decision,
     DeterministicCheck,
     MergeEvidencePacket,
+    SelfAssessment,
     packet_output_schema,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "Decision",
     "DeterministicCheck",
     "MergeEvidencePacket",
+    "SelfAssessment",
     "packet_output_schema",
 ]

--- a/src/mergecraft/evidence/__init__.py
+++ b/src/mergecraft/evidence/__init__.py
@@ -1,0 +1,21 @@
+"""Merge Evidence Packet — durable, structured per-run evidence (#47 W1)."""
+
+from __future__ import annotations
+
+from mergecraft.evidence.packet import (
+    PACKET_SCHEMA_VERSION,
+    AgentMetadata,
+    Decision,
+    DeterministicCheck,
+    MergeEvidencePacket,
+    packet_output_schema,
+)
+
+__all__ = [
+    "PACKET_SCHEMA_VERSION",
+    "AgentMetadata",
+    "Decision",
+    "DeterministicCheck",
+    "MergeEvidencePacket",
+    "packet_output_schema",
+]

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -1,0 +1,141 @@
+"""Pure packet assembly for the Merge Evidence Packet (W1.3 — D3, D7).
+
+The :func:`build_packet` function composes a :class:`MergeEvidencePacket`
+from the sources enumerated in the W0.5 mechanical-evidence inventory —
+analyzer findings, deterministic checks, CI check outcomes, and agent
+metadata — without performing any I/O. The emitter at
+:mod:`mergecraft.evidence.emit` is the thin I/O shell that writes the
+result to a run-local path and stamps it as a CI artifact (convention 5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from mergecraft.analyzers.finding import Finding
+from mergecraft.evidence.packet import (
+    PACKET_SCHEMA_VERSION,
+    AgentMetadata,
+    Decision,
+    DeterministicCheck,
+    MergeEvidencePacket,
+)
+
+
+def _coerce_findings(raw: list[dict[str, Any]] | list[Finding] | None) -> list[Finding]:
+    """Validate analyzer findings into the existing ``Finding`` model (D3).
+
+    Accepts either already-typed ``Finding`` objects or the dicts that
+    ``AnalyzerRunState.findings`` produces (``analyzers/pipeline.py``).
+    Unknown taxonomy violations raise ``FindingValidationError`` — the
+    packet does not silently swallow bad data.
+    """
+    if not raw:
+        return []
+    coerced: list[Finding] = []
+    for item in raw:
+        if isinstance(item, Finding):
+            coerced.append(item)
+            continue
+        coerced.append(Finding.model_validate(item))
+    return coerced
+
+
+def _coerce_deterministic_checks(
+    raw: list[dict[str, Any]] | list[DeterministicCheck] | None,
+) -> list[DeterministicCheck]:
+    """Validate raw check dicts into :class:`DeterministicCheck` rows."""
+    if not raw:
+        return []
+    rows: list[DeterministicCheck] = []
+    for item in raw:
+        if isinstance(item, DeterministicCheck):
+            rows.append(item)
+            continue
+        rows.append(DeterministicCheck.model_validate(item))
+    return rows
+
+
+def _agent_metadata(
+    *,
+    agent_id: str,
+    agent_version: str,
+    model: str,
+) -> AgentMetadata:
+    return AgentMetadata(
+        id=agent_id,
+        version=agent_version,
+        model=model,
+    )
+
+
+def build_packet(
+    *,
+    change_id: str,
+    agent_id: str,
+    agent_version: str,
+    model: str,
+    files_changed: list[str],
+    findings: list[dict[str, Any]] | list[Finding] | None,
+    deterministic_checks: list[dict[str, Any]] | list[DeterministicCheck] | None,
+    decision: Decision | None = None,
+    ci_check_runs: dict[str, Any] | None = None,
+    ci_intelligence: dict[str, Any] | None = None,
+    self_assessment: dict[str, Any] | None = None,
+    usage_entries: Any = None,
+) -> MergeEvidencePacket:
+    """Assemble a :class:`MergeEvidencePacket` from structured sources.
+
+    Parameters match the W0.5 inventory: analyzer findings, deterministic
+    checks, CI check outcomes, CI-intelligence annotations, and agent
+    metadata. The function is **pure** — it performs no I/O and never
+    reads ``os.environ``. The emitter writes the result to disk.
+
+    Nullable-until-later sections (``blast_radius``, ``trajectory``,
+    ``evals``) are intentionally left as ``None`` here; Batches B / C / E
+    extend the packet with their own ``build_packet`` overlays.
+    """
+    coerced_findings = _coerce_findings(findings)
+    coerced_checks = _coerce_deterministic_checks(deterministic_checks)
+
+    if ci_check_runs is not None:
+        logger.debug(
+            "build_packet received ci_check_runs with {} suites",
+            len(ci_check_runs.get("check_suites") or []),
+        )
+    if ci_intelligence is not None:
+        logger.debug(
+            "build_packet received ci_intelligence with {} clusters",
+            len(ci_intelligence.get("clusters") or []),
+        )
+    if usage_entries is not None:
+        logger.debug(
+            "build_packet received {} usage_entries (Batch C consumer)",
+            len(usage_entries) if hasattr(usage_entries, "__len__") else 0,
+        )
+
+    packet = MergeEvidencePacket(
+        schema_version=PACKET_SCHEMA_VERSION,
+        change_id=change_id,
+        agent=_agent_metadata(
+            agent_id=agent_id,
+            agent_version=agent_version,
+            model=model,
+        ),
+        files_changed=list(files_changed),
+        findings=coerced_findings,
+        deterministic_checks=coerced_checks,
+        decision=decision,
+    )
+
+    # Attachment of unbounded-dict inputs is deferred to W2 / Batch C. The
+    # packet shape is frozen at W1; W2 attaches ``self_assessment`` and
+    # Batch C attaches ``trajectory`` as sibling fields rather than
+    # nested dicts, so updating the model is a strict version bump (D7).
+    _ = (self_assessment,)
+    return packet
+
+
+__all__ = ["build_packet"]

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -10,7 +10,7 @@ result to a run-local path and stamps it as a CI artifact (convention 5).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -23,6 +23,9 @@ from mergecraft.evidence.packet import (
     MergeEvidencePacket,
     SelfAssessment,
 )
+
+if TYPE_CHECKING:
+    from mergecraft.classify import BlastRadiusClassification
 
 
 def _coerce_findings(raw: list[dict[str, Any]] | list[Finding] | None) -> list[Finding]:
@@ -111,6 +114,7 @@ def build_packet(
     deterministic_checks: list[dict[str, Any]] | list[DeterministicCheck] | None,
     self_assessment: dict[str, Any] | SelfAssessment | None = None,
     decision: Decision | None = None,
+    blast_radius: BlastRadiusClassification | None = None,
     ci_check_runs: dict[str, Any] | None = None,
     ci_intelligence: dict[str, Any] | None = None,
     usage_entries: Any = None,
@@ -132,9 +136,9 @@ def build_packet(
     :func:`mergecraft.agents.gates.decide_approval` and ``tests/evidence/
     test_self_assessment.py``.
 
-    Nullable-until-later sections (``blast_radius``, ``trajectory``,
-    ``evals``) are intentionally left as ``None`` here; Batches B / C / E
-    extend the packet with their own ``build_packet`` overlays.
+    ``blast_radius`` and ``evals``) remain optional. Batch B populates
+    ``blast_radius`` with a typed ``BlastRadiusClassification``; Batches C / E
+    extend their sections.
     """
     coerced_findings = _coerce_findings(findings)
     coerced_checks = _coerce_deterministic_checks(deterministic_checks)
@@ -175,6 +179,7 @@ def build_packet(
         deterministic_checks=coerced_checks,
         self_assessment=coerced_self_assessment,
         decision=decision,
+        blast_radius=blast_radius,
     )
 
     # Trajectory / usage_entries / ci_check_runs / ci_intelligence are still

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -21,6 +21,7 @@ from mergecraft.evidence.packet import (
     Decision,
     DeterministicCheck,
     MergeEvidencePacket,
+    SelfAssessment,
 )
 
 
@@ -58,6 +59,34 @@ def _coerce_deterministic_checks(
     return rows
 
 
+def _coerce_self_assessment(
+    raw: dict[str, Any] | SelfAssessment | None,
+) -> SelfAssessment | None:
+    """Validate the recorded self-assessment into the ``SelfAssessment`` model (#41, W2.1).
+
+    Accepts either an already-typed ``SelfAssessment`` or a dict that mirrors
+    the ``ApprovalRecord`` shape the legacy ``mcp/review.py`` tool emits
+    (``would_approve`` -> ``approved``, ``sha`` passed through). Unknown
+    fields are rejected — ``extra="forbid"`` is the packet-level honesty rule
+    (W2.4).
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, SelfAssessment):
+        return raw
+    if isinstance(raw, dict):
+        # ``ApprovalRecord`` uses ``would_approve``; the packet uses
+        # ``approved``. Translate so the legacy path can be passed in
+        # without rewriting the call site.
+        if "approved" not in raw and "would_approve" in raw:
+            translated = {**raw, "approved": raw["would_approve"]}
+            translated.pop("would_approve", None)
+            raw = translated
+        return SelfAssessment.model_validate(raw)
+    msg = f"self_assessment must be a dict or SelfAssessment, got {type(raw).__name__}"
+    raise TypeError(msg)
+
+
 def _agent_metadata(
     *,
     agent_id: str,
@@ -80,10 +109,10 @@ def build_packet(
     files_changed: list[str],
     findings: list[dict[str, Any]] | list[Finding] | None,
     deterministic_checks: list[dict[str, Any]] | list[DeterministicCheck] | None,
+    self_assessment: dict[str, Any] | SelfAssessment | None = None,
     decision: Decision | None = None,
     ci_check_runs: dict[str, Any] | None = None,
     ci_intelligence: dict[str, Any] | None = None,
-    self_assessment: dict[str, Any] | None = None,
     usage_entries: Any = None,
 ) -> MergeEvidencePacket:
     """Assemble a :class:`MergeEvidencePacket` from structured sources.
@@ -93,12 +122,23 @@ def build_packet(
     metadata. The function is **pure** — it performs no I/O and never
     reads ``os.environ``. The emitter writes the result to disk.
 
+    W2 (#41) attaches the agent's recorded self-assessment as its own
+    sibling field (``self_assessment``), distinct from the structural
+    evidence verdict (``decision``). The two are independently populated:
+    ``self_assessment`` carries the agent's ``approved`` boolean + the
+    reviewed ``sha``; ``decision`` carries the structural verdict. The
+    verdict function refuses ``auto_merge`` when the recorded self-
+    assessment is the only positive signal — see
+    :func:`mergecraft.agents.gates.decide_approval` and ``tests/evidence/
+    test_self_assessment.py``.
+
     Nullable-until-later sections (``blast_radius``, ``trajectory``,
     ``evals``) are intentionally left as ``None`` here; Batches B / C / E
     extend the packet with their own ``build_packet`` overlays.
     """
     coerced_findings = _coerce_findings(findings)
     coerced_checks = _coerce_deterministic_checks(deterministic_checks)
+    coerced_self_assessment = _coerce_self_assessment(self_assessment)
 
     if ci_check_runs is not None:
         logger.debug(
@@ -115,6 +155,12 @@ def build_packet(
             "build_packet received {} usage_entries (Batch C consumer)",
             len(usage_entries) if hasattr(usage_entries, "__len__") else 0,
         )
+    if coerced_self_assessment is not None:
+        logger.debug(
+            "build_packet received self_assessment approved={} sha={}",
+            coerced_self_assessment.approved,
+            (coerced_self_assessment.sha or "")[:7] or "(none)",
+        )
 
     packet = MergeEvidencePacket(
         schema_version=PACKET_SCHEMA_VERSION,
@@ -127,14 +173,17 @@ def build_packet(
         files_changed=list(files_changed),
         findings=coerced_findings,
         deterministic_checks=coerced_checks,
+        self_assessment=coerced_self_assessment,
         decision=decision,
     )
 
-    # Attachment of unbounded-dict inputs is deferred to W2 / Batch C. The
-    # packet shape is frozen at W1; W2 attaches ``self_assessment`` and
-    # Batch C attaches ``trajectory`` as sibling fields rather than
-    # nested dicts, so updating the model is a strict version bump (D7).
-    _ = (self_assessment,)
+    # Trajectory / usage_entries / ci_check_runs / ci_intelligence are still
+    # deferred (Batch C for trajectory; W9+ for the rest). They are logged at
+    # debug level above for diagnostics and intentionally *not* attached to
+    # the packet here — Batch C owns ``trajectory`` as a sibling field
+    # rather than a nested dict, so updating the model is a strict version
+    # bump (D7).
+    _ = (ci_check_runs, ci_intelligence, usage_entries)
     return packet
 
 

--- a/src/mergecraft/evidence/emit.py
+++ b/src/mergecraft/evidence/emit.py
@@ -1,0 +1,73 @@
+"""I/O shell for the Merge Evidence Packet (W1.4 — convention 5).
+
+The emitter is a thin wrapper around :func:`mergecraft.evidence.build.build_packet`
+that writes the assembled packet to a run-local path and is ready to be
+attached as a CI artifact. All I/O lives here; the builder is pure.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from loguru import logger
+
+from mergecraft.evidence.build import build_packet
+
+if TYPE_CHECKING:
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+
+def write_packet(
+    packet: MergeEvidencePacket,
+    *,
+    output_path: Path,
+) -> Path:
+    """Write a :class:`MergeEvidencePacket` to ``output_path`` as pretty JSON.
+
+    The output path is a run-local artifact (``output_path`` is typically
+    inside the run's tempdir). Action surfaces, GitHub Actions uploads, and
+    any other conveyor should treat this path as opaque — the schema is the
+    contract, not the file location.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = packet.model_dump_json(indent=2, ensure_ascii=False)
+    output_path.write_text(f"{serialized}\n", encoding="utf-8")
+    logger.info(
+        "wrote merge evidence packet to {} (schema_version={}, findings={}, checks={})",
+        output_path,
+        packet.schema_version,
+        len(packet.findings),
+        len(packet.deterministic_checks),
+    )
+    return output_path
+
+
+def write_packet_from_sources(
+    *,
+    output_path: Path,
+    **build_kwargs: object,
+) -> Path:
+    """Compose a packet from sources and write it to ``output_path``.
+
+    Convenience wrapper that ties the pure builder to the I/O shell —
+    callers should prefer this when the source data is already in hand
+    and only the artifact is needed.
+    """
+    packet = build_packet(**build_kwargs)  # type: ignore[arg-type]
+    return write_packet(packet, output_path=output_path)
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    """Load a packet from a JSON file and return it as a dict.
+
+    Pure-deserialisation; re-validating against ``MergeEvidencePacket`` is
+    the caller's job (the emitter does not validate the round-trip — the
+    separate tests at ``tests/evidence/test_packet_round_trip.py`` do).
+    """
+    return cast("dict[str, Any]", json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+__all__ = ["load_packet", "write_packet", "write_packet_from_sources"]

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
 
 from mergecraft.analyzers.finding import Finding
+from mergecraft.classify import BlastRadiusClassification  # noqa: TC001
 
 # D7 — the packet is versioned from day one. Any field-level change (additive
 # or otherwise) that is not accompanied by a bump of this literal must fail
@@ -35,7 +36,10 @@ from mergecraft.analyzers.finding import Finding
 # - 1.1.0 — W2 (#41) adds the ``self_assessment`` section as a sibling of
 #   ``decision``. Additive (minor bump); the verdict function reads the
 #   ``self_assessment`` field but the wire shape is backwards-compatible.
-PACKET_SCHEMA_VERSION = "1.1.0"
+# - 1.2.0 — W5 (#42) replaces the untyped ``blast_radius`` placeholder with
+#   ``BlastRadiusClassification``. The section remains optional, but populated
+#   packets now carry a validated lane, reason, next action, and lane policy.
+PACKET_SCHEMA_VERSION = "1.2.0"
 
 
 class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]
@@ -150,7 +154,7 @@ class MergeEvidencePacket(BaseModel):
     deterministic_checks: list[DeterministicCheck]
     self_assessment: SelfAssessment | None = None
     decision: Decision | None = None
-    blast_radius: dict[str, Any] | None = None
+    blast_radius: BlastRadiusClassification | None = None
     trajectory: dict[str, Any] | None = None
     evals: dict[str, Any] | None = None
 

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -1,0 +1,148 @@
+"""Merge Evidence Packet — the versioned, structured artifact emitted by every run (#47).
+
+The packet composes the existing ``Finding`` model (D3) and is built from the
+sources enumerated in the W0.5 mechanical-evidence inventory — analyzer
+findings, deterministic checks, CI check outcomes, and agent metadata. It is
+**not** a second finding model and contains **no** hand-written JSON Schema:
+the schema is derived from the Pydantic models here, mirroring the precedent
+in ``mergecraft.analyzers.finding.findings_output_schema`` (D3, D7).
+
+W1 ships the schema, the assembly, and the emitter. W2 will populate the
+``decision`` field and split it from ``self_assessment``. Batches B / C / E
+extend the nullable-until-later sections (blast radius, trajectory, evals).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.fields import FieldInfo
+
+from mergecraft.analyzers.finding import Finding
+
+# D7 — the packet is versioned from day one. Any field-level change (additive
+# or otherwise) that is not accompanied by a bump of this literal must fail
+# ``test_packet_schema_version_is_pinned`` at the gate. Bumps are mandatory,
+# not optional.
+PACKET_SCHEMA_VERSION = "1.0.0"
+
+
+class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]
+    """``FieldInfo`` whose ``default`` advertises the pinned version while the
+    validator still treats the field as required.
+
+    Pydantic v2 binds ``is_required()`` to ``default is PydanticUndefined``
+    AND ``default_factory is None`` (see ``pydantic/fields.py``). The WA-T.3
+    test pair asserts both ``is_required() is True`` (the field is required
+    at validation) and ``fields["schema_version"].default == pinned`` (the
+    pinned literal is discoverable on the field). A plain
+    ``Field(default=...)`` is mutually exclusive with ``is_required() is
+    True``; subclassing FieldInfo and pinning ``is_required()`` to True is
+    the minimal way to satisfy both ends of that contract without
+    duplicating the pinned literal.
+    """
+
+    def is_required(self) -> bool:
+        return True
+
+
+def _pinned_version_field() -> FieldInfo:
+    """Return the ``FieldInfo`` carrying the pinned ``schema_version`` literal."""
+    return _PinnedRequiredFieldInfo(default=PACKET_SCHEMA_VERSION)
+
+
+class AgentMetadata(BaseModel):
+    """Identifies the agent that produced the run.
+
+    The carrying fields (``id``, ``version``, ``model``) are the minimum the
+    packet needs to attribute findings and reproduce a run.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    version: str
+    model: str
+
+
+class DeterministicCheck(BaseModel):
+    """One decomposable mechanical check that ran (or was skipped) for the PR."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    status: str
+    command: str
+
+
+class Decision(BaseModel):
+    """The evidence verdict (W2 surface; nullable in W1).
+
+    W1 ships the shape so the packet round-trips end-to-end. W2 populates this
+    from ``decide_approval()`` (D5). ``verdict`` is a string until W9 closes
+    the action vocabulary; today, expected values are ``"auto_merge"`` /
+    ``"block"`` / ``"request_changes"`` / ``"require_human_review"`` /
+    ``"unavailable"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: str
+    reason: str
+    decided_by: str
+
+
+class MergeEvidencePacket(BaseModel):
+    """The versioned, structured record of one mergeCraft run.
+
+    Top-level required fields are the ones every run can populate today.
+    ``blast_radius``, ``trajectory``, and ``evals`` are nullable until later
+    batches land — they are *typed* ``| None`` here, not omitted, so the
+    packet's downstream contract is fixed from W1 (D4).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = _pinned_version_field()  # type: ignore[assignment]
+    change_id: str
+    agent: AgentMetadata
+    files_changed: list[str]
+    findings: list[Finding]
+    deterministic_checks: list[DeterministicCheck]
+    decision: Decision | None = None
+    blast_radius: dict[str, Any] | None = None
+    trajectory: dict[str, Any] | None = None
+    evals: dict[str, Any] | None = None
+
+
+def packet_output_schema() -> dict[str, Any]:
+    """JSON Schema for the Merge Evidence Packet, derived from the models (D3).
+
+    Mirrors ``mergecraft.analyzers.finding.findings_output_schema`` (the
+    precedent at ``analyzers/finding.py:138``): the implementation imports
+    the Pydantic model and calls ``model_json_schema()``. It does **not**
+    maintain a hand-written schema dict in parallel.
+
+    Pydantic v2 emits nested models via ``$ref`` into ``$defs`` by default,
+    which would leak the wrong shape into the WA-T.1 assertion. The Finding
+    schema is therefore inlined into the ``findings.items`` slot, so the
+    packet's wire schema matches ``Finding`` field-for-field (D3).
+    """
+    schema = MergeEvidencePacket.model_json_schema()
+    findings = schema.get("properties", {}).get("findings")
+    if isinstance(findings, dict):
+        items = findings.get("items")
+        if isinstance(items, dict) and "$ref" in items:
+            findings["items"] = Finding.model_json_schema()
+    return schema
+
+
+__all__ = [
+    "PACKET_SCHEMA_VERSION",
+    "AgentMetadata",
+    "Decision",
+    "DeterministicCheck",
+    "MergeEvidencePacket",
+    "packet_output_schema",
+]

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -7,9 +7,13 @@ findings, deterministic checks, CI check outcomes, and agent metadata. It is
 the schema is derived from the Pydantic models here, mirroring the precedent
 in ``mergecraft.analyzers.finding.findings_output_schema`` (D3, D7).
 
-W1 ships the schema, the assembly, and the emitter. W2 will populate the
-``decision`` field and split it from ``self_assessment``. Batches B / C / E
-extend the nullable-until-later sections (blast radius, trajectory, evals).
+W1 shipped the schema, the assembly, and the emitter. W2 (#41) splits the
+recorded ``self_assessment`` from the computed ``decision`` verdict — the
+agent's ``approved`` boolean is now carried as a dedicated ``SelfAssessment``
+row alongside the ``Decision`` so the two signals are independently
+inspectable and the verdict is never a function of the agent's prose alone.
+Batches B / C / E extend the nullable-until-later sections (blast radius,
+trajectory, evals).
 """
 
 from __future__ import annotations
@@ -25,7 +29,13 @@ from mergecraft.analyzers.finding import Finding
 # or otherwise) that is not accompanied by a bump of this literal must fail
 # ``test_packet_schema_version_is_pinned`` at the gate. Bumps are mandatory,
 # not optional.
-PACKET_SCHEMA_VERSION = "1.0.0"
+#
+# Version history:
+# - 1.0.0 — W1 initial schema (#47)
+# - 1.1.0 — W2 (#41) adds the ``self_assessment`` section as a sibling of
+#   ``decision``. Additive (minor bump); the verdict function reads the
+#   ``self_assessment`` field but the wire shape is backwards-compatible.
+PACKET_SCHEMA_VERSION = "1.1.0"
 
 
 class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]
@@ -83,7 +93,13 @@ class Decision(BaseModel):
     from ``decide_approval()`` (D5). ``verdict`` is a string until W9 closes
     the action vocabulary; today, expected values are ``"auto_merge"`` /
     ``"block"`` / ``"request_changes"`` / ``"require_human_review"`` /
-    ``"unavailable"``.
+    ``"unavailable"`` / ``"neutral"``.
+
+    The Decision row is the *authoritative* verdict: when ``decide_approval()``
+    is asked to consume a packet, an explicit ``Decision.verdict`` wins over
+    every other signal — including the agent's recorded self-assessment. That
+    is the #41 hard rule: the agent's prose cannot outvote the structural
+    evidence verdict.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -91,6 +107,28 @@ class Decision(BaseModel):
     verdict: str
     reason: str
     decided_by: str
+
+
+class SelfAssessment(BaseModel):
+    """The agent's recorded self-assessment — what it *said* (#41).
+
+    Distinct from the evidence verdict. The agent calls
+    ``create_pull_request_review(approved=...)`` during the run; that boolean
+    is captured here as the agent's own statement about the PR, with the
+    reviewed commit SHA so the recording is traceable.
+
+    This row is **advisory**. It is never the sole positive input to a
+    decision — when the ``Decision`` field on the same packet is absent and
+    the only positive signal is ``self_assessment.approved == True``, the
+    decision function refuses ``auto_merge``. The verdict is computed from
+    structural evidence (typed findings, deterministic checks, run state,
+    trust tier), not from this row.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    approved: bool
+    sha: str | None = None
 
 
 class MergeEvidencePacket(BaseModel):
@@ -110,6 +148,7 @@ class MergeEvidencePacket(BaseModel):
     files_changed: list[str]
     findings: list[Finding]
     deterministic_checks: list[DeterministicCheck]
+    self_assessment: SelfAssessment | None = None
     decision: Decision | None = None
     blast_radius: dict[str, Any] | None = None
     trajectory: dict[str, Any] | None = None
@@ -144,5 +183,6 @@ __all__ = [
     "Decision",
     "DeterministicCheck",
     "MergeEvidencePacket",
+    "SelfAssessment",
     "packet_output_schema",
 ]

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -147,6 +147,15 @@ def create_pull_request_review_tool(ctx: ToolContext):
             node_id=str(result.get("node_id") or ""),
             reviewed_sha=payload.get("commit_id"),
         )
+        # #41 / W2.1 — the agent's ``approved`` boolean is recorded here as
+        # the legacy ``ApprovalRecord`` and (separately, when the packet is
+        # built at the end of the run) as the packet's ``self_assessment``
+        # row. The two are populated from the same call but kept
+        # structurally distinct so the structural verdict (``Decision``)
+        # can never be derived from the agent's prose. The legacy field
+        # stays for backward compatibility with consumers that still
+        # read ``tool_state.approval.would_approve``; ``build_packet()``
+        # translates it into the packet's ``self_assessment`` row.
         ctx.tool_state.approval = ApprovalRecord(
             would_approve=approved,
             sha=payload.get("commit_id"),

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -88,6 +88,14 @@ class ApprovalRecord:
     structurally by ``mergecraft.agents.gates.decide_approval`` from the typed
     ``Finding`` list, the run's completion state, and the trust tier (D12).
 
+    W2 of the merge-evidence plan (#41) split this signal from the evidence
+    verdict: ``build_packet()`` translates the legacy ``ApprovalRecord`` into
+    the packet's ``self_assessment`` row, and the structural ``Decision``
+    lives in its own sibling field. The legacy ``tool_state.approval``
+    surface stays for backward compatibility with consumers that still
+    read ``would_approve`` directly; new code should consume the packet's
+    ``self_assessment`` row instead.
+
     The field exists for the trajectory / merge-evidence plan (#41) so the
     recorded "self-assessment" can be compared against the structural
     conclusion after the fact. It is not consulted by ``report_status_checks``

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -29,6 +29,7 @@ def test_default_settings_match_upstream() -> None:
     assert settings.shell == "restricted"
     assert settings.pr_approve_enabled is False
     assert settings.auto_merge_enabled is False
+    assert settings.blast_radius_override == {}
     assert settings.signed_commits is False
     assert settings.mode_instructions == {}
     assert settings.static_checks == []
@@ -146,6 +147,17 @@ def test_snake_and_camel_aliases(tmp_path: Path) -> None:
     assert settings.setup_script == "echo hi"
     assert settings.pr_approve_enabled is True
     assert settings.auto_merge_enabled is True
+
+
+def test_blast_radius_override_parses_per_category(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        "blastRadiusOverride:\n  source_without_tests:\n    lane: high\n",
+        encoding="utf-8",
+    )
+    settings = load_repo_settings(cfg, root=tmp_path, load_learnings_files=False)
+    assert settings.blast_radius_override == {"source_without_tests": {"lane": "high"}}
+    assert settings.auto_merge_enabled is False
 
 
 def test_analyzers_block_parses_and_merges(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/evidence/conftest.py
+++ b/tests/evidence/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest fixtures for merge-evidence packet tests (WA-T)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def sample_packet() -> dict[str, object]:
+    """A round-trippable packet payload for the WA-T RED suite."""
+    from tests.evidence.support import sample_minimal_packet_dict
+
+    return sample_minimal_packet_dict()

--- a/tests/evidence/support.py
+++ b/tests/evidence/support.py
@@ -1,0 +1,71 @@
+"""Shared constants and lazy imports for merge-evidence packet RED tests (WA-T)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+_EVIDENCE_DIR = Path(__file__).resolve().parent
+
+
+def import_module(dotted: str) -> Any:
+    """Lazy import so collection succeeds before W1 lands ``src/mergecraft/evidence/``."""
+    return importlib.import_module(dotted)
+
+
+def sample_finding_dict() -> dict[str, Any]:
+    """One taxonomy-valid ``Finding`` payload for packet builder fixtures.
+
+    Mirrors the shape used by the analyzer test suite, so the packet test
+    fixtures stay decoupled from the eventual emission pipeline.
+    """
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import",
+        path="src/mergecraft/evidence/__init__.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        introduced_by_pr="true",
+    )
+    return finding.model_dump()
+
+
+def sample_minimal_packet_dict() -> dict[str, Any]:
+    """The minimal packet payload needed to round-trip the schema (WA-T.2/4).
+
+    Sections marked nullable-until-later (B/C/E) are explicitly present and
+    ``None`` per the WA-T.4 contract — never omitted.
+    """
+    return {
+        "schema_version": "1.0.0",
+        "change_id": "alexhawat/mergeCraft#42",
+        "agent": {
+            "id": "claude",
+            "version": "1.2.3",
+            "model": "claude-sonnet-4-5",
+        },
+        "files_changed": ["src/mergecraft/evidence/packet.py"],
+        "findings": [sample_finding_dict()],
+        "deterministic_checks": [
+            {
+                "name": "lint",
+                "status": "pass",
+                "command": "ruff check src tests scripts",
+            },
+        ],
+        "blast_radius": None,
+        "trajectory": None,
+        "evals": None,
+        "decision": {
+            "verdict": "block",
+            "reason": "self-assessment-only run",
+            "decided_by": "mergecraft.agents.gates.decide_approval",
+        },
+    }

--- a/tests/evidence/support.py
+++ b/tests/evidence/support.py
@@ -42,9 +42,15 @@ def sample_minimal_packet_dict() -> dict[str, Any]:
 
     Sections marked nullable-until-later (B/C/E) are explicitly present and
     ``None`` per the WA-T.4 contract — never omitted.
+
+    The schema version mirrors ``mergecraft.evidence.packet.PACKET_SCHEMA_VERSION``
+    at import time so a schema-version bump in the production module fails
+    the round-trip suite rather than silently desyncing the fixture.
     """
+    from mergecraft.evidence.packet import PACKET_SCHEMA_VERSION
+
     return {
-        "schema_version": "1.0.0",
+        "schema_version": PACKET_SCHEMA_VERSION,
         "change_id": "alexhawat/mergeCraft#42",
         "agent": {
             "id": "claude",

--- a/tests/evidence/test_blast_radius.py
+++ b/tests/evidence/test_blast_radius.py
@@ -109,22 +109,39 @@ def test_classifier_detects_each_named_category(
 
 def test_rule_set_is_overridable_per_repo(classifier_api: Any) -> None:
     """D9: a repository override changes classification without changing code."""
+    from mergecraft.config import RepoSettings
+
     change = _change("src/mergecraft/utils/time.py", files_changed=1)
     default = classifier_api.classify_blast_radius(change)
-    override: dict[str, dict[str, str]] = {"source_without_tests": {"lane": "high"}}
-    overridden = classifier_api.classify_blast_radius(change, rule_set=override)
+    settings = RepoSettings.model_validate(
+        {"blastRadiusOverride": {"source_without_tests": {"lane": "high"}}}
+    )
+    overridden = classifier_api.classify_blast_radius(
+        change, rule_set=settings.blast_radius_override
+    )
     assert default.lane != overridden.lane
     assert overridden.lane == "high"
 
 
-@pytest.mark.xfail(reason="W5 owns lane-policy and packet wiring", run=False)
 def test_decision_output_names_lane_reason_and_next_action(classifier_api: Any) -> None:
     """#42 requires a user-facing lane, reason, and next action."""
     result = classifier_api.classify_blast_radius(_change("docs/guide.md"))
-    assert isinstance(result.lane, str)
-    assert result.reason
-    assert result.next_action
-    assert result.auto_merge_lane == "eligible"
+    from mergecraft.evidence.packet import PACKET_SCHEMA_VERSION, MergeEvidencePacket
+
+    packet = MergeEvidencePacket(
+        schema_version=PACKET_SCHEMA_VERSION,
+        change_id="alexhawat/mergeCraft#42",
+        agent={"id": "test", "version": "1", "model": "test"},
+        files_changed=["docs/guide.md"],
+        findings=[],
+        deterministic_checks=[],
+        blast_radius=result,
+    )
+    assert packet.blast_radius is not None
+    assert isinstance(packet.blast_radius.lane, str)
+    assert packet.blast_radius.reason
+    assert packet.blast_radius.next_action
+    assert packet.blast_radius.auto_merge_lane == "eligible"
 
 
 def test_classifier_is_pure(classifier_api: Any, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/evidence/test_blast_radius.py
+++ b/tests/evidence/test_blast_radius.py
@@ -1,0 +1,155 @@
+"""WB-T RED contract for the #42/#48 blast-radius classifier.
+
+The classifier is intentionally imported inside each test. W6 owns the
+production module; until it lands, these strict=False xfails collect and report
+as expected failures rather than making the suite uncollectable.
+
+Locked surface:
+
+- ``classify_blast_radius(change: ChangeSet, *, rule_set: RuleSet | None =
+  None) -> BlastRadiusClassification``
+- ``BlastRadiusClassification`` exposes ``lane``, ``reason``, ``next_action``,
+  and named ``categories``.
+- ``RepoSettings.blast_radius_override`` supplies an additive per-repository
+  rule override (D9).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def classifier_api() -> Any:
+    """Load the W6 API lazily so the RED suite remains collectable."""
+    from importlib import import_module
+
+    return import_module("mergecraft.classify.blast_radius")
+
+
+def _change(*paths: str, **signals: object) -> dict[str, object]:
+    """Build a side-effect-free change payload for the classifier contract."""
+    return {"changed_paths": list(paths), "diff_stats": signals}
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+def test_classifier_low_risk_examples(classifier_api: Any) -> None:
+    """Docs-only, tests-only, and small isolated changes enter the low lane."""
+    classify = classifier_api.classify_blast_radius
+    cases = (
+        _change("docs/guide.md", files_changed=1, lines_added=8, lines_deleted=2),
+        _change("tests/unit/test_widget.py", files_changed=1, lines_added=12, lines_deleted=4),
+        _change("src/mergecraft/utils/time.py", files_changed=1, lines_added=3, lines_deleted=2),
+    )
+    for change in cases:
+        result = classify(change)
+        assert result.lane == "low"
+        assert result.auto_merge_lane == "eligible"
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+def test_classifier_medium_risk_examples(classifier_api: Any) -> None:
+    """Broad but reversible application changes require assisted review."""
+    classify = classifier_api.classify_blast_radius
+    cases = (
+        _change("src/mergecraft/cli/app.py", "tests/cli/test_app.py", files_changed=2),
+        _change("src/mergecraft/analyzers/pipeline.py", files_changed=1, lines_added=75),
+        _change("src/mergecraft/config/settings.py", "docs/config.md", files_changed=2),
+    )
+    for change in cases:
+        result = classify(change)
+        assert result.lane == "medium"
+        assert result.auto_merge_lane in {"assisted", "human_review"}
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+@pytest.mark.parametrize(
+    ("path", "category"),
+    [
+        ("migrations/20260809_add_index.sql", "migrations"),
+        ("src/auth/session.py", "auth"),
+        ("src/security/tokens.py", "security"),
+        ("src/payments/checkout.py", "payment"),
+        (".github/workflows/deploy.yml", "deployment"),
+        ("infra/terraform/network.tf", "irreversible_infra"),
+        ("src/permissions/policy.py", "permissions"),
+        ("config/production.yaml", "secrets_config"),
+    ],
+)
+def test_classifier_high_risk_examples(classifier_api: Any, path: str, category: str) -> None:
+    """#48 high-risk acceptance categories forbid automatic merging."""
+    result = classifier_api.classify_blast_radius(_change(path, files_changed=1))
+    assert result.lane == "high"
+    assert result.auto_merge_lane == "forbidden"
+    assert category in result.categories
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+@pytest.mark.parametrize(
+    ("path", "category"),
+    [
+        ("db/migrations/001_init.sql", "migrations"),
+        ("src/auth/login.py", "auth_security_payment"),
+        ("src/security/headers.py", "auth_security_payment"),
+        ("src/payment/refunds.py", "auth_security_payment"),
+        (".env.example", "secrets_config_deployment"),
+        ("config/runtime.yaml", "secrets_config_deployment"),
+        (".github/workflows/test.yml", "secrets_config_deployment"),
+        ("src/generated/schema.py", "generated_files"),
+        ("src/mergecraft/__init__.py", "public_api_changes"),
+        ("pyproject.toml", "dependency_changes"),
+        ("src/mergecraft/cli/app.py", "source_without_tests"),
+    ],
+)
+def test_classifier_detects_each_named_category(
+    classifier_api: Any, path: str, category: str
+) -> None:
+    """#48 requires every named category to be observable in the result."""
+    result = classifier_api.classify_blast_radius(_change(path, files_changed=1))
+    assert category in result.categories
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+def test_rule_set_is_overridable_per_repo(classifier_api: Any) -> None:
+    """D9: a repository override changes classification without changing code."""
+    from mergecraft.config.settings import RepoSettings
+
+    change = _change("src/mergecraft/utils/time.py", files_changed=1)
+    default = classifier_api.classify_blast_radius(change)
+    override: dict[str, dict[str, str]] = {"source_without_tests": {"lane": "high"}}
+    settings = RepoSettings(blast_radius_override=override)  # type: ignore[call-arg]
+    overridden = classifier_api.classify_blast_radius(
+        change,
+        rule_set=settings.blast_radius_override,  # type: ignore[attr-defined]
+    )
+    assert default.lane != overridden.lane
+    assert overridden.lane == "high"
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+def test_decision_output_names_lane_reason_and_next_action(classifier_api: Any) -> None:
+    """#42 requires a user-facing lane, reason, and next action."""
+    result = classifier_api.classify_blast_radius(_change("docs/guide.md"))
+    assert isinstance(result.lane, str)
+    assert result.reason
+    assert result.next_action
+    assert result.auto_merge_lane == "eligible"
+
+
+@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+def test_classifier_is_pure(classifier_api: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Convention 5: classification cannot read files, network, or environment."""
+    import builtins
+    import os
+    import socket
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("classifier performed an external side effect")
+
+    monkeypatch.setattr(builtins, "open", fail)
+    monkeypatch.setattr(socket, "socket", fail)
+    monkeypatch.setattr(os, "environ", {})
+    result = classifier_api.classify_blast_radius(_change("docs/guide.md"))
+    assert result.lane == "low"

--- a/tests/evidence/test_blast_radius.py
+++ b/tests/evidence/test_blast_radius.py
@@ -34,7 +34,6 @@ def _change(*paths: str, **signals: object) -> dict[str, object]:
     return {"changed_paths": list(paths), "diff_stats": signals}
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 def test_classifier_low_risk_examples(classifier_api: Any) -> None:
     """Docs-only, tests-only, and small isolated changes enter the low lane."""
     classify = classifier_api.classify_blast_radius
@@ -49,7 +48,6 @@ def test_classifier_low_risk_examples(classifier_api: Any) -> None:
         assert result.auto_merge_lane == "eligible"
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 def test_classifier_medium_risk_examples(classifier_api: Any) -> None:
     """Broad but reversible application changes require assisted review."""
     classify = classifier_api.classify_blast_radius
@@ -64,7 +62,6 @@ def test_classifier_medium_risk_examples(classifier_api: Any) -> None:
         assert result.auto_merge_lane in {"assisted", "human_review"}
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 @pytest.mark.parametrize(
     ("path", "category"),
     [
@@ -86,7 +83,6 @@ def test_classifier_high_risk_examples(classifier_api: Any, path: str, category:
     assert category in result.categories
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 @pytest.mark.parametrize(
     ("path", "category"),
     [
@@ -111,24 +107,17 @@ def test_classifier_detects_each_named_category(
     assert category in result.categories
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 def test_rule_set_is_overridable_per_repo(classifier_api: Any) -> None:
     """D9: a repository override changes classification without changing code."""
-    from mergecraft.config.settings import RepoSettings
-
     change = _change("src/mergecraft/utils/time.py", files_changed=1)
     default = classifier_api.classify_blast_radius(change)
     override: dict[str, dict[str, str]] = {"source_without_tests": {"lane": "high"}}
-    settings = RepoSettings(blast_radius_override=override)  # type: ignore[call-arg]
-    overridden = classifier_api.classify_blast_radius(
-        change,
-        rule_set=settings.blast_radius_override,  # type: ignore[attr-defined]
-    )
+    overridden = classifier_api.classify_blast_radius(change, rule_set=override)
     assert default.lane != overridden.lane
     assert overridden.lane == "high"
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
+@pytest.mark.xfail(reason="W5 owns lane-policy and packet wiring", run=False)
 def test_decision_output_names_lane_reason_and_next_action(classifier_api: Any) -> None:
     """#42 requires a user-facing lane, reason, and next action."""
     result = classifier_api.classify_blast_radius(_change("docs/guide.md"))
@@ -138,7 +127,6 @@ def test_decision_output_names_lane_reason_and_next_action(classifier_api: Any) 
     assert result.auto_merge_lane == "eligible"
 
 
-@pytest.mark.xfail(reason="green after W5/W6", strict=False)
 def test_classifier_is_pure(classifier_api: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Convention 5: classification cannot read files, network, or environment."""
     import builtins

--- a/tests/evidence/test_packet_round_trip.py
+++ b/tests/evidence/test_packet_round_trip.py
@@ -10,8 +10,6 @@ from pydantic import ValidationError
 
 from tests.evidence.support import import_module, sample_minimal_packet_dict
 
-pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
-
 
 def test_evidence_packet_round_trips_through_json() -> None:
     """A fully populated packet serializes to JSON and re-validates with zero errors."""

--- a/tests/evidence/test_packet_round_trip.py
+++ b/tests/evidence/test_packet_round_trip.py
@@ -1,0 +1,60 @@
+"""Merge Evidence Packet — round-trip and ``extra=\"forbid\"`` (WA-T.2)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from tests.evidence.support import import_module, sample_minimal_packet_dict
+
+pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
+
+
+def test_evidence_packet_round_trips_through_json() -> None:
+    """A fully populated packet serializes to JSON and re-validates with zero errors."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    payload = sample_minimal_packet_dict()
+    packet = packet_mod.MergeEvidencePacket(**payload)
+    serialized = packet.model_dump_json()
+    reparsed = packet_mod.MergeEvidencePacket.model_validate_json(serialized)
+    assert reparsed == packet
+
+    # The serialized form must also be plain JSON.
+    json.loads(serialized)
+
+
+def test_evidence_packet_round_trips_through_dict() -> None:
+    """A packet serializes to a dict and re-validates from the dict (no info loss)."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    payload = sample_minimal_packet_dict()
+    packet = packet_mod.MergeEvidencePacket(**payload)
+    dumped = packet.model_dump()
+    reparsed = packet_mod.MergeEvidencePacket(**dumped)
+    assert reparsed == packet
+
+
+def test_evidence_packet_rejects_unknown_fields() -> None:
+    """``extra=\"forbid\"`` rejects unknown fields (D3 — packet composes Finding strictly)."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    payload = sample_minimal_packet_dict()
+    payload_with_extra: dict[str, Any] = {**payload, "rogue_field": "should be rejected"}
+    with pytest.raises(ValidationError):
+        packet_mod.MergeEvidencePacket(**payload_with_extra)
+
+
+def test_evidence_packet_rejects_nested_unknown_fields() -> None:
+    """``extra=\"forbid\"`` also applies to nested models (e.g. ``agent``)."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    payload = sample_minimal_packet_dict()
+    nested = dict(payload["agent"])  # type: ignore[arg-type]
+    nested["rogue_field"] = "should be rejected"
+    payload_bad: dict[str, Any] = {**payload, "agent": nested}
+    with pytest.raises(ValidationError):
+        packet_mod.MergeEvidencePacket(**payload_bad)

--- a/tests/evidence/test_packet_schema.py
+++ b/tests/evidence/test_packet_schema.py
@@ -1,0 +1,107 @@
+"""Merge Evidence Packet — schema derivation and version pinning (WA-T.1, WA-T.3).
+
+Pin the contract that the packet's JSON Schema must come from the Pydantic
+models (mirroring ``mergecraft.analyzers.finding.findings_output_schema`` at
+``src/mergecraft/analyzers/finding.py:138``) and that the version is asserted
+(D7). Tests are xfail until W1 lands ``src/mergecraft/evidence/packet.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.analyzers.support import import_module as import_finding_module
+from tests.evidence.support import import_module
+
+pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
+
+
+def test_evidence_packet_schema_is_derived_not_handwritten() -> None:
+    """The packet's JSON Schema must be derived from the Pydantic models (D3)."""
+    finding_mod = import_finding_module("mergecraft.analyzers.finding")
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    schema = packet_mod.packet_output_schema()
+    assert isinstance(schema, dict)
+    assert schema.get("type") == "object"
+
+    properties = schema.get("properties")
+    assert isinstance(properties, dict)
+
+    # ``findings`` must reuse ``Finding.model_json_schema()`` — never a hand-written
+    # parallel schema (D3 + the precedent at analyzers/finding.py:138).
+    findings_prop = properties.get("findings")
+    assert isinstance(findings_prop, dict)
+    assert findings_prop.get("type") == "array"
+    items = findings_prop.get("items")
+    assert isinstance(items, dict)
+
+    finding_schema = finding_mod.Finding.model_json_schema()
+    assert items == finding_schema or items.get("properties") == finding_schema.get("properties")
+
+
+def test_packet_findings_match_finding_model_json_schema() -> None:
+    """Each ``findings`` item must match ``Finding.model_json_schema()`` (D3)."""
+    finding_mod = import_finding_module("mergecraft.analyzers.finding")
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    packet_cls = packet_mod.MergeEvidencePacket
+    fields = packet_cls.model_fields
+    assert "findings" in fields
+    findings_field = fields["findings"]
+    # The annotation should reference the same ``Finding`` Pydantic model.
+    annotation = getattr(findings_field, "annotation", None)
+    assert annotation is not None
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", ())
+    assert origin is list
+    assert finding_mod.Finding in args
+
+
+def test_evidence_packet_requires_schema_version() -> None:
+    """``schema_version`` is a required top-level field (D7)."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    assert "schema_version" in fields
+    # ``is_required`` is True when no default is supplied.
+    assert fields["schema_version"].is_required() is True
+
+
+def test_packet_schema_version_is_pinned() -> None:
+    """The current schema version is a literal the suite pins (D7).
+
+    Any field-level change to the packet (additive or otherwise) that is not
+    accompanied by a version bump must cause this assertion to fail, so the
+    reviewer catches silent schema drift at the gate.
+    """
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    # The packet must publish a single source of truth for the current version.
+    assert hasattr(packet_mod, "PACKET_SCHEMA_VERSION")
+    pinned = packet_mod.PACKET_SCHEMA_VERSION
+    assert isinstance(pinned, str)
+    assert pinned.count(".") == 2  # major.minor.patch
+
+    # And the same literal must appear in the model field default.
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    assert fields["schema_version"].default == pinned
+
+
+def test_packet_schema_round_trip_json_serializes() -> None:
+    """The derived schema must validate the serialized form of a real packet."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+
+    packet = packet_mod.MergeEvidencePacket(**_packet_kwargs())
+    serialized = packet.model_dump_json()
+    reparsed = packet_mod.MergeEvidencePacket.model_validate_json(serialized)
+    assert reparsed == packet
+    # The serialized form must be valid JSON.
+    json.loads(serialized)
+
+
+def _packet_kwargs() -> dict[str, object]:
+    from tests.evidence.support import sample_minimal_packet_dict
+
+    return sample_minimal_packet_dict()

--- a/tests/evidence/test_packet_schema.py
+++ b/tests/evidence/test_packet_schema.py
@@ -3,19 +3,15 @@
 Pin the contract that the packet's JSON Schema must come from the Pydantic
 models (mirroring ``mergecraft.analyzers.finding.findings_output_schema`` at
 ``src/mergecraft/analyzers/finding.py:138``) and that the version is asserted
-(D7). Tests are xfail until W1 lands ``src/mergecraft/evidence/packet.py``.
+(D7).
 """
 
 from __future__ import annotations
 
 import json
 
-import pytest
-
 from tests.analyzers.support import import_module as import_finding_module
 from tests.evidence.support import import_module
-
-pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
 
 
 def test_evidence_packet_schema_is_derived_not_handwritten() -> None:

--- a/tests/evidence/test_packet_sections.py
+++ b/tests/evidence/test_packet_sections.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
-
 from tests.evidence.support import import_module
-
-pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
-
 
 _REQUIRED_SECTIONS: tuple[str, ...] = (
     "schema_version",

--- a/tests/evidence/test_packet_sections.py
+++ b/tests/evidence/test_packet_sections.py
@@ -46,6 +46,13 @@ def test_packet_contains_nullable_until_later_sections() -> None:
         )
 
 
+def test_packet_blast_radius_uses_classification_model() -> None:
+    """Batch B replaces the untyped placeholder with the classifier result."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    annotation = packet_mod.MergeEvidencePacket.model_fields["blast_radius"].annotation
+    assert "BlastRadiusClassification" in str(annotation)
+
+
 def test_packet_agent_section_carries_id_version_and_model() -> None:
     """The ``agent`` section must record id, version, and model."""
     packet_mod = import_module("mergecraft.evidence.packet")

--- a/tests/evidence/test_packet_sections.py
+++ b/tests/evidence/test_packet_sections.py
@@ -1,0 +1,67 @@
+"""Merge Evidence Packet — required sections and nullable-until-later fields (WA-T.4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.evidence.support import import_module
+
+pytestmark = pytest.mark.xfail(reason="green after W1", strict=False)
+
+
+_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "schema_version",
+    "change_id",
+    "agent",
+    "files_changed",
+    "deterministic_checks",
+    "decision",
+)
+
+
+_NULLABLE_UNTIL_LATER: tuple[str, ...] = (
+    "blast_radius",  # nullable until Batch B (W5)
+    "trajectory",  # nullable until Batch C (W7)
+    "evals",  # nullable until Batch E (W11)
+)
+
+
+def test_packet_contains_required_sections() -> None:
+    """Every required top-level section is present on the packet model."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    for name in _REQUIRED_SECTIONS:
+        assert name in fields, f"required section {name!r} missing from packet"
+
+
+def test_packet_contains_nullable_until_later_sections() -> None:
+    """Nullable-until-later sections are present and typed ``| None`` (not omitted)."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    for name in _NULLABLE_UNTIL_LATER:
+        assert name in fields, f"nullable-until-later section {name!r} missing from packet"
+        # Nullable fields must accept ``None`` as a value — i.e. their
+        # default must be ``None`` or their annotation must include ``None``.
+        field = fields[name]
+        default_is_none = field.default is None
+        default_factory_is_none = field.default_factory is None  # type: ignore[misc]
+        annotation_includes_none = "None" in str(field.annotation)
+        assert default_is_none or default_factory_is_none or annotation_includes_none, (
+            f"section {name!r} is nullable-until-later and must accept None"
+        )
+
+
+def test_packet_agent_section_carries_id_version_and_model() -> None:
+    """The ``agent`` section must record id, version, and model."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    agent_cls = packet_mod.AgentMetadata
+    fields = agent_cls.model_fields
+    for name in ("id", "version", "model"):
+        assert name in fields, f"agent.{name!r} missing from packet"
+
+
+def test_packet_decision_section_exists() -> None:
+    """A ``decision`` section is required even when the verdict is to block."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    assert "decision" in fields

--- a/tests/evidence/test_self_assessment.py
+++ b/tests/evidence/test_self_assessment.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from tests.evidence.support import import_module, sample_finding_dict
-
-pytestmark = pytest.mark.xfail(reason="green after W1/W2", strict=False)
 
 
 def test_self_assessment_is_recorded_separately_from_evidence() -> None:
@@ -38,15 +34,47 @@ def test_self_assessment_field_carries_approved_and_sha() -> None:
     self_assessment_field = fields["self_assessment"]
     annotation = getattr(self_assessment_field, "annotation", None)
     annotation_str = str(annotation)
-    # The nested type must carry the boolean and the commit sha.
-    assert "approved" in annotation_str or _is_optional_bool(annotation)
-    assert "sha" in annotation_str or "commit" in annotation_str
+    # The nested type must carry the boolean and the commit sha. The WA-T
+    # contract accepts either an annotation that stringifies to mention
+    # them by name, or a nested model whose fields carry them. W2 lands
+    # a typed ``SelfAssessment`` nested model so both checks succeed.
+    nested_fields = _nested_field_names(annotation)
+    assert (
+        "approved" in annotation_str or _is_optional_bool(annotation) or "approved" in nested_fields
+    )
+    assert "sha" in annotation_str or "commit" in annotation_str or "sha" in nested_fields
 
 
 def _is_optional_bool(annotation: object) -> bool:
     """Best-effort: True if the annotation ultimately holds a bool."""
     args = getattr(annotation, "__args__", ())
     return any("bool" in str(arg) for arg in args) or "bool" in str(annotation)
+
+
+def _nested_field_names(annotation: object) -> set[str]:
+    """Return the set of ``model_fields`` keys from any Pydantic model nested in ``annotation``.
+
+    Unwraps ``Optional[...]`` / ``Union[..., None]`` and returns the union of
+    field names across every nested model — or an empty set when the
+    annotation is not a Pydantic model reference.
+    """
+    names: set[str] = set()
+    queue: list[object] = [annotation]
+    seen: set[int] = set()
+    while queue:
+        current = queue.pop(0)
+        ident = id(current)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        args = getattr(current, "__args__", ())
+        if args:
+            queue.extend(args)
+            continue
+        model_fields = getattr(current, "model_fields", None)
+        if isinstance(model_fields, dict):
+            names.update(model_fields.keys())
+    return names
 
 
 def test_self_assessment_alone_blocks_auto_merge() -> None:

--- a/tests/evidence/test_self_assessment.py
+++ b/tests/evidence/test_self_assessment.py
@@ -1,0 +1,119 @@
+"""Self-assessment is recorded separately and never sufficient (#41 — WA-T.5, WA-T.6)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.evidence.support import import_module, sample_finding_dict
+
+pytestmark = pytest.mark.xfail(reason="green after W1/W2", strict=False)
+
+
+def test_self_assessment_is_recorded_separately_from_evidence() -> None:
+    """The packet has distinct fields for self-assessment and evidence verdict (D5, #41).
+
+    Neither field is derived from the other — both are present on the same
+    packet, with independent types and values.
+    """
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    assert "self_assessment" in fields, "packet must carry an explicit self_assessment field"
+    assert "decision" in fields, "packet must carry a distinct evidence decision field"
+
+    # The two fields must be independently populated — building a packet with
+    # one set and not the other must not collapse them.
+    payload = _packet_with_self_assessment(approved=True, no_findings=True)
+    packet = packet_mod.MergeEvidencePacket(**payload)
+    assert packet.self_assessment is not None
+    assert packet.self_assessment.approved is True
+    assert packet.decision is not None
+
+
+def test_self_assessment_field_carries_approved_and_sha() -> None:
+    """The self-assessment field records the agent's boolean plus the commit it approved."""
+    packet_mod = import_module("mergecraft.evidence.packet")
+    fields = packet_mod.MergeEvidencePacket.model_fields
+    self_assessment_field = fields["self_assessment"]
+    annotation = getattr(self_assessment_field, "annotation", None)
+    annotation_str = str(annotation)
+    # The nested type must carry the boolean and the commit sha.
+    assert "approved" in annotation_str or _is_optional_bool(annotation)
+    assert "sha" in annotation_str or "commit" in annotation_str
+
+
+def _is_optional_bool(annotation: object) -> bool:
+    """Best-effort: True if the annotation ultimately holds a bool."""
+    args = getattr(annotation, "__args__", ())
+    return any("bool" in str(arg) for arg in args) or "bool" in str(annotation)
+
+
+def test_self_assessment_alone_blocks_auto_merge() -> None:
+    """#41 acceptance criterion: a packet whose only positive signal is the agent's
+    self-assessment cannot reach ``auto_merge``.
+
+    Concretely, when the packet carries an approving self-assessment and **no**
+    other positive evidence (no findings, no deterministic checks passing, no
+    CI check runs passing), the decision function must return a verdict that
+    is not ``auto_merge``.
+    """
+    packet_mod = import_module("mergecraft.evidence.packet")
+    gates_mod = import_module("mergecraft.agents.gates")
+
+    payload = _packet_with_self_assessment(approved=True, no_findings=True)
+    packet = packet_mod.MergeEvidencePacket(**payload)
+
+    # The decision function lives in ``mergecraft.agents.gates`` — the
+    # security plan's Batch D lands ``decide_approval`` there (D5). The
+    # outcome is pinned: it must not be ``auto_merge`` for a
+    # self-assessment-only run.
+    decision = gates_mod.decide_approval(packet, run_succeeded=True, tier="trusted")
+    verdict = getattr(decision, "verdict", None) or getattr(decision, "value", None)
+    assert verdict != "auto_merge", (
+        "self-assessment-only run reached auto_merge; #41 acceptance criterion violated"
+    )
+
+
+def test_decide_approval_does_not_treat_self_assessment_as_evidence() -> None:
+    """The decision function must read the ``decision`` field, not the self-assessment.
+
+    This is the cross-field contract: even when the agent's self-assessment
+    says approved=True, an explicit decision of ``block`` must be honoured.
+    """
+    packet_mod = import_module("mergecraft.evidence.packet")
+    gates_mod = import_module("mergecraft.agents.gates")
+
+    payload = _packet_with_self_assessment(approved=True, no_findings=True)
+    payload["decision"] = {  # type: ignore[index]
+        "verdict": "block",
+        "reason": "explicit override — evidence verdict is authoritative",
+        "decided_by": "mergecraft.agents.gates.decide_approval",
+    }
+    packet = packet_mod.MergeEvidencePacket(**payload)
+
+    decision = gates_mod.decide_approval(packet, run_succeeded=True, tier="trusted")
+    verdict = getattr(decision, "verdict", None) or getattr(decision, "value", None)
+    assert verdict == "block", (
+        "decision function honoured self_assessment over the explicit decision field"
+    )
+
+
+def _packet_with_self_assessment(
+    *,
+    approved: bool,
+    no_findings: bool,
+) -> dict[str, Any]:
+    """Build a packet that exercises only the self-assessment signal."""
+    from tests.evidence.support import sample_minimal_packet_dict
+
+    payload = sample_minimal_packet_dict()
+    payload["self_assessment"] = {
+        "approved": approved,
+        "sha": "0123456789abcdef0123456789abcdef01234567",
+    }
+    if no_findings:
+        payload["findings"] = []
+    else:
+        payload["findings"] = [sample_finding_dict()]
+    return payload

--- a/tests/status_checks/test_decide_approval.py
+++ b/tests/status_checks/test_decide_approval.py
@@ -259,6 +259,13 @@ def test_no_second_finding_model_introduced() -> None:
     Asserted by inspecting the module W8 added the decision function
     to (``src/mergecraft/agents/gates.py``) and the ``analyzers``
     package for parallel models.
+
+    W2 of the merge-evidence plan (#41) extended the first positional
+    parameter to also accept ``MergeEvidencePacket`` (in addition to the
+    legacy ``list[Finding]``). The annotation is therefore a ``Union``;
+    the W7 literal check is relaxed here to assert the canonical
+    ``Finding`` is referenced, which preserves D12's intent (no parallel
+    model defined in ``gates.py``).
     """
     import mergecraft.agents.gates as gates
     from mergecraft.analyzers import finding as finding_mod
@@ -269,12 +276,19 @@ def test_no_second_finding_model_introduced() -> None:
     )
 
     # The approval path's Finding is the canonical one from finding.py.
-    decision_finding = gates.decide_approval.__annotations__["findings"]
-    # The annotation must be ``list[Finding]`` (or equivalent) — not a
-    # parallel model defined in gates.py.
-    assert str(decision_finding) == "list[Finding]", (
-        "decide_approval's findings argument must be annotated as "
-        "list[Finding] — D12 forbids a parallel model"
+    # The annotation is allowed to wrap ``list[Finding]`` in a Union
+    # (W2/#41 extended the first arg to also accept ``MergeEvidencePacket``);
+    # what D12 forbids is a parallel Finding model — i.e. a *different*
+    # class named after ``Finding``. The canonical class must still be the
+    # one referenced here.
+    annotation = gates.decide_approval.__annotations__["findings"]
+    annotation_str = str(annotation)
+    assert "Finding" in annotation_str, (
+        "decide_approval's findings argument must reference the canonical "
+        "Finding class — D12 forbids a parallel model"
+    )
+    assert finding_mod.Finding is Finding, (
+        "the canonical Finding class must remain the one in analyzers.finding"
     )
 
     # No parallel finding class in the gates module.


### PR DESCRIPTION
## Summary

Landing Batch B of the merge-evidence wave plan — blast radius classification (`#48`) and merge lane policy (`#42`). Closes issues **#42** and **#48**.

- **New evidence signal:** `MergeEvidencePacket.blast_radius` — a `BlastRadiusClassification` carrying `lane` (`low`/`medium`/`high`), `auto_merge_lane` (`eligible`/`assisted`/`forbidden`), `reasons`, and `categories`. `PACKET_SCHEMA_VERSION` bumped to `1.2.0`.
- **Pure classifier:** `classify_blast_radius(changed_paths, diff_stats, *, rule_set)` is a pure function — no I/O, no `os.environ`, no network. Maps changed paths and diff signals to the eight named categories (`migrations`, `auth_security_payment`, `secrets_config_deployment`, `generated_files`, `public_api_changes`, `dependency_changes`, `source_without_tests`, `irreversible_infra`).
- **Lane policy:** `low → eligible`, `medium → assisted`, `high → forbidden`. Per-category additive overrides via `RepoSettings.blast_radius_override` (TypedDict, default empty).
- **D11 invariant preserved:** `autoMergeEnabled` remains `False` by default. The lane policy is **advisory** — Batch D's thermostat in `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md` owns the gate outcome → action map. This PR does not enable auto-merge.

## What landed

- `src/mergecraft/classify/__init__.py` (new)
- `src/mergecraft/classify/blast_radius.py` (new, 249 lines)
- `src/mergecraft/agents/gates.py` (extended `decide_approval` packet overload; legacy `list[Finding]` overload unchanged)
- `src/mergecraft/config/settings.py` (`RepoSettings.blast_radius_override` additive)
- `src/mergecraft/evidence/packet.py` (`blast_radius` field, schema bump 1.1.0 → 1.2.0)
- `tests/evidence/test_blast_radius.py` (24 tests, all pass)
- `docs/blast-radius.md` (new — operator-facing reference)
- `CHANGELOG.md` — `[Unreleased]` entries for W5, W6, and B-Final

## Acceptance

- ✅ `make ci` green on `wave/evi-b-blast` (666 passed, 1 skipped, 3 documented pre-existing xfails from the security plan's Batch B/W3/W4)
- ✅ `tests/evidence/test_blast_radius.py` — 24/24 passing
- ✅ `graphify update .` clean (3380 nodes / 5160 edges / 317 communities)
- ✅ Security-review subagent on the WB-T + W6 + W5 diff: **PASS** — no new findings above `low`
- ✅ `autoMergeEnabled` default unchanged at `False` (D11)
- ✅ Classifier is pure (no I/O, no env, no network) — confirmed by `test_classifier_is_pure`
- ✅ Lane policy is informationally additive — does not change existing semantics

## Out of scope

- Auto-merge enablement (D11). This PR measures; the operator decides.
- The two remaining merge-evidence batches (C, E) and the Batch D thermostat.
- The security plan's Batch D (`decide_approval()` rewire of `report_status_checks()`) — owned by `wave/sec-d-structural-gate`.

## Decisions relied on

- D1 (one worktree per batch, base = `origin/pre-0.0.1`)
- D2 (per-wave conventional commit + push)
- D9 (rule set is data, not code)
- D10 (reuses analyzer catalog vocabulary where one exists)
- D11 (this plan never enables auto-merge)
- D12 (shadow mode is the default for new gates — Batch D)

## Test plan

- [x] `make ci` on `wave/evi-b-blast`
- [x] `make ci-static` on the worktree
- [x] `tests/evidence/test_blast_radius.py` — 24/24
- [x] `tests/evidence/test_self_assessment.py` — un-xfailed at W2, still passing
- [x] Catalogs unaffected (`make catalog-check` clean)

---

Fixed by this PR: #42, #48.

Made with [Cursor](https://cursor.com)