### PR TITLE
feat(evidence): trajectory record and auditor for agent-produced changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Reviews now check *how* a change was produced, not only the diff. Eight named
+  trajectory checks read the tool calls mergeCraft mediated and report a file
+  modified but never read, a tool error that was never retried, edits with no
+  verification after them, an identical retry after a failure with nothing read
+  in between, a command that failed and never passed, a repeated call loop, an
+  unusually broad edit, and a run that did work and never signalled completion.
+  Each carries a severity and a recommended action, and lands in the merge
+  evidence packet's finding list — so `decide_approval()` weighs them like any
+  other evidence rather than through a second gate. Checks stay **silent when
+  the evidence is absent**: mergeCraft only sees the calls it mediates, so a
+  driver whose reads never cross MCP yields "unknown", not "unread". Inline
+  slots go to code findings first. `PACKET_SCHEMA_VERSION` moves to `1.4.0` for
+  the new `trajectory` section (#43, #49)
+
 ### Changed
 
 - **BREAKING** — an unrecognised `analyzers:` Action input value now resolves to

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -334,6 +334,40 @@ Formatting rules that are enforced by the prompt:
 - Severity emoji on every section heading, no two consecutive prose paragraphs, backticks around every identifier, no repeated diff content, no line-count stats.
 - The opening callout tier (`[!CAUTION]`, `[!IMPORTANT]`, informational, or ✅) must match the author's actual next action — wrapping mergeable feedback in `[!IMPORTANT]` trains people to ignore it.
 
+## 10. Trajectory checks (#43, #49)
+
+Everything above reads the **diff**. These eight checks read *how the run
+produced it* — the tool calls mergeCraft mediated. A diff can look clean while
+the process that produced it was not, and that is invisible to a diff review.
+
+| Check | Fires when | Severity |
+|---|---|---|
+| `changed-unread-file` | A file was modified that the run never read | Major |
+| `ignored-tool-error` | A tool call errored and that tool was never called again | Major |
+| `no-post-edit-verification` | Files were modified and nothing verifying ran *afterwards* | Major |
+| `repeated-tool-loop` | The same call, with identical arguments, three or more times | Minor |
+| `unresolved-failure` | A command reported failure and no later run of it passed | Critical |
+| `suspicious-broad-edit` | One run modified 25+ files | Minor |
+| `stale-assumption-after-failure` | A failed call was retried byte-identically with nothing read in between | Major |
+| `missing-completion-signal` | The run did work and never signalled completion | Minor |
+
+Each finding carries the severity above and a recommended action.
+
+**Silence on absent evidence.** mergeCraft only sees the calls it mediates, so a
+driver whose file reads never cross MCP produces a record with no reads — which
+is *unknown*, not *unread*. Every check that could fire on missing signal is
+gated on the record carrying that signal at all: `changed-unread-file` needs
+`read_coverage`, `missing-completion-signal` needs at least one recorded call. A
+check that fires on every run is noise, not a gate.
+
+**No second gate.** These are ordinary findings in the packet's finding list, so
+`decide_approval()` weighs them exactly like any other evidence — a `Critical`
+`unresolved-failure` blocks for the same reason a `Critical` analyzer finding
+does. There is no separate trajectory verdict.
+
+**They never crowd out code findings.** Inline slots go to code findings first;
+trajectory findings take only what is left and otherwise report in the body.
+
 ## 9. Address-reviews checks
 
 When mergecraft is on the receiving end of review comments (`AddressReviews` mode), each thread is checked for:

--- a/docs/test-plans/merge-evidence-trajectory.md
+++ b/docs/test-plans/merge-evidence-trajectory.md
@@ -1,0 +1,70 @@
+# Merge evidence & gating — Batch C (trajectory) test plan (WC-T RED)
+
+Wave plan: `.ignorelocal/waves/issues-merge-evidence-gating-wave-plan.md`
+Worktree: `mergecraft-evi-c-trajectory` @ `wave/evi-c-trajectory`
+Tests: `tests/evidence/test_trajectory.py`
+
+Mirrors `docs/test-plans/merge-evidence-blast-radius.md` (Batch B) so the WC-T
+close-out is directly comparable.
+
+## Locked decisions exercised
+
+| ID | Decision | Test(s) |
+|----|----------|---------|
+| **D8** | The record is self-contained — built from the MCP tool-call layer, never gated on #56 | `test_trajectory_record_is_populated_without_external_trace` |
+| **D8** | A richer external trace is *optional enrichment*, declared in the schema | `test_external_trace_is_optional_enrichment` |
+| **D7** | The packet is versioned; changing the `trajectory` section's shape bumps `PACKET_SCHEMA_VERSION` | `tests/evidence/test_packet_schema.py::test_packet_schema_version_is_pinned` |
+| **D3** | The auditor emits the existing `Finding` model — no second finding type | every `_audit(...)` case asserts on `Finding.rule_id` / `.severity` |
+| **D11** | Nothing here enables auto-merge; a blocking finding yields `failure`, not a merge | `test_high_severity_trajectory_finding_blocks_auto_merge` |
+| Convention 5 | The auditor is pure — no filesystem, no network, no `os.environ`, no input mutation | `test_auditor_is_pure`, `test_audit_is_deterministic` |
+
+## Contract matrix
+
+| Issue | Layer | Scenario | Primary test |
+|-------|-------|----------|--------------|
+| **#49** | Unit | A clean trajectory fires nothing (control) | `test_clean_trajectory_fires_nothing` |
+| **#49** | Unit | `changed-unread-file` fires and names the unread file | `test_changed_unread_file_fires` |
+| **#49** | Unit | `changed-unread-file` stays silent with no read coverage | `test_changed_unread_file_is_suppressed_without_read_coverage` |
+| **#49** | Unit | `ignored-tool-error` fires when a failed tool is never called again | `test_ignored_tool_error_fires` |
+| **#49** | Unit | `ignored-tool-error` stays silent when the tool was retried | `test_ignored_tool_error_does_not_fire_when_the_tool_was_retried` |
+| **#49** | Unit | `no-post-edit-verification` fires when verification predates the last edit | `test_no_post_edit_verification_fires` |
+| **#49** | Unit | `repeated-tool-loop` fires at the threshold, not below it | `test_repeated_tool_loop_fires`, `…_does_not_fire_below_the_threshold` |
+| **#49** | Unit | `unresolved-failure` fires on a *result* failure, distinct from a tool error | `test_unresolved_failure_fires` |
+| **#49** | Unit | `suspicious-broad-edit` fires on an implausible file count | `test_suspicious_broad_edit_fires` |
+| **#49** | Unit | `stale-assumption-after-failure` fires only when nothing was read in between | `test_stale_assumption_after_failure_fires`, `…_does_not_fire_when_something_was_read_in_between` |
+| **#49** | Unit | `missing-completion-signal` fires on a run that stopped, not on an empty record | `test_missing_completion_signal_fires`, `…_does_not_fire_on_an_empty_record` |
+| **#49** | Unit | Every check declares a severity and a recommended action | `test_every_named_check_has_a_severity_and_a_recommended_action` |
+| **#43** | Integration | A high-severity trajectory finding reaches the packet verdict | `test_high_severity_trajectory_finding_blocks_auto_merge` |
+| **#43** | Integration | The record is populated on the live `emit_run_packet` path | `test_trajectory_findings_reach_the_packet_from_a_real_run` |
+| **#43** | Unit | The record forbids unknown fields and round-trips through JSON | `test_record_forbids_unknown_fields`, `test_record_round_trips_through_json` |
+| **#49** | Unit | Trajectory findings never displace code findings from the inline budget | `test_trajectory_findings_never_crowd_out_code_findings` |
+
+## Why the negative cases carry the weight
+
+Three of the eight checks all describe "something went wrong", and a suite that
+only asserts they fire could be satisfied by one over-eager check firing on
+everything. Each is therefore pinned to a *distinct* trigger, with a negative
+case that the other two do not cover:
+
+| Check | Trigger | Distinguished from |
+|---|---|---|
+| `ignored-tool-error` | tool call raised; that tool is never called again | `stale-assumption…`, which requires a retry |
+| `stale-assumption-after-failure` | tool call raised; retried with an identical signature and no intervening read | `ignored-tool-error`, which requires no retry |
+| `unresolved-failure` | tool call *succeeded* but reported a failing outcome, never later resolved | both of the above, which key off transport errors |
+
+The same reasoning drives `test_clean_trajectory_fires_nothing` and
+`test_missing_completion_signal_does_not_fire_on_an_empty_record`: without
+them, a check that returned a finding unconditionally would pass every
+positive case in the file.
+
+## xfail schedule
+
+All cases carry a module-level `pytestmark = pytest.mark.xfail(reason="green
+after W7/W8", strict=False)`. `strict=False` overrides the repo-wide
+`xfail_strict=true`, so un-xfailing in W7/W8 flips each case to a pass without
+breaking collection in between.
+
+| Wave | Un-xfails |
+|------|-----------|
+| **W7** (#43) | the record cases — construction, `extra="forbid"`, JSON round-trip, MCP-only population, optional enrichment, live-run population |
+| **W8** (#49) | the eight check cases, their negatives, purity, determinism, packet-decision blocking, noise budget |

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -115,6 +115,7 @@ def build_packet(
     self_assessment: dict[str, Any] | SelfAssessment | None = None,
     decision: Decision | None = None,
     blast_radius: BlastRadiusClassification | None = None,
+    trajectory: dict[str, Any] | None = None,
     ci_check_runs: dict[str, Any] | None = None,
     ci_intelligence: dict[str, Any] | None = None,
     usage_entries: Any = None,
@@ -180,14 +181,12 @@ def build_packet(
         self_assessment=coerced_self_assessment,
         decision=decision,
         blast_radius=blast_radius,
+        trajectory=trajectory,
     )
 
-    # Trajectory / usage_entries / ci_check_runs / ci_intelligence are still
-    # deferred (Batch C for trajectory; W9+ for the rest). They are logged at
-    # debug level above for diagnostics and intentionally *not* attached to
-    # the packet here — Batch C owns ``trajectory`` as a sibling field
-    # rather than a nested dict, so updating the model is a strict version
-    # bump (D7).
+    # ``trajectory`` now lands as a sibling field (Batch C, #43). The rest --
+    # usage_entries / ci_check_runs / ci_intelligence -- remain deferred to W9+
+    # and are logged at debug level above rather than attached here.
     _ = (ci_check_runs, ci_intelligence, usage_entries)
     return packet
 

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -50,7 +50,7 @@ from mergecraft.evals.store import EvalMetadata
 #   packet that previously set it to a dict is no longer wire-compatible
 #   — no live consumer reads the legacy dict shape today, so the bump is
 #   safe.
-PACKET_SCHEMA_VERSION = "1.3.0"
+PACKET_SCHEMA_VERSION = "1.4.0"
 
 
 class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -251,16 +251,27 @@ def build_run_packet(
     diff_text = _read_diff_text(repo_state)
     blast_radius = classify_run_blast_radius(diff_text)
 
+    from mergecraft.evidence.trajectory import build_trajectory_record
+    from mergecraft.evidence.trajectory_audit import audit_trajectory
+
+    changed_paths = changed_paths_from_diff(diff_text)
+    # #43/#49: the record is built from the tool calls mergeCraft mediated, and
+    # its findings join the ordinary finding list rather than a parallel gate —
+    # so `decide_approval` below weighs them exactly like any other evidence.
+    trajectory = build_trajectory_record(state, files_modified=changed_paths)
+    trajectory_findings = audit_trajectory(trajectory)
+
     packet = build_packet(
         change_id=change_id,
         agent_id=ctx.agent_id,
         agent_version=_agent_version(),
         model=ctx.resolved_model or state.model or "(unresolved)",
-        files_changed=changed_paths_from_diff(diff_text),
-        findings=_structural_findings(ctx, extra_findings),
+        files_changed=changed_paths,
+        findings=[*_structural_findings(ctx, extra_findings), *trajectory_findings],
         deterministic_checks=_deterministic_checks(state),
         self_assessment=_self_assessment(state),
         blast_radius=blast_radius,
+        trajectory=trajectory.model_dump(mode="json"),
     )
     decision = decide_approval(packet, run_succeeded=run_succeeded, tier=ctx.trust_tier)
     return packet.model_copy(update={"decision": decision})

--- a/src/mergecraft/evidence/trajectory.py
+++ b/src/mergecraft/evidence/trajectory.py
@@ -1,0 +1,525 @@
+"""The agent trajectory record — how a change was produced (#43, W7, D8).
+
+A final diff can look plausible while the path that produced it reveals risk:
+identical tool calls repeated until the budget ran out, a failure ignored, a
+file edited that was never read, a completion claimed with nothing verifying
+it. #43 asks mergeCraft to preserve that path; :mod:`mergecraft.evidence.
+trajectory_audit` (#49) is what judges it.
+
+**Where the data comes from (D8).** mergeCraft mediates every MCP tool call the
+reviewing/engineering agent makes — ``mcp/server.py``'s ``tools/call`` handler
+is the single choke point, started on every run by ``main.py`` and by the
+offline ``diff-review`` path. :func:`record_tool_call` is called from there, so
+the record is populated with no configuration, no sinks, and no dependency on
+the tracing programme (#56). A richer external trace is declared here as
+*optional enrichment* (:class:`ExternalTraceRef`) and is never required.
+
+**What that substrate can and cannot see — read this before trusting a check.**
+MCP sees every tool mergeCraft exposes: ``shell``, ``git``, ``checkout_pr``,
+``run_analyzers``, ``run_static_checks``, ``create_pull_request_review`` and the
+rest. It does **not** see a driver's *native* file tools — Claude's ``Read`` and
+``Edit``, Codex's equivalents — because those never cross mergeCraft's wire. So
+``files_read`` is complete only for reads that went through ``shell``/``git`` or
+through an attached external trace. :attr:`TrajectoryRecord.read_coverage`
+records that distinction honestly, and the auditor's ``changed-unread-file``
+check is suppressed when it is ``False``: absence of read evidence is *unknown*,
+not *unread*. ``files_modified``, by contrast, is authoritative — it comes from
+the run's own diff, not from what the agent reported.
+
+Note on ``tool_state.usage_entries``: the wave plan described it as the
+trajectory substrate and as "write-only". Neither is right today. It holds
+per-attempt ``AgentUsage`` token counts appended once per run in ``main.py``,
+not tool calls, and the tracing programme's ``cost.*`` span attributes already
+carry that signal. This module therefore adds its own field rather than
+retrofitting that one; ``usage_entries`` is left exactly as it was.
+
+Exports:
+    ExternalTraceRef: Optional enrichment from an external trace (#56).
+    TRAJECTORY_SCHEMA_VERSION: Pinned version of the record's shape.
+    ToolCallRecord: One mediated tool call, normalised.
+    TrajectoryRecord: The full record, ready for the packet and the auditor.
+    build_trajectory_record: Assemble the record from run state (pure).
+    classify_tool_intent: Map a tool call onto its trajectory intent.
+    record_tool_call: Append one mediated call to the run's state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from typing import TYPE_CHECKING, Any, Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from mergecraft.analyzers.redact import redact_secrets
+
+if TYPE_CHECKING:
+    from mergecraft.mcp.tool_state import ToolState
+
+TRAJECTORY_SCHEMA_VERSION: Final[str] = "1.0.0"
+"""Version of the record's shape. Bump with ``PACKET_SCHEMA_VERSION`` (D7)."""
+
+SOURCE_MCP: Final[str] = "mcp-tool-calls"
+SOURCE_RUN_DIFF: Final[str] = "run-diff"
+SOURCE_EXTERNAL_TRACE: Final[str] = "external-trace"
+
+Intent = Literal["read", "modify", "verify", "complete", "report", "other"]
+"""What a tool call was *for*, as far as the trajectory is concerned."""
+
+# Intent by MCP tool name. `shell` and `git` are absent on purpose: both are
+# general-purpose, so their intent is derived from the command (see
+# `_command_intent`). A tool missing from this table lands on "other" — an
+# unknown tool must never be silently counted as verification or completion.
+_TOOL_INTENTS: Final[dict[str, Intent]] = {
+    # read
+    "checkout_pr": "read",
+    "checkout_repo": "read",
+    "list_repos": "read",
+    "get_pull_request": "read",
+    "get_commit_info": "read",
+    "get_issue": "read",
+    "get_issue_comments": "read",
+    "get_issue_events": "read",
+    "get_review_comments": "read",
+    "list_pull_request_reviews": "read",
+    "list_check_runs": "read",
+    "get_check_suite": "read",
+    "get_check_suite_logs": "read",
+    "analyzer_findings": "read",
+    "git_fetch": "read",
+    # verify
+    "run_analyzers": "verify",
+    "run_static_checks": "verify",
+    "analyze_ci_failures": "verify",
+    "verify_agent_findings": "verify",
+    "record_finding_verdict": "verify",
+    # modify
+    "commit_changes": "modify",
+    "push_branch": "modify",
+    "push_tags": "modify",
+    "delete_branch": "modify",
+    "upload_file": "modify",
+    # complete — the run produced its declared output
+    "create_pull_request_review": "complete",
+    "create_pull_request": "complete",
+    "update_pull_request_body": "complete",
+    "close_pull_request": "complete",
+    "set_output": "complete",
+    "report_progress": "complete",
+    "create_issue_comment": "complete",
+    # report — side channels; real work, but never a completion signal
+    "edit_issue_comment": "report",
+    "reply_to_review_comment": "report",
+    "resolve_review_thread": "report",
+    "add_labels": "report",
+    "remove_labels": "report",
+    "create_issue": "report",
+    "close_issue": "report",
+    "reopen_issue": "report",
+    "select_mode": "report",
+    "start_dependency_installation": "report",
+    "await_dependency_installation": "report",
+    "kill_background": "report",
+}
+
+# Leading argv tokens that mean "this command looked at something".
+_READ_COMMANDS: Final[frozenset[str]] = frozenset(
+    {
+        "awk",
+        "bat",
+        "cat",
+        "diff",
+        "find",
+        "grep",
+        "head",
+        "less",
+        "ls",
+        "more",
+        "rg",
+        "sed",
+        "tail",
+        "tree",
+        "wc",
+    }
+)
+
+# Leading argv tokens (or their first sub-command) that mean "this verified
+# something". Anything that can *fail informatively* belongs here.
+_VERIFY_COMMANDS: Final[frozenset[str]] = frozenset(
+    {
+        "cargo",
+        "eslint",
+        "go",
+        "gradle",
+        "jest",
+        "make",
+        "mypy",
+        "npm",
+        "npx",
+        "pnpm",
+        "pyright",
+        "pytest",
+        "ruff",
+        "tox",
+        "tsc",
+        "vitest",
+        "yarn",
+    }
+)
+
+# argv tokens that mean "this changed the tree".
+_MODIFY_COMMANDS: Final[frozenset[str]] = frozenset(
+    {"cp", "install", "mkdir", "mv", "patch", "rm", "sed-i", "tee", "touch"}
+)
+
+# `git` sub-commands that only read.
+_GIT_READ_SUBCOMMANDS: Final[frozenset[str]] = frozenset(
+    {"blame", "diff", "log", "ls-files", "show", "status"}
+)
+
+_MAX_COMMAND_CHARS: Final[int] = 400
+_MAX_ERROR_CHARS: Final[int] = 400
+_MAX_PATHS_PER_CALL: Final[int] = 20
+
+
+class ToolCallRecord(BaseModel):
+    """One tool call mergeCraft mediated, normalised for auditing.
+
+    Deliberately *not* a dump of the arguments. The packet is written to disk
+    and surfaced as an Action output, and tool arguments routinely carry
+    tokens, diff bodies and log excerpts. What the checks actually need is the
+    call's identity, its outcome, and the paths it named — so that is all this
+    keeps, with the command text redacted and truncated.
+
+    ``ok`` and ``outcome_ok`` are different failures and drive different
+    checks. ``ok=False`` means the *call* raised. ``outcome_ok=False`` means
+    the call succeeded and the thing it ran reported failure (a non-zero exit,
+    a failing gate). ``outcome_ok=None`` means the tool has no such notion.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    sequence: int = Field(ge=1)
+    tool: str
+    signature: str
+    """Stable digest of ``(tool, normalised arguments)`` — the loop key."""
+    intent: Intent
+    ok: bool
+    outcome_ok: bool | None = None
+    error: str | None = None
+    command: str | None = None
+    paths: list[str] = Field(default_factory=list)
+
+
+class ExternalTraceRef(BaseModel):
+    """Optional enrichment from an external agent trace (D8, #56).
+
+    Declared in the schema so a consumer can tell an *unenriched* record from
+    an enriched one, and never required: every check runs on the MCP-only
+    record. When mergeCraft's tracing programme (#56) is enabled, its
+    ``tool.call`` spans — which do cover a driver's native ``Read``/``Edit``
+    — can be adapted into ``tool_calls`` here, which is what lifts
+    ``read_coverage`` for drivers whose file access never crosses MCP.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    event_count: int = Field(ge=0)
+    tool_calls: list[ToolCallRecord] = Field(default_factory=list)
+
+
+class TrajectoryRecord(BaseModel):
+    """How this run produced its change (#43).
+
+    Field names track #43's acceptance criteria one-for-one: files read, files
+    modified, commands run, tests run, failures observed, fixes after failures,
+    retries, unresolved errors, completion claims.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = TRAJECTORY_SCHEMA_VERSION
+    sources: list[str] = Field(default_factory=list)
+    """Which substrates populated this record — see the ``SOURCE_*`` constants."""
+    tool_calls: list[ToolCallRecord] = Field(default_factory=list)
+    files_read: list[str] = Field(default_factory=list)
+    files_modified: list[str] = Field(default_factory=list)
+    commands_run: list[str] = Field(default_factory=list)
+    tests_run: list[str] = Field(default_factory=list)
+    failures_observed: list[str] = Field(default_factory=list)
+    fixes_after_failures: int = Field(default=0, ge=0)
+    retries: int = Field(default=0, ge=0)
+    unresolved_errors: list[str] = Field(default_factory=list)
+    completion_claims: list[str] = Field(default_factory=list)
+    read_coverage: bool = False
+    """True when *some* read was observed, so "unread" is a real conclusion."""
+    external_trace: ExternalTraceRef | None = None
+
+
+def _argv(command: str) -> list[str]:
+    """Split a command into argv, falling back to whitespace on bad quoting."""
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _looks_like_path(token: str) -> bool:
+    """True for tokens that plausibly name a file in the checkout.
+
+    Deliberately conservative: a false path in ``files_read`` would make
+    ``changed-unread-file`` silently stop firing, which is worse than missing
+    one. Flags, URLs and bare words are all rejected.
+    """
+    if not token or token.startswith("-") or "://" in token:
+        return False
+    if token.startswith(("/", "~")):
+        return False
+    return "/" in token or "." in token.lstrip(".")
+
+
+def _paths_in(values: Any) -> list[str]:
+    """Collect plausible repo-relative paths from an arbitrary argument tree."""
+    found: list[str] = []
+
+    def walk(node: Any) -> None:
+        if len(found) >= _MAX_PATHS_PER_CALL:
+            return
+        if isinstance(node, str):
+            if _looks_like_path(node):
+                found.append(node)
+            return
+        if isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+            return
+        if isinstance(node, (list, tuple)):
+            for value in node:
+                walk(value)
+
+    walk(values)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for path in found:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def _command_intent(tool: str, command: str) -> Intent:
+    """Derive intent for the general-purpose ``shell`` / ``git`` tools."""
+    argv = _argv(command)
+    if not argv:
+        return "other"
+    head = argv[0].rsplit("/", maxsplit=1)[-1]
+    if tool == "git" or head == "git":
+        sub = next((token for token in argv[1:] if not token.startswith("-")), "")
+        return "read" if sub in _GIT_READ_SUBCOMMANDS else "modify"
+    if head in _VERIFY_COMMANDS:
+        return "verify"
+    if head in _READ_COMMANDS:
+        # `sed -i` edits in place; every other sed invocation only prints.
+        if head == "sed" and any(token.startswith("-i") for token in argv[1:]):
+            return "modify"
+        return "read"
+    if head in _MODIFY_COMMANDS:
+        return "modify"
+    return "other"
+
+
+def classify_tool_intent(tool: str, arguments: dict[str, Any] | None) -> Intent:
+    """Return the trajectory intent of one tool call.
+
+    Named tools resolve from the table; ``shell`` and ``git`` resolve from the
+    command they were asked to run. An unrecognised tool is ``"other"``, never
+    ``"verify"`` or ``"complete"`` — guessing in that direction would let an
+    unknown tool silence ``no-post-edit-verification`` or
+    ``missing-completion-signal``.
+    """
+    known = _TOOL_INTENTS.get(tool)
+    if known is not None:
+        return known
+    command = str((arguments or {}).get("command") or "")
+    if command:
+        return _command_intent(tool, command)
+    return "other"
+
+
+def _signature(tool: str, arguments: dict[str, Any] | None) -> str:
+    """Stable identity for "the same call again", used for loop detection."""
+    payload = repr(sorted((str(key), repr(value)) for key, value in (arguments or {}).items()))
+    digest = hashlib.sha256(f"{tool}\x00{payload}".encode()).hexdigest()
+    return f"{tool}:{digest[:16]}"
+
+
+def _truncate(text: str, limit: int) -> str:
+    return text if len(text) <= limit else f"{text[:limit]}…"
+
+
+def record_tool_call(
+    state: ToolState,
+    *,
+    tool: str,
+    arguments: dict[str, Any] | None,
+    ok: bool,
+    outcome_ok: bool | None = None,
+    error: str | None = None,
+) -> ToolCallRecord:
+    """Append one mediated tool call to the run's trajectory (D8).
+
+    Called from ``mcp/server.py``'s ``tools/call`` handler — the one door
+    every agent tool call goes through — so the record is populated on every
+    run without configuration. Mutates ``state`` and returns the row it
+    appended; no I/O, so it cannot fail a tool call.
+
+    Command text and error text are redacted through
+    :func:`mergecraft.analyzers.redact.redact_secrets` and truncated before
+    they are stored, because the record is serialized into the evidence packet
+    and surfaced as an Action output.
+    """
+    command_raw = str((arguments or {}).get("command") or "") or None
+    row = ToolCallRecord(
+        sequence=len(state.tool_calls) + 1,
+        tool=tool,
+        signature=_signature(tool, arguments),
+        intent=classify_tool_intent(tool, arguments),
+        ok=ok,
+        outcome_ok=outcome_ok,
+        error=_truncate(redact_secrets(error), _MAX_ERROR_CHARS) if error else None,
+        command=_truncate(redact_secrets(command_raw), _MAX_COMMAND_CHARS) if command_raw else None,
+        paths=_paths_in(arguments),
+    )
+    state.tool_calls.append(row)
+    return row
+
+
+def outcome_ok_from_result(result: Any) -> bool | None:
+    """Read "did the thing the tool ran succeed?" out of a tool result.
+
+    Returns ``None`` when the tool has no such notion, which is the common
+    case — only ``shell`` and the gate-running tools report an outcome
+    separate from the call itself. ``None`` is what keeps
+    ``unresolved-failure`` keyed to real reported failures rather than to
+    every tool whose payload happens to lack an ``exitCode``.
+    """
+    if not isinstance(result, dict):
+        return None
+    for key in ("exitCode", "exit_code"):
+        value = result.get(key)
+        if isinstance(value, int):
+            return value == 0
+    for key in ("timedOut", "timed_out"):
+        if result.get(key) is True:
+            return False
+    value = result.get("success")
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def build_trajectory_record(
+    state: ToolState,
+    *,
+    files_modified: list[str] | None = None,
+    external_trace: ExternalTraceRef | None = None,
+) -> TrajectoryRecord:
+    """Assemble the record from recorded tool calls and the run's diff.
+
+    Pure: reads the state it is handed and returns a value. No I/O, no
+    ``os.environ``, no network — the caller (``evidence/run_packet.py``) owns
+    every environment-shaped input, including ``files_modified``, which comes
+    from the run's own unified diff rather than from anything the agent said.
+
+    ``external_trace`` is optional enrichment (D8): its ``tool_calls`` are
+    appended after the mediated ones, which is what can lift
+    ``read_coverage`` for a driver whose file reads never cross MCP.
+    """
+    calls: list[ToolCallRecord] = list(getattr(state, "tool_calls", []) or [])
+    sources: list[str] = []
+    if calls:
+        sources.append(SOURCE_MCP)
+    if external_trace is not None:
+        calls = [*calls, *external_trace.tool_calls]
+        sources.append(SOURCE_EXTERNAL_TRACE)
+    if files_modified:
+        sources.append(SOURCE_RUN_DIFF)
+
+    read_paths: list[str] = []
+    modified_paths: list[str] = list(files_modified or [])
+    commands: list[str] = []
+    tests: list[str] = []
+    failures: list[str] = []
+    completion: list[str] = []
+    observed_read = False
+
+    for call in calls:
+        if call.command:
+            commands.append(call.command)
+        if call.intent == "read":
+            observed_read = True
+            read_paths.extend(call.paths)
+        elif call.intent == "modify":
+            modified_paths.extend(call.paths)
+        elif call.intent == "verify":
+            if call.command:
+                tests.append(call.command)
+        if call.intent == "complete" and call.ok:
+            completion.append(call.tool)
+        if call.outcome_ok is False:
+            failures.append(call.command or call.signature)
+
+    resolved: set[str] = set()
+    for call in calls:
+        if call.outcome_ok is True:
+            resolved.add(call.command or call.signature)
+    unresolved = [item for item in _dedupe(failures) if item not in resolved]
+    fixes = len([item for item in _dedupe(failures) if item in resolved])
+
+    seen_signatures: dict[str, int] = {}
+    for call in calls:
+        seen_signatures[call.signature] = seen_signatures.get(call.signature, 0) + 1
+    retries = sum(count - 1 for count in seen_signatures.values() if count > 1)
+
+    return TrajectoryRecord(
+        sources=_dedupe(sources),
+        tool_calls=calls,
+        files_read=_dedupe(read_paths),
+        files_modified=_dedupe(modified_paths),
+        commands_run=_dedupe(commands),
+        tests_run=_dedupe(tests),
+        failures_observed=_dedupe(failures),
+        fixes_after_failures=fixes,
+        retries=retries,
+        unresolved_errors=unresolved,
+        completion_claims=_dedupe(completion),
+        read_coverage=observed_read or external_trace is not None,
+        external_trace=external_trace,
+    )
+
+
+__all__ = [
+    "SOURCE_EXTERNAL_TRACE",
+    "SOURCE_MCP",
+    "SOURCE_RUN_DIFF",
+    "TRAJECTORY_SCHEMA_VERSION",
+    "ExternalTraceRef",
+    "Intent",
+    "ToolCallRecord",
+    "TrajectoryRecord",
+    "build_trajectory_record",
+    "classify_tool_intent",
+    "outcome_ok_from_result",
+    "record_tool_call",
+]

--- a/src/mergecraft/evidence/trajectory_audit.py
+++ b/src/mergecraft/evidence/trajectory_audit.py
@@ -1,0 +1,372 @@
+"""Pure trajectory auditor — eight named checks over a `TrajectoryRecord` (#49).
+
+The auditor reads *how* a change was produced, not the change itself. The diff
+can look clean while the process that produced it was not: a file edited without
+ever being read, a failing gate re-run byte-identically until it was abandoned,
+a run that simply stopped. Those are invisible to a diff review and visible here.
+
+Two properties are load-bearing:
+
+**Silence on absent evidence.** mergeCraft only sees the tool calls it mediates.
+A driver whose file reads never cross MCP produces a record with no reads — which
+is *unknown*, not *unread*. Every check that could fire on missing signal is
+gated on the record carrying that signal at all (``read_coverage``, a non-empty
+``tool_calls``). A check that fires on every run is noise, not a gate.
+
+**No second gate path.** The checks emit ordinary :class:`Finding` rows that go
+into the packet's finding list, where ``decide_approval()`` — the one gate —
+reads them (D5, W8.2). Nothing here decides anything.
+
+Exports:
+    TrajectoryCheck: One named check's metadata (severity, recommended action).
+    TRAJECTORY_CHECKS: The eight checks, in report order.
+    audit_trajectory: Run every check over a record and return findings.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Final
+
+from pydantic import BaseModel, ConfigDict
+
+from mergecraft.analyzers.finding import Finding, make_finding
+
+if TYPE_CHECKING:
+    from mergecraft.evidence.trajectory import ToolCallRecord, TrajectoryRecord
+
+__all__ = [
+    "TRAJECTORY_CHECKS",
+    "TrajectoryCheck",
+    "TrajectoryPlacement",
+    "audit_trajectory",
+    "place_trajectory_findings",
+]
+
+# A run touching more files than this in one pass is reported for a human look.
+# Not a hard error: large mechanical refactors are legitimate, which is why the
+# check is Minor and names the count rather than asserting wrongdoing.
+BROAD_EDIT_FILE_THRESHOLD: Final[int] = 25
+
+# Two identical calls is a retry. Three is a loop.
+REPEATED_CALL_THRESHOLD: Final[int] = 3
+
+_TOOL = "trajectory"
+_CATEGORY = "Maintainability & Code Quality"
+
+
+class TrajectoryCheck(BaseModel):
+    """One named trajectory check's fixed metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rule_id: str
+    severity: str
+    recommended_action: str
+    summary: str
+
+
+TRAJECTORY_CHECKS: Final[tuple[TrajectoryCheck, ...]] = (
+    TrajectoryCheck(
+        rule_id="changed-unread-file",
+        severity="Major",
+        recommended_action="Read the file before trusting the edit; re-review this change by hand.",
+        summary="A file was modified that the run never read.",
+    ),
+    TrajectoryCheck(
+        rule_id="ignored-tool-error",
+        severity="Major",
+        recommended_action="Re-run the failed tool and act on its output, or state why it was safe to skip.",
+        summary="A tool call errored and was never retried.",
+    ),
+    TrajectoryCheck(
+        rule_id="no-post-edit-verification",
+        severity="Major",
+        recommended_action="Run the repo's gates after the final edit, not before it.",
+        summary="Files were modified and nothing verifying ran afterwards.",
+    ),
+    TrajectoryCheck(
+        rule_id="repeated-tool-loop",
+        severity="Minor",
+        recommended_action="Inspect the loop: the same call repeated unchanged rarely produces new information.",
+        summary="The same call was made with identical arguments three or more times.",
+    ),
+    TrajectoryCheck(
+        rule_id="unresolved-failure",
+        severity="Critical",
+        recommended_action="Fix the failing command, or record why it is expected to fail.",
+        summary="A command reported failure and no later run of it passed.",
+    ),
+    TrajectoryCheck(
+        rule_id="suspicious-broad-edit",
+        severity="Minor",
+        recommended_action="Confirm the breadth is intended; a wide edit is hard to review by diff alone.",
+        summary="One run modified an unusually large number of files.",
+    ),
+    TrajectoryCheck(
+        rule_id="stale-assumption-after-failure",
+        severity="Major",
+        recommended_action="Read the failure output before retrying; an identical retry assumes the cause changed on its own.",
+        summary="A failed call was retried byte-identically with nothing read in between.",
+    ),
+    TrajectoryCheck(
+        rule_id="missing-completion-signal",
+        severity="Minor",
+        recommended_action="Confirm the run finished its work rather than stopping early.",
+        summary="The run did work and never signalled completion.",
+    ),
+)
+
+_BY_ID: Final[dict[str, TrajectoryCheck]] = {c.rule_id: c for c in TRAJECTORY_CHECKS}
+
+
+def _finding(
+    rule_id: str,
+    *,
+    message: str,
+    path: str = "",
+    evidence: list[str] | None = None,
+) -> Finding:
+    """Build a `Finding` for a named check, carrying its severity and action."""
+    check = _BY_ID[rule_id]
+    # A trajectory finding is about the *run*, not a line of code, but
+    # `Finding` requires a 1-based line range. Findings with no offending file
+    # carry an empty path, which no diff hunk matches, so `analyzers/budget.py`
+    # places them in the body rather than inline — where a claim about process
+    # belongs.
+    return make_finding(
+        tool=_TOOL,
+        rule_id=rule_id,
+        category=_CATEGORY,
+        severity=check.severity,
+        confidence="certain",
+        message=message,
+        path=path,
+        start_line=1,
+        end_line=1,
+        source="agent",
+        evidence=evidence or [],
+        remediation=check.recommended_action,
+        introduced_by_pr="true",
+    )
+
+
+def _changed_unread_file(record: TrajectoryRecord) -> list[Finding]:
+    # Without any observed read the record says nothing about reading, so
+    # "unread" would be an inference from missing data rather than evidence.
+    if not record.read_coverage:
+        return []
+    read = set(record.files_read)
+    return [
+        _finding(
+            "changed-unread-file",
+            message=f"{path} was modified but never read during this run",
+            path=path,
+            evidence=[f"files_read={sorted(read)!r}"],
+        )
+        for path in record.files_modified
+        if path not in read
+    ]
+
+
+def _ignored_tool_error(record: TrajectoryRecord) -> list[Finding]:
+    """A call raised and that tool was never invoked again."""
+    findings: list[Finding] = []
+    for call in record.tool_calls:
+        if call.ok:
+            continue
+        retried = any(
+            later.tool == call.tool and later.sequence > call.sequence
+            for later in record.tool_calls
+        )
+        if retried:
+            continue
+        findings.append(
+            _finding(
+                "ignored-tool-error",
+                message=f"{call.tool} failed and was never retried",
+                evidence=[call.error or "tool call reported failure"],
+            )
+        )
+    return findings
+
+
+def _no_post_edit_verification(record: TrajectoryRecord) -> list[Finding]:
+    """Something verifying must run *after* the last modification."""
+    # Trigger on the record's own `files_modified`, not on modify-intent calls:
+    # a driver can edit files through a path mergeCraft never mediated, and the
+    # question "was this verified?" is still answerable and still worth asking.
+    if not record.files_modified:
+        return []
+    edits = [c for c in record.tool_calls if c.intent == "modify"]
+    last_edit = max((c.sequence for c in edits), default=0)
+    verified_after = any(c.intent == "verify" and c.sequence > last_edit for c in record.tool_calls)
+    if verified_after:
+        return []
+    return [
+        _finding(
+            "no-post-edit-verification",
+            message="files were modified and nothing verifying ran afterwards",
+            evidence=[f"last edit at call {last_edit}"],
+        )
+    ]
+
+
+def _repeated_tool_loop(record: TrajectoryRecord) -> list[Finding]:
+    counts = Counter(call.signature for call in record.tool_calls)
+    return [
+        _finding(
+            "repeated-tool-loop",
+            message=f"the same call was repeated {count} times with identical arguments",
+            evidence=[f"signature={signature!r}"],
+        )
+        for signature, count in sorted(counts.items())
+        if count >= REPEATED_CALL_THRESHOLD
+    ]
+
+
+def _unresolved_failure(record: TrajectoryRecord) -> list[Finding]:
+    """The call succeeded; the thing it ran failed, and never later passed."""
+    findings: list[Finding] = []
+    for call in record.tool_calls:
+        if call.outcome_ok is not False:
+            continue
+        later_pass = any(
+            other.signature == call.signature
+            and other.sequence > call.sequence
+            and other.outcome_ok is True
+            for other in record.tool_calls
+        )
+        if later_pass:
+            continue
+        findings.append(
+            _finding(
+                "unresolved-failure",
+                message=f"{call.command or call.tool} reported failure and never passed",
+                evidence=[f"unresolved_errors={record.unresolved_errors!r}"],
+            )
+        )
+    return findings
+
+
+def _suspicious_broad_edit(record: TrajectoryRecord) -> list[Finding]:
+    count = len(record.files_modified)
+    if count < BROAD_EDIT_FILE_THRESHOLD:
+        return []
+    return [
+        _finding(
+            "suspicious-broad-edit",
+            message=f"{count} files were modified in one run",
+            evidence=[f"threshold={BROAD_EDIT_FILE_THRESHOLD}"],
+        )
+    ]
+
+
+def _read_between(calls: list[ToolCallRecord], lower: int, upper: int) -> bool:
+    """True when any read-intent call sits strictly between two sequences."""
+    return any(c.intent == "read" and lower < c.sequence < upper for c in calls)
+
+
+def _stale_assumption_after_failure(record: TrajectoryRecord) -> list[Finding]:
+    """An identical retry with nothing read in between assumes the cause moved."""
+    findings: list[Finding] = []
+    calls = list(record.tool_calls)
+    for index, call in enumerate(calls):
+        if call.ok:
+            continue
+        for later in calls[index + 1 :]:
+            if later.signature != call.signature or later.ok:
+                continue
+            if _read_between(calls, call.sequence, later.sequence):
+                break
+            findings.append(
+                _finding(
+                    "stale-assumption-after-failure",
+                    message=(
+                        f"{call.tool} was retried with identical arguments after failing, "
+                        "with nothing read in between"
+                    ),
+                    evidence=[f"signature={call.signature!r}"],
+                )
+            )
+            break
+    return findings
+
+
+def _missing_completion_signal(record: TrajectoryRecord) -> list[Finding]:
+    # An empty record is a driver mergeCraft did not mediate, not an abandoned
+    # run — firing here would flag every such execution.
+    if not record.tool_calls:
+        return []
+    if record.completion_claims:
+        return []
+    return [
+        _finding(
+            "missing-completion-signal",
+            message="the run performed work and never signalled completion",
+            evidence=[f"tool_calls={len(record.tool_calls)}"],
+        )
+    ]
+
+
+_CHECK_FUNCTIONS = (
+    _changed_unread_file,
+    _ignored_tool_error,
+    _no_post_edit_verification,
+    _repeated_tool_loop,
+    _unresolved_failure,
+    _suspicious_broad_edit,
+    _stale_assumption_after_failure,
+    _missing_completion_signal,
+)
+
+
+def audit_trajectory(record: TrajectoryRecord) -> list[Finding]:
+    """Run every trajectory check over ``record`` and return the findings.
+
+    Pure: no I/O, no logging, no module state, no clock. The same record always
+    yields the same findings, which is what lets a promoted eval case replay a
+    trajectory verdict deterministically.
+
+    Returns findings in check order. An empty list means every check was either
+    satisfied or had no evidence to judge on — the two are deliberately
+    indistinguishable to the caller, because both mean "nothing to report".
+    """
+    findings: list[Finding] = []
+    for check in _CHECK_FUNCTIONS:
+        findings.extend(check(record))
+    return findings
+
+
+class TrajectoryPlacement(BaseModel):
+    """How trajectory findings were placed alongside code findings (W8.3)."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    inline: list[Finding]
+    body: list[Finding]
+
+
+def place_trajectory_findings(
+    code_findings: list[Finding],
+    trajectory_findings: list[Finding],
+    *,
+    inline_budget: int,
+) -> TrajectoryPlacement:
+    """Give code findings every inline slot first; trajectory takes leftovers.
+
+    A trajectory finding is a claim about *process*, and a reviewer reading a
+    diff wants the defect in their code before an observation about how it was
+    produced. So the budget is spent on code findings first and trajectory
+    findings only occupy slots nothing else wanted; the rest go to the body,
+    where they are still reported and still reach the packet.
+
+    Pure: it partitions the inputs and never mutates them.
+    """
+    inline = list(code_findings[:inline_budget])
+    remaining = max(inline_budget - len(inline), 0)
+    inline.extend(trajectory_findings[:remaining])
+    placed = {id(item) for item in inline}
+    body = [item for item in code_findings if id(item) not in placed]
+    body.extend(item for item in trajectory_findings if id(item) not in placed)
+    return TrajectoryPlacement(inline=inline, body=body)

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -202,7 +202,47 @@ def _is_notification(message: Any) -> bool:
     return isinstance(message, dict) and "id" not in message
 
 
-def create_mcp_app(tools: list[ToolSpec]) -> FastAPI:
+def _record_trajectory(
+    ctx: ToolContext | None,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    ok: bool,
+    result: Any = None,
+    error: str | None = None,
+) -> None:
+    """Record one mediated tool call on the run's trajectory (#43, D8).
+
+    This handler is the only door every agent tool call goes through, which is
+    what makes the trajectory record self-contained — no tracing sinks, no
+    #56. Recording is strictly best-effort: an audit trail must never be able
+    to turn a working tool call into a failed one, so every error is swallowed.
+    """
+    if ctx is None:
+        return
+    try:
+        from mergecraft.evidence.trajectory import outcome_ok_from_result, record_tool_call
+
+        record_tool_call(
+            ctx.tool_state,
+            tool=name,
+            arguments=arguments,
+            ok=ok,
+            outcome_ok=outcome_ok_from_result(result) if ok else None,
+            error=error,
+        )
+    except Exception as exc:  # an audit trail never breaks a tool call
+        logger.debug("trajectory: failed to record {} — {}", name, exc)
+
+
+def create_mcp_app(tools: list[ToolSpec], ctx: ToolContext | None = None) -> FastAPI:
+    """Build the MCP app.
+
+    ``ctx`` is optional so a test can stand the app up with bare tool specs;
+    when it is supplied — which is what ``start_mcp_http_server`` does on every
+    real run — each ``tools/call`` is appended to the run's trajectory record.
+    """
+    tool_ctx = ctx
     by_name = {t.name: t for t in tools}
     app = FastAPI(title=MERGECRAFT_MCP_NAME, version="0.0.1")
 
@@ -261,7 +301,9 @@ def create_mcp_app(tools: list[ToolSpec]) -> FastAPI:
                     result = await tool.execute(arguments)
                 except Exception as exc:
                     _span.set_status("error", str(exc))
+                    _record_trajectory(tool_ctx, name, arguments, ok=False, error=str(exc))
                     raise
+                _record_trajectory(tool_ctx, name, arguments, ok=True, result=result)
                 return {
                     "jsonrpc": "2.0",
                     "id": req_id,

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -219,7 +219,17 @@ class ToolState:
     xrepo_learnings_seed: str | None = None
     xrepo_learnings_persist_attempted: bool = False
     output: str | None = None
+    # Per-attempt ``AgentUsage`` token counts, appended once per run by
+    # ``main.py``. Despite what the merge-evidence plan assumed, this is *not*
+    # a tool-call log — the trajectory record (#43) keeps its own field below.
     usage_entries: list[Any] = field(default_factory=list)
+    # Every MCP tool call this run made, in order (#43, D8). Appended by
+    # ``mcp/server.py``'s ``tools/call`` handler — the single door every agent
+    # tool call goes through — and read at end of run by
+    # ``evidence/trajectory.py::build_trajectory_record``. Typed ``list[Any]``
+    # rather than ``list[ToolCallRecord]`` only to keep this module free of an
+    # import cycle back into ``evidence``.
+    tool_calls: list[Any] = field(default_factory=list)
     model: str | None = None
     model_fallback: dict[str, str] | None = None
     unselected_proxy_default: bool | None = None

--- a/tests/evidence/test_run_packet.py
+++ b/tests/evidence/test_run_packet.py
@@ -236,7 +236,10 @@ def test_extra_findings_merge_without_duplicating(tmp_path: Path) -> None:
 
     assert written is not None
     findings = json.loads(written.read_text(encoding="utf-8"))["findings"]
-    assert len(findings) == 1, "the same finding from two sources must not double-count"
+    # Assert the dedup property itself rather than the packet's total, which
+    # also carries trajectory findings since Batch C (#43).
+    matches = [f for f in findings if f["fingerprint"] == duplicate.fingerprint]
+    assert len(matches) == 1, "the same finding from two sources must not double-count"
 
 
 def _sample_finding_kwargs() -> dict[str, Any]:

--- a/tests/evidence/test_trajectory.py
+++ b/tests/evidence/test_trajectory.py
@@ -27,8 +27,6 @@ import pytest
 if TYPE_CHECKING:
     from mergecraft.evidence.trajectory import ToolCallRecord, TrajectoryRecord
 
-pytestmark = pytest.mark.xfail(reason="green after W7/W8", strict=False)
-
 
 # ── record construction helpers ───────────────────────────────────────────────
 
@@ -442,7 +440,6 @@ def test_trajectory_findings_reach_the_packet_from_a_real_run(tmp_path: Any) -> 
 def test_trajectory_record_is_populated_without_external_trace() -> None:
     """D8: the record is built from MCP tool-call state alone."""
     from mergecraft.evidence.trajectory import build_trajectory_record, record_tool_call
-
     from mergecraft.mcp.tool_state import init_tool_state
 
     state = init_tool_state(owner="acme", name="demo", dir="/tmp/demo")
@@ -487,6 +484,7 @@ def test_external_trace_is_optional_enrichment() -> None:
 def test_record_forbids_unknown_fields() -> None:
     """W7.1: `extra="forbid"` on the record."""
     import pydantic
+
     from mergecraft.evidence.trajectory import TrajectoryRecord
 
     payload = _record().model_dump()
@@ -544,9 +542,8 @@ def test_audit_is_deterministic() -> None:
 
 def test_trajectory_findings_never_crowd_out_code_findings() -> None:
     """W8.3: trajectory findings may only take inline slots code findings left."""
-    from mergecraft.evidence.trajectory_audit import place_trajectory_findings
-
     from mergecraft.analyzers.finding import make_finding
+    from mergecraft.evidence.trajectory_audit import place_trajectory_findings
 
     code = [
         make_finding(

--- a/tests/evidence/test_trajectory.py
+++ b/tests/evidence/test_trajectory.py
@@ -1,0 +1,572 @@
+"""RED suite for the trajectory record (#43) and the trajectory auditor (#49).
+
+WC-T of the merge-evidence wave plan. Every case here is written against the
+contract W7/W8 must satisfy, not against an implementation:
+
+* **WC-T.1** — one case per named check, each firing on a crafted record.
+* **WC-T.2** — a high-severity trajectory finding blocks auto-merge *through
+  the packet decision* (#43's acceptance criterion), not through a stub.
+* **WC-T.3** — the record builds from MCP tool-call state alone (D8): no
+  external trace, no tracing sink, no #56.
+* **WC-T.4** — an attached external trace is enrichment; the same record
+  audits identically without it.
+* **WC-T.5** — the auditor is pure.
+
+The eight checks are deliberately given *distinguishable* triggers so that
+disabling any one of them fails cases no other check covers. A suite where
+three checks all fire on "something went wrong" proves only that one of them
+works.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from mergecraft.evidence.trajectory import ToolCallRecord, TrajectoryRecord
+
+pytestmark = pytest.mark.xfail(reason="green after W7/W8", strict=False)
+
+
+# ── record construction helpers ───────────────────────────────────────────────
+
+
+def _call(
+    sequence: int,
+    tool: str,
+    *,
+    intent: str = "other",
+    ok: bool = True,
+    outcome_ok: bool | None = None,
+    error: str | None = None,
+    command: str | None = None,
+    paths: list[str] | None = None,
+    signature: str | None = None,
+) -> ToolCallRecord:
+    from mergecraft.evidence.trajectory import ToolCallRecord
+
+    return ToolCallRecord(
+        sequence=sequence,
+        tool=tool,
+        signature=signature or f"{tool}:{sequence}",
+        intent=intent,
+        ok=ok,
+        outcome_ok=outcome_ok,
+        error=error,
+        command=command,
+        paths=paths or [],
+    )
+
+
+def _record(**overrides: Any) -> TrajectoryRecord:
+    """A clean, complete trajectory that fires no check by default.
+
+    Every positive case below is this record plus exactly one mutation, so a
+    failing case names the check it broke rather than "something is off".
+    """
+    from mergecraft.evidence.trajectory import TrajectoryRecord
+
+    base: dict[str, Any] = {
+        "sources": ["mcp-tool-calls"],
+        "tool_calls": [
+            _call(1, "checkout_pr", intent="read", paths=["src/app.py"]),
+            _call(2, "shell", intent="read", command="cat src/app.py", paths=["src/app.py"]),
+            _call(3, "shell", intent="modify", command="apply patch", paths=["src/app.py"]),
+            _call(4, "shell", intent="verify", command="pytest -q", outcome_ok=True),
+            _call(5, "create_pull_request_review", intent="complete"),
+        ],
+        "files_read": ["src/app.py"],
+        "files_modified": ["src/app.py"],
+        "commands_run": ["cat src/app.py", "apply patch", "pytest -q"],
+        "tests_run": ["pytest -q"],
+        "failures_observed": [],
+        "fixes_after_failures": 0,
+        "retries": 0,
+        "unresolved_errors": [],
+        "completion_claims": ["create_pull_request_review"],
+        "read_coverage": True,
+        "external_trace": None,
+    }
+    base.update(overrides)
+    return TrajectoryRecord(**base)
+
+
+def _rule_ids(findings: list[Any]) -> set[str]:
+    return {finding.rule_id for finding in findings}
+
+
+def _audit(record: TrajectoryRecord) -> list[Any]:
+    from mergecraft.evidence.trajectory_audit import audit_trajectory
+
+    return audit_trajectory(record)
+
+
+# ── WC-T.1 — one case per check ───────────────────────────────────────────────
+
+
+def test_clean_trajectory_fires_nothing() -> None:
+    """The control. Without it every positive case below could be vacuous."""
+    assert _audit(_record()) == []
+
+
+def test_changed_unread_file_fires() -> None:
+    """A file was edited that the run never read (#49 read-before-edit)."""
+    findings = _audit(
+        _record(
+            files_read=["src/other.py"],
+            files_modified=["src/app.py", "src/other.py"],
+        )
+    )
+    assert "changed-unread-file" in _rule_ids(findings)
+    offender = next(f for f in findings if f.rule_id == "changed-unread-file")
+    assert offender.path == "src/app.py", "the finding must name the unread file"
+
+
+def test_changed_unread_file_is_suppressed_without_read_coverage() -> None:
+    """No read signal at all means *unknown*, not *unread*.
+
+    Native `Read` calls are invisible to the MCP layer, so a record with zero
+    observed reads carries no evidence either way. Firing there would flag
+    every run of an agent whose file reads mergeCraft does not mediate — a
+    check that fires on every run is noise, not a gate.
+    """
+    findings = _audit(
+        _record(
+            files_read=[],
+            read_coverage=False,
+            files_modified=["src/app.py"],
+        )
+    )
+    assert "changed-unread-file" not in _rule_ids(findings)
+
+
+def test_ignored_tool_error_fires() -> None:
+    """A tool errored and the run never called that tool again."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "run_static_checks", intent="verify", ok=False, error="boom"),
+                _call(2, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "ignored-tool-error" in _rule_ids(findings)
+
+
+def test_ignored_tool_error_does_not_fire_when_the_tool_was_retried() -> None:
+    """Retrying the failed tool is the sane response — that is not the defect."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "run_static_checks", intent="verify", ok=False, error="boom"),
+                _call(2, "shell", intent="read", command="cat pyproject.toml"),
+                _call(3, "run_static_checks", intent="verify", ok=True, outcome_ok=True),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "ignored-tool-error" not in _rule_ids(findings)
+
+
+def test_no_post_edit_verification_fires() -> None:
+    """Files were edited and nothing verifying ran afterwards."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "shell", intent="verify", command="pytest -q", outcome_ok=True),
+                _call(2, "shell", intent="modify", command="apply patch", paths=["src/app.py"]),
+                _call(3, "create_pull_request_review", intent="complete"),
+            ],
+            tests_run=["pytest -q"],
+        )
+    )
+    assert "no-post-edit-verification" in _rule_ids(findings), (
+        "a verification that ran *before* the last edit does not verify it"
+    )
+
+
+def test_repeated_tool_loop_fires() -> None:
+    """The same call, with the same arguments, three times over."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(index, "shell", intent="read", command="ls", signature="shell:ls")
+                for index in range(1, 4)
+            ]
+            + [_call(4, "create_pull_request_review", intent="complete")],
+            files_read=[],
+            files_modified=[],
+            retries=2,
+        )
+    )
+    assert "repeated-tool-loop" in _rule_ids(findings)
+
+
+def test_repeated_tool_loop_does_not_fire_below_the_threshold() -> None:
+    """Two identical calls is a retry; the check is about a *loop*."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(index, "shell", intent="read", command="ls", signature="shell:ls")
+                for index in range(1, 3)
+            ]
+            + [_call(3, "create_pull_request_review", intent="complete")],
+            files_read=[],
+            files_modified=[],
+            retries=1,
+        )
+    )
+    assert "repeated-tool-loop" not in _rule_ids(findings)
+
+
+def test_unresolved_failure_fires() -> None:
+    """A command reported failure and no later run of it ever passed.
+
+    Distinct from `ignored-tool-error`: the tool call *succeeded*; what failed
+    is the thing it ran.
+    """
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "shell", intent="verify", command="pytest -q", outcome_ok=False),
+                _call(2, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+            failures_observed=["pytest -q"],
+            unresolved_errors=["pytest -q"],
+        )
+    )
+    assert "unresolved-failure" in _rule_ids(findings)
+
+
+def test_suspicious_broad_edit_fires() -> None:
+    """One run touching an implausible number of files."""
+    wide = [f"src/module_{index}.py" for index in range(40)]
+    findings = _audit(_record(files_read=wide, files_modified=wide))
+    assert "suspicious-broad-edit" in _rule_ids(findings)
+
+
+def test_stale_assumption_after_failure_fires() -> None:
+    """A failed call retried byte-identically with nothing read in between."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "shell",
+                    intent="verify",
+                    command="pytest -q",
+                    ok=False,
+                    error="boom",
+                    signature="shell:pytest",
+                ),
+                _call(
+                    2,
+                    "shell",
+                    intent="verify",
+                    command="pytest -q",
+                    ok=False,
+                    error="boom",
+                    signature="shell:pytest",
+                ),
+                _call(3, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "stale-assumption-after-failure" in _rule_ids(findings)
+
+
+def test_stale_assumption_does_not_fire_when_something_was_read_in_between() -> None:
+    """Re-running after actually looking at something is normal debugging."""
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "shell",
+                    intent="verify",
+                    command="pytest -q",
+                    ok=False,
+                    error="boom",
+                    signature="shell:pytest",
+                ),
+                _call(2, "shell", intent="read", command="cat log.txt", paths=["log.txt"]),
+                _call(
+                    3,
+                    "shell",
+                    intent="verify",
+                    command="pytest -q",
+                    ok=False,
+                    error="boom",
+                    signature="shell:pytest",
+                ),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=["log.txt"],
+            files_modified=[],
+        )
+    )
+    assert "stale-assumption-after-failure" not in _rule_ids(findings)
+
+
+def test_missing_completion_signal_fires() -> None:
+    """The run did work and then simply stopped."""
+    findings = _audit(
+        _record(
+            tool_calls=[_call(1, "shell", intent="read", command="ls")],
+            files_read=[],
+            files_modified=[],
+            completion_claims=[],
+        )
+    )
+    assert "missing-completion-signal" in _rule_ids(findings)
+
+
+def test_missing_completion_signal_does_not_fire_on_an_empty_record() -> None:
+    """No recorded calls is no evidence — the auditor must stay silent.
+
+    A driver whose tool calls mergeCraft never mediated would otherwise be
+    reported as an incomplete run on every single execution.
+    """
+    findings = _audit(
+        _record(
+            tool_calls=[],
+            files_read=[],
+            files_modified=[],
+            commands_run=[],
+            tests_run=[],
+            completion_claims=[],
+            read_coverage=False,
+        )
+    )
+    assert findings == []
+
+
+def test_every_named_check_has_a_severity_and_a_recommended_action() -> None:
+    """#49: findings carry severity and recommended action."""
+    from mergecraft.evidence.trajectory_audit import TRAJECTORY_CHECKS
+
+    expected = {
+        "changed-unread-file",
+        "ignored-tool-error",
+        "no-post-edit-verification",
+        "repeated-tool-loop",
+        "unresolved-failure",
+        "suspicious-broad-edit",
+        "stale-assumption-after-failure",
+        "missing-completion-signal",
+    }
+    assert {check.rule_id for check in TRAJECTORY_CHECKS} == expected
+    for check in TRAJECTORY_CHECKS:
+        assert check.severity, f"{check.rule_id} has no severity"
+        assert check.recommended_action, f"{check.rule_id} has no recommended action"
+
+
+# ── WC-T.2 — a high-severity finding blocks auto-merge via the packet ─────────
+
+
+def test_high_severity_trajectory_finding_blocks_auto_merge() -> None:
+    """#43's acceptance criterion, driven through the real decision path.
+
+    The trajectory finding is not handed to a bespoke gate: it goes into the
+    packet's finding list, and `decide_approval` — the one gate — reads it.
+    """
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+    from mergecraft.evidence.build import build_packet
+
+    findings = _audit(_record(completion_claims=[], tool_calls=_record().tool_calls[:1]))
+    blockers = [f for f in findings if f.severity in BLOCKING_SEVERITIES]
+    assert blockers, "no trajectory check produces a blocking severity"
+
+    packet = build_packet(
+        change_id="acme/demo#1",
+        agent_id="claude",
+        agent_version="0.0.1",
+        model="claude-sonnet-4-5",
+        files_changed=["src/app.py"],
+        findings=blockers,
+        deterministic_checks=[],
+        self_assessment={"would_approve": True, "sha": "cafe"},
+    )
+    decision = decide_approval(packet, run_succeeded=True, tier="trusted")
+    assert decision.verdict != "auto_merge"
+    assert decision.verdict == "failure", (
+        "a blocking trajectory finding must reach the packet verdict, not a side channel"
+    )
+
+
+def test_trajectory_findings_reach_the_packet_from_a_real_run(tmp_path: Any) -> None:
+    """The record and its findings must be populated on the live emit path.
+
+    This is the #96 guard in test form: a `TrajectoryRecord` that is merely
+    *constructible* is worth nothing. `emit_run_packet` is what `main()`
+    calls, so this drives the same seam a real Action run enters.
+    """
+    import json
+
+    from tests.evidence.test_run_packet import _make_ctx
+
+    ctx = _make_ctx(tmp_path)
+    from mergecraft.evidence.trajectory import record_tool_call
+
+    record_tool_call(ctx.tool_state, tool="checkout_pr", arguments={}, ok=True)
+    record_tool_call(
+        ctx.tool_state,
+        tool="create_pull_request_review",
+        arguments={"body": "lgtm"},
+        ok=True,
+    )
+
+    from mergecraft.evidence.run_packet import emit_run_packet
+
+    written = emit_run_packet(ctx, run_succeeded=True)
+    assert written is not None
+    packet = json.loads(written.read_text(encoding="utf-8"))
+    assert packet["trajectory"] is not None, "trajectory section stayed None on a real run"
+    assert packet["trajectory"]["tool_calls"], "no MCP tool call reached the record"
+    assert packet["trajectory"]["completion_claims"] == ["create_pull_request_review"]
+
+
+# ── WC-T.3 / WC-T.4 — self-contained record, optional enrichment ─────────────
+
+
+def test_trajectory_record_is_populated_without_external_trace() -> None:
+    """D8: the record is built from MCP tool-call state alone."""
+    from mergecraft.evidence.trajectory import build_trajectory_record, record_tool_call
+
+    from mergecraft.mcp.tool_state import init_tool_state
+
+    state = init_tool_state(owner="acme", name="demo", dir="/tmp/demo")
+    record_tool_call(state, tool="checkout_pr", arguments={}, ok=True)
+    record_tool_call(
+        state, tool="shell", arguments={"command": "pytest -q"}, ok=True, outcome_ok=True
+    )
+    record_tool_call(state, tool="create_pull_request_review", arguments={}, ok=True)
+
+    record = build_trajectory_record(state, files_modified=["src/app.py"])
+
+    assert record.external_trace is None
+    assert record.sources == ["mcp-tool-calls"] or "mcp-tool-calls" in record.sources
+    assert [call.tool for call in record.tool_calls] == [
+        "checkout_pr",
+        "shell",
+        "create_pull_request_review",
+    ]
+    assert record.tests_run == ["pytest -q"]
+    assert record.completion_claims == ["create_pull_request_review"]
+    assert record.files_modified == ["src/app.py"]
+
+
+def test_external_trace_is_optional_enrichment() -> None:
+    """A record without the enrichment field still audits identically."""
+    from mergecraft.evidence.trajectory import ExternalTraceRef
+
+    without = _record()
+    with_trace = _record(
+        external_trace=ExternalTraceRef(
+            source="mergecraft.tracing",
+            event_count=3,
+            tool_calls=[],
+        ),
+        sources=["mcp-tool-calls", "external-trace"],
+    )
+    assert _audit(without) == []
+    assert _audit(with_trace) == []
+    assert with_trace.external_trace is not None
+
+
+def test_record_forbids_unknown_fields() -> None:
+    """W7.1: `extra="forbid"` on the record."""
+    import pydantic
+    from mergecraft.evidence.trajectory import TrajectoryRecord
+
+    payload = _record().model_dump()
+    payload["invented"] = True
+    with pytest.raises(pydantic.ValidationError):
+        TrajectoryRecord(**payload)
+
+
+def test_record_round_trips_through_json() -> None:
+    """The record is a packet section, so it must survive serialization."""
+    from mergecraft.evidence.trajectory import TrajectoryRecord
+
+    record = _record()
+    assert TrajectoryRecord.model_validate_json(record.model_dump_json()) == record
+
+
+# ── WC-T.5 — the auditor is pure ─────────────────────────────────────────────
+
+
+def test_auditor_is_pure() -> None:
+    """No I/O, no environment reads, no mutation of its input (convention 5)."""
+    import ast
+    import inspect
+
+    from mergecraft.evidence import trajectory_audit
+
+    source = inspect.getsource(trajectory_audit)
+    tree = ast.parse(source)
+    banned = {"open", "getenv", "environ", "run", "post", "get", "write_text", "read_text"}
+    seen: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                seen.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                seen.add(node.func.attr)
+    assert not (seen & banned), f"auditor performs I/O: {sorted(seen & banned)}"
+
+    record = _record(completion_claims=[])
+    before = record.model_dump_json()
+    _audit(record)
+    assert record.model_dump_json() == before, "audit_trajectory mutated its input"
+
+
+def test_audit_is_deterministic() -> None:
+    """Same record in, same findings out — fingerprints included."""
+    record = _record(completion_claims=[])
+    first = [(f.rule_id, f.fingerprint, f.severity) for f in _audit(record)]
+    second = [(f.rule_id, f.fingerprint, f.severity) for f in _audit(record)]
+    assert first == second
+
+
+# ── W8.3 — the noise budget ──────────────────────────────────────────────────
+
+
+def test_trajectory_findings_never_crowd_out_code_findings() -> None:
+    """W8.3: trajectory findings may only take inline slots code findings left."""
+    from mergecraft.evidence.trajectory_audit import place_trajectory_findings
+
+    from mergecraft.analyzers.finding import make_finding
+
+    code = [
+        make_finding(
+            tool="ruff",
+            rule_id=f"F{index:03d}",
+            category="Maintainability & Code Quality",
+            severity="Major",
+            confidence="likely",
+            message="problem",
+            path=f"src/mod_{index}.py",
+            start_line=1,
+            end_line=1,
+            source="agent",
+        )
+        for index in range(8)
+    ]
+    trajectory = _audit(_record(completion_claims=[]))
+    assert trajectory, "no trajectory findings to place"
+
+    placement = place_trajectory_findings(code, trajectory, inline_budget=8)
+    inline_ids = {id(item) for item in placement.inline}
+    assert all(id(item) in inline_ids for item in code), "a code finding lost its inline slot"
+    assert all(id(item) not in inline_ids for item in trajectory)

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -171,6 +171,30 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
             "always on or always off regardless of what the consumer asked for (#39, D13)"
         ),
     ),
+    _Contract(
+        symbol="build_trajectory_record",
+        defined_in="evidence/trajectory.py",
+        why=(
+            "no reachable caller means the packet's trajectory section stays None on every "
+            "run and a merely-constructible record proves nothing (#43, the #96 failure mode)"
+        ),
+    ),
+    _Contract(
+        symbol="audit_trajectory",
+        defined_in="evidence/trajectory_audit.py",
+        why=(
+            "no reachable caller means the eight checks never run, so a change produced by a "
+            "bad process is indistinguishable from one produced by a good one (#49)"
+        ),
+    ),
+    _Contract(
+        symbol="record_tool_call",
+        defined_in="evidence/trajectory.py",
+        why=(
+            "no reachable caller means no tool call is ever recorded, so every trajectory "
+            "record is empty and every check stays silent (#43, D8)"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Merge-evidence wave **Batch C** — WC-T (RED suite), W7 (#43), W8 (#49), C Final.

Closes #43
Closes #49

## Why?

Every check mergeCraft had read the **diff**. A diff can look clean while the process that produced it was not: a file edited without ever being read, a failing gate retried byte-identically until it was abandoned, a run that did work and then simply stopped. None of that is visible in a diff review.

## What changed

`TrajectoryRecord` (`evidence/trajectory.py`) is built from the tool calls mergeCraft mediates — **no external trace required** (D8); the tracing programme (#56) can enrich it later. `audit_trajectory()` (`evidence/trajectory_audit.py`) applies eight named checks, each emitting a `Finding` with a severity and a recommended action:

| Check | Severity |
|---|---|
| `unresolved-failure` | Critical |
| `changed-unread-file`, `ignored-tool-error`, `no-post-edit-verification`, `stale-assumption-after-failure` | Major |
| `repeated-tool-loop`, `suspicious-broad-edit`, `missing-completion-signal` | Minor |

**No second gate (W8.2).** Findings join the packet's ordinary finding list, so `decide_approval()` weighs them exactly like analyzer or CI findings. A `Critical` `unresolved-failure` blocks for the same reason any `Critical` does.

**Silence on absent evidence.** mergeCraft only sees the calls it mediates, so a driver whose file reads never cross MCP produces a record with no reads — which is *unknown*, not *unread*. Checks that could fire on missing signal are gated on the record carrying that signal (`read_coverage`, a non-empty call list). A check that fires on every run is noise, not a gate.

**Never crowds out code findings (W8.3).** `place_trajectory_findings()` gives code findings every inline slot first; trajectory findings take only leftovers and otherwise report in the body.

`PACKET_SCHEMA_VERSION` → **1.4.0** for the new `trajectory` section (D7).

## Evidence

- `make ci-reset` then one clean `make ci-resume` — **all 9 steps passed** (1242 passed, 21 skipped, 10 xfailed, 10 xpassed; every xfail/xpass pre-existing)
- **Mutation-tested all eight checks.** Disabling each one in turn against the green implementation fails at least one test — so no check is vacuous:

| disabled check | failing tests |
|---|---|
| `changed-unread-file` | 1 |
| `ignored-tool-error` | 1 |
| `no-post-edit-verification` | 2 |
| `repeated-tool-loop` | 1 |
| `unresolved-failure` | 1 |
| `suspicious-broad-edit` | 1 |
| `stale-assumption-after-failure` | 1 |
| `missing-completion-signal` | 2 |

- `tests/test_runtime_call_sites.py` gains contracts for `record_tool_call`, `build_trajectory_record` and `audit_trajectory`. A merely *constructible* record is worth nothing — this is the #96 failure mode, and the suite now fails if any of the three loses its reachable caller.

## One pre-existing test changed

`test_extra_findings_merge_without_duplicating` asserted `len(findings) == 1` as a proxy for "deduplicated by fingerprint". Packets now also carry trajectory findings, so the proxy broke while the property held. Rewritten to assert the property directly — the duplicate fingerprint appears exactly once — rather than loosening the count.

## Note

Completed by hand after the executing agent hit a spend limit mid-wave; the RED suite (`efffc41`) and the record module were its work, the auditor and the packet wiring were finished from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
