### PR TITLE
feat(analyzers): trust-aware analyzer selection for pull_request_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** — an unrecognised `analyzers:` Action input value now resolves to
+  `untrusted-only` instead of `auto`, and says so at `warning` level. Previously
+  any typo was silently rewritten to `auto`, which on a trusted event selects the
+  whole catalog: the input that looked strictest was the one that did nothing. A
+  misspelled value now narrows selection (57 shipped manifests → 18 on a trusted
+  event) rather than widening it, so the failure mode is missing coverage you can
+  see in the skip rows instead of coverage you only thought you had. Spelling a
+  valid value — `off`, `auto`, `full`, `untrusted-only` — is unaffected, and an
+  absent input still means `auto` (#38)
+- **BREAKING** — `analyzers: auto` under `pull_request_target` and fork-head pull
+  requests now *means* trust-aware selection, resolving to `untrusted-only`
+  rather than being trust-blind. On the catalog as shipped today this changes
+  which analyzers run **not at all**: the untrusted trust tier already excluded
+  every `trust: trusted` manifest on those events, and the one remaining
+  `repo-native` manifest is exempt (see below). What changes is the contract —
+  any future `repo-native` analyzer that declares `trust: untrusted` will be
+  withheld on those events instead of resolved against a PR-authored working
+  tree. It is recorded as breaking because the meaning of an existing input
+  value changed, not because current behaviour did (#38, D8)
+
 ### Added
 
+- Hardened workflows can now ask for trust-aware analyzer selection explicitly:
+  `analyzers: untrusted-only` runs only analyzers that need no secrets, no
+  network, and no PR-authored command construction. It applies two gates at
+  once — manifest selection is evaluated at the `untrusted` trust tier, *and*
+  analyzers needing repo-provided tooling are withheld whatever `shell:` is set
+  to, which the trust tier alone does not do. On a trusted event that narrows
+  the catalog from 57 shipped manifests to 18. Everything excluded is a skipped
+  row with a named reason naming the axis that caused it, never a failure, and
+  `run_static_checks` remains withheld under `shell: disabled` regardless of the
+  mode. The shipped `mergecraft-hardened.yml` example now sets it explicitly, and
+  `docs/ANALYZERS.md` gains a generated mode axis computed from the live
+  predicates (#38)
+- `agentsec` now runs under `shell: disabled` and under `analyzers:
+  untrusted-only`, where it was previously withheld. It declares
+  `runtime: repo-native` — the marker for "resolves against tooling the repo
+  supplies" — but it is mergeCraft's own agent-security policy engine: it is
+  special-cased before the repo-binary preference is ever consulted and executes
+  in-process, with no subprocess and no argv, so no PR-authored command can run
+  through it. Withholding it bought no safety and cost hardened consumers the
+  one analyzer most relevant to `pull_request_target`: the one that reads
+  `.mcp.json`, `CLAUDE.md`, `AGENTS.md` and skill files as data. It is a named
+  exception in `IN_PROCESS_ANALYZER_IDS` with a test asserting it really does
+  resolve without repo-provided tooling, not a widening of the runtime rule
+  (#38, follow-up to #35)
 - Hardening your workflow no longer costs you every mechanical check. A repo
   running `pull_request_target` with `shell: disabled` previously got **no**
   analyzer coverage at all: one boolean withheld mergeCraft's own pinned catalog

--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ The Action image has no `make`, no repo venv, and none of your pinned toolchains
 
 **Analyzers** (actionlint, zizmor, ShellCheck, Hadolint in this release) run deterministically from YAML manifests when paths match — the reviewer calls `run_analyzers` early and places verified hits inline or in `### 🔧 Mechanical findings`. You can override enablement in `analyzers:`; editing the catalog remains possible but is not the headline workflow (D19).
 
+The Action's `analyzers:` input picks how much of the catalog is eligible:
+
+| value | meaning |
+|-------|---------|
+| `off` | the analyzer tools are not registered at all |
+| `auto` *(default)* | detect from changed paths and provision what is needed |
+| `full` | same selection as `auto`, with the baked image tools provisioned up front |
+| `untrusted-only` | trust-aware: only analyzers needing no secrets, no network, and no PR-authored command construction |
+
+Under `pull_request_target` and fork-head pull requests the trust tier is `untrusted`, and `auto` resolves to `untrusted-only` there — so a hardened workflow gets mechanical signal without loosening `shell:`. Anything the mode excludes is reported as a skipped row with a named reason, never as a failure. An unrecognised value also resolves to `untrusted-only`, with a warning, rather than silently widening to `auto`. `full` is a request to provision more tooling; it is never a trust override and cannot re-admit an analyzer the trust tier excluded. The generated matrix in [`docs/ANALYZERS.md`](docs/ANALYZERS.md) shows what each combination selects.
+
 ## Learnings — staging and promotion
 
 `.mergecraft/learnings.md` holds durable cross-run context (test commands, conventions, gotchas, architecture notes) seeded into every review. Since this file is **attacker-controllable input** in any non-maintainer context (a fork PR body, a contributor comment, an agent-written entry from prior untrusted text), entries are now provenance-gated (D10, #74):

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,13 @@ inputs:
     description: "Post mergecraft and mergecraft-approval commit-status checks: disabled (default) or enabled."
     required: false
   analyzers:
-    description: "Analyzer execution tier: off (disabled), auto (detect + provision), or full (baked image tools). Default: auto"
+    description: >-
+      Analyzer execution tier: off (disabled), auto (detect + provision), full (baked image tools),
+      or untrusted-only (trust-aware: run only analyzers that need no secrets, no network and no
+      PR-authored command construction — trusted-tier and repo-native manifests are skipped with a
+      named reason rather than failing). Under `pull_request_target` and fork-head pull requests,
+      `auto` resolves to `untrusted-only`. An unrecognised value also resolves to `untrusted-only`,
+      with a warning. Default: auto
     required: false
     default: auto
   allow_pr_target_comments:

--- a/docs/ANALYZERS.md
+++ b/docs/ANALYZERS.md
@@ -62,15 +62,19 @@ Shipped mergeCraft catalog analyzers. Rows are generated from manifests — run 
 | `yamllint` | lint | yaml | disabled | managed | untrusted | — | — |
 | `zizmor` | ci | — | auto | managed | untrusted | — | — |
 
-## Runtime x shell x trust
+## Runtime x shell x trust x mode
 
-Which analyzers run is decided on two independent axes, each of which can
-skip a manifest with a named reason — a skip is an outcome, never a failure.
+Which analyzers run is decided on three independent axes. Each can skip a
+manifest with a named reason — a skip is an outcome, never a failure, and it
+appears as an `unavailable` row in the Analyzers pre-merge summary.
 
 - **shell** (`shell:` in the workflow) — may mergeCraft execute anything the
   PR could have written? Enforced by `evaluate_manifest_for_shell()`.
 - **trust** (derived from the event) — `pull_request_target` and fork-head PRs
   are `untrusted`. Enforced by `evaluate_manifest_for_tier()`.
+- **mode** (`analyzers:` in the workflow) — `off | auto | full |
+  untrusted-only`. Enforced by `evaluate_manifest_for_mode()` plus
+  `resolve_selection_tier()`.
 
 Under `shell: disabled`, eligible runtimes are `managed` and `container`.
 Their argv is copied verbatim out of a manifest mergeCraft ships, and a binary
@@ -86,7 +90,37 @@ to run the *repo's* tool against the *repo's* config.
 | `managed` (17) | `untrusted` | **runs** (pinned binary only) | runs |
 | `container` (4) | `trusted` | runs on trusted events; skipped with a reason on untrusted ones | runs on trusted events; skipped on untrusted |
 
-Passing the shell axis is necessary, not sufficient: a `container` manifest
+One documented exception to the runtime row: `agentsec`. It declares
+`runtime: repo-native` but `resolve_analyzer()` special-cases it before the
+repo-binary preference is consulted and `run_adapter()` executes it
+in-process — no subprocess, no argv, nothing the PR authored is run. The
+runtime axis asks whether PR content could steer what executes; for these
+the answer is no, so they stay eligible (#38).
+
+### The `analyzers:` mode axis
+
+`untrusted-only` runs only analyzers that need no secrets, no network and no
+PR-authored command construction: manifest selection is evaluated at the
+`untrusted` tier *and* the repo-tooling gate applies whatever the shell is.
+On `pull_request_target` and fork-head pull requests, `auto` resolves to it
+— a narrowing default, so a hardened workflow gets mechanical signal without
+loosening `shell:`. An unrecognised `analyzers:` value resolves there too,
+with a warning, rather than silently widening to `auto`.
+
+`full` requests more provisioning; it is never a trust override, and cannot
+re-admit a manifest the tier axis skipped.
+
+Counts below are analyzers passing selection, out of 57 shipped, with
+`shell: restricted` (the shell axis inert) so the mode axis is isolated.
+
+| mode | trusted event | untrusted event (`pull_request_target`, fork) |
+|------|---------------|-----------------------------------------------|
+| **`off`** | surface not registered | surface not registered |
+| **`auto`** | 57 of 57 | 18 of 57 — `auto` ⇒ `untrusted-only` |
+| **`full`** | 57 of 57 | 18 of 57 |
+| **`untrusted-only`** | 18 of 57 | 18 of 57 |
+
+Passing these axes is necessary, not sufficient: a `container` manifest
 is eligible but still reports `unavailable` wherever no container runtime is
 present, and the seven `declared_unavailable` manifests keep their own skip
 reason. In the shipped Action image that leaves the `managed` rows as the
@@ -95,10 +129,7 @@ analyzers a `shell: disabled` run actually executes.
 Repo-declared `staticChecks` are a third thing and are **always** withheld
 under `shell: disabled`, on every event: they run command strings the PR
 author controls. They report `declared-but-cannot-run` rather than vanishing.
-
-`agentsec` declares `runtime: repo-native` and is therefore withheld under
-`shell: disabled`, even though it runs in-process with no repo binary. That
-is deliberate: eligibility is read off the declared runtime and nothing else.
+No `analyzers:` value re-enables them.
 
 ## Overrides
 

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -306,6 +306,13 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
+          # Trust-aware analyzer selection (#38). `auto` already resolves to this
+          # under `pull_request_target`, but stating it keeps the workflow honest
+          # about what it expects and survives any future change to `auto`.
+          # Only analyzers needing no secrets, no network and no PR-authored
+          # command construction run; the rest are skipped with a named reason in
+          # the Analyzers pre-merge row, never reported as failures.
+          analyzers: untrusted-only
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -306,6 +306,13 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
+          # Trust-aware analyzer selection (#38). `auto` already resolves to this
+          # under `pull_request_target`, but stating it keeps the workflow honest
+          # about what it expects and survives any future change to `auto`.
+          # Only analyzers needing no secrets, no network and no PR-authored
+          # command construction run; the rest are skipped with a named reason in
+          # the Analyzers pre-merge row, never reported as failures.
+          analyzers: untrusted-only
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/src/mergecraft/analyzers/catalog_docs.py
+++ b/src/mergecraft/analyzers/catalog_docs.py
@@ -134,29 +134,61 @@ def _default_enabled_label(value: bool | str) -> str:
 
 
 def _shell_trust_matrix_lines() -> list[str]:
-    """Render the runtime x shell x trust matrix from the live predicates (#35, D5).
+    """Render the runtime x shell x trust x mode matrix from the live predicates.
 
-    Derived from ``SHELL_DISABLED_ELIGIBLE_RUNTIMES`` and the catalog itself so
-    the published matrix cannot drift away from the code that enforces it.
+    Every cell is computed by calling the predicates the pipeline itself calls
+    (`evaluate_manifest_for_shell`, `evaluate_manifest_for_tier`,
+    `evaluate_manifest_for_mode`) over the real catalog, so the published matrix
+    cannot drift away from the code that enforces it (#35 D5, #38 D8/D9).
     """
-    from mergecraft.analyzers.trust import SHELL_DISABLED_ELIGIBLE_RUNTIMES
+    from mergecraft.analyzers.trust import (
+        IN_PROCESS_ANALYZER_IDS,
+        SHELL_DISABLED_ELIGIBLE_RUNTIMES,
+        evaluate_manifest_for_mode,
+        evaluate_manifest_for_shell,
+        evaluate_manifest_for_tier,
+        resolve_effective_analyzers_mode,
+        resolve_selection_tier,
+    )
 
+    manifests = sorted(load_catalog(), key=lambda m: m.id)
+
+    def _selected(*, tier: str, mode: str, shell: str) -> list[str]:
+        """Replay the pipeline's own skip chain for one cell."""
+        effective = resolve_effective_analyzers_mode(mode=mode, tier=tier)  # type: ignore[arg-type]
+        selection_tier = resolve_selection_tier(mode=effective, tier=tier)  # type: ignore[arg-type]
+        chosen: list[str] = []
+        for manifest in manifests:
+            if evaluate_manifest_for_tier(manifest=manifest, tier=selection_tier).skipped:
+                continue
+            if evaluate_manifest_for_shell(manifest=manifest, shell=shell).skipped:
+                continue
+            if evaluate_manifest_for_mode(manifest=manifest, mode=effective).skipped:
+                continue
+            chosen.append(manifest.id)
+        return chosen
+
+    total = len(manifests)
     counts: dict[tuple[str, str], int] = {}
-    for manifest in load_catalog():
+    for manifest in manifests:
         key = (manifest.runtime, manifest.trust)
         counts[key] = counts.get(key, 0) + 1
 
     lines = [
         "",
-        "## Runtime x shell x trust",
+        "## Runtime x shell x trust x mode",
         "",
-        "Which analyzers run is decided on two independent axes, each of which can",
-        "skip a manifest with a named reason — a skip is an outcome, never a failure.",
+        "Which analyzers run is decided on three independent axes. Each can skip a",
+        "manifest with a named reason — a skip is an outcome, never a failure, and it",
+        "appears as an `unavailable` row in the Analyzers pre-merge summary.",
         "",
         "- **shell** (`shell:` in the workflow) — may mergeCraft execute anything the",
         "  PR could have written? Enforced by `evaluate_manifest_for_shell()`.",
         "- **trust** (derived from the event) — `pull_request_target` and fork-head PRs",
         "  are `untrusted`. Enforced by `evaluate_manifest_for_tier()`.",
+        "- **mode** (`analyzers:` in the workflow) — `off | auto | full |",
+        "  untrusted-only`. Enforced by `evaluate_manifest_for_mode()` plus",
+        "  `resolve_selection_tier()`.",
         "",
         "Under `shell: disabled`, eligible runtimes are "
         + " and ".join(
@@ -188,10 +220,62 @@ def _shell_trust_matrix_lines() -> list[str]:
             )
             lines.append(f"| `{runtime}` ({count}) | `{trust}` | {disabled_cell} | {other_cell} |")
 
+    if IN_PROCESS_ANALYZER_IDS:
+        exception_ids = ", ".join(f"`{value}`" for value in sorted(IN_PROCESS_ANALYZER_IDS))
+        lines.extend(
+            [
+                "",
+                f"One documented exception to the runtime row: {exception_ids}. It declares",
+                "`runtime: repo-native` but `resolve_analyzer()` special-cases it before the",
+                "repo-binary preference is consulted and `run_adapter()` executes it",
+                "in-process — no subprocess, no argv, nothing the PR authored is run. The",
+                "runtime axis asks whether PR content could steer what executes; for these",
+                "the answer is no, so they stay eligible (#38).",
+            ]
+        )
+
     lines.extend(
         [
             "",
-            "Passing the shell axis is necessary, not sufficient: a `container` manifest",
+            "### The `analyzers:` mode axis",
+            "",
+            "`untrusted-only` runs only analyzers that need no secrets, no network and no",
+            "PR-authored command construction: manifest selection is evaluated at the",
+            "`untrusted` tier *and* the repo-tooling gate applies whatever the shell is.",
+            "On `pull_request_target` and fork-head pull requests, `auto` resolves to it",
+            "— a narrowing default, so a hardened workflow gets mechanical signal without",
+            "loosening `shell:`. An unrecognised `analyzers:` value resolves there too,",
+            "with a warning, rather than silently widening to `auto`.",
+            "",
+            "`full` requests more provisioning; it is never a trust override, and cannot",
+            "re-admit a manifest the tier axis skipped.",
+            "",
+            f"Counts below are analyzers passing selection, out of {total} shipped, with",
+            "`shell: restricted` (the shell axis inert) so the mode axis is isolated.",
+            "",
+            "| mode | trusted event | untrusted event (`pull_request_target`, fork) |",
+            "|------|---------------|-----------------------------------------------|",
+        ]
+    )
+    for mode in ("off", "auto", "full", "untrusted-only"):
+        cells: list[str] = []
+        for tier in ("trusted", "untrusted"):
+            if mode == "off":
+                cells.append("surface not registered")
+                continue
+            selected = _selected(tier=tier, mode=mode, shell="restricted")
+            note = ""
+            if mode == "auto" and tier == "untrusted":
+                note = " — `auto` ⇒ `untrusted-only`"
+            cells.append(f"{len(selected)} of {total}{note}")
+        # Bolded so `parse_analyzers_doc()` does not read a mode name as an
+        # analyzer id — it scrapes rows whose first cell is a bare code span.
+        lines.append(f"| **`{mode}`** | {cells[0]} | {cells[1]} |")
+
+    lines.extend(
+        [
+            "",
+            "Passing these axes is necessary, not sufficient: a `container` manifest",
             "is eligible but still reports `unavailable` wherever no container runtime is",
             "present, and the seven `declared_unavailable` manifests keep their own skip",
             "reason. In the shipped Action image that leaves the `managed` rows as the",
@@ -200,10 +284,7 @@ def _shell_trust_matrix_lines() -> list[str]:
             "Repo-declared `staticChecks` are a third thing and are **always** withheld",
             "under `shell: disabled`, on every event: they run command strings the PR",
             "author controls. They report `declared-but-cannot-run` rather than vanishing.",
-            "",
-            "`agentsec` declares `runtime: repo-native` and is therefore withheld under",
-            "`shell: disabled`, even though it runs in-process with no repo binary. That",
-            "is deliberate: eligibility is read off the declared runtime and nothing else.",
+            "No `analyzers:` value re-enables them.",
         ]
     )
     return lines

--- a/src/mergecraft/analyzers/pipeline.py
+++ b/src/mergecraft/analyzers/pipeline.py
@@ -21,8 +21,11 @@ from mergecraft.analyzers.scope import (
 )
 from mergecraft.analyzers.trust import (
     allow_repo_provided_binaries,
+    evaluate_manifest_for_mode,
     evaluate_manifest_for_shell,
     evaluate_manifest_for_tier,
+    resolve_effective_analyzers_mode,
+    resolve_selection_tier,
 )
 from mergecraft.config import load_repo_settings
 from mergecraft.mcp.review import format_analyzer_inline_body
@@ -35,6 +38,7 @@ if TYPE_CHECKING:
     from mergecraft.config.settings import AnalyzersSettings
 
 TrustTier = Literal["trusted", "untrusted"]
+AnalyzersMode = Literal["off", "auto", "full", "untrusted-only"]
 
 
 def _serialize_finding(finding: Finding) -> dict[str, Any]:
@@ -103,12 +107,19 @@ def run_analyzer_pipeline(
     offline: bool = False,
     base_ref: str | None = None,
     shell: str = "restricted",
+    mode: AnalyzersMode = "auto",
 ) -> AnalyzerRunState:
     """Run enabled analyzers end-to-end and return scoped, budgeted findings.
 
     ``shell`` is the run's shell policy (``ctx.payload.shell``). Under
     ``"disabled"`` only manifests whose argv mergeCraft ships are selected, and
     repo-provided binaries may not stand in for the pinned ones (#35, D5).
+
+    ``mode`` is the ``analyzers:`` input (``ctx.analyzers_mode``). It narrows
+    *selection* only: ``untrusted-only`` — which ``auto`` resolves to on an
+    untrusted run (D8) — evaluates manifests at the untrusted tier and
+    withholds those needing repo-provided tooling. Execution still uses the
+    derived ``tier``, so a mode can never widen what a run may see (#38).
     """
     from mergecraft.tracing.tracer import get_tracer_from_settings
 
@@ -139,12 +150,22 @@ def run_analyzer_pipeline(
         )
 
     repo_binaries_allowed = allow_repo_provided_binaries(shell=shell)
+    effective_mode = resolve_effective_analyzers_mode(mode=mode, tier=tier)
+    selection_tier = resolve_selection_tier(mode=effective_mode, tier=tier)
+    tier_skip_cause = (
+        "analyzers: untrusted-only"
+        if selection_tier == "untrusted" and tier == "trusted"
+        else "fork PR / pull_request_target"
+    )
 
     with tracer.start_span(
         "mergecraft.analyzers.pipeline",
         attrs_source=lambda: {
             "tier": tier,
             "shell": shell,
+            "analyzers.mode": mode,
+            "analyzers.effective_mode": effective_mode,
+            "analyzers.selection_tier": selection_tier,
             "changed_file_count": len(changed_files),
         },
     ) as parent_span:
@@ -154,9 +175,13 @@ def run_analyzer_pipeline(
         from mergecraft.analyzers.adapters import run_adapter
 
         for manifest in manifests:
-            decision = evaluate_manifest_for_tier(manifest=manifest, tier=tier)
+            decision = evaluate_manifest_for_tier(
+                manifest=manifest, tier=selection_tier, cause=tier_skip_cause
+            )
             if not decision.skipped:
                 decision = evaluate_manifest_for_shell(manifest=manifest, shell=shell)
+            if not decision.skipped:
+                decision = evaluate_manifest_for_mode(manifest=manifest, mode=effective_mode)
             if decision.skipped:
                 rows.append(
                     AnalyzerStatusRow(

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -14,13 +14,39 @@ if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import AnalyzerManifest, TrustTier
     from mergecraft.mcp.context import ToolContext
 
-AnalyzersMode = Literal["off", "auto", "full"]
+AnalyzersMode = Literal["off", "auto", "full", "untrusted-only"]
+
+#: Every value the ``analyzers:`` Action input accepts.
+ANALYZERS_MODES: frozenset[str] = frozenset({"off", "auto", "full", "untrusted-only"})
+
+#: Where an unrecognised ``analyzers:`` value lands. Convention 5 — an ambiguous
+#: input resolves to the *more restrictive* outcome, never the wider one. It is
+#: deliberately not ``off``: a typo should narrow coverage, not delete it.
+UNKNOWN_MODE_FALLBACK: AnalyzersMode = "untrusted-only"
 
 #: Runtimes whose argv comes verbatim from a mergeCraft-shipped manifest and is
 #: therefore safe to run when the working tree is PR-authored (#35, D5).
 #: ``repo-native`` is excluded because it resolves against repo-provided
 #: binaries and repo-provided config — see :func:`allow_repo_provided_binaries`.
 SHELL_DISABLED_ELIGIBLE_RUNTIMES: frozenset[str] = frozenset({"managed", "container"})
+
+#: Analyzers that declare ``runtime: repo-native`` but need no repo-provided
+#: tooling at all: ``resolve_analyzer()`` special-cases them before the
+#: repo-binary preference is ever consulted, and ``run_adapter()`` executes them
+#: in-process — no subprocess, no argv, nothing the PR authored is run.
+#:
+#: The runtime axis exists to answer "could PR content steer what executes?".
+#: For these the answer is no, so withholding them buys no safety and costs a
+#: hardened consumer real coverage (#38). ``agentsec`` is mergeCraft's own
+#: agent-security policy engine and is exactly the signal a ``pull_request_target``
+#: consumer wants most; it reads PR-authored manifests as *data*, which every
+#: other part of a review already does.
+#:
+#: Kept as a narrow, named exception rather than a new ``RuntimeMode`` value,
+#: because convention 6 / D6 forbid widening the taxonomy. A drift guard in
+#: ``tests/analyzers/test_trust_aware_analyzer_mode.py`` asserts each id here
+#: really does resolve without repo-provided tooling.
+IN_PROCESS_ANALYZER_IDS: frozenset[str] = frozenset({"agentsec"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,13 +117,37 @@ def evaluate_manifest_for_tier(
     *,
     manifest: AnalyzerManifest,
     tier: TrustTier,
+    cause: str = "fork PR / pull_request_target",
 ) -> ManifestTierDecision:
-    """Skip trusted-only manifests on untrusted runs (D7)."""
+    """Skip trusted-only manifests on untrusted runs (D7).
+
+    ``cause`` names *why* the run is being evaluated at this tier so the reason
+    string stays true when the tier was chosen by the operator rather than
+    derived from the event — ``analyzers: untrusted-only`` on a same-repo PR
+    is a real untrusted selection, but it is not a fork (D9, #38).
+    """
     if tier == "untrusted" and manifest.trust == "trusted":
-        reason = f"skipped {manifest.id}: requires trusted tier (fork PR / pull_request_target)"
+        reason = f"skipped {manifest.id}: requires trusted tier ({cause})"
         logger.info("{}", reason)
         return ManifestTierDecision(skipped=True, reason=reason)
     return ManifestTierDecision(skipped=False)
+
+
+def _needs_repo_provided_tooling(manifest: AnalyzerManifest) -> bool:
+    """Whether running this manifest means running something the repo supplies."""
+    if manifest.id in IN_PROCESS_ANALYZER_IDS:
+        return False
+    return manifest.runtime not in SHELL_DISABLED_ELIGIBLE_RUNTIMES
+
+
+def _withhold_for_repo_tooling(manifest: AnalyzerManifest, *, because: str) -> ManifestTierDecision:
+    """The one skip row the runtime axis produces, whichever gate asked for it."""
+    reason = (
+        f"skipped {manifest.id}: runtime {manifest.runtime!r} needs repo-provided tooling, "
+        f"withheld under {because}"
+    )
+    logger.info("{}", reason)
+    return ManifestTierDecision(skipped=True, reason=reason)
 
 
 def evaluate_manifest_for_shell(
@@ -122,14 +172,34 @@ def evaluate_manifest_for_shell(
     """
     if shell != "disabled":
         return ManifestTierDecision(skipped=False)
-    if manifest.runtime in SHELL_DISABLED_ELIGIBLE_RUNTIMES:
+    if not _needs_repo_provided_tooling(manifest):
         return ManifestTierDecision(skipped=False)
-    reason = (
-        f"skipped {manifest.id}: runtime {manifest.runtime!r} needs repo-provided tooling, "
-        "withheld under shell: disabled"
-    )
-    logger.info("{}", reason)
-    return ManifestTierDecision(skipped=True, reason=reason)
+    return _withhold_for_repo_tooling(manifest, because="shell: disabled")
+
+
+def evaluate_manifest_for_mode(
+    *,
+    manifest: AnalyzerManifest,
+    mode: AnalyzersMode,
+) -> ManifestTierDecision:
+    """Apply the ``analyzers:`` mode's own runtime gate (#38, D8).
+
+    ``untrusted-only`` means what #38 asks for: run only analyzers safe without
+    secrets, without network, and without PR-authored command construction. The
+    tier half of that is :func:`evaluate_manifest_for_tier` driven by
+    :func:`resolve_selection_tier`; this is the runtime half, and it is what
+    makes the mode more than a relabelling — it withholds repo-native manifests
+    even when the shell is merely ``restricted``, which the tier axis alone
+    does not do.
+
+    Inert for every other mode, and returns the same
+    :class:`ManifestTierDecision` the other two predicates return (D9).
+    """
+    if mode != "untrusted-only":
+        return ManifestTierDecision(skipped=False)
+    if not _needs_repo_provided_tooling(manifest):
+        return ManifestTierDecision(skipped=False)
+    return _withhold_for_repo_tooling(manifest, because="analyzers: untrusted-only")
 
 
 def allow_repo_provided_binaries(*, shell: str) -> bool:
@@ -151,10 +221,60 @@ def allow_repo_command_overrides(tier: TrustTier) -> bool:
 
 
 def resolve_analyzers_mode(raw: str | None) -> AnalyzersMode:
-    value = (raw or "auto").strip().lower()
-    if value in {"off", "auto", "full"}:
+    """Resolve the ``analyzers:`` Action input to a mode.
+
+    An *absent* input is not ambiguous — it is the documented ``auto`` default.
+    An input that is present but unrecognised is ambiguous, and convention 5
+    resolves ambiguity to the more restrictive outcome: it lands on
+    ``untrusted-only`` rather than silently buying the wider ``auto``
+    selection, and it says so at ``warning`` level. Before #38 every typo
+    resolved to ``auto`` with no diagnostic, which under ``pull_request_target``
+    is exactly the permissive reading this issue exists to close.
+    """
+    value = (raw or "").strip().lower()
+    if not value:
+        return "auto"
+    if value in ANALYZERS_MODES:
         return value  # type: ignore[return-value]
-    return "auto"
+    logger.warning(
+        "unrecognised analyzers input {!r}; falling back to the more restrictive {!r} "
+        "(valid values: {})",
+        raw,
+        UNKNOWN_MODE_FALLBACK,
+        ", ".join(sorted(ANALYZERS_MODES)),
+    )
+    return UNKNOWN_MODE_FALLBACK
+
+
+def resolve_effective_analyzers_mode(*, mode: AnalyzersMode, tier: TrustTier) -> AnalyzersMode:
+    """Apply D8: ``auto`` means trust-aware selection on an untrusted run.
+
+    Keyed on the tier :func:`derive_trust_tier` already produced rather than on
+    ``GITHUB_EVENT_NAME``, so the event shape is parsed in exactly one place
+    (W4.2). That also means fork-head ``pull_request`` runs — untrusted for the
+    same reason ``pull_request_target`` is — get the same treatment, which is
+    the safer reading of D8 rather than a wider one.
+    """
+    if mode == "auto" and tier == "untrusted":
+        return "untrusted-only"
+    return mode
+
+
+def resolve_selection_tier(*, mode: AnalyzersMode, tier: TrustTier) -> TrustTier:
+    """The tier manifest *selection* is evaluated at.
+
+    Only ever equal to or stricter than the derived tier: ``untrusted-only``
+    forces an untrusted selection on an otherwise-trusted run, and no mode can
+    turn an untrusted run into a trusted selection. In particular ``full`` is a
+    request to provision more tooling, never a trust override.
+
+    The *execution* tier is untouched — ``build_analyzer_env()`` and
+    ``allow_repo_command_overrides()`` keep reading the derived tier, so this
+    can narrow what runs but never widen what a run is allowed to see.
+    """
+    if tier == "untrusted" or mode == "untrusted-only":
+        return "untrusted"
+    return tier
 
 
 def analyzers_enabled(ctx: ToolContext) -> bool:
@@ -176,7 +296,10 @@ def analyzers_enabled(ctx: ToolContext) -> bool:
 
 
 __all__ = [
+    "ANALYZERS_MODES",
+    "IN_PROCESS_ANALYZER_IDS",
     "SHELL_DISABLED_ELIGIBLE_RUNTIMES",
+    "UNKNOWN_MODE_FALLBACK",
     "AnalyzersMode",
     "ManifestTierDecision",
     "allow_repo_command_overrides",
@@ -184,7 +307,10 @@ __all__ = [
     "analyzers_enabled",
     "build_analyzer_env",
     "derive_trust_tier",
+    "evaluate_manifest_for_mode",
     "evaluate_manifest_for_shell",
     "evaluate_manifest_for_tier",
     "resolve_analyzers_mode",
+    "resolve_effective_analyzers_mode",
+    "resolve_selection_tier",
 ]

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -56,6 +56,10 @@ def run_analyzers_tool(ctx: ToolContext):
             # #35 — the surface now registers under `shell: disabled`, so the
             # shell has to reach manifest selection or the withhold is lost.
             shell=str(ctx.payload.shell),
+            # #38 — likewise the mode: `untrusted-only` (and the `auto` that
+            # resolves to it on untrusted runs) only narrows selection if it
+            # actually reaches the pipeline.
+            mode=ctx.analyzers_mode,
         )
         _store_run_state(ctx, run_state)
 

--- a/src/mergecraft/mcp/context.py
+++ b/src/mergecraft/mcp/context.py
@@ -87,7 +87,7 @@ class ToolContext:
     # reads the consumer's CI and never substitutes a gate outcome.
     ci_gate_checks: dict[str, str] = field(default_factory=dict)
     ci_sarif_artifacts: list[str] = field(default_factory=list)
-    analyzers_mode: Literal["off", "auto", "full"] = "auto"
+    analyzers_mode: Literal["off", "auto", "full", "untrusted-only"] = "auto"
     trust_tier: Literal["trusted", "untrusted"] = "trusted"
     analyzers_settings_enabled: bool = True
     run_id: int | None = None

--- a/tests/analyzers/test_shell_disabled_split.py
+++ b/tests/analyzers/test_shell_disabled_split.py
@@ -84,8 +84,20 @@ def _ids_by_runtime(runtime: str) -> list[str]:
     return sorted(m.id for m in _catalog_manifests() if m.runtime == runtime)
 
 
-REPO_NATIVE_IDS: list[str] = _ids_by_runtime("repo-native")
-ELIGIBLE_IDS: list[str] = _ids_by_runtime("managed") + _ids_by_runtime("container")
+# `agentsec` declares `repo-native` but runs in-process with no subprocess and no
+# repo-provided binary, so the "needs repo tooling" premise this axis rests on is
+# false for it. Batch A withheld it anyway and flagged it; #38 admits it
+# deliberately — see `IN_PROCESS_ANALYZER_IDS` in `analyzers/trust.py`.
+IN_PROCESS_IDS: frozenset[str] = frozenset({"agentsec"})
+
+REPO_NATIVE_IDS: list[str] = [
+    analyzer_id
+    for analyzer_id in _ids_by_runtime("repo-native")
+    if analyzer_id not in IN_PROCESS_IDS
+]
+ELIGIBLE_IDS: list[str] = sorted(
+    _ids_by_runtime("managed") + _ids_by_runtime("container") + sorted(IN_PROCESS_IDS)
+)
 
 
 def _ctx(

--- a/tests/analyzers/test_trust_aware_analyzer_mode.py
+++ b/tests/analyzers/test_trust_aware_analyzer_mode.py
@@ -1,0 +1,581 @@
+"""#38 — trust-aware analyzer selection (Batch B, W3).
+
+Batch A split the *shell* axis: under `shell: disabled` only manifests whose
+argv mergeCraft ships are eligible. That leaves the second half of #38 open —
+the `analyzers:` input itself is still trust-blind. It accepts exactly
+`off | auto | full`, `resolve_analyzers_mode()` silently rewrites anything else
+to `auto`, and nothing anywhere consults the mode when *selecting* manifests.
+
+What #38 asks for is an `untrusted-only` mode meaning "run only analyzers that
+are safe without secrets, without network, and without PR-authored command
+construction" — the issue names both halves of that: `untrusted` **tier** and
+`managed` **runtime**. So the mode applies two gates:
+
+* the tier gate, evaluated as if the run were untrusted, so `trust: trusted`
+  manifests skip with the reason `evaluate_manifest_for_tier()` already
+  produces (D9 — one skip path, not a second vocabulary); and
+* the runtime gate Batch A built for `shell: disabled`, so manifests needing
+  repo-provided tooling skip even when the shell is merely `restricted`.
+
+That second gate is what makes the mode more than a relabelling: on
+`pull_request_target` with `shell: restricted`, today's tier gate alone still
+admits repo-native manifests resolved against a PR-authored `.venv/bin`.
+
+These cases pin:
+
+* `untrusted-only` survives `resolve_analyzers_mode()` (W3.1);
+* `auto` under an untrusted tier resolves to it (W3.2, D8);
+* the full event x trust x mode matrix selects exactly the specified set (W3.3);
+* skipped manifests are outcomes with reasons, never failures (W3.4);
+* `full` on a trusted run is unchanged, and never *loosens* the tier gate on an
+  untrusted one (W3.5);
+* an unrecognised input fails safe to the more restrictive mode (W3.6); and
+* the hardened example adopts the safe default explicitly (W3.7).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.registry import get_manifest, load_catalog
+from mergecraft.analyzers.trust import (
+    analyzers_enabled,
+    derive_trust_tier,
+    evaluate_manifest_for_tier,
+)
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from tests.analyzers.support import import_module
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.manifest import AnalyzerManifest
+
+# W3.8 — RED until W4 lands the mode. Removed in the W4 commit.
+pytestmark = pytest.mark.xfail(reason="green after W4 (#38)", strict=False)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The mode axis under test. `off` short-circuits before the pipeline; the other
+# three reach manifest selection.
+MODES: tuple[str, ...] = ("off", "auto", "full", "untrusted-only")
+
+# The issue's event axis. `offline` is the operator's own local diff review,
+# which `derive_trust_tier(offline=True)` pins to `trusted`.
+EVENTS: tuple[str, ...] = (
+    "pull_request",
+    "pull_request_target",
+    "workflow_dispatch",
+    "offline",
+)
+
+TIERS: tuple[str, ...] = ("trusted", "untrusted")
+
+# Runtimes whose argv is copied verbatim out of a mergeCraft-shipped manifest.
+# Spelled out here rather than imported so the matrix encodes the *policy* and
+# would notice the production constant being widened.
+SHIPPED_ARGV_RUNTIMES: frozenset[str] = frozenset({"managed", "container"})
+
+# Analyzers that declare a `repo-native` runtime but execute in-process, with no
+# subprocess and no repo-provided binary, so no repo tooling is required. See
+# `resolve_analyzer()`'s special case and the W4 decision note.
+IN_PROCESS_IDS: frozenset[str] = frozenset({"agentsec"})
+
+
+# --------------------------------------------------------------------------- #
+# Lazy accessors — the module must still collect before W4 adds the symbols.
+# --------------------------------------------------------------------------- #
+
+
+def _trust() -> Any:
+    return import_module("mergecraft.analyzers.trust")
+
+
+def _resolve_analyzers_mode(raw: str | None) -> Any:
+    return _trust().resolve_analyzers_mode(raw)
+
+
+def _resolve_effective_analyzers_mode(*, mode: str, tier: str) -> Any:
+    return _trust().resolve_effective_analyzers_mode(mode=mode, tier=tier)
+
+
+def _resolve_selection_tier(*, mode: str, tier: str) -> Any:
+    return _trust().resolve_selection_tier(mode=mode, tier=tier)
+
+
+def _evaluate_manifest_for_mode(*, manifest: AnalyzerManifest, mode: str) -> Any:
+    return _trust().evaluate_manifest_for_mode(manifest=manifest, mode=mode)
+
+
+def _catalog() -> list[AnalyzerManifest]:
+    return sorted(load_catalog(), key=lambda m: m.id)
+
+
+def _needs_repo_tooling(manifest: AnalyzerManifest) -> bool:
+    """The runtime axis, restated from the policy rather than from the code."""
+    if manifest.id in IN_PROCESS_IDS:
+        return False
+    return manifest.runtime not in SHIPPED_ARGV_RUNTIMES
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    analyzers_mode: str,
+    shell: str = "restricted",
+    trigger: str = "pull_request",
+    tier: str = "untrusted",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger=trigger),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        static_checks_enabled=False,
+        analyzers_mode=analyzers_mode,  # type: ignore[arg-type]
+        analyzers_settings_enabled=True,
+        trust_tier=tier,  # type: ignore[arg-type]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The specification the matrix asserts against.
+# --------------------------------------------------------------------------- #
+
+
+def _expected_selection(*, tier: str, mode: str, shell: str = "restricted") -> set[str]:
+    """Restate #38's policy independently of the implementation.
+
+    Written as a truth table over the two manifest attributes the policy reads
+    (`trust`, `runtime`) so a drift in the production predicates fails here
+    rather than being mirrored by it.
+    """
+    if mode == "off":
+        return set()
+
+    effective = "untrusted-only" if (mode == "auto" and tier == "untrusted") else mode
+    # `full` must never *loosen* the tier gate on an untrusted run.
+    selection_tier = "untrusted" if effective == "untrusted-only" or tier == "untrusted" else tier
+
+    selected: set[str] = set()
+    for manifest in _catalog():
+        if selection_tier == "untrusted" and manifest.trust == "trusted":
+            continue
+        if _needs_repo_tooling(manifest) and (effective == "untrusted-only" or shell == "disabled"):
+            continue
+        selected.add(manifest.id)
+    return selected
+
+
+def _run_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tier: str,
+    mode: str,
+    shell: str = "restricted",
+) -> tuple[set[str], dict[str, Any]]:
+    """Drive the real pipeline and report which manifests reached the adapter.
+
+    Selection is observed at the adapter boundary rather than by re-calling the
+    predicates, so a predicate that is correct but unwired still fails.
+    """
+    from mergecraft.analyzers import adapters, pipeline
+
+    reached: set[str] = set()
+
+    def _record(**kwargs: Any) -> adapters.AdapterRunResult:
+        reached.add(str(kwargs["tool_id"]))
+        return adapters.AdapterRunResult(findings=[])
+
+    monkeypatch.setattr(adapters, "run_adapter", _record)
+    monkeypatch.setattr(pipeline, "detect_enabled", lambda **_: _catalog())
+
+    state = pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=["a.py", "b.sh", "c.tf", ".mcp.json"],
+        tier=tier,  # type: ignore[arg-type]
+        shell=shell,
+        mode=mode,  # type: ignore[arg-type]
+    )
+    rows = {row.id: row for row in state.analyzers}
+    return reached, rows
+
+
+# --------------------------------------------------------------------------- #
+# W3.1 — `untrusted-only` is a real input value
+# --------------------------------------------------------------------------- #
+
+
+def test_analyzers_input_accepts_untrusted_only() -> None:
+    """#38's first acceptance box: the new value survives resolution."""
+    assert _resolve_analyzers_mode("untrusted-only") == "untrusted-only"
+
+
+@pytest.mark.parametrize("raw", ["UNTRUSTED-ONLY", "  untrusted-only  "])
+def test_untrusted_only_is_normalised_like_the_other_values(raw: str) -> None:
+    assert _resolve_analyzers_mode(raw) == "untrusted-only"
+
+
+@pytest.mark.parametrize("raw", ["off", "auto", "full"])
+def test_existing_mode_values_are_unchanged(raw: str) -> None:
+    """Regression guard: the three shipped values keep resolving to themselves."""
+    assert _resolve_analyzers_mode(raw) == raw
+
+
+@pytest.mark.parametrize("raw", [None, "", "   "])
+def test_unset_input_still_defaults_to_auto(raw: str | None) -> None:
+    """An *absent* input is not ambiguous — it is the documented default."""
+    assert _resolve_analyzers_mode(raw) == "auto"
+
+
+# --------------------------------------------------------------------------- #
+# W3.2 — `auto` implies trust-aware selection on untrusted events (D8)
+# --------------------------------------------------------------------------- #
+
+
+def test_auto_implies_trust_aware_under_pull_request_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D8's behaviour flip, derived from the tier rather than re-read from the event."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_target")
+    tier = derive_trust_tier(event={"pull_request": {}}, shell="restricted")
+    assert tier == "untrusted"
+    assert _resolve_effective_analyzers_mode(mode="auto", tier=tier) == "untrusted-only"
+
+
+def test_auto_is_unchanged_on_trusted_runs() -> None:
+    """The flip is scoped to untrusted runs; a same-repo PR still means `auto`."""
+    assert _resolve_effective_analyzers_mode(mode="auto", tier="trusted") == "auto"
+
+
+def test_auto_implies_trust_aware_on_fork_pull_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """W4.2 reads `derive_trust_tier()`, so fork-head PRs get the same treatment."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(
+        event={"pull_request": {"head": {"repo": {"fork": True}}}},
+        shell="restricted",
+    )
+    assert tier == "untrusted"
+    assert _resolve_effective_analyzers_mode(mode="auto", tier=tier) == "untrusted-only"
+
+
+def test_trusted_only_manifests_skip_under_auto_on_pull_request_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The end-to-end form of D8: named skips, not silent absence."""
+    reached, rows = _run_selection(tmp_path, monkeypatch, tier="untrusted", mode="auto")
+
+    trusted_only = {m.id for m in _catalog() if m.trust == "trusted"}
+    assert not (trusted_only & reached)
+    for analyzer_id in sorted(trusted_only):
+        assert rows[analyzer_id].status == "unavailable"
+        assert rows[analyzer_id].reason
+
+
+# --------------------------------------------------------------------------- #
+# W3.3 — the issue's explicit acceptance criterion: the full matrix
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("event", EVENTS)
+@pytest.mark.parametrize("tier", TIERS)
+@pytest.mark.parametrize("mode", MODES)
+def test_event_trust_analyzers_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    event: str,
+    tier: str,
+    mode: str,
+) -> None:
+    """Every cell of {4 events} x {2 tiers} x {4 modes}.
+
+    Two of the eight event/tier pairs are unreachable in production
+    (`workflow_dispatch` is always trusted, `pull_request_target` always
+    untrusted) — they are asserted anyway as defence in depth, since the
+    pipeline receives the tier as a parameter and must not depend on the event
+    name to behave safely.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "" if event == "offline" else event)
+
+    if mode == "off":
+        ctx = _ctx(tmp_path, analyzers_mode=mode, tier=tier)
+        assert analyzers_enabled(ctx) is False
+        return
+
+    reached, rows = _run_selection(tmp_path, monkeypatch, tier=tier, mode=mode)
+    expected = _expected_selection(tier=tier, mode=mode)
+
+    assert reached == expected
+
+    # Everything the catalog offers but this cell excluded is a named skip.
+    for analyzer_id in sorted({m.id for m in _catalog()} - expected):
+        assert rows[analyzer_id].status == "unavailable"
+        assert rows[analyzer_id].reason
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_tier"),
+    [
+        ("pull_request_target", "untrusted"),
+        ("workflow_dispatch", "trusted"),
+        ("pull_request", "trusted"),
+    ],
+)
+def test_event_axis_derives_the_expected_tier(
+    monkeypatch: pytest.MonkeyPatch, event: str, expected_tier: str
+) -> None:
+    """Pin the event -> tier edge the matrix's tier axis stands on."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", event)
+    assert derive_trust_tier(event={"pull_request": {}}, shell="restricted") == expected_tier
+
+
+def test_offline_event_is_trusted() -> None:
+    assert derive_trust_tier(event=None, offline=True) == "trusted"
+
+
+# --------------------------------------------------------------------------- #
+# W3.4 — skips are outcomes, not failures (D9)
+# --------------------------------------------------------------------------- #
+
+
+def test_trusted_only_analyzers_skip_not_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A skipped manifest yields a row, never a failed run and never a gap."""
+    reached, rows = _run_selection(tmp_path, monkeypatch, tier="trusted", mode="untrusted-only")
+
+    catalog_ids = {m.id for m in _catalog()}
+    assert set(rows) == catalog_ids, "every manifest must produce exactly one row"
+    assert not any(row.status == "failed" for row in rows.values())
+    for analyzer_id in sorted(catalog_ids - reached):
+        assert rows[analyzer_id].status == "unavailable"
+
+
+def test_mode_skip_reuses_the_existing_decision_shape() -> None:
+    """D9: one skip vocabulary — the same dataclass the tier predicate returns."""
+    decision = _evaluate_manifest_for_mode(manifest=get_manifest("ruff"), mode="untrusted-only")
+    tier_decision = evaluate_manifest_for_tier(manifest=get_manifest("ruff"), tier="untrusted")
+    assert type(decision) is type(tier_decision)
+    assert decision.skipped is True
+    assert decision.reason is not None
+    assert "ruff" in decision.reason
+
+
+def test_mode_predicate_is_inert_outside_untrusted_only() -> None:
+    """Off the `untrusted-only` path the mode axis decides nothing."""
+    for mode in ("auto", "full"):
+        decision = _evaluate_manifest_for_mode(manifest=get_manifest("ruff"), mode=mode)
+        assert decision.skipped is False
+
+
+def test_skip_reason_names_the_axis_that_caused_it() -> None:
+    """A reason that names the wrong cause is not a named reason (D9)."""
+    decision = _evaluate_manifest_for_mode(manifest=get_manifest("ruff"), mode="untrusted-only")
+    assert "untrusted-only" in (decision.reason or "")
+
+    tier_decision = evaluate_manifest_for_tier(
+        manifest=get_manifest("pylint"),
+        tier="untrusted",
+        cause="analyzers: untrusted-only",
+    )
+    assert tier_decision.skipped is True
+    assert "untrusted-only" in (tier_decision.reason or "")
+
+
+def test_default_tier_skip_reason_is_unchanged() -> None:
+    """Regression guard: Batch A's reason string still renders for real fork PRs."""
+    decision = evaluate_manifest_for_tier(manifest=get_manifest("pylint"), tier="untrusted")
+    assert decision.skipped is True
+    assert "fork PR / pull_request_target" in (decision.reason or "")
+
+
+# --------------------------------------------------------------------------- #
+# W3.5 — `full` is unchanged on trusted runs and never loosens untrusted ones
+# --------------------------------------------------------------------------- #
+
+
+def test_full_still_means_full_on_trusted_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: the whole catalog is selected, as today."""
+    reached, _ = _run_selection(tmp_path, monkeypatch, tier="trusted", mode="full")
+    assert reached == {m.id for m in _catalog()}
+
+
+def test_full_does_not_loosen_the_tier_gate_on_untrusted_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`full` is a *provisioning* request, never a trust override (convention 5)."""
+    reached, _ = _run_selection(tmp_path, monkeypatch, tier="untrusted", mode="full")
+    trusted_only = {m.id for m in _catalog() if m.trust == "trusted"}
+    assert not (trusted_only & reached)
+
+
+def test_selection_tier_never_relaxes_the_derived_tier() -> None:
+    """No mode may turn an untrusted run into a trusted selection."""
+    for mode in MODES:
+        assert _resolve_selection_tier(mode=mode, tier="untrusted") == "untrusted"
+    assert _resolve_selection_tier(mode="untrusted-only", tier="trusted") == "untrusted"
+    assert _resolve_selection_tier(mode="full", tier="trusted") == "trusted"
+
+
+# --------------------------------------------------------------------------- #
+# W3.6 — unknown values fail safe (convention 5). Security-critical.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("raw", ["untrusted_only", "untrustedonly", "ful", "yes", "on", "true"])
+def test_unknown_mode_value_falls_back_to_the_safer_mode(raw: str) -> None:
+    """A typo must not silently buy the *wider* selection.
+
+    Pre-change this returns `auto` for every one of these, which under
+    `pull_request_target` is exactly the permissive reading #38 exists to close.
+    """
+    assert _resolve_analyzers_mode(raw) == "untrusted-only"
+
+
+def test_unknown_mode_value_is_logged_not_swallowed() -> None:
+    """Failing safe silently is still a silent failure — the operator is told."""
+    from loguru import logger
+
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(message), level="WARNING")
+    try:
+        _resolve_analyzers_mode("untrusted_only")
+    finally:
+        logger.remove(sink_id)
+
+    assert any("untrusted_only" in record for record in records)
+
+
+def test_unknown_mode_value_is_not_more_permissive_than_auto_anywhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback must be a subset of `auto`'s selection on every tier."""
+    fallback = _resolve_analyzers_mode("nonsense-value")
+    for tier in TIERS:
+        fallback_selected, _ = _run_selection(tmp_path, monkeypatch, tier=tier, mode=fallback)
+        auto_selected, _ = _run_selection(tmp_path, monkeypatch, tier=tier, mode="auto")
+        assert fallback_selected <= auto_selected
+
+
+# --------------------------------------------------------------------------- #
+# W3.7 — the hardened example adopts the safe default
+# --------------------------------------------------------------------------- #
+
+
+def test_hardened_example_uses_the_safe_default() -> None:
+    """#38's third acceptance box, asserted on the rendered workflow."""
+    rendered = (REPO_ROOT / "examples" / "workflows" / "mergecraft-hardened.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "analyzers: untrusted-only" in rendered
+
+
+def test_hardened_template_and_render_agree() -> None:
+    """The template is the source of truth; `make example-workflows-check` gates drift."""
+    template = (REPO_ROOT / "scripts" / "example_workflows" / "hardened.yml.tpl").read_text(
+        encoding="utf-8"
+    )
+    assert "analyzers: untrusted-only" in template
+
+
+def test_action_yml_documents_the_new_value() -> None:
+    """W4.4: an input value nobody can discover is not an input value."""
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+    assert "untrusted-only" in action
+
+
+# --------------------------------------------------------------------------- #
+# The `agentsec` allowance (W4 decision — see the wave plan's W0.4 follow-up)
+# --------------------------------------------------------------------------- #
+
+
+def test_agentsec_is_eligible_despite_declaring_repo_native() -> None:
+    """It runs in-process: no subprocess, no repo binary, nothing PR-authored runs."""
+    manifest = get_manifest("agentsec")
+    assert manifest.runtime == "repo-native"
+    assert manifest.trust == "untrusted"
+
+    trust = _trust()
+    assert trust.evaluate_manifest_for_shell(manifest=manifest, shell="disabled").skipped is False
+    assert _evaluate_manifest_for_mode(manifest=manifest, mode="untrusted-only").skipped is False
+
+
+def test_in_process_allowlist_matches_the_resolver(tmp_path: Path) -> None:
+    """Drift guard: every allowlisted id must really bypass repo-binary resolution.
+
+    If `resolve_analyzer()`'s special case is ever removed, the allowlist stops
+    being true and this fails rather than quietly admitting a repo-native tool.
+    """
+    from mergecraft.analyzers.resolve import resolve_analyzer
+
+    for analyzer_id in sorted(_trust().IN_PROCESS_ANALYZER_IDS):
+        plan = resolve_analyzer(
+            manifest=get_manifest(analyzer_id),
+            repo_root=tmp_path,
+            allow_repo_binaries=False,
+        )
+        assert plan.mode != "skip", f"{analyzer_id} must resolve without repo-provided tooling"
+
+
+def test_no_other_repo_native_manifest_is_admitted() -> None:
+    """The allowlist stays a narrow exception, not a hole in the runtime axis."""
+    trust = _trust()
+    for manifest in _catalog():
+        if manifest.runtime in SHIPPED_ARGV_RUNTIMES or manifest.id in IN_PROCESS_IDS:
+            continue
+        assert (
+            trust.evaluate_manifest_for_shell(manifest=manifest, shell="disabled").skipped is True
+        )
+        assert _evaluate_manifest_for_mode(manifest=manifest, mode="untrusted-only").skipped is True
+
+
+# --------------------------------------------------------------------------- #
+# Wiring — the mode must actually reach selection (issue #96 class of bug)
+# --------------------------------------------------------------------------- #
+
+
+def test_mcp_run_analyzers_passes_the_context_mode_to_the_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A correct predicate nobody calls is the bug `test_runtime_call_sites` exists for."""
+    import asyncio
+
+    from mergecraft.analyzers import pipeline
+    from mergecraft.mcp.analyzers import run_analyzers_tool
+    from mergecraft.mcp.tool_state import AnalyzerRunState
+
+    seen: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> AnalyzerRunState:
+        seen.update(kwargs)
+        return AnalyzerRunState(ran=False, reason="stubbed")
+
+    monkeypatch.setattr(pipeline, "run_analyzer_pipeline", _capture)
+
+    ctx = _ctx(tmp_path, analyzers_mode="untrusted-only", tier="untrusted")
+    spec = run_analyzers_tool(ctx)
+    asyncio.run(spec.execute({"repo_root": str(tmp_path), "changed_files": ["a.py"]}))
+
+    assert seen.get("mode") == "untrusted-only"

--- a/tests/analyzers/test_trust_aware_analyzer_mode.py
+++ b/tests/analyzers/test_trust_aware_analyzer_mode.py
@@ -60,9 +60,6 @@ from tests.analyzers.support import import_module
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import AnalyzerManifest
 
-# W3.8 — RED until W4 lands the mode. Removed in the W4 commit.
-pytestmark = pytest.mark.xfail(reason="green after W4 (#38)", strict=False)
-
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # The mode axis under test. `off` short-circuits before the pipeline; the other

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -88,6 +88,30 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
         ),
     ),
     _Contract(
+        symbol="evaluate_manifest_for_mode",
+        defined_in="analyzers/trust.py",
+        why=(
+            "no reachable caller means `analyzers: untrusted-only` stops withholding "
+            "repo-native manifests, so the mode is accepted and does nothing (#38)"
+        ),
+    ),
+    _Contract(
+        symbol="resolve_effective_analyzers_mode",
+        defined_in="analyzers/trust.py",
+        why=(
+            "no reachable caller means `auto` never resolves to trust-aware selection on "
+            "pull_request_target, silently reverting D8 (#38)"
+        ),
+    ),
+    _Contract(
+        symbol="resolve_selection_tier",
+        defined_in="analyzers/trust.py",
+        why=(
+            "no reachable caller means `untrusted-only` never forces an untrusted manifest "
+            "selection, so trusted-tier analyzers still run (#38)"
+        ),
+    ),
+    _Contract(
         symbol="substitute_declared_gates",
         defined_in="ci/evidence.py",
         why="no reachable caller means a gate the consumer's CI proved still reports "


### PR DESCRIPTION
## Why

A repo that hardens correctly — `pull_request_target` plus `shell: disabled` — has no way to *ask* for trust-aware analyzer coverage. The `analyzers:` input accepts `off | auto | full`, none of which means "only what is safe without secrets, without network, and without PR-authored command construction", and `resolve_analyzers_mode()` silently rewrote every unrecognised value to `auto` — so the input that looked strictest was the one that did nothing.

Batch A (#35, PR #107) split the *shell* axis. This is the *mode* axis.

## What changed

**`analyzers: untrusted-only`** applies two gates at once, which is what makes it more than a relabelling of the trust tier:

- selection is evaluated at the `untrusted` tier, so `trust: trusted` manifests skip; and
- analyzers needing repo-provided tooling are withheld **whatever `shell:` is set to** — the tier axis alone still admits a `repo-native` manifest resolved against a PR-authored `.venv/bin` when the shell is merely `restricted`.

On a trusted event that narrows 57 shipped manifests to 18.

**`auto` resolves to `untrusted-only` on untrusted runs** (D8), keyed on the tier `derive_trust_tier()` already produced rather than re-reading `GITHUB_EVENT_NAME`, so fork-head `pull_request` runs are covered by the same rule.

**Unknown values fail safe.** A present-but-unrecognised input lands on `untrusted-only` with a `warning`, not on `auto`. An *absent* input still means `auto` — that is the documented default, not an ambiguity.

**`full` is a provisioning request, never a trust override.** `resolve_selection_tier()` is only ever equal to or stricter than the derived tier.

**One skip vocabulary (D9).** Skips route through the existing `evaluate_manifest_for_tier()` and its `ManifestTierDecision` → `AnalyzerStatusRow(status="unavailable")` shape. Its reason string gained a `cause` parameter so it stays *true* when the untrusted selection was chosen by the operator rather than derived from a fork; the default renders Batch A's string verbatim.

**Execution tier is untouched.** `build_analyzer_env()` and `allow_repo_command_overrides()` keep reading the derived tier, so a mode can narrow what runs but never widen what a run may see.

## The `agentsec` decision

Batch A flagged this rather than deciding it. `agentsec` declares `runtime: repo-native`, but `resolve_analyzer()` special-cases it *before* the repo-binary preference is consulted and `run_adapter()` executes it in-process — no subprocess, no argv, no repo binary. The runtime axis asks "could PR content steer what executes?"; for `agentsec` the answer is no, so withholding it bought no safety while costing hardened consumers the one analyzer most relevant to `pull_request_target` — the one reading `.mcp.json`, `CLAUDE.md`, `AGENTS.md` and skill files as data.

It is admitted via a named `IN_PROCESS_ANALYZER_IDS` exception with a drift-guard test asserting it really does resolve without repo-provided tooling — not a fourth `RuntimeMode` value, which D6 / convention 6 forbid.

This also stops D8 from doing net harm: applied literally, the `auto` flip would have removed `agentsec` — the only `repo-native` + `trust: untrusted` manifest — from hardened runs, which is the opposite of what #38 asks for.

## Measured behaviour change

Diffing selection pre- vs post-change across every tier × shell × `{auto, full}` combination, the **only** difference on the shipped catalog is `+agentsec` under `shell: disabled`. The `auto` flip changes which analyzers run **not at all** today, because the tier gate already excluded every trusted manifest and the one remaining `repo-native` manifest is now exempt. It is recorded as breaking because an existing input value's *meaning* changed — it now binds any future `repo-native` + `trust: untrusted` analyzer — not because current behaviour did. The CHANGELOG says exactly that rather than claiming a coverage change that did not happen.

The genuinely breaking change is the unknown-value fallback: a typo that used to silently select the whole catalog now selects 18 of 57.

## Tests

`tests/analyzers/test_trust_aware_analyzer_mode.py` — the issue's acceptance criterion is parametrized in full: `{pull_request, pull_request_target, workflow_dispatch, offline} × {trusted, untrusted} × {off, auto, full, untrusted-only}`, 32 cells. Selection is observed **at the adapter boundary through the real pipeline**, so a predicate that is correct but unwired still fails; the expected set is restated from the policy in the test rather than by calling the production predicates.

Pre-change proof for the two security-critical cases:

```
>       assert _resolve_analyzers_mode("untrusted-only") == "untrusted-only"
E       AssertionError: assert 'auto' == 'untrusted-only'     # W3.1
>       assert _resolve_analyzers_mode(raw) == "untrusted-only"
E       AssertionError: assert 'auto' == 'untrusted-only'     # W3.6
```

Whole file pre-change: **54 failed / 18 passed**. Post-change: 157 passed across this file, Batch A's suite, and the call-site guard.

`tests/test_runtime_call_sites.py` gains three contracts (`evaluate_manifest_for_mode`, `resolve_effective_analyzers_mode`, `resolve_selection_tier`) — the mode reaches the pipeline through `mcp/analyzers.py`, a seam that could otherwise go wired-but-dead.

Batch A's `repo-native` sweep is narrowed to exclude `agentsec`, which this PR deliberately admits.

## Docs

`docs/ANALYZERS.md` is fully generated, so the mode axis was added to `catalog_docs._shell_trust_matrix_lines()`, which now computes **every cell by calling the same predicates the pipeline calls** over the real catalog. The matrix cannot drift from the code that enforces it.

Also: `action.yml`, `README.md` (input value table), and the hardened workflow template, which now sets `analyzers: untrusted-only` explicitly.

## Verification

- `make ci-reset` then a single `make ci-resume` — **all 9 steps passed** (lockcheck, lint, typecheck, pyright, catalog-check, build, example-workflows-check, security, test)
- `make test` — **1175 passed, 21 skipped**, 10 xfailed / 10 xpassed (all pre-existing on `pre-0.0.1`, none introduced here)
- `make catalog-check` — **catalog OK, 57 manifests**
- `graphify update .` — 5135 nodes, 8269 edges

## Notes

Review gate (D3) was not run locally; deferred to CI / operator review.

Closes #38
