### PR TITLE
feat(evals): score review findings by locality and gate bank integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Review quality can now be measured. `mergecraft eval score` grades a run's
+  findings against a frozen benchmark baseline by **locating** issues — a
+  baseline issue counts as found when a reported finding overlaps its line range
+  in the same file, not when the two rows match structurally. Equality scoring
+  failed a run for rewording a finding it genuinely found, and could never pass
+  against a corpus carrying its own `rule_id` and `fingerprint`. Severity
+  vocabularies are reconciled (`high`/`medium` → `Major`/`Minor`) so agreement is
+  reported honestly instead of always reading 0%. `make bench-review` now takes
+  `REVIEWBENCH_DIR=...`, so the corpus can live outside this repo, and
+  `make eval-gate` checks the eval bank still parses against the current schema
+  — the durable cases can no longer rot in silence (#30, #51)
 - The reviewer's own `Critical` and `Major` findings are now double-checked
   before they are published, not just the ones its linters and CI produced. A
   second read-only agent re-reads the cited code and returns confirm, downgrade,

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 
 .PHONY: help setup install lockcheck lint format typecheck pyright test security \
 	precommit build ci ci-static ci-steps ci-resume ci-reset catalog-check docker-build clean \
-	examples example-workflows-check bench-review
+	examples example-workflows-check bench-review eval-gate
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -106,13 +106,20 @@ ci-reset: ## Clear the ci-resume checkpoint (start the gate over)
 ci: ci-static security test ## Full gate
 	@echo "ci OK"
 
-bench-review: ## Run ReviewBench via Harbor (requires evals/reviewbench corpus)
-	@if [ ! -d evals/reviewbench ]; then \
-	  echo "ReviewBench corpus not present — frozen tasks live in sevn-bot/tripll#64"; \
+REVIEWBENCH_DIR ?= evals/reviewbench
+
+bench-review: ## Run ReviewBench via Harbor (set REVIEWBENCH_DIR to an external corpus)
+	@if [ ! -d "$(REVIEWBENCH_DIR)" ]; then \
+	  echo "ReviewBench corpus not present at '$(REVIEWBENCH_DIR)'."; \
+	  echo "The frozen corpus lives in sevn-bot/tripll (bench/review/) — point at it with:"; \
+	  echo "  make bench-review REVIEWBENCH_DIR=../tripll/bench/review"; \
 	  echo "See evals/README.md"; \
 	  exit 2; \
 	fi
-	$(UV) run --extra harbor harbor run -d evals/reviewbench --agent mergecraft.harbor.agent:MergecraftReviewAgent
+	$(UV) run --extra harbor harbor run -d "$(REVIEWBENCH_DIR)" --agent mergecraft.harbor.agent:MergecraftReviewAgent
+
+eval-gate: ## Check eval-bank integrity (structural; see 'mergecraft eval gate --help')
+	$(UV) run mergecraft eval gate
 
 docker-build: ## Build action Docker image
 	docker build -t mergeCraft:local -f Dockerfile .

--- a/evals/README.md
+++ b/evals/README.md
@@ -2,18 +2,74 @@
 
 ReviewBench-style benchmark infrastructure for mergecraft PR reviews.
 
+## Two mechanisms, two jobs
+
+These are often confused. They measure different things and belong in different places.
+
+| | Eval bank (`evals/cases/`) | ReviewBench (`bench/review/`) |
+|---|---|---|
+| Question | *Did we break something we already fixed?* | *How good is the review?* |
+| Source | real failures, via `mergecraft eval add` | frozen human-curated baselines |
+| Cost | free, deterministic | one Docker environment per task |
+| Gate | `make eval-gate`, plus promoted pytests in `make test` | `make bench-review`, periodic |
+
+Use the **eval bank** for per-PR CI. Use **ReviewBench** to compare versions or
+providers — never as a per-PR gate, regardless of corpus size.
+
 ## Status
 
-The frozen task corpus is **not** checked in here yet. Task definitions, patches, and
-expected-finding labels live in companion work tracked at
-[sevn-bot/tripll#64](https://github.com/sevn-bot/tripll/issues/64).
-
-When tripll delivers a minimal frozen slice, add tasks under `evals/reviewbench/` and
-run benchmarks with:
+The frozen task corpus is **not** vendored here — it lives in
+[sevn-bot/tripll](https://github.com/sevn-bot/tripll) under `bench/review/`
+(delivered by [tripll#64](https://github.com/sevn-bot/tripll/issues/64), closed).
+Point at it directly rather than copying:
 
 ```bash
-make bench-review
+make bench-review REVIEWBENCH_DIR=../tripll/bench/review
 ```
+
+It is currently **one Harbor task with two baseline issues**. That is enough to
+prove the loop end to end and nowhere near enough to detect a quality regression
+— scaling it means running tripll's `findings gate` / `findings promote` pipeline
+over more merged PRs, which needs no new code here.
+
+**Contamination warning:** tripll runs mergeCraft on its own PRs, so mining its
+Finding graph can promote mergeCraft's own accepted findings into the baseline,
+which it would then trivially rediscover. Every baseline row carries a mandatory
+`provenance` field for exactly this reason. Keep `provenance: human` as the
+primary corpus and report scores with and without the rest.
+
+## Scoring
+
+Score a run's findings against a baseline:
+
+```bash
+mergecraft eval score actual-findings.json ../tripll/bench/review/baseline.jsonl
+```
+
+A baseline issue counts as **located** when a reported finding overlaps its line
+range in the same file — not when the two rows are equal. Equality scoring fails a
+run for paraphrasing a finding it genuinely found, and cannot pass at all against
+a corpus whose rows carry their own `rule_id` and `fingerprint`. Severity and
+category agreement are reported alongside each match, never as match conditions;
+corpus severity vocabularies (`high`/`medium`) are normalised onto
+`FINDING_SEVERITIES` (`Major`/`Minor`) first.
+
+`precision` here is **"how much of the output is corpus-confirmed"**, not a
+false-positive rate: a real defect the human curator never recorded scores as
+unmatched.
+
+## Bank integrity
+
+```bash
+make eval-gate
+```
+
+This is **structural, not behavioural**. It proves every durable case still parses
+against the current schema and provenance model and that ids are unique. It does
+not replay verdicts: `replay_case()` is pure and takes the current decision as an
+*input*, so replaying in CI would need a live agent run per case. The behavioural
+signal is `mergecraft eval promote`, which turns a case into a permanent pytest
+that `make test` already runs.
 
 ## Harbor agent
 

--- a/src/mergecraft/cli/eval_cmd.py
+++ b/src/mergecraft/cli/eval_cmd.py
@@ -29,6 +29,13 @@ import typer
 from pydantic import ValidationError
 from rich.console import Console
 
+from mergecraft.evals.scoring import (
+    DEFAULT_LINE_SLACK,
+    format_report,
+    load_baseline_issues,
+    load_reported_findings,
+    score_findings,
+)
 from mergecraft.evals.store import (
     CASE_FILE_SUFFIX,
     CATEGORY_REJECTED,
@@ -427,6 +434,214 @@ def promote(
     except OSError as exc:
         _bail(f"could not write permanent test to {out_dir}: {exc}")
     console.print(f"[green]promoted case {case_id}[/green] → {target}")
+
+
+def _read_json_or_jsonl(path: Path) -> Any:
+    """Decode a corpus file that may be JSON or JSON Lines.
+
+    Benchmark corpora ship both shapes — a ``findings`` envelope for Harbor task
+    fixtures, and one-object-per-line ``baseline.jsonl`` for promoted baselines —
+    so the reader accepts either rather than making the caller know which.
+    """
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        rows = [
+            json.loads(line)
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("//")
+        ]
+        if not rows:
+            raise
+        return rows
+
+
+# ── gate ───────────────────────────────────────────────────────────────
+
+
+@app.command("gate")
+def gate(
+    bank: Path | None = typer.Option(
+        None,
+        "--bank",
+        help="Bank directory (default: evals/cases/).",
+    ),
+    require_promoted: bool = typer.Option(
+        False,
+        "--require-promoted",
+        help="Also fail when a case has no permanent test (default: warn only).",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the result as JSON.",
+    ),
+) -> None:
+    """Check the eval bank's integrity — the CI-safe half of the eval loop.
+
+    This gate is **structural, not behavioural**. It proves every durable case
+    still parses against the current schema and provenance model, that ids are
+    unique, and (optionally) that each case has been promoted into a permanent
+    test. It deliberately does **not** replay verdicts: ``replay_case()`` is a
+    pure function that takes the current decision as an *input*, so replaying in
+    CI would require a live agent run per case — non-deterministic, key-bearing,
+    and far too slow for a per-PR gate.
+
+    The behavioural regression signal is ``mergecraft eval promote``: a promoted
+    case becomes a permanent pytest that ``make test`` already runs. This gate's
+    job is to stop the bank itself from silently rotting in the meantime.
+
+    An empty bank passes with a notice, so the target can be wired into CI now
+    and grow teeth as cases accumulate.
+    """
+    bank_dir = _bank_dir(bank)
+    permanent_dir = _default_permanent_dir()
+
+    if not bank_dir.is_dir():
+        if json_output:
+            typer.echo(json.dumps({"status": "empty", "bank": str(bank_dir), "cases": 0}, indent=2))
+        else:
+            console.print(f"[yellow]eval bank {bank_dir} does not exist yet[/yellow]")
+        return
+
+    paths = sorted(bank_dir.glob(f"*{CASE_FILE_SUFFIX}"))
+    broken: list[dict[str, str]] = []
+    seen: dict[str, str] = {}
+    duplicates: list[dict[str, str]] = []
+    unpromoted: list[str] = []
+
+    for path in paths:
+        try:
+            case = load_case(path)
+        except Exception as exc:  # any parse failure is itself the finding
+            broken.append({"path": str(path), "error": str(exc)})
+            continue
+        if case.id in seen:
+            duplicates.append({"id": case.id, "path": str(path), "first": seen[case.id]})
+        else:
+            seen[case.id] = str(path)
+        if not (permanent_dir / f"test_{case.id.replace('-', '_')}.py").is_file():
+            unpromoted.append(case.id)
+
+    failures = len(broken) + len(duplicates)
+    if require_promoted:
+        failures += len(unpromoted)
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "status": "fail" if failures else "pass",
+                    "bank": str(bank_dir),
+                    "cases": len(paths),
+                    "loaded": len(seen),
+                    "broken": broken,
+                    "duplicates": duplicates,
+                    "unpromoted": unpromoted,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        console.print(f"eval bank: {bank_dir}")
+        console.print(f"  cases    : {len(paths)}")
+        console.print(f"  loaded   : {len(seen)}")
+        for row in broken:
+            console.print(f"  [red]unparsable[/red]: {row['path']} — {row['error']}")
+        for row in duplicates:
+            console.print(
+                f"  [red]duplicate id[/red]: {row['id']} in {row['path']} "
+                f"(first seen {row['first']})"
+            )
+        if unpromoted:
+            colour = "red" if require_promoted else "yellow"
+            console.print(f"  [{colour}]not promoted[/{colour}]: {', '.join(unpromoted)}")
+        if not paths:
+            console.print(
+                "  [yellow]bank is empty — the gate passes, but it is not yet "
+                "measuring anything[/yellow]"
+            )
+        elif failures == 0:
+            console.print("  [green]bank is healthy[/green]")
+
+    if failures:
+        raise typer.Exit(code=1)
+
+
+# ── score ──────────────────────────────────────────────────────────────
+
+
+@app.command("score")
+def score(
+    actual: Path = typer.Argument(..., help="JSON findings a review run produced."),
+    expected: Path = typer.Argument(..., help="JSON baseline issues to score against."),
+    min_recall: float = typer.Option(
+        0.0,
+        "--min-recall",
+        help="Exit non-zero when recall falls below this fraction (0.0-1.0).",
+    ),
+    slack: int = typer.Option(
+        DEFAULT_LINE_SLACK,
+        "--slack",
+        help="Line distance still counted as locating a baseline issue.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the score report as JSON.",
+    ),
+) -> None:
+    """Score review findings against a frozen benchmark baseline.
+
+    A baseline issue counts as located when a reported finding overlaps its line
+    range in the same file — **not** when the two rows are equal. Equality
+    scoring fails a run for paraphrasing a finding it genuinely found, and it
+    cannot pass at all against a corpus whose rows carry their own ``rule_id``
+    and ``fingerprint``.
+
+    Severity and category agreement are reported alongside each match, never as
+    conditions for it.
+    """
+    for path in (actual, expected):
+        if not path.is_file():
+            _bail(f"{path} is not a file")
+    try:
+        actual_payload = _read_json_or_jsonl(actual)
+        expected_payload = _read_json_or_jsonl(expected)
+    except (OSError, json.JSONDecodeError) as exc:
+        _bail(f"could not read scoring inputs: {exc}")
+
+    issues = load_baseline_issues(expected_payload)
+    findings = load_reported_findings(actual_payload)
+    report = score_findings(issues, findings, slack=slack)
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "total_issues": report.total_issues,
+                    "total_reported": report.total_reported,
+                    "found": report.found,
+                    "recall": report.recall,
+                    "precision": report.precision,
+                    "severity_agreement": report.severity_agreement,
+                    "missed_issue_ids": report.missed_issue_ids,
+                    "matches": [m.model_dump() for m in report.matches],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        console.print(format_report(report, corpus=expected))
+
+    if report.recall < min_recall:
+        console.print(
+            f"[red]recall {report.recall:.2%} is below the required {min_recall:.2%}[/red]"
+        )
+        raise typer.Exit(code=1)
 
 
 __all__ = ["CATEGORY_REJECTED", "CATEGORY_REVERTED", "FAILURE_CATEGORIES", "app"]

--- a/src/mergecraft/evals/__init__.py
+++ b/src/mergecraft/evals/__init__.py
@@ -21,6 +21,16 @@ network, and no module-level I/O at import time (§W11.6).
 
 from __future__ import annotations
 
+from mergecraft.evals.scoring import (
+    BaselineIssue,
+    Match,
+    ReportedFinding,
+    ScoreReport,
+    format_report,
+    load_baseline_issues,
+    load_reported_findings,
+    score_findings,
+)
 from mergecraft.evals.store import (
     CASE_FILE_SUFFIX,
     CASE_STATUS_BLOCKED,
@@ -47,14 +57,22 @@ __all__ = [
     "CASE_STATUS_PASSED",
     "CASE_STATUS_REGRESSION",
     "DEFAULT_BANK_DIR",
+    "BaselineIssue",
     "Case",
     "CaseFilter",
+    "Match",
     "ReplayDiff",
+    "ReportedFinding",
+    "ScoreReport",
     "add_case",
     "diff_cases",
+    "format_report",
     "list_cases",
+    "load_baseline_issues",
     "load_case",
+    "load_reported_findings",
     "parse_case_text",
     "render_case_text",
     "replay_case",
+    "score_findings",
 ]

--- a/src/mergecraft/evals/scoring.py
+++ b/src/mergecraft/evals/scoring.py
@@ -1,0 +1,351 @@
+"""Locality-based scoring of review findings against a frozen baseline (#30, C7).
+
+A review benchmark cannot score by equality. The baseline records what a human
+reviewer *concluded* — a path, a line range, and a description — while a review
+run produces mergeCraft's own ``Finding`` rows with their own fingerprints, rule
+ids and wording. Comparing those structurally means a run fails for paraphrasing
+a finding it actually located, which measures nothing.
+
+So a baseline issue counts as **found** when a reported finding overlaps its line
+range in the same file. That is the weakest claim the benchmark can make and
+still be true: the reviewer looked at the right code and said something about it.
+Wording, severity and category are reported as agreement metrics alongside the
+match, never as match conditions.
+
+Exports:
+    BaselineIssue: One frozen expected issue.
+    ReportedFinding: One finding a review run produced.
+    Match: A baseline issue paired with the finding that located it.
+    ScoreReport: Recall, precision and the per-issue breakdown.
+    load_baseline_issues: Parse baseline rows from a JSON payload.
+    load_reported_findings: Parse review output from a JSON payload.
+    score_findings: Match reported findings against baseline issues.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "BaselineIssue",
+    "Match",
+    "ReportedFinding",
+    "ScoreReport",
+    "load_baseline_issues",
+    "load_reported_findings",
+    "normalize_severity",
+    "score_findings",
+]
+
+# A baseline issue anchored at a single line still deserves a match when the
+# reviewer flags the statement just above or below it — reviewers legitimately
+# anchor on the assignment rather than the branch that uses it.
+DEFAULT_LINE_SLACK: Final[int] = 3
+
+
+def _normalize_path(value: str) -> str:
+    """Strip leading ``./`` and ``a/`` / ``b/`` diff prefixes from a path."""
+    text = value.strip().replace("\\", "/")
+    for prefix in ("./", "a/", "b/"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    return text
+
+
+class BaselineIssue(BaseModel):
+    """One frozen expected issue from a benchmark corpus."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    path: str
+    start_line: int
+    end_line: int
+    title: str = ""
+    severity: str = ""
+    category: str = ""
+    provenance: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def _normalize(cls, value: str) -> str:
+        return _normalize_path(value)
+
+
+class ReportedFinding(BaseModel):
+    """One finding produced by a review run."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    path: str
+    start_line: int
+    end_line: int
+    message: str = ""
+    severity: str = ""
+    category: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def _normalize(cls, value: str) -> str:
+        return _normalize_path(value)
+
+
+class Match(BaseModel):
+    """A baseline issue paired with the reported finding that located it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue_id: str
+    finding_index: int
+    severity_agrees: bool
+    category_agrees: bool
+
+
+class ScoreReport(BaseModel):
+    """The outcome of scoring one review run against one baseline."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_issues: int
+    total_reported: int
+    matches: list[Match]
+    missed_issue_ids: list[str]
+    unmatched_finding_indexes: list[int]
+
+    @property
+    def found(self) -> int:
+        """How many baseline issues a reported finding located."""
+        return len(self.matches)
+
+    @property
+    def recall(self) -> float:
+        """Fraction of baseline issues located. ``1.0`` for an empty baseline."""
+        if self.total_issues == 0:
+            return 1.0
+        return self.found / self.total_issues
+
+    @property
+    def precision(self) -> float:
+        """Fraction of reported findings that hit a baseline issue.
+
+        This is a **lower bound on usefulness, not a false-positive rate**: a
+        corpus labels the issues a human chose to record, so a real defect the
+        human never wrote down scores here as unmatched. Read it as "how much of
+        the output is corpus-confirmed", never as "the rest is noise".
+        """
+        if self.total_reported == 0:
+            return 1.0
+        return len(self.matches) / self.total_reported
+
+    @property
+    def severity_agreement(self) -> float:
+        """Fraction of matches whose severity equals the baseline's."""
+        if not self.matches:
+            return 1.0
+        return sum(1 for m in self.matches if m.severity_agrees) / len(self.matches)
+
+
+# Benchmark corpora record severity in their own vocabulary. tripll's
+# ``baseline.jsonl`` uses ``high``/``medium`` where the Harbor fixture promoted
+# from the *same two issues* uses ``Major``/``Minor`` — so scoring severity
+# without normalizing reports 0% agreement on a corpus that in fact agrees
+# perfectly. This map is read off that promotion, not invented here.
+_SEVERITY_ALIASES: Final[dict[str, str]] = {
+    "critical": "Critical",
+    "blocker": "Critical",
+    "high": "Major",
+    "major": "Major",
+    "medium": "Minor",
+    "moderate": "Minor",
+    "minor": "Minor",
+    "low": "Trivial",
+    "trivial": "Trivial",
+    "info": "Trivial",
+    "nit": "Trivial",
+}
+
+
+def normalize_severity(value: str) -> str:
+    """Map a corpus severity onto mergeCraft's ``FINDING_SEVERITIES`` vocabulary.
+
+    Unknown values are returned title-cased rather than dropped, so a corpus
+    using a grade this map has not seen still compares against itself.
+    """
+    text = value.strip().lower()
+    if not text:
+        return ""
+    return _SEVERITY_ALIASES.get(text, value.strip().title())
+
+
+def _rows(payload: Any) -> list[dict[str, Any]]:
+    """Return the finding rows from either a bare list or a ``findings`` envelope."""
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("findings", "issues", "baseline"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+        # A one-row JSONL file is itself valid JSON, so it arrives here as a bare
+        # object rather than a list. Treating that as "no rows" silently scores
+        # recall as a vacuous 1.0, which is the worst possible failure mode for a
+        # benchmark — so recognise a lone row by its anchor fields instead.
+        if "path" in payload and ("line_range" in payload or "start_line" in payload):
+            return [payload]
+    return []
+
+
+def _line_bounds(row: dict[str, Any]) -> tuple[int, int]:
+    """Return ``(start, end)`` from either explicit lines or a ``line_range``."""
+    span = row.get("line_range")
+    if isinstance(span, (list, tuple)) and len(span) == 2:
+        try:
+            start, end = int(span[0]), int(span[1])
+        except TypeError, ValueError:
+            start, end = 1, 1
+    else:
+        try:
+            start = int(row.get("start_line") or row.get("line") or 1)
+        except TypeError, ValueError:
+            start = 1
+        try:
+            end = int(row.get("end_line") or start)
+        except TypeError, ValueError:
+            end = start
+    if end < start:
+        start, end = end, start
+    return start, end
+
+
+def load_baseline_issues(payload: Any, *, source: str = "baseline") -> list[BaselineIssue]:
+    """Parse baseline issues from a decoded JSON payload.
+
+    Accepts both corpus shapes in use: the ``baseline.jsonl``-style row with
+    ``line_range`` and ``description``, and the mergeCraft ``Finding`` shape with
+    ``start_line`` / ``end_line`` / ``message``.
+    """
+    issues: list[BaselineIssue] = []
+    for index, row in enumerate(_rows(payload)):
+        start, end = _line_bounds(row)
+        identifier = str(row.get("id") or row.get("cluster_id") or f"{source}-{index:03d}")
+        issues.append(
+            BaselineIssue(
+                id=identifier,
+                path=_normalize_path(str(row.get("path") or "")),
+                start_line=start,
+                end_line=end,
+                title=str(row.get("title") or row.get("message") or ""),
+                severity=str(row.get("severity") or ""),
+                category=str(row.get("category") or ""),
+                provenance=str(row.get("provenance") or ""),
+            )
+        )
+    return issues
+
+
+def load_reported_findings(payload: Any) -> list[ReportedFinding]:
+    """Parse the findings a review run reported from a decoded JSON payload."""
+    findings: list[ReportedFinding] = []
+    for row in _rows(payload):
+        start, end = _line_bounds(row)
+        findings.append(
+            ReportedFinding(
+                path=_normalize_path(str(row.get("path") or "")),
+                start_line=start,
+                end_line=end,
+                message=str(row.get("message") or row.get("title") or ""),
+                severity=str(row.get("severity") or ""),
+                category=str(row.get("category") or ""),
+            )
+        )
+    return findings
+
+
+def _overlaps(issue: BaselineIssue, finding: ReportedFinding, *, slack: int) -> bool:
+    """True when the finding's line span touches the issue's, within ``slack``."""
+    if not issue.path or issue.path != finding.path:
+        return False
+    return (
+        finding.start_line <= issue.end_line + slack
+        and issue.start_line - slack <= finding.end_line
+    )
+
+
+def _distance(issue: BaselineIssue, finding: ReportedFinding) -> int:
+    """Line distance between two spans; ``0`` when they truly overlap."""
+    if finding.start_line > issue.end_line:
+        return finding.start_line - issue.end_line
+    if issue.start_line > finding.end_line:
+        return issue.start_line - finding.end_line
+    return 0
+
+
+def score_findings(
+    issues: list[BaselineIssue],
+    findings: list[ReportedFinding],
+    *,
+    slack: int = DEFAULT_LINE_SLACK,
+) -> ScoreReport:
+    """Match reported findings against baseline issues by file and line overlap.
+
+    Matching is one-to-one and greedy by proximity: each baseline issue claims
+    the closest not-yet-claimed finding that overlaps it. One finding therefore
+    cannot satisfy two baseline issues, so a single sprawling comment covering a
+    whole file scores one match rather than all of them.
+    """
+    claimed: set[int] = set()
+    matches: list[Match] = []
+    missed: list[str] = []
+
+    for issue in issues:
+        candidates = [
+            (index, finding)
+            for index, finding in enumerate(findings)
+            if index not in claimed and _overlaps(issue, finding, slack=slack)
+        ]
+        if not candidates:
+            missed.append(issue.id)
+            continue
+        index, finding = min(candidates, key=lambda pair: _distance(issue, pair[1]))
+        claimed.add(index)
+        matches.append(
+            Match(
+                issue_id=issue.id,
+                finding_index=index,
+                severity_agrees=bool(issue.severity)
+                and normalize_severity(issue.severity) == normalize_severity(finding.severity),
+                category_agrees=bool(issue.category)
+                and issue.category.lower() == finding.category.lower(),
+            )
+        )
+
+    return ScoreReport(
+        total_issues=len(issues),
+        total_reported=len(findings),
+        matches=matches,
+        missed_issue_ids=missed,
+        unmatched_finding_indexes=[index for index in range(len(findings)) if index not in claimed],
+    )
+
+
+def format_report(report: ScoreReport, *, corpus: Path | str = "") -> str:
+    """Render a human-readable summary of a score report."""
+    header = f"ReviewBench score — {corpus}" if corpus else "ReviewBench score"
+    lines = [
+        header,
+        f"  baseline issues : {report.total_issues}",
+        f"  findings reported: {report.total_reported}",
+        f"  located          : {report.found}",
+        f"  recall           : {report.recall:.2%}",
+        f"  corpus-confirmed : {report.precision:.2%}",
+    ]
+    if report.matches:
+        lines.append(f"  severity agree   : {report.severity_agreement:.2%}")
+    if report.missed_issue_ids:
+        lines.append(f"  missed           : {', '.join(report.missed_issue_ids)}")
+    return "\n".join(lines)

--- a/tests/cli/test_eval_gate_cmd.py
+++ b/tests/cli/test_eval_gate_cmd.py
@@ -1,0 +1,154 @@
+"""``mergecraft eval gate`` — structural integrity of the eval bank (#51, C7)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mergecraft.cli.eval_cmd import app
+
+runner = CliRunner()
+
+_CASE = """---
+id: {case_id}
+title: a recorded failure
+category: missed_finding
+submitted_at: '2026-08-09T10:00:00+00:00'
+run_id: synthetic
+pr_number: 1
+failure_mode: missed_finding
+expected_finding: something
+expected_decision: block
+replay_command: mergecraft eval replay {case_id}
+provenance:
+  run_id: synthetic
+  pr_number: 1
+  source_field: eval_bank
+  author_login: synthetic
+  author_association: OWNER
+  trust_tier: trusted
+  timestamp: '2026-08-09T10:00:00+00:00'
+---
+
+body
+"""
+
+
+def _write_case(bank: Path, case_id: str) -> None:
+    bank.mkdir(parents=True, exist_ok=True)
+    (bank / f"{case_id}.md").write_text(_CASE.format(case_id=case_id), encoding="utf-8")
+
+
+def test_gate_passes_on_a_healthy_bank(tmp_path: Path) -> None:
+    bank = tmp_path / "cases"
+    _write_case(bank, "synthetic-001")
+
+    result = runner.invoke(app, ["gate", "--bank", str(bank), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "pass"
+    assert payload["loaded"] == 1
+
+
+def test_gate_fails_on_an_unparsable_case(tmp_path: Path) -> None:
+    """A durable case that no longer parses is silent rot — the gate's whole job."""
+    bank = tmp_path / "cases"
+    _write_case(bank, "synthetic-001")
+    (bank / "broken.md").write_text("not a case file at all\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["gate", "--bank", str(bank), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "fail"
+    assert len(payload["broken"]) == 1
+
+
+def test_gate_fails_on_duplicate_case_ids(tmp_path: Path) -> None:
+    bank = tmp_path / "cases"
+    _write_case(bank, "synthetic-001")
+    (bank / "copy.md").write_text(_CASE.format(case_id="synthetic-001"), encoding="utf-8")
+
+    result = runner.invoke(app, ["gate", "--bank", str(bank), "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["duplicates"]
+
+
+def test_empty_bank_passes_but_says_it_measures_nothing(tmp_path: Path) -> None:
+    bank = tmp_path / "cases"
+    bank.mkdir()
+
+    result = runner.invoke(app, ["gate", "--bank", str(bank)])
+
+    assert result.exit_code == 0
+    assert "not yet measuring anything" in result.output
+
+
+def test_missing_bank_is_not_an_error(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["gate", "--bank", str(tmp_path / "absent")])
+
+    assert result.exit_code == 0
+
+
+def test_unpromoted_cases_only_fail_when_required(tmp_path: Path) -> None:
+    bank = tmp_path / "cases"
+    _write_case(bank, "synthetic-001")
+
+    warned = runner.invoke(app, ["gate", "--bank", str(bank), "--json"])
+    assert warned.exit_code == 0
+    assert json.loads(warned.stdout)["unpromoted"] == ["synthetic-001"]
+
+    required = runner.invoke(app, ["gate", "--bank", str(bank), "--require-promoted", "--json"])
+    assert required.exit_code == 1
+
+
+def test_score_reports_recall_against_a_baseline(tmp_path: Path) -> None:
+    actual = tmp_path / "actual.json"
+    expected = tmp_path / "expected.jsonl"
+    actual.write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "path": "src/a.py",
+                        "start_line": 11,
+                        "end_line": 12,
+                        "severity": "Major",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    # JSON Lines, the shape a promoted baseline actually ships in.
+    expected.write_text(
+        json.dumps({"id": "x-1", "path": "src/a.py", "line_range": [10, 20], "severity": "high"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["score", str(actual), str(expected), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["recall"] == 1.0
+    assert payload["matches"][0]["severity_agrees"] is True
+
+
+def test_score_fails_below_the_required_recall(tmp_path: Path) -> None:
+    actual = tmp_path / "actual.json"
+    expected = tmp_path / "expected.json"
+    actual.write_text(json.dumps({"findings": []}), encoding="utf-8")
+    expected.write_text(
+        json.dumps([{"id": "x-1", "path": "src/a.py", "line_range": [10, 20]}]),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["score", str(actual), str(expected), "--min-recall", "0.5"])
+
+    assert result.exit_code == 1
+    assert "below the required" in result.output

--- a/tests/evals/test_scoring.py
+++ b/tests/evals/test_scoring.py
@@ -1,0 +1,169 @@
+"""Locality-based ReviewBench scoring (#30, C7).
+
+The point of these tests is that scoring must reward a run for *locating* a
+baseline issue, and must not punish it for wording, rule ids, fingerprints, or a
+severity vocabulary the corpus and the reviewer spell differently.
+"""
+
+from __future__ import annotations
+
+from mergecraft.evals.scoring import (
+    BaselineIssue,
+    ReportedFinding,
+    load_baseline_issues,
+    load_reported_findings,
+    normalize_severity,
+    score_findings,
+)
+
+
+def _issue(
+    identifier: str = "b-1",
+    *,
+    path: str = "src/app.py",
+    start: int = 10,
+    end: int = 20,
+    severity: str = "high",
+) -> BaselineIssue:
+    return BaselineIssue(
+        id=identifier, path=path, start_line=start, end_line=end, severity=severity
+    )
+
+
+def _finding(
+    *,
+    path: str = "src/app.py",
+    start: int = 12,
+    end: int = 14,
+    severity: str = "Major",
+    message: str = "totally different wording",
+) -> ReportedFinding:
+    return ReportedFinding(
+        path=path, start_line=start, end_line=end, severity=severity, message=message
+    )
+
+
+def test_overlapping_finding_locates_the_issue_despite_different_wording() -> None:
+    report = score_findings([_issue()], [_finding()])
+
+    assert report.found == 1
+    assert report.recall == 1.0
+    assert report.missed_issue_ids == []
+
+
+def test_finding_in_another_file_does_not_count() -> None:
+    report = score_findings([_issue()], [_finding(path="src/other.py")])
+
+    assert report.found == 0
+    assert report.recall == 0.0
+    assert report.missed_issue_ids == ["b-1"]
+    assert report.unmatched_finding_indexes == [0]
+
+
+def test_finding_far_from_the_issue_does_not_count() -> None:
+    report = score_findings([_issue(start=10, end=20)], [_finding(start=900, end=901)])
+
+    assert report.found == 0
+
+
+def test_near_miss_within_slack_still_counts() -> None:
+    # The reviewer anchored on the line just above the recorded range.
+    report = score_findings([_issue(start=10, end=20)], [_finding(start=8, end=8)])
+
+    assert report.found == 1
+
+
+def test_one_finding_cannot_satisfy_two_issues() -> None:
+    """A single sprawling comment must not score as locating everything."""
+    issues = [_issue("b-1", start=10, end=12), _issue("b-2", start=10, end=12)]
+    report = score_findings(issues, [_finding(start=10, end=12)])
+
+    assert report.found == 1
+    assert report.missed_issue_ids == ["b-2"]
+
+
+def test_each_issue_claims_its_closest_finding() -> None:
+    issues = [_issue("b-1", start=10, end=10), _issue("b-2", start=100, end=100)]
+    findings = [_finding(start=100, end=100), _finding(start=10, end=10)]
+    report = score_findings(issues, findings)
+
+    assert report.found == 2
+    by_issue = {m.issue_id: m.finding_index for m in report.matches}
+    assert by_issue == {"b-1": 1, "b-2": 0}
+
+
+def test_severity_vocabularies_are_reconciled() -> None:
+    """`high` and `Major` are the same grade; the corpus itself proves it."""
+    report = score_findings([_issue(severity="high")], [_finding(severity="Major")])
+
+    assert report.matches[0].severity_agrees is True
+    assert report.severity_agreement == 1.0
+
+
+def test_severity_disagreement_is_reported_not_fatal() -> None:
+    report = score_findings([_issue(severity="high")], [_finding(severity="Trivial")])
+
+    assert report.found == 1, "a severity mismatch must not un-locate the issue"
+    assert report.matches[0].severity_agrees is False
+
+
+def test_precision_counts_only_corpus_confirmed_findings() -> None:
+    report = score_findings(
+        [_issue(start=10, end=20)],
+        [_finding(start=12, end=14), _finding(start=800, end=801)],
+    )
+
+    assert report.recall == 1.0
+    assert report.precision == 0.5
+
+
+def test_empty_baseline_scores_as_vacuously_complete() -> None:
+    report = score_findings([], [])
+
+    assert report.recall == 1.0
+    assert report.precision == 1.0
+
+
+def test_normalize_severity_passes_unknown_grades_through() -> None:
+    assert normalize_severity("high") == "Major"
+    assert normalize_severity("MEDIUM") == "Minor"
+    assert normalize_severity("") == ""
+    assert normalize_severity("spicy") == "Spicy"
+
+
+def test_loader_accepts_the_baseline_jsonl_row_shape() -> None:
+    rows = [
+        {
+            "id": "x-1",
+            "path": "src/a.py",
+            "line_range": [5, 9],
+            "severity": "high",
+            "title": "t",
+        }
+    ]
+    issues = load_baseline_issues(rows)
+
+    assert issues[0].start_line == 5
+    assert issues[0].end_line == 9
+
+
+def test_loader_accepts_the_findings_envelope_shape() -> None:
+    payload = {
+        "findings": [{"path": "src/a.py", "start_line": 5, "end_line": 9, "severity": "Major"}]
+    }
+    findings = load_reported_findings(payload)
+
+    assert findings[0].start_line == 5
+    assert findings[0].severity == "Major"
+
+
+def test_diff_prefixed_paths_match_plain_paths() -> None:
+    report = score_findings([_issue(path="src/app.py")], [_finding(path="b/src/app.py")])
+
+    assert report.found == 1
+
+
+def test_inverted_line_range_is_tolerated() -> None:
+    issues = load_baseline_issues([{"id": "x", "path": "p", "line_range": [20, 10]}])
+
+    assert (issues[0].start_line, issues[0].end_line) == (10, 20)


### PR DESCRIPTION
## What?

Two new commands — `mergecraft eval score` (locality-based ReviewBench scoring) and `mergecraft eval gate` (eval-bank integrity) — plus `make eval-gate` and a `REVIEWBENCH_DIR` override on `make bench-review`.

Closes #

## Why?

C7 in the parity plan: *"wire the eval bank to a gate so quality changes are measurable."* Investigating it turned up two blockers the plan didn't know about.

**1. The benchmark could never pass.** tripll delivered a real Harbor task (tripll#64, closed), but its `verify_findings.py` scores by exact equality over normalized rows — including `fingerprint`, `rule_id: "baseline:tripll-pr64-01"`, `tool`, and `source: "baseline"`, which isn't even a valid `FindingSource`. mergeCraft cannot reproduce those, so the score would be 0 regardless of review quality. Equality also fails a run for *rewording* a finding it genuinely located.

**2. The corpus disagrees with itself on severity.** `baseline.jsonl` grades the two issues `high`/`medium`; the Harbor fixture promoted from **those same two issues** grades them `Major`/`Minor`. Scoring severity naively reports 0% agreement on a corpus that agrees perfectly. The `high→Major`, `medium→Minor` map is read off that promotion, not invented.

## How

`eval score` counts a baseline issue as **located** when a reported finding overlaps its line range in the same file (±3 lines of slack). Matching is one-to-one and greedy by proximity, so one sprawling comment can't claim every issue in a file. Severity/category agreement is reported *alongside* each match, never as a condition for it.

`precision` is deliberately named **"corpus-confirmed"** in the output: a corpus labels what a human chose to record, so a real defect they never wrote down scores as unmatched. It is a lower bound on usefulness, not a false-positive rate.

`eval gate` is **structural, not behavioural** — and that's a deliberate limit. `replay_case()` is a pure function taking the current decision as an *input*, so replaying verdicts in CI would need a live agent run per case: non-deterministic, key-bearing, far too slow for a per-PR gate. The behavioural regression signal already exists and is unchanged — `eval promote` turns a case into a permanent pytest that `make test` runs. This gate stops the durable cases rotting against schema drift in the meantime. An empty bank passes with a notice saying so.

## Runtime proof

Scoring tripll's golden findings against tripll's baseline:

```
baseline issues  : 2
findings reported: 2
located          : 2
recall           : 100.00%
corpus-confirmed : 100.00%
severity agree   : 100.00%
```

Before severity normalisation that last line read **0.00%** — the corpus inconsistency, caught by the tool rather than by reading it.

## A bug the tests caught

A **single-row** `.jsonl` file is itself valid JSON, so it arrived as a bare object, matched no envelope key, and yielded zero issues — scoring recall as a vacuous **1.0**. That is the worst possible failure mode for a benchmark (a broken corpus reads as a perfect score), so lone rows are now recognised by their anchor fields.

## Test plan

- [x] `make ci-resume` — all 9 steps passed (913 passed, 1 skipped, 3 xfailed, 8 xpassed)
- [x] 15 scoring tests + 8 CLI tests, covering: wording-independence, cross-file rejection, distance rejection, slack, one-finding-one-issue, closest-match assignment, severity reconciliation, severity mismatch not un-locating, precision, empty baseline, unknown grades, both corpus shapes, diff-prefixed paths, inverted ranges
- [x] Driven against the real tripll corpus, not just fixtures

## Not in scope

Seeding the eval bank and scaling the corpus. The bank is empty and the corpus is one task with two issues — enough to prove the loop, nowhere near enough to detect a quality regression. Scaling means running tripll's `findings gate`/`promote` pipeline over more merged PRs, which needs no code here. Neither target is wired into CI as blocking yet, for that reason.

**Contamination note:** tripll runs mergeCraft on its own PRs, so mining its Finding graph can promote mergeCraft's own accepted findings into the baseline — which it would then trivially rediscover. `evals/README.md` now documents keeping `provenance: human` as the primary corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)