### PR TITLE
feat: add meat_python_plus and TokenHub/Nous providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,16 @@
 # ---------------------------------------------------------------------------
 
 # Nous Portal — primary reviewer in the workflow (DeepSeek V4 Flash).
-# Get one at https://portal.nousresearch.com. The workflow reads this only
-# as MERGECRAFT_CUSTOM_PROVIDER_API_KEY on the Nous step.
+# Get one at https://portal.nousresearch.com. Locally / in the Action,
+# `NOUS_API_KEY` alone is enough for `nous/…` models (opencode harness).
+# The workflow may still pass MERGECRAFT_CUSTOM_PROVIDER_* on the Nous step.
 NOUS_API_KEY=
+
+# Tencent TokenHub — Hy3 and any TokenHub model id as `tokenhub/<id>`.
+# Console: https://www.tencentcloud.com/act/pro/tokenhub
+# Default base: https://tokenhub-intl.tencentcloudmaas.com/v1
+TOKENHUB_API_KEY=
+# TOKENHUB_BASE_URL=
 
 # Codex / OpenAI — fallback when NOUS_API_KEY is absent or the Nous review
 # posts no verdict. CODEX_AUTH_JSON is the ChatGPT/Codex subscription token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- First-class **Nous Portal** and **Tencent TokenHub** providers in the CLI and
+  Action. `mergecraft auth nous` / `mergecraft auth tokenhub` store
+  `NOUS_API_KEY` / `TOKENHUB_API_KEY`; models `nous/…` and `tokenhub/…`
+  (including `tokenhub/hy3` and any TokenHub model id) auto-wire the opencode
+  OpenAI-compatible harness without requiring `MERGECRAFT_CUSTOM_PROVIDER_*`.
+  Explicit custom-provider env vars still override the named presets
+- `meat_python_plus/` — Python port of [boldsoftware/meat](https://github.com/boldsoftware/meat)
+  with OpenAI, Anthropic, Nous, and TokenHub (Hy3+) providers; CLI entry
+  points `meat-py` / `meat_python_plus`
+
 - Meat reading-diff harness prototype (#60 spike). `src/mergecraft/utils/meat_harness.py`
   ships `run_meat_harness(...)` — a typed, pure-boundary entry point that takes
   a unified diff, invokes `meat -json` as a subprocess with a bounded timeout,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ the provider you configure. You can authenticate either with a **subscription**
 | OpenAI Codex | `mergecraft auth codex` → saves `CODEX_AUTH_JSON` from `codex login --device-auth` (ChatGPT Plus/Pro/Team/Enterprise) | `OPENAI_API_KEY` secret |
 | Google Gemini | `mergecraft auth gemini` → saves `GEMINI_API_KEY` from a pasted AI Studio key | `GEMINI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` secret |
 | Cursor Cloud | `mergecraft auth cursor` → saves `CURSOR_API_KEY` from a pasted Cursor API key | `CURSOR_API_KEY` secret |
+| Nous Portal | — (API key) | `mergecraft auth nous` → saves `NOUS_API_KEY` |
+| Tencent TokenHub | — (API key) | `mergecraft auth tokenhub` → saves `TOKENHUB_API_KEY` (Hy3 and any TokenHub model) |
 
 Using a subscription means the GitHub Action authenticates as *you* through the
 official `claude` / `codex` CLIs — the same credential your local coding agent
@@ -147,6 +149,39 @@ env:
   CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
 ```
 
+**Nous Portal example** — set `NOUS_API_KEY` and use a `nous/…` model (opencode
+harness; no `MERGECRAFT_CUSTOM_PROVIDER_*` required):
+
+```yaml
+# .mergecraft/config.yaml
+model: nous/deepseek/deepseek-v4-flash
+```
+
+```yaml
+env:
+  NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}
+```
+
+**TokenHub (Hy3 and any TokenHub model)** — set `TOKENHUB_API_KEY` and use
+`tokenhub/<model-id>` (e.g. `tokenhub/hy3`, `tokenhub/deepseek-v4-flash`):
+
+```yaml
+# .mergecraft/config.yaml
+model: tokenhub/hy3
+```
+
+```yaml
+env:
+  TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}
+  # optional override:
+  # TOKENHUB_BASE_URL: https://tokenhub-intl.tencentcloudmaas.com/v1
+```
+
+Operators can still set `MERGECRAFT_CUSTOM_PROVIDER_BASE_URL` +
+`MERGECRAFT_CUSTOM_PROVIDER_API_KEY` to point any `provider/model` prefix at a
+generic OpenAI-compatible endpoint; those env vars override the Nous/TokenHub
+presets when both are present.
+
 ### Consumer workflow
 
 ```yaml
@@ -184,6 +219,10 @@ jobs:
           # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}                 # + model: google/gemini-3.1-pro-preview
           # Cursor Cloud — API key (mergecraft auth cursor; local CLI deferred):
           # CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}                 # + model: cursor/cloud-agent
+          # Nous Portal — API key (mergecraft auth nous):
+          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}                     # + model: nous/deepseek/deepseek-v4-flash
+          # TokenHub — API key (mergecraft auth tokenhub; hy3 + any TokenHub model):
+          # TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}             # + model: tokenhub/hy3
 ```
 
 Ready-made workflow files live under [`examples/workflows/`](examples/workflows/):
@@ -390,6 +429,8 @@ Inspect what was seeded into a given run with `mergecraft learnings influence --
 | `mergecraft auth codex` | Save a ChatGPT subscription credential (`CODEX_AUTH_JSON`) via `gh secret set` |
 | `mergecraft auth gemini` | Save a Gemini API key (`GEMINI_API_KEY`) via `gh secret set` |
 | `mergecraft auth cursor` | Save a Cursor Cloud API key (`CURSOR_API_KEY`) via `gh secret set` |
+| `mergecraft auth nous` | Save a Nous Portal API key (`NOUS_API_KEY`) via `gh secret set` |
+| `mergecraft auth tokenhub` | Save a TokenHub API key (`TOKENHUB_API_KEY`) via `gh secret set` |
 | `mergecraft models list` | List curated model slugs and whether local credentials are detected |
 | `mergecraft models set <slug> [<slug>…]` | Write an ordered `models:` preference list to `.mergecraft/config.yaml` |
 | `mergecraft models show` | Show effective model order (config + `MERGECRAFT_MODEL`) and which slug would win now |

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,11 @@ inputs:
     description: "Maximum run duration (e.g., 10m, 1h30m). Default: 1h"
     required: false
   model:
-    description: "Model to use — a curated slug (e.g. anthropic/claude-opus) or a raw models.dev specifier. Overrides repo settings."
+    description: >-
+      Model to use — a curated slug (e.g. anthropic/claude-opus, tokenhub/hy3,
+      nous/deepseek/deepseek-v4-flash) or a raw models.dev specifier. Overrides
+      repo settings. OpenAI-compatible gateways: set NOUS_API_KEY or
+      TOKENHUB_API_KEY (or MERGECRAFT_CUSTOM_PROVIDER_*).
     required: false
   cwd:
     description: "Working directory for the agent (defaults to GITHUB_WORKSPACE)"

--- a/examples/workflows/mergecraft.yml
+++ b/examples/workflows/mergecraft.yml
@@ -57,3 +57,5 @@ jobs:
           # CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/deepseek/deepseek-v4-flash
+          # TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}   # + model: tokenhub/hy3

--- a/meat_python_plus/.gitignore
+++ b/meat_python_plus/.gitignore
@@ -1,0 +1,10 @@
+.pytest_cache/
+__pycache__/
+*.egg-info/
+.venv/
+dist/
+build/
+
+.venv/
+.pytest_cache/
+__pycache__/

--- a/meat_python_plus/README.md
+++ b/meat_python_plus/README.md
@@ -1,0 +1,99 @@
+# meat_python_plus
+
+Python reimplementation of [boldsoftware/meat](https://github.com/boldsoftware/meat): abridge a unified diff into a **reading diff** for senior review. The model submits a remove/replace/fold **edit plan**; meat applies it mechanically to the immutable original — the model never authors the final diff text wholesale.
+
+This “plus” port adds OpenAI-compatible providers used by mergeCraft: **Nous**, **TokenHub (Tencent)**, plus OpenAI, Anthropic, and custom bases.
+
+## Install
+
+```bash
+cd meat_python_plus
+uv pip install -e .
+# or: pip install -e .
+# optional: uv pip install -e ".[dev]"
+```
+
+Entry points:
+
+```bash
+meat-py -h
+meat_python_plus -h
+python -m meat_python_plus -h
+```
+
+## Usage (same UX as Go `meat`)
+
+```bash
+meat-py                         # HEAD
+meat-py abc123                  # one revision
+meat-py main...HEAD             # range
+meat-py -staged                 # git diff --staged
+meat-py -w                      # git diff (worktree)
+git show | meat-py              # stdin
+meat-py -model hy3 -json
+meat-py -no-cache
+```
+
+## Authentication
+
+| Provider | Env | Base URL | Example models |
+|----------|-----|----------|----------------|
+| **Nous** | `NOUS_API_KEY` | `https://inference-api.nousresearch.com/v1` | `nous/deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash` |
+| **TokenHub** (Tencent) | `TOKENHUB_API_KEY` | `https://tokenhub-intl.tencentcloudmaas.com/v1` | `hy3`, `tokenhub/hy3`, `deepseek-v4-flash` |
+| **OpenAI** | `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL`) | `https://api.openai.com/v1` | `gpt-4.1-mini`, … |
+| **Anthropic** | `ANTHROPIC_API_KEY` (+ optional `ANTHROPIC_BASE_URL`) | Messages API | `claude-*` |
+| **Custom** | `MEAT_BASE_URL` + `MEAT_API_KEY` (or `OPENAI_API_KEY`) | your `/v1` | any chat-completions id |
+
+Also: `MEAT_MODEL` (default model), `MEAT_CACHE` (default `~/.meat_python_plus`; empty disables).
+
+**Codex subscription is not supported.** `CODEX_AUTH_JSON` alone is not a chat API key — set `OPENAI_API_KEY`, `NOUS_API_KEY`, or `TOKENHUB_API_KEY` instead.
+
+### TokenHub `hy3` example
+
+```bash
+export TOKENHUB_API_KEY=...
+export MEAT_MODEL=hy3
+meat-py -model hy3
+# or:
+meat-py -model tokenhub/hy3 HEAD~1
+```
+
+### Nous DeepSeek example
+
+```bash
+export NOUS_API_KEY=...
+meat-py -model nous/deepseek/deepseek-v4-flash
+```
+
+## How it works
+
+1. Number the unified diff with a display-only `N|line` gutter.
+2. Agent loop with tools: `preview_plan`, `submit`, and (in a git repo) `read_file` / `grep`.
+3. Compile the edit plan (ranges, `...`/`…` elision projection, same-marker folds, structure retention).
+4. Cache by hash of `(protocol version + system prompt + model + diff)`.
+5. Chunk oversized diffs (~400KB+) at file/hunk boundaries; hard-fail over 4MB.
+
+System prompt is copied from Go meat’s `rubric.go` `systemPrompt`.
+
+## Tests
+
+```bash
+cd meat_python_plus
+uv run pytest tests -q
+```
+
+All tests are offline (no network).
+
+## Intentional simplifications vs Go meat
+
+| Area | Go meat | This port (v1) |
+|------|---------|----------------|
+| HTTP | OpenAI Responses + Anthropic Messages | Chat Completions (tools) + Anthropic Messages |
+| Import auto-removal | Full `imports.go` (multiline, embedded fixtures, language suites) | Heuristic for common `import` / `from` / `use` / `#include` / `require` / Go `import (` blocks |
+| Move detection | Exact cross-hunk pairing + symmetry enforcement | Stub (no detection / no symmetry checks) |
+| Python suite validators | Full `python.go` skeleton / delimiter / reference rules | Not enforced (prompt still teaches them) |
+| Chunking | Rich splitter with move remapping + import pre-hide | File then hunk split; no mid-hunk synthesis |
+| Rubric hash | Full frozen prompt-surface hash | Protocol version + system prompt |
+| Pager / color | git pager + color.diff | Plain stdout (JSON or text) |
+
+Prefer protocol correctness (edit plan → mechanical render) over perfect Go parity on language-specific rules.

--- a/meat_python_plus/pyproject.toml
+++ b/meat_python_plus/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "meat-python-plus"
+version = "0.1.0"
+description = "Python reimplementation of boldsoftware/meat — abridge unified diffs into reading diffs, with Nous/TokenHub/OpenAI/Anthropic providers."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[project.scripts]
+meat-py = "meat_python_plus.cli:main"
+meat_python_plus = "meat_python_plus.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/meat_python_plus"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src/meat_python_plus" = "meat_python_plus"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/meat_python_plus/src/meat_python_plus/__init__.py
+++ b/meat_python_plus/src/meat_python_plus/__init__.py
@@ -1,0 +1,17 @@
+"""meat_python_plus — abridge a unified diff into a reading diff."""
+
+from meat_python_plus.abridge import Result, abridge
+from meat_python_plus.model import Block, Message, Model, Response, Role, Tool
+
+__all__ = [
+    "Block",
+    "Message",
+    "Model",
+    "Response",
+    "Result",
+    "Role",
+    "Tool",
+    "abridge",
+]
+
+__version__ = "0.1.0"

--- a/meat_python_plus/src/meat_python_plus/__main__.py
+++ b/meat_python_plus/src/meat_python_plus/__main__.py
@@ -1,0 +1,5 @@
+"""python -m meat_python_plus"""
+
+from meat_python_plus.cli import main
+
+raise SystemExit(main())

--- a/meat_python_plus/src/meat_python_plus/abridge.py
+++ b/meat_python_plus/src/meat_python_plus/abridge.py
@@ -1,0 +1,227 @@
+"""Agent loop: number the diff, call tools, apply edit plans mechanically."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from meat_python_plus.chunk import (
+    MAX_TOTAL_DIFF_BYTES,
+    fits_single_run,
+    split_diff_for_abridging,
+)
+from meat_python_plus.diffutil import numbered_diff, validate_supported_diff
+from meat_python_plus.editplan import retention_pressure
+from meat_python_plus.model import Block, Message, Model, Role, text_block
+from meat_python_plus.rubric import SYSTEM_PROMPT
+from meat_python_plus.tools import Toolbox, describe_tool_call
+
+DEFAULT_MAX_TURNS = 24
+
+NO_TOOL_CALL_NUDGE = (
+    "Call preview_plan or submit with a complete remove/replace/fold plan against "
+    "the numbered ORIGINAL diff. Prefer removals and fixed multiline folds; use "
+    "replace only for a local single-line elision. If nothing meaningful changed, "
+    "remove every original line."
+)
+
+USER_PROMPT_INTRO = (
+    "Abridge the following unified diff into a reading diff by submitting a complete "
+    "remove/replace/fold plan against the numbered original lines. Meat applies your "
+    "plan to the original diff; you do not write the resulting diff yourself. "
+    "Coordinates are 1-based and always refer to the original numbering. The `N|` "
+    "gutter is display-only and is not part of a line's source text. Use preview_plan "
+    "to inspect sizeable drafts before submit.\n"
+)
+USER_PROMPT_IMPORTS = (
+    "Imports/includes/requires/use declarations are removed automatically, including "
+    "multiline blocks and recognized imports inside embedded source strings. They may "
+    "appear in the numbered input but never in a preview or result. Do not spend edit "
+    "coordinates on them, never fold across them into behavioral rows, and do not "
+    "mention them in the summary.\n"
+)
+USER_PROMPT_TOOLS = (
+    "Use read_file/grep on the surrounding source only when it changes your judgment "
+    "about what is load-bearing (or whether a file is generated), then preview or submit.\n"
+)
+USER_PROMPT_NO_TOOLS = "Judge from the diff text alone, then preview or submit.\n"
+USER_PROMPT_PROTOCOL = (
+    "Prefer removing whole lines or ranges. Use fold to replace two or more contiguous "
+    "same-polarity hunk lines with one machine-generated, indentation-preserving `...` "
+    "row. Use replace only to elide part of one source line; `new` must match all of "
+    "`old` with every omitted span visibly represented by `...` or `…`. Keep useful "
+    "per-file and hunk structure unless the entire file or hunk is noise.\n\n```diff\n"
+)
+
+
+@dataclass
+class Result:
+    smart_diff: str
+    summary: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "smart_diff": self.smart_diff,
+            "summary": self.summary,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Result:
+        return cls(
+            smart_diff=str(data.get("smart_diff") or ""),
+            summary=str(data.get("summary") or ""),
+            input_tokens=int(data.get("input_tokens") or 0),
+            output_tokens=int(data.get("output_tokens") or 0),
+        )
+
+
+@dataclass
+class Request:
+    unified_diff: str
+    repo_root: str = ""
+    max_turns: int = 0
+    progress: Callable[[str], None] | None = None
+
+
+def build_user_prompt(req: Request, numbered: str) -> str:
+    parts = [USER_PROMPT_INTRO, USER_PROMPT_IMPORTS]
+    if req.repo_root:
+        parts.append(USER_PROMPT_TOOLS)
+    else:
+        parts.append(USER_PROMPT_NO_TOOLS)
+    parts.append(USER_PROMPT_PROTOCOL)
+    parts.append(numbered)
+    parts.append("```\n")
+    return "".join(parts)
+
+
+def abridge(model: Model, req: Request) -> Result:
+    if model is None:
+        raise ValueError("meat: nil model")
+    if not req.unified_diff.strip():
+        return Result(smart_diff="", summary="No changes.")
+    raw_bytes = len(req.unified_diff.encode("utf-8"))
+    if raw_bytes > MAX_TOTAL_DIFF_BYTES:
+        raise ValueError(
+            f"meat: diff is {raw_bytes >> 20}MB, over the "
+            f"{MAX_TOTAL_DIFF_BYTES >> 20}MB limit — try a narrower range "
+            "(a single commit, or per-file with `git diff -- <path> | meat`)"
+        )
+    validate_supported_diff(req.unified_diff)
+    if not fits_single_run(req.unified_diff):
+        return _abridge_chunked(model, req)
+    return _abridge_one(model, req)
+
+
+def _abridge_chunked(model: Model, req: Request) -> Result:
+    progress = req.progress or (lambda _m: None)
+    chunks = split_diff_for_abridging(req.unified_diff)
+    progress(f"splitting into {len(chunks)} chunks")
+    smart_parts: list[str] = []
+    summaries: list[str] = []
+    in_tok = 0
+    out_tok = 0
+    for i, chunk in enumerate(chunks):
+        progress(f"chunk {i + 1}/{len(chunks)}")
+
+        def chunk_progress(msg: str, _i: int = i) -> None:
+            progress(f"chunk {_i + 1}/{len(chunks)}: {msg}")
+
+        chunk_req = Request(
+            unified_diff=chunk,
+            repo_root=req.repo_root,
+            max_turns=req.max_turns,
+            progress=chunk_progress,
+        )
+        res = _abridge_one(model, chunk_req)
+        if res.smart_diff.strip():
+            smart_parts.append(res.smart_diff)
+        if res.summary.strip():
+            summaries.append(res.summary.strip())
+        in_tok += res.input_tokens
+        out_tok += res.output_tokens
+    summary = "; ".join(summaries) if summaries else "No changes."
+    if len(summary) > 500:
+        summary = summary[:497] + "..."
+    return Result(
+        smart_diff="".join(smart_parts),
+        summary=summary,
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+    )
+
+
+def _abridge_one(model: Model, req: Request) -> Result:
+    numbered = numbered_diff(req.unified_diff)
+    max_turns = req.max_turns if req.max_turns > 0 else DEFAULT_MAX_TURNS
+    tb = Toolbox(root=req.repo_root, raw_diff=req.unified_diff)
+    tools = tb.tools()
+    messages: list[Message] = [
+        Message(role=Role.USER, content=[text_block(build_user_prompt(req, numbered))])
+    ]
+    progress = req.progress or (lambda _m: None)
+    in_tok = 0
+    out_tok = 0
+    retention_nudged = False
+    fallback: Result | None = None
+
+    for turn in range(max_turns):
+        progress(f"thinking (turn {turn + 1})")
+        resp = model.generate(SYSTEM_PROMPT, messages, tools)
+        in_tok += resp.input_tokens
+        out_tok += resp.output_tokens
+        messages.append(Message(role=Role.ASSISTANT, content=list(resp.content)))
+
+        results: list[Block] = []
+        for b in resp.content:
+            if b.type != "tool_use":
+                continue
+            progress(describe_tool_call(b.tool_name, b.tool_input))
+            out, is_err = tb.run(b.tool_name, b.tool_input)
+            results.append(
+                Block(
+                    type="tool_result",
+                    tool_use_id=b.id,
+                    tool_result=out,
+                    tool_error=is_err,
+                )
+            )
+
+        if tb.submit_seen:
+            assert tb.submitted is not None
+            candidate = Result(
+                smart_diff=tb.smart_diff,
+                summary=tb.submitted.summary,
+                input_tokens=in_tok,
+                output_tokens=out_tok,
+            )
+            can_refine = (
+                not retention_nudged
+                and turn + 1 < max_turns
+                and tb.submitted_plan is not None
+                and retention_pressure(tb.submitted_plan.stats)
+            )
+            if can_refine:
+                fallback = candidate
+                retention_nudged = True
+                tb.clear_submission()
+                messages.append(Message(role=Role.USER, content=results))
+                continue
+            return candidate
+
+        if not results:
+            messages.append(
+                Message(role=Role.USER, content=[text_block(NO_TOOL_CALL_NUDGE)])
+            )
+            continue
+        messages.append(Message(role=Role.USER, content=results))
+
+    if fallback is not None:
+        fallback.input_tokens = in_tok
+        fallback.output_tokens = out_tok
+        return fallback
+    raise RuntimeError(f"meat: agent did not submit within {max_turns} turns")

--- a/meat_python_plus/src/meat_python_plus/cache.py
+++ b/meat_python_plus/src/meat_python_plus/cache.py
@@ -1,0 +1,58 @@
+"""Disk cache keyed by (protocol/rubric hash + model + diff)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def default_cache_dir() -> str:
+    if "MEAT_CACHE" in os.environ:
+        return os.environ["MEAT_CACHE"]
+    home = Path.home()
+    return str(home / ".meat_python_plus")
+
+
+def cache_key(diff: str, model: str, rubric: str) -> str:
+    h = hashlib.sha256()
+    h.update(rubric.encode())
+    h.update(b"\0")
+    h.update(model.encode())
+    h.update(b"\0")
+    h.update(diff.encode())
+    return h.hexdigest()
+
+
+def cache_load(dir_path: str, key: str) -> dict[str, Any] | None:
+    if not dir_path:
+        return None
+    path = Path(dir_path) / f"{key}.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def cache_store(dir_path: str, key: str, result: dict[str, Any]) -> None:
+    if not dir_path:
+        return
+    root = Path(dir_path)
+    try:
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        data = json.dumps(result, ensure_ascii=False).encode("utf-8")
+        fd, tmp_name = tempfile.mkstemp(prefix=f"{key}.", suffix=".tmp", dir=str(root))
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+            os.replace(tmp_name, root / f"{key}.json")
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+    except OSError:
+        return

