### PR TITLE
feat(models): MiniMax provider via custom-provider helper (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `test_config_tracing_lists_trace_env_vars_when_disabled`,
     `test_config_tracing_prints_next_steps_when_disabled`,
     `test_config_tracing_omits_next_steps_when_enabled`
+- First-class **MiniMax** provider via the existing custom-provider helper
+  (#34 / W6). The catalog now enumerates `minimax/MiniMax-M3` as a curated
+  alias (`PROVIDERS["minimax"]` in `src/mergecraft/models.py`), reachable
+  through the D7 singleton env vars (`MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`
+  + `MERGECRAFT_CUSTOM_PROVIDER_API_KEY`) or an indexed pair
+  (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`). The default
+  endpoint is MiniMax's published OpenAI-compatible URL
+  (`https://api.minimax.io/v1`, documented at
+  <https://platform.minimax.io/docs/api-reference/text-openai-api.md>),
+  added to `GATEWAY_PRESETS` in `src/mergecraft/agents/openai_compatible_gateways.py`
+  so the slug prefix drives the provider lookup without an explicit
+  `<N>` slot. The credential gate honours the D7 singleton and the
+  indexed pair; the binary gate short-circuits to `True` for the
+  `minimax` provider (same posture as `nous` — the opencode harness
+  reads env vars directly, no CLI is required on PATH). A new
+  `mergecraft auth minimax` subcommand (`src/mergecraft/cli/auth_cmd.py`)
+  mirrors `auth gemini` / `auth nous` / `auth tokenhub` line-for-line:
+  prompts with `getpass`, validates against
+  `https://api.minimax.io/v1/chat/completions` (the unauthenticated
+  catalog endpoint would return 200 for a fake bearer; the probe path
+  enforces auth, matching `_validate_nous_api_key`'s shape), then writes
+  `MERGECRAFT_CUSTOM_PROVIDER_API_KEY` via `gh secret set`. The validator
+  returns `True` on 200, `False` on 401/403, and `True` with a
+  `logger.warning` on network errors. A `mergecraft models list` row
+  appears for the new catalog entry; the credentials column flips
+  `no` → `yes` when the env var is set (convention 7 — the key value
+  is never rendered). The pre-existing `opencode/minimax-m2.5` and
+  `opencode/minimax-m2.5-free` entries are untouched (D12 additive
+  invariant — operators using OpenCode as a proxy still work). No
+  Dockerfile change — MiniMax does not require a first-party CLI binary
+  (D10 / option ii: route through the existing helper, not a bespoke
+  `mmx-cli` harness). README "Authentication" table gains a MiniMax
+  row.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Full config reference: [`examples/config.yaml`](examples/config.yaml).
 | Google Gemini | `mergecraft auth gemini` → `GEMINI_API_KEY` (AI Studio) | `GEMINI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` |
 | Nous Portal | — (API key) | `mergecraft auth nous` → `NOUS_API_KEY` (`nous/deepseek/deepseek-v4-flash`) |
 | Tencent TokenHub | — (API key) | `mergecraft auth tokenhub` → `TOKENHUB_API_KEY` (`tokenhub/hy3` + any TokenHub model) |
+| MiniMax | — (API key) | `mergecraft auth minimax` → `MERGECRAFT_CUSTOM_PROVIDER_API_KEY` (`minimax/MiniMax-M3`; OpenAI-compatible, default `https://api.minimax.io/v1`) |
 | Cursor Cloud | `mergecraft auth cursor` → `CURSOR_API_KEY` | `CURSOR_API_KEY` |
 | Logfire tracing | `mergecraft auth logfire` → `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT` (local) and `LOGFIRE_TOKEN` (Actions) | see [`docs/TRACING.md`](docs/TRACING.md) |
 

--- a/docs/test-plans/issues-provider-routing.md
+++ b/docs/test-plans/issues-provider-routing.md
@@ -1,4 +1,168 @@
-# #71 / #37 — Provider routing & chain semantics — W1 RED test plan
+# #71 / #37 / #34 / #57 — Provider routing, chain semantics & MiniMax catalog — RED test plan
+
+Wave plan: `.ignorelocal/waves/issues-provider-routing-wave-plan.md`
+Worktree: `mergecraft-prov-b-routing` (Batch B) → `mergecraft-prov-c-catalog` (Batch C, this wave)
+Batch: B (W1, completed 2026-08-11 on PR #123) and C (W5, this wave)
+
+This file maps every contract W1.1–W1.10 (Batch B, completed) plus
+W5.1–W5.7 (Batch C, this wave) pins to the test that covers it, across
+the smart-coverage matrix (unit / integration / functional; happy / edge /
+error). The test-author wave owns the **RED** half of the tests-first pair:
+the suite must collect with zero errors and pass `make lint` + `make
+typecheck`, with the cross-wave contract assertions xfailed (`strict=False`)
+until W3/W4 (Batch B) or W6/W7 (Batch C) land.
+
+## Batch C — MiniMax (this wave)
+
+Batch C is gated on Batch B's merge (D4); with PR #123 merged into
+`origin/pre-0.0.1` @ `00c5d71` the Batch C worktree exists at
+`../mergecraft-prov-c-catalog` on branch `wave/prov-c-catalog`. W5 owns
+the RED suite for #34 (MiniMax) and #57 (Nous/DeepSeek V4 Flash — but
+#57 was already shipped via PR #122 / `wave/issue-57-nous` so W5.3 is
+**N/A** — see the "W5.3 N/A" section below).
+
+### MiniMax contract locked at W5
+
+MiniMax publishes an OpenAI-compatible endpoint at
+[`https://api.minimax.io/v1`](https://platform.minimax.io/docs/api-reference/text-openai-api.md)
+(verified 2026-08-11). The operator has confirmed D10 / option (ii): MiniMax
+routes through the existing custom-provider helper, **not** a bespoke
+`mmx-cli` harness. The locked model id is `MiniMax-M3` (latest M-series,
+1,000,000-token context, OpenAI-compatible Chat Completions).
+
+- Base URL: `https://api.minimax.io/v1`
+- Slug: `minimax/MiniMax-M3`
+- Env-var convention: inherits the W3 indexed pair (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`,
+  N ≥ 1, provider id `provider_<N>`) **and** the singleton alias
+  (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}` → provider id `default`).
+  Operator picks either surface; W6 owns the W3 helper extension so the
+  slug prefix `minimax/` resolves to either block.
+- W6 must not invent a third env-var family. The D7 contract is binding.
+
+### W5.3 N/A — Nous/DeepSeek V4 Flash already shipped
+
+Issue #57 was closed 2026-08-11T06:06:32Z by
+[PR #122](https://github.com/alexhawat/mergeCraft/pull/122) (`wave/issue-57-nous`,
+merge commit `26bfab9`, with `11035c0 feat(models): first-class Nous Research
+support (#57)`). The Nous catalog entry (`models.py:407` — provider `nous`,
+model `deepseek/deepseek-v4-flash` plus tokenhub variants), credential
+detection, README row, `mergecraft auth nous`, and `--validate` smoke test
+are all on `pre-0.0.1`. **W7's RED suite (W5.3) is already done — Batch C
+does not need to author it.** Batch C's remaining scope is #34 (MiniMax)
+plus any post-#57 cleanup.
+
+The previously authored W1.3 (`test_nous_provider_in_providers_and_aliases`,
+`test_models_list_renders_nous_row_*`) and W1.10 (`test_auth_nous_*`) tests
+live in the `wave/issue-57-nous` worktree and are part of `pre-0.0.1`
+today — they are not re-authored here.
+
+### Batch C xfail schedule
+
+| Wave | Test file | Marker reason prefix |
+|------|-----------|----------------------|
+| **W6** | `tests/agents/test_minimax_routing.py` | `green after W6:` for MiniMax helper routing + Codex config.toml emission + raw pass-through |
+| **W6** | `tests/cli/test_models_list_minimax.py` | `green after W6:` for `mergecraft models list` rendering the `minimax/MiniMax-M3` row |
+| **W6** | `tests/agents/test_minimax_routing.py::test_existing_curated_slug_resolution_is_unchanged` | `green after W6:` for D12 additive invariant (already XPASS vacuously today — assertion guards future catalog mutations) |
+
+All cross-wave markers use `strict=False` so an early-passing xfail is an
+XFAIL → XPASS upgrade, not a hard failure. W6 reconciles by deleting
+markers on tests the implementation now satisfies.
+
+### Batch C — Contract → test matrix (this wave)
+
+| #       | Decision / convention                                  | Test (this wave)                                                    | Scenario class                |
+|---------|--------------------------------------------------------|---------------------------------------------------------------------|-------------------------------|
+| W5.1a   | MiniMax slug routes via opencode + singleton env       | `test_minimax_routes_via_opencode_with_singleton_env`               | happy path (D10 / option ii)  |
+| W5.1b   | MiniMax slug routes via codex config.toml              | `test_minimax_routes_via_codex_with_singleton_env`                  | happy path (D10 / option ii)  |
+| W5.1c   | Indexed pair (provider_1) also works for MiniMax       | `test_minimax_routes_via_indexed_provider_pair`                     | happy path (indexed)          |
+| W5.1d   | Locked base URL matches published docs                 | `test_minimax_base_url_constant_matches_published_docs`             | structural                    |
+| W5.1e   | Locked URL never leaks into a live-call fixture        | `test_minimax_published_docs_url_is_only_referenced_in_documentation` | structural (convention 7)   |
+| W5.2a   | Missing MiniMax credential raises (parametrised)       | `test_minimax_missing_credential_fails_loud[minimax-minimax-m3]`    | error handling (convention 5) |
+| W5.2b   | Missing credential — unknown MiniMax model id          | `test_minimax_missing_credential_fails_loud[minimax-unknown-model]` | error handling (convention 5) |
+| W5.4a   | `models list` enumerates the MiniMax row (no creds)    | `test_mergecraft_models_list_renders_minimax_row_without_credentials` | happy path (CLI surface)    |
+| W5.4b   | `models list` flips credentials column `no` → `yes`    | `test_mergecraft_models_list_renders_minimax_row_with_credentials`  | happy path (CLI surface)      |
+| W5.4c   | `models list` does not leak the api key value          | `test_mergecraft_models_list_minimax_row_does_not_leak_api_key`     | error handling (convention 7) |
+| W5.5    | `resolve_model()` passes un-curated slugs through      | `test_minimax_raw_passthrough_slug_resolves`                        | regression pin (D12)          |
+| W5.6    | New catalog entries do not change existing resolution  | `test_existing_curated_slug_resolution_is_unchanged[slug]` (×72)   | regression pin (D12 additive) |
+| W5.4smoke| `mergecraft models --help` enumerates the subcommand   | `test_models_list_help`                                             | structural (collection smoke) |
+
+### Per-contract rationale (Batch C)
+
+#### D10 — MiniMax routing decision (operator-locked)
+
+The MiniMax base URL and model slug were locked at W5 by reading the
+[published OpenAI SDK integration guide](https://platform.minimax.io/docs/api-reference/text-openai-api.md)
+on 2026-08-11. The decision (route through the W3 custom-provider helper,
+**not** a bespoke `mmx-cli` harness) is operator-confirmed; the tests pin
+the **observable** contract — a `minimax/MiniMax-M3` slug with the
+singleton or indexed env-var pair set results in a provider block in
+both harnesses whose `baseURL` (or `base_url`) matches the published
+endpoint URL. The exact helper surface (whether W6 adds a `minimax`
+preset to `openai_compatible_gateways.GATEWAY_PRESETS` or extends
+`_custom_provider_ids` to honour the active model's prefix even when
+not in the resolver dict) is W6's call — the tests pin the behaviour,
+not the signature.
+
+#### D12 — Additive catalog invariants
+
+The W5.6 parametrized regression pin (`test_existing_curated_slug_resolution_is_unchanged`)
+captures every curated slug's `resolve_cli_model()` value today and
+re-asserts it after W6 lands. The test XPASSes vacuously today (the
+catalog hasn't changed) — the xfail marker is the regression pin
+that says "if W6 mutates any of these resolutions, this test goes
+RED and the W6 wave fails the merge". The 72 parametrized slugs cover
+every provider in `PROVIDERS`: anthropic, openai, google, xai, deepseek,
+moonshotai, opencode, opencode-go, bedrock, vertex, nous, tokenhub,
+openrouter.
+
+#### Convention 5 — Fail-loud, never silent fall-through
+
+W5.2 parametrises two MiniMax slugs (`minimax/MiniMax-M3` and
+`minimax/some-other-model`) and asserts `resolve_runtime_agent()` raises
+with a message that names MiniMax and the env-var names the operator can
+set. The test pins against the failure mode the wave plan flags: a
+provider's model selected without its credential must not silently fall
+through to the opencode harness (whose binary is absent). The test
+explicitly asserts `opencode` does NOT appear in the error message.
+
+#### Convention 7 — No API key in logs / rendered output
+
+W5.1b asserts the resolved key value never appears in the rendered codex
+`config.toml` (convention 7). W5.4c asserts the resolved key value never
+appears in `mergecraft models list` stdout. Both use sentinel key strings
+that would be catastrophic to leak in production.
+
+### Reconciliation plan (after W6 lands)
+
+1. Drop every `@pytest.mark.xfail(reason="green after W6: …", strict=False)`
+   marker on tests the implementation now satisfies.
+2. Keep the structural / regression-pin tests:
+   - `test_minimax_base_url_constant_matches_published_docs`
+   - `test_minimax_published_docs_url_is_only_referenced_in_documentation`
+   - `test_minimax_raw_passthrough_slug_resolves` (vacuous today, but the
+     xfail marker pins the regression intent)
+   - `test_existing_curated_slug_resolution_is_unchanged[*]` (72
+     parametrized cases; the xfail marker is the regression intent)
+3. Reconcile the W5.6 test: if W6 adds a curated `minimax/*` catalog
+   entry that **changes** `resolve_cli_model()` for any pre-existing
+   slug, that change is a Batch C regression and W6 fails the merge.
+
+### Open questions for W6
+
+- Should the helper's `resolve_gateway_endpoints()` add a `minimax`
+  preset to `GATEWAY_PRESETS` (parity with `nous` / `tokenhub`), or
+  should W6 instead extend the multi-provider resolver to honour the
+  active model's prefix even when it is not in the resolver dict?
+  **Recommend the preset** — keeps the surface small and reuses the
+  existing preset path for the harness lookup.
+- For the catalog entry, what should `minimax/MiniMax-M3`'s `env_vars`
+  be? **Recommend** `("MERGECRAFT_CUSTOM_PROVIDER_API_KEY",)` — the
+  singleton is the canonical D7 surface; the indexed-pair form is
+  operator-supplied.
+
+---
+
+## Batch B — Routing & chain semantics (W1, completed 2026-08-11)
 
 Wave plan: `.ignorelocal/waves/issues-provider-routing-wave-plan.md`
 Worktree: `mergecraft-prov-b-routing` @ `wave/prov-b-routing`

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -31,6 +31,16 @@ DEFAULT_TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
 CUSTOM_PROVIDER_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
 CUSTOM_PROVIDER_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
 
+# W6 (#34): MiniMax is reachable through the existing custom-provider helper
+# (operator-locked D10 / option ii). The alias env vars re-use the D7
+# singleton names so the operator's mental model stays uniform with the
+# generic custom-provider surface; the default base URL pins the
+# OpenAI-compatible endpoint documented at
+# https://platform.minimax.io/docs/api-reference/text-openai-api.md.
+MINIMAX_API_KEY_ENV = CUSTOM_PROVIDER_API_KEY_ENV
+MINIMAX_BASE_URL_ENV = CUSTOM_PROVIDER_BASE_URL_ENV
+DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
 # Indexed multi-provider convention (W3 / issue #71). Both halves must be
 # set per index; partial pairs are dropped. Discovery enumerates every
 # matching env-var suffix and pairs by numeric N. Gaps are preserved
@@ -85,6 +95,12 @@ GATEWAY_PRESETS: dict[str, GatewayPreset] = {
         base_url_env=TOKENHUB_BASE_URL_ENV,
         default_base_url=DEFAULT_TOKENHUB_BASE_URL,
     ),
+    "minimax": GatewayPreset(
+        provider_id="minimax",
+        api_key_env=MINIMAX_API_KEY_ENV,
+        base_url_env=MINIMAX_BASE_URL_ENV,
+        default_base_url=DEFAULT_MINIMAX_BASE_URL,
+    ),
 }
 
 
@@ -108,6 +124,8 @@ def has_gateway_credentials(provider_id: str) -> bool:
     that wires the alias alone should still resolve credentials (D4).
     """
     if has_custom_provider_env():
+        return True
+    if resolve_gateway_endpoints():
         return True
     preset = GATEWAY_PRESETS.get(provider_id.lower())
     if preset is None:
@@ -246,9 +264,12 @@ def resolve_gateway_endpoints() -> dict[str, ProviderRecord]:
 __all__ = [
     "CUSTOM_PROVIDER_API_KEY_ENV",
     "CUSTOM_PROVIDER_BASE_URL_ENV",
+    "DEFAULT_MINIMAX_BASE_URL",
     "DEFAULT_NOUS_BASE_URL",
     "DEFAULT_TOKENHUB_BASE_URL",
     "GATEWAY_PRESETS",
+    "MINIMAX_API_KEY_ENV",
+    "MINIMAX_BASE_URL_ENV",
     "NOUS_API_KEY_ENV",
     "NOUS_BASE_URL_ENV",
     "SINGLETON_PROVIDER_ID",

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -29,6 +29,8 @@ CURSOR_API_SECRET = "CURSOR_API_KEY"
 NOUS_API_SECRET = "NOUS_API_KEY"
 NOUS_PORTAL_BASE_URL = "https://inference-api.nousresearch.com/v1"
 TOKENHUB_API_SECRET = "TOKENHUB_API_KEY"
+MINIMAX_API_SECRET = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 CLAUDE_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 DEFAULT_NOUS_PORTAL = "https://inference-api.nousresearch.com/v1"
 DEFAULT_TOKENHUB = "https://tokenhub-intl.tencentcloudmaas.com/v1"
@@ -670,4 +672,82 @@ def auth_logfire(
         f"  - run with traces: [cyan]mergecraft diff-review --tracing --tracing-to logfire[/cyan]\n"
         f"  - in the GitHub Action, the workflow can pass "
         f"[cyan]tracing-to: logfire[/cyan] + [cyan]logfire-token: ${{{{ secrets.{LOGFIRE_TOKEN_SECRET} }}}}[/cyan]"
+    )
+
+
+def _validate_minimax_api_key(api_key: str) -> bool:
+    """Probe the MiniMax OpenAI-compatible endpoint with ``api_key``.
+
+    POSTs a minimal body to ``{MINIMAX_BASE_URL}/chat/completions`` with a
+    ``Bearer`` auth header — mirrors ``_validate_nous_api_key``'s pattern
+    because the unauthenticated catalog endpoint would return 200 for a
+    fake bearer token. Returns:
+
+    - ``True`` on HTTP 200
+    - ``False`` on HTTP 401/403 (the operator's key is wrong)
+    - ``True`` with a ``logger.warning`` on any other status or on
+      ``httpx.HTTPError`` (network/DNS/5xx) so an offline operator can
+      still save the secret locally and retry later.
+    """
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.post(
+                f"{MINIMAX_BASE_URL}/chat/completions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"model": "MiniMax-M3", "messages": []},
+            )
+        if response.status_code == 200:
+            return True
+        if response.status_code in {401, 403}:
+            return False
+        logger.warning(
+            "minimax key validation returned HTTP {} — saving anyway", response.status_code
+        )
+        return True
+    except httpx.HTTPError as exc:
+        logger.warning("minimax key validation skipped (network): {}", exc)
+        return True
+
+
+@app.command("minimax")
+def auth_minimax() -> None:
+    """Save a MiniMax API key as MERGECRAFT_CUSTOM_PROVIDER_API_KEY.
+
+    MiniMax is reachable through the existing custom-provider helper
+    (D10 / option ii) — no first-party ``mmx-cli`` install is required.
+    The key is stored under the D7 singleton secret name so it pairs with
+    the singleton ``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` (which the
+    operator may override, or rely on the preset's default
+    ``https://api.minimax.io/v1``).
+    """
+    _get_gh_token()
+    owner, repo = _parse_git_remote()
+    repo_slug = f"{owner}/{repo}"
+    console.print(f"detected repo [cyan]{repo_slug}[/cyan]")
+    console.print(
+        "create an API key on the MiniMax platform "
+        f"([cyan]{MINIMAX_BASE_URL}[/cyan]), then paste it below."
+    )
+    try:
+        api_key = getpass.getpass("MiniMax API key (Enter to cancel): ").strip()
+    except EOFError, KeyboardInterrupt:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not api_key:
+        console.print("canceled.")
+        raise typer.Exit(0) from None
+    if not _validate_minimax_api_key(api_key):
+        _bail("MiniMax API key validation failed (401/403). Check the key and retry.")
+
+    console.print(f"saving [cyan]{MINIMAX_API_SECRET}[/cyan] via gh secret set...")
+    if not _set_gh_secret(name=MINIMAX_API_SECRET, value=api_key, repo_slug=repo_slug):
+        _bail(
+            f"could not set secret — set it manually at:\n"
+            f"  https://github.com/{repo_slug}/settings/secrets/actions"
+        )
+    console.print(f"[green]saved {MINIMAX_API_SECRET}[/green] to GitHub Actions secrets")
+    console.print(
+        "use model [cyan]minimax/MiniMax-M3[/cyan] (opencode harness; no "
+        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL required if you accept the "
+        f"default endpoint [cyan]{MINIMAX_BASE_URL}[/cyan])."
     )

--- a/src/mergecraft/models.py
+++ b/src/mergecraft/models.py
@@ -451,6 +451,33 @@ PROVIDERS: dict[str, ProviderConfig] = {
             },
         )
     ),
+    "minimax": _provider(
+        ProviderConfig(
+            display_name="MiniMax (OpenAI-compatible)",
+            # W6 (#34): MiniMax rides the D7 custom-provider helper. The
+            # singleton pair is the canonical operator surface; the
+            # ``env_vars`` tuple names the api-key env var so
+            # ``mergecraft models list`` and the credential gate can
+            # detect the operator's configuration. The indexed
+            # ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY_<N>`` form is also
+            # accepted by the helper and documented in the README.
+            env_vars=("MERGECRAFT_CUSTOM_PROVIDER_API_KEY",),
+            models={
+                "MiniMax-M3": ModelDef(
+                    display_name="MiniMax M3 (OpenAI-compatible)",
+                    description=(
+                        "MiniMax M3 via the MiniMax OpenAI-compatible endpoint "
+                        "(https://api.minimax.io/v1). Reachable through the existing "
+                        "custom-provider helper (D10 / option ii) — set "
+                        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
+                        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY, or an indexed pair."
+                    ),
+                    resolve="minimax/MiniMax-M3",
+                    preferred=True,
+                ),
+            },
+        )
+    ),
     "openrouter": _provider(
         ProviderConfig(
             display_name="OpenRouter",

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -106,6 +106,13 @@ def has_credentials_for_slug(slug: str) -> bool:
         return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
     if provider in {"nous", "tokenhub"}:
         return _has_gateway_auth(provider)
+    if provider == "minimax":
+        # W6 (#34): MiniMax is reachable through the existing custom-provider
+        # helper (operator-locked D10 / option ii). The single pair that
+        # surfaces a credential is the D7 singleton; the indexed
+        # ``_N`` form is also accepted because the helper's multi-provider
+        # resolver may surface the provider via ``provider_<N>``.
+        return _has_gateway_auth(provider)
     return False
 
 
@@ -132,6 +139,9 @@ def _agent_binary_available(slug: str) -> bool:
         # so there is no required CLI on PATH. Explicit ``None`` short-circuits
         # the gate to ``True`` and pins the W1.7 regression pin.
         "nous": None,
+        # W6 (#34): MiniMax rides the same env-var-driven opencode harness
+        # path; no CLI binary is required on PATH.
+        "minimax": None,
     }
     binary = binary_by_provider.get(provider)
     if binary is None:
@@ -724,6 +734,25 @@ def resolve_runtime_agent(*, model: str | None = None) -> Agent:
                 f"Set {hints[0]} (via `{hints[1]}` or a GitHub Actions secret), "
                 "or set MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
                 "MERGECRAFT_CUSTOM_PROVIDER_API_KEY, or choose a different model."
+            )
+            raise ValueError(msg)
+
+        if provider == "minimax":
+            # W6 (#34): MiniMax rides the custom-provider helper. Fail loud
+            # (convention 5) rather than silently falling through to the
+            # opencode harness when the env vars are missing — the harness
+            # will not be able to reach MiniMax without them, and the
+            # operator's CLI auth gate would mask the configuration error.
+            if _has_gateway_auth(provider):
+                return agents["opencode"]
+            msg = (
+                f"MiniMax model {model!r} selected but no credential is configured. "
+                "Set MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
+                "MERGECRAFT_CUSTOM_PROVIDER_API_KEY "
+                "(via `mergecraft auth minimax` or GitHub Actions secrets), "
+                "or an indexed pair "
+                "MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_1, "
+                "or choose a different model."
             )
             raise ValueError(msg)
 

--- a/tests/agents/test_minimax_routing.py
+++ b/tests/agents/test_minimax_routing.py
@@ -220,13 +220,16 @@ def test_minimax_routes_via_opencode_with_singleton_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Singleton pair + ``minimax/MiniMax-M3`` → opencode config has a
-    provider block keyed by ``default`` whose ``baseURL`` is MiniMax's
-    OpenAI-compatible endpoint.
+    provider block keyed by ``minimax`` (the model prefix; the W6
+    recommendation adds a ``minimax`` preset so the prefix drives the
+    provider lookup) whose ``baseURL`` is MiniMax's OpenAI-compatible
+    endpoint.
 
     The active model's prefix (``minimax``) is the slug's first path
-    segment; the helper resolves to the singleton ``default`` record
-    when no indexed pair is set. The harness's active-provider lookup
-    must surface a block whose ``baseURL`` is the MiniMax endpoint.
+    segment; the preset's env vars re-use the D7 singleton names, so the
+    block's ``baseURL`` is MiniMax's published endpoint. The harness's
+    active-provider lookup must surface that block and register
+    ``minimax`` under ``enabled_providers``.
     """
     _clear_provider_env(monkeypatch)
     monkeypatch.setenv(SINGLETON_BASE_URL_ENV, MINIMAX_BASE_URL)
@@ -234,7 +237,7 @@ def test_minimax_routes_via_opencode_with_singleton_env(
 
     config = _build_opencode_config(tmp_path, model=MINIMAX_SLUG)
 
-    block = _config_block_for_minimax(config, expected_provider_id="default")
+    block = _config_block_for_minimax(config, expected_provider_id="minimax")
     options = block["options"]
     assert options["apiKey"] == SENTINEL_MINIMAX_KEY
     # The block must register the MiniMax model id so the harness can

--- a/tests/agents/test_minimax_routing.py
+++ b/tests/agents/test_minimax_routing.py
@@ -1,0 +1,592 @@
+"""RED tests for MiniMax provider routing (#34 / W5).
+
+Wave plan: ``.ignorelocal/waves/issues-provider-routing-wave-plan.md``
+(Batch C / W5). The plan locks MiniMax routing through the **existing
+custom-provider helper** (operator-confirmed D10 / option (ii)) — the
+OpenAI-compatible endpoint documented at:
+
+    https://platform.minimax.io/docs/api-reference/text-openai-api.md
+    → ``export OPENAI_BASE_URL=https://api.minimax.io/v1``
+
+Pin one model id from the same docs page: ``MiniMax-M3`` (latest M-series,
+1M-token context; OpenAI-compatible Chat Completions supported via
+``/v1/chat/completions``). The model id is operator-facing — see the
+catalog row W6 adds — and the slug form is ``minimax/MiniMax-M3``.
+
+This file pins the contract for:
+
+- **W5.1** — ``minimax/MiniMax-M3`` is reachable via the existing custom-
+  provider helper (D10 / option ii). Both the OpenCode and Codex harnesses
+  emit a provider block whose ``baseURL`` is MiniMax's published
+  OpenAI-compatible endpoint.
+- **W5.2** — A selected ``minimax/*`` slug with no credential raises a
+  clear, actionable error naming MiniMax + the env-var names, never a
+  silent fall-through to an absent harness binary (convention 5).
+- **W5.5** — ``resolve_model()`` continues to pass slash-containing slugs
+  through unchanged when no curated entry exists (D12 regression pin).
+- **W5.6** — Adding MiniMax catalog entries does not change the resolution
+  of any pre-existing curated slug.
+
+(W5.3 Nous/DeepSeek RED suite was already shipped in PR #122 /
+``wave/issue-57-nous``; this file does NOT re-author it.)
+(W5.4 ``mergecraft models list`` detection lives at
+``tests/cli/test_models_list_minimax.py`` — split for locality with the
+existing ``test_models_list_nous.py``.)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+# ── Locked MiniMax contract (operator-confirmed D10 / option ii) ────────────
+
+# Verified 2026-08-11 against
+# https://platform.minimax.io/docs/api-reference/text-openai-api.md
+# ("Configure Environment Variables" section):
+#     export OPENAI_BASE_URL=https://api.minimax.io/v1
+# The same endpoint is referenced in the OpenAI SDK integration guide.
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+# Verified against the supported-models table on the same docs page;
+# MiniMax-M3 is the latest M-series at 1,000,000-token context. The model
+# id is the OpenAI-compatible model parameter sent to /v1/chat/completions.
+MINIMAX_MODEL = "MiniMax-M3"
+MINIMAX_SLUG = f"minimax/{MINIMAX_MODEL}"
+
+# Env-var convention: MiniMax inherits the W3 indexed pair (operator-locked
+# in the W1 / Batch-B design notes). Provider id derivation:
+#     "provider_" + str(N)  for indexed pairs (N >= 1)
+#     "default"             for the singleton alias
+# MiniMax slugs reach the helper through either the singleton (model
+# prefix falls through to ``default``) or an indexed pair keyed by N
+# that the operator picks.
+INDEXED_BASE_URL_FMT = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}"
+INDEXED_API_KEY_FMT = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}"
+SINGLETON_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
+SINGLETON_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+
+# Sentinel values — never asserted on literally (convention 7).
+SENTINEL_MINIMAX_KEY = "sk-minimax-SENTINEL-LEAK-CHECK-0001"
+
+_PROVIDER_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CODEX_AUTH_JSON",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "CURSOR_API_KEY",
+    "NOUS_API_KEY",
+    "NOUS_BASE_URL",
+    "TOKENHUB_API_KEY",
+    "TOKENHUB_BASE_URL",
+    "MERGECRAFT_AGENT",
+    SINGLETON_BASE_URL_ENV,
+    SINGLETON_API_KEY_ENV,
+)
+
+
+# ── helpers / fixtures ──────────────────────────────────────────────────────
+
+
+def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    # Wipe a generous range of indexed suffixes so a stray index from a
+    # previous test cannot leak into this one.
+    for n in range(1, 8):
+        monkeypatch.delenv(INDEXED_BASE_URL_FMT.format(n=n), raising=False)
+        monkeypatch.delenv(INDEXED_API_KEY_FMT.format(n=n), raising=False)
+
+
+def _load_codex_module():
+    try:
+        return importlib.import_module("mergecraft.agents.codex")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.codex not implemented: {exc}")
+
+
+def _load_opencode_module():
+    try:
+        return importlib.import_module("mergecraft.agents.opencode")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.opencode not implemented: {exc}")
+
+
+def _load_agent_resolve_module():
+    return importlib.import_module("mergecraft.utils.agent_resolve")
+
+
+def _write_codex_config(tmp_path: Path, *, model: str | None) -> Path:
+    """Call ``codex.write_mcp_config`` and return the rendered TOML path."""
+    codex_module = _load_codex_module()
+    ctx = make_agent_run_context(tmp_path, resolved_model=model)
+    ctx.payload.shell = "disabled"
+    return Path(codex_module.write_mcp_config(ctx))
+
+
+def _build_opencode_config(tmp_path: Path, *, model: str | None) -> dict[str, object]:
+    """Call ``opencode.build_security_config`` and return the parsed dict."""
+    opencode_module = _load_opencode_module()
+    ctx = make_agent_run_context(tmp_path, resolved_model=model)
+    return json.loads(opencode_module.build_security_config(ctx, model))
+
+
+def _provider_block_in_opencode(config: dict[str, object]) -> dict[str, object]:
+    """Return ``config["provider"]`` as a dict (or fail loudly)."""
+    provider = config.get("provider")
+    if not isinstance(provider, dict):
+        pytest.fail(
+            f"opencode config missing dict-shaped 'provider' block; got {type(provider).__name__}: {provider!r}"
+        )
+    return provider
+
+
+def _model_providers_in_codex(path: Path) -> dict[str, object]:
+    """Parse the written codex ``config.toml`` and return its ``model_providers`` table."""
+    parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+    providers = parsed.get("model_providers")
+    if not isinstance(providers, dict):
+        pytest.fail(
+            f"codex config.toml missing dict-shaped 'model_providers' table; got: {providers!r}"
+        )
+    return providers
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_provider_env(monkeypatch)
+
+
+# ── W5.1 — MiniMax slug routes through the W3 helper ────────────────────────
+#
+# Both harnesses must surface a provider block whose ``baseURL`` resolves
+# to MiniMax's published OpenAI-compatible endpoint. The block's id is
+# derived from the helper (the singleton maps to ``default``; an indexed
+# pair maps to ``provider_<N>``); the slug ``minimax/MiniMax-M3`` is
+# routed to that block when its provider id is present in the resolver
+# dict (W6 may add a ``minimax`` preset OR extend the multi-provider
+# helper; the tests pin the **observable** contract).
+
+
+def _config_block_for_minimax(
+    config: dict[str, object],
+    *,
+    expected_provider_id: str,
+) -> dict[str, object]:
+    """Pull the provider block whose ``options.baseURL`` matches MiniMax's endpoint.
+
+    The exact key (``default`` vs ``provider_<N>``) is a W6 call —
+    this helper accepts either, asserting the URL matches.
+    """
+    provider = _provider_block_in_opencode(config)
+    candidates = [
+        block
+        for block in provider.values()
+        if isinstance(block, dict)
+        and isinstance(block.get("options"), dict)
+        and block["options"].get("baseURL") == MINIMAX_BASE_URL
+    ]
+    assert candidates, (
+        f"no provider block in opencode config has baseURL={MINIMAX_BASE_URL!r}; "
+        f"provider blocks were: {provider!r}"
+    )
+    block = candidates[0]
+    # Every such block must register the provider id under
+    # ``enabled_providers`` so the harness actually activates it.
+    enabled = config.get("enabled_providers", [])
+    assert expected_provider_id in enabled, (
+        f"provider id {expected_provider_id!r} must be in enabled_providers={enabled!r}"
+    )
+    return block
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: MiniMax routed via the W3 custom-provider helper — "
+        "opencode harness emits a provider block whose baseURL is MiniMax's "
+        "published OpenAI-compatible endpoint"
+    ),
+    strict=False,
+)
+def test_minimax_routes_via_opencode_with_singleton_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Singleton pair + ``minimax/MiniMax-M3`` → opencode config has a
+    provider block keyed by ``default`` whose ``baseURL`` is MiniMax's
+    OpenAI-compatible endpoint.
+
+    The active model's prefix (``minimax``) is the slug's first path
+    segment; the helper resolves to the singleton ``default`` record
+    when no indexed pair is set. The harness's active-provider lookup
+    must surface a block whose ``baseURL`` is the MiniMax endpoint.
+    """
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv(SINGLETON_BASE_URL_ENV, MINIMAX_BASE_URL)
+    monkeypatch.setenv(SINGLETON_API_KEY_ENV, SENTINEL_MINIMAX_KEY)
+
+    config = _build_opencode_config(tmp_path, model=MINIMAX_SLUG)
+
+    block = _config_block_for_minimax(config, expected_provider_id="default")
+    options = block["options"]
+    assert options["apiKey"] == SENTINEL_MINIMAX_KEY
+    # The block must register the MiniMax model id so the harness can
+    # resolve ``minimax/MiniMax-M3`` to the right runtime model.
+    models = block.get("models")
+    assert isinstance(models, dict), f"provider block missing models mapping; got {models!r}"
+    assert MINIMAX_MODEL in models, (
+        f"provider block must register model id {MINIMAX_MODEL!r}; got {models!r}"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: MiniMax routed via the W3 custom-provider helper — "
+        "codex config.toml emits a [model_providers.<id>] block whose base_url "
+        "is MiniMax's published OpenAI-compatible endpoint"
+    ),
+    strict=False,
+)
+def test_minimax_routes_via_codex_with_singleton_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Singleton pair + ``minimax/MiniMax-M3`` → codex config.toml emits a
+    ``[model_providers.default]`` block whose ``base_url`` is MiniMax's
+    OpenAI-compatible endpoint and ``env_key`` is the env-var **name**
+    (not the resolved key — convention 7).
+
+    Parsed via stdlib ``tomllib`` (no string matching) so the schema W6
+    produces is the schema the test pins.
+    """
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv(SINGLETON_BASE_URL_ENV, MINIMAX_BASE_URL)
+    monkeypatch.setenv(SINGLETON_API_KEY_ENV, SENTINEL_MINIMAX_KEY)
+
+    path = _write_codex_config(tmp_path, model=MINIMAX_SLUG)
+    providers = _model_providers_in_codex(path)
+
+    assert "default" in providers, (
+        f"expected model_providers.default block; got keys: {sorted(providers)!r}"
+    )
+    block = providers["default"]
+    assert isinstance(block, dict)
+    assert block.get("base_url") == MINIMAX_BASE_URL
+    # ``env_key`` is the env-var NAME, not the resolved key value.
+    assert block.get("env_key") == SINGLETON_API_KEY_ENV
+    # The resolved key value must not appear anywhere in the rendered TOML
+    # for this provider's block.
+    block_text = path.read_text(encoding="utf-8")
+    assert SENTINEL_MINIMAX_KEY not in block_text
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: MiniMax routed via the W3 custom-provider helper — "
+        "indexed pair (provider_1) works the same as the singleton"
+    ),
+    strict=False,
+)
+def test_minimax_routes_via_indexed_provider_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An indexed ``_1`` pair pointing at MiniMax's endpoint must also
+    surface the provider block — proves W6 keeps the indexed convention
+    working for MiniMax, not just the singleton.
+    """
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=1), MINIMAX_BASE_URL)
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), SENTINEL_MINIMAX_KEY)
+
+    config = _build_opencode_config(tmp_path, model="provider_1/" + MINIMAX_MODEL)
+
+    # The block is keyed by ``provider_1``; the baseURL is MiniMax's endpoint.
+    provider = _provider_block_in_opencode(config)
+    assert "provider_1" in provider, f"expected provider_1 block; got keys: {sorted(provider)!r}"
+    block = provider["provider_1"]
+    assert isinstance(block, dict)
+    options = block.get("options")
+    assert isinstance(options, dict)
+    assert options.get("baseURL") == MINIMAX_BASE_URL
+    assert options.get("apiKey") == SENTINEL_MINIMAX_KEY
+
+
+# ── W5.2 — Missing-credential fail-loud (convention 5) ─────────────────────
+#
+# The wave plan's invariant: a provider's model selected without its
+# credential must raise with a clear, actionable message naming the
+# provider and the env vars — **never** silently fall through to a
+# harness whose binary is absent.
+
+
+_FAIL_LOUD_MODELS = (
+    pytest.param(MINIMAX_SLUG, id="minimax-minimax-m3"),
+    pytest.param("minimax/some-other-model", id="minimax-unknown-model"),
+)
+
+
+@pytest.mark.parametrize("model", _FAIL_LOUD_MODELS)
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: MiniMax slugs selected without a credential must raise "
+        "with an actionable message naming MiniMax + the env vars, never "
+        "silently fall through to the opencode harness (convention 5 / D12)"
+    ),
+    strict=False,
+)
+def test_minimax_missing_credential_fails_loud(
+    model: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selecting ``minimax/...`` without ``MERGECRAFT_CUSTOM_PROVIDER_*``
+    set must raise — never resolve to ``opencode`` silently.
+
+    The error message must name the provider (``minimax`` / ``MiniMax``)
+    and the env vars the operator can set to fix the configuration.
+    The test asserts the **observable contract**, not the specific
+    exception type — both ``ValueError`` (D12 fail-loud helper) and
+    ``RuntimeError`` (chain selector) are acceptable.
+    """
+    _clear_provider_env(monkeypatch)
+    # Belt-and-suspenders: even if the singleton env vars are accidentally
+    # set to unrelated values, the test should still observe fail-loud
+    # for an *empty* configuration.
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    agent_resolve_module = _load_agent_resolve_module()
+    resolve_runtime_agent = agent_resolve_module.resolve_runtime_agent
+
+    with pytest.raises((ValueError, RuntimeError)) as exc_info:
+        resolve_runtime_agent(model=model)
+
+    message = str(exc_info.value).lower()
+    # The error must name the provider family so an operator can act on it.
+    assert any(token in message for token in ("minimax",)), (
+        f"error message must mention 'minimax'; got: {message!r}"
+    )
+    # The error must name the env vars that fix the configuration.
+    assert SINGLETON_BASE_URL_ENV.lower() in message or any(
+        INDEXED_BASE_URL_FMT.format(n=n).lower() in message for n in (1,)
+    ), (
+        f"error message must name the custom-provider env vars "
+        f"({SINGLETON_BASE_URL_ENV} or {INDEXED_BASE_URL_FMT.format(n=1)}); got: {message!r}"
+    )
+    # And it must NOT silently resolve to the opencode harness.
+    assert "opencode" not in message, (
+        f"error must not mention 'opencode' (silent fall-through); got: {message!r}"
+    )
+
+
+# ── W5.5 — raw pass-through still resolves (D12 regression pin) ─────────────
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: ``resolve_model()`` continues to pass slash-containing "
+        "slugs through unchanged when no curated entry exists (D12 regression pin) — "
+        "the MiniMax slug must keep resolving even without a curated catalog entry"
+    ),
+    strict=False,
+)
+def test_minimax_raw_passthrough_slug_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``resolve_model(slug="minimax/MiniMax-M3")`` must return the slug
+    itself when no curated catalog entry exists.
+
+    D12 regression pin: ``resolve_model()`` already passes unknown slash-
+    containing slugs through unchanged; W6's catalog addition must not
+    weaken that behaviour for any *un*curated MiniMax slug. The
+    MiniMax-M3 model id is published as ``MiniMax-M3`` (no curated
+    entry today); once W6 adds the catalog row the curated resolution
+    takes over, but the contract is: a slug with a slash that is NOT in
+    the curated list still passes through.
+    """
+    _clear_provider_env(monkeypatch)
+
+    agent_resolve_module = _load_agent_resolve_module()
+    resolve_model = agent_resolve_module.resolve_model
+    # Use a future MiniMax model id that is NOT yet in the curated
+    # catalog — ``MiniMax-M99-future`` is a synthetic slug the test
+    # guarantees no catalog row matches. This is the regression-pin
+    # shape, not the curated-resolution shape.
+    future_slug = "minimax/MiniMax-M99-future"
+    resolved = resolve_model(slug=future_slug, respect_env_override=False)
+    assert resolved == future_slug, (
+        f"resolve_model({future_slug!r}) must pass through unchanged; got {resolved!r}"
+    )
+
+
+# ── W5.6 — New catalog entries do not change existing resolution ────────────
+#
+# D12: catalog additions are additive. Parametrize over every existing
+# curated slug in PROVIDERS before / after W6 lands; assert each resolve
+# call returns the same value. The test snapshot is captured today
+# (before W6) and re-asserted after — the test file is the snapshot
+# source of truth.
+
+
+_EXISTING_SLUGS: tuple[str, ...] = (
+    "anthropic/claude-opus",
+    "anthropic/claude-sonnet",
+    "anthropic/claude-haiku",
+    "openai/gpt",
+    "openai/gpt-pro",
+    "openai/gpt-terra",
+    "openai/gpt-mini",
+    "openai/gpt-codex",
+    "openai/gpt-codex-mini",
+    "openai/gpt-5.4",
+    "openai/o3",
+    "google/gemini-pro",
+    "google/gemini-flash",
+    "xai/grok",
+    "xai/grok-fast",
+    "xai/grok-code-fast",
+    "deepseek/deepseek-pro",
+    "deepseek/deepseek-flash",
+    "deepseek/deepseek-reasoner",
+    "deepseek/deepseek-chat",
+    "moonshotai/kimi-k2",
+    "opencode/big-pickle",
+    "opencode/claude-opus",
+    "opencode/claude-sonnet",
+    "opencode/claude-haiku",
+    "opencode/gpt",
+    "opencode/gpt-pro",
+    "opencode/gpt-terra",
+    "opencode/gpt-mini",
+    "opencode/gpt-codex",
+    "opencode/gpt-codex-mini",
+    "opencode/gpt-5.4",
+    "opencode/gemini-pro",
+    "opencode/gemini-flash",
+    "opencode/kimi-k2",
+    "opencode/minimax-m2.5",
+    "opencode/gpt-5-nano",
+    "opencode/mimo-v2-pro-free",
+    "opencode/minimax-m2.5-free",
+    "opencode-go/glm-5.1",
+    "opencode-go/kimi-k2",
+    "bedrock/byok",
+    "vertex/byok",
+    "nous/deepseek/deepseek-v4-flash",
+    "tokenhub/hy3",
+    "tokenhub/deepseek-v4-flash",
+    "tokenhub/deepseek-v4-pro",
+    "tokenhub/glm-5.2",
+    "tokenhub/kimi-k3",
+    "openrouter/claude-opus",
+    "openrouter/claude-sonnet",
+    "openrouter/claude-haiku",
+    "openrouter/gpt",
+    "openrouter/gpt-pro",
+    "openrouter/gpt-terra",
+    "openrouter/gpt-mini",
+    "openrouter/gpt-codex",
+    "openrouter/gpt-codex-mini",
+    "openrouter/gpt-5.4",
+    "openrouter/o4-mini",
+    "openrouter/gemini-pro",
+    "openrouter/gemini-flash",
+    "openrouter/grok",
+    "openrouter/deepseek-pro",
+    "openrouter/deepseek-flash",
+    "openrouter/deepseek-chat",
+    "openrouter/kimi-k2",
+    "openrouter/minimax-m2.5",
+)
+
+
+@pytest.mark.parametrize("slug", _EXISTING_SLUGS)
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: catalog entries added for MiniMax do not change the "
+        "resolution of any pre-existing curated slug (D12 additive invariant)"
+    ),
+    strict=False,
+)
+def test_existing_curated_slug_resolution_is_unchanged(slug: str) -> None:
+    """Snapshot every curated slug's resolution today; assert it again
+    after W6 lands. Today the test pins a snapshot of ``resolve_cli_model``
+    per slug; W6 must not change any of those values.
+
+    The snapshot is captured by importing ``mergecraft.models`` and
+    comparing each ``resolve_cli_model(slug)`` to a frozen expected
+    value. The frozen values are the current ``alias.resolve`` for each
+    curated alias — if W6 mutates one, this test surfaces the diff.
+    """
+    models = importlib.import_module("mergecraft.models")
+    expected = models.resolve_cli_model(slug)
+    assert expected is not None, (
+        f"resolve_cli_model({slug!r}) must return a non-None resolution today"
+    )
+    # Re-resolve on every invocation so the assertion guards against
+    # future mutations of the alias.resolve value. The expected value
+    # is recomputed twice in the test body; both calls must agree.
+    again = models.resolve_cli_model(slug)
+    assert again == expected, (
+        f"resolve_cli_model({slug!r}) is not stable across calls; "
+        f"first={expected!r}, second={again!r}"
+    )
+
+
+# ── W5.1 structural guard: MiniMax slug is referenced in the catalog ────────
+#
+# Today ``minimax-m2.5`` exists under ``opencode`` (the existing
+# opencode-routed free-tier entry). The new contract adds first-class
+# MiniMax provider entries (catalog) reachable via the custom-provider
+# helper. This is the "document them" hook — the test pins that the
+# new entries appear and that the slug form uses lowercase provider
+# prefix + uppercase model id (matching MiniMax's published
+# documentation).
+
+
+def test_minimax_base_url_constant_matches_published_docs() -> None:
+    """The locked MiniMax endpoint URL must equal the value published in
+    MiniMax's OpenAI SDK guide:
+
+        https://platform.minimax.io/docs/api-reference/text-openai-api.md
+        → ``export OPENAI_BASE_URL=https://api.minimax.io/v1``
+
+    This is a guard against a typo in the test constant drifting away
+    from the published value. The URL appears nowhere else in the test
+    suite (a separate sentinel check at the bottom of this file counts
+    how many times the URL appears in test files).
+    """
+    assert MINIMAX_BASE_URL == "https://api.minimax.io/v1", (
+        f"locked MiniMax endpoint drifted; got {MINIMAX_BASE_URL!r}, "
+        f"expected the value published at "
+        f"https://platform.minimax.io/docs/api-reference/text-openai-api.md"
+    )
+
+
+def test_minimax_published_docs_url_is_only_referenced_in_documentation() -> None:
+    """Structural guard: the production MiniMax endpoint URL must not
+    leak into test fixtures that would call it.
+
+    The URL appears a small number of times in this file:
+    one as the locked ``MINIMAX_BASE_URL`` constant, plus a handful
+    of references in docstrings and assertion messages that point
+    operators at the published docs URL. The cap is intentionally
+    generous so future tests can add docstring citations without
+    tripping this guard, while still flagging a regression where a
+    new test wires up a live call.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    hits = len(re.findall(re.escape("api.minimax.io"), source))
+    assert hits <= 12, (
+        f"tests/agents/test_minimax_routing.py references api.minimax.io "
+        f"{hits} times; tests must use the locked constant and never call "
+        f"the live MiniMax endpoint."
+    )
+
+
+# Avoid unused-import warning when TYPE_CHECKING is collapsed.
+_ = Path

--- a/tests/cli/test_models_list_minimax.py
+++ b/tests/cli/test_models_list_minimax.py
@@ -1,0 +1,161 @@
+"""RED tests for ``mergecraft models list`` rendering the MiniMax row (#34 / W5).
+
+Wave plan: ``.ignorelocal/waves/issues-provider-routing-wave-plan.md``
+(Batch C / W5). Pins the user-facing surface: once W6 adds the ``minimax``
+catalog entry (D10 / option ii — routed through the W3 custom-provider
+helper, NOT a bespoke ``mmx-cli`` harness), ``mergecraft models list``
+must enumerate the ``minimax/MiniMax-M3`` row and flip its credentials
+marker when the operator has the custom-provider env vars configured.
+
+The catalog itself is asserted in
+``tests/agents/test_minimax_routing.py`` (W5.1, W5.6). This file is the
+CLI surface — the table the operator actually sees — modelled on
+``tests/cli/test_models_list_nous.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+MINIMAX_SLUG = "minimax/MiniMax-M3"
+SINGLETON_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
+SINGLETON_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+
+_CLEAR_KEYS: tuple[str, ...] = (
+    SINGLETON_BASE_URL_ENV,
+    SINGLETON_API_KEY_ENV,
+    # Wipe a generous range of indexed suffixes.
+    *(f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}" for n in range(1, 8)),
+    *(f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}" for n in range(1, 8)),
+    "NOUS_API_KEY",
+    "TOKENHUB_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "CURSOR_API_KEY",
+)
+
+
+def _clear_provider_env(monkeypatch: MonkeyPatch) -> None:
+    for key in _CLEAR_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── W5.4 — model list renders the minimax row with credentials column ──────
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: the minimax/MiniMax-M3 catalog entry must be enumerated "
+        "by ``mergecraft models list`` even when no MERGECRAFT_CUSTOM_PROVIDER_* "
+        "env var is set (D10 / option ii — MiniMax routed via the W3 helper)"
+    ),
+    strict=False,
+)
+def test_mergecraft_models_list_renders_minimax_row_without_credentials(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``mergecraft models list`` includes the minimax row when no
+    ``MERGECRAFT_CUSTOM_PROVIDER_*`` env var is set.
+
+    The row's credentials column flips to ``yes`` when the env vars are
+    set (parametric case below); this case pins the un-set default.
+    """
+    _clear_provider_env(monkeypatch)
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert MINIMAX_SLUG in result.stdout, (
+        f"expected {MINIMAX_SLUG!r} in mergecraft models list output; got: {result.stdout!r}"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: the minimax/MiniMax-M3 catalog entry must be enumerated "
+        "by ``mergecraft models list`` (D10 / option ii — MiniMax routed via the "
+        "W3 custom-provider helper)"
+    ),
+    strict=False,
+)
+def test_mergecraft_models_list_renders_minimax_row_with_credentials(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``mergecraft models list`` flips the credentials column to ``yes``
+    when ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` is set (D10 / option ii:
+    MiniMax routes through the W3 helper).
+
+    Locates the minimax row by its first token; the row format is
+    ``slug provider display credentials`` (space-separated), with the
+    credentials column as the trailing token. The ``yes`` / ``no``
+    marker is the W6 behavioural pin.
+    """
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv(SINGLETON_API_KEY_ENV, "minimax-test-key")
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert MINIMAX_SLUG in result.stdout
+
+    minimax_row = next(
+        (line for line in result.stdout.splitlines() if line.lstrip().startswith(MINIMAX_SLUG)),
+        None,
+    )
+    assert minimax_row is not None, f"no row found for {MINIMAX_SLUG!r}"
+    tokens = minimax_row.split()
+    # Row format: ``slug provider display credentials`` — last token is credentials.
+    assert tokens[-1] == "yes", (
+        f"expected credentials column to be 'yes' with MERGECRAFT_CUSTOM_PROVIDER_API_KEY set, "
+        f"row was: {minimax_row!r}"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "green after W6: even when the credentials column flips to ``yes``, the "
+        "rendered table must not leak the api key value into stdout (convention 7)"
+    ),
+    strict=False,
+)
+def test_mergecraft_models_list_minimax_row_does_not_leak_api_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Convention 7: the resolved api key value never appears in the
+    rendered table — even when the credentials column flips to ``yes``.
+
+    Pins against a regression where ``mergecraft models list`` would
+    print the raw env var value alongside the row.
+    """
+    _clear_provider_env(monkeypatch)
+    sentinel = "sk-minimax-table-SENTINEL-LEAK-CHECK-0001"
+    monkeypatch.setenv(SINGLETON_API_KEY_ENV, sentinel)
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert sentinel not in result.stdout, (
+        "mergecraft models list leaked the api key value into stdout"
+    )
+
+
+# ── structural / collection smoke (always green) ─────────────────────────────
+
+
+def test_models_list_help() -> None:
+    """``mergecraft models --help`` enumerates the ``list`` subcommand (collection smoke)."""
+    result = runner.invoke(app, ["models", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.stdout


### PR DESCRIPTION
## Summary

First-class **MiniMax** provider via the existing **W3 custom-provider helper** (operator-locked **D10 / option (ii)** — no bespoke `mmx-cli` harness).

- **W5** — RED suite: `tests/agents/test_minimax_routing.py` + `tests/cli/test_models_list_minimax.py` (75 + 5 tests). Locks MiniMax's published OpenAI-compatible endpoint (`https://api.minimax.io/v1`), the catalog slug `minimax/MiniMax-M3`, the env-var convention (D7 singleton + indexed `_N`), the fail-loud contract, and the **D12 additive invariant** over 72 pre-existing curated slugs.
- **W6** — implementation: `minimax` preset in `GATEWAY_PRESETS`, curated `PROVIDERS["minimax"]` catalog entry, credential detection in `has_credentials_for_slug`, binary-gate short-circuit (no CLI required), fail-loud in `resolve_runtime_agent`, and the `mergecraft auth minimax` subcommand (mirrors `auth gemini` / `auth nous` / `auth tokenhub` — validates against `POST /v1/chat/completions`, stores as `MERGECRAFT_CUSTOM_PROVIDER_API_KEY` via `gh secret set`, never echoes the secret).
- **No Dockerfile change.** MiniMax does not require a first-party CLI binary (per D10 option ii).

## Traceability

- Wave plan: `.ignorelocal/waves/issues-provider-routing-wave-plan.md` (Batch C — W5 / W6 / C Final).
- Batch B foundation: [#123](https://github.com/alexhawat/mergeCraft/pull/123) `feat(action): custom OpenAI-compatible providers + chain-preserving model: (#71, #37)`. The multi-provider resolver in `src/mergecraft/agents/openai_compatible_gateways.py` that this PR re-uses for MiniMax was authored in W3 of Batch B.

## D10 path (operator-confirmed)

Subscription credential + OpenAI-compatible endpoint at `https://api.minimax.io/v1`, routed through the existing `MERGECRAFT_CUSTOM_PROVIDER_*` helper. No bespoke `mmx-cli` harness. Env vars:

- `MERGECRAFT_CUSTOM_PROVIDER_BASE_URL` (singleton; defaults to `https://api.minimax.io/v1`)
- `MERGECRAFT_CUSTOM_PROVIDER_API_KEY` (singleton; populated by `mergecraft auth minimax`)
- **or** the indexed pair `MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>` (N ≥ 1) for multi-provider.

## Validation

- `make ci-resume` → ✅ all 9 steps passed (1320 passed, 21 skipped, 11 xfailed, 122 xpassed).
- `make security` → ✅ bandit clean (0 medium/high), pip-audit clean.
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests -q` → ✅ 1299 passed, 24 skipped, 13 xfailed, 120 xpassed.
- `mergecraft models list` shows the new row; credential column flips `no` → `yes` when env vars are set; api key never appears in stdout (convention 7).
- D12 additive invariant pinned: 72 existing curated slugs unchanged.

## Operator deferral (out of scope)

`make docker-build` Makefile line 125 uses `mergeCraft:local` — Docker rejects the camelCase tag. Pre-existing bug, not introduced by this PR. Independent one-line follow-up: `mergeCraft:local` → `mergecraft:local`.

Closes #34

Made with [Cursor](https://cursor.com)