### PR TITLE
ci(issues): auto-close issues fixed by PRs on non-default branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,16 @@
 
 <!-- Why is this needed? Link any related issues. -->
 
+Closes #
+
+<!--
+Keep the `Closes #<n>` line above (or `Fixes` / `Resolves`) when this PR fully
+resolves an issue; delete it when it does not. Because mergeCraft develops on a
+non-default branch, GitHub will NOT auto-close from this keyword — the
+`Auto-close fixed issues` workflow does it on merge instead. Without the
+keyword, nothing closes the issue.
+-->
+
 ## Test plan
 
 - [ ] `make ci` green locally

--- a/.github/workflows/auto-close-fixed-issues.yml
+++ b/.github/workflows/auto-close-fixed-issues.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+# Closes issues referenced by closing keywords when a PR merges into a
+# non-default branch.
+#
+# GitHub only auto-closes issues from closing keywords when a PR merges into the
+# repository's *default* branch. mergeCraft develops on `pre-0.0.1`, so every
+# `Closes #N` in a PR body against that branch is silently inert and the wave
+# plans' `Fixed by #PR` step has to be done by hand — which is how #41, #42,
+# #45, #47, #48, #75 and #96 all stayed open after their fixes shipped.
+#
+# Safety: this workflow never checks out or executes PR code. It reads the PR
+# body through `actions/github-script`'s `context.payload` — never through a
+# `run:` interpolation — so an attacker-authored body cannot inject shell.
+# The authorization gate is the merge itself: a maintainer merging a fork PR is
+# the same trust decision GitHub applies natively on the default branch.
+name: Auto-close fixed issues
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: auto-close-fixed-issues-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  close-referenced-issues:
+    # Only merged PRs, and only where GitHub did not already close the issues
+    # natively (i.e. the base branch is not the default branch).
+    if: >-
+      github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+
+            // GitHub's own closing-keyword set, same-repo references only.
+            // Cross-repo (`owner/repo#N`) is deliberately unsupported: this
+            // token has no write scope on other repositories.
+            const pattern =
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:#|GH-)(\d+)\b/gi;
+
+            const referenced = new Set();
+            for (const match of body.matchAll(pattern)) {
+              referenced.add(Number(match[1]));
+            }
+            referenced.delete(pr.number);
+
+            if (referenced.size === 0) {
+              core.info("No closing keywords in the PR body; nothing to do.");
+              return;
+            }
+
+            core.info(`Referenced issues: ${[...referenced].join(", ")}`);
+
+            for (const number of [...referenced].sort((a, b) => a - b)) {
+              let issue;
+              try {
+                const response = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                });
+                issue = response.data;
+              } catch (error) {
+                core.warning(`#${number}: cannot read (${error.status}); skipping.`);
+                continue;
+              }
+
+              // A PR is an issue as far as this endpoint is concerned.
+              if (issue.pull_request) {
+                core.info(`#${number} is a pull request, not an issue; skipping.`);
+                continue;
+              }
+              if (issue.state === "closed") {
+                core.info(`#${number} is already closed; skipping.`);
+                continue;
+              }
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body:
+                    `Fixed by #${pr.number}, merged into \`${pr.base.ref}\` ` +
+                    `at ${pr.merge_commit_sha}.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  state: "closed",
+                  state_reason: "completed",
+                });
+                core.info(`#${number}: commented and closed.`);
+              } catch (error) {
+                // One unclosable issue must not strand the rest.
+                core.warning(`#${number}: could not close (${error.status}).`);
+              }
+            }


### PR DESCRIPTION
## What?

Adds a `Auto-close fixed issues` workflow that closes issues referenced by closing keywords when a PR merges into a **non-default** branch, and restores the `Closes #` line in the PR template.

## Why?

GitHub only honours `Closes #N` when a PR merges into the repository's **default** branch. This repo develops on `pre-0.0.1`, so every closing keyword written so far has been silently inert, and the wave plans' `Fixed by #PR` step has had to be done by hand.

It was missed on every merge this cycle — **#41, #42, #45, #47, #48, #75 and #96** all stayed open after their fixes shipped, and the resulting drift is what made a planning document's status ledger wrong enough to nearly cause duplicate work.

## How it works

On `pull_request_target: [closed]`, guarded by `merged == true` **and** `base.ref != default_branch` — so it stays inert if `pre-0.0.1` ever becomes the default and GitHub handles this natively. It parses closing keywords from the PR body, then for each same-repo issue posts `Fixed by #N, merged into <base> at <sha>` and closes it as `completed`.

Skips: PRs, already-closed issues, unreadable issues, and self-reference. One unclosable issue does not strand the rest.

## Safety

- **Never checks out or executes PR code.** No `actions/checkout`.
- Reads the PR body via `actions/github-script`'s `context.payload` — **never** a `run:` interpolation — so an attacker-authored body cannot inject shell. This is the `pull_request_target` hazard the repo's own #72/#73 work is about; the workflow is built to avoid it rather than mitigate it.
- Permissions are `contents: read` + `issues: write`, nothing more.
- Cross-repo `owner/repo#N` references are deliberately unsupported — the token has no write scope elsewhere.
- **The merge is the authorization gate.** A maintainer merging a fork PR is the same trust decision GitHub applies natively on the default branch.

## Test plan

- [x] `make ci-resume` — all 9 steps passed (890 passed, 1 skipped, 3 xfailed, 8 xpassed)
- [x] `actionlint` clean on the new workflow
- [x] Keyword regex unit-checked against 9 cases: `Closes #45`, `closes: #45`, `Fixes #12 and Resolves #13`, `fix #7`, `Resolved GH-99`, `CLOSES #1, closes #2` all match; `see #45`, `closing #45` and — importantly — the workflow's own `Fixed by #98` comment text do **not**, so it cannot self-trigger

No `CHANGELOG.md` entry: this touches `.github/` only, and the changelog is the consumer-facing product record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)