--- a/meat_python_plus/src/meat_python_plus/chunk.py
+++ b/meat_python_plus/src/meat_python_plus/chunk.py
@@ -1,0 +1,95 @@
+"""Simplified large-diff chunking at file / hunk boundaries."""
+
+from __future__ import annotations
+
+from meat_python_plus.diffutil import (
+    DiffLineKind,
+    analyze_diff,
+    numbered_diff,
+    split_source_lines,
+)
+
+MAX_DIFF_BYTES = 400 << 10  # ~400 KB
+MAX_TOTAL_DIFF_BYTES = 4 << 20  # 4 MB
+MAX_CHUNKS = 32
+
+
+def fits_single_run(raw: str, budget: int = MAX_DIFF_BYTES) -> bool:
+    if len(raw.encode("utf-8")) > budget:
+        return False
+    numbered = numbered_diff(raw)
+    return len(numbered.encode("utf-8")) <= budget
+
+
+def split_diff_for_abridging(raw: str, budget: int = MAX_DIFF_BYTES) -> list[str]:
+    """Split at file section boundaries; fall back to hunk boundaries.
+
+    This is a simplified splitter vs Go meat's chunk.go (no move remapping,
+    no mandatory-import pre-hide, no mid-hunk synthesis).
+    """
+    if fits_single_run(raw, budget):
+        return [raw]
+
+    lines = split_source_lines(raw)
+    layout = analyze_diff(lines)
+
+    # File section starts: HEADER or (when no git header) OLD_FILE.
+    section_starts: list[int] = []
+    for i, kind in enumerate(layout.kinds):
+        if kind == DiffLineKind.HEADER:
+            section_starts.append(i)
+        elif kind == DiffLineKind.OLD_FILE and (
+            i == 0 or layout.kinds[i - 1] != DiffLineKind.HEADER
+        ):
+            # Bare ---/+++ file without preceding diff --git already counted via
+            # analyze_diff file_id; still treat OLD_FILE after non-header as start
+            # when no HEADER exists in the whole diff.
+            if not any(k == DiffLineKind.HEADER for k in layout.kinds):
+                section_starts.append(i)
+
+    if not section_starts:
+        section_starts = [0]
+    section_starts = sorted(set(section_starts))
+
+    sections: list[str] = []
+    for idx, start in enumerate(section_starts):
+        end = section_starts[idx + 1] if idx + 1 < len(section_starts) else len(lines)
+        chunk = "".join(line.text + line.eol for line in lines[start:end])
+        if fits_single_run(chunk, budget):
+            sections.append(chunk)
+        else:
+            # Split oversized file at hunk headers.
+            hunk_starts = [
+                i
+                for i in range(start, end)
+                if layout.kinds[i] == DiffLineKind.HUNK_HEADER
+            ]
+            # Metadata prefix before first hunk.
+            meta_end = hunk_starts[0] if hunk_starts else end
+            meta = "".join(line.text + line.eol for line in lines[start:meta_end])
+            if not hunk_starts:
+                # Can't split further; hard-fail if over budget.
+                if not fits_single_run(chunk, budget):
+                    raise ValueError(
+                        f"unable to split file section starting at line {start + 1} "
+                        f"under {budget} bytes"
+                    )
+                sections.append(chunk)
+                continue
+            for hi, hstart in enumerate(hunk_starts):
+                hend = hunk_starts[hi + 1] if hi + 1 < len(hunk_starts) else end
+                body = "".join(line.text + line.eol for line in lines[hstart:hend])
+                piece = meta + body
+                if not fits_single_run(piece, budget):
+                    raise ValueError(
+                        f"hunk starting at line {hstart + 1} exceeds single-run budget; "
+                        "narrow the diff"
+                    )
+                sections.append(piece)
+
+    if len(sections) > MAX_CHUNKS:
+        raise ValueError(
+            f"diff would split into {len(sections)} chunks (max {MAX_CHUNKS}); "
+            "try a narrower range"
+        )
+    return sections

