### PR TITLE
fix(tracing): wire Logfire OTLP export and guard TracerProvider override

### DIFF
--- a/src/mergecraft/tracing/exporters.py
+++ b/src/mergecraft/tracing/exporters.py
@@ -239,13 +239,27 @@ def _setup_tracer_provider(
     headers: dict[str, str],
     service_name: str,
 ) -> Any | None:
-    """Configure a tracer provider that records serialized spans to ``_RECORDING_PAYLOADS``.
+    """Configure a tracer provider that exports spans to ``endpoint`` and records them.
 
-    Convention 8 — no live network call. The OTel ``TracerProvider`` is
-    installed with a recording span processor that captures each emitted
-    span as a JSON-encoded blob in :data:`_RECORDING_PAYLOADS`. The
-    ``last_otel_endpoint`` / ``last_otel_headers`` module state is updated
-    so tests can assert wiring.
+    Two span processors are attached so the production path and the test seam
+    coexist (D5 / convention 8):
+
+    * A real ``OTLPSpanExporter`` (HTTP) sends spans to ``endpoint`` with
+      ``headers`` — this is what makes spans reach Logfire / a self-hosted
+      collector in production.
+    * The in-memory ``_RecordingSpanProcessor`` keeps capturing spans into
+      :data:`_RECORDING_PAYLOADS` so the test seam continues to assert on the
+      redaction boundary and the D8 payload-cap contract.
+
+    The ``TracerProvider`` override is guarded: when a real provider is already
+    installed in the process (e.g. ``logfire`` activates its own on import, or
+    a prior ``OTLPSink`` already set one), OTel raises
+    ``Overriding of current TracerProvider is not allowed``. We catch that and
+    REUSE the existing provider instead of silently degrading to a no-op — the
+    recording processor is still appended so the test seam keeps working. This
+    is the fix for spans never reaching Logfire: the unguarded
+    ``set_tracer_provider`` used to swallow the override error and return
+    ``None``, turning the sink into a silent no-op.
 
     Returns ``None`` when the optional extra is uninstalled.
     """
@@ -265,6 +279,8 @@ def _setup_tracer_provider(
     # mypy: we re-bind the class names below for the closure.
     Resource = _Resource
     TracerProvider = _TracerProvider
+    OTLPSpanExporter = _OTLPSpanExporter
+    BatchSpanProcessor = _BatchSpanProcessor
 
     _LAST_ENDPOINT = endpoint
     _LAST_HEADERS = dict(headers)
@@ -277,19 +293,47 @@ def _setup_tracer_provider(
     _ACTIVE_TRACER_PROVIDERS = []
 
     try:
-        # AlwaysSample ensures every span reaches the recording processor —
-        # the production equivalent would be a parent-based sampler, but for
-        # the test seam we want deterministic capture.
         from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 
-        provider = TracerProvider(
-            resource=Resource.create({"service.name": service_name}),
-            sampler=ALWAYS_ON,
+        # Guard the override: reuse an already-installed provider rather than
+        # fail. OTel's ProxyTracerProvider is the default before any real
+        # provider is set, so ``get_tracer_provider()`` is not a real one
+        # until ``set_tracer_provider`` has been called successfully.
+        existing = trace_mod.get_tracer_provider()
+        is_proxy = type(existing).__name__ == "ProxyTracerProvider"
+        if is_proxy:
+            provider = TracerProvider(
+                resource=Resource.create({"service.name": service_name}),
+                sampler=ALWAYS_ON,
+            )
+            trace_mod.set_tracer_provider(provider)
+        else:
+            # A real provider already exists (logfire import, prior sink, …).
+            provider = existing
+        # Real exporter first so production spans reach the network.
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                OTLPSpanExporter(
+                    endpoint=endpoint,
+                    headers=headers,
+                )
+            )
         )
+        # Test seam: keep recording so captured_payload / has_active_tracer_provider
+        # still observe spans.
         provider.add_span_processor(_RecordingSpanProcessor())
-        trace_mod.set_tracer_provider(provider)
         _ACTIVE_TRACER_PROVIDERS.append(provider)
-    except Exception as exc:  # pragma: no cover — defensive
+    except Exception as exc:
+        # The only expected failure here is the override error from a stale
+        # global state we could not observe via get_tracer_provider(). Honor
+        # the test seam by reusing whatever provider is live.
+        if "Overriding" in str(exc):
+            existing = trace_mod.get_tracer_provider()
+            if type(existing).__name__ != "ProxyTracerProvider":
+                logger.debug("trace otel provider already set; reusing it")
+                existing.add_span_processor(_RecordingSpanProcessor())
+                _ACTIVE_TRACER_PROVIDERS.append(existing)
+                return existing
         logger.warning("trace otel provider setup failed: {}", exc)
         return None
     return provider
@@ -487,10 +531,11 @@ class OTLPSink:
             provider = self._ensure_provider()
             if provider is None:
                 return
-            for processor in getattr(provider, "_active_span_processors", ()):
-                with contextlib.suppress(Exception):
-                    # Convention 6 — never raise.
-                    processor.force_flush()
+            # Use the public API — it dispatches to every attached span
+            # processor (recording seam + real OTLP exporter) regardless of
+            # SDK-internal storage. Convention 6 — never raise.
+            with contextlib.suppress(Exception):
+                provider.force_flush()
             # Convention 6 / W7.8 — when the endpoint is clearly unreachable
             # (port 1, loopback canary) emit one warning so the operator /
             # test can see that the remote sink was attempted. The warning

--- a/tests/tracing/exporters/test_exporter_fix.py
+++ b/tests/tracing/exporters/test_exporter_fix.py
@@ -1,0 +1,165 @@
+"""Regression tests for the Logfire/OTLP tracer-provider fix.
+
+Two defects were fixed in ``mergecraft.tracing.exporters``:
+
+1. ``_setup_tracer_provider`` called ``set_tracer_provider`` unguarded. When a
+   real ``TracerProvider`` was already installed (``logfire`` activates its own
+   on import; a prior sink may have set one), OTel raised
+   ``Overriding of current TracerProvider is not allowed``. The surrounding
+   ``try/except`` swallowed it and returned ``None`` — silently turning the
+   sink into a no-op so spans never exported.
+
+2. The provider only carried the in-memory ``_RecordingSpanProcessor`` (a test
+   seam) and never attached the real ``OTLPSpanExporter`` — so even after the
+   override was fixed, spans would never reach Logfire.
+
+These tests pin both halves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mergecraft.tracing.exporters as exporters
+
+
+def _span_processors(provider: object) -> tuple[object, ...]:
+    """Read the attached span processors regardless of OTel SDK internals.
+
+    The SDK stores processors on ``provider._active_span_processor`` (a
+    ``SynchronousMultiSpanProcessor``) whose ``_span_processors`` is the tuple
+    of user-added processors. We assert on that tuple rather than the
+    non-existent ``_active_span_processors`` plural attribute.
+    """
+    composite = getattr(provider, "_active_span_processor", None)
+    if composite is None:
+        return ()
+    return tuple(getattr(composite, "_span_processors", ()))
+
+
+def test_set_tracer_provider_reuses_existing_provider() -> None:
+    """When ``set_tracer_provider`` would override, the provider is reused, not None.
+
+    Monkeypatch ``trace.set_tracer_provider`` to raise the OTel override error
+    on the first call (mimicking a provider already installed by ``logfire``).
+    ``_setup_tracer_provider`` must still return a non-None provider and attach
+    a ``_RecordingSpanProcessor`` so the test seam keeps working.
+    """
+    pytest.importorskip("logfire")
+    pytest.importorskip("opentelemetry")
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    original = trace.set_tracer_provider
+
+    def _raise_once(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("Overriding of current TracerProvider is not allowed")
+
+    # Install a real provider first (as logfire would), then make the next
+    # set_tracer_provider attempt raise the override error.
+    trace.set_tracer_provider(TracerProvider())
+    trace.set_tracer_provider = _raise_once  # type: ignore[assignment]
+    try:
+        provider = exporters._setup_tracer_provider(
+            endpoint="https://logfire.pydantic.dev/api/v1/otlp/v1/traces",
+            headers={"authorization": "Bearer pylf_test_aaa"},
+            service_name="mergecraft-logfire",
+        )
+    finally:
+        trace.set_tracer_provider = original  # type: ignore[assignment]
+
+    assert provider is not None, "override guard must reuse an existing provider, not return None"
+    assert any(
+        isinstance(p, exporters._RecordingSpanProcessor) for p in _span_processors(provider)
+    ), "reused provider must still carry the recording processor (test seam)"
+    assert exporters.has_active_tracer_provider()
+
+
+def test_logfire_sink_exports_to_otlp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A logfire entry with a resolved token yields a live OTLPSink that wires an exporter.
+
+    Asserts ``build_remote_sink`` returns an ``OTLPSink`` (not ``NullSink``)
+    when a token is resolved, and that a real ``OTLPSpanExporter``-backed
+    ``BatchSpanProcessor`` is attached to the provider (the production export
+    path to Logfire), while the override guard does not raise.
+    """
+    pytest.importorskip("logfire")
+    pytest.importorskip("opentelemetry")
+
+    # A resolved (fake) token is required for the sink to be live.
+    monkeypatch.setenv("MERGECRAFT_LOGFIRE_TOKEN", "pylf_test_logfire_export")
+
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    from mergecraft.config import RepoSettings
+    from mergecraft.tracing import NullSink, sink_factory
+    from mergecraft.tracing.exporters import OTLPSink
+
+    settings = RepoSettings.model_validate(
+        {
+            "tracing": {
+                "enabled": True,
+                "sinks": [{"type": "logfire", "tokenRef": "MERGECRAFT_LOGFIRE_TOKEN"}],
+            }
+        }
+    ).tracing
+    sink = sink_factory(settings)
+    # sink_factory wraps the live sink in RedactingSink(MultiSink([...])).
+    inner = sink.inner.sinks[0]
+    assert not isinstance(inner, NullSink)
+    assert isinstance(inner, OTLPSink)
+
+    # Build a real span so the provider is constructed, then inspect it.
+    from mergecraft.tracing import TraceEvent
+
+    event = TraceEvent.model_validate(
+        {
+            "kind": "llm.call",
+            "span_id": "fix-1",
+            "parent_span_id": None,
+            "session_id": "fix-run",
+            "turn_id": "t",
+            "tier": "trusted",
+            "ts_start_ns": 0,
+            "ts_end_ns": 1,
+            "status": "ok",
+            "attrs": {},
+        }
+    )
+    inner.write(event)
+    provider = inner._provider
+    assert provider is not None
+    processors = _span_processors(provider)
+    real_exporters = [
+        sp
+        for sp in processors
+        if isinstance(sp, BatchSpanProcessor)
+        and isinstance(getattr(sp, "span_exporter", None), OTLPSpanExporter)
+    ]
+    assert real_exporters, "a real OTLPSpanExporter-backed span processor must be attached"
+    assert any(isinstance(sp, exporters._RecordingSpanProcessor) for sp in processors), (
+        "the recording test seam must still be attached"
+    )
+
+
+def test_logfire_sink_null_when_no_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No token resolves → NullSink (existing behaviour preserved)."""
+    pytest.importorskip("logfire")
+
+    monkeypatch.delenv("MERGECRAFT_LOGFIRE_TOKEN", raising=False)
+
+    from mergecraft.config import RepoSettings
+    from mergecraft.tracing import NullSink, sink_factory
+
+    settings = RepoSettings.model_validate(
+        {"tracing": {"enabled": True, "sinks": [{"type": "logfire", "project": "demo"}]}}
+    ).tracing
+    sink = sink_factory(settings)
+    # sink_factory wraps the no-op in RedactingSink(MultiSink([NullSink])).
+    assert isinstance(sink.inner.sinks[0], NullSink)


### PR DESCRIPTION
## Summary

mergeCraft's tracing exporter never delivered spans to Logfire. Two defects in `src/mergecraft/tracing/exporters.py::_setup_tracer_provider` caused this:

1. **Silent no-op from the override error.** `_setup_tracer_provider` called `set_tracer_provider` unguarded. When a real `TracerProvider` is already installed in the process — `logfire` activates its own on import, or a prior `OTLPSink` already set one — OTel raises `Overriding of current TracerProvider is not allowed`. The surrounding `except` swallowed it and returned `None`, so `OTLPSink._ensure_provider` got `None` and the sink became a silent no-op. Nothing exported.
2. **Missing real exporter.** Even after fixing the override, the provider only carried the in-memory `_RecordingSpanProcessor` (a test seam) and never attached the real `OTLPSpanExporter`. Spans would go nowhere.

## What changed (surgical — only `exporters.py` + its tests)

- **Guard the override:** detect the OTel default `ProxyTracerProvider` via `get_tracer_provider()`; only call `set_tracer_provider` when no real provider exists. When one is already installed, **reuse** it (and still append the recording processor so the test seam keeps working). The `except` now falls back to `get_tracer_provider()` + attach a recording processor on the "overriding not allowed" error.
- **Wire the real exporter:** attach a real `OTLPSpanExporter` (HTTP, resolved `endpoint`/`headers`) to the provider in addition to the recording processor. Production spans now reach **both** the recording seam (tests) and Logfire's OTLP endpoint (`https://logfire.pydantic.dev/api/v1/otlp/v1/traces`).
- **Fix `flush()`:** it iterated a non-existent `_active_span_processors` (plural) attribute and was a no-op; switched to the public `provider.force_flush()` so every processor (recording + real OTLP) is flushed.

`resolve_active_tracing`, `sink_factory`, and the resolution fix are untouched, per scope.

## How to test locally

```bash
uv sync --extra tracing
mergecraft diff-review --tracing --tracing-to logfire
```

## Tests added

- `test_set_tracer_provider_reuses_existing_provider` — override error → non-None reused provider with recording processor attached.
- `test_logfire_sink_exports_to_otlp` — token resolved → live `OTLPSink` with a real `OTLPSpanExporter`-backed `BatchSpanProcessor`.
- `test_logfire_sink_null_when_no_token` — no token → `NullSink` (preserved).

## Validation

- `make lint` clean, `make typecheck` clean (mypy strict + Pyright).
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/tracing/exporters -q` — green on the exporter package. (A pre-existing cross-test global-provider pollution flake in `test_payload_cap_applies_to_remote_sinks` is unrelated to this change — it fails without these edits too and passes when the integration file runs alone.)
- `mergecraft config tracing` still renders. No credential values in logs.

Builds on the merged PR #132 (env/CLI/YAML tracing resolution).

🤖 Generated with [Claude](https://claude.com/claude-code)