### PR TITLE
analyzers: publish findings as code-scanning alerts (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Analyzer findings can now be published as GitHub code-scanning alerts, so
+  mechanical signal stays readable when the review narrative is thin or when
+  findings overflowed the inline comment budget. Opt in with
+  `sarif_upload: enabled` (or `analyzers.sarifUpload: true` in
+  `.mergecraft/config.yaml`) plus `security-events: write` on the job; with the
+  flag unset the run makes no extra API call at all. mergeCraft has exported
+  SARIF since the catalog shipped, but the only caller was the offline
+  `mergecraft analyzers export --sarif` command, so no Action run ever produced
+  a document. Uploads carry only findings from catalog analyzers this run's
+  trust tier, `shell:` policy and `analyzers:` mode actually admitted —
+  re-checked at upload time against the same predicates the pipeline uses — and
+  every message, evidence line, remediation and autofix is redacted while still
+  a typed `Finding`, before SARIF is built. CI-sourced findings (which carry
+  truncated pipeline log excerpts) and agent narrative are never uploaded. The
+  set is the clustered, placed one, so cross-tool duplicates arrive as one
+  alert; it is deliberately *not* truncated at the inline comment budget,
+  because the overflow is what this surface exists to show. A rejected upload —
+  missing permission, no code scanning on the repository, transport error — is
+  logged at `warning` and the review still completes: SARIF is complementary
+  evidence, never a gate (#39, D13/D14)
 - Hardened workflows can now ask for trust-aware analyzer selection explicitly:
   `analyzers: untrusted-only` runs only analyzers that need no secrets, no
   network, and no PR-authored command construction. It applies two gates at

--- a/README.md
+++ b/README.md
@@ -326,6 +326,28 @@ The Action's `analyzers:` input picks how much of the catalog is eligible:
 
 Under `pull_request_target` and fork-head pull requests the trust tier is `untrusted`, and `auto` resolves to `untrusted-only` there — so a hardened workflow gets mechanical signal without loosening `shell:`. Anything the mode excludes is reported as a skipped row with a named reason, never as a failure. An unrecognised value also resolves to `untrusted-only`, with a warning, rather than silently widening to `auto`. `full` is a request to provision more tooling; it is never a trust override and cannot re-admit an analyzer the trust tier excluded. The generated matrix in [`docs/ANALYZERS.md`](docs/ANALYZERS.md) shows what each combination selects.
 
+### SARIF upload to code scanning (opt-in)
+
+Analyzer findings can also be published as GitHub code-scanning alerts, which keeps mechanical signal readable when the review narrative is thin or when findings overflowed the inline comment budget. It is **off by default** and requires `security-events: write`:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write   # required — without it GitHub answers 403
+
+jobs:
+  review:
+    steps:
+      - uses: alexhawat/mergeCraft@<sha>
+        with:
+          sarif_upload: enabled
+```
+
+`.mergecraft/config.yaml`'s `analyzers.sarifUpload: true` does the same; the `sarif_upload` action input wins in both directions when it is set, and an unrecognised value resolves to disabled with a warning.
+
+Only findings from catalog analyzers this run's trust tier, `shell:` policy and `analyzers:` mode actually admitted are uploaded, after secret redaction — CI-sourced findings (which carry pipeline log excerpts) and agent narrative are never uploaded. The upload is complementary evidence, never a gate: a missing permission, a repository without code scanning, or a transport error is logged at `warning` and the review still completes. Details in [`docs/ANALYZERS.md`](docs/ANALYZERS.md#sarif-upload-to-code-scanning-39).
+
 ## Learnings — staging and promotion
 
 `.mergecraft/learnings.md` holds durable cross-run context (test commands, conventions, gotchas, architecture notes) seeded into every review. Since this file is **attacker-controllable input** in any non-maintainer context (a fork PR body, a contributor comment, an agent-written entry from prior untrusted text), entries are now provenance-gated (D10, #74):
@@ -465,7 +487,9 @@ uv run mergecraft traces <run-id>    # read back local spans
 Same contract as upstream mergecraft: `prompt`, `prompt_file`, `timeout`, `model`,
 `cwd`, `push`, `shell`, `status_checks`, `output_schema`, `token` → output `result`,
 plus `allow_pr_target_comments` (default `false`) — see
-[Comment-trigger authorization](#comment-trigger-authorization).
+[Comment-trigger authorization](#comment-trigger-authorization) — and
+`sarif_upload` (default `disabled`, needs `security-events: write`) — see
+[SARIF upload to code scanning](#sarif-upload-to-code-scanning-opt-in).
 
 Tracing inputs (`tracing`, `tracing-to`, `logfire-token`, `otel-endpoint`) — see
 [Tracing](#tracing).

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,21 @@ inputs:
       with a warning. Default: auto
     required: false
     default: auto
+  sarif_upload:
+    description: >-
+      Upload catalog-analyzer findings to GitHub code scanning as SARIF 2.1.0:
+      disabled (default) or enabled. Complementary evidence for when the review
+      narrative is thin or findings overflow the inline comment budget — never a
+      gate: an upload failure is logged and the run still completes. Requires
+      `security-events: write` on the job, and code scanning to be available on
+      the repository. Only findings from catalog analyzers that this run's trust
+      tier, shell policy and `analyzers:` mode actually admitted are uploaded,
+      after secret redaction. CI-sourced and agent-sourced findings are never
+      uploaded. An unrecognised value resolves to disabled, with a warning. When
+      unset, `.mergecraft/config.yaml`'s `analyzers.sarifUpload` decides
+      (default false). See issue #39.
+    required: false
+    default: disabled
   allow_pr_target_comments:
     description: "Opt-in to comment-driven invocation under `pull_request_target`. Default: false (refused). When set to `true`, comments from authors in {OWNER, MEMBER, COLLABORATOR} dispatch the agent even under `pull_request_target`. Set this only on workflows whose `if:` already gates comment triggers to trusted authors; leave it off everywhere else. See issue #72 / D6."
     required: false
@@ -120,6 +135,7 @@ runs:
     INPUT_SHELL: ${{ inputs.shell }}
     INPUT_STATUS_CHECKS: ${{ inputs.status_checks }}
     INPUT_ANALYZERS: ${{ inputs.analyzers }}
+    INPUT_SARIF_UPLOAD: ${{ inputs.sarif_upload }}
     INPUT_OUTPUT_SCHEMA: ${{ inputs.output_schema }}
     INPUT_ALLOW_PR_TARGET_COMMENTS: ${{ inputs.allow_pr_target_comments }}
     MERGECRAFT_CODEX_SANDBOX: ${{ inputs.codex_sandbox }}

--- a/docs/ANALYZERS.md
+++ b/docs/ANALYZERS.md
@@ -170,3 +170,41 @@ ciEvidence:
 - **Green only substitutes.** A declared check run that passed rewrites the gate row to `satisfied-by-ci`. A declared check run that *failed* leaves the row alone and is reported as a `source: ci` finding instead.
 - **Reported, not blamed.** Findings derived from CI start non-blocking with `introduced_by_pr: unknown`; only the CI-intelligence blame layer (`ci/blame.py`, `ci/flaky.py`) may attribute one to this PR.
 - **Redacted.** Log excerpts are truncated and passed through `analyzers/redact.py` before they enter a finding.
+
+## SARIF upload to code scanning (#39)
+
+Opt-in, off by default. When enabled, mergeCraft exports the analyzer findings of a pull-request run as SARIF 2.1.0 and uploads them to GitHub code scanning, so mechanical findings stay readable when the review narrative is thin or when findings overflowed the inline comment budget.
+
+```yaml
+# .github/workflows/mergecraft.yml
+permissions:
+  contents: read
+  pull-requests: write
+  # Required for the upload. Without it GitHub answers 403 and mergeCraft
+  # logs a warning — the review still completes.
+  security-events: write
+
+jobs:
+  review:
+    steps:
+      - uses: alexhawat/mergeCraft@<sha>
+        with:
+          sarif_upload: enabled
+```
+
+Or in `.mergecraft/config.yaml` (the action input wins when it is set):
+
+```yaml
+analyzers:
+  sarifUpload: true
+```
+
+What is and is not uploaded:
+
+- **Catalog analyzers only.** Only `source: analyzer` findings are eligible. `source: ci` findings carry truncated pipeline log excerpts and `source: agent` findings carry narrative; neither is uploaded, and raw logs never leave the process (D13).
+- **The clustered, placed set.** The upload reuses the findings the pipeline already clustered and placed, not the raw analyzer output, so cross-tool duplicates arrive as one alert (D14). It is *not* truncated at the inline comment budget — the overflow is exactly what this surface exists to show.
+- **Trust-gated.** Each finding's analyzer must still pass this run's `trust` x `shell` x `analyzers:` selection chain — the same predicates the pipeline calls, re-evaluated at upload time. A finding from a tool with no catalog manifest cannot be gated, so it is refused.
+- **Redacted before serialization.** `message`, `evidence`, `remediation` and `autofix` pass through `analyzers/redact.py` while still typed `Finding`s, before SARIF is built. `path` is left intact: it becomes `artifactLocation.uri`, and mangling it would detach the alert from its file.
+- **Never a gate.** A rejected upload — missing permission, code scanning unavailable, transport error — is logged at `warning` and the run continues.
+
+Check-run annotations are the documented alternative surface and are not implemented: they need `checks: write` instead, cap at 50 annotations per request, and largely repeat the inline review comments mergeCraft already posts.

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -84,6 +84,11 @@ permissions:
   # Post the mergecraft / mergecraft-approval check-runs.
   checks: write
   statuses: write
+  # Uncomment TOGETHER WITH `sarif_upload: enabled` below to publish analyzer
+  # findings as code-scanning alerts (#39). Left off here so copying this
+  # template changes nothing until you decide to opt in; without the permission
+  # GitHub answers 403 and mergeCraft logs a warning rather than failing.
+  # security-events: write
   # Only needed if mergeCraft mints short-lived tokens via OIDC.
   id-token: write
 
@@ -313,6 +318,15 @@ jobs:
           # command construction run; the rest are skipped with a named reason in
           # the Analyzers pre-merge row, never reported as failures.
           analyzers: untrusted-only
+          # Optional (#39): publish the analyzer findings above as GitHub
+          # code-scanning alerts, so mechanical signal stays readable when the
+          # review narrative is thin or findings overflow the inline comment
+          # budget. Off by default. Uncomment this AND `security-events: write`
+          # in the `permissions:` block. Only findings from analyzers this run's
+          # trust tier admitted are uploaded, after secret redaction; CI log
+          # excerpts and agent narrative are never uploaded, and a rejected
+          # upload is logged rather than failing the review.
+          # sarif_upload: enabled
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -84,6 +84,11 @@ permissions:
   # Post the mergecraft / mergecraft-approval check-runs.
   checks: write
   statuses: write
+  # Uncomment TOGETHER WITH `sarif_upload: enabled` below to publish analyzer
+  # findings as code-scanning alerts (#39). Left off here so copying this
+  # template changes nothing until you decide to opt in; without the permission
+  # GitHub answers 403 and mergeCraft logs a warning rather than failing.
+  # security-events: write
   # Only needed if mergeCraft mints short-lived tokens via OIDC.
   id-token: write
 
@@ -313,6 +318,15 @@ jobs:
           # command construction run; the rest are skipped with a named reason in
           # the Analyzers pre-merge row, never reported as failures.
           analyzers: untrusted-only
+          # Optional (#39): publish the analyzer findings above as GitHub
+          # code-scanning alerts, so mechanical signal stays readable when the
+          # review narrative is thin or findings overflow the inline comment
+          # budget. Off by default. Uncomment this AND `security-events: write`
+          # in the `permissions:` block. Only findings from analyzers this run's
+          # trust tier admitted are uploaded, after secret redaction; CI log
+          # excerpts and agent narrative are never uploaded, and a rejected
+          # upload is logged rather than failing the review.
+          # sarif_upload: enabled
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/src/mergecraft/analyzers/catalog_docs.py
+++ b/src/mergecraft/analyzers/catalog_docs.py
@@ -290,6 +290,77 @@ def _shell_trust_matrix_lines() -> list[str]:
     return lines
 
 
+def _sarif_upload_lines() -> list[str]:
+    """Render the code-scanning upload section (#39, D13/D14).
+
+    Lives in the generator rather than in the markdown because
+    ``docs/ANALYZERS.md`` is written wholesale by ``make catalog-check`` — a
+    hand-written section there is erased on the next run.
+    """
+    from mergecraft.analyzers.sarif_upload import UPLOADABLE_SOURCE
+
+    return [
+        "",
+        "## SARIF upload to code scanning (#39)",
+        "",
+        "Opt-in, off by default. When enabled, mergeCraft exports the analyzer "
+        "findings of a pull-request run as SARIF 2.1.0 and uploads them to GitHub "
+        "code scanning, so mechanical findings stay readable when the review "
+        "narrative is thin or when findings overflowed the inline comment budget.",
+        "",
+        "```yaml",
+        "# .github/workflows/mergecraft.yml",
+        "permissions:",
+        "  contents: read",
+        "  pull-requests: write",
+        "  # Required for the upload. Without it GitHub answers 403 and mergeCraft",
+        "  # logs a warning — the review still completes.",
+        "  security-events: write",
+        "",
+        "jobs:",
+        "  review:",
+        "    steps:",
+        "      - uses: alexhawat/mergeCraft@<sha>",
+        "        with:",
+        "          sarif_upload: enabled",
+        "```",
+        "",
+        "Or in `.mergecraft/config.yaml` (the action input wins when it is set):",
+        "",
+        "```yaml",
+        "analyzers:",
+        "  sarifUpload: true",
+        "```",
+        "",
+        "What is and is not uploaded:",
+        "",
+        f"- **Catalog analyzers only.** Only `source: {UPLOADABLE_SOURCE}` findings are "
+        "eligible. `source: ci` findings carry truncated pipeline log excerpts and "
+        "`source: agent` findings carry narrative; neither is uploaded, and raw logs "
+        "never leave the process (D13).",
+        "- **The clustered, placed set.** The upload reuses the findings the pipeline "
+        "already clustered and placed, not the raw analyzer output, so cross-tool "
+        "duplicates arrive as one alert (D14). It is *not* truncated at the inline "
+        "comment budget — the overflow is exactly what this surface exists to show.",
+        "- **Trust-gated.** Each finding's analyzer must still pass this run's "
+        "`trust` x `shell` x `analyzers:` selection chain — the same predicates the "
+        "pipeline calls, re-evaluated at upload time. A finding from a tool with no "
+        "catalog manifest cannot be gated, so it is refused.",
+        "- **Redacted before serialization.** `message`, `evidence`, `remediation` "
+        "and `autofix` pass through `analyzers/redact.py` while still typed "
+        "`Finding`s, before SARIF is built. `path` is left intact: it becomes "
+        "`artifactLocation.uri`, and mangling it would detach the alert from its "
+        "file.",
+        "- **Never a gate.** A rejected upload — missing permission, code scanning "
+        "unavailable, transport error — is logged at `warning` and the run continues.",
+        "",
+        "Check-run annotations are the documented alternative surface and are not "
+        "implemented: they need `checks: write` instead, cap at 50 annotations per "
+        "request, and largely repeat the inline review comments mergeCraft already "
+        "posts.",
+    ]
+
+
 def generate_analyzers_doc(manifests: Iterable[AnalyzerManifest] | None = None) -> str:
     """Render ``docs/ANALYZERS.md`` from catalog manifests."""
     rows = sorted(manifests or load_catalog(), key=lambda m: m.id)
@@ -382,6 +453,7 @@ def generate_analyzers_doc(manifests: Iterable[AnalyzerManifest] | None = None) 
             "`analyzers/redact.py` before they enter a finding.",
         ]
     )