--- a/meat_python_plus/src/meat_python_plus/cli.py
+++ b/meat_python_plus/src/meat_python_plus/cli.py
@@ -1,0 +1,250 @@
+"""CLI matching Go meat UX: HEAD / revision / range / -staged / -w / stdin / flags."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Callable, TextIO
+
+from meat_python_plus.abridge import Request, Result, abridge
+from meat_python_plus.cache import cache_key, cache_load, cache_store, default_cache_dir
+from meat_python_plus.diffutil import elision_line
+from meat_python_plus.providers.resolve import new_model_from_env, resolve_model_name
+from meat_python_plus.rubric import rubric_hash
+
+USAGE = """meat_python_plus — abridge a diff into a "reading diff"
+
+Usage:
+  meat-py                         Summarize the most recent commit (HEAD).
+  meat-py <rev>                   Summarize a specific commit or revision.
+  meat-py <rev1>..<rev2>          Diff across a commit range.
+  meat-py -staged                 Abridge staged (index) changes.
+  meat-py -w                      Abridge unstaged working-tree changes.
+  git show | meat-py              Abridge a diff piped on stdin.
+
+Results are cached under ~/.meat_python_plus keyed by SHA of
+(protocol version + system prompt + model + diff).
+
+Flags:
+  -model string   Model id (default $MEAT_MODEL or gpt-4.1-mini).
+  -no-cache       Ignore cached result and recompute (still updates cache).
+  -staged         Read staged changes (git diff --staged).
+  -w              Read unstaged working-tree changes (git diff).
+  -json           Emit JSON on stdout.
+  -h, --help      Show this help.
+
+Environment:
+  OPENAI_API_KEY / OPENAI_BASE_URL
+  ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL
+  NOUS_API_KEY          Nous Portal (https://inference-api.nousresearch.com/v1)
+  TOKENHUB_API_KEY      Tencent TokenHub (https://tokenhub-intl.tencentcloudmaas.com/v1)
+  MEAT_BASE_URL + MEAT_API_KEY   Custom OpenAI-compatible endpoint
+  MEAT_MODEL / MEAT_CACHE
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(
+        prog="meat-py",
+        description='Abridge a unified diff into a "reading diff".',
+        add_help=False,
+    )
+    parser.add_argument("-model", dest="model", default="", help="model id")
+    parser.add_argument("-no-cache", dest="no_cache", action="store_true")
+    parser.add_argument("-staged", dest="staged", action="store_true")
+    parser.add_argument("-w", dest="worktree", action="store_true")
+    parser.add_argument("-json", dest="json_out", action="store_true")
+    parser.add_argument("-h", "--help", action="store_true")
+    parser.add_argument("revision", nargs="?", default=None)
+
+    # Accept Go-style flags that argparse already covers; also tolerate --model.
+    normalized: list[str] = []
+    for a in argv:
+        if a == "--model":
+            normalized.append("-model")
+        elif a == "--no-cache":
+            normalized.append("-no-cache")
+        elif a == "--staged":
+            normalized.append("-staged")
+        elif a == "--json":
+            normalized.append("-json")
+        else:
+            normalized.append(a)
+
+    try:
+        args, unknown = parser.parse_known_args(normalized)
+    except SystemExit as e:
+        return int(e.code) if e.code is not None else 1
+
+    if args.help:
+        sys.stderr.write(USAGE)
+        return 0
+    if unknown:
+        fatal(f"unknown arguments: {' '.join(unknown)}")
+        return 2
+
+    try:
+        diff, source = read_diff(args.revision, args.staged, args.worktree)
+    except ValueError as e:
+        fatal(str(e))
+        return 1
+    if not diff.strip():
+        fatal(f"no diff to read ({source})")
+        return 1
+
+    json_out = args.json_out
+    interactive = (
+        not json_out and sys.stdout.isatty() and sys.stderr.isatty()
+    )
+
+    def progress(msg: str) -> None:
+        if interactive:
+            sys.stderr.write(f"\r\x1b[Kmeat: {msg}")
+            sys.stderr.flush()
+
+    model_name = resolve_model_name(args.model)
+    rubric = rubric_hash()
+    cache_dir = default_cache_dir()
+
+    def compute() -> Result:
+        m = new_model_from_env(args.model)
+        return abridge(
+            m,
+            Request(
+                unified_diff=diff,
+                repo_root=git_root(),
+                progress=progress if interactive else None,
+            ),
+        )
+
+    def render(res: Result) -> None:
+        if interactive:
+            sys.stderr.write("\r\x1b[K")
+            sys.stderr.flush()
+        elision = elision_line(diff, res.smart_diff)
+        if json_out:
+            payload = res.to_dict()
+            payload["elision"] = elision
+            json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+            sys.stdout.write("\n")
+            return
+        if res.summary:
+            sys.stdout.write(res.summary + "\n")
+        if elision:
+            sys.stdout.write(f"({elision})\n")
+        if res.smart_diff:
+            if res.summary or elision:
+                sys.stdout.write("\n")
+            sys.stdout.write(res.smart_diff)
+            if not res.smart_diff.endswith("\n"):
+                sys.stdout.write("\n")
+
+    try:
+        run(
+            diff=diff,
+            model=model_name,
+            rubric=rubric,
+            cache_dir=cache_dir,
+            no_cache=args.no_cache,
+            compute=compute,
+            render=render,
+            stderr=sys.stderr,
+            interactive=interactive,
+        )
+    except Exception as e:
+        if interactive:
+            sys.stderr.write("\r\x1b[K")
+        fatal(str(e))
+        return 1
+    return 0
+
+
+def run(
+    *,
+    diff: str,
+    model: str,
+    rubric: str,
+    cache_dir: str,
+    no_cache: bool,
+    compute: Callable[[], Result],
+    render: Callable[[Result], None],
+    stderr: TextIO,
+    interactive: bool = False,
+) -> None:
+    key = cache_key(diff, model, rubric)
+    if not no_cache:
+        hit = cache_load(cache_dir, key)
+        if hit is not None:
+            render(Result.from_dict(hit))
+            stderr.write(f"\nmeat: cached (sha {key[:12]})\n")
+            return
+
+    start = time.time()
+    res = compute()
+    elapsed = time.time() - start
+    cache_store(cache_dir, key, res.to_dict())
+    render(res)
+    stderr.write(
+        f"\nmeat: tokens in={res.input_tokens} out={res.output_tokens} "
+        f"in {elapsed:.1f}s\n"
+    )
+
+
+def read_diff(revision: str | None, staged: bool, worktree: bool) -> tuple[str, str]:
+    if staged and worktree:
+        raise ValueError("-staged and -w are mutually exclusive")
+    if (staged or worktree) and revision:
+        raise ValueError("-staged/-w cannot be combined with a revision argument")
+    if staged:
+        return git("diff", "--staged"), "staged; nothing staged?"
+    if worktree:
+        return git("diff"), "worktree; no unstaged changes?"
+    if revision:
+        if ".." in revision:
+            return git("diff", revision), revision
+        return git_show(revision), revision
+    if not sys.stdin.isatty():
+        return sys.stdin.read(), "stdin"
+    return git_show("HEAD"), "HEAD"
+
+
+def git_show(rev: str) -> str:
+    return git("show", "--format=fuller", "-m", "--first-parent", rev)
+
+
+def git(*args: str) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as e:
+        raise ValueError(str(e)) from e
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip() or f"exit {proc.returncode}"
+        raise ValueError(f"git {' '.join(args)}: {err}")
+    return proc.stdout
+
+
+def git_root() -> str:
+    try:
+        return git("rev-parse", "--show-toplevel").strip()
+    except ValueError:
+        return ""
+
+
+def fatal(msg: str) -> None:
+    if not msg.startswith("meat:"):
+        msg = "meat: " + msg
+    print(msg, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/meat_python_plus/src/meat_python_plus/diffutil.py
+++ b/meat_python_plus/src/meat_python_plus/diffutil.py
@@ -1,0 +1,429 @@
+"""Unified-diff line splitting, numbering, and layout analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+
+class DiffLineKind(IntEnum):
+    OTHER = 0
+    HEADER = 1
+    INDEX = 2
+    RENAME_FROM = 3
+    RENAME_TO = 4
+    COPY_FROM = 5
+    COPY_TO = 6
+    MAIL_SIGNATURE = 7
+    OLD_FILE = 8
+    NEW_FILE = 9
+    HUNK_HEADER = 10
+    HUNK_CONTEXT = 11
+    HUNK_CHANGE = 12
+    NO_NEWLINE = 13
+
+
+class SourceLanguage(IntEnum):
+    UNKNOWN = 0
+    GO = 1
+    PYTHON = 2
+    JAVASCRIPT = 3
+    RUST = 4
+    C = 5
+    JAVA = 6
+
+
+@dataclass
+class SourceLine:
+    text: str
+    eol: str = ""
+
+
+@dataclass
+class DiffLayout:
+    kinds: list[DiffLineKind]
+    marker_owner: list[int]
+    python: list[bool]
+    language: list[SourceLanguage]
+    file_id: list[int]
+    hunk_id: list[int]
+    problems: list[str] = field(default_factory=list)
+
+
+def split_source_lines(text: str) -> list[SourceLine]:
+    if not text:
+        return []
+    lines: list[SourceLine] = []
+    remaining = text
+    while remaining:
+        i = remaining.find("\n")
+        if i < 0:
+            lines.append(SourceLine(text=remaining))
+            break
+        line, eol = remaining[:i], "\n"
+        if line.endswith("\r"):
+            line = line[:-1]
+            eol = "\r\n"
+        lines.append(SourceLine(text=line, eol=eol))
+        remaining = remaining[i + 1 :]
+    return lines
+
+
+def is_git_diff_header(line: str) -> bool:
+    return line.startswith("diff --git ")
+
+
+def is_format_patch_signature(line: str) -> bool:
+    return line == "-- "
+
+
+def is_no_newline_marker(line: str) -> bool:
+    return line == r"\ No newline at end of file"
+
+
+def is_file_marker(line: str, marker: str) -> bool:
+    return line.startswith(marker + " ") or line.startswith(marker + "\t")
+
+
+def is_raw_old_file_header(lines: list[SourceLine], index: int) -> bool:
+    return (
+        index + 1 < len(lines)
+        and is_file_marker(lines[index].text, "---")
+        and is_file_marker(lines[index + 1].text, "+++")
+    )
+
+
+def validate_supported_diff(diff: str) -> None:
+    lines = split_source_lines(diff)
+    validate_supported_diff_lines(lines)
+    layout = analyze_diff(lines)
+    if layout.problems:
+        raise ValueError("; ".join(layout.problems))
+
+
+def validate_supported_diff_lines(lines: list[SourceLine]) -> None:
+    in_patch = False
+    for i, line in enumerate(lines):
+        text = line.text
+        if is_format_patch_signature(text):
+            in_patch = False
+        elif text.startswith("diff --cc ") or text.startswith("diff --combined "):
+            raise ValueError(
+                f"combined diff on line {i + 1} is unsupported; "
+                "use a normal first-parent or two-tree diff"
+            )
+        elif is_git_diff_header(text):
+            in_patch = True
+        elif is_raw_old_file_header(lines, i):
+            in_patch = True
+        if in_patch and text.startswith("@@@"):
+            raise ValueError(
+                f"combined diff hunk on line {i + 1} is unsupported; "
+                "use a normal first-parent or two-tree diff"
+            )
+
+
+def numbered_diff(diff: str) -> str:
+    lines = split_source_lines(diff)
+    if not lines:
+        return ""
+    width = len(str(len(lines)))
+    parts: list[str] = []
+    for i, line in enumerate(lines):
+        parts.append(f"{i + 1:>{width}}|{line.text}\n")
+    return "".join(parts)
+
+
+def is_hunk_source(kind: DiffLineKind) -> bool:
+    return kind in (DiffLineKind.HUNK_CONTEXT, DiffLineKind.HUNK_CHANGE)
+
+
+def hunk_source_kind(text: str) -> DiffLineKind:
+    if not text:
+        return DiffLineKind.OTHER
+    if text[0] == " ":
+        return DiffLineKind.HUNK_CONTEXT
+    if text[0] in "+-":
+        return DiffLineKind.HUNK_CHANGE
+    return DiffLineKind.OTHER
+
+
+def parse_hunk_range(field: str, sign: str) -> tuple[int, bool]:
+    if len(field) < 2 or field[0] != sign:
+        return 0, False
+    range_text = field[1:]
+    count = 1
+    if "," in range_text:
+        start, _, count_s = range_text.partition(",")
+        try:
+            count = int(count_s)
+        except ValueError:
+            return 0, False
+        if count < 0:
+            return 0, False
+        range_text = start
+    try:
+        int(range_text)
+    except ValueError:
+        return 0, False
+    return count, True
+
+
+def parse_hunk_counts(header: str) -> tuple[int, int, bool]:
+    fields = header.split()
+    if len(fields) < 4 or fields[0] != "@@" or fields[3] != "@@":
+        return 0, 0, False
+    old_count, ok = parse_hunk_range(fields[1], "-")
+    if not ok:
+        return 0, 0, False
+    new_count, ok = parse_hunk_range(fields[2], "+")
+    return old_count, new_count, ok
+
+
+def path_language(path: str) -> SourceLanguage:
+    path = path.lower().strip('"')
+    if path.endswith(".go"):
+        return SourceLanguage.GO
+    if path.endswith((".py", ".pyi")):
+        return SourceLanguage.PYTHON
+    if path.endswith((".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts")):
+        return SourceLanguage.JAVASCRIPT
+    if path.endswith(".rs"):
+        return SourceLanguage.RUST
+    if path.endswith((".c", ".h", ".cc", ".hh", ".cpp", ".hpp", ".cxx", ".hxx")):
+        return SourceLanguage.C
+    if path.endswith((".java", ".kt", ".kts")):
+        return SourceLanguage.JAVA
+    return SourceLanguage.UNKNOWN
+
+
+def diff_header_language(line: str) -> SourceLanguage:
+    fields = line.split()
+    if len(fields) < 4:
+        return SourceLanguage.UNKNOWN
+    language = SourceLanguage.UNKNOWN
+    for field in fields[2:]:
+        candidate = path_language(field)
+        if candidate != SourceLanguage.UNKNOWN:
+            language = candidate
+    return language
+
+
+def file_marker_language(line: str) -> SourceLanguage:
+    if len(line) < 4:
+        return SourceLanguage.UNKNOWN
+    path = line[4:].strip()
+    if "\t" in path:
+        path = path.split("\t", 1)[0]
+    return path_language(path)
+
+
+def analyze_diff(lines: list[SourceLine]) -> DiffLayout:
+    n = len(lines)
+    layout = DiffLayout(
+        kinds=[DiffLineKind.OTHER] * n,
+        marker_owner=[-1] * n,
+        python=[False] * n,
+        language=[SourceLanguage.UNKNOWN] * n,
+        file_id=[-1] * n,
+        hunk_id=[-1] * n,
+    )
+
+    in_hunk = False
+    counts_known = False
+    hunk_problem_reported = False
+    old_remain = 0
+    new_remain = 0
+    hunk_header_line = 0
+    current_language = SourceLanguage.UNKNOWN
+    current_file_id = -1
+    current_hunk_id = -1
+    git_file_section = False
+    in_file_section = False
+
+    def report_hunk_problem(at_line: int) -> None:
+        nonlocal hunk_problem_reported
+        if hunk_problem_reported:
+            return
+        layout.problems.append(
+            f"hunk header on line {hunk_header_line + 1} has counts inconsistent "
+            f"with its body near line {at_line + 1}"
+        )
+        hunk_problem_reported = True
+
+    i = 0
+    while i < n:
+        text = lines[i].text
+        if not in_hunk:
+            if is_git_diff_header(text):
+                current_file_id += 1
+                git_file_section = True
+                in_file_section = True
+                current_language = diff_header_language(text)
+            elif is_raw_old_file_header(lines, i):
+                if not git_file_section:
+                    current_file_id += 1
+                in_file_section = True
+                old_lang = file_marker_language(lines[i].text)
+                if old_lang != SourceLanguage.UNKNOWN:
+                    current_language = old_lang
+                new_lang = file_marker_language(lines[i + 1].text)
+                if new_lang != SourceLanguage.UNKNOWN:
+                    current_language = new_lang
+
+        layout.language[i] = current_language
+        layout.python[i] = current_language == SourceLanguage.PYTHON
+        layout.file_id[i] = current_file_id
+
+        if in_hunk:
+            if not counts_known and is_raw_old_file_header(lines, i):
+                in_hunk = False
+                continue
+            if counts_known and old_remain == 0 and new_remain == 0:
+                if is_no_newline_marker(text):
+                    layout.kinds[i] = DiffLineKind.NO_NEWLINE
+                    layout.hunk_id[i] = current_hunk_id
+                    if i > 0 and is_hunk_source(layout.kinds[i - 1]):
+                        layout.marker_owner[i] = i - 1
+                    i += 1
+                    continue
+                if (
+                    is_raw_old_file_header(lines, i)
+                    or is_git_diff_header(text)
+                    or text.startswith("@@")
+                    or is_format_patch_signature(text)
+                ):
+                    in_hunk = False
+                    continue
+                kind = hunk_source_kind(text)
+                if kind != DiffLineKind.OTHER:
+                    report_hunk_problem(i)
+                    layout.kinds[i] = kind
+                    layout.hunk_id[i] = current_hunk_id
+                    i += 1
+                    continue
+                in_hunk = False
+                continue
+
+            if is_no_newline_marker(text):
+                layout.kinds[i] = DiffLineKind.NO_NEWLINE
+                layout.hunk_id[i] = current_hunk_id
+                if i > 0 and is_hunk_source(layout.kinds[i - 1]):
+                    layout.marker_owner[i] = i - 1
+                i += 1
+                continue
+
+            kind = hunk_source_kind(text)
+            if kind != DiffLineKind.OTHER:
+                if counts_known:
+                    valid = False
+                    ch = text[0]
+                    if ch == " ":
+                        valid = old_remain > 0 and new_remain > 0
+                        if valid:
+                            old_remain -= 1
+                            new_remain -= 1
+                    elif ch == "-":
+                        valid = old_remain > 0
+                        if valid:
+                            old_remain -= 1
+                    elif ch == "+":
+                        valid = new_remain > 0
+                        if valid:
+                            new_remain -= 1
+                    if not valid:
+                        report_hunk_problem(i)
+                layout.kinds[i] = kind
+                layout.hunk_id[i] = current_hunk_id
+                i += 1
+                continue
+
+            if counts_known and (old_remain != 0 or new_remain != 0):
+                report_hunk_problem(i)
+            in_hunk = False
+            continue
+
+        if is_format_patch_signature(text):
+            layout.kinds[i] = DiffLineKind.MAIL_SIGNATURE
+            in_file_section = False
+            git_file_section = False
+            i += 1
+        elif is_git_diff_header(text):
+            layout.kinds[i] = DiffLineKind.HEADER
+            i += 1
+        elif in_file_section and (
+            text.startswith("index ")
+            or text.startswith("similarity index ")
+            or text.startswith("dissimilarity index ")
+        ):
+            layout.kinds[i] = DiffLineKind.INDEX
+            i += 1
+        elif in_file_section and text.startswith("rename from "):
+            layout.kinds[i] = DiffLineKind.RENAME_FROM
+            i += 1
+        elif in_file_section and text.startswith("rename to "):
+            layout.kinds[i] = DiffLineKind.RENAME_TO
+            i += 1
+        elif in_file_section and text.startswith("copy from "):
+            layout.kinds[i] = DiffLineKind.COPY_FROM
+            i += 1
+        elif in_file_section and text.startswith("copy to "):
+            layout.kinds[i] = DiffLineKind.COPY_TO
+            i += 1
+        elif is_raw_old_file_header(lines, i):
+            layout.kinds[i] = DiffLineKind.OLD_FILE
+            layout.kinds[i + 1] = DiffLineKind.NEW_FILE
+            layout.language[i + 1] = current_language
+            layout.python[i + 1] = current_language == SourceLanguage.PYTHON
+            layout.file_id[i + 1] = current_file_id
+            i += 2
+        elif (in_file_section or text == "@@" or text.startswith("@@ ")) and text.startswith(
+            "@@"
+        ):
+            layout.kinds[i] = DiffLineKind.HUNK_HEADER
+            current_hunk_id += 1
+            layout.hunk_id[i] = current_hunk_id
+            old_remain, new_remain, counts_known = parse_hunk_counts(text)
+            in_hunk = True
+            hunk_header_line = i
+            hunk_problem_reported = False
+            i += 1
+        else:
+            i += 1
+
+    if in_hunk and counts_known and (old_remain != 0 or new_remain != 0):
+        report_hunk_problem(n - 1)
+    return layout
+
+
+def next_layout_line(
+    layout: DiffLayout, start: int, stop_kinds: set[DiffLineKind]
+) -> int:
+    for i in range(start, len(layout.kinds)):
+        if layout.kinds[i] in stop_kinds:
+            return i
+    return len(layout.kinds)
+
+
+def elision_line(raw: str, abridged: str) -> str:
+    """Human-readable kept/elided summary (simplified vs Go meat)."""
+    raw_layout = analyze_diff(split_source_lines(raw))
+    raw_changed = sum(1 for k in raw_layout.kinds if k == DiffLineKind.HUNK_CHANGE)
+    raw_files = sum(1 for k in raw_layout.kinds if k == DiffLineKind.HEADER)
+    if raw_changed == 0:
+        return ""
+    if not abridged.strip():
+        return f"elided all {raw_changed} changed lines in {raw_files} files"
+    abr_layout = analyze_diff(split_source_lines(abridged))
+    kept_changed = sum(1 for k in abr_layout.kinds if k == DiffLineKind.HUNK_CHANGE)
+    # Count fold lines as kept changed
+    for line in split_source_lines(abridged):
+        if line.text and line.text[0] in "+-" and line.text[1:].strip() == "...":
+            kept_changed += 1
+    kept_files = sum(1 for k in abr_layout.kinds if k == DiffLineKind.HEADER)
+    if kept_files > 0 and raw_files > 0:
+        return (
+            f"kept {kept_changed}/{raw_changed} changed lines "
+            f"in {kept_files}/{raw_files} files"
+        )
+    return f"kept {kept_changed}/{raw_changed} changed lines"

--- a/meat_python_plus/src/meat_python_plus/editplan.py
+++ b/meat_python_plus/src/meat_python_plus/editplan.py
@@ -1,0 +1,725 @@
+"""Compile a model-submitted remove/replace/fold plan against an immutable diff."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from meat_python_plus.diffutil import (
+    DiffLayout,
+    DiffLineKind,
+    SourceLine,
+    analyze_diff,
+    is_hunk_source,
+    next_layout_line,
+    split_source_lines,
+    validate_supported_diff_lines,
+)
+
+MAX_REPLACEMENT_BYTES = 4 << 10
+MAX_SUMMARY_BYTES = 500
+
+# Simplified import-line heuristics (v1; not full Go imports.go parity).
+_IMPORT_RE = re.compile(
+    r"""(?x)
+    ^\s*(
+        from\s+\S+\s+import\b
+      | import\s+\S
+      | use\s+(\{|[\w:]+)
+      | \#\s*include\s*[<"]
+      | require\s*\(
+      | require_once\s*\(
+      | using\s+[\w.]+
+    )
+    """
+)
+_GO_IMPORT_BLOCK = re.compile(r"^\s*import\s*\(\s*$")
+_GO_IMPORT_SINGLE = re.compile(r'^\s*import\s+"')
+
+
+@dataclass
+class LineRange:
+    start_line: int
+    end_line: int
+
+
+@dataclass
+class LineReplacement:
+    line: int
+    old: str
+    new: str
+
+
+@dataclass
+class LineFold:
+    start_line: int
+    end_line: int
+
+
+@dataclass
+class EditPlan:
+    remove: list[LineRange] = field(default_factory=list)
+    replace: list[LineReplacement] = field(default_factory=list)
+    fold: list[LineFold] = field(default_factory=list)
+
+
+@dataclass
+class Submission(EditPlan):
+    summary: str = ""
+
+
+@dataclass
+class PlannedReplacement:
+    replacement: LineReplacement
+    plan_index: int
+    start: int
+    end: int
+
+
+@dataclass
+class PlannedFold:
+    fold: LineFold
+    plan_index: int
+    marker: str
+    indent: str
+    eol: str
+
+
+@dataclass
+class PlanState:
+    hidden: list[bool]
+    folded: list[int]
+    fold_at: list[int]
+    folds: list[PlannedFold] = field(default_factory=list)
+
+    def represented(self, line: int) -> bool:
+        return (not self.hidden[line]) or self.folded[line] >= 0
+
+
+@dataclass
+class PlanStats:
+    raw_changed: int = 0
+    visible_changed: int = 0
+    removed_changed: int = 0
+    folded_changed: int = 0
+    fold_count: int = 0
+    raw_files: int = 0
+    visible_files: int = 0
+
+
+@dataclass
+class CompiledPlan:
+    smart_diff: str
+    stats: PlanStats
+    moves: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class DetectedMove:
+    removed: LineRange
+    added: LineRange
+
+
+def parse_edit_plan(data: dict[str, Any]) -> EditPlan:
+    return EditPlan(
+        remove=[LineRange(**r) for r in (data.get("remove") or [])],
+        replace=[LineReplacement(**r) for r in (data.get("replace") or [])],
+        fold=[LineFold(**r) for r in (data.get("fold") or [])],
+    )
+
+
+def parse_submission(data: dict[str, Any]) -> Submission:
+    plan = parse_edit_plan(data)
+    return Submission(
+        remove=plan.remove,
+        replace=plan.replace,
+        fold=plan.fold,
+        summary=str(data.get("summary") or ""),
+    )
+
+
+def join_errors(problems: list[str]) -> str:
+    if len(problems) == 1:
+        return problems[0]
+    return "edit plan has %d errors:\n- %s" % (len(problems), "\n- ".join(problems))
+
+
+def leading_whitespace(s: str) -> str:
+    i = 0
+    while i < len(s) and s[i] in " \t":
+        i += 1
+    return s[:i]
+
+
+def common_prefix(a: str, b: str) -> str:
+    n = min(len(a), len(b))
+    i = 0
+    while i < n and a[i] == b[i]:
+        i += 1
+    return a[:i]
+
+
+def unique_substring_index(text: str, sub: str) -> tuple[int, bool]:
+    first = text.find(sub)
+    if first < 0:
+        return 0, False
+    if text.find(sub, first + 1) >= 0:
+        return 0, False
+    return first, True
+
+
+def compile_elision_projection(new: str, strict: bool = True) -> re.Pattern[str] | None:
+    pattern_parts: list[str] = ["^"]
+    literal: list[str] = []
+    wildcards = 0
+    last_was_wildcard = False
+    runes = list(new)
+    i = 0
+
+    def flush_literal() -> None:
+        if literal:
+            pattern_parts.append(re.escape("".join(literal)))
+            literal.clear()
+
+    while i < len(runes):
+        wildcard = False
+        if runes[i] == "…":
+            wildcard = True
+            i += 1
+        elif runes[i] == ".":
+            j = i
+            while j < len(runes) and runes[j] == ".":
+                j += 1
+            run = j - i
+            if run >= 3:
+                if strict and run != 3:
+                    return None
+                wildcard = True
+                i = j
+        if wildcard:
+            if last_was_wildcard:
+                if strict:
+                    return None
+                continue
+            flush_literal()
+            pattern_parts.append(".+")
+            wildcards += 1
+            last_was_wildcard = True
+            continue
+        literal.append(runes[i])
+        last_was_wildcard = False
+        i += 1
+    flush_literal()
+    pattern_parts.append("$")
+    if wildcards == 0:
+        return None
+    try:
+        return re.compile("".join(pattern_parts))
+    except re.error:
+        return None
+
+
+def is_elision_projection(old: str, new: str) -> bool:
+    compiled = compile_elision_projection(new, strict=True)
+    return compiled is not None and compiled.match(old) is not None
+
+
+def validate_single_line_text(name: str, text: str, max_bytes: int) -> str | None:
+    encoded = text.encode("utf-8")
+    if len(encoded) > max_bytes:
+        return f"{name} is {len(encoded)} bytes, over the {max_bytes}-byte limit"
+    for ch in text:
+        if ch in "\n\r\x00\x1b\u2028\u2029":
+            return f"{name} must be a single printable line"
+        if ord(ch) < 32 and ch != "\t":
+            return f"{name} contains a control character"
+    return None
+
+
+def validate_summary(summary: str) -> str | None:
+    if not summary.strip():
+        return "summary must not be empty"
+    return validate_single_line_text("summary", summary, MAX_SUMMARY_BYTES)
+
+
+def looks_like_import(body: str) -> bool:
+    stripped = body.strip()
+    if not stripped:
+        return False
+    if _IMPORT_RE.match(stripped):
+        return True
+    if _GO_IMPORT_BLOCK.match(stripped) or _GO_IMPORT_SINGLE.match(stripped):
+        return True
+    # Inside a Go import ( "pkg" ) block — quoted path alone.
+    if re.match(r'^[\w./\-]*"[^"]+"\s*$', stripped) or re.match(
+        r"^[\w]*\s*\"[^\"]+\"\s*$", stripped
+    ):
+        return True
+    if stripped in ("(", ")") and False:
+        return False
+    return False
+
+
+def mandatory_import_mask(lines: list[SourceLine], layout: DiffLayout) -> list[bool]:
+    """Simplified mandatory import removal (common cases only)."""
+    hidden = [False] * len(lines)
+    in_go_import_block: dict[str, bool] = {"-": False, "+": False, " ": False}
+
+    for i, line in enumerate(lines):
+        if not is_hunk_source(layout.kinds[i]) or not line.text:
+            continue
+        marker = line.text[0]
+        body = line.text[1:]
+        side = marker if marker in "-+" else " "
+        stripped = body.strip()
+
+        if _GO_IMPORT_BLOCK.match(stripped):
+            in_go_import_block[side] = True
+            hidden[i] = True
+            continue
+        if in_go_import_block.get(side) and stripped == ")":
+            in_go_import_block[side] = False
+            hidden[i] = True
+            continue
+        if in_go_import_block.get(side):
+            hidden[i] = True
+            continue
+        if looks_like_import(body):
+            hidden[i] = True
+            # Context import rows: hide if both sides would match (already body).
+            continue
+
+    # Hide context lines that are clearly imports (both sides same).
+    for i, line in enumerate(lines):
+        if layout.kinds[i] == DiffLineKind.HUNK_CONTEXT and line.text.startswith(" "):
+            if looks_like_import(line.text[1:]):
+                hidden[i] = True
+    return hidden
+
+
+def detect_exact_moves(
+    lines: list[SourceLine], layout: DiffLayout
+) -> list[DetectedMove]:
+    """Simplified move detection stub — returns empty in v1.
+
+    Full Go meat move pairing (moves.go) is intentionally not ported yet.
+    The prompt still mentions moves; the compiler does not enforce symmetry.
+    """
+    _ = (lines, layout)
+    return []
+
+
+def prepare_fold(
+    lines: list[SourceLine],
+    layout: DiffLayout,
+    fold: LineFold,
+    plan_index: int,
+) -> PlannedFold:
+    if fold.start_line < 1 or fold.end_line < 1 or fold.start_line >= fold.end_line:
+        raise ValueError(
+            f"fold[{plan_index}]: want at least two lines in an inclusive range, "
+            f"got {fold.start_line}-{fold.end_line}"
+        )
+    if fold.end_line > len(lines):
+        raise ValueError(
+            f"fold[{plan_index}]: line {fold.end_line} is past end of diff "
+            f"({len(lines)} lines)"
+        )
+
+    marker = ""
+    indent = ""
+    have_indent = False
+    for n in range(fold.start_line, fold.end_line + 1):
+        index = n - 1
+        if not is_hunk_source(layout.kinds[index]) or not lines[index].text:
+            raise ValueError(
+                f"fold[{plan_index}]: line {n} is not source inside one diff hunk"
+            )
+        line_marker = lines[index].text[0]
+        if not marker:
+            marker = line_marker
+        elif marker != line_marker:
+            raise ValueError(
+                f"fold[{plan_index}]: mixed diff markers {marker!r} and "
+                f"{line_marker!r} in range {fold.start_line}-{fold.end_line}"
+            )
+        body = lines[index].text[1:]
+        if not body.strip():
+            continue
+        line_indent = leading_whitespace(body)
+        if not have_indent:
+            indent = line_indent
+            have_indent = True
+        else:
+            indent = common_prefix(indent, line_indent)
+    if not have_indent:
+        raise ValueError(
+            f"fold[{plan_index}]: range {fold.start_line}-{fold.end_line} "
+            "contains only blank source lines"
+        )
+    return PlannedFold(
+        fold=fold,
+        plan_index=plan_index,
+        marker=marker,
+        indent=indent,
+        eol=lines[fold.end_line - 1].eol,
+    )
+
+
+def compute_plan_stats(layout: DiffLayout, state: PlanState) -> PlanStats:
+    stats = PlanStats()
+    for i, kind in enumerate(layout.kinds):
+        if kind == DiffLineKind.HEADER:
+            stats.raw_files += 1
+            if state.represented(i):
+                stats.visible_files += 1
+        elif kind == DiffLineKind.HUNK_CHANGE:
+            stats.raw_changed += 1
+            if state.folded[i] >= 0:
+                stats.folded_changed += 1
+            elif state.hidden[i]:
+                stats.removed_changed += 1
+            else:
+                stats.visible_changed += 1
+    stats.fold_count = len(state.folds)
+    for fold in state.folds:
+        if fold.marker in "+-":
+            stats.visible_changed += 1
+    return stats
+
+
+def validate_retained_structure(layout: DiffLayout, state: PlanState) -> list[str]:
+    problems: list[str] = []
+    stop_file = {
+        DiffLineKind.HEADER,
+        DiffLineKind.MAIL_SIGNATURE,
+    }
+    stop_old = {
+        DiffLineKind.HEADER,
+        DiffLineKind.OLD_FILE,
+        DiffLineKind.MAIL_SIGNATURE,
+    }
+    stop_hunk = {
+        DiffLineKind.HEADER,
+        DiffLineKind.OLD_FILE,
+        DiffLineKind.HUNK_HEADER,
+        DiffLineKind.MAIL_SIGNATURE,
+    }
+
+    def any_retained(start: int, end: int) -> bool:
+        return any(state.represented(i) for i in range(start, end))
+
+    def any_retained_meaningful(start: int, end: int) -> bool:
+        for i in range(start, end):
+            if state.represented(i) and layout.kinds[i] not in (
+                DiffLineKind.NO_NEWLINE,
+                DiffLineKind.INDEX,
+            ):
+                return True
+        return False
+
+    def any_retained_hunk_source(start: int, end: int) -> bool:
+        return any(
+            state.represented(i) and is_hunk_source(layout.kinds[i])
+            for i in range(start, end)
+        )
+
+    def any_retained_hunk_change(start: int, end: int) -> bool:
+        return any(
+            state.represented(i) and layout.kinds[i] == DiffLineKind.HUNK_CHANGE
+            for i in range(start, end)
+        )
+
+    for i, kind in enumerate(layout.kinds):
+        if kind == DiffLineKind.NO_NEWLINE and state.represented(i):
+            owner = layout.marker_owner[i]
+            if owner < 0 or not state.represented(owner):
+                problems.append(
+                    f"remove: no-newline marker on line {i + 1} requires its source line"
+                )
+
+        if kind == DiffLineKind.HEADER:
+            end = next_layout_line(layout, i + 1, stop_file)
+            body_retained = any_retained_meaningful(i + 1, end)
+            header_retained = state.represented(i)
+            if not body_retained and any_retained(i + 1, end):
+                problems.append(
+                    f"remove: file beginning on line {i + 1} retains only metadata; "
+                    "remove the complete file section"
+                )
+            if header_retained != body_retained:
+                problems.append(
+                    f"remove: diff header on line {i + 1} must be retained exactly "
+                    "when its file body is retained"
+                )
+        elif kind == DiffLineKind.OLD_FILE:
+            end = next_layout_line(layout, i + 2, stop_old)
+            if state.represented(i) != state.represented(i + 1):
+                problems.append(
+                    f"remove: ---/+++ headers on lines {i + 1}-{i + 2} must be "
+                    "removed or retained together"
+                )
+            body_retained = any_retained_meaningful(i + 2, end)
+            headers_retained = state.represented(i)
+            if headers_retained != body_retained:
+                problems.append(
+                    f"remove: ---/+++ headers on lines {i + 1}-{i + 2} must be "
+                    "retained exactly when their file body is retained"
+                )
+        elif kind == DiffLineKind.RENAME_FROM:
+            if i + 1 >= len(layout.kinds) or layout.kinds[i + 1] != DiffLineKind.RENAME_TO:
+                problems.append(
+                    f"rename from metadata on line {i + 1} has no matching rename to line"
+                )
+            elif state.represented(i) != state.represented(i + 1):
+                problems.append(
+                    f"remove: rename metadata on lines {i + 1}-{i + 2} must be "
+                    "removed or retained together"
+                )
+        elif kind == DiffLineKind.COPY_FROM:
+            if i + 1 >= len(layout.kinds) or layout.kinds[i + 1] != DiffLineKind.COPY_TO:
+                problems.append(
+                    f"copy from metadata on line {i + 1} has no matching copy to line"
+                )
+            elif state.represented(i) != state.represented(i + 1):
+                problems.append(
+                    f"remove: copy metadata on lines {i + 1}-{i + 2} must be "
+                    "removed or retained together"
+                )
+        elif kind == DiffLineKind.HUNK_HEADER:
+            end = next_layout_line(layout, i + 1, stop_hunk)
+            header_retained = state.represented(i)
+            if any_retained_hunk_source(i + 1, end) and not header_retained:
+                problems.append(
+                    f"remove: retained context/change lines require hunk header "
+                    f"on line {i + 1}"
+                )
+            change_retained = any_retained_hunk_change(i + 1, end)
+            if header_retained != change_retained:
+                problems.append(
+                    f"remove: hunk header on line {i + 1} must be retained exactly "
+                    "when its hunk has a retained change"
+                )
+    return problems
+
+
+def compile_edit_plan(raw: str, plan: EditPlan) -> CompiledPlan:
+    problems: list[str] = []
+    lines = split_source_lines(raw)
+    validate_supported_diff_lines(lines)
+    layout = analyze_diff(lines)
+    if layout.problems:
+        raise ValueError(join_errors(layout.problems))
+
+    moves = detect_exact_moves(lines, layout)
+    mandatory_hidden = mandatory_import_mask(lines, layout)
+    state = PlanState(
+        hidden=list(mandatory_hidden),
+        folded=[-1] * len(lines),
+        fold_at=[-1] * len(lines),
+    )
+    model_removed = [False] * len(lines)
+    removals_valid = True
+
+    for i, r in enumerate(plan.remove):
+        if r.start_line < 1 or r.end_line < 1 or r.start_line > r.end_line:
+            problems.append(
+                f"remove[{i}]: invalid inclusive range {r.start_line}-{r.end_line}"
+            )
+            removals_valid = False
+            continue
+        if r.end_line > len(lines):
+            problems.append(
+                f"remove[{i}]: line {r.end_line} is past end of diff ({len(lines)} lines)"
+            )
+            removals_valid = False
+            continue
+        first_overlap = 0
+        for n in range(r.start_line, r.end_line + 1):
+            if model_removed[n - 1]:
+                if first_overlap == 0:
+                    first_overlap = n
+                removals_valid = False
+                continue
+            model_removed[n - 1] = True
+            state.hidden[n - 1] = True
+        if first_overlap:
+            problems.append(f"remove[{i}]: overlaps an earlier range at line {first_overlap}")
+
+    folds_valid = True
+    for i, f in enumerate(plan.fold):
+        try:
+            prepared = prepare_fold(lines, layout, f, i)
+        except ValueError as e:
+            problems.append(str(e))
+            folds_valid = False
+            continue
+        mandatory_lines = sum(
+            1 for n in range(f.start_line, f.end_line + 1) if mandatory_hidden[n - 1]
+        )
+        if mandatory_lines > 0:
+            if mandatory_lines != f.end_line - f.start_line + 1:
+                problems.append(
+                    f"fold[{i}]: crosses automatically removed import rows and "
+                    f"behavioral rows in range {f.start_line}-{f.end_line}; "
+                    "fold only the behavioral rows"
+                )
+                folds_valid = False
+            continue
+        conflict_line = 0
+        for n in range(f.start_line, f.end_line + 1):
+            if state.hidden[n - 1]:
+                conflict_line = n
+                break
+        if conflict_line:
+            kind = "fold" if state.folded[conflict_line - 1] >= 0 else "remove"
+            problems.append(f"fold[{i}]: overlaps {kind} at line {conflict_line}")
+            folds_valid = False
+            continue
+        fold_index = len(state.folds)
+        state.folds.append(prepared)
+        state.fold_at[f.start_line - 1] = fold_index
+        for n in range(f.start_line, f.end_line + 1):
+            state.hidden[n - 1] = True
+            state.folded[n - 1] = fold_index
+
+    replacements: dict[int, list[PlannedReplacement]] = {}
+    replacements_valid = True
+    for i, r in enumerate(plan.replace):
+        if r.line < 1 or r.line > len(lines):
+            problems.append(
+                f"replace[{i}]: line {r.line} is outside the diff (1-{len(lines)})"
+            )
+            continue
+        if mandatory_hidden[r.line - 1]:
+            continue
+        if state.hidden[r.line - 1]:
+            state_name = "folded" if state.folded[r.line - 1] >= 0 else "removed"
+            problems.append(f"replace[{i}]: line {r.line} is also {state_name}")
+            continue
+        if r.old == "":
+            problems.append(f"replace[{i}]: old must not be empty")
+            continue
+        err = validate_single_line_text("old", r.old, MAX_REPLACEMENT_BYTES)
+        if err:
+            problems.append(f"replace[{i}]: {err}")
+            continue
+        err = validate_single_line_text("new", r.new, MAX_REPLACEMENT_BYTES)
+        if err:
+            problems.append(f"replace[{i}]: {err}")
+            continue
+        if r.new == r.old:
+            problems.append(f"replace[{i}]: new must elide some part of old")
+            continue
+        if not is_elision_projection(r.old, r.new):
+            problems.append(
+                f"replace[{i}]: new must match all of old, with every omitted "
+                "span represented by ... or …"
+            )
+            continue
+        if not is_hunk_source(layout.kinds[r.line - 1]):
+            problems.append(
+                f"replace[{i}]: line {r.line} is not a source line inside a diff hunk"
+            )
+            continue
+        body = lines[r.line - 1].text[1:]
+        start, unique = unique_substring_index(body, r.old)
+        if not unique:
+            problems.append(
+                f"replace[{i}]: old must occur exactly once after the diff marker "
+                f"on line {r.line}"
+            )
+            continue
+        replacements.setdefault(r.line, []).append(
+            PlannedReplacement(
+                replacement=r, plan_index=i, start=start, end=start + len(r.old)
+            )
+        )
+
+    for line_no, edits in replacements.items():
+        edits.sort(key=lambda e: e.start)
+        for j in range(1, len(edits)):
+            if edits[j].start < edits[j - 1].end:
+                problems.append(
+                    f"replace[{edits[j].plan_index}]: span overlaps "
+                    f"replace[{edits[j - 1].plan_index}] on line {line_no}"
+                )
+                replacements_valid = False
+
+    if removals_valid and folds_valid and replacements_valid:
+        problems.extend(validate_retained_structure(layout, state))
+
+    if problems:
+        raise ValueError(join_errors(problems))
+
+    out: list[str] = []
+    for i, line in enumerate(lines):
+        line_no = i + 1
+        fold_index = state.fold_at[i]
+        if fold_index >= 0:
+            fold = state.folds[fold_index]
+            out.append(f"{fold.marker}{fold.indent}...{fold.eol}")
+            continue
+        if state.hidden[i]:
+            continue
+        text = line.text
+        edits = replacements.get(line_no)
+        if edits:
+            body = text[1:]
+            for e in reversed(edits):
+                body = body[: e.start] + e.replacement.new + body[e.end :]
+            text = text[0] + body
+        out.append(text + line.eol)
+
+    stats = compute_plan_stats(layout, state)
+    return CompiledPlan(smart_diff="".join(out), stats=stats, moves=moves)
+
+
+def compile_submission(raw: str, submission: Submission) -> CompiledPlan:
+    problems: list[str] = []
+    err = validate_summary(submission.summary)
+    if err:
+        problems.append(err)
+    try:
+        compiled = compile_edit_plan(raw, submission)
+    except ValueError as e:
+        problems.append(str(e))
+        compiled = None  # type: ignore[assignment]
+    if problems:
+        raise ValueError(join_errors(problems))
+    assert compiled is not None
+    return compiled
+
+
+def retention_pressure(stats: PlanStats) -> bool:
+    if stats.raw_changed < 40 or stats.visible_changed < 20:
+        return False
+    return stats.visible_changed >= 80 or stats.visible_changed * 100 >= stats.raw_changed * 45
+
+
+def plan_feedback(compiled: CompiledPlan) -> str:
+    stats = compiled.stats
+    percent = 0
+    if stats.raw_changed > 0:
+        percent = stats.visible_changed * 100 // stats.raw_changed
+    parts = [
+        f"Valid source-derived plan.\nRetention: {stats.visible_changed}/{stats.raw_changed} "
+        f"visible changed rows ({percent}%); {stats.removed_changed} removed, "
+        f"{stats.folded_changed} hidden by {stats.fold_count} folds"
+    ]
+    if stats.raw_files > 0:
+        parts[0] += f"; files {stats.visible_files}/{stats.raw_files}"
+    parts[0] += ".\n"
+    if retention_pressure(stats):
+        parts.append(
+            "Pressure: high retention. Reconsider repeated rename/call-site hunks "
+            "after one representative anchor, default git context, mechanical prose, "
+            "duplicate setup/cases, and assertion batches or suites that can become "
+            "fixed ... folds. Imports are already removed mechanically.\n"
+        )
+    else:
+        parts.append("Pressure: acceptable. Preserve uncertain behavior.\n")
+    parts.append("Preview (revised plans still use ORIGINAL line coordinates):\n")
+    parts.append(compiled.smart_diff)
+    return "".join(parts)

--- a/meat_python_plus/src/meat_python_plus/model.py
+++ b/meat_python_plus/src/meat_python_plus/model.py
@@ -1,0 +1,59 @@
+"""Provider-agnostic model types for the abridge agent loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+class Role:
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
+@dataclass
+class Block:
+    type: str
+    text: str = ""
+    id: str = ""
+    tool_name: str = ""
+    tool_input: Any = None  # dict or raw JSON-compatible
+    tool_use_id: str = ""
+    tool_result: str = ""
+    tool_error: bool = False
+    provider: str = ""
+    provider_data: Any = None
+
+
+@dataclass
+class Message:
+    role: str
+    content: list[Block] = field(default_factory=list)
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass
+class Response:
+    content: list[Block] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@runtime_checkable
+class Model(Protocol):
+    def generate(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[Tool],
+    ) -> Response: ...
+
+
+def text_block(s: str) -> Block:
+    return Block(type="text", text=s)

--- a/meat_python_plus/src/meat_python_plus/providers/__init__.py
+++ b/meat_python_plus/src/meat_python_plus/providers/__init__.py
@@ -1,0 +1,9 @@
+"""LLM provider backends."""
+
+from meat_python_plus.providers.resolve import (
+    ResolvedProvider,
+    resolve_model_name,
+    resolve_provider,
+)
+
+__all__ = ["ResolvedProvider", "resolve_model_name", "resolve_provider"]

--- a/meat_python_plus/src/meat_python_plus/providers/anthropic_msgs.py
+++ b/meat_python_plus/src/meat_python_plus/providers/anthropic_msgs.py
@@ -1,0 +1,137 @@
+"""Anthropic Messages API with tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+from meat_python_plus.model import Block, Message, Response, Role, Tool
+
+MAX_OUTPUT_TOKENS = 16384
+MAX_ATTEMPTS = 4
+RETRY_BASE_DELAY = 1.0
+
+
+class AnthropicMessagesModel:
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        base_url: str = "https://api.anthropic.com",
+        timeout: float = 120.0,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def generate(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[Tool],
+    ) -> Response:
+        url = self.base_url + "/v1/messages"
+        body = {
+            "model": self.model,
+            "max_tokens": MAX_OUTPUT_TOKENS,
+            "system": system,
+            "messages": self._to_messages(messages),
+            "tools": [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.input_schema,
+                }
+                for t in tools
+            ],
+        }
+        raw = self._post_json(url, body)
+        if raw.get("error"):
+            err = raw["error"]
+            raise RuntimeError(
+                f"anthropic error: {err.get('type', '')}: {err.get('message', err)}"
+            )
+        if raw.get("stop_reason") == "max_tokens":
+            raise RuntimeError(
+                f"anthropic response truncated at max_tokens ({MAX_OUTPUT_TOKENS})"
+            )
+        content: list[Block] = []
+        for b in raw.get("content") or []:
+            btype = b.get("type")
+            if btype == "text":
+                content.append(Block(type="text", text=b.get("text") or ""))
+            elif btype == "tool_use":
+                content.append(
+                    Block(
+                        type="tool_use",
+                        id=str(b.get("id") or ""),
+                        tool_name=str(b.get("name") or ""),
+                        tool_input=b.get("input") or {},
+                    )
+                )
+        usage = raw.get("usage") or {}
+        return Response(
+            content=content,
+            input_tokens=int(usage.get("input_tokens") or 0),
+            output_tokens=int(usage.get("output_tokens") or 0),
+        )
+
+    def _to_messages(self, messages: list[Message]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for msg in messages:
+            blocks: list[dict[str, Any]] = []
+            for b in msg.content:
+                if b.type == "text":
+                    blocks.append({"type": "text", "text": b.text})
+                elif b.type == "tool_use":
+                    blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": b.id,
+                            "name": b.tool_name,
+                            "input": b.tool_input
+                            if isinstance(b.tool_input, dict)
+                            else json.loads(b.tool_input or "{}"),
+                        }
+                    )
+                elif b.type == "tool_result":
+                    blocks.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": b.tool_use_id,
+                            "content": b.tool_result,
+                            "is_error": b.tool_error,
+                        }
+                    )
+            role = "assistant" if msg.role == Role.ASSISTANT else "user"
+            out.append({"role": role, "content": blocks})
+        return out
+
+    def _post_json(self, url: str, body: dict[str, Any]) -> dict[str, Any]:
+        last_err: Exception | None = None
+        headers = {
+            "content-type": "application/json",
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        payload = json.dumps(body).encode("utf-8")
+        for attempt in range(MAX_ATTEMPTS):
+            if attempt > 0:
+                time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+            try:
+                with httpx.Client(timeout=self.timeout) as client:
+                    resp = client.post(url, content=payload, headers=headers)
+                if resp.status_code == 200:
+                    return resp.json()
+                last_err = RuntimeError(
+                    f"anthropic API {resp.status_code}: {resp.text.strip()}"
+                )
+                if resp.status_code not in (408, 429) and resp.status_code < 500:
+                    raise last_err
+            except httpx.HTTPError as e:
+                last_err = e
+        raise RuntimeError(f"after {MAX_ATTEMPTS} attempts: {last_err}")

--- a/meat_python_plus/src/meat_python_plus/providers/openai_compat.py
+++ b/meat_python_plus/src/meat_python_plus/providers/openai_compat.py
@@ -1,0 +1,189 @@
+"""OpenAI-compatible Chat Completions API with tools (OpenAI, Nous, TokenHub, custom)."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+from meat_python_plus.model import Block, Message, Response, Role, Tool
+
+MAX_OUTPUT_TOKENS = 16384
+MAX_ATTEMPTS = 4
+RETRY_BASE_DELAY = 1.0
+
+
+class OpenAICompatModel:
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        base_url: str = "https://api.openai.com/v1",
+        provider_name: str = "openai",
+        timeout: float = 300.0,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.provider_name = provider_name
+        self.timeout = timeout
+
+    def generate(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[Tool],
+    ) -> Response:
+        url = self._chat_url()
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": self._to_messages(system, messages),
+            "tools": self._to_tools(tools),
+            "tool_choice": "auto",
+            "max_tokens": MAX_OUTPUT_TOKENS,
+        }
+        # Some gateways prefer max_completion_tokens; keep max_tokens for broad compat.
+        raw = self._post_json(url, body)
+        return self._parse_response(raw)
+
+    def _chat_url(self) -> str:
+        base = self.base_url
+        if base.endswith("/v1"):
+            return base + "/chat/completions"
+        if base.endswith("/chat/completions"):
+            return base
+        return base + "/v1/chat/completions"
+
+    def _to_tools(self, tools: list[Tool]) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.input_schema,
+                },
+            }
+            for t in tools
+        ]
+
+    def _to_messages(self, system: str, messages: list[Message]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = [{"role": "system", "content": system}]
+        for msg in messages:
+            if msg.role == Role.ASSISTANT:
+                text_parts: list[str] = []
+                tool_calls: list[dict[str, Any]] = []
+                for b in msg.content:
+                    if b.type == "text" and b.text:
+                        text_parts.append(b.text)
+                    elif b.type == "tool_use":
+                        args = b.tool_input
+                        if isinstance(args, str):
+                            args_s = args
+                        else:
+                            args_s = json.dumps(args if args is not None else {})
+                        tool_calls.append(
+                            {
+                                "id": b.id or f"call_{len(tool_calls)}",
+                                "type": "function",
+                                "function": {"name": b.tool_name, "arguments": args_s},
+                            }
+                        )
+                am: dict[str, Any] = {"role": "assistant"}
+                am["content"] = "\n".join(text_parts) if text_parts else None
+                if tool_calls:
+                    am["tool_calls"] = tool_calls
+                out.append(am)
+            else:
+                # user / tool results
+                text_parts = []
+                for b in msg.content:
+                    if b.type == "text":
+                        text_parts.append(b.text)
+                    elif b.type == "tool_result":
+                        out.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": b.tool_use_id,
+                                "content": b.tool_result
+                                if not b.tool_error
+                                else f"ERROR: {b.tool_result}",
+                            }
+                        )
+                if text_parts:
+                    out.append({"role": "user", "content": "\n".join(text_parts)})
+        return out
+
+    def _parse_response(self, raw: dict[str, Any]) -> Response:
+        if raw.get("error"):
+            err = raw["error"]
+            if isinstance(err, dict):
+                raise RuntimeError(
+                    f"{self.provider_name} error: {err.get('type', '')}: {err.get('message', err)}"
+                )
+            raise RuntimeError(f"{self.provider_name} error: {err}")
+
+        usage = raw.get("usage") or {}
+        choices = raw.get("choices") or []
+        if not choices:
+            raise RuntimeError(f"{self.provider_name}: empty choices in response")
+        message = choices[0].get("message") or {}
+        content: list[Block] = []
+        text = message.get("content")
+        if text:
+            content.append(Block(type="text", text=text))
+        for tc in message.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            args_raw = fn.get("arguments") or "{}"
+            try:
+                args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+            except json.JSONDecodeError:
+                args = args_raw
+            content.append(
+                Block(
+                    type="tool_use",
+                    id=str(tc.get("id") or ""),
+                    tool_name=str(fn.get("name") or ""),
+                    tool_input=args,
+                )
+            )
+        finish = choices[0].get("finish_reason")
+        if finish == "length":
+            raise RuntimeError(
+                f"{self.provider_name} response truncated at max_tokens "
+                f"({MAX_OUTPUT_TOKENS}); the diff may be too large"
+            )
+        return Response(
+            content=content,
+            input_tokens=int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0),
+            output_tokens=int(
+                usage.get("completion_tokens") or usage.get("output_tokens") or 0
+            ),
+        )
+
+    def _post_json(self, url: str, body: dict[str, Any]) -> dict[str, Any]:
+        last_err: Exception | None = None
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"Bearer {self.api_key}",
+        }
+        # TokenHub / some gateways also accept api-key style headers; Bearer is enough.
+        payload = json.dumps(body).encode("utf-8")
+        for attempt in range(MAX_ATTEMPTS):
+            if attempt > 0:
+                time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+            try:
+                with httpx.Client(timeout=self.timeout) as client:
+                    resp = client.post(url, content=payload, headers=headers)
+                if resp.status_code == 200:
+                    return resp.json()
+                last_err = RuntimeError(
+                    f"{self.provider_name} API {resp.status_code}: {resp.text.strip()}"
+                )
+                if resp.status_code not in (408, 429) and resp.status_code < 500:
+                    raise last_err
+            except httpx.HTTPError as e:
+                last_err = e
+        raise RuntimeError(f"after {MAX_ATTEMPTS} attempts: {last_err}")

--- a/meat_python_plus/src/meat_python_plus/providers/resolve.py
+++ b/meat_python_plus/src/meat_python_plus/providers/resolve.py
@@ -1,0 +1,194 @@
+"""Resolve which HTTP backend and credentials to use from env + model id."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from meat_python_plus.model import Model
+from meat_python_plus.providers.anthropic_msgs import AnthropicMessagesModel
+from meat_python_plus.providers.openai_compat import OpenAICompatModel
+
+DEFAULT_MODEL = "gpt-4.1-mini"
+
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+
+CODEX_ONLY_MSG = (
+    "CODEX_AUTH_JSON is a Codex CLI subscription credential, not a Chat Completions "
+    "API key. meat_python_plus needs an HTTP chat API. Set OPENAI_API_KEY, "
+    "NOUS_API_KEY, TOKENHUB_API_KEY, ANTHROPIC_API_KEY, or MEAT_BASE_URL+MEAT_API_KEY "
+    "(or OPENAI_BASE_URL)."
+)
+
+
+@dataclass(frozen=True)
+class ResolvedProvider:
+    kind: str  # openai_compat | anthropic
+    model: str
+    api_key: str
+    base_url: str
+    provider_name: str  # openai | nous | tokenhub | custom | anthropic
+
+
+def resolve_model_name(model: str = "") -> str:
+    if model:
+        return model
+    return os.environ.get("MEAT_MODEL") or DEFAULT_MODEL
+
+
+def is_anthropic_model(model: str) -> bool:
+    m = model.removeprefix("anthropic/")
+    return m.startswith("claude-")
+
+
+def is_nous_model(model: str) -> bool:
+    lower = model.lower()
+    return (
+        lower.startswith("nous/")
+        or lower.startswith("deepseek/")
+        or "deepseek-v4" in lower
+    )
+
+
+def is_tokenhub_model(model: str) -> bool:
+    lower = model.lower()
+    if lower.startswith("tokenhub/"):
+        return True
+    if lower in {"hy3", "tokenhub/hy3"}:
+        return True
+    if lower.startswith("hy3"):
+        return True
+    return False
+
+
+def _env(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def resolve_provider(model: str = "") -> ResolvedProvider:
+    """Pick provider from model id hints and available env credentials.
+
+    Priority when model does not force a vendor:
+      1. MEAT_BASE_URL + (MEAT_API_KEY|OPENAI_API_KEY)
+      2. OPENAI_API_KEY
+      3. NOUS_API_KEY
+      4. TOKENHUB_API_KEY
+      5. ANTHROPIC_API_KEY (only for Claude model ids)
+    Model-id prefixes (claude-, nous/, tokenhub/, hy3, deepseek/) force that vendor.
+    """
+    model = resolve_model_name(model)
+    openai_key = _env("OPENAI_API_KEY")
+    nous_key = _env("NOUS_API_KEY")
+    tokenhub_key = _env("TOKENHUB_API_KEY")
+    anthropic_key = _env("ANTHROPIC_API_KEY")
+    meat_base = (_env("MEAT_BASE_URL") or _env("OPENAI_BASE_URL")).rstrip("/")
+    meat_key = _env("MEAT_API_KEY")
+
+    if is_anthropic_model(model):
+        if not anthropic_key and not _env("ANTHROPIC_BASE_URL"):
+            raise ValueError(
+                "no Anthropic credentials: set ANTHROPIC_API_KEY "
+                "(Claude models require the Messages API)"
+            )
+        base = (_env("ANTHROPIC_BASE_URL") or "https://api.anthropic.com").rstrip("/")
+        return ResolvedProvider(
+            kind="anthropic",
+            model=model.removeprefix("anthropic/"),
+            api_key=anthropic_key,
+            base_url=base,
+            provider_name="anthropic",
+        )
+
+    if is_tokenhub_model(model):
+        if not tokenhub_key:
+            raise ValueError(
+                f"TokenHub model {model!r} requires TOKENHUB_API_KEY "
+                f"(base {TOKENHUB_BASE_URL})"
+            )
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=model.removeprefix("tokenhub/"),
+            api_key=tokenhub_key,
+            base_url=TOKENHUB_BASE_URL,
+            provider_name="tokenhub",
+        )
+
+    if is_nous_model(model):
+        if not nous_key:
+            raise ValueError(
+                f"Nous/DeepSeek model {model!r} requires NOUS_API_KEY "
+                f"(base {NOUS_BASE_URL})"
+            )
+        clean = model[5:] if model.lower().startswith("nous/") else model
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=clean,
+            api_key=nous_key,
+            base_url=NOUS_BASE_URL,
+            provider_name="nous",
+        )
+
+    # Custom OpenAI-compatible (explicit base URL).
+    if meat_base and (meat_key or openai_key):
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=model,
+            api_key=meat_key or openai_key,
+            base_url=meat_base,
+            provider_name="custom",
+        )
+
+    if openai_key:
+        base = meat_base or "https://api.openai.com/v1"
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=model,
+            api_key=openai_key,
+            base_url=base,
+            provider_name="openai",
+        )
+
+    if nous_key:
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=model,
+            api_key=nous_key,
+            base_url=NOUS_BASE_URL,
+            provider_name="nous",
+        )
+
+    if tokenhub_key:
+        return ResolvedProvider(
+            kind="openai_compat",
+            model=model,
+            api_key=tokenhub_key,
+            base_url=TOKENHUB_BASE_URL,
+            provider_name="tokenhub",
+        )
+
+    if _env("CODEX_AUTH_JSON") and not any(
+        [_env("OPENAI_API_KEY"), nous_key, tokenhub_key, anthropic_key, meat_key]
+    ):
+        raise ValueError(CODEX_ONLY_MSG)
+
+    raise ValueError(
+        "no LLM credentials: set OPENAI_API_KEY, NOUS_API_KEY, TOKENHUB_API_KEY, "
+        "ANTHROPIC_API_KEY, or MEAT_BASE_URL+MEAT_API_KEY"
+    )
+
+
+def new_model_from_env(model: str = "") -> Model:
+    resolved = resolve_provider(model)
+    if resolved.kind == "anthropic":
+        return AnthropicMessagesModel(
+            api_key=resolved.api_key,
+            model=resolved.model,
+            base_url=resolved.base_url,
+        )
+    return OpenAICompatModel(
+        api_key=resolved.api_key,
+        model=resolved.model,
+        base_url=resolved.base_url,
+        provider_name=resolved.provider_name,
+    )

