### PR TITLE
fix(tracing): expose Logfire region via MERGECRAFT_TRACING_REGION and --region

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,7 @@ MEAT_MODEL=gpt-5.6-sol
 
 # MERGECRAFT_LOGFIRE_TOKEN=
 # MERGECRAFT_TRACING_PROJECT=
+# MERGECRAFT_TRACING_REGION=        # Logfire data region for the OTLP endpoint: us or eu (default us).
 # OTEL_ENDPOINT=http://127.0.0.1:4318/v1/traces
 
 # ---------------------------------------------------------------------------

--- a/src/mergecraft/cli/tracing_cmd.py
+++ b/src/mergecraft/cli/tracing_cmd.py
@@ -131,6 +131,10 @@ def config_tracing(
     if "tracing_project" in resolved:
         table.add_row("project", resolved["tracing_project"])
 
+    region = resolved.get("region")
+    if region:
+        table.add_row("region", region)
+
     logfire_token = resolved.get("logfire_token")
     if logfire_token is not None:
         table.add_row("logfire_token", f"{_TOKEN_REDACTED_MARKER} [dim](redacted)[/dim]")
@@ -157,6 +161,7 @@ def config_tracing(
         "MERGECRAFT_TRACING_TO",
         "MERGECRAFT_LOGFIRE_TOKEN",
         "MERGECRAFT_TRACING_PROJECT",
+        "MERGECRAFT_TRACING_REGION",
         "MERGECRAFT_OTEL_ENDPOINT",
         "MERGECRAFT_TRACE_DIR",
     )
@@ -276,6 +281,8 @@ def render_resolved(resolved: dict[str, Any]) -> str:
         parts.append(f"  otel_endpoint: {resolved['otel_endpoint']}")
     if "tracing_project" in resolved:
         parts.append(f"  project: {resolved['tracing_project']}")
+    if resolved.get("region"):
+        parts.append(f"  region: {resolved['region']}")
     if "logfire_token" in resolved:
         token = resolved["logfire_token"]
         if token is not None and not _is_redacted(str(token)):
@@ -293,6 +300,7 @@ def render_resolved(resolved: dict[str, Any]) -> str:
         "MERGECRAFT_TRACING_TO",
         "MERGECRAFT_LOGFIRE_TOKEN",
         "MERGECRAFT_TRACING_PROJECT",
+        "MERGECRAFT_TRACING_REGION",
         "MERGECRAFT_OTEL_ENDPOINT",
         "MERGECRAFT_TRACE_DIR",
     )

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -29,6 +29,12 @@ from mergecraft.cli.auth_cmd import (
     _write_env_value,
 )
 
