### PR TITLE
analyzers: run managed analyzers under shell: disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Hardening your workflow no longer costs you every mechanical check. A repo
+  running `pull_request_target` with `shell: disabled` previously got **no**
+  analyzer coverage at all: one boolean withheld mergeCraft's own pinned catalog
+  alongside the repo-declared `staticChecks` it was meant to withhold. Those are
+  now separate decisions. `managed` and `container` analyzers run — 33 of the 57
+  shipped manifests are eligible, whose argv comes verbatim from a manifest
+  mergeCraft ships — while `repo-native` manifests are withheld with a named
+  reason each, since they exist to run *your* tool against *your* config. On that
+  path a binary the repo provides can no longer stand in for the pinned managed
+  one, closing a way a PR could have steered an otherwise-safe analyzer by
+  committing `.venv/bin/<tool>`. `run_static_checks` stays withheld
+  unconditionally and its gates still report `declared-but-cannot-run`; fork,
+  untrusted-tier, and offline `diff-review` behaviour is unchanged. The full
+  runtime × shell × trust matrix is generated into `docs/ANALYZERS.md` (#35)
 - Codex reviews inside a container runner now fail loudly instead of silently.
   Codex CLI runs its own bubblewrap sandbox; inside a Docker container action
   that is already namespaced it cannot create a nested namespace, so every call

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -140,7 +140,9 @@ Offline inspection: `mergecraft analyzers list|detect|run|explain|export --sarif
 
 **Execution preference (D4):** `repo-native` → existing CI result → managed pinned binary → container → **skip with a named reason**. Skipped is skipped — never a finding, never a failed pre-merge row.
 
-**Trust tiers (D7):** `trusted` (same-repo PR, `workflow_dispatch`, offline `diff-review`) vs `untrusted` (fork PR / `pull_request_target` — no secrets, network deny-by-default, no PR-authored command construction; trusted-only manifests skip with reasons). `shell: disabled` withholds both gate and analyzer tools on PR events; offline `diff-review` runs analyzers at trusted tier without shell.
+**Trust tiers (D7):** `trusted` (same-repo PR, `workflow_dispatch`, offline `diff-review`) vs `untrusted` (fork PR / `pull_request_target` — no secrets, network deny-by-default, no PR-authored command construction; trusted-only manifests skip with reasons). Offline `diff-review` runs analyzers at trusted tier without shell.
+
+**`shell: disabled` (#35):** hardening the workflow no longer costs you the catalog. Repo-declared gates stay withheld — they run command strings the PR author controls — but mergeCraft's own **`managed` / `container` analyzers still run**, because their argv comes verbatim from a manifest mergeCraft ships and a repo-provided binary may not stand in for the pinned one. `repo-native` manifests are withheld, each with a named reason, since they exist to run the repo's own tool against the repo's own config. What a consumer sees on a `pull_request_target` + `shell: disabled` run: analyzer rows for the managed tools that matched the diff, `unavailable` rows naming why each other manifest was withheld, and the `staticChecks` gates reported as `declared-but-cannot-run`. The full runtime × shell × trust matrix is generated into [`docs/ANALYZERS.md`](docs/ANALYZERS.md).
 
 **Scoping (D6):** analyzers run on **head** by default; findings outside the diff hunks are dropped unless the path is an explicit exception (new file, dependency manifest, lockfile, workflow, migration). `introduced_by_pr: unknown` when no base run happened — never implied `true`.
 

--- a/docs/ANALYZERS.md
+++ b/docs/ANALYZERS.md
@@ -62,6 +62,44 @@ Shipped mergeCraft catalog analyzers. Rows are generated from manifests — run 
 | `yamllint` | lint | yaml | disabled | managed | untrusted | — | — |
 | `zizmor` | ci | — | auto | managed | untrusted | — | — |
 
+## Runtime x shell x trust
+
+Which analyzers run is decided on two independent axes, each of which can
+skip a manifest with a named reason — a skip is an outcome, never a failure.
+
+- **shell** (`shell:` in the workflow) — may mergeCraft execute anything the
+  PR could have written? Enforced by `evaluate_manifest_for_shell()`.
+- **trust** (derived from the event) — `pull_request_target` and fork-head PRs
+  are `untrusted`. Enforced by `evaluate_manifest_for_tier()`.
+
+Under `shell: disabled`, eligible runtimes are `managed` and `container`.
+Their argv is copied verbatim out of a manifest mergeCraft ships, and a binary
+the repo provides may not stand in for the pinned one, so nothing the PR
+authored is executed. `runtime: repo-native` stays withheld because it exists
+to run the *repo's* tool against the *repo's* config.
+
+| runtime | trust | `shell: disabled` | `shell: restricted` / `enabled` |
+|---------|-------|-------------------|----------------------------------|
+| `repo-native` (23) | `trusted` | withheld — `runtime` needs repo-provided tooling | runs on trusted events; skipped on untrusted |
+| `repo-native` (1) | `untrusted` | withheld — `runtime` needs repo-provided tooling | runs |
+| `managed` (12) | `trusted` | runs on trusted events; skipped with a reason on untrusted ones | runs on trusted events; skipped on untrusted |
+| `managed` (17) | `untrusted` | **runs** (pinned binary only) | runs |
+| `container` (4) | `trusted` | runs on trusted events; skipped with a reason on untrusted ones | runs on trusted events; skipped on untrusted |
+
+Passing the shell axis is necessary, not sufficient: a `container` manifest
+is eligible but still reports `unavailable` wherever no container runtime is
+present, and the seven `declared_unavailable` manifests keep their own skip
+reason. In the shipped Action image that leaves the `managed` rows as the
+analyzers a `shell: disabled` run actually executes.
+
+Repo-declared `staticChecks` are a third thing and are **always** withheld
+under `shell: disabled`, on every event: they run command strings the PR
+author controls. They report `declared-but-cannot-run` rather than vanishing.
+
+`agentsec` declares `runtime: repo-native` and is therefore withheld under
+`shell: disabled`, even though it runs in-process with no repo binary. That
+is deliberate: eligibility is read off the declared runtime and nothing else.
+
 ## Overrides
 
 Enable or disable tools in ``.mergecraft/config.yaml``:

--- a/docs/CONTRIBUTING-ANALYZERS.md
+++ b/docs/CONTRIBUTING-ANALYZERS.md
@@ -26,7 +26,7 @@ Add a new catalog tool with **one manifest YAML**, **one parser fixture**, and *
 | `parser` | Existing parser id (`sarif`, `ruff_json`, …) or `*_native` for inline adapters. |
 | `severity_map` | Maps **every** native severity the parser emits → review taxonomy. |
 | `default_enabled` | `false` for P1–P3 long tail; `auto` only with strong repo detection. |
-| `runtime` | `repo-native` → `managed` → `container` (D4). |
+| `runtime` | `repo-native` → `managed` → `container` (D4). **Also decides eligibility under `shell: disabled`** — see below. |
 | `trust` | `trusted` or `untrusted` (D7). |
 | `exclusive_group` | One winner per group unless repo overrides both (D13/C1). |
 | `declared_unavailable` | Honest skip reason when the tool cannot run yet (C6.4). |
@@ -50,6 +50,31 @@ severities (`Critical`, `Major`, `Minor`, `Trivial`). CI calls `severity_map_com
 - Managed binaries: pin `version`, `provenance[platform].url`, and `sha256`.
 - Untrusted fork PRs: no secret verification, no network unless allowlisted (D7/C2).
 - Container-only heavy tools: `runtime: container`, `default_enabled: false` (D18/C4).
+
+## Eligibility under `shell: disabled` (#35)
+
+Hardened consumers run `pull_request_target` with `shell: disabled`, meaning
+mergeCraft must execute nothing the PR could have written. Your manifest runs on
+that path **only if you declare `runtime: managed` or `runtime: container`**.
+There is no separate opt-in field: `runtime` is the declaration.
+
+What that commits you to:
+
+- **The argv in `command` is the whole command.** It is used verbatim. `{files}`
+  is the only PR-influenced token and it is constrained to paths inside the repo
+  root; `{trufflehog_config}` and `@catalog:` resolve to files mergeCraft ships.
+  If your tool needs a path or flag read out of repo config, it is `repo-native`.
+- **No repo-provided binary.** On this path `resolve_analyzer()` will not fall
+  back to `<repo>/.venv/bin/<tool>` or `<repo>/node_modules/.bin/<tool>`; only
+  the binary pinned by `version` + `provenance` runs. Pin them properly.
+- **`repo-native` is withheld, with a named reason** — not an error, and not
+  silence. That is correct for anything whose contract is "run the repo's tool
+  against the repo's config", which includes every type checker and linter that
+  reads a repo config file.
+
+`agentsec` is `repo-native` and is withheld here even though it runs in-process.
+Eligibility is read off the declared runtime and nothing else, so a manifest is
+never quietly more privileged than it declares.
 
 ## Exception list (bespoke Python allowed)
 

--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -135,8 +135,14 @@ def run_adapter(
     tier: TrustTier = "trusted",
     base_ref: str | None = None,
     offline: bool = False,
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
-    """Run one catalog analyzer and return normalized findings."""
+    """Run one catalog analyzer and return normalized findings.
+
+    ``allow_repo_binaries=False`` (set by the pipeline under ``shell:
+    disabled``) forbids ``resolve_analyzer()`` from preferring a binary the
+    repo provides, so only mergeCraft's pinned managed binary can run (#35).
+    """
     repo_root = repo_root.resolve()
     manifest = get_manifest(tool_id)
 
@@ -155,6 +161,7 @@ def run_adapter(
             changed_files=changed_files,
             base_ref=resolved_base,
             tier=tier,
+            allow_repo_binaries=allow_repo_binaries,
         )
 
     if tool_id in SUPPLY_CHAIN_DIFF_TOOLS:
@@ -172,6 +179,7 @@ def run_adapter(
             changed_files=changed_files,
             base_ref=resolved_base,
             tier=tier,
+            allow_repo_binaries=allow_repo_binaries,
         )
 
     if tool_id == "agentsec":
@@ -208,7 +216,12 @@ def run_adapter(
         logger.info("{}", reason)
         return AdapterRunResult(findings=[], skipped=True, skip_reason=reason)
 
-    plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+    plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=repo_root,
+        managed_available=True,
+        allow_repo_binaries=allow_repo_binaries,
+    )
     if plan.mode == "skip":
         logger.info("{}", plan.reason)
         return AdapterRunResult(findings=[], skipped=True, skip_reason=plan.reason)

--- a/src/mergecraft/analyzers/catalog_docs.py
+++ b/src/mergecraft/analyzers/catalog_docs.py
@@ -133,6 +133,82 @@ def _default_enabled_label(value: bool | str) -> str:
     return "auto"
 
 
+def _shell_trust_matrix_lines() -> list[str]:
+    """Render the runtime x shell x trust matrix from the live predicates (#35, D5).
+
+    Derived from ``SHELL_DISABLED_ELIGIBLE_RUNTIMES`` and the catalog itself so
+    the published matrix cannot drift away from the code that enforces it.
+    """
+    from mergecraft.analyzers.trust import SHELL_DISABLED_ELIGIBLE_RUNTIMES
+
+    counts: dict[tuple[str, str], int] = {}
+    for manifest in load_catalog():
+        key = (manifest.runtime, manifest.trust)
+        counts[key] = counts.get(key, 0) + 1
+
+    lines = [
+        "",
+        "## Runtime x shell x trust",
+        "",
+        "Which analyzers run is decided on two independent axes, each of which can",
+        "skip a manifest with a named reason — a skip is an outcome, never a failure.",
+        "",
+        "- **shell** (`shell:` in the workflow) — may mergeCraft execute anything the",
+        "  PR could have written? Enforced by `evaluate_manifest_for_shell()`.",
+        "- **trust** (derived from the event) — `pull_request_target` and fork-head PRs",
+        "  are `untrusted`. Enforced by `evaluate_manifest_for_tier()`.",
+        "",
+        "Under `shell: disabled`, eligible runtimes are "
+        + " and ".join(
+            f"`{value}`" for value in sorted(SHELL_DISABLED_ELIGIBLE_RUNTIMES, reverse=True)
+        )
+        + ".",
+        "Their argv is copied verbatim out of a manifest mergeCraft ships, and a binary",
+        "the repo provides may not stand in for the pinned one, so nothing the PR",
+        "authored is executed. `runtime: repo-native` stays withheld because it exists",
+        "to run the *repo's* tool against the *repo's* config.",
+        "",
+        "| runtime | trust | `shell: disabled` | `shell: restricted` / `enabled` |",
+        "|---------|-------|-------------------|----------------------------------|",
+    ]
+    for runtime in ("repo-native", "managed", "container"):
+        for trust in ("trusted", "untrusted"):
+            count = counts.get((runtime, trust), 0)
+            if not count:
+                continue
+            eligible = runtime in SHELL_DISABLED_ELIGIBLE_RUNTIMES
+            if not eligible:
+                disabled_cell = "withheld — `runtime` needs repo-provided tooling"
+            elif trust == "trusted":
+                disabled_cell = "runs on trusted events; skipped with a reason on untrusted ones"
+            else:
+                disabled_cell = "**runs** (pinned binary only)"
+            other_cell = (
+                "runs" if trust == "untrusted" else "runs on trusted events; skipped on untrusted"
+            )
+            lines.append(f"| `{runtime}` ({count}) | `{trust}` | {disabled_cell} | {other_cell} |")
+
+    lines.extend(
+        [
+            "",
+            "Passing the shell axis is necessary, not sufficient: a `container` manifest",
+            "is eligible but still reports `unavailable` wherever no container runtime is",
+            "present, and the seven `declared_unavailable` manifests keep their own skip",
+            "reason. In the shipped Action image that leaves the `managed` rows as the",
+            "analyzers a `shell: disabled` run actually executes.",
+            "",
+            "Repo-declared `staticChecks` are a third thing and are **always** withheld",
+            "under `shell: disabled`, on every event: they run command strings the PR",
+            "author controls. They report `declared-but-cannot-run` rather than vanishing.",
+            "",
+            "`agentsec` declares `runtime: repo-native` and is therefore withheld under",
+            "`shell: disabled`, even though it runs in-process with no repo binary. That",
+            "is deliberate: eligibility is read off the declared runtime and nothing else.",
+        ]
+    )
+    return lines
+
+
 def generate_analyzers_doc(manifests: Iterable[AnalyzerManifest] | None = None) -> str:
     """Render ``docs/ANALYZERS.md`` from catalog manifests."""
     rows = sorted(manifests or load_catalog(), key=lambda m: m.id)
@@ -167,6 +243,7 @@ def generate_analyzers_doc(manifests: Iterable[AnalyzerManifest] | None = None) 
             f"{_default_enabled_label(manifest.default_enabled)} | {manifest.runtime} | "
             f"{manifest.trust} | {group} | {note_text} |"
         )
+    lines.extend(_shell_trust_matrix_lines())
     lines.extend(
         [
             "",

--- a/src/mergecraft/analyzers/contracts.py
+++ b/src/mergecraft/analyzers/contracts.py
@@ -140,6 +140,7 @@ def _run_oasdiff(
     changed_files: list[str],
     base_ref: str,
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     scoped = filter_changed_files_for_manifest(manifest, changed_files)
     if not scoped:
@@ -162,7 +163,12 @@ def _run_oasdiff(
             return AdapterRunResult(findings=[], skipped=True, skip_reason=reason)
 
         head_path = repo_root / head_rel
-        plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            managed_available=True,
+            allow_repo_binaries=allow_repo_binaries,
+        )
         provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
         if provisioned is None:
             reason = plan.reason or f"skipped {manifest.id}: provisioning failed"
@@ -196,6 +202,7 @@ def _run_squawk(
     changed_files: list[str],
     base_ref: str,
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     _ = base_ref
     scoped = filter_changed_files_for_manifest(manifest, changed_files)
@@ -214,7 +221,12 @@ def _run_squawk(
             skip_reason=f"skipped {manifest.id}: migration paths missing on disk",
         )
 
-    plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+    plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=repo_root,
+        managed_available=True,
+        allow_repo_binaries=allow_repo_binaries,
+    )
     provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
     if provisioned is None:
         reason = plan.reason or f"skipped {manifest.id}: provisioning failed"
@@ -253,6 +265,7 @@ def _run_buf(
     changed_files: list[str],
     base_ref: str,
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     scoped = filter_changed_files_for_manifest(manifest, changed_files)
     if not scoped:
@@ -275,7 +288,12 @@ def _run_buf(
             return AdapterRunResult(findings=[], skipped=True, skip_reason=reason)
 
         head_path = repo_root / head_rel
-        plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            managed_available=True,
+            allow_repo_binaries=allow_repo_binaries,
+        )
         provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
         if provisioned is None:
             reason = plan.reason or f"skipped {manifest.id}: provisioning failed"
@@ -334,6 +352,7 @@ def run_differential_adapter(
     changed_files: list[str],
     base_ref: str | None,
     tier: TrustTier = "trusted",
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     """Run a differential contract adapter; requires an explicit base ref (D6)."""
     repo_root = repo_root.resolve()
@@ -356,6 +375,7 @@ def run_differential_adapter(
             changed_files=changed_files,
             base_ref=base_ref,
             tier=tier,
+            allow_repo_binaries=allow_repo_binaries,
         )
     if tool_id == "squawk":
         return _run_squawk(
@@ -364,6 +384,7 @@ def run_differential_adapter(
             changed_files=changed_files,
             base_ref=base_ref,
             tier=tier,
+            allow_repo_binaries=allow_repo_binaries,
         )
     if tool_id == "buf":
         return _run_buf(
@@ -372,6 +393,7 @@ def run_differential_adapter(
             changed_files=changed_files,
             base_ref=base_ref,
             tier=tier,
+            allow_repo_binaries=allow_repo_binaries,
         )
     msg = f"unsupported differential contract tool: {tool_id}"
     raise ValueError(msg)

--- a/src/mergecraft/analyzers/pipeline.py
+++ b/src/mergecraft/analyzers/pipeline.py
@@ -19,7 +19,11 @@ from mergecraft.analyzers.scope import (
     scope_findings,
     suppress_withdrawn_findings,
 )
-from mergecraft.analyzers.trust import evaluate_manifest_for_tier
+from mergecraft.analyzers.trust import (
+    allow_repo_provided_binaries,
+    evaluate_manifest_for_shell,
+    evaluate_manifest_for_tier,
+)
 from mergecraft.config import load_repo_settings
 from mergecraft.mcp.review import format_analyzer_inline_body
 from mergecraft.mcp.tool_state import AnalyzerRunState, AnalyzerStatusRow
@@ -98,8 +102,14 @@ def run_analyzer_pipeline(
     inline_budget: int | None = None,
     offline: bool = False,
     base_ref: str | None = None,
+    shell: str = "restricted",
 ) -> AnalyzerRunState:
-    """Run enabled analyzers end-to-end and return scoped, budgeted findings."""
+    """Run enabled analyzers end-to-end and return scoped, budgeted findings.
+
+    ``shell`` is the run's shell policy (``ctx.payload.shell``). Under
+    ``"disabled"`` only manifests whose argv mergeCraft ships are selected, and
+    repo-provided binaries may not stand in for the pinned ones (#35, D5).
+    """
     from mergecraft.tracing.tracer import get_tracer_from_settings
 
     full_settings = load_repo_settings(root=repo_root, load_learnings_files=False)
@@ -128,9 +138,15 @@ def run_analyzer_pipeline(
             ),
         )
 
+    repo_binaries_allowed = allow_repo_provided_binaries(shell=shell)
+
     with tracer.start_span(
         "mergecraft.analyzers.pipeline",
-        attrs_source=lambda: {"tier": tier, "changed_file_count": len(changed_files)},
+        attrs_source=lambda: {
+            "tier": tier,
+            "shell": shell,
+            "changed_file_count": len(changed_files),
+        },
     ) as parent_span:
         rows: list[AnalyzerStatusRow] = []
         raw_findings: list[Finding] = []
@@ -139,6 +155,8 @@ def run_analyzer_pipeline(
 
         for manifest in manifests:
             decision = evaluate_manifest_for_tier(manifest=manifest, tier=tier)
+            if not decision.skipped:
+                decision = evaluate_manifest_for_shell(manifest=manifest, shell=shell)
             if decision.skipped:
                 rows.append(
                     AnalyzerStatusRow(
@@ -166,6 +184,7 @@ def run_analyzer_pipeline(
                         tier=tier,
                         base_ref=base_ref,
                         offline=offline,
+                        allow_repo_binaries=repo_binaries_allowed,
                     )
                 except (KeyError, OSError, ValueError) as exc:
                     logger.info("analyzer {} unavailable: {}", manifest.id, exc)

--- a/src/mergecraft/analyzers/resolve.py
+++ b/src/mergecraft/analyzers/resolve.py
@@ -81,8 +81,18 @@ def resolve_analyzer(
     repo_tool_path: str | None = None,
     repo_tool_version: str | None = None,
     managed_version: str | None = None,
+    allow_repo_binaries: bool = True,
 ) -> AnalyzerPlan:
-    """Resolve D4's preference chain for one manifest."""
+    """Resolve D4's preference chain for one manifest.
+
+    The chain normally prefers a binary the repo provides (``.venv/bin``,
+    ``node_modules/.bin``, …) over mergeCraft's pinned managed one, for every
+    manifest regardless of declared ``runtime``. ``allow_repo_binaries=False``
+    removes that step so only the pinned binary can run — what ``shell:
+    disabled`` requires, since the working tree is then PR-authored (#35, D5).
+    """
+    if not allow_repo_binaries:
+        repo_has_tool = False
     if manifest.declared_unavailable:
         return AnalyzerPlan(
             manifest_id=manifest.id,

--- a/src/mergecraft/analyzers/supply_chain.py
+++ b/src/mergecraft/analyzers/supply_chain.py
@@ -196,11 +196,17 @@ def _run_osv_scan(
     repo_root: Path,
     lockfiles: list[str],
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> tuple[list[Finding], str | None]:
     from mergecraft.analyzers.parsers.osv_json import parse_osv_json
     from mergecraft.analyzers.resolve import resolve_analyzer
 
-    plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+    plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=repo_root,
+        managed_available=True,
+        allow_repo_binaries=allow_repo_binaries,
+    )
     provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
     if provisioned is None:
         return [], plan.reason or f"skipped {manifest.id}: provisioning failed"
@@ -285,10 +291,16 @@ def _run_trivy_fs(
     repo_root: Path,
     files: list[str],
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> tuple[list[Finding], str | None]:
     from mergecraft.analyzers.resolve import resolve_analyzer
 
-    plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+    plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=repo_root,
+        managed_available=True,
+        allow_repo_binaries=allow_repo_binaries,
+    )
     provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
     if provisioned is None:
         return [], plan.reason or f"skipped {manifest.id}: provisioning failed"
@@ -357,13 +369,19 @@ def _run_trivy_config(
     repo_root: Path,
     iac_files: list[str],
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> tuple[list[Finding], str | None]:
     if not iac_files:
         return [], None
 
     from mergecraft.analyzers.resolve import resolve_analyzer
 
-    plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
+    plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=repo_root,
+        managed_available=True,
+        allow_repo_binaries=allow_repo_binaries,
+    )
     provisioned = _provision_plan(plan, manifest=manifest, repo_root=repo_root)
     if provisioned is None:
         return [], plan.reason
@@ -411,6 +429,7 @@ def _scan_side(
     repo_root: Path,
     files: list[str],
     tier: TrustTier,
+    allow_repo_binaries: bool = True,
 ) -> tuple[list[Finding], str | None]:
     snapshot = _snapshot_dir(repo_root, files)
     try:
@@ -420,6 +439,7 @@ def _scan_side(
                 repo_root=snapshot,
                 lockfiles=files,
                 tier=tier,
+                allow_repo_binaries=allow_repo_binaries,
             )
         if tool_id == "trivy":
             fs_findings, err = _run_trivy_fs(
@@ -427,6 +447,7 @@ def _scan_side(
                 repo_root=snapshot,
                 files=files,
                 tier=tier,
+                allow_repo_binaries=allow_repo_binaries,
             )
             if err and not fs_findings:
                 return [], err
@@ -435,6 +456,7 @@ def _scan_side(
                 repo_root=snapshot,
                 iac_files=_iac_files(files),
                 tier=tier,
+                allow_repo_binaries=allow_repo_binaries,
             )
             return fs_findings + config_findings, None
         msg = f"unsupported differential tool: {tool_id}"
@@ -450,6 +472,7 @@ def run_differential_scan(
     head_files: list[str],
     base_files: list[str],
     tier: TrustTier = "trusted",
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     """Run base and head supply-chain scans; publish only the CVE delta (C2.1/C2.2)."""
     repo_root = repo_root.resolve()
@@ -468,6 +491,7 @@ def run_differential_scan(
         repo_root=repo_root,
         files=head_files,
         tier=tier,
+        allow_repo_binaries=allow_repo_binaries,
     )
     if head_err and not head_findings:
         logger.info("{}", head_err)
@@ -479,6 +503,7 @@ def run_differential_scan(
         repo_root=repo_root,
         files=base_files,
         tier=tier,
+        allow_repo_binaries=allow_repo_binaries,
     )
     if base_err and not base_findings and not head_findings:
         return AdapterRunResult(findings=[], skipped=True, skip_reason=base_err)
@@ -493,6 +518,7 @@ def run_supply_chain_adapter(
     changed_files: list[str],
     base_ref: str | None,
     tier: TrustTier = "trusted",
+    allow_repo_binaries: bool = True,
 ) -> AdapterRunResult:
     """Run differential supply-chain adapters through the production adapter path (C2)."""
     from mergecraft.analyzers.registry import filter_changed_files_for_manifest
@@ -521,6 +547,7 @@ def run_supply_chain_adapter(
         head_files=scoped,
         base_files=base_files,
         tier=tier,
+        allow_repo_binaries=allow_repo_binaries,
     )
 
 

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
 
 AnalyzersMode = Literal["off", "auto", "full"]
 
+#: Runtimes whose argv comes verbatim from a mergeCraft-shipped manifest and is
+#: therefore safe to run when the working tree is PR-authored (#35, D5).
+#: ``repo-native`` is excluded because it resolves against repo-provided
+#: binaries and repo-provided config — see :func:`allow_repo_provided_binaries`.
+SHELL_DISABLED_ELIGIBLE_RUNTIMES: frozenset[str] = frozenset({"managed", "container"})
+
 
 @dataclass(frozen=True, slots=True)
 class ManifestTierDecision:
@@ -94,6 +100,51 @@ def evaluate_manifest_for_tier(
     return ManifestTierDecision(skipped=False)
 
 
+def evaluate_manifest_for_shell(
+    *,
+    manifest: AnalyzerManifest,
+    shell: str,
+) -> ManifestTierDecision:
+    """Select manifests eligible to run when the shell is disabled (#35, D5).
+
+    ``shell: disabled`` says "do not execute anything this PR could have
+    written". That rules out ``runtime: repo-native`` manifests, whose whole
+    contract is to run the *repo's* pinned tool against the *repo's* config.
+    It does not rule out ``managed`` / ``container`` manifests, whose argv is
+    copied verbatim out of a manifest mergeCraft ships — which is the coverage
+    hardened consumers were losing.
+
+    Off the ``disabled`` path this predicate is inert, so the tier axis
+    (:func:`evaluate_manifest_for_tier`) keeps deciding alone.
+
+    Returns the same :class:`ManifestTierDecision` shape the tier predicate
+    returns, so skips render through one code path with a named reason (D9).
+    """
+    if shell != "disabled":
+        return ManifestTierDecision(skipped=False)
+    if manifest.runtime in SHELL_DISABLED_ELIGIBLE_RUNTIMES:
+        return ManifestTierDecision(skipped=False)
+    reason = (
+        f"skipped {manifest.id}: runtime {manifest.runtime!r} needs repo-provided tooling, "
+        "withheld under shell: disabled"
+    )
+    logger.info("{}", reason)
+    return ManifestTierDecision(skipped=True, reason=reason)
+
+
+def allow_repo_provided_binaries(*, shell: str) -> bool:
+    """Whether a repo-provided binary may stand in for a pinned one (#35, D5).
+
+    ``resolve_analyzer()`` prefers ``<repo>/.venv/bin/<tool>``,
+    ``<repo>/node_modules/.bin/<tool>`` and friends over mergeCraft's pinned
+    managed binary for *every* manifest, regardless of declared ``runtime``.
+    That preference is what makes an otherwise-safe ``managed`` analyzer
+    steerable by PR content, so under ``shell: disabled`` it is refused and
+    only the pinned binary may run — D5's "constructs no PR-authored command".
+    """
+    return shell != "disabled"
+
+
 def allow_repo_command_overrides(tier: TrustTier) -> bool:
     """Untrusted runs never execute PR-authored command construction (D7)."""
     return tier == "trusted"
@@ -107,24 +158,33 @@ def resolve_analyzers_mode(raw: str | None) -> AnalyzersMode:
 
 
 def analyzers_enabled(ctx: ToolContext) -> bool:
-    """Whether the analyzer MCP surface may register for this run."""
+    """Whether the analyzer MCP surface may register for this run.
+
+    Until #35 this also returned ``False`` for every real PR event whenever
+    ``shell: disabled``, which withheld mergeCraft's own pinned catalog
+    alongside the repo-declared ``staticChecks`` it was meant to withhold — so
+    a repo that hardened correctly got no mechanical coverage at all.
+
+    The two questions are now answered separately. Registration is no longer
+    keyed on the shell; per-manifest eligibility under ``shell: disabled`` is
+    :func:`evaluate_manifest_for_shell`, and ``run_static_checks`` keeps its
+    own unconditional withhold via ``ctx.static_checks_enabled`` (D7).
+    """
     if ctx.analyzers_mode == "off":
         return False
-    if not ctx.analyzers_settings_enabled:
-        return False
-    if ctx.payload.shell == "disabled":
-        # Offline diff-review: operator-owned tree — analyzers still run (W7.8).
-        return ctx.payload.event.trigger == "unknown"
-    return True
+    return bool(ctx.analyzers_settings_enabled)
 
 
 __all__ = [
+    "SHELL_DISABLED_ELIGIBLE_RUNTIMES",
     "AnalyzersMode",
     "ManifestTierDecision",
     "allow_repo_command_overrides",
+    "allow_repo_provided_binaries",
     "analyzers_enabled",
     "build_analyzer_env",
     "derive_trust_tier",
+    "evaluate_manifest_for_shell",
     "evaluate_manifest_for_tier",
     "resolve_analyzers_mode",
 ]

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -53,6 +53,9 @@ def run_analyzers_tool(ctx: ToolContext):
             inline_budget=settings.inline_budget,
             offline=offline,
             base_ref=base_ref,
+            # #35 — the surface now registers under `shell: disabled`, so the
+            # shell has to reach manifest selection or the withhold is lost.
+            shell=str(ctx.payload.shell),
         )
         _store_run_state(ctx, run_state)
 

--- a/tests/analyzers/test_shell_disabled_split.py
+++ b/tests/analyzers/test_shell_disabled_split.py
@@ -64,11 +64,6 @@ def _allow_repo_provided_binaries(*, shell: str) -> Any:
     return trust.allow_repo_provided_binaries(shell=shell)
 
 
-# W1.8 — RED until W2 lands the split. `strict=False` because the regression
-# guards in this module (W1.4/W1.5/W1.6 and the `resolve_analyzer` seam
-# characterisation) already hold today and report XPASS.
-pytestmark = pytest.mark.xfail(reason="green after W2 (#35)", strict=False)
-
 # Real PR triggers — everything that is not the operator-owned offline path.
 PR_TRIGGERS: tuple[str, ...] = ("pull_request", "pull_request_target", "issue_comment")
 
@@ -315,7 +310,12 @@ def test_pipeline_forwards_the_shell_to_the_adapter(
 def test_pipeline_skips_repo_native_manifests_under_shell_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The named skip reaches the operator-visible status rows (D9)."""
+    """The named skip reaches the operator-visible status rows (D9).
+
+    Tier is ``trusted`` here — a same-repo PR that still hardens with
+    ``shell: disabled`` — so the shell axis is the one under test rather than
+    the pre-existing tier axis.
+    """
     from mergecraft.analyzers import adapters, pipeline
 
     def _unexpected(**_: Any) -> adapters.AdapterRunResult:
@@ -328,12 +328,36 @@ def test_pipeline_skips_repo_native_manifests_under_shell_disabled(
     state = pipeline.run_analyzer_pipeline(
         repo_root=tmp_path,
         changed_files=["a.py"],
-        tier="untrusted",
+        tier="trusted",
         shell="disabled",
     )
     rows = {row.id: row for row in state.analyzers}
     assert rows["ruff"].status == "unavailable"
     assert "shell: disabled" in (rows["ruff"].reason or "")
+    assert "repo-native" in (rows["ruff"].reason or "")
+
+
+def test_tier_skip_wins_when_both_axes_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two axes, one row: the tier reason is reported when both would skip."""
+    from mergecraft.analyzers import adapters, pipeline
+
+    monkeypatch.setattr(
+        adapters,
+        "run_adapter",
+        lambda **_: adapters.AdapterRunResult(findings=[], skipped=True, skip_reason="unused"),
+    )
+    monkeypatch.setattr(pipeline, "detect_enabled", lambda **_: [_manifest("ruff")])
+
+    state = pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=["a.py"],
+        tier="untrusted",
+        shell="disabled",
+    )
+    reason = state.analyzers[0].reason or ""
+    assert "requires trusted tier" in reason
 
 
 @pytest.mark.asyncio

--- a/tests/analyzers/test_shell_disabled_split.py
+++ b/tests/analyzers/test_shell_disabled_split.py
@@ -1,0 +1,408 @@
+"""#35 — split the `shell: disabled` withhold (Batch A, W1).
+
+Today `analyzers_enabled()` collapses two unrelated questions into one boolean:
+
+* may the reviewer run **repo-declared `staticChecks`** — PR-authored command
+  strings, which `shell: disabled` exists to forbid; and
+* may the reviewer run **mergeCraft's own pinned catalog analyzers** — argv
+  that comes verbatim from a manifest mergeCraft ships.
+
+Answering "no" to both means a repo that hardens correctly (`pull_request_target`
+plus `shell: disabled`) gets *zero* mechanical coverage on its only real PR path.
+
+These cases pin the split:
+
+* the analyzer surface registers on a real PR event under `shell: disabled`;
+* `run_static_checks` stays withheld unconditionally (D7);
+* only `runtime: managed` / `runtime: container` manifests are eligible, and
+  every ineligible one is skipped with a named reason (D5, D9);
+* a repo-provided binary can never stand in for the pinned managed one on that
+  path — the steerability vector W0.4 found in ``resolve_analyzer()``;
+* the fork/untrusted and offline paths behave exactly as they did before.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.registry import get_manifest, load_catalog
+from mergecraft.analyzers.resolve import resolve_analyzer
+from mergecraft.analyzers.trust import (
+    analyzers_enabled,
+    build_analyzer_env,
+    evaluate_manifest_for_tier,
+)
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.server import build_common_tools
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from tests.analyzers.support import import_module
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.manifest import AnalyzerManifest
+
+
+def _evaluate_manifest_for_shell(*, manifest: AnalyzerManifest, shell: str) -> Any:
+    """Lazy so the module still collects before W2 adds the predicate (W1.8)."""
+    trust = import_module("mergecraft.analyzers.trust")
+    return trust.evaluate_manifest_for_shell(manifest=manifest, shell=shell)
+
+
+def _allow_repo_provided_binaries(*, shell: str) -> Any:
+    trust = import_module("mergecraft.analyzers.trust")
+    return trust.allow_repo_provided_binaries(shell=shell)
+
+
+# W1.8 — RED until W2 lands the split. `strict=False` because the regression
+# guards in this module (W1.4/W1.5/W1.6 and the `resolve_analyzer` seam
+# characterisation) already hold today and report XPASS.
+pytestmark = pytest.mark.xfail(reason="green after W2 (#35)", strict=False)
+
+# Real PR triggers — everything that is not the operator-owned offline path.
+PR_TRIGGERS: tuple[str, ...] = ("pull_request", "pull_request_target", "issue_comment")
+
+# One representative per eligible runtime, plus the ineligible ones W1.3 sweeps.
+MANAGED_ANALYZER_ID = "shellcheck"
+CONTAINER_ANALYZER_ID = "presidio"
+
+
+def _manifest(analyzer_id: str) -> AnalyzerManifest:
+    return get_manifest(analyzer_id)
+
+
+def _catalog_manifests() -> list[AnalyzerManifest]:
+    return sorted(load_catalog(), key=lambda m: m.id)
+
+
+def _ids_by_runtime(runtime: str) -> list[str]:
+    return sorted(m.id for m in _catalog_manifests() if m.runtime == runtime)
+
+
+REPO_NATIVE_IDS: list[str] = _ids_by_runtime("repo-native")
+ELIGIBLE_IDS: list[str] = _ids_by_runtime("managed") + _ids_by_runtime("container")
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    shell: str = "disabled",
+    trigger: str = "pull_request",
+    static_checks_enabled: bool = False,
+    analyzers_mode: str = "auto",
+    analyzers_settings_enabled: bool = True,
+    tier: str = "untrusted",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger=trigger),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        static_checks_enabled=static_checks_enabled,
+        analyzers_mode=analyzers_mode,  # type: ignore[arg-type]
+        analyzers_settings_enabled=analyzers_settings_enabled,
+        trust_tier=tier,  # type: ignore[arg-type]
+    )
+
+
+def _tool_names(ctx: ToolContext) -> set[str]:
+    return {spec.name for spec in build_common_tools(ctx)}
+
+
+# --------------------------------------------------------------------------- #
+# W1.1 — the analyzer surface registers under `shell: disabled` on a PR event
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("trigger", PR_TRIGGERS)
+def test_managed_analyzers_register_when_shell_disabled_on_pr_event(
+    tmp_path: Path, trigger: str
+) -> None:
+    """#35's headline: a hardened repo's real PR path gets the analyzer tools."""
+    ctx = _ctx(tmp_path, shell="disabled", trigger=trigger)
+    assert analyzers_enabled(ctx) is True
+    assert {"run_analyzers", "analyzer_findings"} <= _tool_names(ctx)
+
+
+def test_shell_disabled_surface_still_respects_the_off_switches(tmp_path: Path) -> None:
+    """The split must not swallow the two pre-existing short-circuits."""
+    off = _ctx(tmp_path, shell="disabled", analyzers_mode="off")
+    assert analyzers_enabled(off) is False
+    assert "run_analyzers" not in _tool_names(off)
+
+    disabled_in_config = _ctx(tmp_path, shell="disabled", analyzers_settings_enabled=False)
+    assert analyzers_enabled(disabled_in_config) is False
+    assert "run_analyzers" not in _tool_names(disabled_in_config)
+
+
+# --------------------------------------------------------------------------- #
+# W1.2 — `run_static_checks` stays withheld unconditionally (D7)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("trigger", PR_TRIGGERS)
+def test_static_checks_still_withheld_when_shell_disabled(tmp_path: Path, trigger: str) -> None:
+    """D7: PR-authored command construction is exactly what `disabled` forbids."""
+    ctx = _ctx(tmp_path, shell="disabled", trigger=trigger, static_checks_enabled=False)
+    names = _tool_names(ctx)
+    assert "run_static_checks" not in names
+    # ...while the analyzer surface, which runs no PR-authored command, is present.
+    assert "run_analyzers" in names
+
+
+def test_declared_static_checks_still_report_declared_but_cannot_run() -> None:
+    """The PR-#17 outcome vocabulary is reused, not replaced (D9)."""
+    from mergecraft.review_checks import StaticCheck, declared_cannot_run_outcomes
+
+    checks = [StaticCheck(name="lint", argv=("make", "lint"))]
+    outcomes = declared_cannot_run_outcomes(checks, reason="shell: disabled")
+    assert [row.status for row in outcomes] == ["declared-but-cannot-run"]
+    assert outcomes[0].output == "shell: disabled"
+    assert outcomes[0].ran is False
+
+
+# --------------------------------------------------------------------------- #
+# W1.3 / W1.7 — eligibility is keyed on the declared runtime, skips are named
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("analyzer_id", REPO_NATIVE_IDS)
+def test_repo_native_analyzers_skipped_when_shell_disabled(analyzer_id: str) -> None:
+    """D5: `repo-native` resolves against repo-provided tooling, so it stays withheld."""
+    decision = _evaluate_manifest_for_shell(manifest=_manifest(analyzer_id), shell="disabled")
+    assert decision.skipped is True
+    assert decision.reason
+    assert analyzer_id in decision.reason
+
+
+@pytest.mark.parametrize("analyzer_id", ELIGIBLE_IDS)
+def test_managed_and_container_analyzers_pass_the_shell_gate(analyzer_id: str) -> None:
+    """D5: pinned mergeCraft argv is eligible; 33 of the 57 shipped manifests."""
+    decision = _evaluate_manifest_for_shell(manifest=_manifest(analyzer_id), shell="disabled")
+    assert decision.skipped is False
+    assert decision.reason is None
+
+
+@pytest.mark.parametrize("shell", ["restricted", "enabled"])
+def test_shell_gate_is_inert_when_shell_is_not_disabled(shell: str) -> None:
+    """A regression guard: the new predicate must change nothing off its own path."""
+    for analyzer_id in (MANAGED_ANALYZER_ID, "ruff"):
+        decision = _evaluate_manifest_for_shell(manifest=_manifest(analyzer_id), shell=shell)
+        assert decision.skipped is False
+
+
+def test_skip_reasons_are_named_not_silent() -> None:
+    """D9: every skip is an outcome with a human-readable reason, never a silent drop."""
+    for manifest in _catalog_manifests():
+        decision = _evaluate_manifest_for_shell(manifest=manifest, shell="disabled")
+        if not decision.skipped:
+            continue
+        reason = decision.reason or ""
+        assert reason.startswith(f"skipped {manifest.id}:")
+        assert "shell: disabled" in reason
+        assert manifest.runtime in reason
+
+
+# --------------------------------------------------------------------------- #
+# The W0.4 steerability vector — a repo-provided binary must not stand in
+# --------------------------------------------------------------------------- #
+
+
+def test_repo_provided_binaries_are_refused_when_shell_disabled() -> None:
+    assert _allow_repo_provided_binaries(shell="disabled") is False
+    assert _allow_repo_provided_binaries(shell="restricted") is True
+    assert _allow_repo_provided_binaries(shell="enabled") is True
+
+
+def _plant_fake_binary(repo_root: Path, name: str) -> Path:
+    bin_dir = repo_root / ".venv" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    planted = bin_dir / name
+    planted.write_text("#!/bin/sh\necho 0.0.0-pr-authored\n", encoding="utf-8")
+    planted.chmod(planted.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return planted
+
+
+def test_planted_repo_binary_wins_by_default_but_not_under_shell_disabled(
+    tmp_path: Path,
+) -> None:
+    """The concrete attack W0.4 found, and the seam that closes it.
+
+    ``resolve_analyzer()`` prefers ``<repo>/.venv/bin/<tool>`` over the pinned
+    managed binary for *every* manifest, including ones that declare
+    ``runtime: managed``. Under `shell: disabled` the PR head is untrusted
+    content, so that preference has to be skipped.
+    """
+    manifest = _manifest(MANAGED_ANALYZER_ID)
+    assert manifest.runtime == "managed"
+    planted = _plant_fake_binary(tmp_path, manifest.command[0])
+    assert os.access(planted, os.X_OK)
+
+    default_plan = resolve_analyzer(manifest=manifest, repo_root=tmp_path, managed_available=True)
+    assert default_plan.mode == "repo-native"
+    assert default_plan.argv[0] == str(planted.resolve())
+
+    hardened_plan = resolve_analyzer(
+        manifest=manifest,
+        repo_root=tmp_path,
+        managed_available=True,
+        repo_has_tool=False,
+    )
+    assert hardened_plan.mode == "managed"
+    assert hardened_plan.argv[0] == manifest.command[0]
+    assert str(planted.resolve()) not in hardened_plan.argv
+
+
+# --------------------------------------------------------------------------- #
+# Runtime wiring — the shell has to reach the pipeline and the adapter
+# --------------------------------------------------------------------------- #
+
+
+def test_pipeline_forwards_the_shell_to_the_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A predicate nothing calls is the #96 failure mode. Pin the seam."""
+    from mergecraft.analyzers import adapters, pipeline
+
+    captured: list[dict[str, Any]] = []
+
+    def _fake_run_adapter(**kwargs: Any) -> adapters.AdapterRunResult:
+        captured.append(kwargs)
+        return adapters.AdapterRunResult(findings=[], skipped=True, skip_reason="stubbed")
+
+    monkeypatch.setattr(adapters, "run_adapter", _fake_run_adapter)
+    monkeypatch.setattr(pipeline, "detect_enabled", lambda **_: [_manifest(MANAGED_ANALYZER_ID)])
+
+    pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=["script.sh"],
+        tier="untrusted",
+        shell="disabled",
+    )
+    assert captured, "run_adapter was never reached"
+    assert captured[0]["allow_repo_binaries"] is False
+
+    captured.clear()
+    pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=["script.sh"],
+        tier="trusted",
+        shell="restricted",
+    )
+    assert captured[0]["allow_repo_binaries"] is True
+
+
+def test_pipeline_skips_repo_native_manifests_under_shell_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The named skip reaches the operator-visible status rows (D9)."""
+    from mergecraft.analyzers import adapters, pipeline
+
+    def _unexpected(**_: Any) -> adapters.AdapterRunResult:
+        msg = "a repo-native analyzer must not reach the adapter under shell: disabled"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(adapters, "run_adapter", _unexpected)
+    monkeypatch.setattr(pipeline, "detect_enabled", lambda **_: [_manifest("ruff")])
+
+    state = pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=["a.py"],
+        tier="untrusted",
+        shell="disabled",
+    )
+    rows = {row.id: row for row in state.analyzers}
+    assert rows["ruff"].status == "unavailable"
+    assert "shell: disabled" in (rows["ruff"].reason or "")
+
+
+@pytest.mark.asyncio
+async def test_run_analyzers_tool_passes_the_context_shell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The MCP tool is the only door in; it must forward `ctx.payload.shell`."""
+    import json
+
+    from mergecraft.analyzers import pipeline
+    from mergecraft.mcp.analyzers import run_analyzers_tool
+    from mergecraft.mcp.tool_state import AnalyzerRunState
+
+    seen: dict[str, Any] = {}
+
+    def _fake_pipeline(**kwargs: Any) -> AnalyzerRunState:
+        seen.update(kwargs)
+        return AnalyzerRunState(ran=False, reason="stubbed")
+
+    monkeypatch.setattr(pipeline, "run_analyzer_pipeline", _fake_pipeline)
+
+    ctx = _ctx(tmp_path, shell="disabled", trigger="pull_request_target")
+    result = await run_analyzers_tool(ctx).execute({"changed_files": []})
+    json.loads(result.content[0]["text"])
+    assert seen["shell"] == "disabled"
+
+
+# --------------------------------------------------------------------------- #
+# W1.4 / W1.5 / W1.6 — regression guards: nothing else moves
+# --------------------------------------------------------------------------- #
+
+
+def test_untrusted_tier_selection_unchanged() -> None:
+    """W1.4: the tier axis is orthogonal to the shell axis and must not shift."""
+    trusted_only = _manifest("ruff")
+    assert trusted_only.trust == "trusted"
+    decision = evaluate_manifest_for_tier(manifest=trusted_only, tier="untrusted")
+    assert decision.skipped is True
+    assert "requires trusted tier" in (decision.reason or "")
+
+    untrusted_ok = _manifest(MANAGED_ANALYZER_ID)
+    assert untrusted_ok.trust == "untrusted"
+    assert evaluate_manifest_for_tier(manifest=untrusted_ok, tier="untrusted").skipped is False
+    assert evaluate_manifest_for_tier(manifest=trusted_only, tier="trusted").skipped is False
+
+
+def test_offline_diff_review_path_unchanged(tmp_path: Path) -> None:
+    """W1.5: `trigger == "unknown"` is the operator's own tree — still enabled."""
+    ctx = _ctx(tmp_path, shell="disabled", trigger="unknown", tier="trusted")
+    assert analyzers_enabled(ctx) is True
+    assert {"run_analyzers", "analyzer_findings"} <= _tool_names(ctx)
+
+
+def test_analyzer_env_still_scrubbed_on_untrusted_runs(
+    monkeypatch: pytest.MonkeyPatch, fork_pr_event: dict[str, object]
+) -> None:
+    """W1.6: widening *what runs* must not widen *what it sees*."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_shell_split_canary")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk_shell_split_canary")
+    env = build_analyzer_env(
+        event=fork_pr_event,
+        tier="untrusted",
+        repo_env={
+            "GITHUB_TOKEN": "ghp_shell_split_canary",
+            "ANTHROPIC_API_KEY": "sk_shell_split_canary",
+            "PATH": "/usr/bin",
+        },
+    )
+    joined = " ".join(f"{key}={value}" for key, value in env.items())
+    assert "ghp_shell_split_canary" not in joined
+    assert "sk_shell_split_canary" not in joined
+    assert env.get("PATH") == "/usr/bin"

--- a/tests/analyzers/test_trust.py
+++ b/tests/analyzers/test_trust.py
@@ -57,7 +57,14 @@ def test_trusted_only_manifest_skipped_on_untrusted_tier(fork_pr_event: dict[str
     assert decision.reason
 
 
-def test_shell_disabled_disables_analyzer_surface(tmp_path: Path) -> None:
+def test_shell_disabled_keeps_the_analyzer_surface(tmp_path: Path) -> None:
+    """#35 — `shell: disabled` no longer withholds mergeCraft's own catalog.
+
+    It used to return ``False`` here, which is the whole defect: the withhold
+    was aimed at repo-declared ``staticChecks`` and took the pinned catalog
+    with it. Per-manifest eligibility now lives in
+    ``evaluate_manifest_for_shell`` (see ``test_shell_disabled_split.py``).
+    """
     trust = import_module("mergecraft.analyzers.trust")
     ctx = ToolContext(
         agent_id="claude",
@@ -78,7 +85,7 @@ def test_shell_disabled_disables_analyzer_surface(tmp_path: Path) -> None:
         analyzers_mode="auto",
         analyzers_settings_enabled=True,
     )
-    assert trust.analyzers_enabled(ctx) is False
+    assert trust.analyzers_enabled(ctx) is True
 
 
 def test_w0_probe_event_shape_matches_trusted(same_repo_event: dict[str, object]) -> None:

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -71,6 +71,22 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
         defined_in="agents/verifier.py",
         why="no reachable caller means a `drop` verdict never becomes a withdrawn finding (C6)",
     ),
+    _Contract(
+        symbol="evaluate_manifest_for_shell",
+        defined_in="analyzers/trust.py",
+        why=(
+            "no reachable caller means `shell: disabled` stops filtering manifests at all, so "
+            "repo-native analyzers run against a PR-authored tree (#35)"
+        ),
+    ),
+    _Contract(
+        symbol="allow_repo_provided_binaries",
+        defined_in="analyzers/trust.py",
+        why=(
+            "no reachable caller means a repo-committed .venv/bin binary is preferred over the "
+            "pinned managed one even under `shell: disabled` (#35)"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
## What?

Hardening a workflow no longer costs you every mechanical check.

A repo running pull_request_target with shell: disabled now gets real analyzer findings on its PRs. 33 of the 57 shipped analyzers are eligible there, and the ones that are not are reported as skipped with a reason naming why, rather than disappearing. Repo-declared gates stay withheld exactly as before, and still report declared-but-cannot-run rather than going silent.

The runtime, shell and trust axes are now published as a matrix in docs/ANALYZERS.md, generated from the catalog and the code that enforces it so the two cannot drift apart.

## Why?

Hardened consumers were getting nothing. The safe way to review pull requests from forks is pull_request_target with shell: disabled, and a repo that set that up correctly received zero mechanical coverage on its only real PR path. The only workaround was to loosen shell:, which gives up the reason for hardening in the first place, so it does not count as one.

The withhold was aimed at repo-declared staticChecks, which run command strings the pull request author controls. It also caught mergeCraft's own pinned catalog, whose argv is copied verbatim out of a manifest mergeCraft ships. Those are different risks and they now get different answers. Analyzers that need the repo's own tooling stay withheld, because running the repo's tool against the repo's config is exactly what a PR-authored tree makes unsafe.

Auditing that split turned up a second issue worth closing in the same change. Analyzer resolution preferred a binary the repo provides over mergeCraft's pinned one for every analyzer, regardless of what the analyzer declared, so a pull request that committed an executable at .venv/bin/semgrep would have had it run in place of the pinned scanner. On the shell: disabled path that preference is now refused.

## Note

Nothing changes for repos that do not set shell: disabled. Fork and untrusted-tier selection, secret scrubbing of the analyzer environment, and the offline diff-review path are all unchanged, each with a regression guard.

Eligibility is read off the declared `runtime` field. No manifest field was added and the catalog schema is untouched, so `make catalog-check` is unaffected. One deliberate conservative loss: `agentsec` declares `runtime: repo-native` and is withheld here even though it runs in-process with no repo binary. Following the declared runtime and nothing else keeps a manifest from being quietly more privileged than it says it is. Revisiting it belongs with the mode work in #38.

## Test plan

- [x] `make ci-resume` from a cleared checkpoint: all 9 steps pass (lockcheck, lint, typecheck, pyright, catalog-check, build, example-workflows-check, security, test)
- [x] `make catalog-check`: catalog OK, 57 manifests
- [x] `make test`: 1009 passed, 1 skipped
- [x] New suite `tests/analyzers/test_shell_disabled_split.py`, 77 cases. Against the pre-change tree 70 fail; the 6 that pass are the deliberate regression guards
- [x] `tests/test_runtime_call_sites.py` gains contracts for both new predicates, so neither can become library code with no runtime caller

## Related PR(s)/Issue(s)

Closes #35