--- a/meat_python_plus/src/meat_python_plus/rubric.py
+++ b/meat_python_plus/src/meat_python_plus/rubric.py
@@ -1,0 +1,185 @@
+"""Rubric / system prompt and protocol version for abridge caching."""
+
+from __future__ import annotations
+
+import hashlib
+
+# Protocol version mixed into the cache key. Bump when edit semantics or the
+# frozen prompt surface change in a way that should invalidate caches.
+ABRIDGE_PROTOCOL_VERSION = "source-edit-plan-v10-python-plus-v1"
+
+SYSTEM_PROMPT = """You are a code-reading assistant for a senior engineer who spends their day reading diffs of GOOD code. The code compiles and its tests pass. The reviewer is NOT hunting for nil panics or sweating details. They are trying to understand the change to the program at a high level: what changed, where did data come from, where did it go, what new control flow or behavior appeared.
+
+Your job: given a numbered unified diff (which may span MANY files), choose what to KEEP, REMOVE, and FOLD to produce an abridged "reading diff". Meat applies your edit plan to the immutable original diff. You NEVER write or regenerate the final diff yourself.
+
+Most edits should remove whole original lines. For a contiguous run of source lines that carries useful shape but excessive detail, use a fold: Meat mechanically replaces the range with one correctly marked and indented ... line. When only part of one line is noise, use a local elision whose replacement matches the source while representing every omitted span with ... or …. Folds and elisions preserve a code-shaped reading experience without allowing invented identifiers, comments, or behavior. The result is for reading, not compiling.
+
+Reason across the whole change: a line that looks like noise in one file is often explained by a change in another. You have read-only tools to inspect the surrounding source tree. USE THEM when a clue would change your judgment about whether something is load-bearing. Do NOT over-investigate: most lines can be judged from the diff alone.
+
+When a plan is sizeable, call preview_plan first and inspect the projected diff plus its retention feedback (very large previews are explicitly truncated). Refine once if the preview is still mechanically verbose. Then call submit with complete remove, replace, and fold arrays plus a one-line summary.
+
+## Principles
+
+1. KEEP lines where everything matters: a changed argument, a new condition, a different function being called, a changed return path, anything that alters behavior or data flow.
+
+2. COLLAPSE mechanical repetition. Keep the semantic anchor that names the operation, then fold or remove repeated members, calls, setup, and cases. For a rename or call-site migration repeated across hunks, keep one representative old/new anchor and drop the other purely mechanical hunks; retain another only when it exposes a distinct condition, transformation, effect, or compatibility boundary. Use fold when the omitted block's existence or nesting still helps the reader; Meat emits only a fixed ..., never model prose. Use plain removal when no placeholder is useful. The result should feel like code and need not compile.
+
+Default unified-diff context is not valuable by default. File and hunk headings usually provide orientation already. Remove nearby blank lines, unchanged comments, and the usual three context rows unless they identify the owning definition, close a retained construct, establish data used by a surviving row, or show control flow needed to interpret the change. Treat comments and docstrings the same way: retain contracts, security or compatibility caveats, non-obvious rationale, and conditions the code does not make evident; drop issue restatements, changelog prose, and line-by-line narration.
+
+3. ELIDE error-message construction. If a branch calls t.Errorf / fmt.Errorf / log / returns an error, the reviewer generally trusts the message. Keep the control flow and the fact that it errors; replace noisy message arguments with .... Keep details when error identity, wrapping, type, status, or control behavior is itself changing.
+
+4. DROP entirely changes that are obvious, forced, and behavior-neutral: a zero value added to a return list because a new return value was introduced, gofmt realignment, and mechanical renames already obvious from a kept line.
+
+5. DROP generated code entirely. Machine-generated files are outputs of the change, not the change itself. Remove the full file section and mention regeneration in the summary. Strong clues include a "Code generated ... DO NOT EDIT." header and conventional generated paths. If unsure, use read_file or grep. Keep the hand-written source change that drove generation.
+
+6. IMPORTS ARE REMOVED AUTOMATICALLY, WITHOUT EXCEPTION. Meat removes imports, includes, requires, and use declarations from every preview and result: package swaps, aliases, multiline blocks, unchanged framing rows, and import statements inside embedded source snippets or multiline test-fixture strings. Do not spend remove/fold/replace coordinates on these rows and do not mention them in the summary; shape only the behavioral rows around the import-free preview.
+
+7. TREAT BEHAVIORAL MOVES SYMMETRICALLY. Meat conservatively detects exact source-evidenced moves across hunks and files and reports their paired original coordinates. Give both sides of every aligned pair identical keep/remove/fold/replace treatment, including matching fold boundaries and equivalent local elisions; rows Meat already removed automatically need no coordinates from you. A moved behavioral block must read as relocation, never as a one-sided deletion or one-sided compression.
+
+8. NEVER invent or alter program logic. Removal and compression are allowed; lying is not. If unsure whether something matters, KEEP it.
+
+9. Preserve enough file, hunk, and context structure that the reviewer can locate every retained change. Keep diff/---/+++ and @@ lines for partially retained files and hunks. If an entire file is noise, remove its whole section rather than leaving orphan metadata.
+
+## Edit protocol
+
+The input gutter has the form N|source. N is a 1-based physical line number in the immutable original diff; the gutter is not source text.
+
+- remove contains inclusive start_line/end_line ranges. All coordinates always refer to the original diff and never shift.
+- replace elides part of one original source line inside a hunk. line is its original line number. old is an exact substring AFTER the leading +, -, or context-space diff marker and must occur exactly once there. new must match all of old, with every omitted span represented by ... or ….
+- fold contains inclusive ranges of at least two contiguous hunk source lines. Every line must be in the same hunk and have the same leading diff marker (+, -, or context space). Meat derives their common source indentation and emits exactly one marker + indentation + ... row. You choose only coordinates; never supply fold text.
+- Prefer remove for pure noise, fold for useful block shape with repetitive internals, and replace only when part of one useful line is noise.
+- new may be reading-code and need not compile, but it cannot silently delete characters or invent comments, identifiers, punctuation, or whitespace.
+- Never include the numbered gutter or leading diff marker in old.
+- Do not replace or fold diff metadata or hunk headers. Remove metadata only as part of dropping its complete file or hunk.
+- Every preview and submission is a complete model plan against the ORIGINAL diff, not an incremental edit of a prior preview. Imports may still appear in the numbered input, but they are absent from every preview and result.
+- When Meat reports an exact move pair such as -72..81 ↔ +23..32, give corresponding rows identical keep/remove/fold/replace treatment, including fold starts and ends and equivalent local elisions. Rows Meat removed automatically need no matching coordinates; asymmetric treatment of the rest is rejected.
+- Do not fold across an import row and behavioral rows; fold only the behavioral range. Import-only folds and edits are redundant.
+- Submit empty remove, replace, and fold arrays when no edits of that kind are needed.
+- Retention feedback is advisory, not a quota. If it says retention is high, make one more pass over obvious suites and repetition, but keep uncertain or semantically distinct code.
+- If no meaningful change remains, remove every original line.
+
+## Python: semantic skeletons and suites
+
+For Python files, abridge around a semantic skeleton rather than isolated interesting lines. Preserve the smallest connected path that shows:
+
+1. CONTRACT / DEFINITION — the changed function, method, fixture, class, decorator, marker, or option being introduced or modified.
+2. BEHAVIOR-CHANGING CONDITION — guards, exception boundaries, precedence, async/lifecycle points, and branches that determine when behavior applies.
+3. TRANSFORMATION — the non-obvious computation, normalization, lookup, mutation, or dispatch.
+4. OBSERVABLE EFFECT — return/yield/raise, emitted response, state mutation, warning/log category, callback, or external call.
+5. TEST SPECIFICATION — scenario identity, distinctive stimulus/configuration, and expected result.
+
+Compress everything else around those anchors. Imports are already removed automatically. Python has many other high-yield SUITES: decorator stacks, docstrings, literal tables, fixture bodies, repeated call sites, parametrized cases, assertion batches, and exception setup. Keep the suite's owner and decisive rows, then fold the repetitive interior. In tests, keep setup only when it is required to understand or produce a surviving stimulus or outcome. Keep the scenario owner, distinctive inputs/configuration, and one decisive assertion for each different outcome dimension; fold or remove repeated construction, teardown, equivalent cases, and assertion batches. Never delete a fixture, route, embedded configuration, or state transition that the retained stimulus actually depends on. A surviving loop, comprehension, or parametrized test must not refer to a table or fixture that was deleted so aggressively that its role is unknowable; keep the definition and representative shape, usually with a fold inside it. Meat rejects folds that hide a simple assignment such as tests = [...] while a retained line still references tests.
+
+Python-specific rules:
+
+- Decorators and the definition they govern are atomic. Never leave a decorator detached. Keep decorators whose arguments define behavior: route paths/methods, pytest marks and parameters, fixture scope/autouse, dataclass/typing semantics, caching/registration, or async/task behavior. Meat rejects added/context folds that swallow a decorator or suite owner; keep the anchor and fold only its indented interior.
+- Multiline expressions, calls, comprehensions, signatures, and strings must preserve recognizable boundaries. Prefer folding complete interior rows while keeping opener and closer. Never retain a dangling delimiter, orphan continuation, or misleading fragment. Meat rejects plans that change triple-quote boundary parity within a hunk. Import blocks are the exception: remove the whole block rather than preserving its boundaries.
+- Multiline strings often are the stimulus or expected output. Keep the assignment/call and the distinctive lines that define the case. Fold boring bulk only when the remaining string still communicates its semantic role and shape. In pytester.makeini, keep the relevant section, option name, and value (for example filterwarnings and ignore::UserWarning); in makeconftest, embedded import rows are removed automatically, so keep behavior-changing decorators, hooks, calls, and warning/exception types. Never replace the entire stimulus call with one fold merely because it is multiline.
+- Parametrization values are test specification, not boilerplate. Keep dimensions and boundary/distinctive values; fold truly repetitive middle cases. Keep each surviving expected outcome paired with its input.
+- Fixtures are semantic when scope, autouse, setup/teardown, yield boundary, monkeypatching, environment, or shared state matters. Keep those lifecycle edges; fold incidental construction.
+- Imports are removed automatically (rule 6); do not duplicate those removals in your plan. References to imported names in retained code are expected and need no import context.
+- Preserve async boundaries (async def, await, task/context-manager lifecycle), exception type and control behavior, and warning category/filter when changed. Error message prose may be locally elided unless exact text is part of a public contract or test assertion.
+- For repetitive suites, prefer fold over deleting the entire suite. A fixed indented ... shows that omitted code exists without pretending to explain it.
+
+## Worked examples
+
+Numbered raw field copies:
+    101|+    // Extra data used for cache management but not routing.
+    102|+    resp.SSHKeyID = rd.sshKeyID
+    103|+    resp.UserID = rd.userID
+    104|+    resp.BoxID = int64(rd.boxID)
+    105|+    resp.BoxName = rd.boxName
+    106|+    resp.ExpiresAt = timestamppb.New(rd.expiresAt)
+
+Good plan: keep line 101; remove 103-106; on line 102 replace the exact old span
+    .sshKeyID
+with
+    ...
+The reading result is resp.SSHKeyID = rd...: source-shaped, compact, and made only by elision.
+
+Numbered raw assertion:
+    201|+    if rd.sshKeyID != sshKeyID {
+    202|+        t.Errorf("route SSH Key ID = %d, want %d", rd.sshKeyID, sshKeyID)
+    203|+    }
+
+Keep all three lines; on line 202 replace the exact message-and-arguments span with ... so the reading result is t.Errorf(...). The checked condition remains visible.
+
+When collapsing a test, keep it looking like code review rather than a paragraph. Remove repetitive setup, but retain the signature, stimulus, and assertion lines that communicate the scenario. Do not invent a prose comment to replace the body; when the meaningful body is short, the code itself is faster to read.
+
+Numbered Python table and consumer:
+    220|+CASES = [
+    221|+    ("empty", "", None),
+    222|+    ("simple", "a", "a"),
+    223|+    ("escaped", "a\\nb", "a\nb"),
+    224|+    ("unicode", "π", "π"),
+    225|+]
+    226|+
+    227|+@pytest.mark.parametrize("name, raw, expected", CASES)
+    228|+def test_parse(name, raw, expected):
+    229|+    assert parse(raw) == expected
+Keep 220, representative/distinctive rows, 225, and 227-229. If 222-224 are repetitive enough, fold 222-224 so Meat emits +    .... Do not delete the CASES definition while retaining a test that depends on it, and do not hide the parametrization dimensions or expected outcome.
+
+Numbered multiline call:
+    240|+result = render_template(
+    241|+    template_name,
+    242|+    context,
+    243|+    locale=locale,
+    244|+)
+Keep 240 and 244. Keep any argument whose changed value is the behavior; fold only contiguous same-polarity interior arguments that are routine. Never leave the call without its closer.
+
+Numbered exact move with uniform reindentation:
+    601|-    config_filters = config.getini("filterwarnings")
+    602|-    apply_warning_filters(config_filters, cmdline_filters)
+    603|-    yield log
+    ...
+    711|+        config_filters = config.getini("filterwarnings")
+    712|+        apply_warning_filters(config_filters, cmdline_filters)
+    713|+        yield log
+If Meat reports -601..603 ↔ +711..713, keep both spans, remove both, or use matching folds such as 601-603 and 711-713. Folding or removing only one side is rejected because it makes relocation look like deletion.
+
+Numbered raw context plumbing:
+    301|+    ctx := context.Background()
+    302|@@
+    303|-    m, err := meat.NewAnthropicFromEnv(*model)
+    304|+    m, err := meat.NewAnthropicFromEnv(ctx, *model)
+If this is merely forced context forwarding and the meaningful context origin/use is represented elsewhere, remove the complete hunk or file section. Keep it when timeout, cancellation, values, or Done behavior matters.
+
+Numbered import churn:
+    501| import (
+    502| 	"fmt"
+    503|-	"math/rand"
+    504|+	"crypto/rand"
+    505|+	"encoding/hex"
+    506| )
+    507|@@
+    508|-    return fmt.Sprintf("%x", b)
+    509|+    if _, err := rand.Read(b); err != nil {
+    510|+        panic(err)
+    511|+    }
+    512|+    return hex.EncodeToString(b)
+Meat removes 501-506 automatically even when your plan is empty; keep and shape only 508-512. The package substitution may be security-relevant, but the behavioral body is the meat: rand.Read and the new return path already reveal the change. Imports are scaffolding, hidden automatically. The same machinery handles Python from/import rows, JavaScript imports/requires, Rust use declarations, C/C++ includes, Java/Kotlin imports, and recognized import rows inside multiline source fixtures.
+
+Numbered raw plumbing before a call:
+    401|+    host := cfg.Host
+    402|+    if override != "" {
+    403|+        host = override
+    404|+    }
+    405|+    conn, err := dial(host)
+The override precedence in 401-404 cannot be reconstructed by inventing a comment on 405. If that precedence is reviewer-important, keep the lines. Only remove them when the same behavior is already made explicit elsewhere in the retained change. Never semicolon-pack several removed statements onto line 405.
+
+Keep a changed argument exactly when it is the point of the change:
+    -    p, err := parseSSHKeyPerms(permsJSON)
+    +    p, err := parseSSHKeyPerms(vals.Permissions)
+
+A zero value added only because a new return slot exists elsewhere may be removed with its complete hunk. A generated file may be removed with its complete file section. Mention fully omitted mechanical/generated material in the one-line summary.
+
+The final result should be a dense reading diff made from the original diff by Meat's automatic import removals and only your explicit local compressions. Prefer code-shaped evidence over explanatory prose, and prefer keeping uncertain code over hiding something important."""
+
+
+def rubric_hash() -> str:
+    """Short content hash of protocol version + system prompt (cache identity)."""
+    h = hashlib.sha256()
+    h.update(ABRIDGE_PROTOCOL_VERSION.encode())
+    h.update(b"\0")
+    h.update(SYSTEM_PROMPT.encode())
+    return h.hexdigest()[:16]

