### PR TITLE
fix(budget): give overflowed agent findings distinct fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Findings pushed out of the inline budget into the mechanical section now keep
+  a distinct identity each, so a re-review recognises which ones it already
+  raised and a withdrawn finding stays withdrawn; previously every overflowed
+  agent finding shared one identity and they were indistinguishable across runs
 - Keep mergeCraft run temp / ``CODEX_HOME`` outside ``/tmp`` (prefer
   ``RUNNER_TEMP`` or ``~/.cache/mergecraft``) so Codex can install PATH-alias
   helper binaries; Codex 0.14x refuses helpers under world-writable temp and

--- a/src/mergecraft/analyzers/budget.py
+++ b/src/mergecraft/analyzers/budget.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mergecraft.analyzers.finding import Finding
-from mergecraft.review_taxonomy import BODY_ONLY_EFFORT, BODY_ONLY_SEVERITY, FINDING_SEVERITIES
+from mergecraft.review_taxonomy import (
+    BODY_ONLY_EFFORT,
+    BODY_ONLY_SEVERITY,
+    FINDING_SEVERITIES,
+    finding_fingerprint,
+)
 
 MECHANICAL_SECTION_HEADING = "### 🔧 Mechanical findings"
 
@@ -58,6 +63,22 @@ def _sort_key(item: Finding | dict[str, Any]) -> tuple[int, int, str, int]:
     return (_source_rank(item), _severity_rank(item), path, line)
 
 
+def _overflow_fingerprint(item: dict[str, Any], *, path: str, message: str) -> str:
+    """Return a per-finding fingerprint for an overflowed agent finding.
+
+    The agent rarely supplies its own ``fingerprint``. Falling back to a shared
+    literal would give every overflow finding the same identity, so downstream
+    dedup and the withdrawn-findings memory could not tell them apart. Derive
+    one from the finding's own content instead, matching how inline agent
+    comments are stamped (``path`` + comment body).
+    """
+    supplied = str(item.get("fingerprint", "") or "").strip()
+    if supplied:
+        return supplied
+    body = str(item.get("body", "") or "") or message
+    return finding_fingerprint(path=path, body=body)
+
+
 def _render_mechanical_section(mechanical: list[Finding]) -> str | None:
     if not mechanical:
         return None
@@ -102,6 +123,8 @@ def place_findings(
         if isinstance(item, Finding):
             mechanical.append(item)
         elif not _is_body_only_finding(item):
+            message = str(item.get("message", item.get("body", "")))
+            path = str(item.get("path", ""))
             mechanical.append(
                 Finding(
                     tool=str(item.get("tool", "agent")),
@@ -109,11 +132,11 @@ def place_findings(
                     category=str(item.get("category", "Maintainability & Code Quality")),
                     severity=str(item.get("severity", "Minor")),
                     confidence=str(item.get("confidence", "likely")),
-                    message=str(item.get("message", item.get("body", ""))),
-                    path=str(item.get("path", "")),
+                    message=message,
+                    path=path,
                     start_line=int(item.get("line", item.get("start_line", 1))),
                     end_line=int(item.get("end_line", item.get("line", item.get("start_line", 1)))),
-                    fingerprint=str(item.get("fingerprint", "agent-inline")),
+                    fingerprint=_overflow_fingerprint(item, path=path, message=message),
                     evidence=[],
                     remediation=None,
                     autofix=None,

--- a/tests/analyzers/test_budget.py
+++ b/tests/analyzers/test_budget.py
@@ -56,6 +56,56 @@ def test_low_value_effort_never_inline() -> None:
     assert not any(row.get("effort") == BODY_ONLY_EFFORT for row in placement.inline)
 
 
+def test_overflow_agent_findings_get_distinct_fingerprints() -> None:
+    """Overflowed agent findings must stay individually identifiable (C5)."""
+    budget = import_module("mergecraft.analyzers.budget")
+    taxonomy = import_module("mergecraft.review_taxonomy")
+    agent_findings = [
+        {
+            "severity": "Major",
+            "path": f"src/agent{i:02d}.py",
+            "line": i,
+            "body": f"agent finding number {i}",
+        }
+        for i in range(1, INLINE_BUDGET + 4)
+    ]
+    placement = budget.place_findings(
+        [], inline_budget=INLINE_BUDGET, agent_findings=agent_findings
+    )
+    overflow = [f for f in placement.mechanical if f.source == "agent"]
+    assert len(overflow) == 3
+    fingerprints = [f.fingerprint for f in overflow]
+    assert len(set(fingerprints)) == len(fingerprints)
+    assert "agent-inline" not in fingerprints
+    by_path = {str(row["path"]): str(row["body"]) for row in agent_findings}
+    for finding in overflow:
+        assert finding.fingerprint == taxonomy.finding_fingerprint(
+            path=finding.path, body=by_path[finding.path]
+        )
+
+
+def test_overflow_agent_finding_keeps_supplied_fingerprint() -> None:
+    budget = import_module("mergecraft.analyzers.budget")
+    agent_findings: list[dict[str, object]] = [
+        {"severity": "Major", "path": f"src/a{i:02d}.py", "line": i, "body": f"filler {i}"}
+        for i in range(1, INLINE_BUDGET + 1)
+    ]
+    agent_findings.append(
+        {
+            "severity": "Major",
+            "path": "src/zz-last.py",
+            "line": 3,
+            "body": "already stamped",
+            "fingerprint": "deadbeefcafe",
+        }
+    )
+    placement = budget.place_findings(
+        [], inline_budget=INLINE_BUDGET, agent_findings=agent_findings
+    )
+    overflow = [f for f in placement.mechanical if f.source == "agent"]
+    assert [f.fingerprint for f in overflow] == ["deadbeefcafe"]
+
+
 def test_agent_findings_win_ties_over_analyzer() -> None:
     budget = import_module("mergecraft.analyzers.budget")
     agent = _finding("Major", source="agent", path="src/tie.py", line=10)


### PR DESCRIPTION
## What?

Findings that overflow the inline budget into the mechanical section now keep a distinct identity each, so a later run can tell them apart.

Before this, every agent-sourced overflow finding was stamped with the same literal identity. Two unrelated findings in two unrelated files looked like the same finding to everything downstream.

## Why?

Finding identity is what makes a re-review incremental and what makes the withdrawn-findings memory stick. Collapsing all overflow findings onto one identity meant an incremental review could not tell a re-raised finding from a new one, and withdrawing one overflowed finding effectively withdrew all of them. The damage was silent — nothing errors, the reviewer just quietly loses memory for anything past the inline cap.

The identity is now derived from the finding's own path and body using the same helper that stamps inline comments, so an overflowed finding and the same finding raised inline agree. An identity the agent supplies explicitly is still honoured.

## Test plan

- New regression test asserts distinct overflow findings get distinct identities, and that each matches the value the shared helper computes for its own path and body. Verified it fails against the pre-fix code and passes after.
- Second test covers the agent-supplied identity path.
- `make ci-resume` — all 9 steps passed (796 passed, 1 skipped, 3 xfailed, 8 xpassed).
