### PR TITLE
feat(auth): add `mergecraft auth logfire` (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,9 +99,23 @@ MEAT_MODEL=gpt-5.6-sol
 
 # ---------------------------------------------------------------------------
 # Tracing (opt-in, additive; see docs/TRACING.md and W7/W8 of the tracing plan)
+#
+# The `mergecraft auth logfire` command writes both env vars below. Run it
+# once per checkout:
+#
+#     mergecraft auth logfire                       # both .env + gh secret
+#     mergecraft auth logfire --scope local         # only .env
+#     mergecraft auth logfire --scope github        # only gh secret set
+#
+# `MERGECRAFT_LOGFIRE_TOKEN` is the runtime token (resolved by the sink
+# factory). `MERGECRAFT_TRACING_PROJECT` becomes the `x-logfire-project`
+# header at runtime. For the GitHub Action, mirror the token into the
+# `LOGFIRE_TOKEN` Actions secret and wire `tracing-to: logfire` +
+# `logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` on the workflow step.
 # ---------------------------------------------------------------------------
 
-# LOGFIRE_TOKEN=
+# MERGECRAFT_LOGFIRE_TOKEN=
+# MERGECRAFT_TRACING_PROJECT=
 # OTEL_ENDPOINT=http://127.0.0.1:4318/v1/traces
 
 # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mergecraft auth logfire` — operator-facing setup for the Logfire tracing sink
+  (issue #56 / D5). The subcommand prompts for a Logfire write token via
+  `getpass` and a project label via `typer.prompt`, validates the token against
+  `GET https://logfire.pydantic.dev/api/v1/projects` (OTLP/HTTP returns 200 for
+  invalid tokens — it accepts and discards — so the REST endpoint is the only
+  path that actually enforces the bearer with a real `401`/`403`), then writes
+  `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT` into the local
+  `.env` (via `python-dotenv`'s idempotent `set_key`) and/or the
+  `LOGFIRE_TOKEN` Actions secret via `gh secret set`. `--scope local|github|both`
+  selects where the credentials land; the default is `both`. The `[tracing]`
+  extra check is non-blocking — the command warns when `logfire` is missing
+  but does not auto-install (BYOK / convention 5). New env var
+  `MERGECRAFT_TRACING_PROJECT` plumbed through the precedence layer
+  (`src/mergecraft/cli/tracing_precedence.py`) and the sink factory
+  (`_resolve_logfire_project` in `src/mergecraft/tracing/exporters.py`) so the
+  project label becomes the `x-logfire-project` header at runtime
 - First-class Nous Research / DeepSeek V4 Flash support (#57). The catalog now
   enumerates `nous/deepseek/deepseek-v4-flash` as a curated alias
   (`PROVIDERS["nous"]` in `src/mergecraft/models.py`), with `resolve` set to the

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Full config reference: [`examples/config.yaml`](examples/config.yaml).
 | Nous Portal | — (API key) | `mergecraft auth nous` → `NOUS_API_KEY` (`nous/deepseek/deepseek-v4-flash`) |
 | Tencent TokenHub | — (API key) | `mergecraft auth tokenhub` → `TOKENHUB_API_KEY` (`tokenhub/hy3` + any TokenHub model) |
 | Cursor Cloud | `mergecraft auth cursor` → `CURSOR_API_KEY` | `CURSOR_API_KEY` |
+| Logfire tracing | `mergecraft auth logfire` → `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT` (local) and `LOGFIRE_TOKEN` (Actions) | see [`docs/TRACING.md`](docs/TRACING.md) |
 
 Subscription auth runs the official `claude` / `codex` / `gemini` CLIs as *you*
 — the same credential your local coding agent uses. Only set env vars for
@@ -243,12 +244,13 @@ providers you actually use.
 | Command | Purpose |
 |---------|---------|
 | `mergecraft init` | Scaffold `.mergecraft/config.yaml` + example workflow |
-| `mergecraft auth <provider>` | Save a credential via `gh secret set` (`claude`, `codex`, `gemini`, `nous`, `tokenhub`, `cursor`) |
+| `mergecraft auth <provider>` | Save a credential via `gh secret set` (`claude`, `codex`, `gemini`, `nous`, `tokenhub`, `cursor`, `logfire`) |
 | `mergecraft models list / set / show` | Curated slugs, ordered preference list, effective winner |
 | `mergecraft diff-review` | Offline local git/patch review (`--dry-run`, `--json`) |
 | `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
 | `mergecraft learnings active / staging / influence` | Audit memory entries and their provenance |
 | `mergecraft traces <run-id>` | Read back local tracing spans (re-redacted) |
+| `mergecraft config tracing` | Render resolved tracing state (token redacted) |
 | `mergecraft gha` | Action runtime entry (Docker action) |
 
 ## 🔒 Security model

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -22,6 +22,41 @@ A repo that does not declare a `tracing:` block sees identical behaviour,
 identical performance, and zero egress — the default is off, and the
 disabled path is a true no-op (no directory is created).
 
+## Quick start: enable Logfire tracing
+
+The shortest path from a fresh checkout to spans landing in Logfire:
+
+```bash
+# 1. install the optional extra (one time)
+uv sync --extra tracing
+
+# 2. run the auth command (validates the token, writes .env + gh secret)
+mergecraft auth logfire
+
+# 3. verify wiring (token is redacted in the table)
+mergecraft config tracing
+
+# 4. ship a trace
+mergecraft diff-review --tracing --tracing-to logfire
+```
+
+`mergecraft auth logfire` accepts `--scope local|github|both` (default
+`both`). `local` writes `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT`
+into `.env`; `github` calls `gh secret set LOGFIRE_TOKEN` on the origin
+repo; `both` does both. The validator probes
+`GET https://logfire.pydantic.dev/api/v1/projects` (parity with the other
+`auth` providers) and rejects the token on `401`/`403` before any state
+changes. The `[tracing]` extra must be installed for spans to actually leave
+the runner — the command prints a warning when the extra is missing but does
+not auto-install (BYOK, convention 5).
+
+For the GitHub Action, the workflow step should pass
+`tracing-to: logfire` + `logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` (the
+`LOGFIRE_TOKEN` secret is the same value `auth logfire --scope github`
+sets). The Action input `logfire-token` maps to the runtime
+`MERGECRAFT_LOGFIRE_TOKEN` env var; the project label is read from
+`MERGECRAFT_TRACING_PROJECT` or the YAML `tracing.sinks[].project` field.
+
 ## Config schema
 
 ```yaml

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -9,10 +9,11 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import NoReturn
+from typing import Literal, NoReturn
 
 import httpx
 import typer
+from dotenv import set_key as _dotenv_set_key
 from loguru import logger
 from rich.console import Console
 
@@ -31,6 +32,15 @@ TOKENHUB_API_SECRET = "TOKENHUB_API_KEY"
 CLAUDE_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 DEFAULT_NOUS_PORTAL = "https://inference-api.nousresearch.com/v1"
 DEFAULT_TOKENHUB = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+# Logfire setup (issue #56 / D5). ``LOGFIRE_TOKEN`` is the Action secret the
+# ``logfire-token`` input maps to; ``MERGECRAFT_LOGFIRE_TOKEN`` is the
+# runtime-only env var the sink factory resolves as a fallback; the project
+# label becomes the ``x-logfire-project`` header at runtime.
+LOGFIRE_TOKEN_SECRET = "LOGFIRE_TOKEN"
+LOGFIRE_RUNTIME_TOKEN_ENV = "MERGECRAFT_LOGFIRE_TOKEN"
+LOGFIRE_PROJECT_ENV = "MERGECRAFT_TRACING_PROJECT"
+LOGFIRE_PROBE_URL = "https://logfire.pydantic.dev/api/v1/projects"
+LogfireScope = Literal["local", "github", "both"]
 
 
 def _bail(msg: str) -> NoReturn:
@@ -392,4 +402,245 @@ def auth_tokenhub() -> None:
     console.print(
         "use model [cyan]tokenhub/hy3[/cyan] (or any TokenHub model id as "
         "[cyan]tokenhub/<id>[/cyan]; opencode harness)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ``mergecraft auth logfire`` — Logfire token + project for remote tracing.
+# Issue #56 / D5 / D15. The sink type lives behind the optional ``[tracing]``
+# extra; this command does not auto-install the extra (BYOK / convention 5).
+# ---------------------------------------------------------------------------
+
+
+def _validate_logfire_token(api_key: str) -> bool:
+    """Return whether ``api_key`` authenticates against Logfire.
+
+    Probes ``GET /api/v1/projects`` on the public Logfire ingest host with a
+    ``Bearer`` auth header. Mirrors the other validators' contract:
+
+    - ``200`` → accept (True).
+    - ``401`` / ``403`` → reject (False).
+    - any other status, ``httpx.HTTPError``, network/DNS/5xx → warn and accept
+      (True) so an offline operator can still save the secret locally and
+      retry later.
+
+    The probe path is ``/api/v1/projects`` rather than the OTLP ingest because
+    OTLP/HTTP returns 200 even for invalid tokens (it accepts and discards),
+    while the projects endpoint enforces the bearer token with a real 401/403.
+    """
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.get(
+                LOGFIRE_PROBE_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("logfire key validation skipped (network): {}", exc)
+        return True
+    if response.status_code == 200:
+        return True
+    if response.status_code in {401, 403}:
+        return False
+    logger.warning(
+        "logfire key validation returned HTTP {} — saving anyway",
+        response.status_code,
+    )
+    return True
+
+
+def _logfire_extra_installed() -> bool:
+    """True when the optional ``[tracing]`` extra (``logfire`` package) is present.
+
+    Mirrors ``shutil.which("codex")`` for ``auth_codex``: the auth command
+    never auto-installs, but tells the operator what's missing before saving
+    a token that will silently no-op until the extra lands.
+    """
+    try:
+        import logfire  # noqa: F401 — import probe only
+
+        return True
+    except ImportError:
+        return False
+
+
+def _write_env_value(env_path: Path, key: str, value: str) -> bool:
+    """Write ``key=value`` into ``env_path`` idempotently via ``python-dotenv``.
+
+    Returns ``True`` when the write landed, ``False`` when ``python-dotenv``
+    failed to update the file (rare — a permissions error on ``.env``). The
+    helper is the only code path that writes ``.env``; ``python-dotenv`` is
+    already a base dep (``pyproject.toml``) so this adds zero new surface.
+
+    ``set_key`` preserves comments and other keys, creates the file when
+    absent, and returns the new value verbatim. We do not return the value to
+    the caller — it is already in scope — only success/failure.
+    """
+    try:
+        _dotenv_set_key(str(env_path), key, value, quote_mode="always")
+    except OSError as exc:
+        logger.warning("dotenv set_key failed for {}: {}", env_path, exc)
+        return False
+    return True
+
+
+def _local_env_path() -> Path:
+    """Return the local ``.env`` path the auth command writes to.
+
+    Resolution order: ``$MERGECRAFT_ENV`` if set (lets tests pin a temp file),
+    otherwise ``./.env`` relative to the current working directory. The
+    ``.env.example`` template at the repo root is the documented starting
+    point — operators who haven't initialised run ``cp .env.example .env``
+    first; the auth command writes into whatever ``.env`` they already have.
+    """
+    configured = os.environ.get("MERGECRAFT_ENV")
+    if configured:
+        return Path(configured).resolve()
+    return Path.cwd() / ".env"
+
+
+def _normalise_scope(value: str) -> LogfireScope:
+    """Coerce a CLI string into one of ``local`` / ``github`` / ``both``.
+
+    Accepts ``both`` and ``all`` as synonyms (the latter for parity with how
+    some operators verbalise it). Anything else bails with a hint that points
+    back at ``--help``.
+    """
+    lowered = value.strip().lower()
+    if lowered in {"local"}:
+        return "local"
+    if lowered in {"github", "gh", "action"}:
+        return "github"
+    if lowered in {"both", "all"}:
+        return "both"
+    msg = f"unknown --scope value {value!r}; expected one of: local, github, both"
+    _bail(msg)
+
+
+@app.command("logfire")
+def auth_logfire(
+    scope: str = typer.Option(
+        "both",
+        "--scope",
+        "-s",
+        help=(
+            "Where to persist the credentials: 'local' (.env), 'github' "
+            "(gh secret set), or 'both' (default). 'both' writes the local "
+            ".env AND sets the GitHub Actions secret on the origin repo."
+        ),
+    ),
+) -> None:
+    """Save a Logfire write token + project for the ``logfire`` tracing sink.
+
+    Writes ``MERGECRAFT_LOGFIRE_TOKEN`` and ``MERGECRAFT_TRACING_PROJECT``
+    into the local ``.env`` and/or the ``LOGFIRE_TOKEN`` Actions secret on the
+    ``origin`` GitHub repo. After this runs, ``mergecraft diff-review
+    --tracing --tracing-to logfire`` ships spans to Logfire; ``mergecraft
+    config tracing`` shows the project and a redacted token.
+
+    The ``[tracing]`` extra must be installed for spans to actually leave the
+    runner — install with ``uv pip install 'merge-craft[tracing]'`` (or
+    ``uv sync --extra tracing``) when the warning fires.
+    """
+    target = _normalise_scope(scope)
+
+    # Probe both halves up front so the operator does not half-save a broken
+    # token. Local writes happen after validation; the gh secret set runs
+    # last so a failed ``gh auth`` bails before any state changes. ``gh`` is
+    # only required when the scope actually writes a secret — local-only
+    # operators on a machine without ``gh`` should not be blocked.
+    repo_slug: str | None = None
+    if target in {"github", "both"}:
+        _get_gh_token()
+        owner, repo = _parse_git_remote()
+        repo_slug = f"{owner}/{repo}"
+        console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+
+    console.print(
+        "create a write token at [cyan]https://logfire.pydantic.dev/[/cyan] "
+        "(Settings → Write tokens), then paste it below. The token grants "
+        "trace ingest for the project you name — keep it out of chat and "
+        "logs."
+    )
+    try:
+        token = getpass.getpass("Logfire write token (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not token:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    if not _validate_logfire_token(token):
+        _bail("Logfire token validation failed (401/403). Check the token and retry.")
+
+    project = typer.prompt(
+        "Logfire project label (Enter to cancel)",
+        default="",
+        show_default=False,
+    ).strip()
+    if not project:
+        console.print("canceled.")
+        raise typer.Exit(0)
+    # Same surface as the validator: Logfire accepts arbitrary project strings
+    # via the ``x-logfire-project`` header, but reject whitespace inside the
+    # label so a stray newline does not silently change the routing key.
+    if any(ch.isspace() for ch in project):
+        _bail("Logfire project label must not contain whitespace.")
+
+    # Optional-but-loud check: the [tracing] extra must be installed for
+    # spans to actually leave the runner. Don't fail closed — the operator
+    # may want to set the secret first and install later — but print a clear
+    # one-liner so the failure mode is not "nothing happens".
+    if not _logfire_extra_installed():
+        console.print(
+            "[yellow]warning:[/yellow] the [cyan][tracing][/cyan] extra is "
+            "not installed. Spans will not leave the runner until you run "
+            "[cyan]uv pip install 'merge-craft[tracing]'[/cyan]. The token "
+            "and project were saved regardless — re-running this command "
+            "after install is not required."
+        )
+
+    wrote_local = False
+    if target in {"local", "both"}:
+        env_path = _local_env_path()
+        env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, token)
+        env_project_ok = _write_env_value(env_path, LOGFIRE_PROJECT_ENV, project)
+        wrote_local = env_token_ok and env_project_ok
+        if wrote_local:
+            console.print(
+                f"[green]wrote[/green] {LOGFIRE_RUNTIME_TOKEN_ENV} and "
+                f"{LOGFIRE_PROJECT_ENV} to {env_path}"
+            )
+        else:
+            console.print(
+                f"[yellow]warning:[/yellow] could not update {env_path} "
+                f"— set {LOGFIRE_RUNTIME_TOKEN_ENV} and "
+                f"{LOGFIRE_PROJECT_ENV} manually or check file permissions."
+            )
+
+    wrote_github = False
+    if target in {"github", "both"}:
+        assert repo_slug is not None
+        console.print(f"saving [cyan]{LOGFIRE_TOKEN_SECRET}[/cyan] via gh secret set...")
+        wrote_github = _set_gh_secret(name=LOGFIRE_TOKEN_SECRET, value=token, repo_slug=repo_slug)
+        if wrote_github:
+            console.print(f"[green]saved {LOGFIRE_TOKEN_SECRET}[/green] to GitHub Actions secrets")
+        else:
+            console.print(
+                f"[yellow]warning:[/yellow] gh secret set failed — set it manually at:\n"
+                f"  https://github.com/{repo_slug}/settings/secrets/actions"
+            )
+
+    if not wrote_local and not wrote_github:
+        _bail(
+            "nothing was written — both local and github scopes failed. "
+            "retry with --scope local or --scope github to isolate the failure."
+        )
+
+    console.print(
+        "\n[bold]next steps[/bold]\n"
+        f"  - verify wiring: [cyan]mergecraft config tracing[/cyan] "
+        f"(token is redacted)\n"
+        f"  - run with traces: [cyan]mergecraft diff-review --tracing --tracing-to logfire[/cyan]\n"
+        f"  - in the GitHub Action, the workflow can pass "
+        f"[cyan]tracing-to: logfire[/cyan] + [cyan]logfire-token: ${{{{ secrets.{LOGFIRE_TOKEN_SECRET} }}}}[/cyan]"
     )

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -611,8 +611,10 @@ def auth_logfire(
                 f"{LOGFIRE_PROJECT_ENV} to {env_path}"
             )
         else:
+            # Bandit's B608 fires on the interpolated `env_path`; this is a
+            # console warning, not a SQL statement (no DB engine involved).
             console.print(
-                f"[yellow]warning:[/yellow] could not update {env_path} "
+                f"[yellow]warning:[/yellow] could not update {env_path} "  # nosec B608
                 f"— set {LOGFIRE_RUNTIME_TOKEN_ENV} and "
                 f"{LOGFIRE_PROJECT_ENV} manually or check file permissions."
             )

--- a/src/mergecraft/cli/tracing_cmd.py
+++ b/src/mergecraft/cli/tracing_cmd.py
@@ -102,6 +102,9 @@ def config_tracing(
     if "otel_endpoint" in resolved:
         table.add_row("otel_endpoint", resolved["otel_endpoint"])
 
+    if "tracing_project" in resolved:
+        table.add_row("project", resolved["tracing_project"])
+
     logfire_token = resolved.get("logfire_token")
     if logfire_token is not None:
         table.add_row("logfire_token", f"{_TOKEN_REDACTED_MARKER} [dim](redacted)[/dim]")
@@ -211,6 +214,8 @@ def render_resolved(resolved: dict[str, Any]) -> str:
         parts.append(f"  trace_dir: {resolved['trace_dir']}")
     if "otel_endpoint" in resolved:
         parts.append(f"  otel_endpoint: {resolved['otel_endpoint']}")
+    if "tracing_project" in resolved:
+        parts.append(f"  project: {resolved['tracing_project']}")
     if "logfire_token" in resolved:
         token = resolved["logfire_token"]
         if token is not None and not _is_redacted(str(token)):

--- a/src/mergecraft/cli/tracing_precedence.py
+++ b/src/mergecraft/cli/tracing_precedence.py
@@ -108,6 +108,14 @@ def _resolve_env_layer(env: dict[str, str]) -> dict[str, Any]:
         out["logfire_token"] = env["MERGECRAFT_LOGFIRE_TOKEN"]
     if "MERGECRAFT_OTEL_ENDPOINT" in env:
         out["otel_endpoint"] = env["MERGECRAFT_OTEL_ENDPOINT"]
+    # ``MERGECRAFT_TRACING_PROJECT`` carries the Logfire project label that
+    # becomes the ``x-logfire-project`` header at runtime. The CLI
+    # ``auth logfire`` command writes this alongside ``MERGECRAFT_LOGFIRE_TOKEN``
+    # so the operator never has to edit ``.env`` by hand.
+    if "MERGECRAFT_TRACING_PROJECT" in env:
+        project = env["MERGECRAFT_TRACING_PROJECT"].strip()
+        if project:
+            out["tracing_project"] = project
     return out
 
 
@@ -130,6 +138,11 @@ def _resolve_config_layer(config_path: str | None) -> dict[str, Any]:
             out["tracing_to"] = sink_type
             if first.get("endpoint"):
                 out["otel_endpoint"] = first["endpoint"]
+            # Surface the per-sink ``project`` field for ``logfire`` entries so
+            # ``mergecraft config tracing`` and the sink factory can render
+            # the project the YAML declared (parity with the env layer).
+            if sink_type == "logfire" and first.get("project"):
+                out["tracing_project"] = first["project"]
     return out
 
 

--- a/src/mergecraft/tracing/exporters.py
+++ b/src/mergecraft/tracing/exporters.py
@@ -549,6 +549,28 @@ def _event_for_emit(*, kind: str, attrs: dict[str, Any], session_id: str) -> Any
     )
 
 
+def _resolve_logfire_project(entry: Any) -> str | None:
+    """Resolve the Logfire project label.
+
+    Order of precedence:
+
+    1. The sink entry's own ``project`` field (``tracing.sinks[].project``).
+    2. The ``MERGECRAFT_TRACING_PROJECT`` env var, written by
+       ``mergecraft auth logfire`` and surfaced through the precedence layer
+       (``mergecraft.cli.tracing_precedence``).
+
+    The env-var fallback lets an operator who set up Logfire via the CLI never
+    touch the YAML config — the project label travels with the token.
+    """
+    project = getattr(entry, "project", None)
+    if project:
+        return str(project)
+    import os
+
+    env_project = os.environ.get("MERGECRAFT_TRACING_PROJECT", "").strip()
+    return env_project or None
+
+
 def _build_logfire_sink(
     entry: Any,
     logfire_module: Any | None,
@@ -566,7 +588,7 @@ def _build_logfire_sink(
 
         return NullSink()
     return OTLPSink.for_logfire(
-        project=getattr(entry, "project", None),
+        project=_resolve_logfire_project(entry),
         token=token,
         logfire_module=logfire_module,
     )

--- a/tests/cli/test_auth_logfire_cmd.py
+++ b/tests/cli/test_auth_logfire_cmd.py
@@ -1,0 +1,391 @@
+"""RED contracts for ``mergecraft auth logfire`` (issue #56 / D5 / D15).
+
+Wave plan: ``.ignorelocal/waves/issues-tracing-observability-wave-plan.md``
+W-tracing-auth — the operator-facing setup command for Logfire as a tracing
+sink. Pins the contract for the new ``auth logfire`` subcommand:
+
+- ``getpass`` prompt for the token + ``typer.prompt`` for the project label
+  (project is **not** a secret — it is a routing string).
+- Validator probes ``GET /api/v1/projects`` on the public Logfire ingest host
+  (OTLP/HTTP returns 200 for invalid tokens — it accepts and discards — so
+  we have to probe the REST endpoint). 200 → accept; 401/403 → reject;
+  5xx / ``httpx.HTTPError`` → warn-and-save (parity with the other
+  validators).
+- ``--scope local|github|both`` controls where the credentials land:
+  - ``local`` writes ``MERGECRAFT_LOGFIRE_TOKEN`` and ``MERGECRAFT_TRACING_PROJECT``
+    into ``.env`` via ``python-dotenv``'s ``set_key`` (idempotent — re-running
+    updates, never duplicates).
+  - ``github`` calls ``gh secret set LOGFIRE_TOKEN`` on the origin repo.
+  - ``both`` (default) does both.
+- Fails closed when ``gh auth token`` returns nothing or ``gh`` is absent —
+  but only when ``--scope github|both`` (a local-only operator without ``gh``
+  is not blocked).
+- Network access goes through ``httpx.MockTransport`` only — no real call to
+  ``logfire.pydantic.dev`` from this file.
+"""
+
+from __future__ import annotations
+
+import getpass
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+LOGFIRE_PROBE_PATH = "/api/v1/projects"
+LOGFIRE_PROBE_URL = "https://logfire.pydantic.dev/api/v1/projects"
+
+
+def _load_auth_cmd() -> object:
+    """Lazy import so missing symbols fail with a clear message, not at collection time."""
+    try:
+        return importlib.import_module("mergecraft.cli.auth_cmd")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.cli.auth_cmd not importable: {exc}")
+
+
+def _load_validator() -> Any:
+    """Return the ``_validate_logfire_token`` symbol (or fail loudly if absent)."""
+    module = _load_auth_cmd()
+    validator = getattr(module, "_validate_logfire_token", None)
+    if validator is None:
+        pytest.fail("mergecraft.cli.auth_cmd._validate_logfire_token is not implemented")
+    return validator
+
+
+def _patch_httpx_with(monkeypatch: MonkeyPatch, handler) -> None:
+    """Replace ``httpx.Client`` in the ``auth_cmd`` module with a MockTransport-backed client."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _factory(*args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs.setdefault("transport", transport)
+        kwargs.setdefault("timeout", 15.0)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr("mergecraft.cli.auth_cmd.httpx.Client", _factory)
+
+
+def _stub_gh_token(monkeypatch: MonkeyPatch, token: str | None = "gh-token") -> None:
+    """Stub ``_get_gh_token`` so the subcommand never shells out to ``gh``."""
+    module = _load_auth_cmd()
+    monkeypatch.setattr(module, "_get_gh_token", lambda: token or "")
+
+
+def _stub_git_remote(monkeypatch: MonkeyPatch, owner: str = "acme", repo: str = "widgets") -> None:
+    """Stub ``_parse_git_remote`` so the subcommand never shells out to ``git``."""
+    module = _load_auth_cmd()
+    monkeypatch.setattr(module, "_parse_git_remote", lambda: (owner, repo))
+
+
+def _capture_secret_set(monkeypatch: MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``_set_gh_secret`` with a recorder that always reports success."""
+    captured: list[dict[str, Any]] = []
+
+    def _recorder(*, name: str, value: str, repo_slug: str) -> bool:
+        captured.append({"name": name, "value": value, "repo_slug": repo_slug})
+        return True
+
+    module = _load_auth_cmd()
+    monkeypatch.setattr(module, "_set_gh_secret", _recorder)
+    return captured
+
+
+def _stub_typer_prompt(
+    monkeypatch: MonkeyPatch, project_label: str | None = "acme/widgets"
+) -> None:
+    """Stub ``typer.prompt`` so the subcommand never reads from stdin."""
+    import typer
+
+    def _prompt(_message: str, **kwargs):  # type: ignore[no-untyped-def]
+        if project_label is None:
+            return ""  # operator pressed Enter → cancel
+        return project_label
+
+    monkeypatch.setattr(typer, "prompt", _prompt)
+
+
+# ── happy path: default --scope both writes .env AND gh secret set ──────────
+
+
+def test_auth_logfire_default_scope_writes_env_and_github(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Default ``--scope both`` writes both layers and the validator runs against /api/v1/projects."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == LOGFIRE_PROBE_PATH
+        return httpx.Response(200, json=[{"project_name": "acme/widgets"}])
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_gh_token(monkeypatch)
+    _stub_git_remote(monkeypatch)
+    captured = _capture_secret_set(monkeypatch)
+    _stub_typer_prompt(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "lf-test-token")
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+    # Pre-existing keys must be preserved by python-dotenv set_key.
+    env_path = tmp_path / ".env"
+    env_path.write_text("NOUS_API_KEY=existing-value\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["auth", "logfire"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert len(captured) == 1
+    assert captured[0]["name"] == "LOGFIRE_TOKEN"
+    assert captured[0]["repo_slug"] == "acme/widgets"
+
+    written = env_path.read_text(encoding="utf-8")
+    assert "MERGECRAFT_LOGFIRE_TOKEN=" in written
+    assert "MERGECRAFT_TRACING_PROJECT=" in written
+    assert "NOUS_API_KEY=existing-value" in written  # preserved
+
+
+# ── --scope local: writes .env, never calls gh ──────────────────────────────
+
+
+def test_auth_logfire_scope_local_only_writes_env(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``--scope local`` skips the gh helpers entirely and writes only the local file."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    _patch_httpx_with(monkeypatch, _handler)
+
+    # Both gh helpers must NOT be called — install a tripwire.
+    def _gh_fail(*_a, **_kw):  # type: ignore[no-untyped-def]
+        pytest.fail("gh helpers must not be invoked under --scope local")
+
+    module = _load_auth_cmd()
+    monkeypatch.setattr(module, "_get_gh_token", _gh_fail)
+    monkeypatch.setattr(module, "_parse_git_remote", _gh_fail)
+    captured = _capture_secret_set(monkeypatch)
+    _stub_typer_prompt(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "lf-test-token")
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+
+    result = runner.invoke(app, ["auth", "logfire", "--scope", "local"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert captured == []  # gh secret set never called
+    written = env_path.read_text(encoding="utf-8")
+    assert "MERGECRAFT_LOGFIRE_TOKEN=" in written
+    assert "MERGECRAFT_TRACING_PROJECT=" in written
+
+
+# ── --scope github: writes gh secret only, never touches .env ───────────────
+
+
+def test_auth_logfire_scope_github_only_writes_github(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``--scope github`` writes only the gh secret and does not touch .env."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_gh_token(monkeypatch)
+    _stub_git_remote(monkeypatch)
+    captured = _capture_secret_set(monkeypatch)
+    _stub_typer_prompt(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "lf-test-token")
+    # The .env path must NOT be written — point at a directory the test will
+    # inspect for absence.
+    env_path = tmp_path / ".env"
+    monkeypatch.setenv("MERGECRAFT_ENV", str(env_path))
+
+    result = runner.invoke(app, ["auth", "logfire", "--scope", "github"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert len(captured) == 1
+    assert captured[0]["name"] == "LOGFIRE_TOKEN"
+    assert not env_path.exists(), (
+        f"--scope github must not write {env_path}; contents: "
+        f"{env_path.read_text() if env_path.exists() else '<absent>'}"
+    )
+
+
+# ── 401 / 403 → subcommand bails before any state changes ───────────────────
+
+
+def test_auth_logfire_rejects_on_401_or_403(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """401/403 from the validator → subcommand bails before .env and gh writes."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Invalid token"})
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_gh_token(monkeypatch)
+    _stub_git_remote(monkeypatch)
+    captured = _capture_secret_set(monkeypatch)
+    _stub_typer_prompt(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "bogus-token")
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+
+    result = runner.invoke(app, ["auth", "logfire"])
+
+    assert result.exit_code != 0
+    assert captured == []
+    assert not (tmp_path / ".env").exists()
+    output = (result.stdout + result.stderr).lower()
+    assert "401" in output or "403" in output or "validation" in output or "invalid" in output
+
+
+# ── network error → warn-and-save (parity with the other validators) ───────
+
+
+def test_auth_logfire_warns_and_saves_on_network_error(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``httpx.ConnectError`` → warning + both writes still run."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated dns failure")
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_gh_token(monkeypatch)
+    _stub_git_remote(monkeypatch)
+    captured = _capture_secret_set(monkeypatch)
+    _stub_typer_prompt(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "lf-test-token")
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+
+    result = runner.invoke(app, ["auth", "logfire"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert len(captured) == 1
+    assert captured[0]["name"] == "LOGFIRE_TOKEN"
+    assert (tmp_path / ".env").exists()
+    written = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "MERGECRAFT_LOGFIRE_TOKEN=" in written
+    assert "MERGECRAFT_TRACING_PROJECT=" in written
+
+
+# ── direct unit tests for the validator ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (200, True),
+        (401, False),
+        (403, False),
+        (500, True),  # 5xx → warn-and-save (parity with the other validators)
+        (502, True),
+    ],
+)
+def test_auth_logfire_validator_returns_correct_status(
+    monkeypatch: MonkeyPatch, status: int, expected: bool
+) -> None:
+    """Direct unit tests for ``_validate_logfire_token`` with a mocked httpx transport."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == LOGFIRE_PROBE_PATH, (
+            f"validator must probe {LOGFIRE_PROBE_PATH}, got {request.url.path}"
+        )
+        auth_header = request.headers.get("authorization", "")
+        assert auth_header.startswith("Bearer "), (
+            f"expected Bearer auth header, got {auth_header!r}"
+        )
+        if status == 200:
+            return httpx.Response(200, json=[])
+        if status in {401, 403}:
+            return httpx.Response(status, json={"detail": "unauthorized"})
+        return httpx.Response(status, text="server error")
+
+    _patch_httpx_with(monkeypatch, _handler)
+
+    validator = _load_validator()
+    assert validator("lf-test-token") is expected
+
+
+def test_auth_logfire_validator_warns_and_returns_true_on_network_error(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Network failure → ``logger.warning(...)`` and the validator still returns ``True``."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated dns failure")
+
+    _patch_httpx_with(monkeypatch, _handler)
+
+    from loguru import logger
+
+    captured: list[tuple[str, str]] = []
+
+    def _sink(record):  # type: ignore[no-untyped-def]
+        entry = record.record  # type: ignore[attr-defined]
+        captured.append((entry["level"].name, entry["message"]))
+
+    sink_id = logger.add(_sink, level="WARNING")
+    try:
+        validator = _load_validator()
+        result = validator("lf-test-token")
+    finally:
+        logger.remove(sink_id)
+
+    assert result is True
+    assert any(
+        level == "WARNING" and "logfire" in message.lower() for level, message in captured
+    ), f"expected a warning mentioning 'logfire', got: {captured}"
+
+
+# ── scope validation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad_scope", ["", "everywhere", "global", "12"])
+def test_auth_logfire_rejects_unknown_scope(bad_scope: str, monkeypatch: MonkeyPatch) -> None:
+    """Unknown ``--scope`` values bail with a hint before any prompt or write."""
+    module = _load_auth_cmd()
+    # Both gh helpers must NOT be called.
+    monkeypatch.setattr(module, "_get_gh_token", lambda: pytest.fail("must not be called"))
+    monkeypatch.setattr(module, "_parse_git_remote", lambda: pytest.fail("must not be called"))
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: pytest.fail("must not prompt"))
+    import typer
+
+    monkeypatch.setattr(typer, "prompt", lambda *_a, **_kw: pytest.fail("must not prompt"))
+
+    result = runner.invoke(app, ["auth", "logfire", "--scope", bad_scope])
+
+    assert result.exit_code != 0
+    output = (result.stdout + result.stderr).lower()
+    assert "scope" in output or "local" in output  # the help points at valid values
+
+
+# ── structural / collection smoke (always green) ────────────────────────────
+
+
+def test_auth_logfire_subcommand_is_collectable() -> None:
+    """``mergecraft auth logfire`` must register as a Typer subcommand (collection-only)."""
+    result = runner.invoke(app, ["auth", "--help"])
+    assert result.exit_code == 0
+    assert "logfire" in result.stdout.lower(), (
+        f"expected 'logfire' in auth --help output, got: {result.stdout!r}"
+    )
+
+
+def test_no_real_logfire_call_in_unit_tests() -> None:
+    """Structural guard: the production Logfire URL never appears outside doc comments."""
+    import re
+
+    test_file = Path(__file__).resolve()
+    source = test_file.read_text(encoding="utf-8")
+
+    hits = re.findall(r"logfire\.pydantic\.dev", source)
+    assert len(hits) <= 4, (
+        f"tests/cli/test_auth_logfire_cmd.py references the production Logfire "
+        f"URL ({len(hits)} occurrences); unit tests must mock httpx."
+    )

--- a/tests/tracing/exporters/test_cli_precedence.py
+++ b/tests/tracing/exporters/test_cli_precedence.py
@@ -239,6 +239,105 @@ def test_trace_dir_flag_overrides_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path
 
 
 # ---------------------------------------------------------------------------
+# W8.4 — ``MERGECRAFT_TRACING_PROJECT`` env var (auth logfire surface).
+# Issue #56 / D5 — the Logfire project label becomes the
+# ``x-logfire-project`` header at runtime. The CLI ``auth logfire`` command
+# writes this alongside ``MERGECRAFT_LOGFIRE_TOKEN``; the precedence layer
+# surfaces it for ``mergecraft config tracing`` and the sink factory.
+# ---------------------------------------------------------------------------
+
+
+def test_tracing_project_env_var_is_surfaced(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``MERGECRAFT_TRACING_PROJECT`` shows up in the resolved tracing state."""
+    config = tmp_path / "config.yaml"
+    config.write_text("tracing:\n  enabled: true\n", encoding="utf-8")
+    monkeypatch.setenv("MERGECRAFT_CONFIG", str(config))
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_TRACING_TO", "logfire")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "acme/widgets")
+
+    patch = tmp_path / "in.diff"
+    patch.write_text("diff --git a/x b/x\n+1\n", encoding="utf-8")
+
+    resolved = _resolve_tracing_for_args(
+        ["diff-review", "--diff", str(patch), "--cwd", str(tmp_path), "--dry-run"],
+        env=_env_from(monkeypatch, config),
+        cwd=tmp_path,
+    )
+    assert resolved.get("tracing_project") == "acme/widgets", resolved
+
+
+def test_tracing_project_env_var_overrides_yaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``MERGECRAFT_TRACING_PROJECT`` wins over the YAML ``sinks[].project`` field.
+
+    Parity with the other MERGECRAFT_TRACING_* env vars — env > config —
+    so the ``auth logfire`` command (which writes the env var) overrides any
+    project the repo author baked into ``.mergecraft/config.yaml``.
+    """
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "tracing:\n  enabled: true\n  sinks:\n    - type: logfire\n      project: yaml-project\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MERGECRAFT_CONFIG", str(config))
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_TRACING_TO", "logfire")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "env-project")
+
+    resolved = _resolve_tracing_for_args(
+        ["diff-review", "--diff", str(tmp_path / "x.diff"), "--cwd", str(tmp_path), "--dry-run"],
+        env=_env_from(monkeypatch, config),
+        cwd=tmp_path,
+    )
+    assert resolved.get("tracing_project") == "env-project", resolved
+
+
+def test_tracing_project_blank_env_value_is_dropped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty/whitespace ``MERGECRAFT_TRACING_PROJECT`` does not surface."""
+    config = tmp_path / "config.yaml"
+    config.write_text("tracing:\n  enabled: true\n", encoding="utf-8")
+    monkeypatch.setenv("MERGECRAFT_CONFIG", str(config))
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_TRACING_TO", "logfire")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "   ")
+
+    resolved = _resolve_tracing_for_args(
+        ["diff-review", "--diff", str(tmp_path / "x.diff"), "--cwd", str(tmp_path), "--dry-run"],
+        env=_env_from(monkeypatch, config),
+        cwd=tmp_path,
+    )
+    assert "tracing_project" not in resolved, resolved
+
+
+def test_tracing_project_unset_does_not_appear(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With no env var and no YAML ``project``, ``tracing_project`` is absent."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "tracing:\n  enabled: true\n  sinks:\n    - type: logfire\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MERGECRAFT_CONFIG", str(config))
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_TRACING_TO", "logfire")
+    monkeypatch.delenv("MERGECRAFT_TRACING_PROJECT", raising=False)
+
+    resolved = _resolve_tracing_for_args(
+        ["diff-review", "--diff", str(tmp_path / "x.diff"), "--cwd", str(tmp_path), "--dry-run"],
+        env=_env_from(monkeypatch, config),
+        cwd=tmp_path,
+    )
+    assert "tracing_project" not in resolved, resolved
+
+
+# ---------------------------------------------------------------------------
 # Helpers — small harness around the precedence arithmetic.
 # ---------------------------------------------------------------------------
 
@@ -254,6 +353,7 @@ def _env_from(monkeypatch: pytest.MonkeyPatch, config: Path) -> dict[str, str]:
         "MERGECRAFT_TRACE_DIR",
         "MERGECRAFT_LOGFIRE_TOKEN",
         "MERGECRAFT_OTEL_ENDPOINT",
+        "MERGECRAFT_TRACING_PROJECT",
     ]
     return {key: os.environ[key] for key in keys if key in os.environ}
 


### PR DESCRIPTION
## Summary

- `mergecraft auth logfire` — operator-facing setup for the Logfire tracing sink (#56 / D5)
- `MERGECRAFT_TRACING_PROJECT` env var plumbed through precedence layer + sink factory so the project label becomes the `x-logfire-project` header at runtime
- `--scope local|github|both` flag selects where the credentials land; default is `both`

## What it does

`mergecraft auth logfire` mirrors the existing `auth nous` / `auth gemini` / `auth cursor` shape line-for-line:

- `getpass` prompt for the write token, `typer.prompt` for the project label (project is a routing string, not a secret)
- Validator probes `GET https://logfire.pydantic.dev/api/v1/projects` with a Bearer header. OTLP/HTTP returns 200 for invalid tokens (it accepts and discards), so the REST endpoint is the only path that actually enforces the bearer with a real `401`/`403`. 200 → accept; `401`/`403` → reject; 5xx / `httpx.HTTPError` → warn-and-save (parity with the other auth validators).
- `--scope local|github|both`:
  - `local` — writes `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT` into `.env` via `python-dotenv`'s idempotent `set_key`
  - `github` — calls `gh secret set LOGFIRE_TOKEN` on the origin repo
  - `both` — does both
- `gh` is only required when the scope actually writes a secret; `--scope local` works without `gh` on PATH.
- The `[tracing]` extra check is non-blocking — the command warns when `logfire` is missing but does not auto-install (BYOK / convention 5).

## Plumbing for `MERGECRAFT_TRACING_PROJECT`

- `mergecraft.cli.tracing_precedence` — env layer reads `MERGECRAFT_TRACING_PROJECT` and surfaces it as `tracing_project` in the resolved state; YAML `sinks[].project` parity.
- `mergecraft config tracing` — renders the project in the table form and the plain-text render helper.
- `mergecraft.tracing.exporters` — new `_resolve_logfire_project` is the sink-side env-var fallback: when the YAML sink entry has no `project`, the runtime reads `MERGECRAFT_TRACING_PROJECT` so the CLI-wired project travels with the token.

## Operator quick start

```bash
uv sync --extra tracing        # install the optional extra
mergecraft auth logfire        # validates + writes .env + gh secret set
mergecraft config tracing      # verify wiring (token is redacted)
mergecraft diff-review --tracing --tracing-to logfire
```

For the GitHub Action, the workflow step should pass `tracing-to: logfire` + `logfire-token: ${{ secrets.LOGFIRE_TOKEN }}`.

## Tests

- `tests/cli/test_auth_logfire_cmd.py` (new) — happy path for `--scope both`, `--scope local` (no gh helpers called), `--scope github` (no `.env` written), validator unit matrix (200/401/403/5xx), network-error warn-and-save, scope validation, no-real-API structural guard.
- `tests/tracing/exporters/test_cli_precedence.py` — extends `_env_from` snapshot to include `MERGECRAFT_TRACING_PROJECT` and pins four new precedence contracts (env-var surfaces, env > YAML, blank dropped, unset absent).

`make lint`, `make typecheck`, `make pyright`, `make catalog-check`, `make lockcheck` all green; targeted pytest passes 30/30; broader tracing+cli suite passes 185/185; full `make test` only fails on a preexisting xdist flake in `test_adapters_supply_chain.py::test_trufflehog_remediation_is_rotation_first` (passes in isolation, including under xdist).

## Docs

- `docs/TRACING.md` — new Quick start section pointing at the new command.
- `.env.example` — tracing block corrected to the names the code actually reads (`MERGECRAFT_LOGFIRE_TOKEN`, `MERGECRAFT_TRACING_PROJECT`); the prior commented `LOGFIRE_TOKEN=` was stale and never read by the sink factory.
- `README.md` — provider table and commands table include `logfire`.
- `CHANGELOG.md` — `[Unreleased]` entry.

Closes #56 (D5 / D15 — operator UX gap).

🤖 Generated with [opencode](https://opencode.ai)

Made with [Cursor](https://cursor.com)