--- a/meat_python_plus/src/meat_python_plus/tools.py
+++ b/meat_python_plus/src/meat_python_plus/tools.py
@@ -1,0 +1,340 @@
+"""Read-only agent tools: preview_plan, submit, read_file, grep."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from meat_python_plus.editplan import (
+    CompiledPlan,
+    Submission,
+    compile_edit_plan,
+    compile_submission,
+    parse_edit_plan,
+    parse_submission,
+    plan_feedback,
+    retention_pressure,
+)
+from meat_python_plus.model import Tool
+
+MAX_TOOL_OUTPUT = 16 * 1024
+
+EDIT_PLAN_PROPERTIES = {
+    "remove": {
+        "type": "array",
+        "description": (
+            "Inclusive 1-based ranges of original diff lines to omit. "
+            "Coordinates never shift."
+        ),
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "start_line": {"type": "integer", "minimum": 1},
+                "end_line": {"type": "integer", "minimum": 1},
+            },
+            "required": ["start_line", "end_line"],
+        },
+    },
+    "replace": {
+        "type": "array",
+        "description": (
+            "Single-line source elisions. new must match old with each omitted "
+            "span visibly replaced by ... or … ."
+        ),
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "line": {"type": "integer", "minimum": 1},
+                "old": {"type": "string", "minLength": 1},
+                "new": {"type": "string"},
+            },
+            "required": ["line", "old", "new"],
+        },
+    },
+    "fold": {
+        "type": "array",
+        "description": (
+            "Ranges of two or more same-polarity hunk source lines to replace "
+            "with one machine-generated, indentation-preserving ... row."
+        ),
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "start_line": {"type": "integer", "minimum": 1},
+                "end_line": {"type": "integer", "minimum": 1},
+            },
+            "required": ["start_line", "end_line"],
+        },
+    },
+}
+
+
+def edit_plan_schema(with_summary: bool) -> dict[str, Any]:
+    props = dict(EDIT_PLAN_PROPERTIES)
+    required = ["remove", "replace", "fold"]
+    if with_summary:
+        props["summary"] = {
+            "type": "string",
+            "description": "One-line, high-level description of what the change does.",
+        }
+        required = required + ["summary"]
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": props,
+        "required": required,
+    }
+
+
+def truncate_for_tool(s: str) -> str:
+    if len(s.encode("utf-8")) <= MAX_TOOL_OUTPUT:
+        return s
+    # Truncate by characters approximating byte budget.
+    cut = MAX_TOOL_OUTPUT
+    encoded = s.encode("utf-8")[:cut]
+    while encoded:
+        try:
+            text = encoded.decode("utf-8")
+            break
+        except UnicodeDecodeError:
+            encoded = encoded[:-1]
+    else:
+        text = ""
+    return text + f"\n... (truncated, {len(s.encode('utf-8'))} total bytes)"
+
+
+def cap_lines(s: str, max_lines: int) -> str:
+    lines = s.splitlines(keepends=True)
+    if len(lines) <= max_lines:
+        return s
+    return "".join(lines[:max_lines]) + f"... (truncated, more than {max_lines} lines)\n"
+
+
+def slice_lines(text: str, start: int, end: int) -> str:
+    lines = text.split("\n")
+    if start < 1:
+        start = 1
+    if end < 1 or end > len(lines):
+        end = len(lines)
+    if start > len(lines):
+        return ""
+    parts = [f"{i}\t{lines[i - 1]}\n" for i in range(start, end + 1)]
+    return "".join(parts)
+
+
+class Toolbox:
+    def __init__(self, root: str, raw_diff: str) -> None:
+        self.root = root
+        self.raw_diff = raw_diff
+        self.smart_diff = ""
+        self.submitted: Submission | None = None
+        self.submitted_plan: CompiledPlan | None = None
+        self.submit_seen = False
+
+    def tools(self) -> list[Tool]:
+        preview = Tool(
+            name="preview_plan",
+            description=(
+                "Validate a complete remove/replace/fold plan against the numbered "
+                "ORIGINAL diff and preview the resulting reading diff with retention "
+                "statistics. Imports are removed automatically. Large previews are "
+                "explicitly truncated. Plans are never incremental."
+            ),
+            input_schema=edit_plan_schema(False),
+        )
+        submit = Tool(
+            name="submit",
+            description=(
+                "Submit a final complete remove/replace/fold plan against the numbered "
+                "ORIGINAL diff plus a one-line summary. Meat applies the plan locally; "
+                "do not submit a rewritten diff."
+            ),
+            input_schema=edit_plan_schema(True),
+        )
+        if not self.root:
+            return [preview, submit]
+        return [
+            Tool(
+                name="read_file",
+                description=(
+                    "Read a UTF-8 text file from the repository. Paths are relative to "
+                    "the repo root. Optionally restrict to start_line/end_line."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "start_line": {"type": "integer"},
+                        "end_line": {"type": "integer"},
+                    },
+                    "required": ["path"],
+                },
+            ),
+            Tool(
+                name="grep",
+                description=(
+                    "Search the repository for a regular expression (git grep). "
+                    "Optionally scope to a path prefix."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "path": {"type": "string"},
+                    },
+                    "required": ["pattern"],
+                },
+            ),
+            preview,
+            submit,
+        ]
+
+    def run(self, name: str, tool_input: Any) -> tuple[str, bool]:
+        if isinstance(tool_input, str):
+            try:
+                tool_input = json.loads(tool_input) if tool_input.strip() else {}
+            except json.JSONDecodeError as e:
+                return f"invalid input: {e}", True
+        if tool_input is None:
+            tool_input = {}
+        if name == "read_file":
+            return self._read_file(tool_input)
+        if name == "grep":
+            return self._grep(tool_input)
+        if name == "preview_plan":
+            return self._preview_plan(tool_input)
+        if name == "submit":
+            return self._submit(tool_input)
+        return f'unknown tool "{name}"', True
+
+    def resolve_in_root(self, rel: str) -> str:
+        clean = Path(rel)
+        if clean.is_absolute():
+            raise ValueError("path must be relative to the repo root")
+        root_abs = Path(self.root).resolve()
+        abs_path = (root_abs / clean).resolve()
+        try:
+            abs_path.relative_to(root_abs)
+        except ValueError as e:
+            raise ValueError("path escapes the repo root") from e
+        return str(abs_path)
+
+    def _read_file(self, inp: dict[str, Any]) -> tuple[str, bool]:
+        path = str(inp.get("path") or "")
+        try:
+            abs_path = self.resolve_in_root(path)
+        except ValueError as e:
+            return str(e), True
+        try:
+            data = Path(abs_path).read_text(encoding="utf-8")
+        except OSError as e:
+            return f"read {path}: {e}", True
+        start = int(inp.get("start_line") or 0)
+        end = int(inp.get("end_line") or 0)
+        if start > 0 or end > 0:
+            data = slice_lines(data, start, end)
+        return truncate_for_tool(data), False
+
+    def _grep(self, inp: dict[str, Any]) -> tuple[str, bool]:
+        pattern = str(inp.get("pattern") or "").strip()
+        if not pattern:
+            return "pattern is required", True
+        args = ["git", "grep", "-n", "-I", "--no-color", "-e", pattern]
+        path = str(inp.get("path") or "")
+        if path:
+            try:
+                self.resolve_in_root(path)
+            except ValueError as e:
+                return str(e), True
+            args.extend(["--", path])
+        try:
+            proc = subprocess.run(
+                args,
+                cwd=self.root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as e:
+            return f"git grep: {e}", True
+        out = proc.stdout or ""
+        if not out:
+            if proc.returncode in (0, 1):
+                return "(no matches)", False
+            return f"git grep: {(proc.stderr or '').strip()}", True
+        return truncate_for_tool(cap_lines(out, 200)), False
+
+    def _require_arrays(self, data: dict[str, Any]) -> str | None:
+        for key in ("remove", "replace", "fold"):
+            if key not in data or data[key] is None:
+                return "remove, replace, and fold must all be JSON arrays (use [] when empty)"
+            if not isinstance(data[key], list):
+                return "remove, replace, and fold must all be JSON arrays (use [] when empty)"
+        return None
+
+    def _preview_plan(self, data: dict[str, Any]) -> tuple[str, bool]:
+        err = self._require_arrays(data)
+        if err:
+            return f"invalid input: {err}", True
+        try:
+            plan = parse_edit_plan(data)
+            compiled = compile_edit_plan(self.raw_diff, plan)
+        except (TypeError, ValueError, KeyError) as e:
+            return truncate_for_tool(f"invalid edit plan: {e}"), True
+        return truncate_for_tool(plan_feedback(compiled)), False
+
+    def _submit(self, data: dict[str, Any]) -> tuple[str, bool]:
+        if self.submit_seen:
+            return "a submission has already been accepted", True
+        err = self._require_arrays(data)
+        if err:
+            return f"invalid input: {err}", True
+        try:
+            submission = parse_submission(data)
+            compiled = compile_submission(self.raw_diff, submission)
+        except (TypeError, ValueError, KeyError) as e:
+            return truncate_for_tool(f"invalid edit plan: {e}"), True
+        self.submitted = submission
+        self.submitted_plan = compiled
+        self.smart_diff = compiled.smart_diff
+        self.submit_seen = True
+        return truncate_for_tool(plan_feedback(compiled)), False
+
+    def clear_submission(self) -> None:
+        self.smart_diff = ""
+        self.submitted = None
+        self.submitted_plan = None
+        self.submit_seen = False
+
+
+def describe_tool_call(name: str, tool_input: Any) -> str:
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except json.JSONDecodeError:
+            tool_input = {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    if name == "read_file":
+        return f"read_file {tool_input.get('path', '')}".strip()
+    if name == "grep":
+        return f'grep "{tool_input.get("pattern", "")}"'
+    if name == "preview_plan":
+        return "previewing"
+    if name == "submit":
+        return "submitting"
+    return name
+
+
+__all__ = [
+    "Toolbox",
+    "describe_tool_call",
+    "retention_pressure",
+    "truncate_for_tool",
+]

--- a/meat_python_plus/tests/test_abridge_offline.py
+++ b/meat_python_plus/tests/test_abridge_offline.py
@@ -1,0 +1,74 @@
+"""Offline abridge test with a fake Model that submits a remove plan."""
+
+from meat_python_plus.abridge import Request, abridge
+from meat_python_plus.model import Block, Message, Response, Tool
+
+DIFF = """diff --git a/demo.py b/demo.py
+--- a/demo.py
++++ b/demo.py
+@@ -1,3 +1,3 @@
+ keep_me = True
+-noise_one = 1
+-noise_two = 2
++noise_one = 10
++noise_two = 20
+"""
+
+
+class KeepOneChange:
+    """Submit a plan that keeps one behavioral change line."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def generate(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[Tool],
+    ) -> Response:
+        self.calls += 1
+        assert "reading diff" in system.lower() or "code-reading" in system.lower()
+        assert any(t.name == "submit" for t in tools)
+        # 1 header, 2 ---, 3 +++, 4 @@, 5 keep_me, 6-7 old, 8-9 new
+        return Response(
+            content=[
+                Block(
+                    type="tool_use",
+                    id="call_1",
+                    tool_name="submit",
+                    tool_input={
+                        "remove": [
+                            {"start_line": 6, "end_line": 7},
+                            {"start_line": 9, "end_line": 9},
+                        ],
+                        "replace": [],
+                        "fold": [],
+                        "summary": "Shows the noise_one update.",
+                    },
+                )
+            ],
+            input_tokens=3,
+            output_tokens=2,
+        )
+
+
+def test_abridge_offline_remove_plan():
+    model = KeepOneChange()
+    res = abridge(model, Request(unified_diff=DIFF, repo_root=""))
+    assert model.calls == 1
+    assert "Shows the noise_one update" in res.summary
+    assert "+noise_one = 10" in res.smart_diff
+    assert "-noise_one" not in res.smart_diff
+    assert "noise_two" not in res.smart_diff
+    assert "keep_me" in res.smart_diff
+    assert res.input_tokens == 3
+
+
+def test_abridge_empty_diff():
+    class Boom:
+        def generate(self, *a, **k):  # type: ignore[no-untyped-def]
+            raise AssertionError("should not call model")
+
+    res = abridge(Boom(), Request(unified_diff="   "))  # type: ignore[arg-type]
+    assert res.summary == "No changes."

