### PR TITLE
fix(agents): scope has_gateway_credentials to avoid cross-provider false-positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `has_gateway_credentials` no longer false-positives for unrelated gateway
+  presets. A Batch C (#34 / PR #126) addition let an indexed custom-provider
+  pair (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`) or the singleton
+  pair make `has_gateway_credentials("minimax")` / `"nous"` / `"tokenhub"` all
+  return `True` regardless of whether that preset's own env vars were set,
+  partly undercutting the minimax fail-loud guarantee. The `resolve_gateway_endpoints()`
+  short-circuit was removed from `has_gateway_credentials` so a named preset
+  only reports credentials when its own env vars are set; the singleton is still
+  honoured for minimax via `MINIMAX_API_KEY_ENV == CUSTOM_PROVIDER_API_KEY_ENV`,
+  and the D4 `NOUS_API_KEY` back-compat alias for nous is preserved. Surfaced by
+  the Thermos review (Blocker #1). Regression tests:
+  `tests/agents/test_openai_compatible_gateways.py::test_indexed_pair_does_not_grant_minimax_credentials`,
+  `::test_singleton_still_grants_minimax_credentials`,
+  `::test_nous_back_compat_alias_still_grants_nous_credentials`
 - `mergecraft config tracing` now reports `enabled: true` immediately after
   `mergecraft auth logfire` (or `tracing logfire enable`) writes to `.env`.
   Root cause: the CLI's `main()` did not load `.env` into `os.environ`, so the

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -125,8 +125,6 @@ def has_gateway_credentials(provider_id: str) -> bool:
     """
     if has_custom_provider_env():
         return True
-    if resolve_gateway_endpoints():
-        return True
     preset = GATEWAY_PRESETS.get(provider_id.lower())
     if preset is None:
         return False

--- a/tests/agents/test_openai_compatible_gateways.py
+++ b/tests/agents/test_openai_compatible_gateways.py
@@ -54,6 +54,8 @@ def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for n in range(1, 8):
         monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}", raising=False)
         monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}", raising=False)
+    monkeypatch.delenv("NOUS_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENHUB_API_KEY", raising=False)
 
 
 # -- W1.4: shared helper returns a multi-provider shape --------------------
@@ -213,6 +215,54 @@ def test_shared_multi_provider_resolver_indexed_overrides_singleton(
     as_dict = _coerce_to_dict(result)
     assert PROVIDER_1_ID in as_dict
     assert DEFAULT_PROVIDER_ID not in as_dict
+
+
+# -- Thermos Blocker #1: scoped credential gate -----------------------------
+#
+# ``has_gateway_credentials`` must only report credentials for a named preset
+# when THAT preset's own env vars are set. An unrelated indexed custom-provider
+# pair (``MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>``) maps to a generic
+# ``provider_<N>`` id, NOT to the named ``minimax`` / ``nous`` / ``tokenhub``
+# presets — so it must not make ``has_gateway_credentials`` return True for them.
+# Regression: a Batch C addition let ``resolve_gateway_endpoints()`` short-circuit
+# the gate, causing every preset to false-positive.
+
+
+def test_indexed_pair_does_not_grant_minimax_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated indexed pair must NOT make ``minimax`` report credentials."""
+    from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
+
+    monkeypatch.setenv(
+        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_1", "https://provider-1.example.test/v1"
+    )
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY_1", "key-1")
+
+    assert has_gateway_credentials("minimax") is False
+
+
+def test_singleton_still_grants_minimax_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The singleton custom-provider pair still honours ``minimax`` (back-compat)."""
+    from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
+
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", "https://default.example.test/v1")
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", "default-key")
+
+    assert has_gateway_credentials("minimax") is True
+
+
+def test_nous_back_compat_alias_still_grants_nous_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``NOUS_API_KEY`` still grants ``nous`` credentials (D4 back-compat alias)."""
+    from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
+
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+
+    assert has_gateway_credentials("nous") is True
 
 
 # -- helpers -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Thermos review (Blocker #1) surfaced a scoped-credential-gate defect in `src/mergecraft/agents/openai_compatible_gateways.py`.

### The defect
`has_gateway_credentials(provider_id)` contained a short-circuit:

```python
if resolve_gateway_endpoints():
    return True
```

`resolve_gateway_endpoints()` returns a non-empty dict whenever **any** indexed custom-provider pair (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`) **or** the singleton pair is set — it does **not** check whether the *requested* `provider_id` is among the returned providers. So configuring an unrelated indexed pair (e.g. `MERGECRAFT_CUSTOM_PROVIDER_API_KEY_1` for Nous) made `has_gateway_credentials("minimax")`, `("nous")`, and `("tokenhub")` **all** return `True` regardless of whether that specific preset's env vars were set.

Impact: an operator with an unrelated indexed pair set causes `has_credentials_for_slug("minimax/MiniMax-M3")` to return `True` when no MiniMax credential exists, so `resolve_runtime_agent(model="minimax/...")` routes to `opencode` (which then fails at runtime) instead of raising the loud `ValueError` the minimax branch was added to guarantee — partly undercutting Batch C's own fail-loud guarantee (PR #126 / #34).

### The fix
Deleted the `if resolve_gateway_endpoints(): return True` line. A named preset now only reports credentials when its **own** env vars are set:
- The singleton is still honoured for `minimax` via `MINIMAX_API_KEY_ENV == CUSTOM_PROVIDER_API_KEY_ENV` (the existing `_has_env(preset.api_key_env)` line).
- The D4 `NOUS_API_KEY` back-compat alias for `nous` is preserved by the explicit nous line.

Indexed `provider_<N>` pairs remain a generic custom-provider surface for slugs like `provider_1/<model>`, and `resolve_gateway_endpoints()` itself is unchanged — the opencode/codex config emission still reads it directly, so W1/W3 and W5 routing contracts are unaffected.

## Test plan
- Added regression tests in `tests/agents/test_openai_compatible_gateways.py`:
  - `test_indexed_pair_does_not_grant_minimax_credentials` — only an indexed pair set → `has_gateway_credentials("minimax")` is `False`.
  - `test_singleton_still_grants_minimax_credentials` — singleton pair set → `True` (back-compat preserved).
  - `test_nous_back_compat_alias_still_grants_nous_credentials` — `NOUS_API_KEY` set → `True` (D4 preserved).
- `make lint` clean, `make typecheck` clean.
- Targeted + regression pytest green (W1 `resolve_gateway_endpoints` tests and W5 minimax fail-loud tests unaffected).

This is a follow-up to **PR #126** (Batch C / issue #34). **Do not merge** — operator gates it.

Made with [Cursor](https://cursor.com)