### PR TITLE
chore: ignore .claude, .cursor, and CLAUDE.md in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ graphify-out/
 
 # Analyzer adapter test artifacts
 tests/analyzers/fixtures/repo/.mergecraft/
+/.claude
+/.cursor
+CLAUDE.md


### PR DESCRIPTION
Keep local-only editor/agent config out of version control; they are operator-specific and should not be tracked on the branch.

## What?

<!-- What does this change do? Keep it short and concrete. -->

## Why?

<!-- Why is this needed? Link any related issues. -->

## Test plan

- [ ] `make ci` green locally
- [ ] Added or updated tests where it makes sense

> Note: code changes under `src/mergecraft/**` or `scripts/**` require a matching
> `## [Unreleased]` entry in [`CHANGELOG.md`](../CHANGELOG.md) — see
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).