--- a/meat_python_plus/tests/test_editplan.py
+++ b/meat_python_plus/tests/test_editplan.py
@@ -1,0 +1,83 @@
+import pytest
+
+from meat_python_plus.editplan import (
+    EditPlan,
+    LineFold,
+    LineRange,
+    LineReplacement,
+    Submission,
+    compile_edit_plan,
+    compile_submission,
+    is_elision_projection,
+)
+
+DIFF = """diff --git a/x.py b/x.py
+--- a/x.py
++++ b/x.py
+@@ -1,4 +1,4 @@
+ import os
+-old_a = 1
+-old_b = 2
++new_a = 1
++new_b = 2
+ context
+"""
+
+
+def test_elision_projection():
+    assert is_elision_projection("hello world", "hello ...")
+    assert is_elision_projection("sshKeyID", "...")
+    assert not is_elision_projection("hello", "hello")
+    assert not is_elision_projection("hello world", "hello")
+
+
+def test_remove_lines():
+    # 1 header 2 --- 3 +++ 4 @@ 5 import 6 -old_a 7 -old_b 8 +new_a 9 +new_b 10 context
+    plan = EditPlan(remove=[LineRange(6, 7)], replace=[], fold=[])
+    compiled = compile_edit_plan(DIFF, plan)
+    assert "-old_a" not in compiled.smart_diff
+    assert "-old_b" not in compiled.smart_diff
+    assert "+new_a" in compiled.smart_diff
+    assert "import os" not in compiled.smart_diff
+
+
+def test_fold_same_marker():
+    plan = EditPlan(remove=[], replace=[], fold=[LineFold(8, 9)])
+    compiled = compile_edit_plan(DIFF, plan)
+    assert "+new_a" not in compiled.smart_diff
+    assert "..." in compiled.smart_diff
+
+
+def test_replace_elision():
+    plan = EditPlan(
+        remove=[],
+        replace=[LineReplacement(line=8, old="new_a = 1", new="new_a = ...")],
+        fold=[],
+    )
+    compiled = compile_edit_plan(DIFF, plan)
+    assert "new_a = ..." in compiled.smart_diff
+
+
+def test_invalid_overlap_remove():
+    plan = EditPlan(
+        remove=[LineRange(6, 7), LineRange(7, 8)],
+        replace=[],
+        fold=[],
+    )
+    with pytest.raises(ValueError, match="overlaps"):
+        compile_edit_plan(DIFF, plan)
+
+
+def test_submission_requires_summary():
+    with pytest.raises(ValueError, match="summary"):
+        compile_submission(
+            DIFF,
+            Submission(remove=[], replace=[], fold=[], summary=""),
+        )
+
+
+def test_structure_retention_hunk_header():
+    # Remove every change; only context remains → hunk header must not survive alone.
+    plan = EditPlan(remove=[LineRange(6, 9)], replace=[], fold=[])
+    with pytest.raises(ValueError, match="hunk header"):
+        compile_edit_plan(DIFF, plan)

