### PR TITLE
feat(ci): normalise existing CI results into review evidence (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unconditionally and its gates still report `declared-but-cannot-run`; fork,
   untrusted-tier, and offline `diff-review` behaviour is unchanged. The full
   runtime × shell × trust matrix is generated into `docs/ANALYZERS.md` (#35)
+- A gate your own CI already proved no longer reports `unavailable`. The Action
+  image has no `make`, no repo venv, and none of your pinned toolchains, so a
+  repo-native gate could only report that it judged nothing — even when a
+  `Verify (…)` job had just run the identical command on the same commit.
+  Declaring `ciEvidence.gates` in `.mergecraft/config.yaml` (a gate name mapped
+  to the exact GitHub check-run name that proves it) rewrites that row to a new
+  `satisfied-by-ci` status naming the check run and its URL. Nothing is inferred:
+  a check run merely *named* like a gate proves nothing, because a pull request
+  can add a workflow with any name it likes, and with no `ciEvidence` block
+  mergeCraft never reads your check runs at all. Only a passing declared run may
+  substitute — a declared run that failed leaves the honest row in place and is
+  reported as a finding instead — and a gate that actually ran in the review
+  always outranks any CI claim about it (#36)
+- CI outcomes are now recorded as structured findings, not just narrated. Each
+  clustered failure from `analyze_ci_failures`, plus any failing check run
+  mapped to a declared gate, becomes a `source: ci` finding on the run and is
+  carried into the merge evidence packet. The blame verdict travels with it:
+  a failure attributed to the diff is `Major` / `introduced_by_pr: true`, while
+  a flaky or pre-existing one is `Minor` / `introduced_by_pr: false`. Since every
+  consumer of findings is monotone in blocking severities, that is what makes
+  "reported, not blamed" mechanical rather than a matter of wording — a flaky
+  pipeline cannot block a clean pull request (#36)
+- SARIF your CI already produced can be read back as review evidence. Naming
+  workflow artifacts under `ciEvidence.sarifArtifacts` ingests their SARIF
+  through the same parser the analyzer catalog uses. Default is empty, in which
+  case no artifact API call is made; ingested results are reported at a
+  non-blocking severity with `introduced_by_pr: unknown`, since SARIF from
+  another pipeline describes the tree rather than this diff (#36)
 - Codex reviews inside a container runner now fail loudly instead of silently.
   Codex CLI runs its own bubblewrap sandbox; inside a Docker container action
   that is already namespaced it cannot create a nested namespace, so every call

--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ signedCommits: false
 staticChecks:                 # mechanical gates the reviewer runs; optional
   - name: lint
     command: make lint
+# ciEvidence:                   # reuse CI you already ran (see REVIEW-CHECKS.md)
+#   gates:                      # <gate name>: <exact GitHub check-run name>
+#     lint: Verify (drift gates)
+#   sarifArtifacts:             # workflow artifacts whose SARIF to ingest
+#     - ruff-sarif
 # analyzers:                    # deterministic catalog tools (see REVIEW-CHECKS.md)
 #   enabled: true               # omit for auto-detect from changed paths
 #   inlineBudget: 8
@@ -305,6 +310,8 @@ staticChecks:                 # mechanical gates the reviewer runs; optional
 ```
 
 With no `staticChecks`, mergecraft discovers `lint` / `format-check` / `typecheck` / `ci-static` targets in your `Makefile` instead.
+
+The Action image has no `make`, no repo venv, and none of your pinned toolchains, so those gates often report `unavailable` even when your own CI just proved them. `ciEvidence.gates` maps a gate to the exact check-run name that proves it, and a **passing** declared run reports the gate as `satisfied-by-ci` instead. Declaration is required — a check run merely *named* like a gate proves nothing — and with no `ciEvidence` block mergecraft never reads your check runs at all.
 
 **Analyzers** (actionlint, zizmor, ShellCheck, Hadolint in this release) run deterministically from YAML manifests when paths match — the reviewer calls `run_analyzers` early and places verified hits inline or in `### 🔧 Mechanical findings`. You can override enablement in `analyzers:`; editing the catalog remains possible but is not the headline workflow (D19).
 

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -113,7 +113,7 @@ Your repo's own gate — unchanged from prior mergeCraft behavior:
 - **Discovered gates** — with nothing declared, mergecraft looks for `lint`, `format-check`, `typecheck`, and `ci-static` Makefile targets. Skipped when `make` is not installed.
 - **Nothing found** → skipped. mergecraft will **not** substitute a linter of its own (`except A, B:` is legal on Python 3.14 and a syntax error on 3.13 — version mismatch manufactures false positives).
 
-Each gate returns one of five statuses; only **`failed`** is a finding:
+Each gate returns one of six statuses; only **`failed`** is a finding:
 
 | Status | Meaning |
 |---|---|
@@ -122,8 +122,24 @@ Each gate returns one of five statuses; only **`failed`** is a finding:
 | `timed_out` | exceeded the per-gate timeout |
 | `unavailable` | executable not installed — judged nothing |
 | `declared-but-cannot-run` | gate is declared in config but this environment cannot execute it (for example `shell: disabled` on a pull-request event) — judged nothing, but the gate is visible instead of silently omitted |
+| `satisfied-by-ci` | the gate did not run here, but a check run your repo **declared** as proof of it passed on this commit — green, with the check run named |
 
 When `staticChecks` are configured but every gate is `unavailable` or `declared-but-cannot-run`, `run_static_checks` returns `ran: false` with an explicit reason and one row per configured gate so the **Mechanical gates** pre-merge row can report skipped instead of implying the repo has no gates.
+
+#### Reusing your CI as gate evidence (`ciEvidence`, #36)
+
+The Action image usually has no `make`, no repo venv, and none of your pinned toolchains — so a gate reports `unavailable` even when your own CI just proved it on the same commit. Declare the mapping and that finished CI stands in:
+
+```yaml
+ciEvidence:
+  gates:
+    lint: Verify (drift gates)   # <gate name>: <exact GitHub check-run name>
+```
+
+- **Declared only.** A check run merely *named* like a gate proves nothing — a pull request can add a workflow with any name it likes. With no `ciEvidence` block mergeCraft never reads your check runs at all.
+- **Only green substitutes.** A declared check run that passed rewrites that gate's row to `satisfied-by-ci`, replacing the `unavailable` row rather than adding a second one. A declared check run that **failed** leaves the honest row in place and is reported as a CI finding — the report never claims a green gate on red evidence.
+- **A gate that actually ran here always wins.** CI cannot overwrite a verdict mergeCraft produced against this diff.
+- **Best effort.** No head SHA, no declared mapping, or a GitHub API error → the gate report is exactly what it would have been without the feature.
 
 ### Catalog analyzers (`run_analyzers`)
 
@@ -181,6 +197,10 @@ To discover a `check_suite_id` for a commit, call `list_check_runs` with the PR 
 - Flaky failures are named flaky rather than treated as the author's defect
 
 The review publishes `### 🚨 CI failures` with clustered root causes, flaky/blame verdicts, and redacted excerpts. The pre-merge **CI** row reports failure count, cluster count, flaky count, PR-attributed count, and whether truncation occurred. Inline CI comments may carry a one-click `suggestion` when the fix is a contained single-hunk edit; pushing a fix commit stays behind the existing `push` permission.
+
+**Recorded as evidence (#36).** Each clustered CI failure is also recorded as a `source: ci` finding on the run and carried into the [merge evidence packet](docs/REVIEW-DOCTRINE.md), keeping the blame verdict it was given: a failure attributed to this PR is `Major` / `introduced_by_pr: true`, while a flaky or pre-existing one is `Minor` / `introduced_by_pr: false`. Since every gate that consumes findings is monotone in blockers, that annotation is what makes "reported, not blamed" mechanical rather than a matter of wording — a flaky pipeline cannot block a clean pull request.
+
+**SARIF your CI already produced.** Naming artifacts under `ciEvidence.sarifArtifacts` lets the reviewer ingest their SARIF as CI findings through the same parser the analyzer catalog uses. Default is empty, in which case no artifact API call is made. Ingested results are reported at a non-blocking severity with `introduced_by_pr: unknown` — SARIF from another pipeline describes the tree, not this diff.
 
 Implementation: [`src/mergecraft/ci/intelligence.py`](src/mergecraft/ci/intelligence.py), [`src/mergecraft/ci/review.py`](src/mergecraft/ci/review.py), [`src/mergecraft/ci/cluster.py`](src/mergecraft/ci/cluster.py), [`src/mergecraft/mcp/ci_intelligence.py`](src/mergecraft/mcp/ci_intelligence.py), [`src/mergecraft/mcp/check_suite.py`](src/mergecraft/mcp/check_suite.py), [`src/mergecraft/mcp/check_runs.py`](src/mergecraft/mcp/check_runs.py).
 

--- a/docs/ANALYZERS.md
+++ b/docs/ANALYZERS.md
@@ -112,3 +112,30 @@ analyzers:
 ```
 
 See [CONTRIBUTING-ANALYZERS.md](CONTRIBUTING-ANALYZERS.md) to add a tool.
+
+## Execution preference
+
+For any given gate, in order — the first that can produce a verdict wins:
+
+1. **`repo-native`** — the repo's own pinned toolchain, when this environment can run it.
+2. **An existing CI result** — a check run the repo *declared* as proof of that gate (#36).
+3. **A managed pinned binary**, then **a container**.
+4. **Skip, with a named reason.** A skip is never a finding.
+
+## CI evidence (#36)
+
+The Action image usually lacks `make`, the repo's venv, and its pinned toolchains, so a repo-native gate reports `unavailable` even when the consumer's own CI just proved the same thing. Declaring the mapping lets that finished CI stand in:
+
+```yaml
+ciEvidence:
+  gates:
+    # <mergeCraft gate name>: <exact GitHub check-run name>
+    lint: Verify (drift gates)
+  sarifArtifacts:
+    - ruff-sarif
+```
+
+- **Declared only.** mergeCraft never infers that a check run *named* `lint` proves the `lint` gate — a pull request can add a workflow with any name it likes. With no `ciEvidence` block nothing is read and no extra API call is made.
+- **Green only substitutes.** A declared check run that passed rewrites the gate row to `satisfied-by-ci`. A declared check run that *failed* leaves the row alone and is reported as a `source: ci` finding instead.
+- **Reported, not blamed.** Findings derived from CI start non-blocking with `introduced_by_pr: unknown`; only the CI-intelligence blame layer (`ci/blame.py`, `ci/flaky.py`) may attribute one to this PR.
+- **Redacted.** Log excerpts are truncated and passed through `analyzers/redact.py` before they enter a finding.

--- a/docs/test-plans/ci-evidence.md
+++ b/docs/test-plans/ci-evidence.md
@@ -1,0 +1,95 @@
+# CI results as analyzer / gate evidence (#36) — test plan
+
+Wave plan: `.ignorelocal/waves/issues-analyzer-ci-evidence-wave-plan.md` (Batch C, W5–W6)
+Worktree: `mergecraft-anz-c-ci-evidence` @ `wave/anz-c-ci-evidence`
+
+Companion to [`ci-intelligence.md`](ci-intelligence.md), which covers the layer this
+one consumes: normalisation, clustering, flaky classification, and blame. This plan
+covers what happens to those signals *afterwards* — how a finished CI outcome becomes
+a `Finding` and when it may change a gate's reported outcome.
+
+## Test files
+
+| File | Covers |
+|------|--------|
+| `tests/ci/test_evidence.py` | The pure contract: check run → `Finding`, SARIF → `Finding`s, declared-mapping resolution, substitution, truncation + redaction, recording round-trip |
+| `tests/ci/test_evidence_seams.py` | The runtime seams: `run_static_checks`, `analyze_ci_failures`, and the end-of-run merge evidence packet |
+| `tests/test_runtime_call_sites.py` | Drift guard — the three CI-evidence entry points must stay reachable from `main.py` / `cli/app.py` *and* stay wired into the tools a review actually calls |
+
+No `xfail` markers survive: the suite was authored red against the pre-change tree
+(both modules failed to import, since `mergecraft.ci.evidence` did not exist) and is
+green as of W6.
+
+## Substitution decision matrix (D10)
+
+Read left to right; the first row that matches decides. "Declared" means the repo's
+`ciEvidence.gates` maps this gate name to this exact check-run name.
+
+| Gate row status | Declared? | Check-run conclusion | Result |
+|---|---|---|---|
+| `passed` / `failed` / `timed_out` | any | any | **Unchanged.** A verdict produced here outranks any CI claim about it |
+| `unavailable` / `declared-but-cannot-run` | no | any | **Unchanged.** Undeclared CI is context, never gate satisfaction |
+| `unavailable` / `declared-but-cannot-run` | yes | `success` | **`satisfied-by-ci`** — the row is *replaced*, never duplicated, and names the check run + URL |
+| `unavailable` / `declared-but-cannot-run` | yes | `failure` / `timed_out` / `action_required` | **Unchanged row**, plus a recorded `source: ci` finding |
+| `unavailable` / `declared-but-cannot-run` | yes | `skipped` / `neutral` / still running | **Unchanged.** No verdict to borrow |
+
+The second row is the security-relevant one: `test_gate_substitution_requires_a_declared_mapping`
+uses a check run named *exactly* like the gate and asserts the similarity buys nothing.
+
+## Blame matrix for CI-derived findings (D11)
+
+| Source | Severity | `introduced_by_pr` | Can block? |
+|---|---|---|---|
+| Bare check run (no retry history, no base comparison) | `Minor` | `unknown` | No |
+| SARIF artifact from the consumer's CI | capped at `Minor` | `unknown` | No |
+| Clustered failure, `annotate_not_caused_by_pr` (flaky / pre-existing) | `Minor` | `false` | No |
+| Clustered failure, `annotate_caused_by_pr` (diff overlap) | `Major` | `true` | Yes |
+
+"Can block" is not a description — it is the property under test. Every consumer of
+findings (`agents.gates.decide_approval`, the merge evidence packet's verdict) is
+monotone in `BLOCKING_SEVERITIES = {Critical, Major}`, so keeping flaky failures at
+`Minor` is *the* mechanism behind "reported, not blamed". Covered by
+`test_flaky_ci_finding_never_blocks_the_approval_gate` and
+`test_flaky_ci_finding_does_not_flip_the_packet_verdict`, with
+`test_pr_attributed_ci_finding_does_block_the_packet_verdict` as the mirror image so
+neither assertion can pass vacuously.
+
+## Runtime seams (the #96 lesson)
+
+Structural tests are not sufficient evidence: `build_packet`, `write_packet` and
+`classify_blast_radius` all shipped with thorough unit tests and no consumer. Each
+CI-evidence entry point therefore has a named runtime call site, asserted by module:
+
+| Symbol | Called from | What breaks silently without it |
+|---|---|---|
+| `substitute_declared_gates` | `mcp/static_checks.py` | A gate the consumer's CI proved goes back to reporting `unavailable` |
+| `record_ci_findings` | `mcp/static_checks.py`, `ci/intelligence.py` | A CI outcome never becomes a `Finding` |
+| `ci_evidence_findings` | `evidence/run_packet.py` | Recorded CI evidence never reaches the packet |
+
+Both seams hang off MCP tools the Review / IncrementalReview prompts name in their
+checklists (`run_static_checks` in step 2, `analyze_ci_failures` when CI failed on the
+head), so reachability is not merely theoretical.
+
+## Redaction (convention 8)
+
+`ci_evidence_lines()` truncates to the *tail* of an excerpt (a build log's informative
+part is where it died), clips each line, caps the total, and passes every surviving
+line through `analyzers/redact.py`. `tests/ci/test_evidence.py` plants
+`tests/ci/support.CANARY_SECRET` in both a raw excerpt and a check-run finding and
+asserts it never appears in the message or the evidence list.
+
+## Failure modes deliberately made non-fatal
+
+| Failure | Behaviour | Test |
+|---|---|---|
+| GitHub check-runs API error | Gate report returned untouched | `test_github_failure_leaves_the_gate_report_unchanged` |
+| No head SHA on the run | No substitution attempted | covered by the early return; no API call |
+| Unreadable / non-SARIF artifact archive | Logged, ingest returns what it has | `_sarif_documents` swallows `BadZipFile` |
+| Malformed recorded finding row | Dropped at read time, packet still built | `ci_evidence_findings` |
+
+## Out of scope
+
+- Fuzzy matching of CI check names to gates (D10).
+- Extending `Finding` (D12) — CI evidence uses `evidence` and `source`.
+- Uploading anything *to* GitHub; that is #39 / Batch D.
+- Non-GitHub CI providers, which remain honestly stubbed.

--- a/src/mergecraft/analyzers/catalog_docs.py
+++ b/src/mergecraft/analyzers/catalog_docs.py
@@ -259,6 +259,46 @@ def generate_analyzers_doc(manifests: Iterable[AnalyzerManifest] | None = None) 
             "```",
             "",
             "See [CONTRIBUTING-ANALYZERS.md](CONTRIBUTING-ANALYZERS.md) to add a tool.",
+            "",
+            "## Execution preference",
+            "",
+            "For any given gate, in order — the first that can produce a verdict wins:",
+            "",
+            "1. **`repo-native`** — the repo's own pinned toolchain, when this "
+            "environment can run it.",
+            "2. **An existing CI result** — a check run the repo *declared* as proof of "
+            "that gate (#36).",
+            "3. **A managed pinned binary**, then **a container**.",
+            "4. **Skip, with a named reason.** A skip is never a finding.",
+            "",
+            "## CI evidence (#36)",
+            "",
+            "The Action image usually lacks `make`, the repo's venv, and its pinned "
+            "toolchains, so a repo-native gate reports `unavailable` even when the "
+            "consumer's own CI just proved the same thing. Declaring the mapping lets "
+            "that finished CI stand in:",
+            "",
+            "```yaml",
+            "ciEvidence:",
+            "  gates:",
+            "    # <mergeCraft gate name>: <exact GitHub check-run name>",
+            "    lint: Verify (drift gates)",
+            "  sarifArtifacts:",
+            "    - ruff-sarif",
+            "```",
+            "",
+            "- **Declared only.** mergeCraft never infers that a check run *named* "
+            "`lint` proves the `lint` gate — a pull request can add a workflow with "
+            "any name it likes. With no `ciEvidence` block nothing is read and no "
+            "extra API call is made.",
+            "- **Green only substitutes.** A declared check run that passed rewrites "
+            "the gate row to `satisfied-by-ci`. A declared check run that *failed* "
+            "leaves the row alone and is reported as a `source: ci` finding instead.",
+            "- **Reported, not blamed.** Findings derived from CI start non-blocking "
+            "with `introduced_by_pr: unknown`; only the CI-intelligence blame layer "
+            "(`ci/blame.py`, `ci/flaky.py`) may attribute one to this PR.",
+            "- **Redacted.** Log excerpts are truncated and passed through "
+            "`analyzers/redact.py` before they enter a finding.",
         ]
     )
     return "\n".join(lines) + "\n"

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -22,7 +22,20 @@ if TYPE_CHECKING:
 CHECK_TIMEOUT_S = 300
 MAX_OUTPUT_CHARS = 8_000
 
-CheckStatus = Literal["passed", "failed", "timed_out", "unavailable", "declared-but-cannot-run"]
+CheckStatus = Literal[
+    "passed",
+    "failed",
+    "timed_out",
+    "unavailable",
+    "declared-but-cannot-run",
+    # #36: the gate did not run *here*, but the consumer's CI ran an
+    # equivalent one and it passed. Only reachable through an explicitly
+    # declared gate → check-run mapping (D10); never inferred from a name.
+    "satisfied-by-ci",
+]
+
+# Statuses that mean "this environment produced no verdict about the diff".
+_NO_VERDICT: frozenset[str] = frozenset({"unavailable", "declared-but-cannot-run"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,11 +51,12 @@ class AnalyzerOutcome:
 
     @property
     def passed(self) -> bool:
-        return self.status == "passed"
+        """True when the gate is proved green — here, or by declared CI evidence."""
+        return self.status in {"passed", "satisfied-by-ci"}
 
     @property
     def ran(self) -> bool:
-        return self.status not in {"unavailable", "declared-but-cannot-run"}
+        return self.status not in _NO_VERDICT
 
 
 def _run_tmpdir(plan: AnalyzerPlan) -> Path:

--- a/src/mergecraft/ci/evidence.py
+++ b/src/mergecraft/ci/evidence.py
@@ -1,0 +1,490 @@
+"""Normalise the consumer's *already-finished* CI into review evidence (#36).
+
+The Action image usually lacks `make`, the repo's venv, and its pinned
+toolchains, so a repo-native gate reports ``unavailable`` even when the
+consumer's own CI just proved the very same thing. This module turns that
+finished CI into two things mergeCraft can use:
+
+* **Findings.** A failing check run, a clustered pipeline failure, or a SARIF
+  artifact becomes a :class:`~mergecraft.analyzers.finding.Finding` with
+  ``source="ci"`` — the one finding model, read and produced, never extended
+  (D12). CI evidence that needs somewhere to live goes in ``evidence``.
+* **Gate substitution.** An ``unavailable`` / ``declared-but-cannot-run`` row
+  becomes ``satisfied-by-ci`` — *only* when the repo declared which CI check
+  run proves that gate (D10). Fuzzy name matching is deliberately absent: a
+  check run merely *named* like a gate must buy nothing, or "CI was green"
+  would silently satisfy a gate CI never ran.
+
+Two rules keep this from turning into author-blame:
+
+* Only a **successful** declared check run may substitute. A declared gate that
+  CI proved *broken* leaves the row alone and is reported as a finding instead,
+  so the report never claims a green gate on red evidence.
+* Findings derived from CI start at a non-blocking severity with
+  ``introduced_by_pr="unknown"``. Attribution is the CI-intelligence layer's
+  job (``ci/blame.py``, ``ci/flaky.py``); until it speaks, a CI failure is
+  *reported, not blamed* (D11). The approval gate is monotone in blockers, so
+  this is what stops a flaky pipeline from blocking a clean PR.
+
+Everything here is pure. The MCP tools stay the I/O boundary.
+
+Exports:
+    GateSubstitution: One audited gate outcome change, with its check run.
+    check_run_to_finding: Normalise one GitHub check run into a Finding.
+    ci_evidence_findings: Read back the run's recorded CI findings.
+    ci_evidence_lines: Truncate + redact a log excerpt for a finding.
+    declared_check_run: Resolve a gate to its declared check run (D10).
+    declared_gate_findings: Findings for declared gates CI proved broken.
+    record_ci_findings: Record CI findings on the run's tool state.
+    record_gate_substitutions: Record substitutions for audit.
+    sarif_findings: Parse a CI SARIF artifact into CI-sourced findings.
+    substitute_declared_gates: Replace unavailable rows CI already proved.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from mergecraft.analyzers.finding import Finding, FindingValidationError, make_finding
+from mergecraft.analyzers.manifest import AnalyzerManifest, DetectRules
+from mergecraft.analyzers.parsers.sarif import parse_sarif
+from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.ci.paths import failure_line, primary_failure_path
+from mergecraft.review_taxonomy import finding_fingerprint
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from mergecraft.analyzers.run import AnalyzerOutcome, CheckStatus
+    from mergecraft.mcp.tool_state import CiEvidenceState, ToolState
+
+CI_TOOL = "ci"
+"""``Finding.tool`` for evidence read straight off a check run."""
+
+CI_CATEGORY = "Stability & Availability"
+"""A pipeline outcome is an availability signal, whatever the gate measured."""
+
+SATISFIED_BY_CI: CheckStatus = "satisfied-by-ci"
+"""Gate status meaning: not run here, proved by a declared CI check run."""
+
+# Statuses a declared CI result is allowed to replace. A gate mergeCraft
+# actually executed always outranks a CI claim about it — otherwise a stale
+# green check run could paper over a gate failing on this very diff.
+_REPLACEABLE: frozenset[str] = frozenset({"unavailable", "declared-but-cannot-run"})
+
+# GitHub check-run conclusions that mean "this gate did not pass".
+_FAILING_CONCLUSIONS: frozenset[str] = frozenset(
+    {"failure", "timed_out", "action_required", "startup_failure"}
+)
+
+# The only conclusion that may stand in for a gate mergeCraft could not run.
+_PASSING_CONCLUSION = "success"
+
+# Severity ceiling for anything derived from CI (D11). Nothing here may reach
+# `agents.gates.BLOCKING_SEVERITIES` on its own; only the blame layer promotes.
+_UNBLAMED_SEVERITY = "Minor"
+
+_EXCERPT_LINES = 12
+_EXCERPT_LINE_CHARS = 200
+_EXCERPT_TOTAL_CHARS = 2_000
+
+
+@dataclass(frozen=True, slots=True)
+class GateSubstitution:
+    """One gate outcome a declared CI check run changed, recorded for audit."""
+
+    gate: str
+    check_run: str
+    conclusion: str
+    url: str | None = None
+
+    @property
+    def summary(self) -> str:
+        """Human-readable provenance for the substituted row."""
+        tail = f" — {self.url}" if self.url else ""
+        return (
+            f"not run here; the repo declares CI check run `{self.check_run}` as proof "
+            f"of this gate, and it concluded `{self.conclusion}`{tail}"
+        )
+
+    def as_row(self) -> dict[str, Any]:
+        """Serialise for the MCP payload and the recorded audit trail."""
+        return {
+            "gate": self.gate,
+            "checkRun": self.check_run,
+            "conclusion": self.conclusion,
+            "url": self.url,
+        }
+
+
+# ── log excerpts ──────────────────────────────────────────────────────────────
+
+
+def ci_evidence_lines(
+    text: str,
+    *,
+    limit: int = _EXCERPT_LINES,
+    max_chars: int = _EXCERPT_TOTAL_CHARS,
+) -> list[str]:
+    """Return the tail of a CI log excerpt, truncated and redacted.
+
+    The tail, not the head: a build log's informative part is where it died.
+    Redaction runs *after* truncation on the surviving lines, so a secret can
+    never ride along in a line that was going to be kept anyway.
+    """
+    if limit <= 0 or not text.strip():
+        return []
+    kept = [line.strip() for line in text.splitlines() if line.strip()][-limit:]
+    lines: list[str] = []
+    budget = max_chars
+    for line in kept:
+        clipped = redact_secrets(line[:_EXCERPT_LINE_CHARS])
+        if len(clipped) > budget:
+            clipped = clipped[:budget]
+        if not clipped:
+            continue
+        lines.append(clipped)
+        budget -= len(clipped)
+        if budget <= 0:
+            break
+    return lines
+
+
+# ── check runs → findings ─────────────────────────────────────────────────────
+
+
+def _check_run_name(check_run: Mapping[str, Any]) -> str:
+    return str(check_run.get("name") or "").strip()
+
+
+def _check_run_conclusion(check_run: Mapping[str, Any]) -> str:
+    return str(check_run.get("conclusion") or "").strip().lower()
+
+
+def _check_run_url(check_run: Mapping[str, Any]) -> str | None:
+    url = check_run.get("html_url") or check_run.get("details_url")
+    return str(url) if url else None
+
+
+def _output_title(check_run: Mapping[str, Any]) -> str:
+    output = check_run.get("output")
+    if isinstance(output, Mapping):
+        title = output.get("title")
+        if title:
+            return redact_secrets(str(title))
+    return ""
+
+
+def check_run_to_finding(
+    check_run: Mapping[str, Any],
+    *,
+    gate: str | None = None,
+    log_excerpt: str | None = None,
+) -> Finding | None:
+    """Normalise one completed check run into a CI finding, or ``None``.
+
+    ``None`` for anything that is not a completed failure: a green, skipped, or
+    still-running check run is *evidence*, and manufacturing a finding from it
+    would put noise where the issue asked for signal.
+
+    The finding is deliberately unblamed — ``Minor`` / ``unknown`` — because a
+    bare check run carries no retry history and no base-branch comparison, so
+    nothing here can honestly say this PR caused it (D11). ``ci/blame.py`` and
+    ``ci/flaky.py`` promote it when they can prove attribution.
+    """
+    if str(check_run.get("status") or "completed").strip().lower() != "completed":
+        return None
+    conclusion = _check_run_conclusion(check_run)
+    if conclusion not in _FAILING_CONCLUSIONS:
+        return None
+
+    name = _check_run_name(check_run) or "unnamed check run"
+    excerpt = log_excerpt or ""
+    path = primary_failure_path(excerpt) if excerpt else "ci/pipeline"
+    line = failure_line(excerpt, path=path) if excerpt and path != "ci/pipeline" else 1
+
+    title = _output_title(check_run)
+    gate_clause = f" (declared proof of gate `{gate}`)" if gate else ""
+    message = f"CI check run `{name}` concluded `{conclusion}`{gate_clause}"
+    if title:
+        message = f"{message} — {title}"
+
+    evidence = [f"check run: {name} ({conclusion})"]
+    url = _check_run_url(check_run)
+    if url:
+        evidence.append(url)
+    evidence.extend(ci_evidence_lines(excerpt))
+
+    return make_finding(
+        tool=CI_TOOL,
+        rule_id=f"check-run/{conclusion}",
+        category=CI_CATEGORY,
+        severity=_UNBLAMED_SEVERITY,
+        confidence="likely",
+        message=message,
+        path=path,
+        start_line=line,
+        end_line=line,
+        source="ci",
+        evidence=evidence,
+        introduced_by_pr="unknown",
+    )
+
+
+# ── declared gate mapping (D10) ───────────────────────────────────────────────
+
+
+def declared_check_run(
+    gate: str,
+    *,
+    mapping: Mapping[str, str],
+    check_runs: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the completed check run the repo *declared* as proof of ``gate``.
+
+    Exact, declared, completed — all three. No mapping means no match however
+    suggestive the names are; that absence is the whole security property of
+    D10, so it is expressed as an early return rather than a scoring rule.
+    """
+    declared = str(mapping.get(gate) or "").strip()
+    if not declared:
+        return None
+    for check_run in check_runs:
+        if _check_run_name(check_run) != declared:
+            continue
+        if str(check_run.get("status") or "completed").strip().lower() != "completed":
+            continue
+        return dict(check_run)
+    return None
+
+
+def substitute_declared_gates(
+    outcomes: Sequence[AnalyzerOutcome],
+    *,
+    mapping: Mapping[str, str],
+    check_runs: Sequence[Mapping[str, Any]],
+) -> tuple[list[AnalyzerOutcome], list[GateSubstitution]]:
+    """Replace gates CI already proved with ``satisfied-by-ci`` rows.
+
+    Returns the rewritten outcome list — same length, same order, one row per
+    gate — and the substitutions that were applied. Replacing rather than
+    appending is what removes the duplicate/``unavailable`` noise the issue
+    names; a caller that appended would report the gate twice.
+    """
+    if not mapping or not check_runs:
+        return list(outcomes), []
+
+    updated: list[AnalyzerOutcome] = []
+    substitutions: list[GateSubstitution] = []
+    for outcome in outcomes:
+        if outcome.status not in _REPLACEABLE:
+            updated.append(outcome)
+            continue
+        check_run = declared_check_run(outcome.name, mapping=mapping, check_runs=check_runs)
+        if check_run is None or _check_run_conclusion(check_run) != _PASSING_CONCLUSION:
+            updated.append(outcome)
+            continue
+        substitution = GateSubstitution(
+            gate=outcome.name,
+            check_run=_check_run_name(check_run),
+            conclusion=_check_run_conclusion(check_run),
+            url=_check_run_url(check_run),
+        )
+        substitutions.append(substitution)
+        updated.append(
+            dataclasses.replace(
+                outcome,
+                status=SATISFIED_BY_CI,
+                output=substitution.summary,
+                exit_code=None,
+            )
+        )
+    return updated, substitutions
+
+
+def declared_gate_findings(
+    outcomes: Sequence[AnalyzerOutcome],
+    *,
+    mapping: Mapping[str, str],
+    check_runs: Sequence[Mapping[str, Any]],
+) -> list[Finding]:
+    """Findings for declared gates whose CI check run did *not* pass.
+
+    The mirror of :func:`substitute_declared_gates`: a gate mergeCraft could not
+    run and CI proved broken must not vanish into an ``unavailable`` row, but it
+    also must not be silently upgraded to a green one. It is reported.
+    """
+    if not mapping or not check_runs:
+        return []
+    findings: list[Finding] = []
+    for outcome in outcomes:
+        if outcome.status not in _REPLACEABLE:
+            continue
+        check_run = declared_check_run(outcome.name, mapping=mapping, check_runs=check_runs)
+        if check_run is None:
+            continue
+        finding = check_run_to_finding(check_run, gate=outcome.name)
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+# ── SARIF artifacts ───────────────────────────────────────────────────────────
+
+
+def _ci_sarif_manifest(artifact: str) -> AnalyzerManifest:
+    """A synthetic manifest so CI SARIF reuses the catalog's SARIF parser.
+
+    ``parse_sarif`` reads exactly three things off a manifest — the tool id, the
+    taxonomy category, and the native-severity map. Building those here reuses
+    the audited parser instead of forking a second SARIF reader that would drift
+    from it. The manifest never enters the catalog, so ``make catalog-check``
+    neither sees nor validates it.
+    """
+    return AnalyzerManifest(
+        id=f"{CI_TOOL}:{artifact}",
+        category="lint",
+        languages=[],
+        detect=DetectRules(files=["**/*"]),
+        command=[],
+        scope="diff",
+        parser="sarif",
+        supports_fix=False,
+        default_enabled=False,
+        version="0",
+        runtime="managed",
+        timeout_s=1,
+        trust="untrusted",
+        severity_map={"error": "Major", "warning": "Minor", "note": "Trivial"},
+        provenance={},
+        network_allowlist=[],
+    )
+
+
+def _as_unblamed_ci_finding(finding: Finding, *, tool: str) -> Finding:
+    """Re-stamp an analyzer-shaped finding as unblamed CI evidence.
+
+    Severity is capped rather than preserved: SARIF uploaded by someone else's
+    pipeline describes the tree, not this diff, so it may inform a reviewer but
+    must never block a merge on its own (D11). The message is redacted and the
+    fingerprint recomputed from the redacted text, so the stored hash always
+    matches the text a human will read.
+    """
+    message = redact_secrets(finding.message)
+    severity = finding.severity if finding.severity in {"Minor", "Trivial"} else _UNBLAMED_SEVERITY
+    return finding.model_copy(
+        update={
+            "tool": tool,
+            "source": "ci",
+            "severity": severity,
+            "introduced_by_pr": "unknown",
+            "message": message,
+            "evidence": [redact_secrets(item) for item in finding.evidence],
+            "fingerprint": finding_fingerprint(path=finding.path, body=message),
+        }
+    )
+
+
+def sarif_findings(raw: str, *, artifact: str, repo_root: Path) -> list[Finding]:
+    """Parse a SARIF artifact produced by the consumer's CI into CI findings.
+
+    Raises whatever ``parse_sarif`` raises for a malformed document — the
+    caller decides whether a bad artifact is fatal (it is not, at the MCP
+    boundary) rather than having that decision baked in here.
+    """
+    tool = f"{CI_TOOL}:{artifact}"
+    parsed = parse_sarif(raw, manifest=_ci_sarif_manifest(artifact), repo_root=repo_root)
+    return [_as_unblamed_ci_finding(finding, tool=tool) for finding in parsed]
+
+
+# ── recording on the run's state ──────────────────────────────────────────────
+
+
+def _evidence_state(state: ToolState) -> CiEvidenceState:
+    from mergecraft.mcp.tool_state import CiEvidenceState
+
+    if state.ci_evidence is None:
+        state.ci_evidence = CiEvidenceState()
+    return state.ci_evidence
+
+
+def record_ci_findings(state: ToolState, findings: Iterable[Finding]) -> list[Finding]:
+    """Record CI findings on the run, deduplicated on fingerprint.
+
+    Deduplication matters because the approval gate and the evidence packet are
+    monotone in blockers: the same failure read twice (once off a check run,
+    once off the clustered logs) must not count twice. Returns the findings
+    that were newly added.
+    """
+    evidence = _evidence_state(state)
+    seen = {str(row.get("fingerprint")) for row in evidence.findings}
+    added: list[Finding] = []
+    for finding in findings:
+        if finding.fingerprint in seen:
+            continue
+        seen.add(finding.fingerprint)
+        evidence.findings.append(finding.model_dump())
+        added.append(finding)
+    if added:
+        logger.info("ci evidence: recorded {} finding(s) from CI", len(added))
+    return added
+
+
+def record_gate_substitutions(
+    state: ToolState, substitutions: Iterable[GateSubstitution]
+) -> list[dict[str, Any]]:
+    """Record which gates a declared CI result satisfied, for audit."""
+    evidence = _evidence_state(state)
+    rows = [substitution.as_row() for substitution in substitutions]
+    evidence.substitutions.extend(rows)
+    for row in rows:
+        logger.info(
+            "ci evidence: gate {} reported satisfied by CI check run {}",
+            row["gate"],
+            row["checkRun"],
+        )
+    return rows
+
+
+def ci_evidence_findings(state: ToolState) -> list[Finding]:
+    """Return the run's recorded CI findings as typed ``Finding`` objects.
+
+    Malformed rows are dropped with a debug line rather than raised: CI
+    evidence is supplementary, and one bad row must not take down the packet
+    that carries the rest of the run's evidence.
+    """
+    evidence = state.ci_evidence
+    if evidence is None:
+        return []
+    typed: list[Finding] = []
+    for row in evidence.findings:
+        if not isinstance(row, dict):
+            continue
+        try:
+            typed.append(Finding.model_validate(row))
+        except (FindingValidationError, ValueError) as err:
+            logger.debug("ci evidence: dropping malformed finding row: {}", err)
+    return typed
+
+
+__all__ = [
+    "CI_CATEGORY",
+    "CI_TOOL",
+    "SATISFIED_BY_CI",
+    "GateSubstitution",
+    "check_run_to_finding",
+    "ci_evidence_findings",
+    "ci_evidence_lines",
+    "declared_check_run",
+    "declared_gate_findings",
+    "record_ci_findings",
+    "record_gate_substitutions",
+    "sarif_findings",
+    "substitute_declared_gates",
+]

--- a/src/mergecraft/ci/intelligence.py
+++ b/src/mergecraft/ci/intelligence.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import re
+import zipfile
+from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from loguru import logger
 
 from mergecraft.ci.providers.github_actions import GitHubActionsProvider
 
 if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
     from mergecraft.ci.review import CiClusterReport, CiReviewStats
     from mergecraft.mcp.context import ToolContext
 
 _COMMAND_HINT = re.compile(r"(make\s+\S+|uv run\s+\S+|pytest[^\n]*)")
 _GITHUB_PROVIDER = GitHubActionsProvider()
+
+# A consumer's SARIF artifact is a zip; only these members are parsed.
+_SARIF_SUFFIXES = (".sarif", ".sarif.json")
 
 
 def provider_jobs_to_raw_failures(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -133,6 +142,69 @@ def intelligence_from_failures(
     return payload
 
 
+def _sarif_documents(archive: bytes) -> list[str]:
+    """Return every SARIF document inside an artifact zip."""
+    try:
+        with zipfile.ZipFile(BytesIO(archive)) as zf:
+            return [
+                zf.read(name).decode("utf-8", errors="replace")
+                for name in zf.namelist()
+                if name.lower().endswith(_SARIF_SUFFIXES)
+            ]
+    except (zipfile.BadZipFile, OSError, KeyError) as err:
+        logger.warning("ci evidence: unreadable SARIF artifact archive — {}", err)
+        return []
+
+
+async def collect_ci_sarif_findings(
+    ctx: ToolContext,
+    *,
+    check_suite_id: int,
+) -> list[Finding]:
+    """Ingest SARIF the consumer's CI already produced, for declared artifacts only.
+
+    Opt-in by construction: with no ``ciEvidence.sarifArtifacts`` declared this
+    makes no API call at all. Every failure is logged and swallowed — SARIF is a
+    supplementary evidence source and must never take a review down with it.
+    """
+    wanted = {name.strip() for name in ctx.ci_sarif_artifacts if name.strip()}
+    if not wanted:
+        return []
+
+    from mergecraft.ci.evidence import sarif_findings
+    from mergecraft.mcp.tool_state import primary_repo_state
+
+    repo_root = Path(primary_repo_state(ctx.tool_state).dir)
+    findings: list[Finding] = []
+    try:
+        payload = await ctx.github.get(
+            f"/repos/{ctx.repo.owner}/{ctx.repo.name}/actions/runs",
+            params={"check_suite_id": check_suite_id, "per_page": 100},
+        )
+        runs = payload.get("workflow_runs") or [] if isinstance(payload, dict) else []
+        for run in runs:
+            run_id = run.get("id")
+            if not isinstance(run_id, int):
+                continue
+            artifacts = await ctx.github.list_workflow_run_artifacts(
+                ctx.repo.owner, ctx.repo.name, run_id
+            )
+            for artifact in artifacts:
+                name = str(artifact.get("name") or "")
+                artifact_id = artifact.get("id")
+                if name not in wanted or not isinstance(artifact_id, int):
+                    continue
+                archive = await ctx.github.download_artifact_zip(
+                    ctx.repo.owner, ctx.repo.name, artifact_id
+                )
+                for document in _sarif_documents(archive):
+                    findings.extend(sarif_findings(document, artifact=name, repo_root=repo_root))
+    except Exception as err:
+        logger.warning("ci evidence: SARIF artifact ingest failed — {}", err)
+        return findings
+    return findings
+
+
 async def run_ci_intelligence(
     ctx: ToolContext,
     *,
@@ -143,8 +215,21 @@ async def run_ci_intelligence(
     base_branch_status: str | None = None,
     fix_suggestions: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Fetch check-suite logs, analyze failures, and return review-ready CI intelligence."""
+    """Fetch check-suite logs, analyze failures, and return review-ready CI intelligence.
+
+    Also *records* what it derived (#36). Before this, the clustered findings
+    existed only inside the rendered markdown the agent pasted into its review —
+    nothing structural kept them, so the merge evidence packet could not see that
+    CI had failed at all. They are recorded carrying their blame annotations, so a
+    flaky failure stays ``Minor`` / ``introduced_by_pr="false"`` and cannot block
+    (D11).
+    """
+    from mergecraft.ci.evidence import record_ci_findings
     from mergecraft.ci.review import analyze_ci_failures
+
+    sarif = await collect_ci_sarif_findings(ctx, check_suite_id=check_suite_id)
+    if sarif:
+        record_ci_findings(ctx.tool_state, sarif)
 
     suite = await _GITHUB_PROVIDER.fetch_check_suite_logs(ctx, check_suite_id=check_suite_id)
     jobs = suite.get("jobs") or []
@@ -158,6 +243,7 @@ async def run_ci_intelligence(
             "section": "",
             "preMergeSummary": "",
             "comments": [],
+            "sarifFindingCount": len(sarif),
             "stats": {
                 "failureCount": 0,
                 "clusterCount": 0,
@@ -186,13 +272,17 @@ async def run_ci_intelligence(
         raw_failures=raw_failures,
         fix_suggestions=fix_suggestions,
     )
+    recorded = record_ci_findings(ctx.tool_state, [report.finding for report in reports])
     payload["available"] = True
     payload["checkSuiteId"] = check_suite_id
+    payload["recordedFindingCount"] = len(recorded) + len(sarif)
+    payload["sarifFindingCount"] = len(sarif)
     return payload
 
 
 __all__ = [
     "build_ci_intelligence_payload",
+    "collect_ci_sarif_findings",
     "intelligence_from_failures",
     "provider_jobs_to_raw_failures",
     "run_ci_intelligence",

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -61,6 +61,28 @@ class StaticCheckDefinition(BaseModel):
     suffixes: list[str] = Field(default_factory=list)
 
 
+class CiEvidenceSettings(BaseModel):
+    """Which of the repo's *own* CI results mergeCraft may treat as evidence (#36).
+
+    Both fields default empty, so a repo that declares no ``ciEvidence`` block
+    sees identical behaviour and makes zero extra API calls (convention 9).
+
+    ``gates`` maps a mergeCraft gate name — a ``staticChecks`` entry's ``name``,
+    or a discovered Makefile target — to the exact GitHub check-run name that
+    proves it. The mapping is explicit on purpose (D10): mergeCraft never infers
+    that a check run *called* ``lint`` proves the ``lint`` gate, because a PR
+    could add a workflow with any name it likes.
+
+    ``sarifArtifacts`` lists workflow artifact names whose SARIF the reviewer may
+    ingest as CI findings.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    gates: dict[str, str] = Field(default_factory=dict)
+    sarif_artifacts: list[str] = Field(default_factory=list, alias="sarifArtifacts")
+
+
 class AnalyzerOverride(BaseModel):
     """Per-analyzer config override."""
 
@@ -207,6 +229,9 @@ class RepoSettings(BaseModel):
     signed_commits: bool = Field(default=False, alias="signedCommits")
     mode_instructions: dict[str, str] = Field(default_factory=dict, alias="modeInstructions")
     static_checks: list[StaticCheckDefinition] = Field(default_factory=list, alias="staticChecks")
+    # #36 / D10 — declared-only reuse of the repo's finished CI. Default empty:
+    # no declaration, no substitution, no extra API call.
+    ci_evidence: CiEvidenceSettings = Field(default_factory=CiEvidenceSettings, alias="ciEvidence")
     analyzers: AnalyzersSettings = Field(default_factory=AnalyzersSettings)
     learnings: str | None = None
     learnings_headings: list[LearningsHeading] = Field(

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -205,14 +205,23 @@ def _structural_findings(
     deduplicated on ``Finding.fingerprint`` — the model's own stable content
     hash — because an analyzer finding the agent also reported must not be
     counted twice by a gate that is monotone in blockers.
+
+    CI evidence (#36) joins here rather than in ``_load_structural_findings``
+    on purpose. The packet is evidence *for this merge*, so a failure the
+    consumer's CI already proved belongs in it; the ``mergecraft-approval``
+    check-run keeps its existing, narrower input set. Flaky and pre-existing
+    CI failures arrive annotated ``Minor`` / ``introduced_by_pr="false"``, so
+    they are recorded without ever reaching the packet's blocker set (D11).
     """
+    from mergecraft.ci.evidence import ci_evidence_findings
     from mergecraft.utils.status_checks import _load_structural_findings
 
     merged: list[Finding] = list(_load_structural_findings(ctx))
-    if not extra:
+    incoming = [*ci_evidence_findings(ctx.tool_state), *(extra or [])]
+    if not incoming:
         return merged
     seen = {item.fingerprint for item in merged}
-    for item in extra:
+    for item in incoming:
         if item.fingerprint in seen:
             continue
         seen.add(item.fingerprint)

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -249,6 +249,8 @@ async def main() -> MainResult:
             static_checks_enabled=(
                 ctx_payload.shell != "disabled" and allow_repo_command_overrides(trust_tier)
             ),
+            ci_gate_checks=dict(settings.ci_evidence.gates),
+            ci_sarif_artifacts=list(settings.ci_evidence.sarif_artifacts),
             analyzers_mode=analyzers_mode,
             trust_tier=trust_tier,
             analyzers_settings_enabled=settings.analyzers.enabled,

--- a/src/mergecraft/mcp/context.py
+++ b/src/mergecraft/mcp/context.py
@@ -81,6 +81,12 @@ class ToolContext:
     # `diff-review` path sets this True regardless, because there the config and
     # the working tree both belong to the operator who started the run.
     static_checks_enabled: bool = False
+    # #36 / D10 — repo-declared mapping from a mergeCraft gate name to the CI
+    # check-run name that proves it, and the workflow artifacts whose SARIF may
+    # be ingested. Both empty by default: with no declaration mergeCraft never
+    # reads the consumer's CI and never substitutes a gate outcome.
+    ci_gate_checks: dict[str, str] = field(default_factory=dict)
+    ci_sarif_artifacts: list[str] = field(default_factory=list)
     analyzers_mode: Literal["off", "auto", "full"] = "auto"
     trust_tier: Literal["trusted", "untrusted"] = "trusted"
     analyzers_settings_enabled: bool = True

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -7,11 +7,18 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from mergecraft.ci.evidence import (
+    declared_gate_findings,
+    record_ci_findings,
+    record_gate_substitutions,
+    substitute_declared_gates,
+)
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import primary_repo_state
 from mergecraft.review_checks import declared_cannot_run_outcomes, plan_checks, run_checks
 
 if TYPE_CHECKING:
+    from mergecraft.ci.evidence import GateSubstitution
     from mergecraft.mcp.context import ToolContext
     from mergecraft.review_checks import StaticCheckOutcome
 
@@ -24,6 +31,74 @@ def _serialize(outcome: StaticCheckOutcome) -> dict[str, Any]:
         "exitCode": outcome.exit_code,
         "output": outcome.output,
     }
+
+
+def _report(
+    outcomes: list[StaticCheckOutcome],
+    substitutions: list[GateSubstitution],
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    """Render the tool payload from whatever verdicts this run ended up with.
+
+    ``ran`` asks whether any gate produced a verdict about the diff — a gate a
+    declared CI check run proved counts, which is exactly how #36 removes the
+    duplicate ``unavailable`` row without inventing a second reporting shape.
+    """
+    executed = [outcome for outcome in outcomes if outcome.ran]
+    payload: dict[str, Any] = {"checks": [_serialize(o) for o in outcomes]}
+    if substitutions:
+        payload["ciEvidence"] = [substitution.as_row() for substitution in substitutions]
+    if not executed:
+        payload["ran"] = False
+        payload["reason"] = reason
+        return payload
+    payload["ran"] = True
+    payload["allPassed"] = all(outcome.passed for outcome in executed)
+    return payload
+
+
+async def _apply_ci_evidence(
+    ctx: ToolContext,
+    outcomes: list[StaticCheckOutcome],
+) -> tuple[list[StaticCheckOutcome], list[GateSubstitution]]:
+    """Let the consumer's finished CI speak for gates this environment cannot run.
+
+    Best-effort and declared-only (#36 / D10):
+
+    * no declared mapping ⇒ GitHub is never even asked;
+    * no head SHA ⇒ nothing to read CI for;
+    * an API error ⇒ the gate report is returned exactly as it was.
+
+    Failing here must never degrade the honest ``unavailable`` report that
+    already works, so every failure path returns the untouched outcomes.
+    """
+    mapping = ctx.ci_gate_checks
+    if not mapping or not outcomes:
+        return outcomes, []
+    ref = primary_repo_state(ctx.tool_state).checkout_sha
+    if not ref:
+        logger.debug("ci evidence: no checkout SHA on this run — skipping gate substitution")
+        return outcomes, []
+    try:
+        payload = await ctx.github.list_check_runs_for_ref(ctx.repo.owner, ctx.repo.name, ref)
+    except Exception as err:
+        logger.warning("ci evidence: could not read check runs for {} — {}", ref, err)
+        return outcomes, []
+
+    check_runs = [run for run in (payload.get("check_runs") or []) if isinstance(run, dict)]
+    if not check_runs:
+        return outcomes, []
+
+    findings = declared_gate_findings(outcomes, mapping=mapping, check_runs=check_runs)
+    if findings:
+        record_ci_findings(ctx.tool_state, findings)
+    updated, substitutions = substitute_declared_gates(
+        outcomes, mapping=mapping, check_runs=check_runs
+    )
+    if substitutions:
+        record_gate_substitutions(ctx.tool_state, substitutions)
+    return updated, substitutions
 
 
 def run_static_checks_tool(ctx: ToolContext):
@@ -58,14 +133,12 @@ def run_static_checks_tool(ctx: ToolContext):
                 "staticChecks are configured but cannot run in this environment — "
                 "shell is disabled on pull-request events"
             )
-            outcomes = declared_cannot_run_outcomes(checks, reason=reason)
-            return {
-                "ran": False,
-                "reason": reason,
-                "checks": [_serialize(o) for o in outcomes],
-            }
+            declared = declared_cannot_run_outcomes(checks, reason=reason)
+            outcomes, substitutions = await _apply_ci_evidence(ctx, declared)
+            return _report(outcomes, substitutions, reason=reason)
 
         outcomes = run_checks(checks, root=root)
+        outcomes, substitutions = await _apply_ci_evidence(ctx, outcomes)
         executed = [o for o in outcomes if o.ran]
         logger.info(
             "static checks: {} executed, {} failing, {} unavailable",
@@ -73,23 +146,17 @@ def run_static_checks_tool(ctx: ToolContext):
             sum(1 for o in executed if not o.passed),
             len(outcomes) - len(executed),
         )
-        if not executed:
-            return {
-                "ran": False,
-                "reason": (
-                    "every gate this repo declares is unavailable here — the "
-                    "executables are not installed in this environment. Report the "
-                    "Mechanical gates pre-merge check as skipped. This is not a "
-                    "finding about the diff, and it is not a reason to run a linter "
-                    "or interpreter of your own."
-                ),
-                "checks": [_serialize(o) for o in outcomes],
-            }
-        return {
-            "ran": True,
-            "allPassed": all(o.passed for o in executed),
-            "checks": [_serialize(o) for o in outcomes],
-        }
+        return _report(
+            outcomes,
+            substitutions,
+            reason=(
+                "every gate this repo declares is unavailable here — the "
+                "executables are not installed in this environment. Report the "
+                "Mechanical gates pre-merge check as skipped. This is not a "
+                "finding about the diff, and it is not a reason to run a linter "
+                "or interpreter of your own."
+            ),
+        )
 
     return tool(
         name="run_static_checks",
@@ -102,8 +169,11 @@ def run_static_checks_tool(ctx: ToolContext):
             "when none of its gates are installed in this environment; either way "
             "report the check as skipped rather than running a linter or interpreter "
             "of your own, whose version may not match the repo's. Per-gate status is "
-            "passed, failed, timed_out, unavailable, or declared-but-cannot-run — "
-            "only `failed` says anything about the diff."
+            "passed, failed, timed_out, unavailable, declared-but-cannot-run, or "
+            "satisfied-by-ci — only `failed` says anything about the diff. "
+            "`satisfied-by-ci` means the repo declared a CI check run as proof of that "
+            "gate and it passed; cite the check run from `ciEvidence` and report the "
+            "gate as green, not skipped."
         ),
         input_schema={
             "type": "object",

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -155,6 +155,25 @@ class AnalyzerRunState:
 
 
 @dataclass(slots=True)
+class CiEvidenceState:
+    """Evidence normalised from the consumer's *already-finished* CI (#36).
+
+    Kept separate from ``AnalyzerRunState`` on purpose: ``run_analyzers``
+    replaces its run state wholesale on every call, so anything merged into it
+    would silently vanish if the reviewing agent re-ran the analyzers after
+    reading CI. CI evidence outlives that.
+
+    ``findings`` holds ``Finding.model_dump()`` rows — the same dict shape
+    ``AnalyzerRunState.findings`` uses, so the packet's loader reads one shape.
+    ``substitutions`` records every gate outcome a declared CI check run
+    changed, so a reader can audit *why* a gate stopped saying ``unavailable``.
+    """
+
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    substitutions: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class ToolState:
     repos: dict[str, RepoToolState]
     primary_repo_key: str
@@ -211,6 +230,10 @@ class ToolState:
     agent_diagnostic: Any = None
     browser_daemon: Any = None
     analyzer_run: AnalyzerRunState | None = None
+    # Evidence normalised from the consumer's finished CI (#36). ``None`` until
+    # a CI source is actually read, so a run that consulted no CI records
+    # nothing rather than an empty section.
+    ci_evidence: CiEvidenceState | None = None
     # True once ``run_static_checks`` has been called this session. Read by the
     # verification tools (D14): an LLM judge may not evaluate a finding before
     # the deterministic checks it is meant to supplement have had their turn.

--- a/src/mergecraft/utils/github.py
+++ b/src/mergecraft/utils/github.py
@@ -436,6 +436,59 @@ class GitHubClient:
     ) -> dict[str, Any]:
         return _as_dict(await self.get(f"/repos/{owner}/{repo}/check-suites/{check_suite_id}"))
 
+    async def list_check_runs_for_ref(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """List individual check runs for a commit ref (#36 gate evidence).
+
+        ``list_check_suites_for_ref`` returns suites, whose conclusion is the
+        rollup of every job in them. Gate substitution needs the *named* run —
+        a repo declaring ``lint: "Verify (lint)"`` is pointing at one job, not
+        at whether the whole suite went green.
+        """
+        params = {"per_page": 100, **(kwargs.pop("params", None) or {})}
+        return _as_dict(
+            await self.get(
+                f"/repos/{owner}/{repo}/commits/{ref}/check-runs", params=params, **kwargs
+            )
+        )
+
+    async def list_workflow_run_artifacts(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int,
+    ) -> list[dict[str, Any]]:
+        """List artifacts a workflow run uploaded."""
+        payload = await self.get(
+            f"/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+            params={"per_page": 100},
+        )
+        if not isinstance(payload, dict):
+            return []
+        return _as_list(payload.get("artifacts"))
+
+    async def download_artifact_zip(
+        self,
+        owner: str,
+        repo: str,
+        artifact_id: int,
+    ) -> bytes:
+        """Download one artifact's zip archive, following GitHub's redirect."""
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
+            headers={"Accept": DEFAULT_ACCEPT},
+            follow_redirects=True,
+        )
+        if response.status_code >= 400:
+            msg = f"artifact download failed: {response.status_code}"
+            raise RuntimeError(msg)
+        return response.content
+
 
 async def resolve_run_context_data(
     client: GitHubClient,

--- a/tests/ci/test_evidence.py
+++ b/tests/ci/test_evidence.py
@@ -1,0 +1,390 @@
+"""RED suite for #36 — existing CI results as analyzer / gate evidence (W5).
+
+Four properties carry the issue's acceptance criteria and this plan's locked
+decisions:
+
+* **D10** — a CI check run may change a mergeCraft gate's reported outcome only
+  when the repo *declared* the mapping. Fuzzy name matching is explicitly out of
+  scope, so an undeclared check run named exactly like a gate must still be
+  context, never gate satisfaction.
+* **D11** — findings derived from CI carry the CI-intelligence blame verdicts
+  through to ``Finding.introduced_by_pr``. Flaky and pre-existing failures are
+  *reported*, never *blamed*: they must never reach a blocking severity, because
+  the approval gate is monotone in blockers.
+* **D12** — ``Finding`` is read and produced here, never extended. ``extra=
+  "forbid"`` makes any field change breaking for three separate wave plans.
+* **Convention 8** — nothing leaves the process unredacted; log excerpts are
+  truncated *and* redacted before they enter a finding.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.run import AnalyzerOutcome
+from mergecraft.ci.evidence import (
+    SATISFIED_BY_CI,
+    check_run_to_finding,
+    ci_evidence_findings,
+    ci_evidence_lines,
+    declared_check_run,
+    declared_gate_findings,
+    record_ci_findings,
+    record_gate_substitutions,
+    sarif_findings,
+    substitute_declared_gates,
+)
+from mergecraft.ci.verification import annotate_not_caused_by_pr
+from mergecraft.mcp.tool_state import init_tool_state
+from tests.ci.support import CANARY_SECRET
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _check_run(
+    *,
+    name: str = "Verify (drift gates)",
+    conclusion: str = "success",
+    status: str = "completed",
+    url: str | None = "https://github.com/acme/demo/runs/1",
+) -> dict[str, Any]:
+    return {
+        "id": 1,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": url,
+        "output": {"title": "3 gates", "summary": "lint, typecheck, tests"},
+    }
+
+
+def _unavailable(name: str = "lint") -> AnalyzerOutcome:
+    return AnalyzerOutcome(
+        name=name,
+        command="make lint",
+        status="unavailable",
+        output="make: command not found",
+    )
+
+
+def _cannot_run(name: str = "lint") -> AnalyzerOutcome:
+    return AnalyzerOutcome(
+        name=name,
+        command="make lint",
+        status="declared-but-cannot-run",
+        output="shell is disabled on pull-request events",
+    )
+
+
+_SARIF = json.dumps(
+    {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "ruff", "rules": [{"id": "F401"}]}},
+                "results": [
+                    {
+                        "ruleId": "F401",
+                        "level": "error",
+                        "message": {"text": "unused import `os`"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "src/app.py"},
+                                    "region": {"startLine": 3, "endLine": 3},
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+# ── W5.1 — a CI outcome becomes a Finding ────────────────────────────────────
+
+
+def test_ci_check_run_becomes_a_finding() -> None:
+    """A failed consumer check run normalises into a valid ``source: ci`` finding."""
+    finding = check_run_to_finding(_check_run(conclusion="failure"))
+
+    assert finding is not None
+    assert isinstance(finding, Finding)
+    assert finding.source == "ci"
+    assert finding.tool == "ci"
+    assert "Verify (drift gates)" in finding.message
+    assert finding.evidence, "a CI finding must cite the check run it came from"
+
+
+def test_successful_check_run_produces_no_finding() -> None:
+    """Green CI is evidence, not a finding — a passing run must not manufacture one."""
+    assert check_run_to_finding(_check_run(conclusion="success")) is None
+    assert check_run_to_finding(_check_run(conclusion="skipped")) is None
+    assert check_run_to_finding(_check_run(status="in_progress", conclusion="")) is None
+
+
+# ── W5.2 — SARIF artifacts reuse the existing parser ──────────────────────────
+
+
+def test_ci_sarif_artifact_becomes_findings(tmp_path: Path) -> None:
+    """A SARIF artifact from the consumer's CI parses through ``analyzers/parsers``."""
+    findings = sarif_findings(_SARIF, artifact="ruff-sarif", repo_root=tmp_path)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.source == "ci"
+    assert finding.path == "src/app.py"
+    assert finding.rule_id == "F401"
+    assert "ruff-sarif" in finding.tool
+
+
+def test_ci_sarif_findings_are_never_blamed_on_this_pr(tmp_path: Path) -> None:
+    """SARIF from someone else's pipeline says nothing about *who* introduced it (D11)."""
+    findings = sarif_findings(_SARIF, artifact="ruff-sarif", repo_root=tmp_path)
+
+    assert [f.introduced_by_pr for f in findings] == ["unknown"]
+    assert all(f.severity not in {"Critical", "Major"} for f in findings)
+
+
+# ── W5.3 — substitution requires a declared mapping (D10) ─────────────────────
+
+
+def test_gate_substitution_requires_a_declared_mapping() -> None:
+    """An undeclared CI result is context, never gate satisfaction.
+
+    The check run here is named *exactly* like the gate. Without a declared
+    mapping that similarity must buy it nothing — this is the assertion that
+    keeps "CI was green" from silently satisfying a gate CI never ran.
+    """
+    outcomes = [_unavailable("lint")]
+    check_runs = [_check_run(name="lint", conclusion="success")]
+
+    updated, substitutions = substitute_declared_gates(outcomes, mapping={}, check_runs=check_runs)
+
+    assert substitutions == []
+    assert [o.status for o in updated] == ["unavailable"]
+    assert declared_check_run("lint", mapping={}, check_runs=check_runs) is None
+
+
+def test_failed_declared_check_run_does_not_satisfy_the_gate() -> None:
+    """Only a *successful* declared run may stand in for a gate mergeCraft cannot run."""
+    outcomes = [_cannot_run("lint")]
+    check_runs = [_check_run(name="Verify (lint)", conclusion="failure")]
+
+    updated, substitutions = substitute_declared_gates(
+        outcomes,
+        mapping={"lint": "Verify (lint)"},
+        check_runs=check_runs,
+    )
+
+    assert substitutions == []
+    assert [o.status for o in updated] == ["declared-but-cannot-run"]
+
+
+def test_substitution_never_overwrites_a_gate_that_actually_ran() -> None:
+    """A gate mergeCraft executed here outranks any CI claim about it."""
+    executed = AnalyzerOutcome(
+        name="lint", command="make lint", status="failed", output="E501", exit_code=1
+    )
+    updated, substitutions = substitute_declared_gates(
+        [executed],
+        mapping={"lint": "Verify (lint)"},
+        check_runs=[_check_run(name="Verify (lint)", conclusion="success")],
+    )
+
+    assert substitutions == []
+    assert [o.status for o in updated] == ["failed"]
+
+
+# ── W5.4 — the declared mapping removes the unavailable row ───────────────────
+
+
+@pytest.mark.parametrize("row", ["unavailable", "declared-but-cannot-run"])
+def test_declared_mapping_removes_the_unavailable_row(row: str) -> None:
+    """CI-proved gates report as satisfied-by-CI instead of duplicating noise."""
+    outcomes = [_unavailable("lint") if row == "unavailable" else _cannot_run("lint")]
+
+    updated, substitutions = substitute_declared_gates(
+        outcomes,
+        mapping={"lint": "Verify (lint)"},
+        check_runs=[_check_run(name="Verify (lint)", conclusion="success")],
+    )
+
+    assert len(updated) == 1, "substitution replaces the row; it never appends a second one"
+    assert updated[0].status == SATISFIED_BY_CI
+    assert updated[0].passed is True
+    assert updated[0].ran is True
+    assert "Verify (lint)" in updated[0].output
+    assert "https://github.com/acme/demo/runs/1" in updated[0].output
+
+    assert len(substitutions) == 1
+    assert substitutions[0].gate == "lint"
+    assert substitutions[0].check_run == "Verify (lint)"
+
+
+# ── W5.5 / W5.6 — reported, not blamed (D11) ─────────────────────────────────
+
+
+def test_flaky_failure_is_reported_not_blamed() -> None:
+    """A failure the flaky detector flags must never reach a blocking severity.
+
+    ``annotate_not_caused_by_pr`` is the CI-intelligence rule; this asserts the
+    property the rule exists for, at the severity the approval gate reads.
+    """
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES
+
+    blamed = check_run_to_finding(_check_run(conclusion="failure"))
+    assert blamed is not None
+    flaky = annotate_not_caused_by_pr(blamed)
+
+    assert flaky.introduced_by_pr == "false"
+    assert flaky.severity not in BLOCKING_SEVERITIES
+
+
+def test_flaky_ci_finding_never_blocks_the_approval_gate() -> None:
+    """The property, end to end: a flaky CI finding cannot fail a run's verdict."""
+    from mergecraft.agents.gates import decide_approval
+
+    blamed = check_run_to_finding(_check_run(conclusion="failure"))
+    assert blamed is not None
+    flaky = annotate_not_caused_by_pr(blamed)
+
+    assert decide_approval([flaky], run_succeeded=True, tier="trusted") != "failure"
+
+
+def test_not_caused_by_pr_annotation_survives_normalisation() -> None:
+    """The annotation round-trips through the recorded (dict) evidence store."""
+    state = init_tool_state(owner="acme", name="demo", dir=".")
+    blamed = check_run_to_finding(_check_run(conclusion="failure"))
+    assert blamed is not None
+    flaky = annotate_not_caused_by_pr(blamed)
+
+    record_ci_findings(state, [flaky])
+    restored = ci_evidence_findings(state)
+
+    assert [f.introduced_by_pr for f in restored] == ["false"]
+    assert [f.severity for f in restored] == [flaky.severity]
+    assert [f.fingerprint for f in restored] == [flaky.fingerprint]
+
+
+def test_recording_is_idempotent_on_fingerprint() -> None:
+    """Re-recording the same CI finding must not double-count it for the gate."""
+    state = init_tool_state(owner="acme", name="demo", dir=".")
+    finding = check_run_to_finding(_check_run(conclusion="failure"))
+    assert finding is not None
+
+    record_ci_findings(state, [finding])
+    record_ci_findings(state, [finding])
+
+    assert len(ci_evidence_findings(state)) == 1
+
+
+def test_declared_gate_findings_report_a_failing_mapped_check_run() -> None:
+    """A declared gate CI proved *broken* is reported — unblamed — not hidden."""
+    findings = declared_gate_findings(
+        [_cannot_run("lint")],
+        mapping={"lint": "Verify (lint)"},
+        check_runs=[_check_run(name="Verify (lint)", conclusion="failure")],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].source == "ci"
+    assert findings[0].introduced_by_pr == "unknown"
+    assert findings[0].severity not in {"Critical", "Major"}
+    assert "lint" in findings[0].message
+
+
+def test_declared_gate_findings_ignore_undeclared_check_runs() -> None:
+    """D10 again, on the finding side: no mapping, no derived gate finding."""
+    assert (
+        declared_gate_findings(
+            [_cannot_run("lint")],
+            mapping={},
+            check_runs=[_check_run(name="lint", conclusion="failure")],
+        )
+        == []
+    )
+
+
+# ── W5.7 — truncation + redaction (convention 8) ─────────────────────────────
+
+
+def test_log_excerpts_are_truncated_and_redacted() -> None:
+    """No secret-shaped string survives into a finding's evidence list."""
+    noisy = "\n".join([f"line {i}" for i in range(200)] + [f"token={CANARY_SECRET}"])
+
+    lines = ci_evidence_lines(noisy, limit=5)
+
+    assert len(lines) <= 5
+    joined = "\n".join(lines)
+    assert CANARY_SECRET not in joined
+    assert len(joined) <= 2000
+
+
+def test_check_run_finding_evidence_is_redacted() -> None:
+    """The redaction boundary holds on the path a real run actually takes."""
+    finding = check_run_to_finding(
+        _check_run(conclusion="failure"),
+        log_excerpt=f"##[error] auth failed\napi_key={CANARY_SECRET}",
+    )
+
+    assert finding is not None
+    blob = "\n".join([finding.message, *finding.evidence])
+    assert CANARY_SECRET not in blob
+
+
+# ── W5.8 — Finding is never extended (D12) ───────────────────────────────────
+
+
+def test_no_new_finding_fields_introduced(tmp_path: Path) -> None:
+    """CI evidence uses ``evidence`` and ``source``; it adds no field to ``Finding``."""
+    expected = {
+        "tool",
+        "rule_id",
+        "category",
+        "severity",
+        "confidence",
+        "message",
+        "path",
+        "start_line",
+        "end_line",
+        "fingerprint",
+        "evidence",
+        "remediation",
+        "autofix",
+        "introduced_by_pr",
+        "source",
+        "cluster_id",
+    }
+    assert set(Finding.model_fields) == expected
+
+    produced = [
+        check_run_to_finding(_check_run(conclusion="failure")),
+        *sarif_findings(_SARIF, artifact="ruff-sarif", repo_root=tmp_path),
+    ]
+    for finding in produced:
+        assert finding is not None
+        assert set(finding.model_dump()) == expected
+
+
+def test_gate_substitutions_are_recorded_for_audit() -> None:
+    """A substitution that changed a reported outcome must be inspectable."""
+    state = init_tool_state(owner="acme", name="demo", dir=".")
+    _, substitutions = substitute_declared_gates(
+        [_unavailable("lint")],
+        mapping={"lint": "Verify (lint)"},
+        check_runs=[_check_run(name="Verify (lint)", conclusion="success")],
+    )
+
+    record_gate_substitutions(state, substitutions)
+
+    assert state.ci_evidence is not None
+    assert state.ci_evidence.substitutions[0]["gate"] == "lint"
+    assert state.ci_evidence.substitutions[0]["checkRun"] == "Verify (lint)"

--- a/tests/ci/test_evidence_seams.py
+++ b/tests/ci/test_evidence_seams.py
@@ -1,0 +1,310 @@
+"""Runtime seams for #36 — CI evidence must be *produced*, not merely producible.
+
+Two merged batches (#47, #41, #42, #48) shipped library code with no runtime
+call site, so nothing a real run entered ever exercised it (#96). These tests
+drive the two seams a live run actually goes through:
+
+1. ``run_static_checks`` — the MCP tool the review prompt calls in step 2. This
+   is where an ``unavailable`` / ``declared-but-cannot-run`` row becomes a
+   ``satisfied-by-ci`` row, and where a declared-but-failing CI gate becomes a
+   recorded finding.
+2. ``emit_run_packet`` — the end-of-run consumer ``main()`` invokes. CI evidence
+   recorded during the run has to reach the packet, and a *flaky* CI finding has
+   to leave the packet's verdict alone (D11).
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from io import BytesIO
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+from mergecraft.ci.evidence import check_run_to_finding, record_ci_findings
+from mergecraft.ci.verification import annotate_caused_by_pr, annotate_not_caused_by_pr
+from mergecraft.evidence.run_packet import emit_run_packet
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.static_checks import run_static_checks_tool
+from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
+from mergecraft.modes import compute_modes
+from mergecraft.review_checks import StaticCheckConfig
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HEAD_SHA = "cafebabecafebabecafebabecafebabecafebabe"
+
+
+class _CheckRunGitHub(GitHubClient):
+    """Serves one page of check runs and records that it was asked."""
+
+    def __init__(self, check_runs: list[dict[str, Any]]) -> None:
+        super().__init__(token="test-token")
+        self._check_runs = check_runs
+        self.refs: list[str] = []
+
+    async def list_check_runs_for_ref(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.refs.append(ref)
+        return {"total_count": len(self._check_runs), "check_runs": self._check_runs}
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    github: GitHubClient | None = None,
+    ci_gate_checks: dict[str, str] | None = None,
+    static_checks: list[StaticCheckConfig] | None = None,
+    shell: str = "disabled",
+    is_pr: bool = True,
+) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    state.pr_number = 7
+    primary_repo_state(state).checkout_sha = HEAD_SHA
+    ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request_target", issue_number=7, is_pr=is_pr),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=github or GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        static_checks=static_checks or [],
+        static_checks_enabled=True,
+        ci_gate_checks=ci_gate_checks or {},
+    )
+    ctx.trust_tier = "untrusted"
+    return ctx
+
+
+async def _run_static_checks(ctx: ToolContext, **params: Any) -> dict[str, Any]:
+    result = await run_static_checks_tool(ctx).execute(params)
+    return json.loads(result.content[0]["text"])
+
+
+def _check_run(name: str, conclusion: str) -> dict[str, Any]:
+    return {
+        "id": 11,
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "html_url": f"https://github.com/acme/demo/runs/{name}",
+    }
+
+
+# ── seam 1: run_static_checks ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_declared_ci_gate_replaces_the_unavailable_row(tmp_path: Path) -> None:
+    """The issue's headline: CI already proved the gate, so stop saying `unavailable`."""
+    github = _CheckRunGitHub([_check_run("Verify (drift gates)", "success")])
+    ctx = _ctx(
+        tmp_path,
+        github=github,
+        ci_gate_checks={"lint": "Verify (drift gates)"},
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+    )
+
+    payload = await _run_static_checks(ctx)
+
+    assert github.refs == [HEAD_SHA], "the head SHA is the only ref CI evidence may be read from"
+    statuses = [check["status"] for check in payload["checks"]]
+    assert statuses == ["satisfied-by-ci"]
+    assert "declared-but-cannot-run" not in statuses
+    assert payload["ran"] is True
+    assert payload["allPassed"] is True
+    assert payload["ciEvidence"][0]["gate"] == "lint"
+    assert payload["ciEvidence"][0]["checkRun"] == "Verify (drift gates)"
+
+
+@pytest.mark.asyncio
+async def test_undeclared_ci_results_never_touch_a_gate(tmp_path: Path) -> None:
+    """No declared mapping means mergeCraft must not even ask GitHub (D10)."""
+    github = _CheckRunGitHub([_check_run("lint", "success")])
+    ctx = _ctx(
+        tmp_path,
+        github=github,
+        ci_gate_checks={},
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+    )
+
+    payload = await _run_static_checks(ctx)
+
+    assert github.refs == []
+    assert [check["status"] for check in payload["checks"]] == ["declared-but-cannot-run"]
+    assert payload["ran"] is False
+
+
+@pytest.mark.asyncio
+async def test_failing_declared_gate_is_recorded_but_not_substituted(tmp_path: Path) -> None:
+    """A declared gate CI proved broken stays honest *and* becomes CI evidence."""
+    github = _CheckRunGitHub([_check_run("Verify (drift gates)", "failure")])
+    ctx = _ctx(
+        tmp_path,
+        github=github,
+        ci_gate_checks={"lint": "Verify (drift gates)"},
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+    )
+
+    payload = await _run_static_checks(ctx)
+
+    assert [check["status"] for check in payload["checks"]] == ["declared-but-cannot-run"]
+    assert payload.get("ciEvidence") in (None, [])
+    assert ctx.tool_state.ci_evidence is not None
+    assert len(ctx.tool_state.ci_evidence.findings) == 1
+    assert ctx.tool_state.ci_evidence.findings[0]["source"] == "ci"
+
+
+@pytest.mark.asyncio
+async def test_github_failure_leaves_the_gate_report_unchanged(tmp_path: Path) -> None:
+    """CI evidence is best-effort: an API error must not break the gate report."""
+
+    class _BrokenGitHub(GitHubClient):
+        async def list_check_runs_for_ref(
+            self, owner: str, repo: str, ref: str, **kwargs: Any
+        ) -> dict[str, Any]:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    ctx = _ctx(
+        tmp_path,
+        github=_BrokenGitHub(token=""),
+        ci_gate_checks={"lint": "Verify (drift gates)"},
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'pass'")],
+    )
+
+    payload = await _run_static_checks(ctx)
+
+    assert payload["ran"] is False
+    assert [check["status"] for check in payload["checks"]] == ["declared-but-cannot-run"]
+
+
+# ── seam 2: the merge evidence packet ────────────────────────────────────────
+
+
+def _packet(ctx: ToolContext, tmp_path: Path) -> dict[str, Any]:
+    written = emit_run_packet(
+        ctx,
+        run_succeeded=True,
+        output_path=tmp_path / "packet.json",
+    )
+    assert written is not None
+    return json.loads(written.read_text(encoding="utf-8"))
+
+
+def test_ci_findings_reach_the_merge_evidence_packet(tmp_path: Path) -> None:
+    """A CI outcome recorded during the run is evidence for the merge."""
+    ctx = _ctx(tmp_path)
+    finding = check_run_to_finding(_check_run("Verify (drift gates)", "failure"))
+    assert finding is not None
+    record_ci_findings(ctx.tool_state, [annotate_caused_by_pr(finding)])
+
+    packet = _packet(ctx, tmp_path)
+
+    sources = [row["source"] for row in packet["findings"]]
+    assert "ci" in sources, "no CI-sourced finding reached the packet"
+
+
+def test_flaky_ci_finding_does_not_flip_the_packet_verdict(tmp_path: Path) -> None:
+    """D11, where it bites: a flaky failure is recorded but never blocks the merge."""
+    ctx = _ctx(tmp_path)
+    finding = check_run_to_finding(_check_run("Verify (drift gates)", "failure"))
+    assert finding is not None
+    record_ci_findings(ctx.tool_state, [annotate_not_caused_by_pr(finding)])
+
+    packet = _packet(ctx, tmp_path)
+
+    assert [row["source"] for row in packet["findings"]] == ["ci"]
+    assert packet["decision"]["verdict"] != "failure"
+
+
+def test_pr_attributed_ci_finding_does_block_the_packet_verdict(tmp_path: Path) -> None:
+    """The mirror image — otherwise "reported, not blamed" would be vacuous."""
+    ctx = _ctx(tmp_path)
+    finding = check_run_to_finding(_check_run("Verify (drift gates)", "failure"))
+    assert finding is not None
+    record_ci_findings(ctx.tool_state, [annotate_caused_by_pr(finding)])
+
+    packet = _packet(ctx, tmp_path)
+
+    assert packet["decision"]["verdict"] == "failure"
+
+
+# ── seam 3: analyze_ci_failures records what it already clustered ────────────
+
+
+class _WorkflowLogGitHub(GitHubClient):
+    """Serves one failing workflow run whose log archive is the given text."""
+
+    def __init__(self, log_text: str) -> None:
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w") as archive:
+            archive.writestr("0_build.txt", log_text)
+        payload = buf.getvalue()
+        super().__init__(
+            token="test-token",
+            client=httpx.AsyncClient(
+                base_url="https://api.github.com",
+                transport=_ZipTransport(payload),
+            ),
+        )
+
+    async def get(self, path: str, **kwargs: Any) -> Any:
+        if path.endswith("/actions/runs"):
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 99,
+                        "name": "Verify (drift gates)",
+                        "conclusion": "failure",
+                        "html_url": "https://github.com/acme/demo/actions/runs/99",
+                    }
+                ]
+            }
+        return {}
+
+
+class _ZipTransport(httpx.AsyncBaseTransport):
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=self._payload)
+
+
+@pytest.mark.asyncio
+async def test_analyze_ci_failures_records_its_clusters_as_ci_evidence(tmp_path: Path) -> None:
+    """The clustered findings already existed; nothing kept them. Now they persist."""
+    from mergecraft.mcp.ci_intelligence import analyze_ci_failures_tool
+
+    log_text = "##[error]make: *** [lint] Error 1\nFAILED src/app.py::test_thing\n"
+    ctx = _ctx(tmp_path, github=_WorkflowLogGitHub(log_text))
+
+    raw = await analyze_ci_failures_tool(ctx).execute({"check_suite_id": 42})
+    payload = json.loads(raw.content[0]["text"])
+
+    assert payload["available"] is True
+    assert ctx.tool_state.ci_evidence is not None
+    recorded = ctx.tool_state.ci_evidence.findings
+    assert recorded, "analyze_ci_failures clustered findings but recorded none"
+    assert {row["source"] for row in recorded} == {"ci"}
+    # No diff paths were supplied, so nothing may be attributed to this PR.
+    assert {row["introduced_by_pr"] for row in recorded} == {"false"}
+    assert {row["severity"] for row in recorded}.isdisjoint({"Critical", "Major"})

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -87,6 +87,22 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
             "pinned managed one even under `shell: disabled` (#35)"
         ),
     ),
+    _Contract(
+        symbol="substitute_declared_gates",
+        defined_in="ci/evidence.py",
+        why="no reachable caller means a gate the consumer's CI proved still reports "
+        "`unavailable` (#36)",
+    ),
+    _Contract(
+        symbol="record_ci_findings",
+        defined_in="ci/evidence.py",
+        why="no reachable caller means a CI outcome never becomes a Finding (#36)",
+    ),
+    _Contract(
+        symbol="ci_evidence_findings",
+        defined_in="ci/evidence.py",
+        why="no reachable caller means recorded CI evidence never reaches the packet (#36)",
+    ),
 )
 
 
@@ -268,6 +284,32 @@ def test_agent_finding_verification_is_offered_on_every_run() -> None:
             f"mcp/server.py no longer registers {factory}() — the reviewing agent has no "
             "way to send its own findings to the verifier (C6)"
         )
+
+
+def test_ci_evidence_is_wired_into_the_tools_a_review_actually_calls() -> None:
+    """Reachability is not enough — the door has to be one the reviewer opens.
+
+    Both CI-evidence seams hang off MCP tools the review prompt names in its
+    checklist. Pinning the call sites by module means a refactor that moves the
+    substitution somewhere the reviewing agent never reaches fails here rather
+    than silently reverting #36 to "library code, no consumer" (#96).
+    """
+    static_checks = _invoked_names(_parsed((_SRC_DIR / "mcp" / "static_checks.py").resolve()))
+    assert "substitute_declared_gates" in static_checks, (
+        "run_static_checks no longer applies declared CI gate substitution — a gate the "
+        "consumer's CI already proved is back to reporting `unavailable` (#36)"
+    )
+
+    intelligence = _invoked_names(_parsed((_SRC_DIR / "ci" / "intelligence.py").resolve()))
+    assert "record_ci_findings" in intelligence, (
+        "analyze_ci_failures no longer records its clustered findings — CI failures never "
+        "reach the merge evidence packet (#36)"
+    )
+
+    packet = _invoked_names(_parsed((_SRC_DIR / "evidence" / "run_packet.py").resolve()))
+    assert "ci_evidence_findings" in packet, (
+        "the evidence packet no longer reads recorded CI evidence (#36)"
+    )
 
 
 def test_review_prompts_tell_the_agent_to_verify_its_own_findings() -> None:


### PR DESCRIPTION
Analyzer wave **Batch C** (W5 test-creator + W6 executor), per `issues-analyzer-ci-evidence-wave-plan.md` decisions D10–D12.

Closes #36

## Why?

The Action image ships `git`, `gh`, `jq`, `node`, `npm` — no `make`, no repo venv, no pinned toolchains. So a repo-native gate could only ever report that it judged nothing, even when a `Verify (…)` job had just run the identical command on the same commit. The evidence existed; mergeCraft just never looked at it.

## What changed

**Declared gate substitution.** `ciEvidence.gates` in `.mergecraft/config.yaml` maps a gate name to the exact check-run name that proves it. A match rewrites the row to a new `satisfied-by-ci` status naming the run and its URL.

Nothing is inferred, and that is the load-bearing part:
- A check run merely *named* like a gate proves nothing — a pull request can add a workflow with any name it likes — so only an explicitly declared mapping counts.
- With no `ciEvidence` block, mergeCraft never reads your check runs at all.
- Only a **passing** declared run may substitute; a declared run that failed leaves the honest row in place and is reported as a finding instead.
- A gate that actually ran during the review always outranks any CI claim about it.

**CI outcomes as structured findings.** Check runs, SARIF artifacts and log excerpts normalise into `Finding`s that reach the merge evidence packet, so "CI was red" becomes reviewable evidence rather than prose.

**Flaky and pre-existing failures are reported, not blamed (D11).** A result the existing `ci/` intelligence flags as flaky, or as not introduced by this PR, is surfaced without becoming a blocking finding.

## Test plan

- [x] `make ci-reset` then one clean `make ci-resume` — **all 9 steps passed** (1077 passed, 21 skipped, 12 xfailed, 8 xpassed)
- [x] `make catalog-check` — catalog OK, 57 manifests
- [x] New suites `tests/ci/test_evidence.py` and `tests/ci/test_evidence_seams.py`
- [x] `tests/test_runtime_call_sites.py` extended with three contracts, so a future change that leaves `substitute_declared_gates`, `record_ci_findings` or `ci_evidence_findings` without a reachable caller fails the suite — the wired-but-dead failure mode of issue #96

## Rebase note

Rebased onto `pre-0.0.1` after **#107 (Batch A)** merged. Two additive conflicts, both resolved by keeping both sides: the `## [Unreleased]` changelog block and the `_Contract` list in `tests/test_runtime_call_sites.py`. The gate above was re-run from a clean checkpoint on the rebased tree, not carried over from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)