### PR TITLE
chore(ci): mirror sevn mergecraft workflow (Nous primary, Codex fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,120 @@
+# mergeCraft local environment example
+#
+# Copy this file to `.env` and fill in the values you need:
+#
+#     cp .env.example .env
+#     $EDITOR .env
+#
+# Rules:
+#   - `.env` is gitignored. Never commit it. Never paste real values into
+#     chat, logs, the spike report, or a commit message — reference env-var
+#     names only (convention 8 of the meat reading-diff plan).
+#   - This repo's `.gitignore` already excludes `.env` and `.env.*` and
+#     whitelists `.env.example` so this file is safe to commit.
+#   - Keys here are *operator* keys for local runs and the meat spike.
+#     In the GitHub Action, the same names are populated from
+#     `secrets.*` in your workflow (see `action.yml` and
+#     `.github/workflows/mergecraft.yml`); this file is only the local mirror.
+#
+# === Reviewer cascade (matches .github/workflows/mergecraft.yml) ===
+#   - NOUS_API_KEY              — primary (DeepSeek V4 Flash via Nous Portal)
+#   - CODEX_AUTH_JSON / OPENAI_API_KEY — fallback when NOUS_API_KEY is absent
+#     or the Nous review posts no mergecraft-approval verdict
+#   - ANTHROPIC_API_KEY         — not used by the workflow (the workflow
+#     explicitly does not route through Claude); keep here for local
+#     `mergecraft run` experiments only
+# `mergecraft run` picks whichever auth is set; the workflow in
+# `.github/workflows/mergecraft.yml` is the authoritative cascade shape.
+
+# ---------------------------------------------------------------------------
+# Reviewer LLM provider — at least one is required for `mergecraft run`.
+# BYOK; mergeCraft never stores these values.
+# ---------------------------------------------------------------------------
+
+# Nous Portal — primary reviewer in the workflow (DeepSeek V4 Flash).
+# Get one at https://portal.nousresearch.com. The workflow reads this only
+# as MERGECRAFT_CUSTOM_PROVIDER_API_KEY on the Nous step.
+NOUS_API_KEY=
+
+# Codex / OpenAI — fallback when NOUS_API_KEY is absent or the Nous review
+# posts no verdict. CODEX_AUTH_JSON is the ChatGPT/Codex subscription token
+# produced by `mergecraft auth codex`; OPENAI_API_KEY is the plain OpenAI
+# API key (same Codex harness). Either is enough.
+CODEX_AUTH_JSON=
+OPENAI_API_KEY=
+
+# Anthropic — NOT used by .github/workflows/mergecraft.yml (the workflow
+# explicitly skips Claude). KEPT here for local `mergecraft run` experiments
+# against the Anthropic API; leave unset unless you are running the CLI
+# outside the workflow.
+# ANTHROPIC_API_KEY=
+
+# Optional base-URL overrides for the providers above.
+# OPENAI_BASE_URL=        # optional override (e.g. a local gateway)
+# ANTHROPIC_BASE_URL=     # optional override
+# CODEX_BASE_URL=         # optional override for the Codex harness
+
+# ---------------------------------------------------------------------------
+# Nous custom OpenAI-compatible provider (CLI + workflow)
+# ---------------------------------------------------------------------------
+# The workflow registers a custom provider on mergeCraft's opencode harness
+# from these two vars. The provider id is taken from the model prefix, so
+# `nous/deepseek/deepseek-v4-flash` registers provider `nous` serving
+# `deepseek/deepseek-v4-flash`. The API key is typically the same value as
+# NOUS_API_KEY; the separate name lets the mergeCraft CLI read it without
+# re-reading the portal-specific env var.
+MERGECRAFT_CUSTOM_PROVIDER_BASE_URL=https://inference-api.nousresearch.com/v1
+MERGECRAFT_CUSTOM_PROVIDER_API_KEY=        # typically same as NOUS_API_KEY
+
+# ---------------------------------------------------------------------------
+# Model override (local CLI; the workflow sets `model:` directly on each step)
+# ---------------------------------------------------------------------------
+# Default below matches the workflow's primary. If unset, the repo's
+# `.mergecraft/config.yaml` (or the Action input) decides.
+MERGECRAFT_MODEL=nous/deepseek/deepseek-v4-flash
+
+# ---------------------------------------------------------------------------
+# Meat reading-diff spike (plan: .ignorelocal/waves/issues-meat-reading-diff-wave-plan.md)
+#
+# Meat is an opt-in second LLM that abridges the diff the reviewer sees.
+# It is OFF by default and is gated on a trusted tier + explicit opt-in
+# + shell not disabled (D7). The key here is consumed by `meat` itself,
+# never logged or written into any report (D7, convention 8).
+# ---------------------------------------------------------------------------
+
+# OpenAI is the default Meat provider. Per upstream commit 4272f70 the
+# default model is gpt-5.6-sol (OpenAI Responses API, medium reasoning).
+# Leave MEAT_MODEL empty to use the upstream default.
+OPENAI_API_KEY_MEAT=          # alias supported by some shells; many tools
+                              # just read OPENAI_API_KEY — keep both in sync
+MEAT_MODEL=gpt-5.6-sol
+# MEAT_CACHE=                  # optional; default ~/.meat; empty disables
+
+# ---------------------------------------------------------------------------
+# Tracing (opt-in, additive; see docs/TRACING.md and W7/W8 of the tracing plan)
+# ---------------------------------------------------------------------------
+
+# LOGFIRE_TOKEN=
+# OTEL_ENDPOINT=http://127.0.0.1:4318/v1/traces
+
+# ---------------------------------------------------------------------------
+# Local-dev / CI knobs (no secrets, but useful to set per shell)
+# ---------------------------------------------------------------------------
+
+# Disable pytest-xdist parallelism when a test conflicts.
+# MERGECRAFT_PYTEST_JOBS=0
+# Pin the random seed for deterministic ordering.
+# MERGECRAFT_PYTEST_RANDOM_SEED=424242
+# Skip pre-commit for one-shot scripted commits (the meat plan forbids
+# `--no-verify` on wave close-outs; use this only for ad-hoc work).
+# MERGECRAFT_SKIP_PRECOMMIT=1
+# CI sharding.
+# MERGECRAFT_TEST_SPLITS=2
+# MERGECRAFT_TEST_GROUP=0
+
+# ---------------------------------------------------------------------------
+# GitHub token (only needed for local scripts that hit the GitHub API;
+# the Action uses the workflow's job token automatically).
+# ---------------------------------------------------------------------------
+
+# GITHUB_TOKEN=

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -1,0 +1,543 @@
+# mergeCraft PR review (BYOK; https://github.com/alexhawat/mergeCraft).
+#
+# === THIS IS THE mergeCraft REPO'S OWN CONSUMER WORKFLOW ===
+# Mirrored from https://raw.githubusercontent.com/sevn-bot/sevn/main/.github/workflows/mergecraft.yml
+# (the workflow that actually runs in sevn-bot/sevn). A reader should NOT
+# confuse the two:
+#   - sevn-bot/sevn/.github/workflows/mergecraft.yml — the live copy that runs
+#     in the sevn-bot/sevn repo.
+#   - THIS FILE — the mergeCraft repo's own self-review workflow, kept in
+#     sync with the sevn copy so the cascade shape stays consistent.
+# Edits land first here (and any future `MERGECRAFT_REF` Makefile rule in this
+# repo, when added), then mirror to the sevn copy.
+#
+# Replaces the upstream pullfrog/pullfrog action AND CodeRabbit. Auto-reviews PRs
+# on open / ready / new commits, posting inline comments + a summary as
+# github-actions[bot], plus opt-in `mergecraft` / `mergecraft-approval` check-runs.
+# The enforce step below fails the job unless `mergecraft-approval` is a
+# confirmed "success" (outstanding feedback, no check posted at all, and an
+# unreachable check-runs API after retries all fail closed — see that step).
+#
+# Provider priority: DeepSeek V4 Flash via the Nous Portal is primary; OpenAI
+# (Codex) is the one-shot fallback when Nous is absent or its review posts no
+# verdict. Claude is not used.
+#
+# Codex reviews previously posted mergecraft-approval=neutral because every tool
+# call failed with "MCP server 'mergecraft' was not ready for this step". Root
+# cause was in mergeCraft, not Codex: its MCP endpoint answered the
+# `notifications/initialized` NOTIFICATION with a JSON-RPC response object
+# carrying `"id": null`, which Codex's rmcp client cannot deserialize — the
+# transport worker quit fatally mid-handshake, so the server was never ready for
+# the rest of the session. Fixed upstream in alexhawat/mergeCraft#78 (the
+# endpoint now returns 202 with no body for notification-only POSTs).
+#
+# DeepSeek V4 Flash runs through the Nous Portal OpenAI-compatible endpoint — the
+# same model sevn.bot's own runtime uses (DEFAULT_NOUS_INFERENCE_BASE_URL /
+# NOUS_PORTAL_DEEPSEEK_V4_FLASH_MODEL_ID in src/sevn/config/defaults.py). It
+# reaches mergeCraft's `opencode` harness, not the Codex one: mergeCraft routes
+# any model whose provider isn't anthropic/openai/google/cursor to opencode
+# (src/mergecraft/utils/agent_resolve.py resolve_runtime_agent()), and the Codex
+# harness cannot stand in because Codex 0.146 dropped `wire_api = "chat"`
+# ("no longer supported; set wire_api = \"responses\"") while Nous Portal serves
+# only chat-completions. Both blockers are fixed upstream in
+# alexhawat/mergeCraft#79 (closes #57 and #71): the image now installs
+# `opencode-ai`, and the harness registers a custom OpenAI-compatible provider
+# from MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + MERGECRAFT_CUSTOM_PROVIDER_API_KEY.
+# The provider id comes from the model prefix, so `nous/deepseek/deepseek-v4-flash`
+# registers provider `nous` serving `deepseek/deepseek-v4-flash`.
+#
+# mergeCraft reads the native GITHUB_EVENT_PATH, so the workflow just passes a
+# prompt — no ~mergecraft JSON payload needed.
+#
+# Auth (same-repo only — forks skip):
+# - NOUS_API_KEY — Nous Portal API key — primary (DeepSeek V4 Flash)
+# - CODEX_AUTH_JSON — ChatGPT/Codex subscription (`mergecraft auth codex`) — fallback
+# - OPENAI_API_KEY — OpenAI API key (same Codex harness as CODEX_AUTH_JSON)
+# The job skips gracefully when none are set (e.g. fork PRs). Without
+# NOUS_API_KEY the primary is inert and Codex is the only reviewer; without
+# CODEX_AUTH_JSON / OPENAI_API_KEY, Nous is the only reviewer.
+#
+# Trigger: pull_request_target (not pull_request). GitHub skips pull_request
+# workflows when refs/pull/N/merge cannot be built (merge conflicts), which
+# leaves ruleset require-mergecraft-review with a permanently missing check.
+# pull_request_target always fires on synchronize even with merge conflicts.
+#
+# Workflow resolution (GitHub Nov 2025 policy, effective 2025-12-08): pull_request_target
+# definitions are read from the repository default branch (`main`), not the PR base.
+# Therefore a PR that edits this file cannot review itself with its own changes;
+# they take effect on the next PR after merge.
+#
+# The bootstrap `pull_request` trigger has been removed: running BOTH triggers made
+# each synchronize fire two runs that resolved to the SAME concurrency group (see
+# below) — with cancel-in-progress they cancelled each other, and a cancelled
+# `mergecraft review` is a non-success on the required check. Do not re-add it.
+#
+# Same-repo guard below keeps fork PRs from receiving secrets (prior pull_request
+# behavior). mergeCraft uses checkout_pr + API with push/shell disabled — no
+# PR-controlled scripts run in CI.
+#
+# Merge gate: ruleset `require-mergecraft-review` requires the **mergeCraft
+# review** job check only — not the raw `mergecraft` completion check (which goes
+# red on agent infra failures). The enforce step now fails closed on every
+# non-success `mergecraft-approval` outcome (no fail-open path remains).
+#
+# === ACTION PIN ===
+# The action is pinned to a FULL SHA on both review steps. This is MANDATORY,
+# not a preference: enforcement expects every `uses:` ref for third-party
+# actions to resolve to a full-length commit SHA. A branch ref like
+# `@pre-0.0.1` is rejected at action-resolution time before the review step
+# runs. When bumping the action in this repo, mirror the change to the
+# corresponding step in the sevn-side workflow so the two stay in sync. If a
+# future `MERGECRAFT_REF` parity rule is added to this repo's Makefile
+# (modelled on sevn's `make mergecraft-ref-check`), bump the action SHA and
+# `MERGECRAFT_REF` together there — a one-sided bump in this file is
+# invisible to that gate.
+# 2026-08-07: rolled back from 88c6f419 to 8d747f39 — Codex stdin hang regression. See PR #246.
+name: mergecraft
+
+on:
+  pull_request_target:
+    # `pre-*` glob keeps every release-staging branch (pre-0.0.1, pre-0.0.2, …)
+    # auto-reviewed without editing this list each cut (matches the old
+    # .coderabbit.yaml `pre-.*` coverage).
+    branches: [main, develop, test-pre, "pre-*"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent (workflow_dispatch only)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  # Post inline PR review + comments.
+  pull-requests: write
+  issues: write
+  # Post mergecraft / mergecraft-approval check-runs.
+  checks: write
+  statuses: write
+  # mergeCraft can mint short-lived tokens via OIDC when configured.
+  id-token: write
+
+concurrency:
+  # pull_request_target resolves github.ref to the default branch; key on PR number
+  # so concurrent reviews do not cancel each other (GitHub Nov 2025 policy).
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Hold the review until mergeCraft's own CI has finished on the PR head SHA, so the
+  # reviewer can read real lint/typecheck/test outcomes instead of guessing.
+  # `needs:` cannot reference another workflow file, so this polls the check-runs
+  # API for ci.yml's `Verify (…)` jobs.
+  #
+  # ALWAYS fail-open (`exit 0` on every path): mergecraft review is a required
+  # check, so a wait that could fail would convert a slow or absent CI run into a
+  # permanent merge block. Timing out just means the review proceeds without CI
+  # context, which is the pre-existing behavior.
+  wait-for-ci:
+    name: mergecraft wait for CI
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      # complete | timeout | absent | skipped
+      state: ${{ steps.wait.outputs.state || 'skipped' }}
+      failed_count: ${{ steps.wait.outputs.failed_count || '0' }}
+      failed_names: ${{ steps.wait.outputs.failed_names || '' }}
+      check_suite_id: ${{ steps.wait.outputs.check_suite_id || '' }}
+    steps:
+      - name: Wait for CI checks on the PR head SHA
+        id: wait
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Total budget. ci.yml runs ~12-15 min; 20 leaves headroom without
+          # pinning a runner for the job's full 25.
+          WAIT_BUDGET_SECONDS: "1200"
+          # If no Verify job has even appeared by then, assume CI is not running
+          # for this PR and stop waiting.
+          APPEAR_BUDGET_SECONDS: "300"
+        run: |
+          set -uo pipefail
+          # Selector for ci.yml's jobs — all of them are named "Verify (…)".
+          jq_verify='[.check_runs[]? | select(.name | startswith("Verify ("))]'
+          started="$(date +%s)"
+          state="timeout"
+          failed_count=0
+          failed_names=""
+          check_suite_id=""
+
+          while :; do
+            now="$(date +%s)"
+            elapsed=$(( now - started ))
+
+            if runs="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null)"; then
+              total="$(printf '%s' "${runs}" | jq "${jq_verify} | length")"
+              pending="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.status != \"completed\")) | length")"
+
+              if [ "${total}" -gt 0 ] && [ "${pending}" -eq 0 ]; then
+                state="complete"
+                failed_count="$(printf '%s' "${runs}" | jq "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\")) | length")"
+                failed_names="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .name) | join(\", \")")"
+                # Any failing Verify job carries the check_suite id the reviewer
+                # needs for get_check_suite_logs().
+                check_suite_id="$(printf '%s' "${runs}" | jq -r "${jq_verify} | map(select(.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\") | .check_suite.id) | first // \"\"")"
+                break
+              fi
+
+              if [ "${total}" -eq 0 ] && [ "${elapsed}" -ge "${APPEAR_BUDGET_SECONDS}" ]; then
+                state="absent"
+                break
+              fi
+            else
+              echo "check-runs query failed (elapsed ${elapsed}s) — retrying" >&2
+            fi
+
+            if [ "${elapsed}" -ge "${WAIT_BUDGET_SECONDS}" ]; then
+              state="timeout"
+              break
+            fi
+            sleep 20
+          done
+
+          {
+            echo "state=${state}"
+            echo "failed_count=${failed_count}"
+            echo "failed_names=${failed_names}"
+            echo "check_suite_id=${check_suite_id}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "CI wait finished: state=${state} failed=${failed_count} suite=${check_suite_id:-none}"
+          case "${state}" in
+            timeout) echo "::notice title=mergecraft CI wait::CI did not finish within ${WAIT_BUDGET_SECONDS}s — reviewing without CI context." ;;
+            absent) echo "::notice title=mergecraft CI wait::No Verify checks appeared for ${HEAD_SHA} — reviewing without CI context." ;;
+          esac
+          exit 0
+
+  review:
+    name: mergecraft review
+    needs: wait-for-ci
+    # `always()` keeps the required check reporting even if the (fail-open) wait
+    # job errors out on a runner fault; a skipped wait job still skips the review,
+    # because the draft/dispatch condition below is the same one it uses.
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+      # Nous/DeepSeek primary; Codex fallback when Nous auth is absent or the
+      # Nous review does not post a mergecraft-approval verdict.
+      HAS_CODEX: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      HAS_NOUS: ${{ secrets.NOUS_API_KEY != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          # Persist the checkout token so the mergeCraft action's own git layer
+          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
+          # fail and the action marks its `mergecraft` self-status check red even
+          # though the review completes via the GitHub API. Read-only escalation
+          # only: the action already sets ``push: disabled`` / ``shell: disabled``
+          # below, so a persisted token cannot be used to push.
+          persist-credentials: true
+
+      - name: Ensure PR base ref exists locally
+        if: github.event_name == 'pull_request_target'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags origin "${base}:refs/remotes/origin/${base}"
+          # pull_request_target checks out the default branch (`main`). When the
+          # PR targets `main`, `git branch -f main …` fails because that branch
+          # is the active worktree — origin/main is already fetched above.
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${base}" ]; then
+            git branch -f "${base}" "origin/${base}"
+          fi
+
+      - name: Skip when provider auth is not configured
+        if: env.HAS_AUTH != 'true'
+        run: |
+          if [ "${{ env.IS_SAME_REPO }}" != "true" ]; then
+            echo "::notice title=mergecraft skipped::Fork PR — review skipped (same as before)."
+          else
+            echo '::notice title=mergecraft skipped::Configure CODEX_AUTH_JSON (`mergecraft auth codex`), OPENAI_API_KEY, or NOUS_API_KEY to enable mergeCraft reviews.'
+          fi
+
+      # Composed in a step rather than inline in `with:` so the CI-context clause
+      # stays readable. Every interpolated value is repo-controlled (PR number,
+      # base ref, our own wait-job outputs) — no PR-authored free text reaches the
+      # prompt.
+      - name: Compose review prompt
+        id: prompt
+        if: env.HAS_AUTH == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PROMPT: ${{ inputs.prompt }}
+          CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
+          CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
+          CI_FAILED_NAMES: ${{ needs.wait-for-ci.outputs.failed_names }}
+          CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
+            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          else
+            # Codex presents mergeCraft MCP tools as mergecraft_. Naming the
+            # bare tool (checkout_pr) makes Codex request a GitHub *plugin* that is
+            # never installed in the Action image, then abort with
+            # mergecraft-approval=neutral (alexhawat/mergeCraft#40).
+            text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
+            # The Action runs with `shell: disabled`, so the reviewer cannot run
+            # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
+            # check_suite id, because no MCP tool can discover one.
+            case "${CI_STATE}" in
+              complete)
+                if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then
+                  text="${text} CI has finished on this head commit and ${CI_FAILED_COUNT} job(s) FAILED (${CI_FAILED_NAMES}). Call mergecraft_get_check_suite_logs with check_suite_id ${CI_CHECK_SUITE_ID} and ground your review in those failures — report the underlying defect, not the log line."
+                else
+                  text="${text} CI has finished green on this head commit, so lint, typecheck, and the full test suite already pass; do not speculate about mechanical failures those gates would have caught, and spend the review on logic, design, and missing coverage."
+                fi
+                ;;
+              *)
+                text="${text} CI results are NOT available for this head commit (wait state: ${CI_STATE}), so no lint/typecheck/test signal informs this review. Do not assert that the change passes or fails those gates."
+                ;;
+            esac
+          fi
+          {
+            echo "text<<MERGECRAFT_PROMPT_EOF"
+            echo "${text}"
+            echo "MERGECRAFT_PROMPT_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Record mergecraft-approval baseline before the Nous review
+        id: approval_baseline
+        # The fallback below must judge THIS Nous attempt, not a verdict an
+        # earlier run left on the same head SHA (a re-run, or the enforce step's
+        # own retry loop). Capturing the newest check-run id first makes "did
+        # Nous post a verdict?" answerable by identity rather than by recency.
+        if: >-
+          env.HAS_NOUS == 'true' &&
+          env.HAS_CODEX == 'true' &&
+          github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          id=""
+          for attempt in $(seq 1 3); do
+            if id="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+              | sort_by(.completed_at // .started_at) | last | .id // ""')"; then
+              break
+            fi
+            echo "check-runs baseline query failed (attempt ${attempt}/3); retrying in 3s…" >&2
+            sleep 3
+          done
+          echo "baseline mergecraft-approval check-run: ${id:-none}"
+          echo "id=${id}" >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review (Nous DeepSeek V4 Flash)
+        if: env.HAS_NOUS == 'true'
+        id: mergecraft_nous
+        continue-on-error: true
+        # 2026-08-07: rolled back from 88c6f419 to 8d747f39 — Codex stdin hang regression. See PR #246.
+        uses: alexhawat/mergeCraft@8d747f39d3d36d889e0a85c2dcf691d1bdb91536 # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: 25m
+          # Provider prefix `nous/` selects the opencode harness and names the
+          # provider registered from the MERGECRAFT_CUSTOM_PROVIDER_* env vars.
+          model: nous/deepseek/deepseek-v4-flash
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+        env:
+          MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
+          MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
+
+      - name: Decide Codex fallback after Nous
+        id: fallback
+        # Deliberately NOT gated on steps.mergecraft_nous.outcome. The failure
+        # this fallback exists for — mergecraft-approval=neutral, the MCP
+        # handshake symptom — leaves the action exiting 0 while posting no
+        # usable verdict. Gating on a non-success outcome would skip the
+        # fallback in exactly that case and hand the enforce step a
+        # fail-closed no-verdict. Route on the verdict itself instead.
+        if: >-
+          env.HAS_NOUS == 'true' &&
+          env.HAS_CODEX == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASELINE_ID: ${{ steps.approval_baseline.outputs.id }}
+          NOUS_OUTCOME: ${{ steps.mergecraft_nous.outcome }}
+        run: |
+          set -euo pipefail
+          need="false"
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            latest=""
+            for attempt in $(seq 1 3); do
+              if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+                | sort_by(.completed_at // .started_at) | last
+                | "\(.id // "")|\(.conclusion // "")"')"; then
+                break
+              fi
+              echo "check-runs query failed (attempt ${attempt}/3); retrying in 3s…" >&2
+              sleep 3
+            done
+            id="${latest%%|*}"
+            conclusion="${latest#*|}"
+            # A verdict only counts when the check-run is NOT the one that was
+            # already there before this Nous attempt ran.
+            if [ -n "${id}" ] && [ "${id}" = "${BASELINE_ID}" ]; then
+              echo "mergecraft-approval ${id} predates this Nous attempt — treating as no verdict."
+              conclusion=""
+            fi
+            case "${conclusion}" in
+              failure|success)
+                echo "mergecraft-approval=${conclusion} — Nous review posted a verdict; not falling back to Codex."
+                ;;
+              *)
+                need="true"
+                echo "::notice title=mergecraft Codex fallback::Nous review posted no verdict (action outcome: ${NOUS_OUTCOME}); retrying with openai/gpt-codex."
+                ;;
+            esac
+          elif [ "${NOUS_OUTCOME}" != "success" ]; then
+            need="true"
+            echo "::notice title=mergecraft Codex fallback::Nous review failed; retrying with openai/gpt-codex."
+          fi
+          echo "need=${need}" >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review (Codex)
+        if: >-
+          env.HAS_CODEX == 'true' &&
+          (
+            env.HAS_NOUS != 'true' ||
+            steps.fallback.outputs.need == 'true'
+          )
+        id: mergecraft_codex
+        continue-on-error: true
+        # mergeCraft — full SHA pinned to the alexhawat/mergeCraft `pre-0.0.1` head.
+        # The pin is MANDATORY, not a preference: a branch ref like `@pre-0.0.1`
+        # is rejected at action-resolution time before the review step runs.
+        # Bump this SHA and the corresponding step in the sevn-side workflow
+        # together; if a future `MERGECRAFT_REF` parity rule is added to this
+        # repo's Makefile, bump that var in unison.
+        # 2026-08-07: rolled back from 88c6f419 to 8d747f39 — Codex stdin hang regression. See PR #246.
+        uses: alexhawat/mergeCraft@8d747f39d3d36d889e0a85c2dcf691d1bdb91536 # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
+          # first, the action never posts its `mergecraft` completion check and the
+          # only diagnostic is lost. Leaving 5 min of headroom lets it exit
+          # cleanly and report failure instead.
+          timeout: 25m
+          model: openai/gpt-codex
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: mergeCraft review incomplete (non-fatal)
+        if: >-
+          env.HAS_AUTH == 'true' &&
+          (
+            (
+              env.HAS_NOUS == 'true' &&
+              steps.mergecraft_nous.outcome != 'success' &&
+              steps.fallback.outputs.need != 'true'
+            ) ||
+            (
+              env.HAS_NOUS == 'true' &&
+              steps.fallback.outputs.need == 'true' &&
+              steps.mergecraft_codex.outcome != 'success'
+            ) ||
+            (
+              env.HAS_NOUS != 'true' &&
+              steps.mergecraft_codex.outcome != 'success'
+            )
+          )
+        run: |
+          echo "::notice title=mergecraft incomplete::Review step did not finish successfully (see its log — e.g. provider session limit or a runtime error). Approval enforcement below will fail closed on this."
+
+      - name: Fail when mergeCraft would not approve
+        # Gate directly on the `mergecraft-approval` check-run, decoupled from the
+        # review step's own exit code (which can be non-zero on a benign output
+        # hiccup even when the review + approval check posted fine). Runs on every
+        # PR where auth is present.
+        #
+        # FAIL CLOSED on every non-success outcome. PR #194 showed the review can
+        # fail outright (there, a bwrap sandbox namespace failure), posting no
+        # `mergecraft-approval` check at all — the prior version treated that
+        # ("no check posted") and a check-runs API
+        # outage identically as fail-open, so a PR could merge with zero review
+        # signal and nothing visibly red. The only passing outcome now is a
+        # definitive conclusion=success: a review that actually ran and approved.
+        # Retries below only smooth over a single transient API blip; once
+        # retries are exhausted without success, this step exits 1.
+        if: >-
+          github.event_name == 'pull_request_target' &&
+          env.HAS_AUTH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # The action posts a `mergecraft-approval` check-run on the PR head SHA:
+          # conclusion=success => no outstanding feedback; anything else (failure,
+          # no check posted at all, or the query itself failing after retries)
+          # means the review was never confirmed successful, so none of those
+          # paths may pass this gate.
+          conclusion=""; queried=""
+          for attempt in $(seq 1 5); do
+            if conclusion="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+              | sort_by(.completed_at // .started_at) | last | .conclusion // ""')"; then
+              queried="yes"; break
+            fi
+            echo "check-runs query failed (attempt ${attempt}/5); retrying in 5s…" >&2
+            sleep 5
+          done
+          if [ -z "${queried}" ]; then
+            # FAIL CLOSED: an unreachable check-runs API after retries is not
+            # evidence a review ran and approved, so it cannot pass the gate.
+            # This deliberately accepts that a sustained GitHub API outage blocks
+            # merges on gated branches until the query succeeds (or someone
+            # re-runs the job) — "the review actually ran and approved" is the
+            # only condition that may pass, full stop.
+            echo "::error title=mergecraft approval unknown::Could not query check-runs for ${HEAD_SHA} after retries — cannot confirm mergecraft-approval. Failing closed."
+            exit 1
+          fi
+          case "${conclusion}" in
+            success)
+              echo "mergecraft approval: no outstanding review feedback."
+              ;;
+            failure)
+              echo "::error title=mergecraft requested changes::mergecraft-approval check failed — address the review feedback on this PR."
+              exit 1
+              ;;
+            *)
+              # No mergecraft-approval check at all: the review failed to produce
+              # any verdict — e.g. PR #194, where a Codex sandbox crash left zero
+              # review signal. Fail closed rather than merge unreviewed.
+              echo "::error title=mergecraft review incomplete::No mergecraft-approval check on ${HEAD_SHA} — the review did not complete (see the review job's logs). Failing closed: this gate only passes once mergeCraft has actually reviewed and approved."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary
- Mirror the mergeCraft review workflow from `sevn-bot/sevn@main` into this repo. Cascade: **Nous/DeepSeek V4 Flash primary** via the opencode harness with a custom OpenAI-compatible provider; **OpenAI/Codex fallback** when Nous is absent or its review posts no `mergecraft-approval` verdict; Claude is not used. Fail-closed `mergecraft-approval` check-run gate is preserved.
- Update `.env.example` to expose the same env-var surface (`NOUS_API_KEY`, `CODEX_AUTH_JSON`, `MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`, `MERGECRAFT_CUSTOM_PROVIDER_API_KEY`) and flip the default `MERGECRAFT_MODEL` to match the workflow primary.
- Action pinned to **`8d747f39d3d36d889e0a85c2dcf691d1bdb91536`** (full SHA) on both review steps. Sevn rolled back from `88c6f419` to `8d747f3` over a Codex stdin hang regression; this repo's `pre-0.0.1` head is now `bd39bfe` (one commit past the `fdb41be`/chore-sync merge), but the action pin is unchanged. Bump the pin in this file and `MERGECRAFT_REF` in the Makefile together if/when a parity rule is added.

## Notes for reviewers
- This is the **mergeCraft repo's own consumer-side workflow**; the `sevn-bot/sevn` copy is the one that actually runs. A top comment in the new file makes that explicit.
- Sevn-specific paragraphs about `make mergecraft-ref-check` / `MERGECRAFT_REF` / the 3-way mirror are removed (they do not apply here). The SHA-pinning comment is preserved because it is independently load-bearing.

## Validation
- `make ci-static` green in the worktree
- `make lint`, `make typecheck`, `make catalog-check` clean
- YAML parse sanity check pass
- `gh secret set` not run by this PR; secrets are operator-managed (see `mergecraft auth codex` for the Codex path)

## Test plan
- [ ] Reviewers: confirm the action pin and the Nous/Codex cascade shape against the sevn source
- [ ] After merge, configure the three optional Actions secrets on this repo (`NOUS_API_KEY`, `CODEX_AUTH_JSON`, `OPENAI_API_KEY`) to exercise the cascade
- [ ] Open a draft PR on a test branch and verify the wait-for-ci → Nous review → Codex fallback → fail-closed gate path

🤖 Generated with mergeCraft (in the next CI run, anyway)

Made with [Cursor](https://cursor.com)