--- a/meat_python_plus/tests/test_numbered_diff.py
+++ b/meat_python_plus/tests/test_numbered_diff.py
@@ -1,0 +1,28 @@
+from meat_python_plus.diffutil import numbered_diff, split_source_lines
+
+
+SAMPLE = """diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+-old
++new
+"""
+
+
+def test_numbered_diff_gutter():
+    out = numbered_diff(SAMPLE)
+    lines = out.splitlines()
+    assert lines[0].startswith("1|")
+    assert "|diff --git" in lines[0]
+    assert lines[-1].endswith("|+new")
+    # gutter is display-only width-padded
+    assert all("|" in line for line in lines)
+
+
+def test_split_source_lines_preserves_eol():
+    lines = split_source_lines("a\r\nb\n")
+    assert lines[0].text == "a"
+    assert lines[0].eol == "\r\n"
+    assert lines[1].text == "b"
+    assert lines[1].eol == "\n"

--- a/meat_python_plus/tests/test_resolve_provider.py
+++ b/meat_python_plus/tests/test_resolve_provider.py
@@ -1,0 +1,100 @@
+import pytest
+
+from meat_python_plus.providers.resolve import (
+    CODEX_ONLY_MSG,
+    NOUS_BASE_URL,
+    TOKENHUB_BASE_URL,
+    resolve_model_name,
+    resolve_provider,
+)
+
+
+def test_resolve_model_from_env(monkeypatch):
+    monkeypatch.delenv("MEAT_MODEL", raising=False)
+    assert resolve_model_name("") == "gpt-4.1-mini"
+    monkeypatch.setenv("MEAT_MODEL", "hy3")
+    assert resolve_model_name("") == "hy3"
+    assert resolve_model_name("explicit") == "explicit"
+
+
+def test_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("NOUS_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENHUB_API_KEY", raising=False)
+    monkeypatch.delenv("MEAT_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    r = resolve_provider("gpt-4.1-mini")
+    assert r.provider_name == "openai"
+    assert r.base_url.endswith("/v1")
+    assert r.api_key == "sk-test"
+
+
+def test_nous_by_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENHUB_API_KEY", raising=False)
+    monkeypatch.delenv("MEAT_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    r = resolve_provider("gpt-4.1-mini")
+    assert r.provider_name == "nous"
+    assert r.base_url == NOUS_BASE_URL
+
+
+def test_nous_by_model(monkeypatch):
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ignored-for-nous-model")
+    r = resolve_provider("nous/deepseek/deepseek-v4-flash")
+    assert r.provider_name == "nous"
+    assert r.model == "deepseek/deepseek-v4-flash"
+    assert r.base_url == NOUS_BASE_URL
+
+
+def test_tokenhub_hy3(monkeypatch):
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ignored")
+    r = resolve_provider("hy3")
+    assert r.provider_name == "tokenhub"
+    assert r.model == "hy3"
+    assert r.base_url == TOKENHUB_BASE_URL
+
+
+def test_tokenhub_prefix(monkeypatch):
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    r = resolve_provider("tokenhub/deepseek-v4-flash")
+    assert r.provider_name == "tokenhub"
+    assert r.model == "deepseek-v4-flash"
+
+
+def test_anthropic(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-key")
+    r = resolve_provider("claude-opus-4-8")
+    assert r.kind == "anthropic"
+    assert r.provider_name == "anthropic"
+    assert r.model == "claude-opus-4-8"
+
+
+def test_custom_base(monkeypatch):
+    monkeypatch.setenv("MEAT_BASE_URL", "https://example.com/v1")
+    monkeypatch.setenv("MEAT_API_KEY", "custom-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    r = resolve_provider("my-model")
+    assert r.provider_name == "custom"
+    assert r.base_url == "https://example.com/v1"
+    assert r.api_key == "custom-key"
+
+
+def test_codex_only_fails(monkeypatch):
+    for k in (
+        "OPENAI_API_KEY",
+        "NOUS_API_KEY",
+        "TOKENHUB_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "MEAT_API_KEY",
+        "MEAT_BASE_URL",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"tokens":{}}')
+    with pytest.raises(ValueError, match="CODEX_AUTH_JSON"):
+        resolve_provider("gpt-4.1-mini")
+    assert "OPENAI_API_KEY" in CODEX_ONLY_MSG

--- a/meat_python_plus/uv.lock
+++ b/meat_python_plus/uv.lock
@@ -1,0 +1,161 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "meat-python-plus"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/scripts/example_workflows/minimal.yml.tpl
+++ b/scripts/example_workflows/minimal.yml.tpl
@@ -57,3 +57,5 @@ jobs:
           # CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/deepseek/deepseek-v4-flash
+          # TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}   # + model: tokenhub/hy3

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -1,0 +1,122 @@
+"""Known OpenAI-compatible gateways (Nous Portal, Tencent TokenHub).
+
+These providers are reached through the opencode harness via
+``@ai-sdk/openai-compatible``. Callers may still set
+``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` + ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY``
+to override any preset; when those are absent, model prefixes ``nous/`` and
+``tokenhub/`` resolve from ``NOUS_API_KEY`` / ``TOKENHUB_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+NOUS_API_KEY_ENV = "NOUS_API_KEY"
+NOUS_BASE_URL_ENV = "NOUS_BASE_URL"
+DEFAULT_NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+
+TOKENHUB_API_KEY_ENV = "TOKENHUB_API_KEY"
+TOKENHUB_BASE_URL_ENV = "TOKENHUB_BASE_URL"
+DEFAULT_TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+
+CUSTOM_PROVIDER_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
+CUSTOM_PROVIDER_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayPreset:
+    """One named OpenAI-compatible inference gateway."""
+
+    provider_id: str
+    api_key_env: str
+    base_url_env: str
+    default_base_url: str
+
+
+GATEWAY_PRESETS: dict[str, GatewayPreset] = {
+    "nous": GatewayPreset(
+        provider_id="nous",
+        api_key_env=NOUS_API_KEY_ENV,
+        base_url_env=NOUS_BASE_URL_ENV,
+        default_base_url=DEFAULT_NOUS_BASE_URL,
+    ),
+    "tokenhub": GatewayPreset(
+        provider_id="tokenhub",
+        api_key_env=TOKENHUB_API_KEY_ENV,
+        base_url_env=TOKENHUB_BASE_URL_ENV,
+        default_base_url=DEFAULT_TOKENHUB_BASE_URL,
+    ),
+}
+
+
+def _has_env(name: str) -> bool:
+    val = os.environ.get(name)
+    return isinstance(val, str) and bool(val.strip())
+
+
+def has_custom_provider_env() -> bool:
+    """Return whether both generic custom-provider env vars are set."""
+    return _has_env(CUSTOM_PROVIDER_BASE_URL_ENV) and _has_env(CUSTOM_PROVIDER_API_KEY_ENV)
+
+
+def has_gateway_credentials(provider_id: str) -> bool:
+    """Return whether ``provider_id`` can authenticate from the environment."""
+    if has_custom_provider_env():
+        return True
+    preset = GATEWAY_PRESETS.get(provider_id.lower())
+    if preset is None:
+        return False
+    return _has_env(preset.api_key_env)
+
+
+def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
+    """Resolve ``(provider_id, base_url, api_key)`` for an OpenAI-compatible model.
+
+    Preference order:
+
+    1. Explicit ``MERGECRAFT_CUSTOM_PROVIDER_*`` pair (any ``provider/model`` slug)
+    2. Named preset matching the model prefix (``nous/…``, ``tokenhub/…``)
+
+    Returns ``None`` when credentials or a usable model prefix are missing.
+    """
+    if not model:
+        return None
+    slash = model.find("/")
+    if slash <= 0:
+        return None
+    provider_id = model[:slash].lower()
+    model_id = model[slash + 1 :]
+    if not model_id:
+        return None
+
+    custom_base = os.environ.get(CUSTOM_PROVIDER_BASE_URL_ENV, "").strip()
+    custom_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()
+    if custom_base and custom_key:
+        return provider_id, custom_base, custom_key
+
+    preset = GATEWAY_PRESETS.get(provider_id)
+    if preset is None:
+        return None
+    api_key = os.environ.get(preset.api_key_env, "").strip()
+    if not api_key:
+        return None
+    base_url = os.environ.get(preset.base_url_env, "").strip() or preset.default_base_url
+    return provider_id, base_url, api_key
+
+
+__all__ = [
+    "CUSTOM_PROVIDER_API_KEY_ENV",
+    "CUSTOM_PROVIDER_BASE_URL_ENV",
+    "DEFAULT_NOUS_BASE_URL",
+    "DEFAULT_TOKENHUB_BASE_URL",
+    "GATEWAY_PRESETS",
+    "NOUS_API_KEY_ENV",
+    "NOUS_BASE_URL_ENV",
+    "TOKENHUB_API_KEY_ENV",
+    "TOKENHUB_BASE_URL_ENV",
+    "GatewayPreset",
+    "has_custom_provider_env",
+    "has_gateway_credentials",
+    "resolve_gateway_endpoint",
+]

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -14,6 +14,11 @@ import httpx
 from loguru import logger
 
 from mergecraft.agents.gates import build_opencode_native_fs_permission
+from mergecraft.agents.openai_compatible_gateways import (
+    CUSTOM_PROVIDER_API_KEY_ENV,
+    CUSTOM_PROVIDER_BASE_URL_ENV,
+    resolve_gateway_endpoint,
+)
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
 from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
@@ -26,26 +31,30 @@ from mergecraft.agents.shared import (
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
 from mergecraft.types import MERGECRAFT_MCP_NAME
 
-CUSTOM_PROVIDER_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
-CUSTOM_PROVIDER_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+# Re-exported for tests / callers that import these names from opencode.
+__all_gateway_envs__ = (CUSTOM_PROVIDER_BASE_URL_ENV, CUSTOM_PROVIDER_API_KEY_ENV)
 
 
 def build_custom_provider(model: str | None) -> dict[str, object] | None:
-    """Describe an OpenAI-compatible provider declared through the environment.
+    """Describe an OpenAI-compatible provider for opencode.
+
+    Resolution order (see :func:`resolve_gateway_endpoint`):
+
+    1. ``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` + ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY``
+    2. Named presets: ``nous/*`` via ``NOUS_API_KEY``, ``tokenhub/*`` via
+       ``TOKENHUB_API_KEY`` (optional ``NOUS_BASE_URL`` / ``TOKENHUB_BASE_URL``)
 
     The provider id is the segment of ``model`` before the first slash, so
-    ``nous/deepseek/deepseek-v4-flash`` registers provider ``nous`` serving model
-    ``deepseek/deepseek-v4-flash``. Returns ``None`` unless both the base URL and
-    the API key are set, since opencode cannot authenticate with either alone.
+    ``nous/deepseek/deepseek-v4-flash`` registers provider ``nous`` serving
+    ``deepseek/deepseek-v4-flash``, and ``tokenhub/hy3`` registers ``tokenhub``
+    serving ``hy3``.
     """
-    base_url = os.environ.get(CUSTOM_PROVIDER_BASE_URL_ENV, "").strip()
-    api_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()
-    if not (base_url and api_key and model):
+    endpoint = resolve_gateway_endpoint(model)
+    if endpoint is None or not model:
         return None
+    provider_id, base_url, api_key = endpoint
     slash = model.find("/")
-    if slash <= 0:
-        return None
-    provider_id, model_id = model[:slash].lower(), model[slash + 1 :]
+    model_id = model[slash + 1 :]
     return {
         provider_id: {
             "npm": "@ai-sdk/openai-compatible",

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -25,7 +25,11 @@ CODEX_AUTH_SECRET = "CODEX_AUTH_JSON"
 CLAUDE_OAUTH_SECRET = "CLAUDE_CODE_OAUTH_TOKEN"
 GEMINI_API_SECRET = "GEMINI_API_KEY"
 CURSOR_API_SECRET = "CURSOR_API_KEY"
+NOUS_API_SECRET = "NOUS_API_KEY"
+TOKENHUB_API_SECRET = "TOKENHUB_API_KEY"
 CLAUDE_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
+DEFAULT_NOUS_PORTAL = "https://inference-api.nousresearch.com/v1"
+DEFAULT_TOKENHUB = "https://tokenhub-intl.tencentcloudmaas.com/v1"
 
 
 def _bail(msg: str) -> NoReturn:
@@ -256,3 +260,103 @@ def auth_cursor() -> None:
             f"  https://github.com/{repo_slug}/settings/secrets/actions"
         )
     console.print(f"[green]saved {CURSOR_API_SECRET}[/green] to GitHub Actions secrets")
+
+
+def _validate_openai_compatible_key(*, api_key: str, base_url: str, label: str) -> bool:
+    """GET ``{base}/models`` with a Bearer token; treat 401/403 as invalid."""
+    url = base_url.rstrip("/") + "/models"
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.get(
+                url,
+                headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+                params={"limit": 1},
+            )
+        if response.status_code == 200:
+            return True
+        if response.status_code in {401, 403}:
+            return False
+        logger.warning(
+            "{} key validation returned HTTP {} — saving anyway",
+            label,
+            response.status_code,
+        )
+        return True
+    except httpx.HTTPError as exc:
+        logger.warning("{} key validation skipped (network): {}", label, exc)
+        return True
+
+
+@app.command("nous")
+def auth_nous() -> None:
+    """Save a Nous Portal API key as NOUS_API_KEY."""
+    _get_gh_token()
+    owner, repo = _parse_git_remote()
+    repo_slug = f"{owner}/{repo}"
+    console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+    console.print(
+        "create an API key in the Nous Portal, then paste it below "
+        f"(OpenAI-compatible endpoint [cyan]{DEFAULT_NOUS_PORTAL}[/cyan])."
+    )
+    try:
+        api_key = getpass.getpass("Nous Portal API key (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not api_key:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    if not _validate_openai_compatible_key(
+        api_key=api_key, base_url=DEFAULT_NOUS_PORTAL, label="nous"
+    ):
+        _bail("Nous API key validation failed (401/403). Check the key and retry.")
+
+    console.print(f"saving [cyan]{NOUS_API_SECRET}[/cyan] via gh secret set...")
+    if not _set_gh_secret(name=NOUS_API_SECRET, value=api_key, repo_slug=repo_slug):
+        _bail(
+            f"could not set secret — set it manually at:\n"
+            f"  https://github.com/{repo_slug}/settings/secrets/actions"
+        )
+    console.print(f"[green]saved {NOUS_API_SECRET}[/green] to GitHub Actions secrets")
+    console.print(
+        "use model [cyan]nous/deepseek/deepseek-v4-flash[/cyan] "
+        "(opencode harness; no MERGECRAFT_CUSTOM_PROVIDER_* required)."
+    )
+
+
+@app.command("tokenhub")
+def auth_tokenhub() -> None:
+    """Save a Tencent TokenHub API key as TOKENHUB_API_KEY."""
+    _get_gh_token()
+    owner, repo = _parse_git_remote()
+    repo_slug = f"{owner}/{repo}"
+    console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+    console.print(
+        "create an API key in the TokenHub console, then paste it below "
+        f"(OpenAI-compatible endpoint [cyan]{DEFAULT_TOKENHUB}[/cyan]; models include "
+        "[cyan]hy3[/cyan], DeepSeek, GLM, Kimi)."
+    )
+    try:
+        api_key = getpass.getpass("TokenHub API key (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not api_key:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    if not _validate_openai_compatible_key(
+        api_key=api_key, base_url=DEFAULT_TOKENHUB, label="tokenhub"
+    ):
+        _bail("TokenHub API key validation failed (401/403). Check the key and retry.")
+
+    console.print(f"saving [cyan]{TOKENHUB_API_SECRET}[/cyan] via gh secret set...")
+    if not _set_gh_secret(name=TOKENHUB_API_SECRET, value=api_key, repo_slug=repo_slug):
+        _bail(
+            f"could not set secret — set it manually at:\n"
+            f"  https://github.com/{repo_slug}/settings/secrets/actions"
+        )
+    console.print(f"[green]saved {TOKENHUB_API_SECRET}[/green] to GitHub Actions secrets")
+    console.print(
+        "use model [cyan]tokenhub/hy3[/cyan] (or any TokenHub model id as "
+        "[cyan]tokenhub/<id>[/cyan]; opencode harness)."
+    )

--- a/src/mergecraft/models.py
+++ b/src/mergecraft/models.py
@@ -404,6 +404,59 @@ PROVIDERS: dict[str, ProviderConfig] = {
             },
         )
     ),
+    "nous": _provider(
+        ProviderConfig(
+            display_name="Nous Portal",
+            env_vars=("NOUS_API_KEY",),
+            models={
+                "deepseek-v4-flash": ModelDef(
+                    display_name="DeepSeek V4 Flash (Nous)",
+                    description=(
+                        "DeepSeek V4 Flash via the Nous Portal OpenAI-compatible endpoint. "
+                        "Pass as nous/deepseek/deepseek-v4-flash for the portal model id."
+                    ),
+                    resolve="nous/deepseek/deepseek-v4-flash",
+                    preferred=True,
+                ),
+                "deepseek/deepseek-v4-flash": ModelDef(
+                    display_name="DeepSeek V4 Flash",
+                    resolve="nous/deepseek/deepseek-v4-flash",
+                    preferred=True,
+                    hidden=True,
+                ),
+            },
+        )
+    ),
+    "tokenhub": _provider(
+        ProviderConfig(
+            display_name="Tencent TokenHub",
+            env_vars=("TOKENHUB_API_KEY",),
+            models={
+                "hy3": ModelDef(
+                    display_name="Hy3",
+                    description="Tencent Hunyuan Hy3 via TokenHub (OpenAI-compatible).",
+                    resolve="tokenhub/hy3",
+                    preferred=True,
+                ),
+                "deepseek-v4-flash": ModelDef(
+                    display_name="DeepSeek V4 Flash (TokenHub)",
+                    resolve="tokenhub/deepseek-v4-flash",
+                ),
+                "deepseek-v4-pro": ModelDef(
+                    display_name="DeepSeek V4 Pro (TokenHub)",
+                    resolve="tokenhub/deepseek-v4-pro",
+                ),
+                "glm-5.2": ModelDef(
+                    display_name="GLM 5.2 (TokenHub)",
+                    resolve="tokenhub/glm-5.2",
+                ),
+                "kimi-k3": ModelDef(
+                    display_name="Kimi K3 (TokenHub)",
+                    resolve="tokenhub/kimi-k3",
+                ),
+            },
+        )
+    ),
     "openrouter": _provider(
         ProviderConfig(
             display_name="OpenRouter",

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -71,6 +71,12 @@ def _has_cursor_auth() -> bool:
     return _has_env("CURSOR_API_KEY")
 
 
+def _has_gateway_auth(provider: str) -> bool:
+    from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
+
+    return has_gateway_credentials(provider)
+
+
 def has_credentials_for_slug(slug: str) -> bool:
     """Return whether the current environment has credentials for ``slug``."""
     try:
@@ -90,6 +96,8 @@ def has_credentials_for_slug(slug: str) -> bool:
         return _has_bedrock_auth() and bool(os.environ.get(BEDROCK_MODEL_ID_ENV, "").strip())
     if provider == "vertex":
         return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
+    if provider in {"nous", "tokenhub"}:
+        return _has_gateway_auth(provider)
     return False
 
 
@@ -646,6 +654,22 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
 
         if provider == "anthropic" and _has_claude_code_auth():
             return agents["claude"]
+
+        if provider in {"nous", "tokenhub"}:
+            if _has_gateway_auth(provider):
+                return agents["opencode"]
+            hints = (
+                ("NOUS_API_KEY", "mergecraft auth nous")
+                if provider == "nous"
+                else ("TOKENHUB_API_KEY", "mergecraft auth tokenhub")
+            )
+            msg = (
+                f"{provider} model {model!r} selected but no credential is configured. "
+                f"Set {hints[0]} (via `{hints[1]}` or a GitHub Actions secret), "
+                "or set MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
+                "MERGECRAFT_CUSTOM_PROVIDER_API_KEY, or choose a different model."
+            )
+            raise ValueError(msg)
 
     return agents["opencode"]
 

--- a/src/mergecraft/utils/meat_harness.py
+++ b/src/mergecraft/utils/meat_harness.py
@@ -100,7 +100,15 @@ _MEAT_REQUIRED_KEYS: frozenset[str] = frozenset({"smart_diff", "summary"})
 #: Env-var names the harness promises it never reads or logs (convention 8).
 #: They are present so a static check can assert the harness does not
 #: ``os.environ.get(name)`` them directly.
-MEAT_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset({"OPENAI_API_KEY", "ANTHROPIC_API_KEY"})
+MEAT_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "NOUS_API_KEY",
+        "TOKENHUB_API_KEY",
+        "MEAT_API_KEY",
+    }
+)
 
 #: Env-var names whose **values** are stripped from subprocess stderr tails
 #: before they are surfaced in a log record, stored on
@@ -111,6 +119,9 @@ MEAT_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset({"OPENAI_API_KEY", "ANTHROP
 _MEAT_REDACT_ENVVARS: tuple[str, ...] = (
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
+    "NOUS_API_KEY",
+    "TOKENHUB_API_KEY",
+    "MEAT_API_KEY",
     "MEAT_MODEL",
 )
 
@@ -305,12 +316,14 @@ def run_meat_harness(
     if not meat_binary.exists():
         logger.warning(
             "meat binary not found at {}; skipping reading-diff lens "
-            "(install via `go install meat.dev/cmd/meat@latest`).",
+            "(install meat_python_plus for `meat-py`, or "
+            "`go install meat.dev/cmd/meat@latest`).",
             meat_binary,
         )
         return _skip_result(
             raw_diff,
-            "skip: meat binary not found; install via `go install meat.dev/cmd/meat@latest`",
+            "skip: meat binary not found; install meat_python_plus (`meat-py`) "
+            "or `go install meat.dev/cmd/meat@latest`",
         )
 
     # The subprocess inherits the *process* env unchanged. The harness

--- a/tests/agents/test_opencode_custom_provider.py
+++ b/tests/agents/test_opencode_custom_provider.py
@@ -25,6 +25,10 @@ NOUS_MODEL = "nous/deepseek/deepseek-v4-flash"
 def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(CUSTOM_PROVIDER_BASE_URL_ENV, raising=False)
     monkeypatch.delenv(CUSTOM_PROVIDER_API_KEY_ENV, raising=False)
+    monkeypatch.delenv("NOUS_API_KEY", raising=False)
+    monkeypatch.delenv("NOUS_BASE_URL", raising=False)
+    monkeypatch.delenv("TOKENHUB_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENHUB_BASE_URL", raising=False)
 
 
 def _config(tmp_path: Path, model: str | None) -> dict[str, object]:
@@ -79,3 +83,55 @@ def test_unconfigured_environment_leaves_config_unchanged(tmp_path: Path) -> Non
 
     assert "provider" not in config
     assert config["enabled_providers"] == ["nous"]
+
+
+def test_nous_api_key_alone_registers_preset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+
+    config = _config(tmp_path, NOUS_MODEL)
+
+    assert config["provider"] == {
+        "nous": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "nous",
+            "options": {"baseURL": NOUS_BASE_URL, "apiKey": "nous-key"},
+            "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
+        }
+    }
+
+
+def test_tokenhub_api_key_registers_hy3(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+
+    config = _config(tmp_path, "tokenhub/hy3")
+
+    assert config["provider"] == {
+        "tokenhub": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "tokenhub",
+            "options": {
+                "baseURL": "https://tokenhub-intl.tencentcloudmaas.com/v1",
+                "apiKey": "th-key",
+            },
+            "models": {"hy3": {"name": "hy3"}},
+        }
+    }
+    assert config["enabled_providers"] == ["tokenhub"]
+    assert config["model"] == "tokenhub/hy3"
+
+
+def test_custom_provider_env_overrides_named_preset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    monkeypatch.setenv(CUSTOM_PROVIDER_BASE_URL_ENV, "https://example.test/v1")
+    monkeypatch.setenv(CUSTOM_PROVIDER_API_KEY_ENV, "custom-key")
+
+    config = _config(tmp_path, NOUS_MODEL)
+
+    assert config["provider"]["nous"]["options"] == {
+        "baseURL": "https://example.test/v1",
+        "apiKey": "custom-key",
+    }

--- a/tests/utils/test_gateway_providers.py
+++ b/tests/utils/test_gateway_providers.py
@@ -1,0 +1,72 @@
+"""Unit tests for Nous / TokenHub gateway credential resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents.openai_compatible_gateways import (
+    resolve_gateway_endpoint,
+)
+from mergecraft.utils.agent_resolve import (
+    has_credentials_for_slug,
+    resolve_runtime_agent,
+)
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.fixture(autouse=True)
+def _clear_gateway_env(monkeypatch: MonkeyPatch) -> None:
+    for key in (
+        "NOUS_API_KEY",
+        "NOUS_BASE_URL",
+        "TOKENHUB_API_KEY",
+        "TOKENHUB_BASE_URL",
+        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL",
+        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+        "MERGECRAFT_AGENT",
+        "OPENAI_API_KEY",
+        "CODEX_AUTH_JSON",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_has_credentials_for_nous_and_tokenhub(monkeypatch: MonkeyPatch) -> None:
+    assert not has_credentials_for_slug("nous/deepseek/deepseek-v4-flash")
+    assert not has_credentials_for_slug("tokenhub/hy3")
+
+    monkeypatch.setenv("NOUS_API_KEY", "n-key")
+    assert has_credentials_for_slug("nous/deepseek/deepseek-v4-flash")
+
+    monkeypatch.delenv("NOUS_API_KEY")
+    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
+    assert has_credentials_for_slug("tokenhub/hy3")
+    assert has_credentials_for_slug("tokenhub/deepseek-v4-flash")
+
+
+def test_resolve_runtime_agent_routes_gateways_to_opencode(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
+    agent = resolve_runtime_agent(model="tokenhub/hy3")
+    assert agent.name == "opencode"
+
+    monkeypatch.delenv("TOKENHUB_API_KEY")
+    monkeypatch.setenv("NOUS_API_KEY", "n-key")
+    agent = resolve_runtime_agent(model="nous/deepseek/deepseek-v4-flash")
+    assert agent.name == "opencode"
+
+
+def test_resolve_gateway_endpoint_tokenhub_default_url(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
+    endpoint = resolve_gateway_endpoint("tokenhub/hy3")
+    assert endpoint == (
+        "tokenhub",
+        "https://tokenhub-intl.tencentcloudmaas.com/v1",
+        "t-key",
+    )


### PR DESCRIPTION
## Summary
- Add `meat_python_plus/`: Python reading-diff port of [boldsoftware/meat](https://github.com/boldsoftware/meat) with OpenAI, Anthropic, Nous, and TokenHub (hy3 + any TokenHub model id)
- First-class `nous/*` and `tokenhub/*` in mergeCraft CLI (`auth nous` / `auth tokenhub`), opencode harness, Action, and example workflows — `NOUS_API_KEY` / `TOKENHUB_API_KEY` alone are enough (`MERGECRAFT_CUSTOM_PROVIDER_*` still overrides)
- Codex subscription path unchanged for mergeCraft reviews; meat_python_plus fails clearly if only `CODEX_AUTH_JSON` is set (no chat API)

## Why
Operators need BYOK paths beyond metered API keys: Codex subscription auth for reviews, plus OpenAI-compatible gateways (Nous Portal, Tencent TokenHub/Hy3) without hand-wiring custom provider env vars every time.

## Note
The follow-up commit that updates `.github/workflows/mergecraft.yml` (TokenHub primary when Nous is absent) is committed locally but not on this branch tip yet — the push token lacks `workflow` scope. After `gh auth refresh -s workflow`, push from the worktree to include it.

## Test plan
- [x] `make lint` / `make typecheck`
- [x] Gateway + opencode custom-provider + meat harness pytest
- [x] `meat_python_plus` offline suite (20 passed)
- [ ] Push workflow commit after `gh auth refresh -s workflow`
- [ ] Optional live: `TOKENHUB_API_KEY` + `model: tokenhub/hy3`; `NOUS_API_KEY` + `nous/deepseek/deepseek-v4-flash`
