### PR TITLE
fix(tracing): correct region-aware Logfire OTLP endpoint (404 fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,8 +108,9 @@ MEAT_MODEL=gpt-5.6-sol
 #     mergecraft auth logfire --scope github        # only gh secret set
 #
 # `MERGECRAFT_LOGFIRE_TOKEN` is the runtime token (resolved by the sink
-# factory). `MERGECRAFT_TRACING_PROJECT` becomes the `x-logfire-project`
-# header at runtime. For the GitHub Action, mirror the token into the
+# factory). `MERGECRAFT_TRACING_PROJECT` is an informational project label;
+# Logfire routes spans by token, not a header. For the GitHub Action, mirror
+# the token into the
 # `LOGFIRE_TOKEN` Actions secret and wire `tracing-to: logfire` +
 # `logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` on the workflow step.
 # ---------------------------------------------------------------------------

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -295,10 +295,13 @@ tracing:
         x-tenant: mergecraft
 ```
 
-For Logfire, the endpoint is hard-coded to the public ingest URL
-(`https://logfire.pydantic.dev/api/v1/otlp/v1/traces`); the `project`
-field is forwarded as the `x-logfire-project` header. The token is
-resolved through `tokenRef` (D5) — see *Token resolution* below.
+For Logfire, the endpoint is the region-aware OTLP/HTTP ingest URL —
+`https://logfire-us.pydantic.dev/v1/traces` (US) or
+`https://logfire-eu.pydantic.dev/v1/traces` (EU), selected by the sink's
+`region` field (default `us`). The `project` field is informational only;
+Logfire routes spans by the token itself, so no `x-logfire-project` header
+is sent. The token is resolved through `tokenRef` (D5) — see *Token
+resolution* below.
 
 ## Token resolution (W8.2 / D5)
 

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -37,7 +37,7 @@ DEFAULT_TOKENHUB = "https://tokenhub-intl.tencentcloudmaas.com/v1"
 # Logfire setup (issue #56 / D5). ``LOGFIRE_TOKEN`` is the Action secret the
 # ``logfire-token`` input maps to; ``MERGECRAFT_LOGFIRE_TOKEN`` is the
 # runtime-only env var the sink factory resolves as a fallback; the project
-# label becomes the ``x-logfire-project`` header at runtime.
+# label is informational only — Logfire routes spans by token, not a header.
 LOGFIRE_TOKEN_SECRET = "LOGFIRE_TOKEN"
 LOGFIRE_RUNTIME_TOKEN_ENV = "MERGECRAFT_LOGFIRE_TOKEN"
 LOGFIRE_PROJECT_ENV = "MERGECRAFT_TRACING_PROJECT"
@@ -598,9 +598,8 @@ def auth_logfire(
     if not project:
         console.print("canceled.")
         raise typer.Exit(0)
-    # Same surface as the validator: Logfire accepts arbitrary project strings
-    # via the ``x-logfire-project`` header, but reject whitespace inside the
-    # label so a stray newline does not silently change the routing key.
+    # Same surface as the validator: reject whitespace inside the project label
+    # so a stray newline does not silently change the stored value.
     if any(ch.isspace() for ch in project):
         _bail("Logfire project label must not contain whitespace.")
 

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -106,7 +106,7 @@ def logfire_enable(
     project: str | None = typer.Option(
         None,
         "--project",
-        help="Logfire project label (becomes the ``x-logfire-project`` header).",
+        help="Logfire project label (informational; Logfire routes by token, not a header).",
     ),
     scope: str = typer.Option(
         "both",

--- a/src/mergecraft/cli/tracing_precedence.py
+++ b/src/mergecraft/cli/tracing_precedence.py
@@ -108,10 +108,11 @@ def _resolve_env_layer(env: dict[str, str]) -> dict[str, Any]:
         out["logfire_token"] = env["MERGECRAFT_LOGFIRE_TOKEN"]
     if "MERGECRAFT_OTEL_ENDPOINT" in env:
         out["otel_endpoint"] = env["MERGECRAFT_OTEL_ENDPOINT"]
-    # ``MERGECRAFT_TRACING_PROJECT`` carries the Logfire project label that
-    # becomes the ``x-logfire-project`` header at runtime. The CLI
-    # ``auth logfire`` command writes this alongside ``MERGECRAFT_LOGFIRE_TOKEN``
-    # so the operator never has to edit ``.env`` by hand.
+    # ``MERGECRAFT_TRACING_PROJECT`` carries the Logfire project label. This is
+    # informational only — Logfire routes spans by the token itself, not a
+    # header. The CLI ``auth logfire`` command writes this alongside
+    # ``MERGECRAFT_LOGFIRE_TOKEN`` so the operator never has to edit ``.env``
+    # by hand.
     if "MERGECRAFT_TRACING_PROJECT" in env:
         project = env["MERGECRAFT_TRACING_PROJECT"].strip()
         if project:

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -175,6 +175,7 @@ class TraceSinkEntry(BaseModel):
     path: str | None = None
     token_ref: str | None = Field(default=None, alias="tokenRef")
     project: str | None = None
+    region: Literal["us", "eu"] = Field(default="us", alias="region")
     endpoint: str | None = None
     headers: dict[str, str] | None = None
 

--- a/src/mergecraft/tracing/exporters.py
+++ b/src/mergecraft/tracing/exporters.py
@@ -154,21 +154,28 @@ def resolve_token_ref(token_ref: str | None) -> str | None:
 def _build_logfire_endpoint_and_headers(
     project: str | None,
     token: str | None,
+    region: str = "us",
+    endpoint_override: str | None = None,
 ) -> tuple[str, dict[str, str]]:
     """Derive the OTLP endpoint and headers for a Logfire sink.
 
-    Logfire speaks OTLP/HTTP at ``https://logfire.pydantic.dev/api/v1/otlp/v1/traces``
-    (the public ingest endpoint). Authorization is the bearer token. The
-    ``project`` attribute maps to a Logfire project label via a header so the
-    incoming spans are routed correctly inside the Logfire backend.
+    Logfire speaks OTLP/HTTP (``http/protobuf``) at the region-aware ingest
+    endpoint — ``https://logfire-us.pydantic.dev/v1/traces`` (US) or
+    ``https://logfire-eu.pydantic.dev/v1/traces`` (EU). Authorization is the
+    bearer token; Logfire routes spans to the project encoded **in the token
+    itself** — there is no ``x-logfire-project`` header and emitting one is
+    incorrect. ``project`` is retained only as an informational label.
+
+    When ``endpoint_override`` is set (self-hosted/testing) it is used verbatim.
     """
-    endpoint = "https://logfire.pydantic.dev/api/v1/otlp/v1/traces"
+    if endpoint_override:
+        endpoint = endpoint_override
+    else:
+        host = "logfire-eu.pydantic.dev" if region == "eu" else "logfire-us.pydantic.dev"
+        endpoint = f"https://{host}/v1/traces"
     headers: dict[str, str] = {}
     if token:
         headers["authorization"] = f"Bearer {token}"
-    if project:
-        # Logfire projects are routed by a header (see Logfire docs).
-        headers["x-logfire-project"] = project
     return endpoint, headers
 
 
@@ -446,10 +453,14 @@ class OTLPSink:
         *,
         project: str | None,
         token: str | None,
+        region: str = "us",
+        endpoint_override: str | None = None,
         logfire_module: Any | None = None,
     ) -> OTLPSink:
         """Build an :class:`OTLPSink` configured for Logfire."""
-        endpoint, headers = _build_logfire_endpoint_and_headers(project, token)
+        endpoint, headers = _build_logfire_endpoint_and_headers(
+            project, token, region=region, endpoint_override=endpoint_override
+        )
         return cls(
             endpoint=endpoint,
             headers=headers,
@@ -635,7 +646,9 @@ def _build_logfire_sink(
     return OTLPSink.for_logfire(
         project=_resolve_logfire_project(entry),
         token=token,
+        region=getattr(entry, "region", "us") or "us",
         logfire_module=logfire_module,
+        endpoint_override=getattr(entry, "endpoint", None) or None,
     )
 
 

--- a/tests/tracing/exporters/test_cli_precedence.py
+++ b/tests/tracing/exporters/test_cli_precedence.py
@@ -240,8 +240,8 @@ def test_trace_dir_flag_overrides_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path
 
 # ---------------------------------------------------------------------------
 # W8.4 — ``MERGECRAFT_TRACING_PROJECT`` env var (auth logfire surface).
-# Issue #56 / D5 — the Logfire project label becomes the
-# ``x-logfire-project`` header at runtime. The CLI ``auth logfire`` command
+# Issue #56 / D5 — the Logfire project label is informational only; Logfire
+# routes spans by token, not a header. The CLI ``auth logfire`` command
 # writes this alongside ``MERGECRAFT_LOGFIRE_TOKEN``; the precedence layer
 # surfaces it for ``mergecraft config tracing`` and the sink factory.
 # ---------------------------------------------------------------------------

--- a/tests/tracing/exporters/test_logfire_endpoint.py
+++ b/tests/tracing/exporters/test_logfire_endpoint.py
@@ -1,0 +1,55 @@
+"""Regression tests for the Logfire OTLP endpoint/header fix.
+
+The Logfire OTLP/HTTP endpoint was ``https://logfire.pydantic.dev/api/v1/otlp/v1/traces``
+with a spurious ``x-logfire-project`` header — both wrong, producing a 404
+(``Failed to export span batch code: 404, reason: Not Found``). Logfire routes
+spans by the token itself; the correct endpoints are region-aware:
+
+- US: ``https://logfire-us.pydantic.dev/v1/traces``
+- EU: ``https://logfire-eu.pydantic.dev/v1/traces``
+
+These tests pin the corrected endpoint host/path and the absence of the
+``x-logfire-project`` header.
+"""
+
+from __future__ import annotations
+
+import mergecraft.tracing.exporters as exporters
+
+
+def test_logfire_endpoint_uses_correct_us_region() -> None:
+    """Default region yields the US ingest endpoint and no project header."""
+    endpoint, _headers = exporters._build_logfire_endpoint_and_headers(
+        project="demo", token="pylf_test_us", region="us"
+    )
+    assert endpoint == "https://logfire-us.pydantic.dev/v1/traces"
+
+
+def test_logfire_endpoint_eu_region() -> None:
+    """``region='eu'`` yields the EU ingest endpoint."""
+    endpoint, _headers = exporters._build_logfire_endpoint_and_headers(
+        project="demo", token="pylf_test_eu", region="eu"
+    )
+    assert endpoint == "https://logfire-eu.pydantic.dev/v1/traces"
+
+
+def test_logfire_endpoint_no_project_header() -> None:
+    """Headers carry the auth token and never the ``x-logfire-project`` header."""
+    for project in ("demo", None, ""):
+        _endpoint, headers = exporters._build_logfire_endpoint_and_headers(
+            project=project, token="pylf_test_xxx", region="us"
+        )
+        assert "authorization" in headers
+        assert headers["authorization"] == "Bearer pylf_test_xxx"
+        assert "x-logfire-project" not in headers
+
+
+def test_logfire_endpoint_explicit_override() -> None:
+    """An explicit entry endpoint is used verbatim (self-hosted/testing)."""
+    endpoint, _headers = exporters._build_logfire_endpoint_and_headers(
+        project="demo",
+        token="pylf_test_ovr",
+        region="us",
+        endpoint_override="https://otel-collector.internal:4318/v1/traces",
+    )
+    assert endpoint == "https://otel-collector.internal:4318/v1/traces"


### PR DESCRIPTION
## Summary
- Fixes `Failed to export span batch code: 404, reason: Not Found` when exporting traces to Logfire.
- Root cause: mergeCraft sent spans to `https://logfire.pydantic.dev/api/v1/otlp/v1/traces` (wrong domain/path) **and** emitted a spurious `x-logfire-project` header. Logfire routes by the token, not a header, and the correct ingest URLs are `https://logfire-us.pydantic.dev/v1/traces` (US) / `https://logfire-eu.pydantic.dev/v1/traces` (EU).
- Adds a `region` field (`us`/`eu`, default `us`) to `TraceSinkEntry`; endpoint is now region-aware. `endpoint` override is still honored for self-hosted/testing.
- Updates misleading CLI help/comments that claimed the project becomes an `x-logfire-project` header.

## Test plan
- New `tests/tracing/exporters/test_logfire_endpoint.py` (4 tests): US/EU endpoint, no `x-logfire-project` header, explicit endpoint override.
- `make lint` clean; `make typecheck`/`make pyright` clean; `tests/tracing` green (133 passed, 9 xfailed).
- Manual: set `MERGECRAFT_LOGFIRE_TOKEN` to a valid write token for the project's region (default `us`; `region: eu` in config for EU projects), then `mergecraft diff-review --tracing --tracing-to logfire` — 404 should be gone.

Builds on the merged PR #133 (TracerProvider override guard + real OTLP exporter wiring).

🤖 Generated with [Claude](https://claude.com/claude-code)