### PR TITLE
fix(diff-review): accept git -C/-c global opts and handle provider read timeouts

### DIFF
--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -36,6 +36,16 @@ from mergecraft.types import MERGECRAFT_MCP_NAME
 __all_gateway_envs__ = (CUSTOM_PROVIDER_BASE_URL_ENV, CUSTOM_PROVIDER_API_KEY_ENV)
 
 
+class ProviderTimeoutError(RuntimeError):
+    """Raised when the opencode provider endpoint times out.
+
+    This is a controlled domain error so callers (``shared.run`` /
+    ``offline_review._run_agent_review``) treat the attempt as a clean failure
+    instead of letting a raw ``httpx.ReadTimeout`` traceback abort the whole
+    review.
+    """
+
+
 def build_custom_provider(model: str | None) -> dict[str, object] | None:
     """Describe an OpenAI-compatible provider (or several) for opencode.
 
@@ -256,16 +266,20 @@ async def _prompt_session(
     if model:
         payload["model"] = model
     async with httpx.AsyncClient(timeout=600.0) as client:
-        resp = await client.post(
-            f"{base_url}/session/{session_id}/message",
-            json=payload,
-        )
-        if resp.status_code >= 400:
-            # Fallback path for older/newer API shapes
+        try:
             resp = await client.post(
-                f"{base_url}/session/{session_id}/prompt",
+                f"{base_url}/session/{session_id}/message",
                 json=payload,
             )
+            if resp.status_code >= 400:
+                # Fallback path for older/newer API shapes
+                resp = await client.post(
+                    f"{base_url}/session/{session_id}/prompt",
+                    json=payload,
+                )
+        except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.TimeoutException) as exc:
+            logger.warning("opencode provider request timed out: {}", exc)
+            raise ProviderTimeoutError(f"opencode provider request timed out: {exc}") from exc
         if resp.status_code >= 400:
             return AgentResult(
                 success=False,
@@ -362,7 +376,12 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
                 model=model_obj,
             )
 
-        result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
+        try:
+            result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
+        except ProviderTimeoutError as exc:
+            # Controlled domain error: surface as a clean failed attempt
+            # rather than letting a raw httpx traceback abort the review.
+            return AgentResult(success=False, error=str(exc))
         return await finalize_agent_result(ctx, result)
     finally:
         handle.close()

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -94,6 +94,58 @@ def _git_env(token: str) -> dict[str, str]:
     return env
 
 
+# Git global options that may precede the subcommand. `-C`/`-c` take a
+# separate argument; the `--git-dir`/`--work-tree`/`--namespace` family may
+# be spelled as `--flag value` or `--flag=value`.
+_GLOBAL_OPTS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+_GLOBAL_OPT_RE = re.compile(r"^--(?:git-dir|work-tree|namespace)(?:=.*)?$")
+
+# Tokens that take a separate value argument rather than an inline `=value`.
+_GLOBAL_OPT_TAKES_VALUE = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+
+
+def _extract_global_opts(
+    cmd_tokens: list[str], args: list[str]
+) -> tuple[str, list[str], list[str]]:
+    """Pull global git options out of command tokens + args, placing them first.
+
+    git requires global options (``-C``/``-c``/``--git-dir``/``--work-tree``/
+    ``--namespace``) before the subcommand, but the reviewing agent may emit
+    them anywhere (e.g. ``command="status"`` with ``args=["-C", dir]`` or
+    ``command="git -C dir status"``). Extract them regardless of position,
+    collect them into ``global_opts`` (flag plus its value when separate), and
+    return the real subcommand plus the remaining positional args. The
+    subcommand is validated separately so these options are forwarded rather
+    than rejected as an "invalid subcommand".
+    """
+    tokens: list[str] = list(cmd_tokens)
+    tokens.extend(args)
+
+    global_opts: list[str] = []
+    rest: list[str] = []
+    subcommand = ""
+    idx = 0
+    while idx < len(tokens):
+        tok = tokens[idx]
+        is_global = tok in _GLOBAL_OPTS or _GLOBAL_OPT_RE.fullmatch(tok) is not None
+        if not is_global:
+            if not subcommand:
+                subcommand = tok
+            else:
+                rest.append(tok)
+            idx += 1
+            continue
+        global_opts.append(tok)
+        inline_value = "=" in tok
+        if not inline_value and idx + 1 < len(tokens):
+            global_opts.append(tokens[idx + 1])
+            idx += 2
+        else:
+            idx += 1
+
+    return subcommand, rest, global_opts
+
+
 def git_tool(ctx: ToolContext):
     async def _run(params: dict[str, Any]):
         command = str(params["command"]).strip()
@@ -102,10 +154,23 @@ def git_tool(ctx: ToolContext):
         # trained on `git <subcommand>` examples, so it may pass the redundant
         # `git ` prefix in `command` or repeat the subcommand as args[0]. Normalize
         # both instead of erroring, then validate the cleaned subcommand.
+        had_git_prefix = command.lower().startswith("git ") or command.lower() == "git"
         if command.lower() == "git":
             command = ""
         elif command.lower().startswith("git "):
             command = command[len("git ") :].strip()
+        # Only a command that arrived with a `git ` prefix (a full git
+        # invocation string, e.g. `git -C /abs status`) is tokenized for
+        # global-option extraction. A bare non-prefix multi-token command like
+        # `rm -rf` must still be rejected as an invalid subcommand.
+        cmd_tokens = command.split() if had_git_prefix and command else [command] if command else []
+        # Pull any global git options (e.g. `-C <dir>`, `-c key=val`) out of
+        # command/args and forward them before the subcommand, rather than
+        # treating them as the subcommand or rejecting them as an
+        # "invalid subcommand".
+        subcommand, rest_args, global_opts = _extract_global_opts(cmd_tokens, args)
+        command = subcommand
+        args = rest_args
         if command and args and args[0].lower() == command.lower():
             # Agent redundantly repeated the subcommand as the first arg; honor
             # the call rather than rejecting it.
@@ -126,7 +191,7 @@ def git_tool(ctx: ToolContext):
                 if any(arg == flag or arg.startswith(f"{flag}=") for flag in _NOSHELL_BLOCKED_ARGS):
                     msg = f"Blocked: '{arg}' flag can execute arbitrary code."
                     raise RuntimeError(msg)
-        output = _run_git([command, *args], cwd=cwd)
+        output = _run_git([*global_opts, command, *args], cwd=cwd)
         if len(output) > 50_000:
             temp = os.environ.get("MERGECRAFT_TEMP_DIR") or ctx.tmpdir
             path = str(Path(temp) / f"git-{command}-{uuid.uuid4().hex[:8]}.txt")

--- a/tests/agents/test_opencode_timeout.py
+++ b/tests/agents/test_opencode_timeout.py
@@ -1,0 +1,58 @@
+"""OpenCode provider read-timeout handling (PR: diff-review failures)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mergecraft.agents.opencode import ProviderTimeoutError, _prompt_session
+
+
+class _TimeoutClient:
+    """Stub httpx.AsyncClient whose post() raises a read timeout."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._entered = False
+
+    async def __aenter__(self) -> _TimeoutClient:
+        self._entered = True
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._entered = False
+
+    async def post(self, *args: object, **kwargs: object) -> object:
+        raise httpx.ReadTimeout("timed out reading response")
+
+
+@pytest.fixture
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
+
+
+@pytest.mark.usefixtures("_patch_httpx")
+async def test_opencode_read_timeout_is_handled() -> None:
+    """A provider ReadTimeout must become a controlled ProviderTimeoutError,
+    not a raw httpx traceback crashing the review.
+    """
+    with pytest.raises(ProviderTimeoutError):
+        await _prompt_session(
+            base_url="http://127.0.0.1:9999",
+            session_id="sess-1",
+            text="review this",
+            model=None,
+        )
+
+
+@pytest.mark.usefixtures("_patch_httpx")
+async def test_opencode_client_identifies_timeout() -> None:
+    """With the client patched to raise, _prompt_session must raise the
+    domain error rather than propagating httpx.ReadTimeout.
+    """
+    with pytest.raises(ProviderTimeoutError):
+        await _prompt_session(
+            base_url="http://127.0.0.1:9999",
+            session_id="sess-2",
+            text="review this",
+            model={"providerID": "default", "modelID": "x"},
+        )

--- a/tests/mcp/test_git_tool.py
+++ b/tests/mcp/test_git_tool.py
@@ -98,3 +98,56 @@ async def test_invalid_subcommand_after_normalization_rejected(
     assert result.is_error is True
     assert "invalid git subcommand" in result.content[0]["text"]
     assert recorder.calls == []
+
+
+async def test_global_c_option_is_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute(
+        {"command": "status", "args": ["-C", "/some/repo/dir"]}
+    )
+    assert result.is_error is False, result.content[0]["text"]
+    # `-C` must be forwarded before the subcommand, not rejected as a
+    # subcommand and not swallowed.
+    assert recorder.calls == [["-C", "/some/repo/dir", "status"]]
+
+
+async def test_c_config_option_forwarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute(
+        {"command": "status", "args": ["-c", "core.quotepath=false", "-s"]}
+    )
+    assert result.is_error is False, result.content[0]["text"]
+    assert recorder.calls == [["-c", "core.quotepath=false", "status", "-s"]]
+
+
+async def test_git_dir_global_option_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute(
+        {"command": "git status", "args": ["--work-tree", "/some/repo/dir", "-s"]}
+    )
+    assert result.is_error is False, result.content[0]["text"]
+    assert recorder.calls == [["--work-tree", "/some/repo/dir", "status", "-s"]]
+
+
+async def test_global_opt_in_command_string_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    # Agent passes the global option as part of the `command` string.
+    result = await git_tool(_ctx(tmp_path)).execute(
+        {"command": "git -C /some/repo/dir status", "args": []}
+    )
+    assert result.is_error is False, result.content[0]["text"]
+    assert recorder.calls == [["-C", "/some/repo/dir", "status"]]


### PR DESCRIPTION
## Summary

Two distinct failures observed when running `mergecraft diff-review`, both fixed surgically.

### 1. `[git] error: invalid git subcommand: '-C'`
The reviewing agent legitimately calls git with global options **before** the subcommand — e.g. `command="git -C /abs status"` or `command="status"` with `args=["-C", "/abs/path", ...]`. The PR-#131 git-call normalization was too strict: it only stripped a redundant `git ` prefix and a repeated subcommand, then validated the bare subcommand, so `-C`/`--git-dir`/etc. were rejected as an "invalid subcommand".

Fix (`src/mergecraft/mcp/git.py`): parse leading global git options (`-C`, `-c`, `--git-dir`/`--work-tree`/`--namespace`) out of command/args, forward them **before** the subcommand, and validate only the real subcommand. The existing security guards (`_NOSHELL_BLOCKED_ARGS`, `_AUTH_REQUIRED`, `shell == "disabled"`) are untouched. Only a command string that arrived with a `git ` prefix is tokenized for this; a bare non-prefix multi-token command like `rm -rf` is still rejected as before.

### 2. `httpx.ReadTimeout` crashed the whole `diff-review`
The opencode agent's HTTP `client.post` to the provider endpoint timed out reading the response, and `httpx.ReadTimeout` propagated up, aborting offline diff-review with a raw httpcore/httpx traceback ending in `» diff-review failed`.

Fix (`src/mergecraft/agents/opencode.py`): catch `httpx.ReadTimeout` / `httpx.ConnectTimeout` / `httpx.TimeoutException` around the provider `post` in `_prompt_session`, log a warning, and raise a controlled `ProviderTimeoutError`. `_run` converts that into a graceful `AgentResult(success=False, error=...)` so the caller (`offline_review._run_agent_review`) treats it as a failed attempt instead of dumping a traceback. Retry/budget logic is unchanged.

## Test plan
- `tests/mcp/test_git_tool.py`: added `test_global_c_option_is_forwarded`, `test_c_config_option_forwarded`, `test_git_dir_global_option_forwarded`, `test_global_opt_in_command_string_forwarded`; existing PR-#131 tests still pass.
- `tests/agents/test_opencode_timeout.py`: `test_opencode_read_timeout_is_handled`, `test_opencode_client_identifies_timeout` assert the provider read timeout surfaces as `ProviderTimeoutError` (not raw httpx).
- `make lint`, `make typecheck` (mypy strict + Pyright), and `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/mcp/test_git_tool.py tests/agents -q` are all green.

## Notes
- The `skipped trufflehog/semgrep: failed to parse analyzer output` lines in the original run are a **separate stale-checkout artifact** — that run came from a checkout behind PR #131. They are **not** addressed here and resolve once running from an up-to-date checkout.
- No live `diff-review` against a real provider was run (would hit network/timeouts); the unit tests cover both fixes.

🚫 Operator-gated — do not merge without review.