+# ``MERGECRAFT_TRACING_REGION`` selects the Logfire OTLP data region; it is
+# written by ``tracing logfire enable --region`` and read by the precedence
+# layer alongside the other ``MERGECRAFT_*`` tracing vars.
+LOGFIRE_REGION_ENV = "MERGECRAFT_TRACING_REGION"
+_VALID_REGIONS = ("us", "eu")
+
 app = typer.Typer(
     name="tracing",
     help="Trace export configuration (Logfire). Mirrors ``sevn tracing logfire``.",
@@ -114,6 +120,11 @@ def logfire_enable(
         "-s",
         help="Where to persist: 'local' (.env), 'github' (gh secret), or 'both'.",
     ),
+    region: str | None = typer.Option(
+        None,
+        "--region",
+        help="Logfire data region for the OTLP endpoint: 'us' or 'eu' (default us).",
+    ),
 ) -> None:
     """Enable Logfire tracing by writing the token + project locally and on GitHub.
 
@@ -125,6 +136,11 @@ def logfire_enable(
     from mergecraft.cli.auth_cmd import _normalise_scope
 
     target = _normalise_scope(scope)
+
+    if region is not None:
+        region = region.strip().lower()
+        if region not in _VALID_REGIONS:
+            _bail(f"--region must be one of: {', '.join(_VALID_REGIONS)} (got {region!r}).")
 
     if token is None:
         token = getpass.getpass("Logfire write token (Enter to cancel): ").strip()
@@ -150,12 +166,20 @@ def logfire_enable(
         env_path = _local_env_path()
         env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, token)
         env_project_ok = _write_env_value(env_path, LOGFIRE_PROJECT_ENV, project)
-        wrote_local = env_token_ok and env_project_ok
+        # ``--region`` (when given) is persisted so ``config tracing`` and the
+        # sink factory pick it up through the same ``MERGECRAFT_*`` seam as
+        # the token; it never lands in the model dump / config on disk.
+        env_region_ok = True
+        if region is not None:
+            env_region_ok = _write_env_value(env_path, LOGFIRE_REGION_ENV, region)
+        wrote_local = env_token_ok and env_project_ok and env_region_ok
         if wrote_local:
             console.print(
                 f"[green]wrote[/green] {LOGFIRE_RUNTIME_TOKEN_ENV} and "
                 f"{LOGFIRE_PROJECT_ENV} to {env_path}"
             )
+            if region is not None:
+                console.print(f"[green]wrote[/green] {LOGFIRE_REGION_ENV}={region} to {env_path}")
         else:
             # Bandit's B608 fires on the interpolated `env_path`; this is a
             # console warning, not a SQL statement (no DB engine involved).

--- a/src/mergecraft/cli/tracing_precedence.py
+++ b/src/mergecraft/cli/tracing_precedence.py
@@ -90,6 +90,9 @@ def _resolve_cli_layer(args: list[str]) -> dict[str, Any]:
     otel_endpoint = _flag_value(args, "--otel-endpoint")
     if otel_endpoint is not None:
         out["otel_endpoint"] = otel_endpoint
+    region = _flag_value(args, "--region")
+    if region is not None:
+        out["region"] = region.strip().lower()
     return out
 
 
@@ -117,6 +120,15 @@ def _resolve_env_layer(env: dict[str, str]) -> dict[str, Any]:
         project = env["MERGECRAFT_TRACING_PROJECT"].strip()
         if project:
             out["tracing_project"] = project
+    # ``MERGECRAFT_TRACING_REGION`` selects the Logfire OTLP data region
+    # (``us`` / ``eu``). Logfire routes spans to region-specific ingest
+    # endpoints; this overrides the YAML ``region`` default (``us``). The
+    # CLI ``--region`` flag (``tracing logfire enable``) sits above this in
+    # the precedence stack via the merged dict.
+    if "MERGECRAFT_TRACING_REGION" in env:
+        region = env["MERGECRAFT_TRACING_REGION"].strip().lower()
+        if region in {"us", "eu"}:
+            out["region"] = region
     return out
 
 

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -15,7 +15,7 @@ Exports:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from mergecraft.cli.tracing_precedence import resolve_tracing_settings
 from mergecraft.config.settings import (
@@ -41,6 +41,8 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
     tracing_project: str | None = merged.get("tracing_project")
     otel_endpoint: str | None = merged.get("otel_endpoint")
     trace_dir: str | None = merged.get("trace_dir")
+    raw_region = merged.get("region")
+    region: Literal["us", "eu"] = raw_region if raw_region in ("us", "eu") else "us"
 
     # A logfire destination is selected when the operator explicitly asked for
     # it, or when a token is present and nothing else overrides the
@@ -53,6 +55,7 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
             TraceSinkEntry(
                 type="logfire",
                 project=tracing_project,
+                region=region,
             )
             # The resolved ``logfire_token`` is forwarded separately via the
             # env-var seam that ``build_remote_sink`` consults

--- a/tests/cli/test_tracing_region_env.py
+++ b/tests/cli/test_tracing_region_env.py
@@ -1,0 +1,191 @@
+"""RED contracts for the Logfire data-region env var + CLI flag (issue #134 follow-up).
+
+The Logfire OTLP data region (``us`` / ``eu``) must be settable both via the
+``MERGECRAFT_TRACING_REGION`` ``.env`` variable and via
+``mergecraft tracing logfire enable --region <region>``. The precedence is
+CLI ``--region`` > env ``MERGECRAFT_TRACING_REGION`` > YAML ``region``
+(default ``us``). The resolved region flows through
+:func:`mergecraft.tracing.resolve.resolve_active_tracing` into the
+``TraceSinkEntry.region`` field that :func:`_build_logfire_sink` reads.
+
+These tests never touch the real repo ``.env`` — ``MERGECRAFT_ENV`` points the
+env-writer helper at a temp file. Tokens are fake (``pylf_test_xxx``).
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_REGION_ENV = "MERGECRAFT_TRACING_REGION"
+
+
+def _load_logfire_cmd() -> object:
+    try:
+        return importlib.import_module("mergecraft.cli.tracing_logfire_cmd")
+    except ImportError as exc:  # pragma: no cover
+        pytest.fail(f"mergecraft.cli.tracing_logfire_cmd not importable: {exc}")
+
+
+def _patch_httpx_with(monkeypatch: MonkeyPatch, handler) -> None:
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _factory(*args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        kwargs.setdefault("transport", transport)
+        kwargs.setdefault("timeout", 15.0)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr("mergecraft.cli.auth_cmd.httpx.Client", _factory)
+
+
+def _stub_repo_slug(monkeypatch: MonkeyPatch, slug: str = "acme/widgets") -> None:
+    consumer_module = importlib.import_module("mergecraft.cli.tracing_logfire_cmd")
+
+    def _factory() -> str:
+        return slug
+
+    monkeypatch.setattr(consumer_module, "_parse_repo_slug", _factory)
+
+
+def _clear_region_env(monkeypatch: MonkeyPatch) -> None:
+    for key in (
+        "MERGECRAFT_TRACING",
+        "MERGECRAFT_TRACING_TO",
+        "MERGECRAFT_LOGFIRE_TOKEN",
+        "MERGECRAFT_TRACING_PROJECT",
+        "MERGECRAFT_OTEL_ENDPOINT",
+        "MERGECRAFT_TRACE_DIR",
+        _REGION_ENV,
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── precedence: env var overrides the YAML default ───────────────────────────
+
+
+def test_env_var_overrides_yaml_default(monkeypatch: MonkeyPatch) -> None:
+    """``MERGECRAFT_TRACING_REGION=eu`` → resolved logfire sink region ``eu``."""
+    _clear_region_env(monkeypatch)
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_LOGFIRE_TOKEN", "pylf_test_xxx")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "mergecraft-dev")
+    monkeypatch.setenv(_REGION_ENV, "eu")
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing()
+    assert settings.enabled is True
+    assert len(settings.sinks) == 1
+    assert settings.sinks[0].type == "logfire"
+    assert settings.sinks[0].region == "eu"
+
+
+def test_default_region_is_us(monkeypatch: MonkeyPatch) -> None:
+    """With no env and no config, the resolved logfire region defaults to ``us``."""
+    _clear_region_env(monkeypatch)
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_LOGFIRE_TOKEN", "pylf_test_xxx")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "mergecraft-dev")
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing()
+    assert settings.sinks[0].region == "us"
+
+
+def test_cli_flag_overrides_env(monkeypatch: MonkeyPatch) -> None:
+    """CLI ``--region eu`` wins over env ``MERGECRAFT_TRACING_REGION=us``."""
+    _clear_region_env(monkeypatch)
+    monkeypatch.setenv("MERGECRAFT_TRACING", "true")
+    monkeypatch.setenv("MERGECRAFT_LOGFIRE_TOKEN", "pylf_test_xxx")
+    monkeypatch.setenv("MERGECRAFT_TRACING_PROJECT", "mergecraft-dev")
+    monkeypatch.setenv(_REGION_ENV, "us")
+
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = resolve_active_tracing(cli_args=["--region", "eu"])
+    assert settings.sinks[0].region == "eu"
+
+
+# ── CLI: ``enable --region`` writes the env var ──────────────────────────────
+
+
+def test_cli_region_writes_env(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``enable --region eu`` writes ``MERGECRAFT_TRACING_REGION=eu`` to .env."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"project_name": "acme/widgets"}])
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_repo_slug(monkeypatch)
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "tracing",
+            "logfire",
+            "enable",
+            "--token",
+            "pylf_test_xxx",
+            "--project",
+            "mergecraft-dev",
+            "--region",
+            "eu",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    written = env_path.read_text(encoding="utf-8")
+    # ``python-dotenv`` quotes values (``quote_mode="always"``); accept both
+    # quoted and unquoted forms so the assertion matches the writer's output.
+    assert f"{_REGION_ENV}=eu" in written or f"{_REGION_ENV}='eu'" in written
+
+
+def test_cli_region_invalid_rejected(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``--region de`` is rejected cleanly with a non-zero exit code."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    _patch_httpx_with(monkeypatch, _handler)
+    _stub_repo_slug(monkeypatch)
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "tracing",
+            "logfire",
+            "enable",
+            "--token",
+            "pylf_test_xxx",
+            "--project",
+            "mergecraft-dev",
+            "--region",
+            "de",
+        ],
+    )
+
+    assert result.exit_code != 0
+    output = (result.stdout + result.stderr).lower()
+    assert "region" in output
+    # No env write happened because the region was rejected before writing.
+    assert _REGION_ENV not in env_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds operator-facing control over the **Logfire OTLP data region** (`us` / `eu`) — the same `region` field already on `TraceSinkEntry` (introduced in merged PR #134, which fixed the region-aware endpoint). Previously `region` was only settable through the YAML `tracing.sinks[].region` field; this exposes it through env and the CLI without introducing any general/provider-wide region concept (scoped to Logfire only).

### New surface

- **`.env` variable `MERGECRAFT_TRACING_REGION`** — read during tracing resolution, overrides the YAML `region` default when set. Follows the exact precedence pattern of the other `MERGECRAFT_*` tracing vars (`MERGECRAFT_TRACING`, `MERGECRAFT_LOGFIRE_TOKEN`, `MERGECRAFT_TRACING_PROJECT`).
- **CLI flag `--region` on `mergecraft tracing logfire enable`** — when provided, writes `MERGECRAFT_TRACING_REGION=<value>` into `.env` (reusing the same dotenv writer as the token/project), and validates the value is `us` or `eu` (rejects otherwise). Keeps `enable`'s existing behaviour (flips master switch + sets token if provided).
- **`config tracing` reflects the region** — the resolved Logfire region is surfaced as a `region` row; token stays redacted.
- **Exporters consume it** — `resolve.py` now carries `region` into `TraceSinkEntry.region`, which `_build_logfire_sink` already reads to pick the `us`/`eu` endpoint.

### Precedence

```
CLI --region  >  env MERGECRAFT_TRACING_REGION  >  YAML region  (default: us)
```

The resolution does **not** require region to be set; default `us` when unset everywhere.

### How to test

```bash
# manual .env:
MERGECRAFT_TRACING_REGION=eu
# or CLI:
mergecraft tracing logfire enable --region eu
```

Then verify:

```bash
MERGECRAFT_TRACING=true MERGECRAFT_LOGFIRE_TOKEN=pylf_test_xxx \
  MERGECRAFT_TRACING_PROJECT=mergecraft-dev MERGECRAFT_TRACING_REGION=eu \
  mergecraft config tracing
# → shows "region: eu", token redacted
```

### Validation

- `make lint` clean, `make typecheck` clean (mypy strict + Pyright)
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/cli tests/tracing -q` — new `tests/cli/test_tracing_region_env.py` (5 tests) green; the one pre-existing `tests/tracing/exporters/test_integration.py::test_payload_cap_applies_to_remote_sinks` global-provider flake is unrelated (passes when run alone).
- Tokens used in tests are fake (`pylf_test_xxx`); no credentials in logs.

Builds on merged PR #134 (region-aware Logfire OTLP endpoint).

**Operator-gated — do NOT merge.**