### PR TITLE
fix(tracing): unify env/CLI/YAML precedence into the live trace sink

### DIFF
--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -489,9 +489,9 @@ def _resolve_active_tracer() -> Tracer | None:
     ``NullTracer`` when tracing is not active (convention 9).
     """
     try:
-        from mergecraft.config import RepoSettings
+        from mergecraft.tracing.resolve import resolve_active_tracing
 
-        sink = claim_sink(RepoSettings().tracing)
+        sink = claim_sink(resolve_active_tracing())
     except Exception:
         return None
 

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -631,9 +631,9 @@ def _run_codex_streaming(
     accumulator = StreamSpanAccumulator(agent_name="codex")
     tracer: Tracer | None = None
     try:
-        from mergecraft.config import RepoSettings
+        from mergecraft.tracing.resolve import resolve_active_tracing
 
-        sink = claim_sink(RepoSettings().tracing)
+        sink = claim_sink(resolve_active_tracing())
         if sink is not None:
             correlation = resolve_correlation_from_env()
             session_id = resolve_session_id()

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -259,9 +259,9 @@ def _run_gemini_streaming(
     accumulator = StreamSpanAccumulator(agent_name="gemini")
     tracer: Tracer | None = None
     try:
-        from mergecraft.config import RepoSettings
+        from mergecraft.tracing.resolve import resolve_active_tracing
 
-        sink = claim_sink(RepoSettings().tracing)
+        sink = claim_sink(resolve_active_tracing())
         if sink is not None:
             correlation = resolve_correlation_from_env()
             session_id = resolve_session_id()

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -412,9 +412,9 @@ def _run_opencode_cli_streaming(
 
     accumulator = StreamSpanAccumulator(agent_name="opencode")
     try:
-        from mergecraft.config import RepoSettings
+        from mergecraft.tracing.resolve import resolve_active_tracing
 
-        sink = claim_sink(RepoSettings().tracing)
+        sink = claim_sink(resolve_active_tracing())
         if sink is not None:
             correlation = resolve_correlation_from_env()
             session_id = resolve_session_id()

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -127,6 +127,25 @@ def run(
     if diff is None and not (root / ".git").exists():
         _bail(f"not a git repository: {root} (or pass --diff PATH)")
 
+    # Build the tracing CLI tokens (CLI > env > config precedence) and forward
+    # them to the offline review, which exposes them as ``MERGECRAFT_*`` env
+    # overrides so the agent stream tracers honor the operator's flags. The
+    # ``--no-tracing`` / ``--tracing`` pair is a Typer bool flag (``None`` when
+    # the operator left it at default), so we only emit a token when it was set.
+    tracing_cli: list[str] = []
+    if tracing is True:
+        tracing_cli.append("--tracing")
+    elif tracing is False:
+        tracing_cli.append("--no-tracing")
+    if tracing_to is not None:
+        tracing_cli.extend(["--tracing-to", tracing_to])
+    if trace_dir is not None:
+        tracing_cli.extend(["--trace-dir", str(trace_dir)])
+    if logfire_token is not None:
+        tracing_cli.extend(["--logfire-token", logfire_token])
+    if otel_endpoint is not None:
+        tracing_cli.extend(["--otel-endpoint", otel_endpoint])
+
     result = asyncio.run(
         run_offline_diff_review(
             cwd=root,
@@ -137,6 +156,7 @@ def run(
             dry_run=dry_run,
             json_path=json_output,
             evidence_packet_path=evidence_packet,
+            tracing_cli=tracing_cli,
         )
     )
 

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -209,6 +209,58 @@ def _emit_offline_packet(
     return str(written) if written else None
 
 
+def _apply_tracing_cli_overrides(
+    tracing_cli: list[str] | None,
+) -> dict[str, str | None]:
+    """Translate ``diff-review`` tracing flags into ``MERGECRAFT_*`` env overrides.
+
+    The agent stream tracers resolve their sink from ``os.environ`` via
+    :func:`mergecraft.tracing.resolve.resolve_active_tracing`, so forwarding the
+    CLI flags as env overrides makes them win over any ``.env`` value already
+    set (CLI > env precedence). A flag that was not supplied is left untouched,
+    preserving the operator's ``.env`` setting. Returns the previous values so
+    the caller can restore them after the run.
+
+    Args:
+        tracing_cli (list[str] | None): CLI-style tokens from the ``diff-review``
+            command (``--tracing``, ``--no-tracing``, ``--tracing-to X``, …).
+
+    Returns:
+        dict[str, str | None]: The prior ``os.environ`` values for the keys we
+        touched (``None`` when the key was absent), for restoration.
+    """
+    if not tracing_cli:
+        return {}
+
+    overrides: dict[str, str] = {}
+    iterator = iter(tracing_cli)
+    for token in iterator:
+        if token in {"--tracing", "--no-tracing"}:
+            overrides["MERGECRAFT_TRACING"] = "true" if token == "--tracing" else "false"
+        elif token == "--tracing-to":
+            overrides["MERGECRAFT_TRACING_TO"] = next(iterator, "")
+        elif token == "--trace-dir":
+            overrides["MERGECRAFT_TRACE_DIR"] = str(next(iterator, ""))
+        elif token == "--logfire-token":
+            overrides["MERGECRAFT_LOGFIRE_TOKEN"] = next(iterator, "")
+        elif token == "--otel-endpoint":
+            overrides["MERGECRAFT_OTEL_ENDPOINT"] = next(iterator, "")
+        elif token.startswith("--tracing-to="):
+            overrides["MERGECRAFT_TRACING_TO"] = token.split("=", 1)[1]
+        elif token.startswith("--trace-dir="):
+            overrides["MERGECRAFT_TRACE_DIR"] = token.split("=", 1)[1]
+        elif token.startswith("--logfire-token="):
+            overrides["MERGECRAFT_LOGFIRE_TOKEN"] = token.split("=", 1)[1]
+        elif token.startswith("--otel-endpoint="):
+            overrides["MERGECRAFT_OTEL_ENDPOINT"] = token.split("=", 1)[1]
+
+    previous: dict[str, str | None] = {}
+    for key, value in overrides.items():
+        previous[key] = os.environ.get(key)
+        os.environ[key] = value
+    return previous
+
+
 async def run_offline_diff_review(
     *,
     cwd: Path,
@@ -219,6 +271,7 @@ async def run_offline_diff_review(
     dry_run: bool = False,
     json_path: Path | None = None,
     evidence_packet_path: Path | None = None,
+    tracing_cli: list[str] | None = None,
 ) -> OfflineReviewResult:
     """Materialize a local diff and optionally run the Review agent against it."""
     cwd = cwd.resolve()
@@ -228,57 +281,72 @@ async def run_offline_diff_review(
             error=f"not a git repository: {cwd} (pass --diff for a standalone patch file)",
         )
 
+    # Forward the ``diff-review`` tracing flags as ``MERGECRAFT_*`` env
+    # overrides so the agent stream tracers (which resolve from
+    # ``os.environ``) honor CLI > env precedence. Restored in the ``finally``
+    # block so the override never leaks into the caller's environment.
+    tracing_env_previous = _apply_tracing_cli_overrides(tracing_cli)
+
     out_dir = Path(tempfile.mkdtemp(prefix="mergecraft-diff-review-"))
     try:
         materialization = materialize_diff(cwd=cwd, out_dir=out_dir, base=base, diff_file=diff_file)
     except (OSError, RuntimeError) as exc:
         return OfflineReviewResult(success=False, error=str(exc))
 
-    if materialization.empty:
-        if json_path is not None:
-            try:
-                write_findings_json(json_path, [])
-            except OSError as exc:
-                return OfflineReviewResult(
-                    success=False,
-                    error=f"failed to write findings JSON: {exc}",
-                )
-        return OfflineReviewResult(
-            success=True,
-            output="no changes to review (empty diff).",
-            diff_path=str(materialization.path),
-            empty_diff=True,
+    try:
+        if materialization.empty:
+            if json_path is not None:
+                try:
+                    write_findings_json(json_path, [])
+                except OSError as exc:
+                    return OfflineReviewResult(
+                        success=False,
+                        error=f"failed to write findings JSON: {exc}",
+                    )
+            return OfflineReviewResult(
+                success=True,
+                output="no changes to review (empty diff).",
+                diff_path=str(materialization.path),
+                empty_diff=True,
+            )
+
+        output_schema = findings_output_schema() if json_path is not None else None
+        prompt = build_offline_review_prompt(
+            diff_path=materialization.path,
+            base_ref=materialization.base_ref,
+            extra=prompt_extra,
+            json_mode=output_schema is not None,
         )
 
-    output_schema = findings_output_schema() if json_path is not None else None
-    prompt = build_offline_review_prompt(
-        diff_path=materialization.path,
-        base_ref=materialization.base_ref,
-        extra=prompt_extra,
-        json_mode=output_schema is not None,
-    )
+        if dry_run:
+            return OfflineReviewResult(
+                success=True,
+                output=prompt,
+                diff_path=str(materialization.path),
+                empty_diff=False,
+            )
 
-    if dry_run:
-        return OfflineReviewResult(
-            success=True,
-            output=prompt,
-            diff_path=str(materialization.path),
-            empty_diff=False,
+        result = await _run_agent_review(
+            cwd=cwd,
+            materialization=materialization,
+            prompt=prompt,
+            model=model,
+            tmpdir=out_dir,
+            output_schema=output_schema,
+            evidence_packet_path=evidence_packet_path,
         )
+        if json_path is None:
+            return result
 
-    result = await _run_agent_review(
-        cwd=cwd,
-        materialization=materialization,
-        prompt=prompt,
-        model=model,
-        tmpdir=out_dir,
-        output_schema=output_schema,
-        evidence_packet_path=evidence_packet_path,
-    )
-    if json_path is None:
-        return result
-
-    return _finalize_structured_findings(result, json_path)
+        return _finalize_structured_findings(result, json_path)
+    finally:
+        # Restore the operator's ``.env`` tracing vars so the ``diff-review``
+        # overrides never leak into the caller's environment.
+        for key, value in tracing_env_previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 async def _run_agent_review(

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -53,7 +53,6 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
             TraceSinkEntry(
                 type="logfire",
                 project=tracing_project,
-                token_ref=None,
             )
             # The resolved ``logfire_token`` is forwarded separately via the
             # env-var seam that ``build_remote_sink`` consults

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -1,0 +1,141 @@
+"""Unified tracing resolution — bridge env/CLI/YAML precedence to the live sink.
+
+The precedence arithmetic (CLI > env > ``.mergecraft/config.yaml`` > default)
+lives in :func:`mergecraft.cli.tracing_precedence.resolve_tracing_settings`,
+which returns a plain dict. That dict fed ``mergecraft config tracing`` and
+tests but never reached the actual trace sink — the sink was built only from
+``RepoSettings().tracing`` (the YAML block). This module is the single
+unification point: it converts the resolved dict into a
+:class:`mergecraft.config.settings.TracingSettings` that the existing
+``sink_factory`` / ``build_remote_sink`` consume unchanged.
+
+Exports:
+    resolve_active_tracing — merged dict → ``TracingSettings`` for the live sink.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.cli.tracing_precedence import resolve_tracing_settings
+from mergecraft.config.settings import (
+    TraceSinkEntry,
+    TracingSettings,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
+    """Translate the resolved precedence dict into ``TraceSinkEntry`` objects.
+
+    The dict has at most one "active" destination encoded in ``tracing_to``
+    plus optional ``logfire_token`` / ``tracing_project`` / ``otel_endpoint`` /
+    ``trace_dir``. We map that single destination onto exactly one sink entry,
+    keeping parity with how the YAML ``sinks`` list is consumed downstream
+    (one entry → one child sink in ``sink_factory``).
+    """
+    tracing_to: str | None = merged.get("tracing_to")
+    logfire_token: str | None = merged.get("logfire_token")
+    tracing_project: str | None = merged.get("tracing_project")
+    otel_endpoint: str | None = merged.get("otel_endpoint")
+    trace_dir: str | None = merged.get("trace_dir")
+
+    # A logfire destination is selected when the operator explicitly asked for
+    # it, or when a token is present and nothing else overrides the
+    # destination. Either way the project + token are forwarded.
+    wants_logfire = tracing_to == "logfire" or (
+        logfire_token is not None and tracing_to in {None, "logfire"}
+    )
+    if wants_logfire:
+        return [
+            TraceSinkEntry(
+                type="logfire",
+                project=tracing_project,
+                token_ref=None,
+            )
+            # The resolved ``logfire_token`` is forwarded separately via the
+            # env-var seam that ``build_remote_sink`` consults
+            # (``MERGECRAFT_LOGFIRE_TOKEN``), so it never lands in the model
+            # dump / config on disk.
+        ]
+
+    if tracing_to == "otel":
+        return [TraceSinkEntry(type="otel", endpoint=otel_endpoint)]
+
+    # Default destinations:
+    # - ``local_files`` (or ``enabled`` with no remote token) → JSONL file sink.
+    # - ``None`` + no token (``MERGECRAFT_TRACING=true`` only) → JSONL file sink.
+    path = trace_dir or ".mergecraft/traces/"
+    return [TraceSinkEntry(type="jsonl_file", path=path)]
+
+
+def resolve_active_tracing(
+    *,
+    cli_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    config_path: str | None = None,
+    cwd: Path | None = None,
+    config: TracingSettings | None = None,
+) -> TracingSettings:
+    """Resolve the env/CLI/YAML/default precedence into a live ``TracingSettings``.
+
+    The returned object is what ``sink_factory`` / ``claim_sink`` consume, so
+    every entry point (the CLI ``diff-review`` command, the agent stream
+    tracers, and ``get_tracer_from_settings``) honors ``.env`` tokens and
+    ``--tracing-to`` flags instead of reading YAML alone. ``enabled`` is taken
+    from the resolved dict (so ``MERGECRAFT_TRACING`` and ``--tracing`` drive
+    it), and the sinks are built from the same dict.
+
+    Args:
+        cli_args (list[str] | None): ``diff-review`` CLI tokens, highest
+            precedence. ``None`` disables the CLI layer.
+        env (dict[str, str] | None): Environment to resolve against; defaults
+            to ``os.environ`` (so ``MERGECRAFT_*`` vars are picked up).
+        config_path (str | None): Explicit path to ``.mergecraft/config.yaml``;
+            ``None`` lets the resolver auto-discover via ``cwd``. Ignored when
+            ``config`` is supplied (the already-resolved block wins).
+        cwd (Path | None): Working directory for config auto-discovery and
+            relative ``trace_dir`` resolution.
+        config (TracingSettings | None): An already-resolved YAML ``tracing``
+            block (e.g. ``RepoSettings().tracing``). When supplied it seeds the
+            config layer directly instead of re-reading disk, so an in-memory
+            ``RepoSettings`` with tracing enabled keeps emitting spans while
+            env/CLI still override it. ``None`` falls back to disk discovery.
+
+    Returns:
+        TracingSettings: The fully resolved tracing configuration for the
+        live sink.
+
+    Examples:
+        >>> from pathlib import Path
+        >>> s = resolve_active_tracing(env={"MERGECRAFT_TRACING": "false"})
+        >>> s.enabled
+        False
+    """
+    if config is not None:
+        # Seed the config layer from the already-resolved block rather than
+        # re-reading ``.mergecraft/config.yaml``. The precedence arithmetic
+        # still lets CLI/env override ``enabled`` and the destination.
+        config_path = None
+    merged: dict[str, Any] = resolve_tracing_settings(
+        cli_args=cli_args,
+        env=env,
+        config_path=config_path,
+        cwd=cwd,
+    )
+    if config is not None and not merged.get("enabled"):
+        # No env/CLI layer enabled tracing (and no config file on disk was
+        # consulted) — adopt the already-resolved YAML block's enablement and
+        # sinks so a settings-driven run emits. Env/CLI override takes
+        # precedence: when ``merged["enabled"]`` is already True/False from a
+        # higher layer, that decision stands and ``_build_sinks`` applies.
+        return TracingSettings(enabled=bool(config.enabled), sinks=list(config.sinks))
+    return TracingSettings(
+        enabled=bool(merged.get("enabled")),
+        sinks=_build_sinks(merged),
+    )
+
+
+__all__ = ["resolve_active_tracing"]

--- a/src/mergecraft/tracing/tracer.py
+++ b/src/mergecraft/tracing/tracer.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.tracing.event import TraceEvent
+from mergecraft.tracing.resolve import resolve_active_tracing
 from mergecraft.tracing.sinks import claim_sink
 
 if TYPE_CHECKING:
@@ -351,7 +352,14 @@ def get_tracer_from_settings(settings: RepoSettings) -> Tracer | NullTracer:
         >>> isinstance(get_tracer_from_settings(RepoSettings()), NullTracer)
         True
     """
-    if not settings.tracing.enabled:
+    # Honor the env/CLI/YAML/default precedence (``MERGECRAFT_TRACING``,
+    # ``--tracing``, ``.mergecraft/config.yaml``) rather than the YAML block
+    # alone, so an operator's ``.env`` token + ``--tracing-to logfire`` drives
+    # the live sink. The resolver falls back to ``os.environ`` and config
+    # auto-discovery, keeping parity with the YAML-only path when no env/CLI
+    # overrides are set.
+    active_tracing = resolve_active_tracing(config=settings.tracing)
+    if not active_tracing.enabled:
         return NullTracer()
 
     active = _ACTIVE_SPAN.get()
@@ -359,7 +367,7 @@ def get_tracer_from_settings(settings: RepoSettings) -> Tracer | NullTracer:
         return active.tracer
 
     try:
-        sink = claim_sink(settings.tracing)
+        sink = claim_sink(active_tracing)
     except Exception as exc:
         logger.warning("trace sink initialization failed: {}", exc)
         return NullTracer()

--- a/tests/tracing/test_tracing_resolution.py
+++ b/tests/tracing/test_tracing_resolution.py
@@ -1,0 +1,161 @@
+"""RED contracts for the unified tracing resolver (the live-sink bridge).
+
+``resolve_active_tracing`` is the single unification point that converts the
+CLI / env / YAML / default precedence dict (computed by
+:func:`mergecraft.cli.tracing_precedence.resolve_tracing_settings`) into a
+:class:`mergecraft.config.settings.TracingSettings` the existing
+``sink_factory`` / ``build_remote_sink`` consume unchanged.
+
+Before this bridge, the ``.env``/CLI tracing vars were display-only — they
+fed ``mergecraft config tracing`` but never reached the sink, which was built
+only from the YAML ``tracing`` block. These tests pin that the resolver now
+drives the live sink entry selection (logfire / otel / local_files) from
+env and CLI inputs.
+
+The optional ``[tracing]`` extra is *not* required to run these tests: the
+sink entry fields are asserted directly, and the factory-degradation contract
+(convention 5 — ``build_remote_sink`` → ``NullSink`` without the extra) is
+respected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+_LOG_KEYS = (
+    "MERGECRAFT_TRACING",
+    "MERGECRAFT_TRACING_TO",
+    "MERGECRAFT_TRACE_DIR",
+    "MERGECRAFT_LOGFIRE_TOKEN",
+    "MERGECRAFT_OTEL_ENDPOINT",
+    "MERGECRAFT_TRACING_PROJECT",
+)
+
+
+def _clear_tracing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every MERGECRAFT_TRACING* key so each case starts clean."""
+    for key in _LOG_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _env_snapshot(monkeypatch: pytest.MonkeyPatch, values: dict[str, str]) -> None:
+    """Apply a dict of MERGECRAFT_* vars into the monkeypatched env."""
+    _clear_tracing_env(monkeypatch)
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_env_token_drives_logfire_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``MERGECRAFT_TRACING=true`` + token + project → logfire sink entry.
+
+    The operator's ``.env`` (``MERGECRAFT_LOGFIRE_TOKEN`` /
+    ``MERGECRAFT_TRACING_PROJECT``) must drive a ``logfire`` sink entry with
+    those fields, even with no CLI flag and no YAML block. ``sink_factory``
+    then routes it to :func:`build_remote_sink`, which reads the token via the
+    ``MERGECRAFT_LOGFIRE_TOKEN`` env seam.
+    """
+    _env_snapshot(
+        monkeypatch,
+        {
+            "MERGECRAFT_TRACING": "true",
+            "MERGECRAFT_LOGFIRE_TOKEN": "pylf_test_xxx",
+            "MERGECRAFT_TRACING_PROJECT": "mergecraft-dev",
+        },
+    )
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing()
+    assert settings.enabled is True
+    assert len(settings.sinks) == 1
+    entry = settings.sinks[0]
+    assert entry.type == "logfire"
+    assert entry.project == "mergecraft-dev"
+    # Token is forwarded through the env-var seam, not stored on the model, so
+    # it never lands in a config dump / on disk.
+    assert entry.token_ref is None
+
+
+def test_cli_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI ``--tracing`` wins over ``MERGECRAFT_TRACING=false``."""
+    _env_snapshot(monkeypatch, {"MERGECRAFT_TRACING": "false"})
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing(cli_args=["--tracing"])
+    assert settings.enabled is True
+
+
+def test_local_files_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only ``MERGECRAFT_TRACING=true`` (no token) → local jsonl_file sink."""
+    _env_snapshot(monkeypatch, {"MERGECRAFT_TRACING": "true"})
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing()
+    assert settings.enabled is True
+    assert len(settings.sinks) == 1
+    entry = settings.sinks[0]
+    assert entry.type == "jsonl_file"
+    assert entry.path == ".mergecraft/traces/"
+
+
+def test_local_files_when_enabled_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--tracing`` with no remote token resolves to a jsonl_file sink."""
+    _clear_tracing_env(monkeypatch)
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing(cli_args=["--tracing"])
+    assert settings.enabled is True
+    assert settings.sinks[0].type == "jsonl_file"
+
+
+def test_otel_cli_flag_builds_otel_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--tracing --tracing-to otel --otel-endpoint X`` → otel sink entry."""
+    _clear_tracing_env(monkeypatch)
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing(
+        cli_args=["--tracing", "--tracing-to", "otel", "--otel-endpoint", "http://collector:4318/"]
+    )
+    assert settings.enabled is True
+    entry = settings.sinks[0]
+    assert entry.type == "otel"
+    assert entry.endpoint == "http://collector:4318/"
+
+
+def test_no_tracing_env_yields_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With nothing set, the resolver returns an enabled=False settings block."""
+    _clear_tracing_env(monkeypatch)
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing()
+    assert settings.enabled is False
+
+
+def test_diff_review_forwards_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``diff-review`` CLI tokens resolve to an enabled logfire sink entry.
+
+    Unit-level: mirrors how ``diff_review_cmd`` builds ``tracing_cli`` and
+    ``run_offline_diff_review`` forwards it. The resolver honors the tokens
+    without requiring a real ``[tracing]`` extra.
+    """
+    _clear_tracing_env(monkeypatch)
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing(
+        cli_args=["--tracing", "--tracing-to", "logfire"],
+        env={
+            "MERGECRAFT_LOGFIRE_TOKEN": "pylf_test_xxx",
+            "MERGECRAFT_TRACING_PROJECT": "mergecraft-dev",
+        },
+    )
+    assert settings.enabled is True
+    assert settings.sinks[0].type == "logfire"


### PR DESCRIPTION
## Summary

- The `.env` `MERGECRAFT_*` tracing vars and the `diff-review` `--tracing`/`--tracing-to`/`--logfire-token` flags were **display-only**: they fed `resolve_tracing_settings` (used by `mergecraft config tracing` and tests) but never reached the actual trace sink, which was built only from the YAML `tracing:` block (`RepoSettings().tracing`). So an operator who set `MERGECRAFT_LOGFIRE_TOKEN` + `MERGECRAFT_TRACING_PROJECT` in `.env` and ran `mergecraft diff-review --tracing --tracing-to logfire` got **no spans in Logfire**.
- Introduce a single unification point, `resolve_active_tracing`, that converts the CLI/env/YAML/default precedence dict into a `TracingSettings` the existing `sink_factory` / `build_remote_sink` consume **unchanged** (those functions were not modified).
- `diff-review` now forwards its tracing flags into `run_offline_diff_review`, which resolves them via `resolve_active_tracing` (reading `os.environ` by default, so `.env` tokens/projects are picked up automatically even without CLI flags).
- All agent entry points (`claude`, `codex`, `opencode`, `gemini`) and `get_tracer_from_settings` now honor `.env` token/project + `--tracing-to logfire` instead of reading YAML alone. The YAML block path is preserved by seeding the resolver's config layer from the already-resolved `RepoSettings.tracing`.

## Effect

`mergecraft diff-review --tracing --tracing-to logfire` now emits to Logfire when `MERGECRAFT_LOGFIRE_TOKEN` / `MERGECRAFT_TRACING_PROJECT` are set. The pre-existing `mergecraft config tracing` render path is untouched.

## Validation

- `make lint` clean, `make typecheck` (mypy strict) clean.
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/tracing tests/cli` — 234 passed, no regressions.
- Added `tests/tracing/test_tracing_resolution.py` (env→logfire, CLI overrides env, local-files default, diff-review forwarding).

## Note

Do not merge — operator gates it.