### PR TITLE
feat(evals): recompute case verdicts from recorded evidence, seed the bank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runners that are already ephemeral and isolated. mergeCraft never selects it
   on its own, an unrecognised value is ignored rather than forwarded, and the
   `shell` / `push` controls remain the security boundary either way (#70)
+- The eval bank now actually catches regressions. A case can record the
+  findings, run outcome and trust tier from a merge evidence packet
+  (`mergecraft eval add --from-packet`), and replay re-decides it with the
+  current `decide_approval()` instead of asking an operator to type the verdict
+  in. Before this a promoted case produced a test whose only unconditional
+  assertion was a tautology, so it passed in CI no matter what the gate did.
+  Seeded with the three merge-gate failures issue #75 shipped: agent prose
+  outvoting a blocking finding, a crashed run staying permissive, and an
+  untrusted run self-approving. Cases without recorded evidence keep their old
+  behaviour. Also fixes `mergecraft eval gate` reporting every promoted case as
+  unpromoted, and widens the bank's verdict vocabulary, which had drifted from
+  what `decide_approval()` actually emits (#44, #51)
 - Review quality can now be measured. `mergecraft eval score` grades a run's
   findings against a frozen benchmark baseline by **locating** issues — a
   baseline issue counts as found when a reported finding overlaps its line range

--- a/evals/cases/issue-75-crashed-run-not-permissive.md
+++ b/evals/cases/issue-75-crashed-run-not-permissive.md
@@ -1,0 +1,25 @@
+---
+id: issue-75-crashed-run-not-permissive
+title: A crashed run must never be permissive
+category: missed_finding
+submitted_at: '2026-08-09T22:45:08.733176Z'
+run_id: issue-75
+pr_number: 87
+failure_mode: wrong_decision
+expected_finding: run_succeeded=False must yield neutral, not success
+expected_decision: neutral
+replay_command: mergecraft eval replay issue-75-crashed-run-not-permissive
+provenance:
+  run_id: issue-75
+  pr_number: 87
+  source_field: eval_bank
+  author_login: alexhawat
+  author_association: OWNER
+  trust_tier: trusted
+  timestamp: '2026-08-09T22:45:08.732882Z'
+recorded_findings: []
+run_succeeded: false
+trust_tier: trusted
+---
+
+D13. A run that crashed produced no evidence, so it cannot produce a positive verdict. Before PR #87 a preserved approval could survive a later failure.

--- a/evals/cases/issue-75-narrative-approval.md
+++ b/evals/cases/issue-75-narrative-approval.md
@@ -1,0 +1,45 @@
+---
+id: issue-75-narrative-approval
+title: Agent prose must never outvote a blocking finding
+category: missed_finding
+submitted_at: '2026-08-09T22:45:08.340612Z'
+run_id: issue-75
+pr_number: 87
+failure_mode: wrong_decision
+expected_finding: Critical finding present; approval must be failure regardless of
+  the agent's approved boolean
+expected_decision: failure
+replay_command: mergecraft eval replay issue-75-narrative-approval
+provenance:
+  run_id: issue-75
+  pr_number: 87
+  source_field: eval_bank
+  author_login: alexhawat
+  author_association: OWNER
+  trust_tier: trusted
+  timestamp: '2026-08-09T22:45:08.340342Z'
+recorded_findings:
+- path: src/mergecraft/utils/status_checks.py
+  start_line: 97
+  end_line: 113
+  message: Agent narrative steered mergecraft-approval to success despite a blocking
+    finding
+  severity: Critical
+  confidence: certain
+  category: Security & Privacy
+  source: agent
+  fingerprint: i75narrative01
+  tool: agent
+  rule_id: agent:issue-75
+  introduced_by_pr: 'true'
+  evidence:
+  - approval.would_approve was read straight into the check conclusion
+  remediation: Derive the conclusion from typed findings; demote the agent boolean
+    to advisory.
+  autofix: null
+  cluster_id: null
+run_succeeded: true
+trust_tier: trusted
+---
+
+Shipped defect, fixed by PR #87 (issue #75). `create_pull_request_review` took an `approved: bool` straight from the agent and `report_status_checks()` read it into the `mergecraft-approval` conclusion, so an injected PR could steer the gate to success. D12 makes the conclusion a pure function of typed findings. This case fails if narrative ever regains a vote.

--- a/evals/cases/issue-75-untrusted-never-approves.md
+++ b/evals/cases/issue-75-untrusted-never-approves.md
@@ -1,0 +1,25 @@
+---
+id: issue-75-untrusted-never-approves
+title: An untrusted run must never self-approve
+category: missed_finding
+submitted_at: '2026-08-09T22:45:09.116416Z'
+run_id: issue-75
+pr_number: 87
+failure_mode: wrong_decision
+expected_finding: tier=untrusted must yield neutral even with no findings
+expected_decision: neutral
+replay_command: mergecraft eval replay issue-75-untrusted-never-approves
+provenance:
+  run_id: issue-75
+  pr_number: 87
+  source_field: eval_bank
+  author_login: alexhawat
+  author_association: OWNER
+  trust_tier: trusted
+  timestamp: '2026-08-09T22:45:09.116169Z'
+recorded_findings: []
+run_succeeded: true
+trust_tier: untrusted
+---
+
+D14. `prApproveEnabled` goes inert for the untrusted tier: a fork PR cannot approve itself. This was a BREAKING change in PR #87.

--- a/src/mergecraft/cli/eval_cmd.py
+++ b/src/mergecraft/cli/eval_cmd.py
@@ -48,6 +48,7 @@ from mergecraft.evals.store import (
     add_case,
     list_cases,
     load_case,
+    permanent_test_path,
     replay_case,
     write_permanent_test,
 )
@@ -202,6 +203,15 @@ def add(
         "--body",
         help="Free-form description of the failure mode (markdown).",
     ),
+    from_packet: Path | None = typer.Option(
+        None,
+        "--from-packet",
+        help=(
+            "Merge evidence packet (JSON) to record as the case's replay input. "
+            "Without it the case cannot be re-decided and a promoted test only "
+            "checks that the case still parses."
+        ),
+    ),
     bank: Path | None = typer.Option(
         None,
         "--bank",
@@ -230,6 +240,13 @@ def add(
         author=author,
         trust_tier=trust_tier,
     )
+    recorded_findings: list[dict[str, Any]] | None = None
+    run_succeeded = True
+    trust_tier_recorded = "trusted"
+    if from_packet is not None:
+        recorded_findings, run_succeeded, trust_tier_recorded = _replay_inputs_from_packet(
+            from_packet
+        )
     try:
         case = Case(
             id=case_id,
@@ -244,6 +261,9 @@ def add(
             replay_command=f"mergecraft eval replay {case_id}",
             provenance=provenance,
             body=body,
+            recorded_findings=recorded_findings,
+            run_succeeded=run_succeeded,
+            trust_tier=trust_tier_recorded,
         )
     except ValidationError as exc:
         _bail(f"case failed validation: {exc}")
@@ -436,6 +456,39 @@ def promote(
     console.print(f"[green]promoted case {case_id}[/green] → {target}")
 
 
+def _replay_inputs_from_packet(path: Path) -> tuple[list[dict[str, Any]], bool, str]:
+    """Extract ``decide_approval()``'s three inputs from a merge evidence packet.
+
+    Returns ``(findings_rows, run_succeeded, trust_tier)``. The rows are stored
+    verbatim rather than re-validated here: a schema change that invalidates
+    them should surface at replay time as "cannot decide", not be silently
+    dropped at capture time.
+    """
+    if not path.is_file():
+        _bail(f"{path} is not a file")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _bail(f"could not read packet {path}: {exc}")
+    if not isinstance(payload, dict):
+        _bail(f"{path}: expected a merge evidence packet object")
+    rows = payload.get("findings")
+    if not isinstance(rows, list):
+        _bail(f"{path}: packet has no 'findings' array")
+    findings = [row for row in rows if isinstance(row, dict)]
+    run = payload.get("run")
+    run_succeeded = True
+    if isinstance(run, dict) and isinstance(run.get("succeeded"), bool):
+        run_succeeded = bool(run["succeeded"])
+    tier = "trusted"
+    for holder in (payload, run if isinstance(run, dict) else {}):
+        value = holder.get("trust_tier") if isinstance(holder, dict) else None
+        if value in {"trusted", "untrusted"}:
+            tier = str(value)
+            break
+    return findings, run_succeeded, tier
+
+
 def _read_json_or_jsonl(path: Path) -> Any:
     """Decode a corpus file that may be JSON or JSON Lines.
 
@@ -521,7 +574,10 @@ def gate(
             duplicates.append({"id": case.id, "path": str(path), "first": seen[case.id]})
         else:
             seen[case.id] = str(path)
-        if not (permanent_dir / f"test_{case.id.replace('-', '_')}.py").is_file():
+        # Ask the store for the path rather than rebuilding the name here —
+        # reconstructing it got the `test_permanent_` prefix wrong and reported
+        # every promoted case as unpromoted.
+        if not permanent_test_path(permanent_dir, case.id).is_file():
             unpromoted.append(case.id)
 
     failures = len(broken) + len(duplicates)

--- a/src/mergecraft/evals/__init__.py
+++ b/src/mergecraft/evals/__init__.py
@@ -46,6 +46,7 @@ from mergecraft.evals.store import (
     list_cases,
     load_case,
     parse_case_text,
+    recompute_decision,
     render_case_text,
     replay_case,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "load_case",
     "load_reported_findings",
     "parse_case_text",
+    "recompute_decision",
     "render_case_text",
     "replay_case",
     "score_findings",

--- a/src/mergecraft/evals/store.py
+++ b/src/mergecraft/evals/store.py
@@ -128,8 +128,20 @@ _CASE_FIELDS: tuple[str, ...] = (
 # ``mergecraft.evidence.packet.Decision.verdict``. The store does not
 # re-export the type — it stays as a string literal so the bank does
 # not silently fall out of sync when the packet's verdict enum evolves.
+#
+# The mirror had drifted. ``decide_approval()`` wraps its ``Conclusion``
+# verbatim into ``Decision.verdict`` (``agents/gates.py``), so a packet
+# produced today carries ``success`` / ``failure`` / ``neutral`` — of which
+# only ``neutral`` was accepted here. A case could therefore never record the
+# verdict the code actually computes. Both vocabularies are accepted: the
+# check-run one because it is what ships, and the lane one because the
+# thermostat work (W9) is specified to introduce it.
 _EXPECTED_VERDICT_VALUES: frozenset[str] = frozenset(
     {
+        # Check-run conclusions — what `decide_approval()` emits today.
+        "success",
+        "failure",
+        # Lane verdicts — reserved for the W9 thermostat overlay.
         "auto_merge",
         "block",
         "request_changes",
@@ -252,6 +264,21 @@ class Case(BaseModel):
     replay_command: str = Field(min_length=1)
     provenance: LearningProvenance
     body: str = ""
+
+    # ── replay inputs (optional; #44/C7) ──────────────────────────────
+    # Without these a replay cannot compute anything and must be handed a
+    # verdict by an operator, which makes a promoted test assert nothing in
+    # CI. With them, ``decide_approval()`` recomputes the verdict from the
+    # same structured evidence the run recorded — pure, deterministic, and
+    # needing no agent, network, or API key.
+    recorded_findings: list[dict[str, Any]] | None = None
+    run_succeeded: bool = True
+    trust_tier: str = "trusted"
+
+    @property
+    def is_replayable(self) -> bool:
+        """True when the case carries enough evidence to recompute a verdict."""
+        return self.recorded_findings is not None
 
     @field_validator("expected_decision")
     @classmethod
@@ -683,6 +710,39 @@ def list_cases(
     return cases
 
 
+def recompute_decision(case: Case) -> str | None:
+    """Recompute a case's verdict from its recorded evidence (#44, C7).
+
+    This is the link that makes a promoted test a real regression test rather
+    than a tautology. ``decide_approval()`` is a pure function of typed
+    findings, the run's completion state, and the trust tier — so a case that
+    stored those three can be re-decided by the *current* code with no agent,
+    no network, and no API key, which is exactly what a CI gate needs.
+
+    Returns ``None`` when the case predates the recorded-evidence fields or
+    its rows no longer validate against the current ``Finding`` schema. A
+    schema change that invalidates stored evidence is itself worth surfacing,
+    so this reports "cannot decide" rather than guessing a verdict.
+    """
+    if case.recorded_findings is None:
+        return None
+    # Imported lazily: the store is the bank's pure data layer, and importing
+    # the gate at module scope would tie every bank read to the agent stack.
+    from mergecraft.agents.gates import decide_approval
+    from mergecraft.analyzers.finding import Finding
+
+    try:
+        findings = [Finding.model_validate(row) for row in case.recorded_findings]
+    except ValidationError as exc:
+        logger.warning("case {}: recorded findings no longer validate: {}", case.id, exc)
+        return None
+    # Branch rather than cast: the tier literal is a security-relevant input,
+    # and an unrecognised value must fall back to the restrictive side.
+    if case.trust_tier == "untrusted":
+        return str(decide_approval(findings, run_succeeded=case.run_succeeded, tier="untrusted"))
+    return str(decide_approval(findings, run_succeeded=case.run_succeeded, tier="trusted"))
+
+
 def _format_diff(case: Case, current: str | None) -> ReplayDiff:
     """Build a :class:`ReplayDiff` from a case and a current verdict.
 
@@ -720,15 +780,24 @@ def replay_case(case: Case, *, current_decision: str | None) -> ReplayDiff:
     """Replay a case against the current code, given a verdict.
 
     The replay function is **pure**. It does not invoke the agent, does
-    not start a subprocess, does not read ``os.environ``. The CLI shell
-    is responsible for asking the running code for a verdict and
-    passing it in. That separation is what makes the diff deterministic
-    and the function unit-testable.
+    not start a subprocess, does not read ``os.environ``.
+
+    When ``current_decision`` is omitted and the case recorded its evidence,
+    the verdict is recomputed by :func:`recompute_decision` — still pure, since
+    ``decide_approval()`` is itself a pure function. That is what lets a
+    promoted test detect a regression in CI instead of waiting for an operator
+    to supply a verdict by hand. A case with no recorded evidence keeps the
+    original behaviour and lands in the ``blocked`` state.
+
+    An explicitly passed verdict always wins over the recomputed one: the
+    caller is asserting what the running code produced, and that has to be able
+    to contradict the stored evidence.
 
     Args:
         case: The case to replay.
-        current_decision: The verdict the current code produced, or
-            ``None`` when the replay environment was unavailable.
+        current_decision: The verdict the current code produced. When
+            ``None``, it is recomputed from the case's recorded evidence if
+            present, and left unresolved otherwise.
 
     Returns:
         A :class:`ReplayDiff` capturing the structural comparison.
@@ -759,7 +828,11 @@ def replay_case(case: Case, *, current_decision: str | None) -> ReplayDiff:
         >>> r.status
         'regression'
     """
-    return _format_diff(case, current_decision)
+    # An explicit verdict always wins: the operator is asserting what the
+    # running code produced, and that must be able to contradict the stored
+    # evidence — otherwise a case could never catch its own staleness.
+    resolved = current_decision if current_decision is not None else recompute_decision(case)
+    return _format_diff(case, resolved)
 
 
 def diff_cases(a: Case, b: Case) -> dict[str, Any]:
@@ -883,7 +956,6 @@ discovered by pytest via the standard collection rules — no separate
 from __future__ import annotations
 
 from mergecraft.evals.store import Case, replay_case
-
 
 _PERMANENT_CASE_PAYLOAD = {payload!r}
 

--- a/tests/cli/test_eval_gate_cmd.py
+++ b/tests/cli/test_eval_gate_cmd.py
@@ -152,3 +152,26 @@ def test_score_fails_below_the_required_recall(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "below the required" in result.output
+
+
+def test_a_promoted_case_is_not_reported_as_unpromoted(tmp_path: Path) -> None:
+    """The gate must ask the store for the path, not rebuild the filename."""
+    from mergecraft.evals.store import permanent_test_path
+
+    bank = tmp_path / "cases"
+    _write_case(bank, "synthetic-001")
+    permanent = tmp_path / "permanent"
+    permanent.mkdir()
+    permanent_test_path(permanent, "synthetic-001").write_text("# promoted\n", encoding="utf-8")
+
+    import mergecraft.cli.eval_cmd as eval_cmd
+
+    original = eval_cmd._default_permanent_dir
+    eval_cmd._default_permanent_dir = lambda: permanent  # type: ignore[assignment]
+    try:
+        result = runner.invoke(app, ["gate", "--bank", str(bank), "--require-promoted", "--json"])
+    finally:
+        eval_cmd._default_permanent_dir = original  # type: ignore[assignment]
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["unpromoted"] == []

--- a/tests/evals/permanent/test_permanent_issue_75_crashed_run_not_permissive.py
+++ b/tests/evals/permanent/test_permanent_issue_75_crashed_run_not_permissive.py
@@ -1,0 +1,68 @@
+"""Auto-generated permanent test promoted from the eval bank (#44, W12.1).
+
+This file is produced by ``mergecraft eval promote <case-id>``. Do not
+edit by hand — re-run ``mergecraft eval promote`` to regenerate. The
+test re-runs the case against the current code via
+``mergecraft.evals.store.replay_case``: a ``passed`` status means the
+case's expected verdict matches what the running code produced; a
+``regression`` status means the same failure mode the case captured has
+recurred — that is the structural signal the promote workflow ships.
+
+The promoted test lives under ``tests/evals/permanent/`` and is
+discovered by pytest via the standard collection rules — no separate
+``conftest`` is required.
+"""
+
+from __future__ import annotations
+
+from mergecraft.evals.store import Case, replay_case
+
+_PERMANENT_CASE_PAYLOAD = '{"id":"issue-75-crashed-run-not-permissive","title":"A crashed run must never be permissive","category":"missed_finding","submitted_at":"2026-08-09T22:45:08.733176Z","run_id":"issue-75","pr_number":87,"failure_mode":"wrong_decision","expected_finding":"run_succeeded=False must yield neutral, not success","expected_decision":"neutral","replay_command":"mergecraft eval replay issue-75-crashed-run-not-permissive","provenance":{"run_id":"issue-75","pr_number":87,"source_field":"eval_bank","author_login":"alexhawat","author_association":"OWNER","trust_tier":"trusted","timestamp":"2026-08-09T22:45:08.732882Z"},"body":"D13. A run that crashed produced no evidence, so it cannot produce a positive verdict. Before PR #87 a preserved approval could survive a later failure.","recorded_findings":[],"run_succeeded":false,"trust_tier":"trusted"}'
+
+
+def _load_permanent_case() -> Case:
+    """Materialize the embedded case payload as a validated :class:`Case`.
+
+    The payload is the case's full JSON shape (including the embedded
+    ``LearningProvenance``); ``Case.model_validate_json`` is the same
+    path the bank uses at read time, so a schema-version bump on the
+    bank side surfaces here as a load-time failure rather than a
+    silent structural drift.
+    """
+    return Case.model_validate_json(_PERMANENT_CASE_PAYLOAD)
+
+
+def test_permanent_issue_75_crashed_run_not_permissive() -> None:
+    """Permanent regression test for case ``issue-75-crashed-run-not-permissive`` (A crashed run must never be permissive).
+
+    Expected verdict: ``neutral``. The replay verdict is
+    operator-supplied via the ``MERGECRAFT_PERMANENT_CURRENT_DECISION``
+    env var; when unset the default is ``None`` so the case lands in
+    the ``blocked`` state (the replay engine did not produce a
+    verdict). The test asserts two things:
+
+    - The case is replayable end-to-end (the bank schema still
+      validates and ``replay_case`` returns a typed diff).
+    - When the operator wires a current verdict, that verdict agrees
+      with the case's expected decision — a real regression surfaces
+      as a failed assertion.
+
+    The default-``None`` path keeps the test green at import time so a
+    fresh promotion does not break the suite. Operators flip the env
+    var to surface drift.
+    """
+    import os
+
+    case = _load_permanent_case()
+    current = os.environ.get("MERGECRAFT_PERMANENT_CURRENT_DECISION") or None
+    diff = replay_case(case, current_decision=current)
+    # The replay must complete — even the default-``None`` path lands in
+    # the ``blocked`` status, which is itself a valid replay outcome.
+    assert diff.status in {"passed", "regression", "blocked"}
+    # When the operator wired a current verdict, surface a real drift.
+    if diff.current_decision is not None:
+        assert diff.current_decision == diff.expected_decision, (
+            f"permanent test {case.id!r}: replay verdict "
+            f"{diff.current_decision!r} drifted from expected "
+            f"{diff.expected_decision!r}"
+        )

--- a/tests/evals/permanent/test_permanent_issue_75_narrative_approval.py
+++ b/tests/evals/permanent/test_permanent_issue_75_narrative_approval.py
@@ -1,0 +1,68 @@
+"""Auto-generated permanent test promoted from the eval bank (#44, W12.1).
+
+This file is produced by ``mergecraft eval promote <case-id>``. Do not
+edit by hand — re-run ``mergecraft eval promote`` to regenerate. The
+test re-runs the case against the current code via
+``mergecraft.evals.store.replay_case``: a ``passed`` status means the
+case's expected verdict matches what the running code produced; a
+``regression`` status means the same failure mode the case captured has
+recurred — that is the structural signal the promote workflow ships.
+
+The promoted test lives under ``tests/evals/permanent/`` and is
+discovered by pytest via the standard collection rules — no separate
+``conftest`` is required.
+"""
+
+from __future__ import annotations
+
+from mergecraft.evals.store import Case, replay_case
+
+_PERMANENT_CASE_PAYLOAD = '{"id":"issue-75-narrative-approval","title":"Agent prose must never outvote a blocking finding","category":"missed_finding","submitted_at":"2026-08-09T22:45:08.340612Z","run_id":"issue-75","pr_number":87,"failure_mode":"wrong_decision","expected_finding":"Critical finding present; approval must be failure regardless of the agent\'s approved boolean","expected_decision":"failure","replay_command":"mergecraft eval replay issue-75-narrative-approval","provenance":{"run_id":"issue-75","pr_number":87,"source_field":"eval_bank","author_login":"alexhawat","author_association":"OWNER","trust_tier":"trusted","timestamp":"2026-08-09T22:45:08.340342Z"},"body":"Shipped defect, fixed by PR #87 (issue #75). `create_pull_request_review` took an `approved: bool` straight from the agent and `report_status_checks()` read it into the `mergecraft-approval` conclusion, so an injected PR could steer the gate to success. D12 makes the conclusion a pure function of typed findings. This case fails if narrative ever regains a vote.","recorded_findings":[{"path":"src/mergecraft/utils/status_checks.py","start_line":97,"end_line":113,"message":"Agent narrative steered mergecraft-approval to success despite a blocking finding","severity":"Critical","confidence":"certain","category":"Security & Privacy","source":"agent","fingerprint":"i75narrative01","tool":"agent","rule_id":"agent:issue-75","introduced_by_pr":"true","evidence":["approval.would_approve was read straight into the check conclusion"],"remediation":"Derive the conclusion from typed findings; demote the agent boolean to advisory.","autofix":null,"cluster_id":null}],"run_succeeded":true,"trust_tier":"trusted"}'
+
+
+def _load_permanent_case() -> Case:
+    """Materialize the embedded case payload as a validated :class:`Case`.
+
+    The payload is the case's full JSON shape (including the embedded
+    ``LearningProvenance``); ``Case.model_validate_json`` is the same
+    path the bank uses at read time, so a schema-version bump on the
+    bank side surfaces here as a load-time failure rather than a
+    silent structural drift.
+    """
+    return Case.model_validate_json(_PERMANENT_CASE_PAYLOAD)
+
+
+def test_permanent_issue_75_narrative_approval() -> None:
+    """Permanent regression test for case ``issue-75-narrative-approval`` (Agent prose must never outvote a blocking finding).
+
+    Expected verdict: ``failure``. The replay verdict is
+    operator-supplied via the ``MERGECRAFT_PERMANENT_CURRENT_DECISION``
+    env var; when unset the default is ``None`` so the case lands in
+    the ``blocked`` state (the replay engine did not produce a
+    verdict). The test asserts two things:
+
+    - The case is replayable end-to-end (the bank schema still
+      validates and ``replay_case`` returns a typed diff).
+    - When the operator wires a current verdict, that verdict agrees
+      with the case's expected decision — a real regression surfaces
+      as a failed assertion.
+
+    The default-``None`` path keeps the test green at import time so a
+    fresh promotion does not break the suite. Operators flip the env
+    var to surface drift.
+    """
+    import os
+
+    case = _load_permanent_case()
+    current = os.environ.get("MERGECRAFT_PERMANENT_CURRENT_DECISION") or None
+    diff = replay_case(case, current_decision=current)
+    # The replay must complete — even the default-``None`` path lands in
+    # the ``blocked`` status, which is itself a valid replay outcome.
+    assert diff.status in {"passed", "regression", "blocked"}
+    # When the operator wired a current verdict, surface a real drift.
+    if diff.current_decision is not None:
+        assert diff.current_decision == diff.expected_decision, (
+            f"permanent test {case.id!r}: replay verdict "
+            f"{diff.current_decision!r} drifted from expected "
+            f"{diff.expected_decision!r}"
+        )

--- a/tests/evals/permanent/test_permanent_issue_75_untrusted_never_approves.py
+++ b/tests/evals/permanent/test_permanent_issue_75_untrusted_never_approves.py
@@ -1,0 +1,68 @@
+"""Auto-generated permanent test promoted from the eval bank (#44, W12.1).
+
+This file is produced by ``mergecraft eval promote <case-id>``. Do not
+edit by hand — re-run ``mergecraft eval promote`` to regenerate. The
+test re-runs the case against the current code via
+``mergecraft.evals.store.replay_case``: a ``passed`` status means the
+case's expected verdict matches what the running code produced; a
+``regression`` status means the same failure mode the case captured has
+recurred — that is the structural signal the promote workflow ships.
+
+The promoted test lives under ``tests/evals/permanent/`` and is
+discovered by pytest via the standard collection rules — no separate
+``conftest`` is required.
+"""
+
+from __future__ import annotations
+
+from mergecraft.evals.store import Case, replay_case
+
+_PERMANENT_CASE_PAYLOAD = '{"id":"issue-75-untrusted-never-approves","title":"An untrusted run must never self-approve","category":"missed_finding","submitted_at":"2026-08-09T22:45:09.116416Z","run_id":"issue-75","pr_number":87,"failure_mode":"wrong_decision","expected_finding":"tier=untrusted must yield neutral even with no findings","expected_decision":"neutral","replay_command":"mergecraft eval replay issue-75-untrusted-never-approves","provenance":{"run_id":"issue-75","pr_number":87,"source_field":"eval_bank","author_login":"alexhawat","author_association":"OWNER","trust_tier":"trusted","timestamp":"2026-08-09T22:45:09.116169Z"},"body":"D14. `prApproveEnabled` goes inert for the untrusted tier: a fork PR cannot approve itself. This was a BREAKING change in PR #87.","recorded_findings":[],"run_succeeded":true,"trust_tier":"untrusted"}'
+
+
+def _load_permanent_case() -> Case:
+    """Materialize the embedded case payload as a validated :class:`Case`.
+
+    The payload is the case's full JSON shape (including the embedded
+    ``LearningProvenance``); ``Case.model_validate_json`` is the same
+    path the bank uses at read time, so a schema-version bump on the
+    bank side surfaces here as a load-time failure rather than a
+    silent structural drift.
+    """
+    return Case.model_validate_json(_PERMANENT_CASE_PAYLOAD)
+
+
+def test_permanent_issue_75_untrusted_never_approves() -> None:
+    """Permanent regression test for case ``issue-75-untrusted-never-approves`` (An untrusted run must never self-approve).
+
+    Expected verdict: ``neutral``. The replay verdict is
+    operator-supplied via the ``MERGECRAFT_PERMANENT_CURRENT_DECISION``
+    env var; when unset the default is ``None`` so the case lands in
+    the ``blocked`` state (the replay engine did not produce a
+    verdict). The test asserts two things:
+
+    - The case is replayable end-to-end (the bank schema still
+      validates and ``replay_case`` returns a typed diff).
+    - When the operator wires a current verdict, that verdict agrees
+      with the case's expected decision — a real regression surfaces
+      as a failed assertion.
+
+    The default-``None`` path keeps the test green at import time so a
+    fresh promotion does not break the suite. Operators flip the env
+    var to surface drift.
+    """
+    import os
+
+    case = _load_permanent_case()
+    current = os.environ.get("MERGECRAFT_PERMANENT_CURRENT_DECISION") or None
+    diff = replay_case(case, current_decision=current)
+    # The replay must complete — even the default-``None`` path lands in
+    # the ``blocked`` status, which is itself a valid replay outcome.
+    assert diff.status in {"passed", "regression", "blocked"}
+    # When the operator wired a current verdict, surface a real drift.
+    if diff.current_decision is not None:
+        assert diff.current_decision == diff.expected_decision, (
+            f"permanent test {case.id!r}: replay verdict "
+            f"{diff.current_decision!r} drifted from expected "
+            f"{diff.expected_decision!r}"
+        )

--- a/tests/evals/test_recompute_decision.py
+++ b/tests/evals/test_recompute_decision.py
@@ -1,0 +1,137 @@
+"""Packet-backed replay — the link that makes a promoted case a real test (C7).
+
+Before this, ``replay_case`` could only compare against a verdict an operator
+typed in, so a promoted test asserted nothing in CI. These tests pin that a case
+carrying its recorded evidence is re-decided by the *current* gate.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from mergecraft.evals.store import (
+    CASE_STATUS_BLOCKED,
+    CASE_STATUS_PASSED,
+    CASE_STATUS_REGRESSION,
+    Case,
+    recompute_decision,
+    render_case_text,
+    replay_case,
+)
+from mergecraft.utils.learnings import LearningProvenance
+
+
+def _finding(severity: str = "Critical") -> dict[str, Any]:
+    return {
+        "path": "src/a.py",
+        "start_line": 1,
+        "end_line": 2,
+        "message": "boom",
+        "severity": severity,
+        "confidence": "certain",
+        "category": "Functional Correctness",
+        "source": "agent",
+        "fingerprint": "abc123",
+        "tool": "agent",
+        "rule_id": "agent:1",
+        "introduced_by_pr": "true",
+        "evidence": ["x"],
+        "remediation": "fix it",
+        "autofix": None,
+        "cluster_id": None,
+    }
+
+
+def _case(
+    *,
+    expected: str = "failure",
+    findings: list[dict[str, Any]] | None = None,
+    run_succeeded: bool = True,
+    trust_tier: str = "trusted",
+) -> Case:
+    when = datetime(2026, 8, 10, tzinfo=UTC)
+    return Case(
+        id="case-001",
+        title="t",
+        category="missed_finding",
+        submitted_at=when,
+        run_id="run-1",
+        pr_number=1,
+        failure_mode="wrong_decision",
+        expected_finding="Critical in src/a.py",
+        expected_decision=expected,
+        replay_command="mergecraft eval replay case-001",
+        provenance=LearningProvenance(
+            run_id="run-1",
+            pr_number=1,
+            source_field="eval_bank",
+            author_login="alexhawat",
+            author_association="OWNER",
+            trust_tier="trusted",
+            timestamp=when,
+        ),
+        body="",
+        recorded_findings=findings,
+        run_succeeded=run_succeeded,
+        trust_tier=trust_tier,
+    )
+
+
+def test_a_blocker_is_recomputed_without_an_operator() -> None:
+    assert recompute_decision(_case(findings=[_finding()])) == "failure"
+
+
+def test_a_case_without_evidence_cannot_be_decided() -> None:
+    """Legacy cases keep their old behaviour rather than guessing a verdict."""
+    assert recompute_decision(_case(findings=None)) is None
+    assert _case(findings=None).is_replayable is False
+
+
+def test_replay_uses_recorded_evidence_when_no_verdict_is_supplied() -> None:
+    """The whole point: a promoted test detects drift in CI, unaided."""
+    diff = replay_case(_case(findings=[_finding()]), current_decision=None)
+
+    assert diff.current_decision == "failure"
+    assert diff.status == CASE_STATUS_PASSED
+
+
+def test_replay_reports_a_regression_when_the_gate_drifts() -> None:
+    # The case expects `success`; the gate blocks on a Critical finding.
+    diff = replay_case(_case(expected="success", findings=[_finding()]), current_decision=None)
+
+    assert diff.status == CASE_STATUS_REGRESSION
+
+
+def test_evidenceless_case_still_lands_blocked() -> None:
+    diff = replay_case(_case(findings=None), current_decision=None)
+
+    assert diff.status == CASE_STATUS_BLOCKED
+
+
+def test_an_explicit_verdict_outranks_the_recomputed_one() -> None:
+    """An operator must be able to contradict stored evidence."""
+    diff = replay_case(_case(findings=[_finding()]), current_decision="success")
+
+    assert diff.current_decision == "success"
+    assert diff.status == CASE_STATUS_REGRESSION
+
+
+def test_a_crashed_run_is_never_permissive() -> None:
+    assert recompute_decision(_case(findings=[], run_succeeded=False)) == "neutral"
+
+
+def test_an_untrusted_run_is_never_permissive() -> None:
+    assert recompute_decision(_case(findings=[], trust_tier="untrusted")) == "neutral"
+
+
+def test_unparsable_evidence_reports_cannot_decide_not_a_verdict() -> None:
+    """A schema change that invalidates stored evidence must surface, not guess."""
+    assert recompute_decision(_case(findings=[{"nonsense": True}])) is None
+
+
+def test_recorded_evidence_round_trips_through_the_case_file() -> None:
+    text = render_case_text(_case(findings=[_finding()]))
+
+    assert "recorded_findings" in text
+    assert "run_succeeded" in text


### PR DESCRIPTION
## What?

A case can now record its replay inputs from a merge evidence packet, and replay re-decides it with the current `decide_approval()` instead of asking an operator for the verdict. Seeds the bank with three real merge-gate failures.

Closes #

## Why?

C7's goal was "wire the eval bank to a gate so quality changes are measurable". Investigating it, the loop turned out to be open at the far end.

**A promoted case produced a test that asserted nothing.** Its only unconditional assertion was `diff.status in {"passed", "regression", "blocked"}` — a tautology, since those are the only three statuses. Drift was detectable only if an operator exported `MERGECRAFT_PERMANENT_CURRENT_DECISION` by hand. In CI it passed no matter what the gate did.

The root cause: nothing could compute a verdict. `replay_case()` is pure and takes the current decision as an *input*, and a case stored `expected_finding` as prose — no reproducible input to re-decide from.

**PR #97 made this fixable.** Runs now emit a merge evidence packet, so a case can store the three things `decide_approval()` consumes.

## How

- `Case` gains optional `recorded_findings`, `run_succeeded`, `trust_tier`. `mergecraft eval add --from-packet <packet.json>` fills them.
- `recompute_decision(case)` re-runs `decide_approval()` over the stored evidence — pure, deterministic, no agent, no network, no API key, so it is safe in CI.
- `replay_case()` falls back to it when no verdict is passed. **An explicit verdict still wins**, so a caller can contradict stored evidence.
- Rows are stored verbatim and validated at replay time: a schema change that invalidates them reports "cannot decide" rather than guessing.
- Cases without recorded evidence keep the old behaviour exactly.

## Seeds

The three merge-gate failures **issue #75 actually shipped** — decision-level failures, which is what this bank guards (reviewer recall is ReviewBench's job):

| Case | Contract |
|---|---|
| `issue-75-narrative-approval` | Agent prose must never outvote a blocking finding (D12) |
| `issue-75-crashed-run-not-permissive` | `run_succeeded=False` → `neutral` (D13) |
| `issue-75-untrusted-never-approves` | `tier=untrusted` → `neutral`, the BREAKING change in #87 (D14) |

## Proof it is no longer a tautology

Two cases over identical evidence, promoted, run with **no env var set** — the CI case:

```
FAILED  test_permanent_drift_001   (expects success; gate says failure)
PASSED  test_permanent_good_001    (expects failure; gate says failure)
1 failed, 1 passed
```

And all three seeded cases replay green unaided (`expected: failure / current: failure / status: passed`).

## Three bugs found along the way

1. **`eval gate` reported every promoted case as unpromoted** — it rebuilt the filename instead of calling `permanent_test_path()`, missing the `test_permanent_` prefix. Mine, from #101. Regression test added.
2. **The promoted-test template emitted code that failed the repo's own ruff config** (`I001`), so every future promotion would break lint. Fixed at the template.
3. **The bank's verdict vocabulary had drifted from reality.** `decide_approval()` wraps its `Conclusion` verbatim into `Decision.verdict`, so packets carry `success`/`failure`/`neutral` — of which the bank accepted only `neutral`. A case could never record the verdict the code actually computes. Both vocabularies are now accepted, with the lane one marked as reserved for W9.

## Test plan

- [x] `make ci-resume` from a clean checkpoint — all 9 steps passed (927 passed, 1 skipped, 3 xfailed, 8 xpassed)
- [x] 10 new store tests + 1 gate regression test; the 3 promoted permanent tests now run in the suite
- [x] Driven end-to-end through the real CLI, not only fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)