### PR TITLE
docs(examples): document comment-trigger authorization and its knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configured `staticChecks` now report a `declared-but-cannot-run` row when the gate
   cannot execute in this environment (for example `shell: disabled`), instead of
   disappearing silently (#8)
+- `.mergecraft/config.yaml` accepts `commentInvocationAllowlist`, a comma-separated
+  list of extra GitHub logins (release bots, automation) allowed to invoke by comment
+  despite an `author_association` outside `OWNER`/`MEMBER`/`COLLABORATOR`. It does not
+  re-open comment invocation under `pull_request_target` and does not override the
+  fail-closed default when the association field is missing (#72)
 - Per-run nonce fence (`mergecraft.utils.fence`) wraps every untrusted PR prose field
   — PR title, PR body, `eventInstructions`, `previousRunsNote`, review/issue comment
   bodies, commit messages, patch headers — with a closing delimiter bound to a CSPRNG
@@ -125,6 +130,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrite README with a 3-step quickstart and a dedicated Authentication section
   documenting Claude/Codex subscription auth (`mergecraft auth claude` /
   `auth codex`, `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_AUTH_JSON`) alongside API keys.
+- New README section "Comment-trigger authorization" spells out who may start a run by
+  comment, what a refusal looks like (no reply posted, one warning line, `unknown`
+  trigger), and the reach of each opt-in knob — `allow_pr_target_comments` (action
+  input) and `commentInvocationAllowlist` (repo config). `examples/config.yaml` now
+  carries a commented `commentInvocationAllowlist` example, and the hardened example
+  workflow explains why it declares no comment triggers under `pull_request_target` (#72)
 - Add OSS governance files for parity with sevn-bot/sevn: `SECURITY.md`,
   `CODE_OF_CONDUCT.md`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`,
   and `.github/ISSUE_TEMPLATE/` (bug report, feature request, security contact link).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Claude subscription, API key, or other provider credential.**
 
 3. **Commit and push** the scaffolded workflow, then trigger it by opening a PR or running it manually from the Actions tab.
 
-> **Comment-driven invocation is authorized.** A comment on an issue or PR will start a run only when (a) its author has one of `OWNER` / `MEMBER` / `COLLABORATOR` association with the target repo, **and** (b) the workflow is not running under `pull_request_target` (the default refuses comment invocation in that event — opt in with `with: allow_pr_target_comments: 'true'` only on workflows whose `if:` already gates comment triggers to trusted authors). The authorization decision reads `comment.author_association` from the payload, **never** the comment body — so an attacker cannot elevate themselves by writing `author_association: OWNER` into a comment. Strangers, first-time contributors, and `NONE`-association commenters cannot start a run. See [issue #72](https://github.com/alexhawat/mergeCraft/issues/72).
+> **Comment-driven invocation is authorized.** A comment on an issue or PR will start a run only when (a) its author has one of `OWNER` / `MEMBER` / `COLLABORATOR` association with the target repo, **and** (b) the workflow is not running under `pull_request_target` (the default refuses comment invocation in that event — opt in with `with: allow_pr_target_comments: 'true'` only on workflows whose `if:` already gates comment triggers to trusted authors). The authorization decision reads `comment.author_association` from the payload, **never** the comment body — so an attacker cannot elevate themselves by writing `author_association: OWNER` into a comment. Strangers, first-time contributors, and `NONE`-association commenters cannot start a run. Full rules and the two opt-in knobs: [Comment-trigger authorization](#comment-trigger-authorization) · [issue #72](https://github.com/alexhawat/mergeCraft/issues/72).
 
 That's it — no server, dashboard, or account to sign up for.
 
@@ -355,7 +355,9 @@ create the JSON file.
 ## Action inputs
 
 Same contract as upstream mergecraft: `prompt`, `prompt_file`, `timeout`, `model`,
-`cwd`, `push`, `shell`, `status_checks`, `output_schema`, `token` → output `result`.
+`cwd`, `push`, `shell`, `status_checks`, `output_schema`, `token` → output `result`,
+plus `allow_pr_target_comments` (default `false`) — see
+[Comment-trigger authorization](#comment-trigger-authorization).
 
 ### Native event triggers
 
@@ -363,7 +365,8 @@ The Action reads the native `GITHUB_EVENT_PATH` / `GITHUB_EVENT_NAME`, so
 workflows can trigger on `pull_request` (e.g. auto-review on open/sync),
 `issue_comment`, or `pull_request_review_comment` events and the agent gets PR
 context (number, branch, `is_pr`) automatically — no hand-built `~mergecraft` JSON
-payload required. With `status_checks: enabled`, PR runs always post the `mergecraft`
+payload required. Comment events are subject to the authorization gate below.
+With `status_checks: enabled`, PR runs always post the `mergecraft`
 and `mergecraft-approval` commit-status checks.
 
 The approval check is **structural**: its conclusion is a pure function of the
@@ -387,6 +390,36 @@ not just a missing check. The pre-W8 "neutral is non-blocking" framing is
 removed: a crashed / injected / fork-suppressed review must not pass the gate
 silently. An explicit `~mergecraft` payload event still takes precedence when
 provided.
+
+### Comment-trigger authorization
+
+A comment never carries its own authority. Before an `issue_comment` or
+`pull_request_review_comment` event can start a run, mergeCraft reads
+`comment.author_association` from `GITHUB_EVENT_PATH` and requires one of
+`OWNER`, `MEMBER`, or `COLLABORATOR`. Everything else — `CONTRIBUTOR`,
+`FIRST_TIME_CONTRIBUTOR`, `NONE`, or a payload with the field missing entirely —
+is refused: the run resolves to the `unknown` trigger, no agent is dispatched,
+and a single `logger.warning` records the event name and association. The comment
+body is never logged and never consulted, so writing `author_association: OWNER`
+into a comment changes nothing.
+
+Two knobs widen this, each on exactly one axis:
+
+| Knob | Where | Default | What it widens |
+|------|-------|---------|----------------|
+| `allow_pr_target_comments` | action input (`with:`) | `false` | Permits comment-driven invocation when `GITHUB_EVENT_NAME` is `pull_request_target`. The association gate still applies. |
+| `commentInvocationAllowlist` | `.mergecraft/config.yaml` | empty | Comma-separated extra logins (matched case-insensitively against `comment.user.login`) that may invoke despite their association. Does not affect the `pull_request_target` refusal, and does not override the missing-field fail-closed default. |
+
+`pull_request_target` runs hold repository secrets, which is why comment
+invocation there is off by default. Enable it only on a workflow whose `if:`
+condition already restricts comment triggers to trusted authors.
+
+Both shipped examples — [`examples/workflows/mergecraft.yml`](examples/workflows/mergecraft.yml)
+and [`examples/workflows/mergecraft-hardened.yml`](examples/workflows/mergecraft-hardened.yml)
+— deliberately declare no `issue_comment` / `pull_request_review_comment`
+triggers and drive on-demand runs from `workflow_dispatch` instead.
+[`examples/config.yaml`](examples/config.yaml) shows the
+`commentInvocationAllowlist` shape.
 
 ## Development
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -10,6 +10,12 @@ autoMergeEnabled: false
 # postCheckoutScript: |
 #   echo ready
 # envAllowlist: NODE_ENV,CI
+# Extra GitHub logins allowed to invoke mergeCraft by comment even though their
+# `author_association` is outside {OWNER, MEMBER, COLLABORATOR}. Empty (the
+# default) means the association gate alone decides. Matched case-insensitively
+# against `comment.user.login`; does not re-open comment invocation under
+# `pull_request_target` (that needs the `allow_pr_target_comments` action input).
+# commentInvocationAllowlist: release-bot,dependabot[bot]
 # modeInstructions:
 #   Build: Prefer minimal diffs.
 # Mechanical gates the reviewer runs over changed files (see REVIEW-CHECKS.md).

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -56,6 +56,14 @@
 name: mergeCraft
 
 on:
+  # NOTE: no `issue_comment` / `pull_request_review_comment` triggers here, by
+  # design. This job runs under `pull_request_target` with repository secrets in
+  # scope, and a comment trigger would let any commenter hand the agent a prompt
+  # inside that context (issue #72 / D6). mergeCraft refuses comment-driven
+  # invocation under `pull_request_target` at runtime regardless — the
+  # `allow_pr_target_comments: 'true'` input exists only for workflows whose
+  # `if:` condition already restricts comment triggers to trusted authors. Use
+  # `workflow_dispatch` below for on-demand runs.
   pull_request_target:
     # Add every base branch that should be auto-reviewed. Globs work:
     # branches: [main, develop, "release-*"]

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -56,6 +56,14 @@
 name: mergeCraft
 
 on:
+  # NOTE: no `issue_comment` / `pull_request_review_comment` triggers here, by
+  # design. This job runs under `pull_request_target` with repository secrets in
+  # scope, and a comment trigger would let any commenter hand the agent a prompt
+  # inside that context (issue #72 / D6). mergeCraft refuses comment-driven
+  # invocation under `pull_request_target` at runtime regardless — the
+  # `allow_pr_target_comments: 'true'` input exists only for workflows whose
+  # `if:` condition already restricts comment triggers to trusted authors. Use
+  # `workflow_dispatch` below for on-demand runs.
   pull_request_target:
     # Add every base branch that should be auto-reviewed. Globs work:
     # branches: [main, develop, "release-*"]

--- a/tests/utils/test_payload.py
+++ b/tests/utils/test_payload.py
@@ -8,8 +8,9 @@ from typing import TYPE_CHECKING
 import pytest
 from pydantic import ValidationError
 
-from mergecraft.config.settings import default_settings
+from mergecraft.config.settings import RepoSettings, default_settings
 from mergecraft.utils.payload import (
+    TRUSTED_AUTHOR_ASSOCIATIONS,
     JsonPayload,
     resolve_native_event,
     resolve_output_schema,
@@ -498,3 +499,184 @@ def test_pull_request_review_comment_from_non_collaborator_does_not_dispatch(
     )
     payload = resolve_payload()
     assert payload["event"]["trigger"] != "pull_request_review_comment_created"
+
+
+# ----------------------------------------------------------------------------
+# W2.3 / W2.4 — escape hatch and opt-in boundaries.
+#
+# The association gate ships with two deliberate widening knobs: the repo-level
+# `commentInvocationAllowlist` (extra logins) and the workflow-level
+# `allow_pr_target_comments` input. Both are security-relevant, so each one's
+# reach is pinned here — in particular that neither knob widens further than the
+# single axis it names.
+# ----------------------------------------------------------------------------
+
+
+def _comment_event_with_login(*, author_association: str | None, login: str) -> dict[str, object]:
+    """`issue_comment` fixture carrying a `comment.user.login`."""
+    event = _comment_event(author_association=author_association)
+    comment = event["comment"]
+    assert isinstance(comment, dict)
+    comment["user"] = {"login": login}
+    return event
+
+
+def test_comment_invocation_allowlist_admits_an_untrusted_association(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A login on `commentInvocationAllowlist` dispatches despite a `NONE` association (W2.3)."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "issue_comment",
+        _comment_event_with_login(author_association="NONE", login="release-bot"),
+    )
+    settings = RepoSettings.model_validate({"commentInvocationAllowlist": "release-bot, other-bot"})
+    payload = resolve_payload(repo_settings=settings)
+    assert payload["event"]["trigger"] == "issue_comment_created"
+
+
+def test_comment_invocation_allowlist_matches_login_case_insensitively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GitHub logins are case-insensitive; the allowlist match must be too."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "issue_comment",
+        _comment_event_with_login(author_association="CONTRIBUTOR", login="Release-Bot"),
+    )
+    settings = RepoSettings.model_validate({"commentInvocationAllowlist": "release-bot"})
+    payload = resolve_payload(repo_settings=settings)
+    assert payload["event"]["trigger"] == "issue_comment_created"
+
+
+def test_comment_invocation_allowlist_does_not_admit_unlisted_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-empty allowlist admits only the logins it names."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "issue_comment",
+        _comment_event_with_login(author_association="NONE", login="stranger"),
+    )
+    settings = RepoSettings.model_validate({"commentInvocationAllowlist": "release-bot"})
+    payload = resolve_payload(repo_settings=settings)
+    assert payload["event"]["trigger"] != "issue_comment_created"
+
+
+def test_comment_invocation_allowlist_does_not_bypass_missing_association(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The allowlist widens the association set — it does not disable the fail-closed default.
+
+    A payload with no `comment.author_association` at all is malformed for this
+    decision point, so convention 5 (fail closed) wins over the escape hatch.
+    """
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "issue_comment",
+        _comment_event_with_login(author_association=None, login="release-bot"),
+    )
+    settings = RepoSettings.model_validate({"commentInvocationAllowlist": "release-bot"})
+    payload = resolve_payload(repo_settings=settings)
+    assert payload["event"]["trigger"] != "issue_comment_created"
+
+
+def test_comment_invocation_allowlist_does_not_bypass_pull_request_target_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repo-level allowlist cannot re-open the `pull_request_target` path (D6).
+
+    The two knobs are orthogonal: only the workflow-level opt-in unlocks
+    comment invocation under `pull_request_target`.
+    """
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    monkeypatch.delenv("INPUT_ALLOW_PR_TARGET_COMMENTS", raising=False)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "pull_request_target",
+        _comment_event_with_login(author_association="OWNER", login="release-bot"),
+    )
+    settings = RepoSettings.model_validate({"commentInvocationAllowlist": "release-bot"})
+    payload = resolve_payload(repo_settings=settings)
+    assert payload["event"]["trigger"] != "issue_comment_created"
+
+
+def test_pull_request_target_optin_still_enforces_the_association_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`allow_pr_target_comments` unlocks the event, not the author (D5 survives D6's opt-in)."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    monkeypatch.setenv("INPUT_ALLOW_PR_TARGET_COMMENTS", "true")
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "pull_request_target",
+        _comment_event(author_association="NONE"),
+    )
+    assert resolve_native_event() is None
+
+
+@pytest.mark.parametrize("raw", ["", "false", "no", "0", "off", "maybe", " TRUE-ish "])
+def test_pull_request_target_optin_only_accepts_affirmative_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """Anything that is not an explicit affirmative leaves the refusal in place (D6)."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    monkeypatch.setenv("INPUT_ALLOW_PR_TARGET_COMMENTS", raw)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "pull_request_target",
+        _comment_event(author_association="OWNER"),
+    )
+    assert resolve_native_event() is None, f"opt-in value {raw!r} must not unlock the path"
+
+
+@pytest.mark.parametrize("raw", ["true", "TRUE", " True ", "1", "yes", "on"])
+def test_pull_request_target_optin_accepts_the_documented_affirmatives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """The affirmative vocabulary is pinned so `action.yml` docs cannot drift from the code."""
+    monkeypatch.setenv("INPUT_PROMPT", "do work")
+    monkeypatch.delenv("INPUT_PROMPT_FILE", raising=False)
+    monkeypatch.setenv("INPUT_ALLOW_PR_TARGET_COMMENTS", raw)
+    _write_event(
+        tmp_path,
+        monkeypatch,
+        "pull_request_target",
+        _comment_event(author_association="OWNER"),
+    )
+    native = resolve_native_event()
+    assert native is not None
+    assert native["trigger"] == "issue_comment_created"
+
+
+def test_trusted_author_associations_is_the_single_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """W2.2: exactly one definition of "trusted comment author" exists in the module."""
+    assert sorted(TRUSTED_AUTHOR_ASSOCIATIONS) == ["COLLABORATOR", "MEMBER", "OWNER"]
+    for association in sorted(TRUSTED_AUTHOR_ASSOCIATIONS):
+        _write_event(
+            tmp_path,
+            monkeypatch,
+            "issue_comment",
+            _comment_event(author_association=association),
+        )
+        assert resolve_native_event() is not None, association


### PR DESCRIPTION
## Why

The `#72` invocation-authorization gate merged in #85: `payload.py` enforces the `OWNER`/`MEMBER`/`COLLABORATOR` association gate, refuses comment invocation under `pull_request_target` by default, and honours a `commentInvocationAllowlist` escape hatch. `action.yml` exposes `allow_pr_target_comments` and the README carries a quickstart blockquote.

What did not ship was the operator-facing surface. An operator copying `examples/` had no way to discover either opt-in knob, and the hardened template — which runs under `pull_request_target` with secrets in scope — said nothing about why it declares no comment triggers. `commentInvocationAllowlist` existed in `config/settings.py` but appeared in no doc, no example, and no changelog entry.

## What changed

- **`README.md`** — new `### Comment-trigger authorization` section: the association gate, what a refusal actually does (resolves to the `unknown` trigger, dispatches nothing, emits one `logger.warning` naming the event and reason, posts no reply), and a table pinning the reach of each knob. The action-inputs list now names `allow_pr_target_comments`, and the native-event-triggers paragraph points at the gate.
- **`examples/config.yaml`** — commented `commentInvocationAllowlist` example, stating that it does not re-open `pull_request_target` and does not override the fail-closed default.
- **`scripts/example_workflows/hardened.yml.tpl`** — a `NOTE` under `on:` explaining that the absent comment triggers are deliberate, that mergeCraft refuses them under `pull_request_target` at runtime anyway, and that `workflow_dispatch` is the on-demand path. Regenerated `examples/workflows/mergecraft-hardened.yml` with `make examples`, so template and committed output stay in sync (`make example-workflows-check` is green).
- **`tests/utils/test_payload.py`** — 9 tests pinning the reach of both knobs, which mainline did not cover at all: the allowlist admits an untrusted association, matches logins case-insensitively, admits only listed logins, does **not** bypass a missing `author_association`, and does **not** bypass the `pull_request_target` refusal; the opt-in unlocks the event but not the author and only accepts the documented affirmative vocabulary; and `TRUSTED_AUTHOR_ASSOCIATIONS` is asserted to be the single definition.

`examples/workflows/mergecraft.yml` already documented its own omission of comment triggers on mainline and needed no change.

No behaviour change — docs, examples, and coverage only.

## Verification

`make ci-resume` — all 9 steps passed (equivalent to `make ci`): 642 passed, 1 skipped, 3 xfailed, 8 xpassed.

Refs #72