### PR TITLE
fix(codex): report nested-sandbox failures and add an opt-out (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Codex reviews inside a container runner now fail loudly instead of silently.
+  Codex CLI runs its own bubblewrap sandbox; inside a Docker container action
+  that is already namespaced it cannot create a nested namespace, so every call
+  died before doing any work — and `continue-on-error` made that look like a
+  review that simply found nothing. mergeCraft now recognises the failure and
+  returns the remedy with it. New `codex_sandbox: danger-full-access` Action
+  input (env `MERGECRAFT_CODEX_SANDBOX`) skips the redundant nested sandbox on
+  runners that are already ephemeral and isolated. mergeCraft never selects it
+  on its own, an unrecognised value is ignored rather than forwarded, and the
+  `shell` / `push` controls remain the security boundary either way (#70)
 - Review quality can now be measured. `mergecraft eval score` grades a run's
   findings against a frozen benchmark baseline by **locating** issues — a
   baseline issue counts as found when a reported finding overlaps its line range

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+> **Codex inside a container runner.** Codex CLI runs its own bubblewrap +
+> Landlock sandbox on Linux. Inside a container that is already namespaced — a
+> Docker container action, or a runner without unprivileged user namespaces —
+> bubblewrap cannot create a nested namespace and **every** Codex call fails
+> before doing any work, including a bare `pwd`. mergeCraft reports that
+> explicitly rather than letting `continue-on-error` swallow it as an empty
+> review. If the runner is already ephemeral and isolated, skip the redundant
+> nested sandbox:
+>
+> ```yaml
+> - uses: alexhawat/mergeCraft@v0
+>   with:
+>     codex_sandbox: danger-full-access
+> ```
+>
+> mergeCraft never sets this itself — whether a second sandbox is redundant is a
+> fact about *your* runner. mergeCraft's own `shell` and `push` controls are
+> unaffected either way; they remain the security boundary. See
+> [issue #70](https://github.com/alexhawat/mergeCraft/issues/70).
+
 **Gemini API key example** — set `GEMINI_API_KEY` and point the repo at a
 curated `google/*` slug (`gemini-pro` → `google/gemini-3.1-pro-preview`,
 `gemini-flash` → `google/gemini-3.5-flash`):

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
     description: "Opt-in to comment-driven invocation under `pull_request_target`. Default: false (refused). When set to `true`, comments from authors in {OWNER, MEMBER, COLLABORATOR} dispatch the agent even under `pull_request_target`. Set this only on workflows whose `if:` already gates comment triggers to trusted authors; leave it off everywhere else. See issue #72 / D6."
     required: false
     default: "false"
+  codex_sandbox:
+    description: "Codex platform-sandbox policy. Leave unset (default) to keep Codex's own bubblewrap/Landlock sandbox. Set to `danger-full-access` ONLY when the runner is already an ephemeral, isolated container — inside a Docker container action, bubblewrap cannot create a nested user namespace and every Codex call fails before doing work. mergeCraft's own shell/push controls are unaffected either way. See issue #70."
+    required: false
   output_schema:
     description: "JSON Schema (draft-07) for structured output validation."
     required: false
@@ -84,6 +87,7 @@ runs:
     INPUT_ANALYZERS: ${{ inputs.analyzers }}
     INPUT_OUTPUT_SCHEMA: ${{ inputs.output_schema }}
     INPUT_ALLOW_PR_TARGET_COMMENTS: ${{ inputs.allow_pr_target_comments }}
+    MERGECRAFT_CODEX_SANDBOX: ${{ inputs.codex_sandbox }}
     INPUT_TOKEN: ${{ inputs.token }}
     INPUT_SUGGEST_EVAL_ADD: ${{ inputs.suggest_eval_add }}
 

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -28,6 +28,25 @@ CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
 OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 CODEX_REVIEW_PERMISSION_PROFILE = "mergecraft-review"
 
+# Codex CLI's Linux platform sandbox is bubblewrap + Landlock. Inside a
+# container that is *already* namespaced — such as a Docker container action —
+# bwrap cannot create a second unprivileged user namespace, and every
+# ``codex exec`` dies before doing any work, including a bare ``pwd``. Codex
+# recognises these strings for its own probe path but ships no non-interactive
+# fallback for a real exec, so mergeCraft has to name the failure itself (#70).
+USER_NAMESPACE_FAILURES: tuple[str, ...] = (
+    "No permissions to create a new namespace",
+    "kernel does not allow non-privileged user namespaces",
+    "Failed to create new user namespace",
+)
+
+# Operator escape hatch. mergeCraft never selects this on its own: relaxing an
+# OS-level sandbox is a judgement about the *environment*, which only the
+# workflow author can make. Setting it says "this runner is already an
+# ephemeral, isolated container; the nested sandbox is redundant".
+CODEX_SANDBOX_ENV = "MERGECRAFT_CODEX_SANDBOX"
+CODEX_SANDBOX_UNSANDBOXED = "danger-full-access"
+
 # Mirrors mergecraft.utils.git_setup — Codex refuses PATH aliases under these.
 _FORBIDDEN_TEMP_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/usr/tmp")
 
@@ -202,7 +221,64 @@ def _build_subagent_instructions() -> str:
     )
 
 
+def _operator_sandbox_override() -> str | None:
+    """Return the operator's explicit Codex sandbox choice, if any (#70).
+
+    mergeCraft only honours a value it recognises. An unrecognised value is
+    ignored with a warning rather than passed through to the CLI, so a typo
+    cannot silently widen or narrow the sandbox.
+    """
+    raw = os.environ.get(CODEX_SANDBOX_ENV, "").strip().lower()
+    if not raw:
+        return None
+    if raw == CODEX_SANDBOX_UNSANDBOXED:
+        return CODEX_SANDBOX_UNSANDBOXED
+    logger.warning(
+        "ignoring {}={!r}: the only supported value is {!r}",
+        CODEX_SANDBOX_ENV,
+        raw,
+        CODEX_SANDBOX_UNSANDBOXED,
+    )
+    return None
+
+
+def _sandbox_is_disabled_by_operator() -> bool:
+    """True when the workflow explicitly opted out of Codex's platform sandbox."""
+    return _operator_sandbox_override() == CODEX_SANDBOX_UNSANDBOXED
+
+
+def is_user_namespace_failure(text: str) -> bool:
+    """True when CLI output carries bubblewrap's nested-namespace signature (#70)."""
+    return any(signature in text for signature in USER_NAMESPACE_FAILURES)
+
+
+def user_namespace_failure_hint() -> str:
+    """Return the actionable remedy for a nested-sandbox failure (#70).
+
+    The failure is environmental, not a reviewer error, and the two are worth
+    telling apart: a caller that swallows this with ``continue-on-error`` would
+    otherwise see no difference between "this runner cannot sandbox Codex" and
+    "the review ran and found nothing".
+    """
+    return (
+        "Codex could not start its Linux platform sandbox: bubblewrap cannot create "
+        "a user namespace inside a container that is already namespaced (a Docker "
+        "container action, or a runner without unprivileged user namespaces). No "
+        "review ran.\n"
+        "Remedies:\n"
+        f"  - If the runner is already an ephemeral, isolated container, set "
+        f"{CODEX_SANDBOX_ENV}={CODEX_SANDBOX_UNSANDBOXED} on the mergeCraft step to "
+        "skip Codex's redundant nested sandbox. mergeCraft's own shell/push controls "
+        "still apply.\n"
+        "  - On a self-hosted runner, enable unprivileged user namespaces "
+        "(sysctl kernel.unprivileged_userns_clone=1).\n"
+        "  - Or run the review with a provider that does not nest a sandbox."
+    )
+
+
 def _sandbox_mode(ctx: AgentRunContext) -> str:
+    if _sandbox_is_disabled_by_operator():
+        return CODEX_SANDBOX_UNSANDBOXED
     shell = payload_shell_mode(ctx)
     if shell == "enabled":
         return "workspace-write"
@@ -457,10 +533,21 @@ def _run_codex_once(
     output, usage = _parse_codex_stdout(stdout)
 
     if completed.returncode != 0:
+        error = stderr.strip() or f"codex exited {completed.returncode}"
+        # bwrap fails on the very first exec, so this is the difference between
+        # "the environment cannot run Codex" and "the reviewer errored" (#70).
+        if is_user_namespace_failure(f"{stderr}\n{stdout}"):
+            logger.error(
+                "codex platform sandbox could not start; no review ran. Set {}={} "
+                "if this runner is already an isolated container.",
+                CODEX_SANDBOX_ENV,
+                CODEX_SANDBOX_UNSANDBOXED,
+            )
+            error = f"{user_namespace_failure_hint()}\n\ncodex stderr:\n{error}"
         return AgentResult(
             success=False,
             output=output or None,
-            error=stderr.strip() or f"codex exited {completed.returncode}",
+            error=error,
             usage=usage,
         )
     return AgentResult(success=True, output=output or None, usage=usage)

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -256,3 +256,113 @@ def test_codex_home_relocates_off_tmp(
     home = codex_module._codex_home(ctx)
     assert str(home).startswith(str(safe))
     assert home.name == ".codex"
+
+
+# ── nested-sandbox failure and the operator opt-in (#70) ────────────────
+
+
+def test_user_namespace_failure_is_recognised() -> None:
+    """The bwrap signature must be told apart from an ordinary reviewer error."""
+    codex_module = _load_codex_module()
+    bwrap_stderr = (
+        "bwrap: No permissions to create a new namespace, likely because the kernel "
+        "does not allow non-privileged user namespaces."
+    )
+
+    assert codex_module.is_user_namespace_failure(bwrap_stderr) is True
+    assert codex_module.is_user_namespace_failure("TypeError: nope") is False
+
+
+def test_sandbox_stays_on_by_default(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """mergeCraft must never relax Codex's sandbox on its own (#70)."""
+    codex_module = _load_codex_module()
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    assert codex_module._sandbox_mode(ctx) == "read-only"
+
+
+def test_operator_can_opt_out_of_the_nested_sandbox(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    codex_module = _load_codex_module()
+    monkeypatch.setenv(codex_module.CODEX_SANDBOX_ENV, codex_module.CODEX_SANDBOX_UNSANDBOXED)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    assert codex_module._sandbox_mode(ctx) == codex_module.CODEX_SANDBOX_UNSANDBOXED
+    # The legacy --sandbox path owns policy here, so the flag reaches the CLI
+    # instead of a read-only permission profile.
+    assert codex_module._codex_use_permission_profiles(ctx) is False
+
+
+def test_unrecognised_sandbox_value_is_ignored_not_forwarded(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """A typo must not silently change the sandbox in either direction."""
+    codex_module = _load_codex_module()
+    monkeypatch.setenv(codex_module.CODEX_SANDBOX_ENV, "danger-ful-access")
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    assert codex_module._sandbox_mode(ctx) == "read-only"
+
+
+def test_opt_in_is_written_into_codex_config(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    codex_module = _load_codex_module()
+    monkeypatch.setenv(codex_module.CODEX_SANDBOX_ENV, codex_module.CODEX_SANDBOX_UNSANDBOXED)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    config = Path(codex_module.write_mcp_config(ctx)).read_text(encoding="utf-8")
+
+    assert f'sandbox_mode = "{codex_module.CODEX_SANDBOX_UNSANDBOXED}"' in config
+
+
+def test_bwrap_failure_returns_an_actionable_error(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """A silent continue-on-error swallow is the bug; the remedy must be in the error."""
+    codex_module = _load_codex_module()
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del cmd, kwargs
+        return subprocess.CompletedProcess(
+            args=["codex"],
+            returncode=1,
+            stdout="",
+            stderr="bwrap: No permissions to create a new namespace, likely because",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    result = codex_module._run_codex_once(cli="codex", prompt="p", ctx=ctx, mcp_config="")
+
+    assert result.success is False
+    assert result.error is not None
+    assert codex_module.CODEX_SANDBOX_ENV in result.error
+    assert "No review ran" in result.error or "no review ran" in result.error.lower()
+
+
+def test_ordinary_failures_do_not_get_the_sandbox_hint(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    codex_module = _load_codex_module()
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("CI", "true")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del cmd, kwargs
+        return subprocess.CompletedProcess(
+            args=["codex"], returncode=1, stdout="", stderr="model overloaded"
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    result = codex_module._run_codex_once(cli="codex", prompt="p", ctx=ctx, mcp_config="")
+
+    assert result.success is False
+    assert result.error is not None
+    assert codex_module.CODEX_SANDBOX_ENV not in result.error


### PR DESCRIPTION
## What?

Recognises Codex's nested-sandbox failure and returns an actionable error instead of an opaque one, and adds a `codex_sandbox` Action input for runners that are already isolated.

Closes #70

## Why?

Codex CLI runs its own bubblewrap + Landlock sandbox on Linux. Inside a container that is **already** namespaced — a Docker container action, or a runner without unprivileged user namespaces — bwrap cannot create a nested namespace and every `codex exec` dies before doing any work, including a bare `pwd`.

Because the review step runs `continue-on-error: true` and posts no approval check on this path, the failure was **indistinguishable from a review that ran and found nothing**. That is the part that actually hurt: a consumer got no review and no signal that no review happened.

I confirmed the reporter's trace against `agents/codex.py`: `_sandbox_mode()` only ever returns `read-only` or `workspace-write`, and Codex decides to platform-sandbox from the *effective* FS policy — so both the legacy `--sandbox` path and the newer permission-profile path land in bwrap.

## What I did NOT do

The issue's first suggestion was to auto-retry with the sandbox bypassed when `IS_SANDBOX=1`. **Deliberately not implemented.** Whether a second sandbox is redundant is a fact about the *runner*, and inferring it from a string match on stderr is not mergeCraft's call to make. The decision stays with the workflow author, who knows their environment.

## How

- `is_user_namespace_failure()` matches the three known bwrap signatures. On that failure the error carries the diagnosis plus three remedies (opt out, enable `kernel.unprivileged_userns_clone`, or use another provider); other failures are untouched.
- `codex_sandbox: danger-full-access` (env `MERGECRAFT_CODEX_SANDBOX`) makes `_sandbox_mode()` return `danger-full-access`, which flows into both the CLI flag and `config.toml`.
- **An unrecognised value is ignored with a warning, never forwarded** — a typo like `danger-ful-access` cannot silently widen *or* narrow the sandbox.
- mergeCraft's `shell` / `push` controls are unaffected and remain the security boundary.

## Runtime proof

With `MERGECRAFT_CODEX_SANDBOX=danger-full-access`, against real code:

```
sandbox_mode        : danger-full-access
permission profiles : False
config sandbox lines: ['sandbox_mode = "danger-full-access"']
```

So the opt-in reaches both the CLI argv path and the written `config.toml`, not just the helper that reads the env var.

## Test plan

- [x] `make ci-resume` — all 9 steps passed (920 passed, 1 skipped, 3 xfailed, 8 xpassed)
- [x] 7 new tests: signature recognition, **sandbox stays on by default**, opt-in changes the mode, opt-in reaches `config.toml`, typo'd value is ignored, bwrap failure carries the remedy, and ordinary failures do **not** get the hint

## Note for the reporter

This does not make Codex work unattended inside a Docker container action — it makes the failure legible, and gives you a supported way to opt out when you know the runner is already isolated. For sevn-bot/sevn's case, adding `codex_sandbox: danger-full-access` to the mergeCraft step should restore the fallback review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)