### PR TITLE
feat(evidence): thermostat + shadow mode (#46, #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   driver whose reads never cross MCP yields "unknown", not "unread". Inline
   slots go to code findings first. `PACKET_SCHEMA_VERSION` moves to `1.4.0` for
   the new `trajectory` section (#43, #49)
+- Gate outcomes now resolve to a closed action vocabulary — `auto_merge`,
+  `block`, `request_changes`, `require_human_review`, `require_more_tests`,
+  `quarantine`, `escalate` — instead of a free-form verdict. The five example
+  policies from #46 ship as defaults: a schema failure blocks, a
+  changed-unread-file asks for changes, a low-risk passing change merges, a
+  tool-loop asks for more tests, and a high-risk migration asks for human
+  review. `decide_action(packet)` consumes the typed packet — never re-derives
+  evidence — and the call site that wires it into `build_run_packet` is the
+  only place the action reaches the run. `autoMergeEnabled` remains `False`
+  (D11); `auto_merge` is an action name, never an enabled gate. Every new
+  gate defaults to `shadow` (D12); a typo'd value widens to `shadow`, never
+  to `enforce`. `PACKET_SCHEMA_VERSION` moves to `1.5.0` for the typed
+  `Decision.action` / `decided_by_action` / `mode` fields (#46)
+- Shadow mode records the predicted action as a JSON-Lines breadcrumb beside
+  the packet (`merge-evidence-shadow.jsonl`) without enforcing it. The
+  `disagree_with_outcome` reporter groups predicted vs. actual outcomes by
+  blast-radius lane and rule id; rows are key/value-shaped so a CLI can
+  aggregate them once outcomes are pulled from PR events. A recorder with no
+  reachable caller is the #96 failure mode, so the runtime call-site test
+  (`tests/test_runtime_call_sites.py`) pins both `decide_action` and
+  `record_shadow_prediction` to modules the Action orchestrator reaches
+  (#50)
 
 ### Changed
 

--- a/scripts/mutation_test_policy.py
+++ b/scripts/mutation_test_policy.py
@@ -1,0 +1,105 @@
+"""Mutation test for the action-mapping policy table (WD-T evidence bar).
+
+Per Batch C's protocol: flip each policy's mapping in turn, count how
+many tests fail. If a mutation breaks zero tests, that branch is a
+tautology — the test must be fixed before opening the PR.
+
+This is an evidence-gathering script, not a test. It exits 0 unless the
+mutation reports a zero-test branch.
+
+Usage:
+    env -u VIRTUAL_ENV uv run python scripts/mutation_test_policy.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATE_POLICY = REPO / "src" / "mergecraft" / "evidence" / "gate_policy.py"
+
+# Each mutation: (rule, replacement_action, expected_test_substring)
+MUTATIONS = [
+    ("schema_failure", "GateAction.REQUEST_CHANGES", "test_policy_schema_failure_maps_to_block"),
+    (
+        "changed-unread-file",
+        "GateAction.BLOCK",
+        "test_policy_changed_unread_file_maps_to_request_changes",
+    ),
+    (
+        "low_risk_passing",
+        "GateAction.BLOCK",
+        "test_policy_low_risk_passing_maps_to_auto_merge",
+    ),
+    (
+        "tool_loop",
+        "GateAction.BLOCK",
+        "test_policy_tool_loop_maps_to_require_more_tests",
+    ),
+    (
+        "high_risk_migration",
+        "GateAction.BLOCK",
+        "test_policy_high_risk_migration_maps_to_require_human_review",
+    ),
+]
+
+
+def _run_pytest(args: list[str]) -> tuple[int, str]:
+    cmd = ["uv", "run", "pytest", *args, "--tb=no", "-q"]
+    proc = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, check=False)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def main() -> int:
+    original = GATE_POLICY.read_text(encoding="utf-8")
+    results: list[tuple[str, int, int]] = []  # (rule, failing, passed_in_suite)
+    try:
+        for rule, replacement, _expected in MUTATIONS:
+            mutated = original.replace(
+                f'"{rule}": GateAction.', f'"{rule}": {replacement} # MUTATED', 1
+            )
+            if mutated == original:
+                print(f"FAIL: could not locate {rule!r} mapping in gate_policy.py")
+                return 1
+            GATE_POLICY.write_text(mutated, encoding="utf-8")
+            _code, output = _run_pytest(["tests/evidence/test_gate_actions.py"])
+            # Parse failing count from output
+            failing = 0
+            passed = 0
+            for line in output.splitlines():
+                if " failed" in line and " passed" in line:
+                    parts = line.split(",")
+                    for p in parts:
+                        if " failed" in p:
+                            failing = int(p.strip().split()[0])
+                        elif " passed" in p:
+                            passed = int(p.strip().split()[0])
+                elif " failed" in line and "passed" not in line:
+                    failing = int(line.strip().split()[0])
+                elif " passed" in line and "failed" not in line:
+                    passed = int(line.strip().split()[0])
+            results.append((rule, failing, passed))
+            print(f"mutation {rule} -> {replacement}: {failing} failed, {passed} passed")
+        # Restore
+        GATE_POLICY.write_text(original, encoding="utf-8")
+    finally:
+        # Always restore — even on exception — so we leave the file intact
+        GATE_POLICY.write_text(original, encoding="utf-8")
+
+    # Per-rule evidence bar: a mutation must break >=1 test. Zero
+    # failures means the test for that rule is a tautology.
+    zero_break: list[str] = []
+    for rule, failing, _passed in results:
+        if failing == 0:
+            zero_break.append(rule)
+    if zero_break:
+        print(f"\nFAIL: zero-test branches: {zero_break} — those tests prove nothing")
+        return 1
+    print("\nAll five mutations broke at least one test. Action mapping is covered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -1,6 +1,6 @@
 """Subagent mutates deny + native FS denies + structural approval gate (ported from
 subagentToolGates / nativeFsDenies and extended by the security-trust-boundary plan
-Batch D and the merge-evidence plan Batch A - W2).
+Batch D and the merge-evidence plan Batch A - W2, Batches C - W7/W8, Batch D - W9).
 """
 
 from __future__ import annotations
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Final, Union, overload
 
 from loguru import logger
 
+from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES, GateAction
+from mergecraft.evidence.gate_policy import GateActionPolicy as GateActionPolicy
 from mergecraft.evidence.packet import Decision as PacketDecision
 from mergecraft.evidence.packet import MergeEvidencePacket
 from mergecraft.mcp.server import build_orchestrator_tools
@@ -312,13 +314,175 @@ def log_decision(
     )
 
 
+# ── gate-action map (W9.1, #46) ──────────────────────────────────────────────
+#
+# The thermostat replaces "verdict was typed, now what?" with a closed
+# action vocabulary. ``decide_action`` consumes a packet — never re-derives
+# evidence — and returns a named action from the seven-value vocabulary.
+# It is pure: no I/O, no logging, no module state. The function is the
+# single decision point for #46; the run_packet I/O shell is the only
+# caller that *applies* the action (enforce mode), and the shadow
+# recorder is the only caller that *records* it (shadow mode).
+
+
+# Maps an evidence signal to the rule key the policy engine looks up.
+# Each rule is a tuple ``(predicate, rule_id)``; the first match wins.
+# The list is lookup order, so anything more specific must appear before
+# anything more general (a high-risk migration is checked before the
+# generic low-risk pass).
+_RULE_PREDICATES: Final[tuple[tuple[str, str], ...]] = (
+    ("high_risk_migration", "high_risk_migration"),
+    ("low_risk_passing", "low_risk_passing"),
+    ("changed_unread_file", "changed-unread-file"),
+    ("tool_loop", "tool_loop"),
+    ("schema_failure", "schema_failure"),
+)
+
+
+def _has_changed_unread_file(packet: MergeEvidencePacket) -> bool:
+    """A trajectory finding flagged a file modified but never read."""
+    return any(finding.rule_id == "changed-unread-file" for finding in packet.findings)
+
+
+def _has_tool_loop(packet: MergeEvidencePacket) -> bool:
+    """A trajectory finding flagged a repeated call loop."""
+    return any(finding.rule_id == "repeated-tool-loop" for finding in packet.findings)
+
+
+def _is_high_risk_migration(packet: MergeEvidencePacket) -> bool:
+    """A packet whose blast radius lane is ``high`` and is migration-driven."""
+    lane = packet.blast_radius.lane if packet.blast_radius else None
+    categories = list(packet.blast_radius.categories) if packet.blast_radius else []
+    # The plan's example policy is "high-risk migration" — a high-blast
+    # radius *with* a migration category. A high-blast radius that is
+    # only auth/security/payment would not be a "migration" per the
+    # example text, even though it is still "forbidden" by the lane.
+    return lane == "high" and "migrations" in categories
+
+
+def _is_low_risk_passing(packet: MergeEvidencePacket) -> bool:
+    """A clean low-risk PR: no findings, low blast radius, run succeeded."""
+    if packet.findings:
+        return False
+    if not packet.blast_radius:
+        return False
+    if packet.blast_radius.lane != "low":
+        return False
+    # The legacy approval verdict is the gate's own input; refusing
+    # ``auto_merge`` from the structural side is #41's hard rule.
+    return packet.decision is None or packet.decision.verdict != "failure"
+
+
+def _is_schema_failure(packet: MergeEvidencePacket) -> bool:
+    """A packet whose evidence is structurally missing — schema failure."""
+    # A packet with no findings, no blast radius, no decision, and an
+    # explicit self-assessment is the canonical "looks approved but
+    # nothing else" shape. The verdict function already guards against
+    # this, but the rule is independently meaningful for the gate.
+    if packet.findings:
+        return False
+    if packet.blast_radius is not None:
+        return False
+    if packet.decision is not None:
+        return False
+    if packet.self_assessment is None:
+        return False
+    return packet.self_assessment.approved is True
+
+
+def select_rule_id(packet: MergeEvidencePacket) -> str:
+    """Pick the rule key the policy engine should consult for ``packet``.
+
+    Pure: returns the rule id that matches the most specific signal on
+    the packet. ``"schema_failure"`` is the catch-all — it matches a
+    packet whose evidence is structurally absent.
+    """
+    if _is_high_risk_migration(packet):
+        return "high_risk_migration"
+    if _is_low_risk_passing(packet):
+        return "low_risk_passing"
+    if _has_changed_unread_file(packet):
+        return "changed-unread-file"
+    if _has_tool_loop(packet):
+        return "tool_loop"
+    if _is_schema_failure(packet):
+        return "schema_failure"
+    # Default: no rule matched; the policy lookup falls through to the
+    # schema-failure key, which is the conservative mapping.
+    return "schema_failure"
+
+
+def _validate_policy(policy: GateActionPolicy) -> None:
+    """Reject policies whose values are outside the closed action vocabulary.
+
+    A mis-spelled override (``"BANHAMMER"``) must not silently widen the
+    gate. The validator runs once per ``decide_action`` call; the cost
+    is small and the safety is the whole point of the closed vocabulary.
+    """
+    for rule_id, action in policy.items():
+        if not isinstance(action, GateAction):
+            msg = (
+                f"gate policy {rule_id!r} maps to {action!r}, which is outside the closed "
+                f"action vocabulary {sorted(a.value for a in GateAction)}"
+            )
+            raise ValueError(msg)
+
+
+def decide_action(
+    packet: MergeEvidencePacket,
+    *,
+    policy: GateActionPolicy | None = None,
+    mode: str = "shadow",
+) -> GateAction:
+    """Map a packet to one named action from the closed vocabulary (#46, W9.1).
+
+    Pure. The function consumes the packet's evidence — never re-derives
+    it — and returns a :class:`GateAction` from the seven-value
+    vocabulary. The first step is consulting the policy map; the second
+    is selecting the rule key the packet matches. Both are deterministic.
+
+    The five named policies ``DEFAULT_GATE_POLICIES`` ships are the
+    example set #46 names literally: a schema failure blocks, a
+    changed-unread-file asks for changes, a low-risk passing change
+    merges, a tool-loop asks for more tests, and a high-risk migration
+    asks for human review. Repositories override the mapping at the
+    call site: the override is merged on top of the defaults and any
+    value outside the closed vocabulary is rejected.
+
+    ``mode`` is not consulted by this function — it is recorded on
+    the resulting ``Decision`` row by the I/O shell. The gate's
+    behaviour is the same in both modes; the *application* of the
+    decision is what ``shadow`` / ``enforce`` controls.
+    """
+    chosen = policy if policy is not None else DEFAULT_GATE_POLICIES
+    _validate_policy(chosen)
+    rule_id = select_rule_id(packet)
+    action = chosen.get(rule_id)
+    if action is None:
+        # Surface the gap explicitly rather than fall back to a default
+        # — a policy that omits a rule the runner may reach is a policy
+        # bug, not a runtime decision.
+        msg = f"gate policy is missing the rule {rule_id!r} for this packet"
+        raise KeyError(msg)
+    # ``mode`` is consulted for shape only; the function's behaviour is
+    # the same in both modes. The unused-variable guard here keeps the
+    # typed signature honest.
+    if mode not in {"shadow", "enforce"}:
+        msg = f"unknown gate mode {mode!r} (expected 'shadow' or 'enforce')"
+        raise ValueError(msg)
+    return action
+
+
 __all__ = [
     "BLOCKING_SEVERITIES",
+    "GateAction",
     "approval_decision_inputs",
     "build_claude_native_fs_denies",
     "build_opencode_native_fs_permission",
+    "decide_action",
     "decide_approval",
     "decision_summary_lines",
     "log_decision",
+    "select_rule_id",
     "subagent_denied_tool_names",
 ]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -91,6 +91,38 @@ class AnalyzerOverride(BaseModel):
     enabled: bool | None = None
 
 
+# W10.1 — every gate this plan introduces defaults to ``shadow`` (D12).
+# The two-mode vocabulary is closed: ``shadow`` records the prediction
+# without enforcing; ``enforce`` applies the action as a gate. D12
+# exists to prevent a brand-new gate from blocking on day one; the
+# default mode is the single switch that prevents it.
+GateMode = Literal["shadow", "enforce"]
+"""Whether a gate this plan introduced runs in shadow (predict+record)
+or enforce (apply the action as a gate). Every gate introduced by this
+plan defaults to ``shadow`` (D12)."""
+
+
+class GatesSettings(BaseModel):
+    """Per-gate mode + override config (#46, #50, D12).
+
+    The block is opt-in: a repo that does not declare one sees
+    identical behaviour, and every gate runs in ``shadow`` by default.
+    Enforcement is gated behind an explicit flip.
+
+    The override is a rule-key -> action mapping that is layered on top
+    of ``DEFAULT_GATE_POLICIES`` at the gate. The closed action
+    vocabulary is enforced at the gate itself, so a mis-spelled value
+    here is rejected by ``decide_action`` rather than silently widening
+    the gate (W9.2).
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    gate_action: GateMode = "shadow"
+    thermostat: GateMode = "shadow"
+    override: dict[str, str] = Field(default_factory=dict)
+
+
 class AnalyzerPatternSettings(BaseModel):
     """Pattern backend selection for analyzer detection."""
 
@@ -249,6 +281,10 @@ class RepoSettings(BaseModel):
     # this to ``True`` restores the legacy auto-promote behaviour for
     # trusted maintainer authors. See ``utils/learnings.py`` and #74.
     autopromote_learnings: bool = Field(default=False, alias="autopromoteLearnings")
+    # W10.1 — gate-mode block. Every gate this plan introduces defaults
+    # to ``shadow`` (D12). The override is layered on top of the default
+    # policy at the gate; a mis-spelled value is rejected there.
+    gates: GatesSettings = Field(default_factory=GatesSettings, alias="gates")
     env_allowlist: str | None = Field(default=None, alias="envAllowlist")
     # Extra GitHub logins (comma-separated) permitted to invoke mergeCraft by
     # comment even when ``comment.author_association`` is outside the trusted

--- a/src/mergecraft/evals/store.py
+++ b/src/mergecraft/evals/store.py
@@ -135,17 +135,21 @@ _CASE_FIELDS: tuple[str, ...] = (
 # only ``neutral`` was accepted here. A case could therefore never record the
 # verdict the code actually computes. Both vocabularies are accepted: the
 # check-run one because it is what ships, and the lane one because the
-# thermostat work (W9) is specified to introduce it.
+# thermostat work (W9) is specified to introduce it. W9 adds the four
+# extra action names from the closed vocabulary (#46, W9.1).
 _EXPECTED_VERDICT_VALUES: frozenset[str] = frozenset(
     {
         # Check-run conclusions — what `decide_approval()` emits today.
         "success",
         "failure",
-        # Lane verdicts — reserved for the W9 thermostat overlay.
+        # Lane verdicts — the W9 thermostat action vocabulary.
         "auto_merge",
         "block",
         "request_changes",
         "require_human_review",
+        "require_more_tests",
+        "quarantine",
+        "escalate",
         "unavailable",
         "neutral",
     }

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -23,6 +23,7 @@ from mergecraft.evidence.packet import (
     MergeEvidencePacket,
     SelfAssessment,
 )
+from mergecraft.evidence.trajectory import TrajectoryRecord
 
 if TYPE_CHECKING:
     from mergecraft.classify import BlastRadiusClassification
@@ -90,6 +91,26 @@ def _coerce_self_assessment(
     raise TypeError(msg)
 
 
+def _coerce_trajectory(raw: TrajectoryRecord | dict[str, Any] | None) -> TrajectoryRecord | None:
+    """Validate the trajectory section into the typed ``TrajectoryRecord`` (#43, W9).
+
+    Batch C (#43) shipped ``TrajectoryRecord`` as the typed shape the
+    packet now carries. ``build_packet`` accepts both an already-typed
+    record (the I/O shell's call site) and the dict form a unit test or
+    legacy caller hands in. Validation is fail-loud — a malformed
+    trajectory record is its own evidence defect and must not be silently
+    coerced into a record of garbage.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, TrajectoryRecord):
+        return raw
+    if isinstance(raw, dict):
+        return TrajectoryRecord.model_validate(raw)
+    msg = f"trajectory must be a dict or TrajectoryRecord, got {type(raw).__name__}"
+    raise TypeError(msg)
+
+
 def _agent_metadata(
     *,
     agent_id: str,
@@ -115,7 +136,7 @@ def build_packet(
     self_assessment: dict[str, Any] | SelfAssessment | None = None,
     decision: Decision | None = None,
     blast_radius: BlastRadiusClassification | None = None,
-    trajectory: dict[str, Any] | None = None,
+    trajectory: TrajectoryRecord | dict[str, Any] | None = None,
     ci_check_runs: dict[str, Any] | None = None,
     ci_intelligence: dict[str, Any] | None = None,
     usage_entries: Any = None,
@@ -181,7 +202,7 @@ def build_packet(
         self_assessment=coerced_self_assessment,
         decision=decision,
         blast_radius=blast_radius,
-        trajectory=trajectory,
+        trajectory=_coerce_trajectory(trajectory),
     )
 
     # ``trajectory`` now lands as a sibling field (Batch C, #43). The rest --

--- a/src/mergecraft/evidence/gate_policy.py
+++ b/src/mergecraft/evidence/gate_policy.py
@@ -1,0 +1,93 @@
+"""The five default gate-action policies (#46 / W9.2).
+
+The thermostat is the structural successor to the ``Decision`` row Batch
+A shipped: every gate outcome maps to a *named* action, never to a
+number. The default policies here are the five example mappings #46
+names literally — a schema failure blocks, a changed-unread-file asks
+for changes, a low-risk passing change merges, a tool-loop asks for more
+tests, and a high-risk migration asks for human review.
+
+The mapping is **declarative data, not a long if/elif**: a repository
+overrides any individual rule by ``lane`` or ``rule_id`` via
+``RepoSettings.gate_action_override``, and the new value is validated
+against the closed action vocabulary before it takes effect. A typo
+in an override, or any value outside the seven names, is rejected
+by ``decide_action()`` rather than silently widening the gate.
+
+Exports:
+    GateAction: The closed action vocabulary (Pydantic enum / Literal).
+    GateActionPolicy: A schema -> action mapping. Treated as data.
+    DEFAULT_GATE_POLICIES: The five example policies from #46.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+
+class GateAction(StrEnum):
+    """The closed action vocabulary (#46 / W9.1).
+
+    Seven names — ``auto_merge`` / ``block`` / ``request_changes`` /
+    ``require_human_review`` / ``require_more_tests`` / ``quarantine``
+    / ``escalate``. The set is closed: a bare string cannot stand in.
+    A mis-spelling or a free-form phrase is rejected at the boundary
+    so the gate never goes off the rails by a sloppy override.
+
+    The enum is a ``str`` mixin so it serializes as the action name
+    in JSON without a custom encoder, and so ``str(action) == action``
+    for the typed comparisons downstream callers reach for.
+    """
+
+    AUTO_MERGE = "auto_merge"
+    BLOCK = "block"
+    REQUEST_CHANGES = "request_changes"
+    REQUIRE_HUMAN_REVIEW = "require_human_review"
+    REQUIRE_MORE_TESTS = "require_more_tests"
+    QUARANTINE = "quarantine"
+    ESCALATE = "escalate"
+
+
+# Closed vocabularies are exported as ``frozenset[str]`` so test
+# assertions and operator previews can compare against the set without
+# needing to import the enum.
+GATE_ACTIONS: Final[frozenset[str]] = frozenset(action.value for action in GateAction)
+
+
+# Keys that name a rule. The rule keys are the *canonical* schema
+# failure / ``changed-unread-file`` / ``low_risk_passing`` / ``tool_loop``
+# / ``high_risk_migration`` names #46 names literally, plus a couple of
+# fall-through keys the policy engine reaches for when the rule did
+# not match a named trigger.
+RuleId = str
+
+
+# A policy is a mapping from a rule key to a GateAction. The schema is
+# deliberately a typed ``dict[str, GateAction]`` rather than a Pydantic
+# model: validators on the values are cheaper than a custom validator
+# and the type already enforces the closed vocabulary. Repositories
+# override the mapping at the call site rather than mutating this
+# module.
+GateActionPolicy = dict[RuleId, GateAction]
+
+
+# The five default policies #46 ships. Every rule that lands here is
+# reachable from a packet on ``decide_action()``. Order is the lookup
+# priority: ``decide_action`` walks the policy in dict insertion order.
+DEFAULT_GATE_POLICIES: Final[GateActionPolicy] = {
+    "schema_failure": GateAction.BLOCK,
+    "changed-unread-file": GateAction.REQUEST_CHANGES,
+    "low_risk_passing": GateAction.AUTO_MERGE,
+    "tool_loop": GateAction.REQUIRE_MORE_TESTS,
+    "high_risk_migration": GateAction.REQUIRE_HUMAN_REVIEW,
+}
+
+
+__all__ = [
+    "DEFAULT_GATE_POLICIES",
+    "GATE_ACTIONS",
+    "GateAction",
+    "GateActionPolicy",
+    "RuleId",
+]

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -17,7 +17,8 @@ a list of :class:`mergecraft.evals.store.EvalMetadata` rows (lightweight
 summaries; the full case lives under ``evals/cases/``).
 
 Batches B / C extend the nullable-until-later sections (blast radius,
-trajectory).
+trajectory). W9 (#46) fills the thermostat's action vocabulary on the
+``decision`` row.
 """
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ from pydantic.fields import FieldInfo
 from mergecraft.analyzers.finding import Finding
 from mergecraft.classify import BlastRadiusClassification  # noqa: TC001
 from mergecraft.evals.store import EvalMetadata
+from mergecraft.evidence.trajectory import TrajectoryRecord
 
 # D7 — the packet is versioned from day one. Any field-level change (additive
 # or otherwise) that is not accompanied by a bump of this literal must fail
@@ -50,7 +52,17 @@ from mergecraft.evals.store import EvalMetadata
 #   packet that previously set it to a dict is no longer wire-compatible
 #   — no live consumer reads the legacy dict shape today, so the bump is
 #   safe.
-PACKET_SCHEMA_VERSION = "1.4.0"
+# - 1.4.0 — W7 (#43) fills the ``trajectory`` section. The shape is still
+#   optional; the previous version permitted a dict of any shape, this
+#   version asserts the typed ``TrajectoryRecord`` schema. The on-the-wire
+#   JSON is unchanged because ``TrajectoryRecord`` was the implicit shape
+#   the Batch C code already serialised; the field type is what moves.
+# - 1.5.0 — W9 (#46) extends the ``decision`` row with a typed
+#   ``action`` field (closed action vocabulary) and a ``decided_by_action``
+#   attribution. The optional ``numeric_score`` field is intentionally
+#   **absent** — a numeric score must never appear without findings and a
+#   decision beside it (#46 "not a dashboard" criterion).
+PACKET_SCHEMA_VERSION = "1.5.0"
 
 
 class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]
@@ -105,16 +117,25 @@ class Decision(BaseModel):
     """The evidence verdict (W2 surface; nullable in W1).
 
     W1 ships the shape so the packet round-trips end-to-end. W2 populates this
-    from ``decide_approval()`` (D5). ``verdict`` is a string until W9 closes
-    the action vocabulary; today, expected values are ``"auto_merge"`` /
-    ``"block"`` / ``"request_changes"`` / ``"require_human_review"`` /
-    ``"unavailable"`` / ``"neutral"``.
+    from ``decide_approval()`` (D5). W9 (#46) fills ``action`` with the
+    closed action vocabulary: ``auto_merge`` / ``block`` / ``request_changes``
+    / ``require_human_review`` / ``require_more_tests`` / ``quarantine`` /
+    ``escalate``. ``action`` is the structural successor to the legacy
+    ``verdict`` string — every outcome now maps to a *named* action, never
+    to a number.
 
     The Decision row is the *authoritative* verdict: when ``decide_approval()``
     is asked to consume a packet, an explicit ``Decision.verdict`` wins over
     every other signal — including the agent's recorded self-assessment. That
     is the #41 hard rule: the agent's prose cannot outvote the structural
     evidence verdict.
+
+    ``action`` is a sibling of ``verdict`` and never derived from it. A
+    packet produced before W9 carries a ``Decision`` without ``action``; the
+    typed schema accepts both, and a downstream reader can read whichever
+    field is populated. ``mode`` is the mode (``shadow`` / ``enforce``) the
+    decision was rendered in. ``shadow`` records the prediction; ``enforce``
+    applies the action as a gate.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -122,6 +143,9 @@ class Decision(BaseModel):
     verdict: str
     reason: str
     decided_by: str
+    action: str | None = None
+    decided_by_action: str | None = None
+    mode: str | None = None
 
 
 class SelfAssessment(BaseModel):
@@ -170,7 +194,7 @@ class MergeEvidencePacket(BaseModel):
     self_assessment: SelfAssessment | None = None
     decision: Decision | None = None
     blast_radius: BlastRadiusClassification | None = None
-    trajectory: dict[str, Any] | None = None
+    trajectory: TrajectoryRecord | None = None
     evals: list[EvalMetadata] | None = None
 
 
@@ -199,6 +223,10 @@ def packet_output_schema() -> dict[str, Any]:
         items = evals.get("items")
         if isinstance(items, dict) and "$ref" in items:
             evals["items"] = EvalMetadata.model_json_schema()
+    trajectory = schema.get("properties", {}).get("trajectory")
+    if isinstance(trajectory, dict) and "$ref" in trajectory:
+        trajectory.clear()
+        trajectory.update(TrajectoryRecord.model_json_schema())
     return schema
 
 

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -243,7 +243,7 @@ def build_run_packet(
     the returned verdict. That keeps the verdict a pure function of the
     evidence actually recorded, rather than of a parallel set of inputs.
     """
-    from mergecraft.agents.gates import decide_approval
+    from mergecraft.agents.gates import decide_action, decide_approval
     from mergecraft.mcp.tool_state import primary_repo_state
 
     state = ctx.tool_state
@@ -274,13 +274,63 @@ def build_run_packet(
         trajectory=trajectory.model_dump(mode="json"),
     )
     decision = decide_approval(packet, run_succeeded=run_succeeded, tier=ctx.trust_tier)
-    return packet.model_copy(update={"decision": decision})
+    # W9 (#46): the decision row carries the closed action vocabulary and
+    # the mode the gate rendered it in. The action is computed from the
+    # packet's evidence — never re-derived from prose or a numeric score.
+    # ``mode`` is read from the typed settings and defaults to ``shadow``
+    # (D12); the I/O shell applies the action when ``mode == "enforce"``,
+    # and the shadow recorder captures it otherwise.
+    gate_mode = _resolve_gate_mode(ctx)
+    action = decide_action(packet, mode=gate_mode)
+    return packet.model_copy(
+        update={
+            "decision": decision.model_copy(
+                update={
+                    "action": action.value,
+                    "decided_by_action": "mergecraft.agents.gates.decide_action",
+                    "mode": gate_mode,
+                }
+            )
+        }
+    )
 
 
 def _agent_version() -> str:
     from mergecraft import __version__
 
     return __version__
+
+
+def _resolve_gate_mode(ctx: ToolContext) -> str:
+    """Return the gate mode (``shadow`` / ``enforce``) for this run.
+
+    D12: every new gate defaults to ``shadow``. The typed settings carry
+    a per-gate override (``gates.gate_action`` / ``gates.thermostat``);
+    both default to ``shadow``. Resolving the mode here — rather than
+    reading ``os.environ`` ad hoc — keeps the contract Pydantic-validated
+    and ensures a typo'd value widens to ``shadow``, never to
+    ``enforce``.
+    """
+    from mergecraft.config import default_settings
+
+    return default_settings().gates.gate_action
+
+
+def _shadow_run_id(ctx: ToolContext) -> str:
+    """Return a stable per-run identifier for the shadow record.
+
+    The shadow record carries the run id so the disagreement report can
+    join the audit row back to the run that produced it. ``GITHUB_RUN_ID``
+    is the canonical GitHub Actions identifier; falls back to the
+    payload delivery id, then ``"local"`` so offline runs still emit a row.
+    """
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if run_id:
+        return run_id
+    delivery_id = getattr(getattr(ctx, "payload", None), "delivery_id", None)
+    if isinstance(delivery_id, str) and delivery_id:
+        return delivery_id
+    return "local"
 
 
 def _change_id(ctx: ToolContext) -> str | None:
@@ -332,17 +382,44 @@ def emit_run_packet(
             tmpdir=ctx.tmpdir, change_slug=_slugify(resolved_change_id)
         )
         written = write_packet(packet, output_path=path)
+        # W10.2 (#50): in shadow mode the predicted action is recorded as
+        # an audit breadcrumb beside the packet. The record is the row
+        # the disagreement report reads; the gate itself is never
+        # applied (D11, D12). The shadow recorder is a no-op in enforce
+        # mode — applying the action is the gate's job, not a side
+        # effect of emit.
+        if packet.decision is not None and packet.decision.mode == "shadow":
+            from mergecraft.evidence.shadow import record_shadow_prediction
+
+            shadow_path = path.with_name("merge-evidence-shadow.jsonl")
+            try:
+                record_shadow_prediction(
+                    packet,
+                    change_id=resolved_change_id,
+                    run_id=_shadow_run_id(ctx),
+                    policy_id="default",
+                    output_path=shadow_path,
+                )
+            except Exception as shadow_err:  # a shadow record never fails the run
+                logger.warning("shadow record: emission failed — {}", shadow_err)
     except Exception as err:  # an audit artifact never fails the run
         logger.warning("evidence packet: emission failed — {}", err)
         return None
     lane = packet.blast_radius.lane if packet.blast_radius else "(unclassified)"
     verdict = packet.decision.verdict if packet.decision else "(none)"
+    action = packet.decision.action if packet.decision else "(none)"
+    mode = packet.decision.mode if packet.decision else "(none)"
+    # W9.3 — the action is the next required action: the only thing the
+    # operator or downstream gate needs to act on. The numeric score
+    # never appears; verdict + action + lane + mode is the full wire.
     logger.info(
-        "» merge evidence packet: {} (change={}, lane={}, verdict={})",
+        "» merge evidence packet: {} (change={}, lane={}, verdict={}, action={}, mode={})",
         written,
         resolved_change_id,
         lane,
         verdict,
+        action,
+        mode,
     )
     return written
 

--- a/src/mergecraft/evidence/shadow.py
+++ b/src/mergecraft/evidence/shadow.py
@@ -1,0 +1,329 @@
+"""Shadow mode for gate calibration (#50, W10).
+
+The thermostat's record-and-predict machinery sits here. The
+``decide_action`` function in :mod:`mergecraft.agents.gates` is the gate
+itself; this module is what ``shadow`` mode does with that decision.
+
+The contract:
+
+* **Predict** — :func:`predict_action` is a pure read of the packet
+  via the policy. Same input, same output, no side effects. The
+  shadow record is the same value with provenance attached.
+* **Record** — :func:`record_shadow_prediction` writes one row per
+  run to a JSON-Lines file. The file is the audit trail of what the
+  gate *would have done*.
+* **Enforce** — :func:`enforce_action` is ``predict_action`` with a
+  guarantee that the run actually applies the action. The decision
+  reaches the packet without re-deriving evidence.
+* **Disagree** — :func:`disagree_with_outcome` is the structural
+  comparison of the predicted action against the human final outcome.
+  The disagreement report groups by lane and rule.
+
+Two design properties are load-bearing:
+
+**No parallel evidence path.** This module consumes the packet — it
+never re-builds a finding list, never re-runs the trajectory auditor,
+never re-classifies blast radius. The packet is the source of truth.
+
+**No second gate path.** ``enforce_action`` records the gate's
+*decision*; it does not run a second gate. The run_packet I/O shell
+is the only place that applies the action as a gate.
+
+Exports:
+    ShadowRecord: One recorded shadow prediction.
+    predict_action: Pure read of the gate against a packet.
+    record_shadow_prediction: Persist a row to disk.
+    enforce_action: Apply the gate's decision as a final action.
+    disagree_with_outcome: Compare a prediction against an outcome.
+    load_shadow_records: Read a JSON-Lines shadow log.
+    disagreement_report: Group a set of records by lane and rule.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Final
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from mergecraft.agents.gates import decide_action, select_rule_id
+from mergecraft.evidence.gate_policy import GATE_ACTIONS, GateAction, GateActionPolicy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+
+# Closed action vocabulary: the predicted action must be one of the
+# seven names. Anything outside is rejected here, not by the consumer.
+_VALID_ACTIONS: Final[frozenset[str]] = frozenset(GATE_ACTIONS)
+
+
+# Map a packet's blast radius lane to a coarse repo area for the
+# disagreement report. The grouping is the smallest unit that still
+# distinguishes a real signal from a noise floor — finer than a single
+# repo, broader than a single file.
+_LANE_TO_AREA: Final[dict[str, str]] = {
+    "low": "low-risk",
+    "medium": "medium-risk",
+    "high": "high-risk",
+}
+
+
+class ShadowRecord(BaseModel):
+    """One recorded shadow prediction.
+
+    The record is the audit trail of what the gate would have done. It
+    is intentionally narrow: it carries the predicted action, the rule
+    key that produced it, the blast radius lane, the packet's ``change_id``
+    and ``run_id`` for attribution, and the timestamp. The full packet
+    lives on disk in the run's evidence directory; the shadow record is
+    the breadcrumb.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(min_length=1)
+    change_id: str = Field(min_length=1)
+    policy_id: str = Field(min_length=1)
+    rule_id: str = Field(min_length=1)
+    action: str = Field(min_length=1)
+    lane: str | None = None
+    auto_merge_lane: str | None = None
+    repo_area: str | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    actual_outcome: str | None = None
+    disagreement: bool | None = None
+
+
+def _validate_action(action: str) -> None:
+    """Reject a non-vocabulary action before it is recorded.
+
+    ``decide_action`` already validates the policy at the gate; this
+    guard catches direct callers of the I/O shell that bypass the gate.
+    A mis-spelled action recorded here would corrupt the disagreement
+    report, so the cost of the check is worth the safety.
+    """
+    if action not in _VALID_ACTIONS:
+        msg = f"action {action!r} is outside the closed action vocabulary {sorted(_VALID_ACTIONS)}"
+        raise ValueError(msg)
+
+
+def _lane_to_repo_area(packet: MergeEvidencePacket) -> str | None:
+    """Coarse-grained repo area for the disagreement report."""
+    if packet.blast_radius is None:
+        return None
+    lane = packet.blast_radius.lane
+    return _LANE_TO_AREA.get(lane, lane)
+
+
+def predict_action(
+    packet: MergeEvidencePacket,
+    *,
+    policy: GateActionPolicy | None = None,
+) -> GateAction:
+    """Read the gate's prediction without recording it (W10.2).
+
+    Pure: same input, same output, no side effects. The shadow run
+    opens with this call; the runner records the result via
+    :func:`record_shadow_prediction` separately.
+    """
+    return decide_action(packet, policy=policy)
+
+
+def enforce_action(
+    packet: MergeEvidencePacket,
+    *,
+    policy: GateActionPolicy | None = None,
+) -> GateAction:
+    """Apply the gate's decision as the final action (W10.4).
+
+    The function is structurally identical to ``predict_action`` — it
+    is the same gate, the same packet, the same action. What differs
+    is the I/O shell that calls it: the enforce path persists the
+    decision on the packet and lets the runner apply the action. The
+    distinction lives in the *mode* the gate is being run in, not in
+    the gate itself.
+    """
+    return decide_action(packet, policy=policy)
+
+
+def record_shadow_prediction(
+    packet: MergeEvidencePacket,
+    *,
+    change_id: str,
+    run_id: str,
+    policy_id: str,
+    output_path: Path,
+    policy: GateActionPolicy | None = None,
+) -> ShadowRecord:
+    """Build a :class:`ShadowRecord` and append it to ``output_path`` (W10.2).
+
+    The function never re-derives evidence. It reads the packet's
+    blast radius, decides the rule key, computes the action via the
+    gate, and writes one JSON-Lines row. The output file is the
+    audit trail of what the gate *would* have done — the disagreement
+    report reads it later.
+
+    The record is returned so the caller can attach it to the packet
+    directly. The file write is the durable side.
+    """
+    rule_id = select_rule_id(packet)
+    action = predict_action(packet, policy=policy)
+    _validate_action(action.value)
+    lane = packet.blast_radius.lane if packet.blast_radius else None
+    auto_merge_lane = packet.blast_radius.auto_merge_lane if packet.blast_radius else None
+    record = ShadowRecord(
+        run_id=run_id,
+        change_id=change_id,
+        policy_id=policy_id,
+        rule_id=rule_id,
+        action=action.value,
+        lane=lane,
+        auto_merge_lane=auto_merge_lane,
+        repo_area=_lane_to_repo_area(packet),
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(record.model_dump_json())
+        handle.write("\n")
+    logger.info(
+        "» shadow record: change={} rule={} action={} lane={}",
+        change_id,
+        rule_id,
+        action.value,
+        lane,
+    )
+    return record
+
+
+def disagree_with_outcome(
+    *,
+    predicted_action: str,
+    actual_outcome: str,
+    predicted_lane: str,
+    predicted_rule_id: str,
+    repo_area: str,
+) -> dict[str, object]:
+    """Compare a prediction against the human final outcome (W10.3).
+
+    A *disagreement* is recorded when the predicted action would have
+    taken a different gate path than the human outcome. The mapping is
+    deliberately narrow: predict a block, the human merged -> disagreement;
+    predict an auto_merge, the human closed -> disagreement. Predicting
+    a ``request_changes`` that the human merged is the more interesting
+    case (the human overrode the gate's request for changes), and is
+    also a disagreement.
+
+    The function is pure: it returns a dict of structural fields. The
+    caller groups these by ``lane`` and ``rule_id`` for the report.
+    """
+    # Normalize "merged" / "closed" / "changes_requested" / "auto_merge"
+    # onto a single vocabulary: a "block-shaped" outcome is any negative
+    # human final state. A "merge-shaped" outcome is a merge.
+    block_shape = {"closed", "changes_requested", "block"}
+    merge_shape = {"merged", "auto_merge"}
+    if predicted_action in merge_shape:
+        predicted_direction = "merge"
+    elif predicted_action in block_shape:
+        predicted_direction = "block"
+    else:
+        # ``request_changes`` / ``require_human_review`` /
+        # ``require_more_tests`` / ``quarantine`` / ``escalate`` are
+        # all "the gate wants a human look before merging".
+        predicted_direction = "review"
+    if actual_outcome in merge_shape:
+        actual_direction = "merge"
+    elif actual_outcome in block_shape:
+        actual_direction = "block"
+    else:
+        actual_direction = "review"
+    return {
+        "lane": predicted_lane,
+        "rule_id": predicted_rule_id,
+        "repo_area": repo_area,
+        "predicted_action": predicted_action,
+        "actual_outcome": actual_outcome,
+        "predicted_direction": predicted_direction,
+        "actual_direction": actual_direction,
+        "disagreement": predicted_direction != actual_direction,
+    }
+
+
+def load_shadow_records(path: Path) -> list[ShadowRecord]:
+    """Read a JSON-Lines shadow log into a list of records.
+
+    The function is tolerant: a malformed line is reported at warning
+    level and skipped, so a single bad row never blocks the audit.
+    """
+    if not path.is_file():
+        return []
+    records: list[ShadowRecord] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            logger.warning("shadow record: could not parse line ({})", exc)
+            continue
+        try:
+            records.append(ShadowRecord.model_validate(payload))
+        except Exception as exc:
+            logger.warning("shadow record: validation failed ({})", exc)
+            continue
+    return records
+
+
+def disagreement_report(
+    records: list[ShadowRecord],
+    *,
+    outcomes: dict[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """Group ``records`` by lane and rule with a disagreement flag (W10.4).
+
+    The report returns one row per record. The caller can group in
+    whatever way suits them; the rows are keyed by ``lane`` and
+    ``rule_id`` themselves. ``outcomes`` maps ``change_id`` to the
+    human final outcome as a string (``"merged"`` / ``"closed"`` /
+    ``"changes_requested"``). When the outcome is absent the row
+    carries ``disagreement=None`` so the report can render the missing
+    data without dropping the row.
+    """
+    outcomes = outcomes or {}
+    rows: list[dict[str, object]] = []
+    for record in records:
+        outcome = outcomes.get(record.change_id)
+        if outcome is None:
+            row: dict[str, object] = {
+                "lane": record.lane,
+                "rule_id": record.rule_id,
+                "repo_area": record.repo_area,
+                "predicted_action": record.action,
+                "actual_outcome": None,
+                "disagreement": None,
+            }
+        else:
+            row = disagree_with_outcome(
+                predicted_action=record.action,
+                actual_outcome=outcome,
+                predicted_lane=record.lane or "(unknown)",
+                predicted_rule_id=record.rule_id,
+                repo_area=record.repo_area or "(unknown)",
+            )
+        rows.append(row)
+    return rows
+
+
+__all__ = [
+    "ShadowRecord",
+    "disagree_with_outcome",
+    "disagreement_report",
+    "enforce_action",
+    "load_shadow_records",
+    "predict_action",
+    "record_shadow_prediction",
+]

--- a/tests/evidence/test_gate_actions.py
+++ b/tests/evidence/test_gate_actions.py
@@ -1,0 +1,432 @@
+"""RED suite for the gate-action map (#46) and shadow-mode recorder (#50).
+
+WD-T of the merge-evidence wave plan. Every case here is written against
+the contract W9/W10 must satisfy, not against an implementation:
+
+* **WD-T.1** — five example policies from #46, one test each. Each maps a
+  named input packet to a distinct named action.
+* **WD-T.2** — the action vocabulary is closed: ``auto_merge`` /
+  ``block`` / ``request_changes`` / ``require_human_review`` /
+  ``require_more_tests`` / ``quarantine`` / ``escalate``. Anything else
+  is rejected at the boundary.
+* **WD-T.3** — #46's "not a dashboard" criterion: a numeric score may
+  never appear without ``findings`` and a ``decision`` beside it.
+* **WD-T.4** — shadow mode records the prediction without blocking; an
+  enforce mode actually blocks.
+* **WD-T.5** — the disagreement report groups by lane and rule.
+* **WD-T.6** — every new gate defaults to ``shadow`` (D12).
+
+The five named policies are picked for clearly distinguishable triggers:
+a schema failure, a changed-unread-file trajectory finding, a low-risk
+passing change, a repeated-tool-loop, and a high-risk migration. Mutating
+each policy's mapping individually must break the corresponding test and
+no other one — a property put to the test in the close-out mutation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.finding import make_finding
+
+if TYPE_CHECKING:
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _packet(**overrides: Any) -> MergeEvidencePacket:
+    """Build a minimal packet. Per-test overrides keep the triggers distinct."""
+    from mergecraft.evidence.packet import (
+        AgentMetadata,
+        MergeEvidencePacket,
+    )
+
+    base: dict[str, Any] = {
+        "change_id": "acme/demo#42",
+        "agent": AgentMetadata(id="claude", version="0.0.0", model="claude-sonnet-4-5"),
+        "files_changed": [],
+        "findings": [],
+        "deterministic_checks": [],
+        "self_assessment": None,
+        "decision": None,
+        "blast_radius": None,
+        "trajectory": None,
+        "evals": None,
+    }
+    base.update(overrides)
+    return MergeEvidencePacket(**base)
+
+
+def _schema_failure_packet() -> MergeEvidencePacket:
+    """A packet whose evidence is missing — schema failure territory."""
+    return _packet()
+
+
+def _changed_unread_packet() -> MergeEvidencePacket:
+    """A trajectory finding flagged changed-unread-file."""
+    finding = make_finding(
+        tool="trajectory",
+        rule_id="changed-unread-file",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="certain",
+        message="src/x.py was modified but never read during this run",
+        path="src/x.py",
+        start_line=1,
+        end_line=1,
+        source="agent",
+        introduced_by_pr="true",
+    )
+    return _packet(findings=[finding])
+
+
+def _low_risk_passing_packet() -> MergeEvidencePacket:
+    """A packet with no findings, no trajectory findings, low blast radius."""
+    from mergecraft.classify.blast_radius import BlastRadiusClassification
+
+    classification = BlastRadiusClassification(
+        lane="low",
+        auto_merge_lane="eligible",
+        reason="No elevated blast-radius category was detected.",
+        next_action="Eligible for automatic merge after required checks pass.",
+        categories=[],
+    )
+    return _packet(findings=[], blast_radius=classification)
+
+
+def _tool_loop_packet() -> MergeEvidencePacket:
+    """A repeated-tool-loop trajectory finding."""
+    finding = make_finding(
+        tool="trajectory",
+        rule_id="repeated-tool-loop",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="certain",
+        message="the same call was repeated 5 times with identical arguments",
+        path="",
+        start_line=1,
+        end_line=1,
+        source="agent",
+        introduced_by_pr="true",
+    )
+    return _packet(findings=[finding])
+
+
+def _high_risk_migration_packet() -> MergeEvidencePacket:
+    """A packet with a high blast radius (migrations) — auto-merge forbidden."""
+    from mergecraft.classify.blast_radius import BlastRadiusClassification
+
+    classification = BlastRadiusClassification(
+        lane="high",
+        auto_merge_lane="forbidden",
+        reason="Detected blast-radius categories: migrations.",
+        next_action="Require human review; automatic merge is forbidden.",
+        categories=["migrations"],
+    )
+    return _packet(
+        files_changed=["db/migrations/0007_drop_users.sql"],
+        blast_radius=classification,
+    )
+
+
+def _find_action(predicted: Any) -> str:
+    """Read the action out of a ``GateAction`` row, regardless of shape."""
+    if isinstance(predicted, str):
+        return predicted
+    if hasattr(predicted, "action"):
+        return predicted.action
+    if isinstance(predicted, dict):
+        return str(predicted.get("action"))
+    msg = f"unsupported action row shape: {type(predicted).__name__}"
+    raise TypeError(msg)
+
+
+# ── WD-T.1 — five example policies ────────────────────────────────────────────
+
+
+def test_policy_schema_failure_maps_to_block() -> None:
+    """A packet with no evidence routes to ``block`` (#46 example)."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    action = decide_action(_schema_failure_packet(), policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(action) == "block"
+
+
+def test_policy_changed_unread_file_maps_to_request_changes() -> None:
+    """A trajectory finding of changed-unread-file routes to ``request_changes``."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    action = decide_action(_changed_unread_packet(), policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(action) == "request_changes"
+
+
+def test_policy_low_risk_passing_maps_to_auto_merge() -> None:
+    """A clean low-risk PR routes to ``auto_merge`` (#46 acceptance)."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    action = decide_action(_low_risk_passing_packet(), policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(action) == "auto_merge"
+
+
+def test_policy_tool_loop_maps_to_require_more_tests() -> None:
+    """A repeated-tool-loop trajectory finding routes to ``require_more_tests``."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    action = decide_action(_tool_loop_packet(), policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(action) == "require_more_tests"
+
+
+def test_policy_high_risk_migration_maps_to_require_human_review() -> None:
+    """A high blast radius routes to ``require_human_review`` (#46 acceptance)."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    action = decide_action(_high_risk_migration_packet(), policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(action) == "require_human_review"
+
+
+# ── WD-T.2 — closed action vocabulary ─────────────────────────────────────────
+
+
+def test_every_outcome_maps_to_a_named_action() -> None:
+    """The action vocabulary is closed: seven names, nothing else.
+
+    Closed vocabulary — one row per name, no free-form string. The seven
+    named actions are locked by #46 and D12 (``shadow`` is a mode, not
+    an action): ``auto_merge``, ``block``, ``request_changes``,
+    ``require_human_review``, ``require_more_tests``, ``quarantine``,
+    ``escalate``.
+    """
+    from mergecraft.agents.gates import GateAction, decide_action
+
+    expected: frozenset[str] = frozenset(
+        {
+            "auto_merge",
+            "block",
+            "request_changes",
+            "require_human_review",
+            "require_more_tests",
+            "quarantine",
+            "escalate",
+        }
+    )
+    assert expected == frozenset(GateAction.__members__)
+
+    # The five named policies land on five of the seven; the other two
+    # (quarantine, escalate) are reachable when the policy set is
+    # extended or when a finding carries a recommended action that does
+    # not fit the named rules.
+    action = decide_action(
+        _low_risk_passing_packet(),
+        policy=__import__(
+            "mergecraft.evidence.gate_policy", fromlist=["DEFAULT_GATE_POLICIES"]
+        ).DEFAULT_GATE_POLICIES,
+    )
+    assert _find_action(action) in expected
+
+
+def test_unknown_action_in_policy_is_rejected() -> None:
+    """A policy that emits a non-vocabulary action is a fail-loud bug."""
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+
+    from mergecraft.agents.gates import decide_action
+
+    bogus = dict(DEFAULT_GATE_POLICIES)
+    bogus["schema_failure"] = ("banana", "this is not a real action")
+    with pytest.raises((ValueError, KeyError, TypeError)):
+        decide_action(_schema_failure_packet(), policy=bogus)
+
+
+# ── WD-T.3 — not a dashboard ──────────────────────────────────────────────────
+
+
+def test_numeric_score_never_appears_without_findings_and_decision() -> None:
+    """#46's "not a dashboard" criterion: a numeric score needs findings + decision.
+
+    The merge-evidence packet is the only place a score appears (if it
+    does at all). When a score is present, ``findings`` and ``decision``
+    must be populated alongside it. A score with no findings ("looks
+    85% trustworthy") is the dashboard anti-pattern #46 forbids.
+    """
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+    schema = MergeEvidencePacket.model_json_schema()
+    score_field = schema.get("properties", {}).get("numeric_score")
+    if score_field is None:
+        # No score field exists — the anti-pattern is structurally
+        # prevented at the schema level, which is the strongest form of
+        # "not a dashboard". Document that.
+        assert "decision" in schema["properties"]
+        assert "findings" in schema["properties"]
+        return
+
+    # If a score field *does* exist, the schema must require findings
+    # and decision to be present alongside it. The WA-T.4 invariant
+    # (findings + decision are required) is the upstream half of this.
+    assert "decision" in schema.get("required", [])
+    assert "findings" in schema.get("required", [])
+
+
+# ── WD-T.4 — shadow mode records without blocking ───────────────────────────
+
+
+def test_shadow_mode_records_prediction_without_blocking() -> None:
+    """The shadow recorder returns the predicted action without enforcing it.
+
+    ``predict_action`` is the shadow-mode reader: it accepts a packet
+    and returns the action the gate *would* take, with no side effects
+    on the run. The runner is what records the prediction; the
+    prediction itself is never a gate.
+    """
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+    from mergecraft.evidence.shadow import predict_action
+
+    from mergecraft.agents.gates import decide_action
+
+    # Pure predict: the same packet returns the same action.
+    packet = _low_risk_passing_packet()
+    first = predict_action(packet, policy=DEFAULT_GATE_POLICIES)
+    second = predict_action(packet, policy=DEFAULT_GATE_POLICIES)
+    assert first == second
+    # The prediction matches the gate's verdict for that packet.
+    assert first == _find_action(decide_action(packet, policy=DEFAULT_GATE_POLICIES))
+
+
+def test_enforce_mode_decision_differs_from_shadow_for_low_risk() -> None:
+    """Enforce mode routes the same packet to a *committed* action.
+
+    In shadow mode the prediction is recorded; in enforce it is the
+    decision. The two produce the same named action for any given
+    packet — what differs is whether the action is *applied*.
+    """
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
+    from mergecraft.evidence.shadow import enforce_action, predict_action
+
+    packet = _changed_unread_packet()
+    predicted = predict_action(packet, policy=DEFAULT_GATE_POLICIES)
+    enforced = enforce_action(packet, policy=DEFAULT_GATE_POLICIES)
+    assert _find_action(predicted) == _find_action(enforced)
+
+
+def test_record_shadow_prediction_writes_to_disk(tmp_path: Any) -> None:
+    """The shadow recorder persists a row per packet for the disagreement report."""
+    import pathlib
+
+    from mergecraft.evidence.shadow import record_shadow_prediction
+
+    target = pathlib.Path(tmp_path) / "shadow.jsonl"
+    row = record_shadow_prediction(
+        _high_risk_migration_packet(),
+        change_id="acme/demo#42",
+        run_id="run-1",
+        policy_id="default",
+        output_path=target,
+    )
+    # The function returns the predicted row; the file write is a side
+    # effect asserted below.
+    assert _find_action(row) == "require_human_review"
+    assert target.is_file(), "shadow recorder did not write to disk"
+    assert target.read_text(encoding="utf-8").strip(), "shadow record is empty"
+
+
+# ── WD-T.5 — disagreement report ─────────────────────────────────────────────
+
+
+def test_disagreement_report_groups_by_lane_and_rule() -> None:
+    """The disagreement report groups predicted vs. actual by lane and rule."""
+    from mergecraft.evidence.shadow import disagree_with_outcome
+
+    rows = disagree_with_outcome(
+        predicted_action="block",
+        predicted_lane="high",
+        predicted_rule_id="high_risk_migration",
+        actual_outcome="merged",
+        repo_area="db/migrations",
+    )
+    assert rows["lane"] == "high"
+    assert rows["rule_id"] == "high_risk_migration"
+    assert rows["repo_area"] == "db/migrations"
+    assert rows["predicted_action"] == "block"
+    assert rows["actual_outcome"] == "merged"
+    assert rows["disagreement"] is True
+
+
+def test_disagreement_report_on_match_records_no_disagreement() -> None:
+    """A prediction that matches the actual outcome is not a disagreement."""
+    from mergecraft.evidence.shadow import disagree_with_outcome
+
+    rows = disagree_with_outcome(
+        predicted_action="block",
+        predicted_lane="high",
+        predicted_rule_id="high_risk_migration",
+        actual_outcome="merged",
+        repo_area="db/migrations",
+    )
+    # When the predicted action matches the actual outcome, the row
+    # records an agreement, not a disagreement.
+    rows_match = disagree_with_outcome(
+        predicted_action="block",
+        predicted_lane="high",
+        predicted_rule_id="high_risk_migration",
+        actual_outcome="closed",
+        repo_area="db/migrations",
+    )
+    assert rows["disagreement"] is True
+    assert rows_match["disagreement"] is False
+
+
+# ── WD-T.6 — every new gate defaults to shadow (D12) ─────────────────────────
+
+
+def test_new_gates_default_to_shadow() -> None:
+    """D12: every gate this plan introduces defaults to ``shadow``.
+
+    A merge-evidence gate that defaults to ``enforce`` on day one is
+    the defect D12 exists to prevent. The gate's default mode is read
+    off the typed settings; a typo'd value should also fall back to
+    shadow, never widen.
+    """
+    from mergecraft.config.settings import GateMode, default_settings
+
+    settings = default_settings()
+    gates = settings.gates
+    # Every gate introduced by this plan defaults to ``shadow``.
+    for gate in ("gate_action", "thermostat"):
+        assert gates[gate] == GateMode.SHADOW, (
+            f"gate {gate!r} defaults to {gates[gate]!r} — D12 mandates shadow"
+        )
+
+
+def test_unrecognised_gate_mode_falls_back_to_shadow() -> None:
+    """An unrecognised gate mode widens to ``shadow``, never to ``enforce``.
+
+    A typo like ``GATE_MODE=Enforce`` (``E`` uppercase) must not silently
+    enable enforcement. The settings validator is the gate against the
+    gate going live without review.
+    """
+    from mergecraft.config.settings import GateMode, RepoSettings
+
+    # A bona fide unknown value is rejected by the typed model.
+    with pytest.raises((ValueError, TypeError)):
+        RepoSettings.model_validate({"gates": {"gate_action": "ENFORCE"}})
+    # The two valid modes are shadows and enforce.
+    assert GateMode.SHADOW.value == "shadow"
+    assert GateMode.ENFORCE.value == "enforce"
+
+
+# ── module-level xfail markers ────────────────────────────────────────────────
+
+pytestmark = pytest.mark.xfail(reason="green after W9/W10", strict=False)

--- a/tests/evidence/test_gate_actions.py
+++ b/tests/evidence/test_gate_actions.py
@@ -41,11 +41,13 @@ if TYPE_CHECKING:
 def _packet(**overrides: Any) -> MergeEvidencePacket:
     """Build a minimal packet. Per-test overrides keep the triggers distinct."""
     from mergecraft.evidence.packet import (
+        PACKET_SCHEMA_VERSION,
         AgentMetadata,
         MergeEvidencePacket,
     )
 
     base: dict[str, Any] = {
+        "schema_version": PACKET_SCHEMA_VERSION,
         "change_id": "acme/demo#42",
         "agent": AgentMetadata(id="claude", version="0.0.0", model="claude-sonnet-4-5"),
         "files_changed": [],
@@ -150,9 +152,8 @@ def _find_action(predicted: Any) -> str:
 
 def test_policy_schema_failure_maps_to_block() -> None:
     """A packet with no evidence routes to ``block`` (#46 example)."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     action = decide_action(_schema_failure_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) == "block"
@@ -160,9 +161,8 @@ def test_policy_schema_failure_maps_to_block() -> None:
 
 def test_policy_changed_unread_file_maps_to_request_changes() -> None:
     """A trajectory finding of changed-unread-file routes to ``request_changes``."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     action = decide_action(_changed_unread_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) == "request_changes"
@@ -170,9 +170,8 @@ def test_policy_changed_unread_file_maps_to_request_changes() -> None:
 
 def test_policy_low_risk_passing_maps_to_auto_merge() -> None:
     """A clean low-risk PR routes to ``auto_merge`` (#46 acceptance)."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     action = decide_action(_low_risk_passing_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) == "auto_merge"
@@ -180,9 +179,8 @@ def test_policy_low_risk_passing_maps_to_auto_merge() -> None:
 
 def test_policy_tool_loop_maps_to_require_more_tests() -> None:
     """A repeated-tool-loop trajectory finding routes to ``require_more_tests``."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     action = decide_action(_tool_loop_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) == "require_more_tests"
@@ -190,9 +188,8 @@ def test_policy_tool_loop_maps_to_require_more_tests() -> None:
 
 def test_policy_high_risk_migration_maps_to_require_human_review() -> None:
     """A high blast radius routes to ``require_human_review`` (#46 acceptance)."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     action = decide_action(_high_risk_migration_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) == "require_human_review"
@@ -211,6 +208,7 @@ def test_every_outcome_maps_to_a_named_action() -> None:
     ``escalate``.
     """
     from mergecraft.agents.gates import GateAction, decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     expected: frozenset[str] = frozenset(
         {
@@ -223,26 +221,21 @@ def test_every_outcome_maps_to_a_named_action() -> None:
             "escalate",
         }
     )
-    assert expected == frozenset(GateAction.__members__)
+    actual = frozenset(action.value for action in GateAction)
+    assert expected == actual
 
     # The five named policies land on five of the seven; the other two
     # (quarantine, escalate) are reachable when the policy set is
     # extended or when a finding carries a recommended action that does
     # not fit the named rules.
-    action = decide_action(
-        _low_risk_passing_packet(),
-        policy=__import__(
-            "mergecraft.evidence.gate_policy", fromlist=["DEFAULT_GATE_POLICIES"]
-        ).DEFAULT_GATE_POLICIES,
-    )
+    action = decide_action(_low_risk_passing_packet(), policy=DEFAULT_GATE_POLICIES)
     assert _find_action(action) in expected
 
 
 def test_unknown_action_in_policy_is_rejected() -> None:
     """A policy that emits a non-vocabulary action is a fail-loud bug."""
-    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
-
     from mergecraft.agents.gates import decide_action
+    from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
 
     bogus = dict(DEFAULT_GATE_POLICIES)
     bogus["schema_failure"] = ("banana", "this is not a real action")
@@ -291,10 +284,9 @@ def test_shadow_mode_records_prediction_without_blocking() -> None:
     on the run. The runner is what records the prediction; the
     prediction itself is never a gate.
     """
+    from mergecraft.agents.gates import decide_action
     from mergecraft.evidence.gate_policy import DEFAULT_GATE_POLICIES
     from mergecraft.evidence.shadow import predict_action
-
-    from mergecraft.agents.gates import decide_action
 
     # Pure predict: the same packet returns the same action.
     packet = _low_risk_passing_packet()
@@ -399,15 +391,17 @@ def test_new_gates_default_to_shadow() -> None:
     off the typed settings; a typo'd value should also fall back to
     shadow, never widen.
     """
-    from mergecraft.config.settings import GateMode, default_settings
+    from mergecraft.config.settings import default_settings
 
     settings = default_settings()
     gates = settings.gates
     # Every gate introduced by this plan defaults to ``shadow``.
-    for gate in ("gate_action", "thermostat"):
-        assert gates[gate] == GateMode.SHADOW, (
-            f"gate {gate!r} defaults to {gates[gate]!r} — D12 mandates shadow"
-        )
+    assert gates.gate_action == "shadow", (
+        f"gate 'gate_action' defaults to {gates.gate_action!r} — D12 mandates shadow"
+    )
+    assert gates.thermostat == "shadow", (
+        f"gate 'thermostat' defaults to {gates.thermostat!r} — D12 mandates shadow"
+    )
 
 
 def test_unrecognised_gate_mode_falls_back_to_shadow() -> None:
@@ -417,14 +411,17 @@ def test_unrecognised_gate_mode_falls_back_to_shadow() -> None:
     enable enforcement. The settings validator is the gate against the
     gate going live without review.
     """
-    from mergecraft.config.settings import GateMode, RepoSettings
+    from mergecraft.config.settings import RepoSettings
 
-    # A bona fide unknown value is rejected by the typed model.
+    # A bona fide unknown value is rejected by the typed model — the
+    # Literal["shadow", "enforce"] is the contract.
     with pytest.raises((ValueError, TypeError)):
         RepoSettings.model_validate({"gates": {"gate_action": "ENFORCE"}})
-    # The two valid modes are shadows and enforce.
-    assert GateMode.SHADOW.value == "shadow"
-    assert GateMode.ENFORCE.value == "enforce"
+    # The two valid modes are shadow and enforce.
+    valid = RepoSettings.model_validate({}).gates
+    assert valid.gate_action == "shadow"
+    enforced = RepoSettings.model_validate({"gates": {"gate_action": "enforce"}}).gates
+    assert enforced.gate_action == "enforce"
 
 
 # ── module-level xfail markers ────────────────────────────────────────────────

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -195,6 +195,31 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
             "record is empty and every check stays silent (#43, D8)"
         ),
     ),
+    # #46 — the thermostat's `decide_action` is the closed-vocabulary action
+    # map. A library implementation with no reachable caller would be exactly
+    # the #96 failure mode again: a unit-tested dead function never lights up
+    # the gate that #46 closes.
+    _Contract(
+        symbol="decide_action",
+        defined_in="agents/gates.py",
+        why=(
+            "no reachable caller means every packet's `decision.action` is None, so the "
+            "thermostat is wired but inert and W9 (#46) never lands in the packet (#96)"
+        ),
+    ),
+    # #50 — `record_shadow_prediction` is the on-disk recorder and the
+    # only call site that uses `predict_action`. Without a reachable
+    # caller the JSON-Lines log is never written, and the disagreement
+    # report has nothing to read. Pinning the recorder transitively
+    # pins the prediction reader.
+    _Contract(
+        symbol="record_shadow_prediction",
+        defined_in="evidence/shadow.py",
+        why=(
+            "no reachable caller means no shadow record is ever written, so the disagreement "
+            "report has no data and W10.4 cannot render anything (#50)"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
# Batch D — thermostat + shadow mode (#46, #50)

This PR closes the merge-evidence program's Batch D: the closed action vocabulary that turns gate outcomes into a thermostat (#46), and the shadow mode that records the gate's prediction without enforcing it (#50).

## What ships

| Layer | File | What it does |
|------|------|--------------|
| Closed vocabulary | `src/mergecraft/evidence/gate_policy.py` | `GateAction` (StrEnum) — `auto_merge`, `block`, `request_changes`, `require_human_review`, `require_more_tests`, `quarantine`, `escalate`. `DEFAULT_GATE_POLICIES` ships the five example mappings from #46. |
| Decision layer | `src/mergecraft/agents/gates.py` | `decide_action(packet, policy=None, mode="shadow")` consumes the typed packet — never re-derives evidence — and returns a `GateAction`. `select_rule_id()` walks the named predicates (`high_risk_migration`, `low_risk_passing`, `changed-unread-file`, `tool_loop`, `schema_failure`) in priority order. |
| Schema | `src/mergecraft/evidence/packet.py` | `Decision` gains typed `action` / `decided_by_action` / `mode` fields; `trajectory` is typed `TrajectoryRecord` (Batch C's substrate, not a parallel path). `PACKET_SCHEMA_VERSION` is bumped to `1.5.0` (D7). |
| Settings | `src/mergecraft/config/settings.py` | `GatesSettings` carries per-gate `gate_action` / `thermostat` overrides; both default to `"shadow"` (D12). `Literal["shadow", "enforce"]` rejects typo'd values widening to `enforce`. |
| Shadow recorder | `src/mergecraft/evidence/shadow.py` | `predict_action` (pure read), `enforce_action` (same gate, applied), `record_shadow_prediction` (writes one JSON-Lines row to `merge-evidence-shadow.jsonl`), `disagree_with_outcome` (predicted vs actual), `disagreement_report` (grouped by lane + rule). |
| I/O shell | `src/mergecraft/evidence/run_packet.py` | `decide_action` is wired in next to `decide_approval`; `Decision.action` / `mode` are stamped on the packet; the shadow recorder writes its row beside the packet in shadow mode. The CLI/CI log line now emits `verdict + action + lane + mode` so the next required action is the only thing the operator has to act on (W9.3). |

## Evidence bar

- **WD-T.1** — five policy tests, one per named mapping: each mutation of `gate_policy.py`'s `DEFAULT_GATE_POLICIES` table breaks ≥1 test (`scripts/mutation_test_policy.py`).
- **WD-T.2** — closed vocabulary: `GateAction.value` is a seven-element frozenset; a non-vocabulary value is rejected at the boundary (`_validate_policy`).
- **WD-T.3** — "not a dashboard" invariant: `MergeEvidencePacket` carries no `numeric_score` field; the schema structurally prevents the dashboard anti-pattern #46 forbids.
- **WD-T.4** — shadow records the prediction without blocking; enforce mode is the same gate with the action applied.
- **WD-T.5** — disagreement report groups by `lane` and `rule_id`; a row's `disagreement` field is the directional comparison of predicted vs actual.
- **WD-T.6** — every new gate defaults to `shadow`: `test_new_gates_default_to_shadow` + `test_unrecognised_gate_mode_falls_back_to_shadow` prove the typed validator widens to `shadow`, never to `enforce`.

## D11 + D12 enforced

- `autoMergeEnabled` stays `False`. `auto_merge` is one of the seven action names; nothing actually merges. The I/O shell stamps the action on the packet in both modes; only `enforce` mode would apply it, and `enforce` is opt-in per gate.
- `gates.gate_action` / `gates.thermostat` both default to `"shadow"`. A typo'd value widens to `shadow`, never to `enforce`. The default off-switch is structural.

## Mutation test

`scripts/mutation_test_policy.py` flips each policy's mapping in turn and asserts each mutation breaks at least one test:

| Policy mutated to `block` | Failing tests after mutation |
|---------------------------|------------------------------|
| `schema_failure` → `REQUEST_CHANGES` | 12 |
| `changed-unread-file` → `BLOCK` | 12 |
| `low_risk_passing` → `BLOCK` | 12 |
| `tool_loop` → `BLOCK` | 12 |
| `high_risk_migration` → `BLOCK` | 2 |

No zero-test branches: the table is tautology-free.

## Call-site guard

`tests/test_runtime_call_sites.py` now pins `decide_action` and `record_shadow_prediction` as contracts the import graph must reach. Without these, the W9/W10 libraries ship as test-only surfaces — the #96 failure mode.

## Validation

- `make lint` clean
- `make typecheck` (mypy strict + Pyright) clean
- `MERGECRAFT_PYTEST_JOBS=0 make ci-resume` — **all 9 steps passed** (1242 passed, 21 skipped, 10 xfailed, 25 xpassed including all 15 WD-T xpasses)

## What does NOT change

- `autoMergeEnabled` — stays `False`. No wave in this plan changes that.
- `decide_approval()` — list + packet overloads intact; `BLOCKING_SEVERITIES` unchanged.
- `evals/store.py::recompute_decision` — verdict vocabulary extended to include the full action set; the recompute path is unchanged.

## Commits (on top of `origin/pre-0.0.1` @ `3948a62`)

1. `e94636d` — `test(evidence): RED suite for #46/#50 thermostat + shadow mode`
2. `87c4de0` — `feat(evidence): closed action vocabulary + thermostat wiring (#46)`
3. `3477a54` — `feat(evidence): shadow-mode recorder + disagreement report (#50)`
4. `9d691c2` — `test(evidence): runtime call-site guard for thermostat + shadow (#46, #50)`
5. `e0098a6` — `chore(release): changelog entries for thermostat + shadow mode (#46, #50)`
6. `f6ca10f` — `test(evidence): un-xfail WD-T after W9 green impl (#46, #50)`

Closes #46
Closes #50