+    lines.extend(_sarif_upload_lines())
     return "\n".join(lines) + "\n"
 
 

--- a/src/mergecraft/analyzers/sarif_upload.py
+++ b/src/mergecraft/analyzers/sarif_upload.py
@@ -1,0 +1,231 @@
+"""Gate, redact and encode analyzer findings for code-scanning upload (#39).
+
+``export_sarif()`` has existed since the catalog landed, reachable only from
+``mergecraft analyzers export --sarif`` — an offline CLI command. Nothing an
+Action run enters ever produced a SARIF document, so a consumer whose LLM
+narrative was thin, or whose findings overflowed the inline noise budget, had
+no mechanical surface to read. This module is everything that has to be true
+*before* those findings may leave the process; ``utils/code_scanning.py`` does
+the actual POST.
+
+Three properties are load-bearing, in this order (D13, convention 8):
+
+1. **Opt-in.** :func:`resolve_sarif_upload_enabled` defaults to off and treats
+   an unrecognised flag value as off. A code-scanning alert is permanent and
+   externally visible, so an ambiguous input must never publish one.
+2. **Trust-gated.** :func:`select_uploadable_findings` replays the pipeline's
+   own tier -> shell -> mode skip chain over each finding's manifest. It is the
+   *same* predicates the pipeline calls, not a fourth selection path — a
+   divergent copy would drift into publishing findings the run's tier never
+   admitted.
+3. **Redacted.** :func:`redact_findings_for_upload` runs before serialization,
+   not after, so no intermediate the exporter touches ever holds the secret.
+
+Scope is deliberately narrow: only ``source="analyzer"`` findings are
+uploadable. ``ci``-sourced findings carry truncated pipeline log excerpts in
+``evidence`` (Batch C, ``ci/evidence.py``), and D13 says never upload log
+excerpts wholesale; ``agent``-sourced findings are narrative, which is what the
+review body is for.
+
+Exports:
+    UPLOADABLE_SOURCE: The one ``Finding.source`` this surface publishes.
+    build_upload_document: Export findings to SARIF and validate before upload.
+    encode_sarif_payload: gzip + base64 a document for the REST field.
+    redact_findings_for_upload: Redact every text field a finding can carry.
+    resolve_sarif_upload_enabled: Resolve the opt-in flag, failing closed.
+    select_uploadable_findings: Apply the trust gate to a finding list.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+from typing import TYPE_CHECKING, Any, Final
+
+from loguru import logger
+
+from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.analyzers.registry import get_manifest
+from mergecraft.analyzers.sarif import export_sarif, validate_sarif_document
+from mergecraft.analyzers.trust import (
+    evaluate_manifest_for_mode,
+    evaluate_manifest_for_shell,
+    evaluate_manifest_for_tier,
+    resolve_effective_analyzers_mode,
+    resolve_selection_tier,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from mergecraft.analyzers.finding import Finding
+    from mergecraft.analyzers.manifest import TrustTier
+    from mergecraft.analyzers.trust import AnalyzersMode
+
+UPLOADABLE_SOURCE: Final[str] = "analyzer"
+"""The only ``Finding.source`` this surface publishes (#39, D13)."""
+
+_ENABLED_VALUES: Final[frozenset[str]] = frozenset({"enabled"})
+_DISABLED_VALUES: Final[frozenset[str]] = frozenset({"disabled"})
+
+
+def resolve_sarif_upload_enabled(*, action_input: str | None, repo_setting: bool) -> bool:
+    """Resolve the opt-in SARIF upload flag (D13, convention 5).
+
+    An *absent* input is not a decision — it defers to
+    ``.mergecraft/config.yaml``'s ``analyzers.sarifUpload``, which itself
+    defaults to ``False``. A *present* input is a decision and wins in both
+    directions, so an operator can turn the upload off on one workflow without
+    editing repo config.
+
+    An input that is present but unrecognised is ambiguous, and ambiguity
+    resolves to the more restrictive outcome — off — with a warning. Reading a
+    typo as "enabled" would publish findings to a permanent, externally visible
+    surface that nobody asked for.
+    """
+    value = (action_input or "").strip().lower()
+    if not value:
+        return repo_setting
+    if value in _ENABLED_VALUES:
+        return True
+    if value in _DISABLED_VALUES:
+        return False
+    logger.warning(
+        "unrecognised sarif_upload input {!r}; SARIF upload stays off "
+        "(valid values: disabled, enabled)",
+        action_input,
+    )
+    return False
+
+
+def _selection_admits(
+    finding: Finding, *, tier: TrustTier, shell: str, mode: AnalyzersMode
+) -> bool:
+    """Whether manifest selection admits this finding's analyzer at this run's axes.
+
+    Deliberately re-derived from the manifest rather than trusted from the
+    recorded run: the finding rows are stored as plain dicts on ``ToolState``
+    and are replaced wholesale on every ``run_analyzers`` call, so a row can
+    outlive the selection that produced it. Re-asking the predicates costs
+    nothing and closes that window.
+
+    A ``tool`` with no catalog manifest cannot be gated at all, so it is
+    refused — an ungatable finding is exactly the one that must not be
+    published.
+    """
+    try:
+        manifest = get_manifest(finding.tool)
+    except KeyError:
+        logger.debug(
+            "sarif upload: dropping finding from unknown analyzer {!r}",
+            finding.tool,
+        )
+        return False
+
+    effective = resolve_effective_analyzers_mode(mode=mode, tier=tier)
+    selection_tier = resolve_selection_tier(mode=effective, tier=tier)
+    return not (
+        evaluate_manifest_for_tier(manifest=manifest, tier=selection_tier).skipped
+        or evaluate_manifest_for_shell(manifest=manifest, shell=shell).skipped
+        or evaluate_manifest_for_mode(manifest=manifest, mode=effective).skipped
+    )
+
+
+def select_uploadable_findings(
+    findings: Sequence[Finding],
+    *,
+    tier: TrustTier,
+    shell: str,
+    mode: AnalyzersMode,
+) -> list[Finding]:
+    """Return the findings this run is permitted to publish (D13).
+
+    Two filters, both narrowing:
+
+    * **Source.** #39 scopes the surface to catalog analyzers. ``ci`` findings
+      carry log excerpts and ``agent`` findings carry narrative; neither
+      belongs in a code-scanning alert.
+    * **Selection.** The finding's analyzer must still pass the pipeline's own
+      tier -> shell -> mode chain, evaluated with this run's axes.
+    """
+    selected: list[Finding] = []
+    for finding in findings:
+        if finding.source != UPLOADABLE_SOURCE:
+            continue
+        if not _selection_admits(finding, tier=tier, shell=shell, mode=mode):
+            continue
+        selected.append(finding)
+    return selected
+
+
+def _redact_optional(value: str | None) -> str | None:
+    return None if value is None else redact_secrets(value)
+
+
+def redact_findings_for_upload(findings: Sequence[Finding]) -> list[Finding]:
+    """Redact every free-text field a finding carries, before serialization.
+
+    Runs on the typed ``Finding`` set rather than on the encoded blob so no
+    intermediate the exporter touches holds the secret — redacting after
+    serialization would leave it in the document, in any log line that echoed
+    the document, and in whatever the exporter cached.
+
+    ``path`` is deliberately *not* redacted. It is a repo-relative file path
+    the analyzer parsers derive against the repo root, not a secret channel,
+    and it becomes ``artifactLocation.uri``: a mangled path silently detaches
+    the alert from its file, which is a worse outcome than the risk it would
+    buy. ``tool`` and ``rule_id`` come from mergeCraft's own manifests, and
+    ``fingerprint`` is already computed over redacted material
+    (``redact_for_fingerprint``).
+
+    Returns new ``Finding`` instances — the one finding model, never extended
+    (D12).
+    """
+    redacted: list[Finding] = []
+    for finding in findings:
+        redacted.append(
+            finding.model_copy(
+                update={
+                    "message": redact_secrets(finding.message),
+                    "evidence": [redact_secrets(line) for line in finding.evidence],
+                    "remediation": _redact_optional(finding.remediation),
+                    "autofix": _redact_optional(finding.autofix),
+                }
+            )
+        )
+    return redacted
+
+
+def build_upload_document(findings: Sequence[Finding]) -> dict[str, Any]:
+    """Export findings as SARIF 2.1.0 and validate before anything is uploaded.
+
+    Validation is not decoration: GitHub rejects a malformed document with an
+    opaque 4xx, and a document that *is* accepted but wrong publishes wrong
+    alerts. Raising here keeps a bad document off the wire; the caller turns
+    that into a logged refusal rather than a failed run (W8.5).
+    """
+    document = export_sarif(list(findings))
+    validate_sarif_document(document)
+    return document
+
+
+def encode_sarif_payload(document: Mapping[str, Any]) -> str:
+    """Encode a SARIF document for the ``sarif`` REST field: gzip, then base64.
+
+    ``mtime=0`` keeps the gzip header byte-identical for identical input, so
+    re-running a review on the same commit produces the same payload instead of
+    a timestamp-only diff.
+    """
+    raw = json.dumps(document, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return base64.b64encode(gzip.compress(raw, mtime=0)).decode("ascii")
+
+
+__all__ = [
+    "UPLOADABLE_SOURCE",
+    "build_upload_document",
+    "encode_sarif_payload",
+    "redact_findings_for_upload",
+    "resolve_sarif_upload_enabled",
+    "select_uploadable_findings",
+]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -109,6 +109,12 @@ class AnalyzersSettings(BaseModel):
     base_comparison: str = Field(default="diff", alias="baseComparison")
     overrides: dict[str, AnalyzerOverride] = Field(default_factory=dict)
     pattern: AnalyzerPatternSettings = Field(default_factory=AnalyzerPatternSettings)
+    # #39 / D13 — opt-in upload of analyzer findings to GitHub code scanning.
+    # Off by default: a code-scanning alert is permanent and externally
+    # visible, and the workflow also has to grant `security-events: write`
+    # before the upload can succeed. The `sarif_upload` action input overrides
+    # this in both directions when it is set (`resolve_sarif_upload_enabled`).
+    sarif_upload: bool = Field(default=False, alias="sarifUpload")
 
 
 # D5 / D9 / D15 — `tracing` block on `RepoSettings`. Additive-only, default off.

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -14,6 +14,7 @@ from mergecraft.agents.gates import subagent_denied_tool_names
 from mergecraft.agents.post_run import finalize_agent_result
 from mergecraft.agents.shared import AgentResult, AgentRunContext
 from mergecraft.analyzers.redact import install_loguru_redaction_filter
+from mergecraft.analyzers.sarif_upload import resolve_sarif_upload_enabled
 from mergecraft.analyzers.trust import (
     allow_repo_command_overrides,
     derive_trust_tier,
@@ -33,6 +34,7 @@ from mergecraft.utils.agent_resolve import (
     run_with_model_chain,
     select_runnable_model_slug,
 )
+from mergecraft.utils.code_scanning import report_sarif_upload
 from mergecraft.utils.git_setup import create_temp_directory, setup_git, wipe_runner_leak_surface
 from mergecraft.utils.github import GitHubClient, resolve_run_context_data
 from mergecraft.utils.instructions import resolve_instructions
@@ -212,6 +214,10 @@ async def main() -> MainResult:
 
         ctx_payload = _payload_to_ctx(payload)
         analyzers_mode = resolve_analyzers_mode(os.environ.get("INPUT_ANALYZERS"))
+        sarif_upload_enabled = resolve_sarif_upload_enabled(
+            action_input=os.environ.get("INPUT_SARIF_UPLOAD"),
+            repo_setting=settings.analyzers.sarif_upload,
+        )
         github_event = read_github_event()
         trust_tier = derive_trust_tier(
             event=github_event,
@@ -254,6 +260,7 @@ async def main() -> MainResult:
             analyzers_mode=analyzers_mode,
             trust_tier=trust_tier,
             analyzers_settings_enabled=settings.analyzers.enabled,
+            sarif_upload_enabled=sarif_upload_enabled,
             run_id=int(os.environ["GITHUB_RUN_ID"]) if os.environ.get("GITHUB_RUN_ID") else None,
             job_id=os.environ.get("GITHUB_JOB"),
             oss=run_context.oss,
@@ -446,6 +453,9 @@ async def main() -> MainResult:
                     run_succeeded=result.success,
                     failure_reason=result.error if not result.success else None,
                 )
+                # #39 — opt-in, off by default, and never a gate: with
+                # `sarif_upload` unset this returns before making any request.
+                await report_sarif_upload(tool_context)
                 # Emit the merge evidence packet last, so it records the run's
                 # final state. A blocked or failed run is exactly when the
                 # evidence matters most, so this runs on both branches below.

--- a/src/mergecraft/mcp/context.py
+++ b/src/mergecraft/mcp/context.py
@@ -90,6 +90,11 @@ class ToolContext:
     analyzers_mode: Literal["off", "auto", "full", "untrusted-only"] = "auto"
     trust_tier: Literal["trusted", "untrusted"] = "trusted"
     analyzers_settings_enabled: bool = True
+    # #39 / D13 — whether this run may upload analyzer findings to GitHub code
+    # scanning. Default False: with it unset nothing is built, nothing is
+    # posted, and the run makes no extra API call. Resolved once in `main.py`
+    # from the `sarif_upload` action input and `analyzers.sarifUpload`.
+    sarif_upload_enabled: bool = False
     run_id: int | None = None
     job_id: str | None = None
     oss: bool = False

--- a/src/mergecraft/utils/code_scanning.py
+++ b/src/mergecraft/utils/code_scanning.py
@@ -1,0 +1,180 @@
+"""Opt-in upload of analyzer findings to GitHub code scanning (#39).
+
+Why code scanning rather than check-run annotations (W8.3, one primary surface
+chosen deliberately):
+
+* ``export_sarif()`` already produces exactly the artifact code scanning
+  consumes. Annotations would need a second serializer with its own severity
+  mapping and its own truncation rules, for a surface that largely repeats the
+  inline review comments mergeCraft already posts — the "no duplicate spam"
+  criterion D14 exists to protect.
+* Code-scanning alerts survive the review thread. #39's premise is a consumer
+  whose LLM narrative was thin or whose findings overflowed the inline budget;
+  an annotation set attached to one check run is a worse home for that than an
+  alert list GitHub dedupes by fingerprint across pushes.
+* The failure mode is single and legible. Code scanning answers one POST with
+  one status: 403 without ``security-events: write``, 404 on a repo without
+  Advanced Security. Annotations fail per-check-run and partially — GitHub caps
+  them at 50 per request — and a partial failure is much harder to report
+  honestly than a refused upload.
+
+Check-run annotations remain the documented optional second surface; nothing
+here forecloses them, and ``utils/status_checks.py`` already owns the
+check-run creation shape they would reuse.
+
+Nothing in this module may fail a run. SARIF is complementary evidence, never
+the gate (W8.5): every failure path logs at ``warning`` and returns ``None``.
+
+Exports:
+    CODE_SCANNING_PATH: REST path template for the SARIF upload endpoint.
+    report_sarif_upload: Upload this run's analyzer findings, if opted in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from mergecraft.analyzers.sarif_upload import (
+    build_upload_document,
+    encode_sarif_payload,
+    redact_findings_for_upload,
+    select_uploadable_findings,
+)
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
+    from mergecraft.mcp.context import ToolContext
+
+CODE_SCANNING_PATH = "/repos/{owner}/{repo}/code-scanning/sarifs"
+
+
+def _typed_analyzer_findings(ctx: ToolContext) -> list[Finding]:
+    """Read the run's stored analyzer findings back into typed ``Finding`` rows.
+
+    ``AnalyzerRunState.findings`` holds the *clustered* set the pipeline placed
+    (``pipeline.py`` serializes ``cluster_findings(...)`` output), so reading it
+    is what makes the upload the clustered, budgeted set rather than the raw one
+    (D14). Nothing is re-clustered here.
+
+    A row that fails validation is dropped with a debug line, matching
+    ``utils/status_checks.py``: a malformed analyzer row must not crash the run.
+    """
+    run_state = getattr(ctx.tool_state, "analyzer_run", None)
+    if run_state is None:
+        return []
+    rows = list(getattr(run_state, "findings", []) or [])
+    if not rows:
+        return []
+
+    from mergecraft.analyzers.finding import Finding, FindingValidationError
+
+    typed: list[Finding] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            typed.append(Finding.model_validate(row))
+        except FindingValidationError as err:
+            logger.debug("sarif upload: dropping malformed finding row: {}", err)
+    return typed
+
+
+async def _resolve_pr_head_sha(ctx: ToolContext, pull_number: int) -> str | None:
+    try:
+        pull = await ctx.github.get_pull(ctx.repo.owner, ctx.repo.name, pull_number)
+    except Exception as err:
+        logger.debug("sarif upload: failed to resolve PR #{} head sha: {}", pull_number, err)
+        return None
+    head_sha = str(pull.get("head", {}).get("sha") or "")
+    return head_sha or None
+
+
+async def report_sarif_upload(ctx: ToolContext) -> str | None:
+    """Upload this run's analyzer findings to code scanning when opted in.
+
+    Returns the upload's ``id`` when GitHub accepted it, and ``None`` on every
+    other path — disabled, no pull request, nothing uploadable, an invalid
+    document, or a rejected POST. Never raises.
+
+    The order of the guards is the contract: the flag is checked before any
+    work at all, so a repo that did not opt in makes **no request** rather than
+    building a document and discarding the reply (D13).
+    """
+    if not ctx.sarif_upload_enabled:
+        return None
+
+    event = ctx.payload.event
+    pull_number = event.issue_number
+    if event.is_pr is not True or not isinstance(pull_number, int):
+        logger.debug("sarif upload: no pull request on this event — nothing to attach results to")
+        return None
+
+    findings = _typed_analyzer_findings(ctx)
+    if not findings:
+        logger.debug("sarif upload: the run recorded no analyzer findings")
+        return None
+
+    selected = select_uploadable_findings(
+        findings,
+        tier=ctx.trust_tier,
+        shell=str(ctx.payload.shell),
+        mode=ctx.analyzers_mode,
+    )
+    if not selected:
+        logger.info(
+            "» sarif upload: no findings passed the trust gate ({} of {} eligible)",
+            0,
+            len(findings),
+        )
+        return None
+
+    redacted = redact_findings_for_upload(selected)
+    try:
+        document = build_upload_document(redacted)
+    except Exception as err:
+        logger.warning("sarif upload: refusing to upload an invalid SARIF document: {}", err)
+        return None
+
+    head_sha = await _resolve_pr_head_sha(ctx, pull_number)
+    if not head_sha:
+        return None
+
+    body: dict[str, Any] = {
+        "commit_sha": head_sha,
+        "ref": f"refs/pull/{pull_number}/head",
+        "sarif": encode_sarif_payload(document),
+        "tool_name": "mergecraft",
+    }
+    if ctx.run_id:
+        body["checkout_uri"] = (
+            f"https://github.com/{ctx.repo.owner}/{ctx.repo.name}/actions/runs/{ctx.run_id}"
+        )
+
+    path = CODE_SCANNING_PATH.format(owner=ctx.repo.owner, repo=ctx.repo.name)
+    try:
+        response = await ctx.github.post(path, json=body)
+    except Exception as err:
+        # 403 without `security-events: write` and 404 on a repo without code
+        # scanning are the *expected* answers for most consumers. Failing the
+        # run on either would turn an opt-in complementary surface into a merge
+        # blocker (W8.5).
+        logger.warning(
+            "sarif upload: code scanning rejected {} finding(s) on {}: {}",
+            len(redacted),
+            head_sha[:7],
+            err,
+        )
+        return None
+
+    upload_id = str(response.get("id") or "") if isinstance(response, dict) else ""
+    logger.info(
+        "» uploaded {} analyzer finding(s) to code scanning on {}",
+        len(redacted),
+        head_sha[:7],
+    )
+    return upload_id or None
+
+
+__all__ = ["CODE_SCANNING_PATH", "report_sarif_upload"]

--- a/tests/analyzers/test_sarif_upload.py
+++ b/tests/analyzers/test_sarif_upload.py
@@ -46,6 +46,11 @@ import httpx
 import pytest
 import yaml
 from loguru import logger
+
+from mergecraft.analyzers.budget import place_findings
+from mergecraft.analyzers.cluster import cluster_findings
+from mergecraft.analyzers.finding import Finding, make_finding
+from mergecraft.analyzers.redact import assert_no_canary
 from mergecraft.analyzers.sarif_upload import (
     build_upload_document,
     encode_sarif_payload,
@@ -53,25 +58,15 @@ from mergecraft.analyzers.sarif_upload import (
     resolve_sarif_upload_enabled,
     select_uploadable_findings,
 )
-from mergecraft.utils.code_scanning import report_sarif_upload
-
-from mergecraft.analyzers.budget import place_findings
-from mergecraft.analyzers.cluster import cluster_findings
-from mergecraft.analyzers.finding import Finding, make_finding
-from mergecraft.analyzers.redact import assert_no_canary
 from mergecraft.config.settings import AnalyzersSettings
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.tool_state import AnalyzerRunState, AnalyzerStatusRow, init_tool_state
 from mergecraft.modes import compute_modes
+from mergecraft.utils.code_scanning import report_sarif_upload
 from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-pytestmark = pytest.mark.xfail(
-    reason="RED suite for #39 — green after W8 wires the upload path",
-    strict=False,
-)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PR_HEAD_SHA = "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00"
@@ -368,6 +363,14 @@ async def test_upload_is_redacted(tmp_path: Path, carrier: str) -> None:
     Code-scanning alerts are permanent and externally visible, so this is the
     assertion whose silent failure is unrecoverable — the secret is published
     before anyone reads the log.
+
+    Note what each carrier actually proves. `message` is serialized into SARIF,
+    so that case fails the moment redaction stops running. `evidence` is *not*
+    serialized by `export_sarif()` today, so that case is a forward guard
+    against an exporter that starts emitting it — the case that pins evidence
+    redaction itself is
+    `test_redaction_happens_before_serialization_not_after`, which asserts on
+    the typed set.
     """
     if carrier == "message":
         finding = _finding(message=f"leaked credential {TOKEN_CANARY} in header")
@@ -574,6 +577,13 @@ async def test_no_raw_logs_uploaded(tmp_path: Path) -> None:
     wholesale, and #39 scopes the surface to catalog analyzers. So a `source`
     of `ci` or `agent` is excluded outright, and `evidence` is not serialized
     on any finding.
+
+    The CI rows deliberately use a **catalog** `tool` id (`semgrep`). Batch C
+    namespaces its own CI findings `ci:<artifact>`, which the upload gate would
+    drop anyway as an unknown analyzer — so a fixture using that shape would
+    pass even with the source filter deleted, and would prove nothing about the
+    filter this case exists to pin. `tool` is a free string on `Finding`;
+    isolating the `source` check is the point.
     """
     log_excerpt = [
         f"2026-08-10T09:14:02Z build#941 export GH_TOKEN={TOKEN_CANARY}",
@@ -581,8 +591,14 @@ async def test_no_raw_logs_uploaded(tmp_path: Path) -> None:
     ]
     findings = [
         _finding(tool="semgrep", message="clean analyzer finding"),
-        _finding(tool="ci", rule_id="ci:build", source="ci", evidence=log_excerpt),
-        _finding(tool="agent", rule_id="agent:review", source="agent", message="narrative"),
+        _finding(
+            tool="semgrep",
+            rule_id="semgrep:from-ci",
+            source="ci",
+            message="reported by the consumer's own pipeline",
+            evidence=log_excerpt,
+        ),
+        _finding(tool="semgrep", rule_id="agent:review", source="agent", message="narrative"),
     ]
     github = _RecordingGitHub()
     ctx = _ctx(tmp_path, github=github, findings=findings)
@@ -599,7 +615,11 @@ async def test_no_raw_logs_uploaded(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("source", ["ci", "agent"])
 def test_only_analyzer_sourced_findings_are_uploadable(source: str) -> None:
-    """#39 scopes the surface to catalog analyzers; other sources drop."""
+    """#39 scopes the surface to catalog analyzers; other sources drop.
+
+    `tool` is a real catalog id here so the assertion turns on `source` alone —
+    an unknown-tool fixture would be dropped by a different guard entirely.
+    """
     selected = select_uploadable_findings(
         [_finding(tool="semgrep", source=source)],
         tier="trusted",

--- a/tests/analyzers/test_sarif_upload.py
+++ b/tests/analyzers/test_sarif_upload.py
@@ -1,0 +1,707 @@
+"""#39 — optional SARIF upload to GitHub code scanning (Batch D, W7).
+
+`export_sarif()` has existed since the catalog landed, and exactly one caller
+reaches it: `mergecraft analyzers export --sarif`, an offline CLI command. No
+Action run has ever produced a SARIF document, so a consumer whose LLM summary
+is thin — or whose findings overflowed the inline noise budget — has no
+mechanical surface to read at all. #39 asks for one.
+
+Wiring an existing exporter into the Action path is precisely the shape of
+issue #96 (a library implemented, exported, documented and unit-tested while
+nothing reachable called it), so these cases pin the *seam* as hard as they pin
+the behaviour: `tests/test_runtime_call_sites.py` gains contracts for every
+load-bearing function this batch adds.
+
+The upload writes to a permanent, externally-visible surface, so the safety
+cases are the point and the plumbing is incidental:
+
+* **off by default** (W7.1, D13) — no flag means no upload *attempt*, not a
+  discarded response, and an unrecognised flag value fails closed;
+* **validated before upload** (W7.2) — a malformed document is refused loudly
+  rather than posted;
+* **clustered, budgeted set** (W7.3, D14) — the upload reuses the placed
+  finding set, never the raw one;
+* **redacted before serialization** (W7.4, convention 8) — a secret-shaped
+  string in a message or in evidence never reaches the wire;
+* **trust-gated** (W7.5, D13) — on an untrusted run only findings from
+  analyzers that selection actually admits at that tier may be uploaded, and
+  the gate is the *existing* tier/shell/mode predicate chain, not a fourth
+  selection path;
+* **non-fatal** (W7.6) — a code-scanning API error is logged and the run still
+  completes; SARIF is complementary, never the gate;
+* **no raw logs** (W7.7, D13) — CI-sourced findings carry truncated pipeline
+  log excerpts in `evidence`; those never enter the document, and `evidence` is
+  not serialized at all.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+import yaml
+from loguru import logger
+from mergecraft.analyzers.sarif_upload import (
+    build_upload_document,
+    encode_sarif_payload,
+    redact_findings_for_upload,
+    resolve_sarif_upload_enabled,
+    select_uploadable_findings,
+)
+from mergecraft.utils.code_scanning import report_sarif_upload
+
+from mergecraft.analyzers.budget import place_findings
+from mergecraft.analyzers.cluster import cluster_findings
+from mergecraft.analyzers.finding import Finding, make_finding
+from mergecraft.analyzers.redact import assert_no_canary
+from mergecraft.config.settings import AnalyzersSettings
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import AnalyzerRunState, AnalyzerStatusRow, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.xfail(
+    reason="RED suite for #39 — green after W8 wires the upload path",
+    strict=False,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PR_HEAD_SHA = "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00"
+PR_NUMBER = 42
+
+# A GitHub PAT-shaped canary. `redact_secrets()` matches `gh[pousr]_` + 20 or
+# more word characters, so this is redacted by pattern and not merely by the
+# entropy heuristic — the assertion cannot pass by accident on a lucky score.
+TOKEN_CANARY = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+class _RecordingGitHub(GitHubClient):
+    """Records every REST call instead of reaching the API.
+
+    Records *all* requests, not just code-scanning POSTs: W7.1 asserts that a
+    disabled upload makes no request at all, which a sink that only captured
+    the final POST could not tell apart from a refused one.
+    """
+
+    def __init__(self, *, post_error: Exception | None = None) -> None:
+        super().__init__(token="test-token")
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+        self.post_error = post_error
+
+    async def get_pull(self, owner: str, repo: str, pull_number: int) -> dict[str, Any]:
+        self.requests.append(("GET", f"/repos/{owner}/{repo}/pulls/{pull_number}", {}))
+        return {"head": {"sha": PR_HEAD_SHA}}
+
+    async def post(self, path: str, **kwargs: Any) -> Any:
+        body = kwargs.get("json")
+        self.requests.append(("POST", path, body if isinstance(body, dict) else {}))
+        if self.post_error is not None:
+            raise self.post_error
+        return {"id": 1, "url": "https://api.github.com/…/sarifs/1"}
+
+    @property
+    def sarif_posts(self) -> list[dict[str, Any]]:
+        return [
+            body
+            for method, path, body in self.requests
+            if method == "POST" and path.endswith("/code-scanning/sarifs")
+        ]
+
+
+def _finding(
+    *,
+    tool: str = "semgrep",
+    rule_id: str | None = None,
+    message: str = "hardcoded credential in request header",
+    path: str = "src/app.py",
+    start_line: int = 12,
+    severity: str = "Major",
+    source: str = "analyzer",
+    evidence: list[str] | None = None,
+) -> Finding:
+    return make_finding(
+        tool=tool,
+        rule_id=rule_id or f"{tool}:rule-{start_line}",
+        category="Security & Privacy",
+        severity=severity,
+        confidence="likely",
+        message=message,
+        path=path,
+        start_line=start_line,
+        end_line=start_line,
+        source=source,  # type: ignore[arg-type]
+        evidence=evidence or [],
+    )
+
+
+def _run_state(findings: list[Finding]) -> AnalyzerRunState:
+    return AnalyzerRunState(
+        ran=True,
+        analyzers=[
+            AnalyzerStatusRow(id=f.tool, status="failed", finding_count=1) for f in findings
+        ],
+        findings=[f.model_dump() for f in findings],
+    )
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    github: _RecordingGitHub | None = None,
+    findings: list[Finding] | None = None,
+    upload_enabled: bool = True,
+    tier: str = "trusted",
+    shell: str = "restricted",
+    mode: str = "auto",
+) -> ToolContext:
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    tool_state.analyzer_run = _run_state(findings if findings is not None else [_finding()])
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=PR_NUMBER, is_pr=True),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=github or _RecordingGitHub(),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        analyzers_mode=mode,  # type: ignore[arg-type]
+        trust_tier=tier,  # type: ignore[arg-type]
+        sarif_upload_enabled=upload_enabled,
+    )
+
+
+@pytest.fixture
+def warnings_sink() -> Iterator[list[str]]:
+    """Capture loguru WARNING+ records so "logged, not raised" is assertable."""
+    captured: list[str] = []
+    sink_id = logger.add(lambda message: captured.append(str(message)), level="WARNING")
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
+
+def _uploaded_documents(github: _RecordingGitHub) -> list[dict[str, Any]]:
+    """Decode every uploaded SARIF blob back into a document.
+
+    The wire field is base64-encoded gzip, so searching the request body for a
+    canary would pass on any input — including one carrying the secret. Decode
+    first, then search; otherwise the redaction assertions are vacuous.
+    """
+    documents: list[dict[str, Any]] = []
+    for body in github.sarif_posts:
+        raw = gzip.decompress(base64.b64decode(body["sarif"])).decode("utf-8")
+        documents.append(json.loads(raw))
+    return documents
+
+
+def _document_text(github: _RecordingGitHub) -> str:
+    """Every byte the upload puts on the wire, decoded into one searchable string."""
+    return json.dumps(_uploaded_documents(github))
+
+
+# --------------------------------------------------------------------------
+# W7.1 — opt-in only (D13)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sarif_upload_is_off_by_default(tmp_path: Path) -> None:
+    """No flag means no upload *attempt* — not a discarded response (W7.1).
+
+    The distinction matters: an implementation that builds the document, posts
+    it and throws the reply away would satisfy a weaker assertion while still
+    publishing findings from a repo that never asked for it. Assert on the
+    request log, which is empty only if nothing was sent.
+    """
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, upload_enabled=False)
+
+    result = await report_sarif_upload(ctx)
+
+    assert result is None
+    assert github.requests == [], "upload disabled but requests were made"
+
+
+def test_default_off_across_every_surface_that_can_enable_it() -> None:
+    """The default is off in config, in the ToolContext, and in `action.yml`."""
+    assert AnalyzersSettings().sarif_upload is False
+    assert ToolContext.__dataclass_fields__["sarif_upload_enabled"].default is False
+
+    action = yaml.safe_load((REPO_ROOT / "action.yml").read_text(encoding="utf-8"))
+    spec = action["inputs"]["sarif_upload"]
+    assert spec.get("required") is not True
+    assert str(spec.get("default", "")).strip().lower() in {"", "disabled", "false"}
+    assert action["runs"]["env"]["INPUT_SARIF_UPLOAD"] == "${{ inputs.sarif_upload }}"
+
+
+@pytest.mark.parametrize(
+    ("action_input", "repo_setting", "expected"),
+    [
+        (None, False, False),
+        ("", False, False),
+        (None, True, True),
+        ("", True, True),
+        ("enabled", False, True),
+        ("ENABLED", False, True),
+        ("disabled", True, False),
+        # Convention 5 — ambiguity resolves to the more restrictive outcome,
+        # and an operator typo must not silently publish to code scanning.
+        ("yes", True, False),
+        ("true", True, False),
+    ],
+    ids=[
+        "unset_off",
+        "blank_off",
+        "unset_defers_to_config",
+        "blank_defers_to_config",
+        "input_enables",
+        "input_case_insensitive",
+        "input_disable_wins",
+        "unknown_fails_closed",
+        "unknown_true_fails_closed",
+    ],
+)
+def test_flag_resolution_defaults_off_and_fails_closed(
+    action_input: str | None, repo_setting: bool, expected: bool
+) -> None:
+    assert (
+        resolve_sarif_upload_enabled(action_input=action_input, repo_setting=repo_setting)
+        is expected
+    )
+
+
+# --------------------------------------------------------------------------
+# W7.2 — validate before upload
+# --------------------------------------------------------------------------
+
+
+def test_build_upload_document_validates_against_the_sarif_schema() -> None:
+    document = build_upload_document([_finding()])
+    assert document["version"] == "2.1.0"
+    assert len(document["runs"][0]["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_document_is_refused_loudly_and_never_uploaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, warnings_sink: list[str]
+) -> None:
+    """An invalid document fails loudly rather than uploading (W7.2)."""
+    import mergecraft.analyzers.sarif_upload as upload_mod
+
+    monkeypatch.setattr(upload_mod, "export_sarif", lambda findings: {"version": "1.0"})
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+
+    result = await report_sarif_upload(ctx)
+
+    assert result is None
+    assert github.sarif_posts == [], "an invalid SARIF document was uploaded"
+    assert any("sarif" in line.lower() for line in warnings_sink), "refusal was silent"
+
+
+# --------------------------------------------------------------------------
+# W7.3 — the clustered, budgeted set (D14)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uploaded_findings_are_the_clustered_budgeted_set(tmp_path: Path) -> None:
+    """The upload reads the *placed* set the pipeline stored, not a raw list.
+
+    Two tools reporting the same defect at the same location collapse into one
+    cluster, so a correct upload carries fewer results than the raw list. The
+    second half of the assertion is just as load-bearing: every placed finding
+    is uploaded, inline *and* mechanical. Truncating code scanning at the
+    inline budget would throw away exactly the overflow #39 exists to surface.
+    """
+    raw = [
+        _finding(tool="semgrep", rule_id="semgrep:sql-injection", start_line=12),
+        _finding(tool="opengrep", rule_id="opengrep:sql-injection", start_line=12),
+        *[
+            _finding(tool="semgrep", rule_id=f"semgrep:r{n}", start_line=n, path=f"src/m{n}.py")
+            for n in range(20, 32)
+        ],
+    ]
+    clustered = cluster_findings(raw)
+    placement = place_findings(clustered, inline_budget=3)
+    placed_rules = {f.rule_id for f in [*placement.inline, *placement.mechanical]}
+
+    assert len(clustered) < len(raw), "fixture does not exercise clustering"
+    assert placement.mechanical, "fixture does not overflow the inline budget"
+
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, findings=clustered)
+    await report_sarif_upload(ctx)
+
+    results = _uploaded_documents(github)[0]["runs"][0]["results"]
+    assert len(results) == len(clustered)
+    assert len(results) > 3, "upload was truncated at the inline budget"
+    assert {row["ruleId"] for row in results} <= placed_rules
+
+
+# --------------------------------------------------------------------------
+# W7.4 — redaction before serialization (convention 8)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("carrier", ["message", "evidence"])
+@pytest.mark.asyncio
+async def test_upload_is_redacted(tmp_path: Path, carrier: str) -> None:
+    """A secret-shaped string never reaches the wire, whichever field holds it.
+
+    Code-scanning alerts are permanent and externally visible, so this is the
+    assertion whose silent failure is unrecoverable — the secret is published
+    before anyone reads the log.
+    """
+    if carrier == "message":
+        finding = _finding(message=f"leaked credential {TOKEN_CANARY} in header")
+    else:
+        finding = _finding(evidence=[f"Authorization: Bearer {TOKEN_CANARY}"])
+
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, findings=[finding])
+    await report_sarif_upload(ctx)
+
+    assert github.sarif_posts, "nothing was uploaded — the assertion would be vacuous"
+    assert_no_canary(_document_text(github), TOKEN_CANARY)
+
+
+@pytest.mark.parametrize("carrier", ["message", "evidence", "remediation"])
+def test_redaction_happens_before_serialization_not_after(carrier: str) -> None:
+    """Redaction is a property of the finding set, not of the encoded blob.
+
+    Asserting only on the encoded payload would pass for an implementation that
+    serialized the secret and then string-replaced it, which leaves the secret
+    in every intermediate the exporter touched. Pin the typed set instead.
+    """
+    payload = f"token {TOKEN_CANARY}"
+    if carrier == "message":
+        finding = _finding(message=payload)
+    elif carrier == "evidence":
+        finding = _finding(evidence=[payload])
+    else:
+        finding = _finding().model_copy(update={"remediation": payload})
+
+    redacted = redact_findings_for_upload([finding])
+
+    assert len(redacted) == 1
+    assert_no_canary(redacted[0].model_dump_json(), TOKEN_CANARY)
+    assert isinstance(redacted[0], Finding), "redaction must preserve the one finding model (D12)"
+
+
+def test_redaction_does_not_corrupt_the_location(tmp_path: Path) -> None:
+    """Paths survive redaction: a mangled `artifactLocation.uri` drops the alert."""
+    finding = _finding(path="src/mergecraft/analyzers/sarif_upload.py", start_line=7)
+    redacted = redact_findings_for_upload([finding])
+    assert redacted[0].path == finding.path
+    assert redacted[0].start_line == finding.start_line
+
+
+# --------------------------------------------------------------------------
+# W7.5 — trust gate (D13), routed through the existing predicates
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tier", "shell", "mode", "expected"),
+    [
+        ("trusted", "restricted", "auto", {"semgrep", "pylint", "ruff", "agentsec"}),
+        ("trusted", "restricted", "full", {"semgrep", "pylint", "ruff", "agentsec"}),
+        # `pylint` is managed/trusted, `ruff` repo-native/trusted — both drop.
+        ("untrusted", "restricted", "auto", {"semgrep", "agentsec"}),
+        ("untrusted", "restricted", "full", {"semgrep", "agentsec"}),
+        # `shell: disabled` withholds repo-provided tooling; `agentsec` is the
+        # documented in-process exception and stays.
+        ("trusted", "disabled", "auto", {"semgrep", "pylint", "agentsec"}),
+        ("untrusted", "disabled", "auto", {"semgrep", "agentsec"}),
+        # The mode axis narrows on an otherwise-trusted run.
+        ("trusted", "restricted", "untrusted-only", {"semgrep", "agentsec"}),
+    ],
+    ids=[
+        "trusted_auto",
+        "trusted_full",
+        "untrusted_auto",
+        "untrusted_full",
+        "trusted_shell_disabled",
+        "untrusted_shell_disabled",
+        "trusted_untrusted_only",
+    ],
+)
+def test_untrusted_tier_upload_scope(tier: str, shell: str, mode: str, expected: set[str]) -> None:
+    """Only findings selection admits at this tier/shell/mode may be uploaded.
+
+    The expected sets are restated from the policy, not read back off the
+    predicates, so a predicate that stopped skipping would fail here rather
+    than quietly agree with itself.
+    """
+    findings = [_finding(tool=tool) for tool in ("semgrep", "pylint", "ruff", "agentsec")]
+
+    selected = select_uploadable_findings(findings, tier=tier, shell=shell, mode=mode)  # type: ignore[arg-type]
+
+    assert {f.tool for f in selected} == expected
+
+
+def test_upload_scope_reuses_the_pipeline_predicates_not_a_fourth_path() -> None:
+    """The gate agrees with the pipeline's own skip chain, manifest by manifest.
+
+    Batch B added `cause` to `evaluate_manifest_for_tier()` rather than a
+    second skip vocabulary; the same discipline applies here. This sweeps the
+    whole catalog so a divergent copy of the policy shows up as a disagreement
+    rather than as a plausible-looking allowlist.
+    """
+    from mergecraft.analyzers.registry import load_catalog
+    from mergecraft.analyzers.trust import (
+        evaluate_manifest_for_mode,
+        evaluate_manifest_for_shell,
+        evaluate_manifest_for_tier,
+        resolve_effective_analyzers_mode,
+        resolve_selection_tier,
+    )
+
+    manifests = sorted(load_catalog(), key=lambda m: m.id)
+    for tier in ("trusted", "untrusted"):
+        for shell in ("restricted", "disabled"):
+            for mode in ("auto", "full", "untrusted-only"):
+                effective = resolve_effective_analyzers_mode(mode=mode, tier=tier)  # type: ignore[arg-type]
+                selection_tier = resolve_selection_tier(mode=effective, tier=tier)  # type: ignore[arg-type]
+                expected = {
+                    m.id
+                    for m in manifests
+                    if not evaluate_manifest_for_tier(manifest=m, tier=selection_tier).skipped
+                    and not evaluate_manifest_for_shell(manifest=m, shell=shell).skipped
+                    and not evaluate_manifest_for_mode(manifest=m, mode=effective).skipped
+                }
+                findings = [_finding(tool=m.id) for m in manifests]
+                selected = select_uploadable_findings(
+                    findings,
+                    tier=tier,  # type: ignore[arg-type]
+                    shell=shell,
+                    mode=mode,  # type: ignore[arg-type]
+                )
+                assert {f.tool for f in selected} == expected, (
+                    f"upload gate disagrees with the pipeline at "
+                    f"tier={tier} shell={shell} mode={mode}"
+                )
+
+
+def test_findings_from_unknown_tools_are_not_uploaded() -> None:
+    """A tool with no manifest cannot be trust-gated, so it is not uploaded."""
+    selected = select_uploadable_findings(
+        [_finding(tool="not-a-catalog-analyzer")],
+        tier="trusted",
+        shell="restricted",
+        mode="auto",
+    )
+    assert selected == []
+
+
+# --------------------------------------------------------------------------
+# W7.6 — upload failure is never the gate
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.HTTPStatusError(
+            "403 Forbidden",
+            request=httpx.Request("POST", "https://api.github.com"),
+            response=httpx.Response(403),
+        ),
+        httpx.ConnectError("connection refused"),
+        RuntimeError("boom"),
+    ],
+    ids=["forbidden", "transport", "unexpected"],
+)
+@pytest.mark.asyncio
+async def test_upload_failure_does_not_fail_the_run(
+    tmp_path: Path, error: Exception, warnings_sink: list[str]
+) -> None:
+    """A code-scanning error is logged at warning and the run still completes.
+
+    `security-events: write` is missing from most workflows and code scanning
+    is unavailable on private repos without Advanced Security, so 403 is the
+    *expected* response for a large share of consumers. If that failed the run,
+    an opt-in complementary surface would become a merge blocker.
+    """
+    github = _RecordingGitHub(post_error=error)
+    ctx = _ctx(tmp_path, github=github)
+
+    result = await report_sarif_upload(ctx)
+
+    assert result is None
+    assert warnings_sink, "upload failure was swallowed silently"
+
+
+@pytest.mark.asyncio
+async def test_upload_is_skipped_when_the_run_produced_no_findings(tmp_path: Path) -> None:
+    """Nothing to publish means no request — an empty SARIF run is not signal."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, findings=[])
+
+    assert await report_sarif_upload(ctx) is None
+    assert github.sarif_posts == []
+
+
+# --------------------------------------------------------------------------
+# W7.7 — no raw logs (D13)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_raw_logs_uploaded(tmp_path: Path) -> None:
+    """CI-sourced findings carry pipeline log excerpts; they never leave here.
+
+    Batch C's `ci_evidence_lines()` truncates and redacts a log excerpt into
+    `Finding.evidence` so the *reviewing agent* can read it. Code scanning is a
+    different audience and a permanent one: D13 says never upload log excerpts
+    wholesale, and #39 scopes the surface to catalog analyzers. So a `source`
+    of `ci` or `agent` is excluded outright, and `evidence` is not serialized
+    on any finding.
+    """
+    log_excerpt = [
+        f"2026-08-10T09:14:02Z build#941 export GH_TOKEN={TOKEN_CANARY}",
+        "2026-08-10T09:14:03Z build#941 make: *** [test] Error 1",
+    ]
+    findings = [
+        _finding(tool="semgrep", message="clean analyzer finding"),
+        _finding(tool="ci", rule_id="ci:build", source="ci", evidence=log_excerpt),
+        _finding(tool="agent", rule_id="agent:review", source="agent", message="narrative"),
+    ]
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github, findings=findings)
+
+    await report_sarif_upload(ctx)
+
+    wire = _document_text(github)
+    assert github.sarif_posts, "nothing was uploaded — the assertion would be vacuous"
+    assert_no_canary(wire, TOKEN_CANARY)
+    assert "Error 1" not in wire, "a raw CI log line reached the upload"
+    assert "narrative" not in wire, "an agent narrative finding reached the upload"
+    assert "evidence" not in wire, "the evidence field was serialized into SARIF"
+
+
+@pytest.mark.parametrize("source", ["ci", "agent"])
+def test_only_analyzer_sourced_findings_are_uploadable(source: str) -> None:
+    """#39 scopes the surface to catalog analyzers; other sources drop."""
+    selected = select_uploadable_findings(
+        [_finding(tool="semgrep", source=source)],
+        tier="trusted",
+        shell="restricted",
+        mode="auto",
+    )
+    assert selected == []
+
+
+# --------------------------------------------------------------------------
+# Wire shape — the upload has to be something code scanning accepts
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_targets_the_code_scanning_endpoint_for_the_pr_head(tmp_path: Path) -> None:
+    """The POST names the code-scanning SARIF endpoint, the PR head, and its ref."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+
+    await report_sarif_upload(ctx)
+
+    posts = [
+        (path, body)
+        for method, path, body in github.requests
+        if method == "POST" and path.endswith("/code-scanning/sarifs")
+    ]
+    assert len(posts) == 1
+    path, body = posts[0]
+    assert path == "/repos/acme/demo/code-scanning/sarifs"
+    assert body["commit_sha"] == PR_HEAD_SHA
+    assert body["ref"] == f"refs/pull/{PR_NUMBER}/head"
+    assert isinstance(body["sarif"], str)
+    assert body["sarif"]
+
+
+def test_encoded_payload_round_trips() -> None:
+    """`sarif` is base64-encoded gzip, which is the only shape GitHub accepts."""
+    import base64
+    import gzip
+
+    document = build_upload_document([_finding()])
+    encoded = encode_sarif_payload(document)
+    assert json.loads(gzip.decompress(base64.b64decode(encoded)).decode("utf-8")) == document
+
+
+@pytest.mark.asyncio
+async def test_upload_is_skipped_when_the_event_has_no_pull_request(tmp_path: Path) -> None:
+    """Code-scanning results are diff-scoped; with no PR there is nothing to attach."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+    ctx.payload.event.is_pr = False
+    ctx.payload.event.issue_number = None
+
+    assert await report_sarif_upload(ctx) is None
+    assert github.sarif_posts == []
+
+
+# --------------------------------------------------------------------------
+# Docs / template — opt-in stays visibly opt-in
+# --------------------------------------------------------------------------
+
+
+def test_hardened_example_documents_the_flag_without_enabling_it() -> None:
+    """The hardened template shows how to opt in, and does not opt in.
+
+    Enabling it there would contradict D13's "with the flag unset nothing
+    changes" acceptance criterion for every consumer who copies the template.
+    """
+    rendered = (REPO_ROOT / "examples" / "workflows" / "mergecraft-hardened.yml").read_text(
+        encoding="utf-8"
+    )
+    template = (REPO_ROOT / "scripts" / "example_workflows" / "hardened.yml.tpl").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (rendered, template):
+        assert "sarif_upload" in text, "the template does not mention the opt-in flag"
+        assert "security-events: write" in text, "the required permission is undocumented"
+        # Both the flag and the permission must be commented out.
+        active = [
+            line
+            for line in text.splitlines()
+            if line.strip().startswith(("sarif_upload:", "security-events:"))
+        ]
+        assert not active, f"the hardened example enables SARIF upload: {active}"
+
+    workflow = yaml.safe_load(rendered)
+    assert "security-events" not in workflow["permissions"]
+
+
+def test_readme_documents_the_permission_and_the_flag() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "sarif_upload" in readme
+    assert "security-events: write" in readme
+
+
+def test_analyzers_doc_is_generated_with_the_sarif_section() -> None:
+    """`docs/ANALYZERS.md` is fully generated — the section lives in the generator."""
+    from mergecraft.analyzers.catalog_docs import generate_analyzers_doc
+
+    generated = generate_analyzers_doc()
+    assert "code scanning" in generated.lower()
+    assert "security-events: write" in generated
+    assert generated == (REPO_ROOT / "docs" / "ANALYZERS.md").read_text(encoding="utf-8")

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -127,6 +127,50 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
         defined_in="ci/evidence.py",
         why="no reachable caller means recorded CI evidence never reaches the packet (#36)",
     ),
+    # #39 — `export_sarif()` was implemented, exported and unit-tested for two
+    # releases while its only caller was an offline CLI command, so no Action
+    # run ever produced a SARIF document. That is the #96 shape exactly, and
+    # re-wiring it is the whole of Batch D. Pin every link of the new chain.
+    _Contract(
+        symbol="report_sarif_upload",
+        defined_in="utils/code_scanning.py",
+        why=(
+            "no reachable caller means no Action run uploads SARIF, so `sarif_upload: enabled` "
+            "is accepted and does nothing (#39)"
+        ),
+    ),
+    _Contract(
+        symbol="select_uploadable_findings",
+        defined_in="analyzers/sarif_upload.py",
+        why=(
+            "no reachable caller means the trust gate is skipped and findings from analyzers "
+            "the run's tier never admitted are published to code scanning (#39, D13)"
+        ),
+    ),
+    _Contract(
+        symbol="redact_findings_for_upload",
+        defined_in="analyzers/sarif_upload.py",
+        why=(
+            "no reachable caller means unredacted findings are serialized into a permanent, "
+            "externally-visible code-scanning alert (#39, convention 8)"
+        ),
+    ),
+    _Contract(
+        symbol="build_upload_document",
+        defined_in="analyzers/sarif_upload.py",
+        why=(
+            "no reachable caller means nothing validates the SARIF document before it is "
+            "uploaded (#39)"
+        ),
+    ),
+    _Contract(
+        symbol="resolve_sarif_upload_enabled",
+        defined_in="analyzers/sarif_upload.py",
+        why=(
+            "no reachable caller means the opt-in flag is never read, so upload is either "
+            "always on or always off regardless of what the consumer asked for (#39, D13)"
+        ),
+    ),
 )
 
 
@@ -291,6 +335,19 @@ def test_packet_emission_is_wired_into_the_action_orchestrator() -> None:
     invoked = _invoked_names(_parsed((_SRC_DIR / "main.py").resolve()))
     assert "emit_run_packet" in invoked, (
         "main.py no longer invokes emit_run_packet() — no Action run emits an evidence packet"
+    )
+
+
+def test_sarif_upload_is_wired_into_the_action_orchestrator() -> None:
+    """The SARIF seam is pinned to `main()`, beside the other publish steps.
+
+    Reachability alone would be satisfied by a call from some CLI-only branch —
+    which is exactly the state #39 found `export_sarif()` in. Name the call
+    site an Action run actually enters.
+    """
+    invoked = _invoked_names(_parsed((_SRC_DIR / "main.py").resolve()))
+    assert "report_sarif_upload" in invoked, (
+        "main.py no longer invokes report_sarif_upload() — no Action run uploads SARIF (#39)"
     )
 
 


### PR DESCRIPTION
## What?

Analyzer findings can now show up on a pull request as GitHub code-scanning alerts, not only as review comments.

- Off by default. Turn it on with `sarif_upload: enabled` on the action (or `analyzers.sarifUpload: true` in `.mergecraft/config.yaml`) plus `security-events: write` on the job. With it unset the run makes no extra API call at all.
- Only findings from catalog analyzers this run's trust tier, `shell:` policy and `analyzers:` mode actually admitted are published. Findings derived from the consumer's own CI, and anything the reviewing agent wrote, are never published.
- Secrets are stripped from every text field before anything is serialized.
- Duplicates that two tools reported at the same place arrive as one alert, and the set is not cut off at the inline comment budget — the overflow is exactly what this surface is for.
- A rejected upload never fails the review. Missing permission, a repository without code scanning, a network error: all logged and the run carries on.

## Why?

A repo that hardens correctly gets the thinnest review. `shell: disabled` under `pull_request_target` means the agent cannot run anything itself, so the mechanical half of the review arrives entirely as prose — and when there are more than a handful of findings, most of it is pushed out of the inline comments and into a collapsed summary table nobody reads. Code scanning gives those findings a durable home with GitHub's own dedup and triage, and it is the surface security reviewers already have open.

mergeCraft has been able to write SARIF since the analyzer catalog shipped. The only thing that ever called it was an offline CLI command, so no CI run has ever produced a document.

## Note

Reviewer heads-up on the two decisions worth arguing about:

**Code scanning rather than check-run annotations.** The issue names both. One was picked deliberately: the existing exporter already emits exactly what code scanning consumes, alerts outlive the review thread that this issue's premise is about, and the failure mode is one call with one status code. Annotations need a different permission, cap at 50 per request, fail partially in a way that is hard to report honestly, and largely repeat comments that are already on the PR. Annotations stay documented as the alternative; nothing here forecloses them.

**The upload is not truncated at the inline budget.** The budget exists to stop comment spam. Applying it here would drop precisely the findings a consumer opted in to see.

The trust gate re-derives its answer from each finding's manifest through the same predicates the analyzer pipeline uses, rather than trusting the recorded run — analyzer state is replaced wholesale on every `run_analyzers` call, so a stored row can outlive the selection that produced it. A finding from a tool with no catalog manifest cannot be gated at all and is refused.

`docs/ANALYZERS.md` is fully generated, so the new section lives in the generator. The hardened workflow example documents the flag and the permission with both commented out — enabling it there would change behaviour for everyone who copies the template.

## Test plan

- [x] `make ci-reset` then a single `make ci-resume` — all 9 steps passed (lockcheck, lint, typecheck, pyright, catalog-check, build, example-workflows-check, security, test). 1218 passed / 21 skipped. The xfail and xpass rows are pre-existing on `pre-0.0.1`; none are introduced here.
- [x] `make catalog-check` — catalog OK, 57 manifests.
- [x] New suite: 42 cases green, plus the reachability guard in `tests/test_runtime_call_sites.py`, which gains contracts for every function in the new chain and pins the call site in `main()`. Wiring a previously CLI-only exporter into the Action path is the exact shape of #96.
- [x] Mutation-checked, because the safety properties are the point and a silent pass would publish a secret to a permanent surface:
  - redaction turned into a passthrough → 4 cases fail
  - the source filter removed → 3 cases fail
  - the trust gate removed → 7 cases fail

## Related PR(s)/Issue(s)

Closes #39

Final batch of the analyzer trust / CI evidence program: #107 (#35), #108 (#36), #112 (#38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
