### PR TITLE
feat(tracing): enrich spans with tool/agent/llm attrs + OTel GenAI conventions

### DIFF
--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -55,6 +55,30 @@ def _strip_provider_prefix(specifier: str) -> str:
     return specifier[slash + 1 :] if slash > 0 else specifier
 
 
+def _truncate_tool_payload(value: Any) -> str:
+    """Render a tool input/output payload as a redacted, truncated string.
+
+    Tool inputs/outputs can carry repo content (D15), so they are capped to a
+    safe length and passed through the shared secret matcher. Returns ``""``
+    for non-string payloads that cannot be meaningfully inlined.
+    """
+    from mergecraft.analyzers.redact import redact_secrets
+
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, (dict, list)):
+        try:
+            text = json.dumps(value, default=str)
+        except TypeError, ValueError:
+            text = str(value)
+    else:
+        return ""
+    text = redact_secrets(text)
+    if len(text) > 2048:
+        return text[:2048] + "…"
+    return text
+
+
 def write_mcp_config(ctx: AgentRunContext) -> str:
     config_dir = Path(ctx.tmpdir) / ".claude"
     config_dir.mkdir(parents=True, exist_ok=True)
@@ -245,6 +269,15 @@ def _claude_stream_event_handler(
                 "cost.tokens_out",
                 int(usage_payload.get("output_tokens") or 0),
             )
+            span.set_attribute("gen_ai.operation.name", "chat")
+            span.set_attribute("gen_ai.request.model", model_id)
+            span.set_attribute("gen_ai.response.model", model_id)
+            span.set_attribute(
+                "gen_ai.usage.input_tokens", int(usage_payload.get("input_tokens") or 0)
+            )
+            span.set_attribute(
+                "gen_ai.usage.output_tokens", int(usage_payload.get("output_tokens") or 0)
+            )
             span.ts_start_ns = time.time_ns()
             span.__enter__()
             open_llm_spans[message_id] = {
@@ -284,6 +317,7 @@ def _claude_stream_event_handler(
             span_obj: Span | None = target.get("span")
             if span_obj is not None:
                 span_obj.set_attribute("cost.tokens_out", target["tokens_out"])
+                span_obj.set_attribute("gen_ai.usage.output_tokens", target["tokens_out"])
             return
 
         if event_type == "message_stop":
@@ -315,6 +349,10 @@ def _claude_stream_event_handler(
             span.set_attribute("tool.id", tool_id)
             span.set_attribute("tool.server", "claude")
             span.set_attribute("tool.input", tool_input)
+            span.set_attribute("gen_ai.operation.name", "execute_tool")
+            span.set_attribute("gen_ai.tool.name", tool_name)
+            span.set_attribute("gen_ai.tool.call.id", tool_id)
+            span.set_attribute("gen_ai.tool.input", _truncate_tool_payload(tool_input))
             span.ts_start_ns = time.time_ns()
             span.__enter__()
             open_tool_spans[tool_id] = span
@@ -342,6 +380,9 @@ def _claude_stream_event_handler(
             if span is not None:
                 span.ts_end_ns = time.time_ns()
                 span.set_attribute("tool.output", event.get("content") or "")
+                span.set_attribute(
+                    "gen_ai.tool.output", _truncate_tool_payload(event.get("content") or "")
+                )
                 span.__exit__(None, None, None)
             return
 

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -70,6 +70,16 @@ def _strip_provider_prefix(specifier: str) -> str:
     return specifier[slash + 1 :] if slash > 0 else specifier
 
 
+def _codex_truncate_tool_payload(value: str) -> str:
+    """Render a codex tool payload as a redacted, truncated string (GenAI attr)."""
+    from mergecraft.analyzers.redact import redact_secrets
+
+    text = redact_secrets(value or "")
+    if len(text) > 2048:
+        return text[:2048] + "…"
+    return text
+
+
 def _is_under_forbidden_temp(path: Path) -> bool:
     try:
         resolved = path.resolve()
@@ -779,6 +789,9 @@ def _codex_stream_event_handler(
                 span.__enter__()
                 span.set_attribute("model.id", model_id)
                 span.set_attribute("model.event", "thread.started")
+                span.set_attribute("gen_ai.operation.name", "chat")
+                span.set_attribute("gen_ai.request.model", model_id)
+                span.set_attribute("gen_ai.response.model", model_id)
                 open_llm_spans[thread_id] = {
                     "span": span,
                     "tokens_in": 0,
@@ -802,6 +815,9 @@ def _codex_stream_event_handler(
                 span.set_attribute("tool.name", tool_name)
                 span.set_attribute("tool.id", tool_id)
                 span.set_attribute("tool.server", "codex")
+                span.set_attribute("gen_ai.operation.name", "execute_tool")
+                span.set_attribute("gen_ai.tool.name", tool_name)
+                span.set_attribute("gen_ai.tool.call.id", tool_id)
                 open_tool_spans[tool_id] = {"span": span, "name": tool_name}
             return
 
@@ -817,10 +833,14 @@ def _codex_stream_event_handler(
                     return
                 span_obj = entry.get("span")
                 if span_obj is not None:
+                    resolved_name = str(item.get("name") or entry.get("name") or "unknown")
+                    span_obj.set_attribute("tool.name", resolved_name)
+                    span_obj.set_attribute("gen_ai.tool.name", resolved_name)
+                    tool_input = str(item.get("input") or "")
+                    span_obj.set_attribute("tool.input", tool_input)
                     span_obj.set_attribute(
-                        "tool.name", str(item.get("name") or entry.get("name") or "unknown")
+                        "gen_ai.tool.input", _codex_truncate_tool_payload(tool_input)
                     )
-                    span_obj.set_attribute("tool.input", str(item.get("input") or ""))
                     span_obj.ts_end_ns = time.time_ns()
                     span_obj.__exit__(None, None, None)
                 return
@@ -850,6 +870,8 @@ def _codex_stream_event_handler(
                 if span_obj is not None:
                     span_obj.set_attribute("cost.tokens_in", entry["tokens_in"])
                     span_obj.set_attribute("cost.tokens_out", entry["tokens_out"])
+                    span_obj.set_attribute("gen_ai.usage.input_tokens", entry["tokens_in"])
+                    span_obj.set_attribute("gen_ai.usage.output_tokens", entry["tokens_out"])
                     span_obj.ts_end_ns = time.time_ns()
                     span_obj.__exit__(None, None, None)
             open_llm_spans.clear()

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -39,6 +39,16 @@ def _strip_provider_prefix(specifier: str) -> str:
     return specifier[slash + 1 :] if slash > 0 else specifier
 
 
+def _gemini_truncate_tool_payload(value: str) -> str:
+    """Render a gemini tool payload as a redacted, truncated string (GenAI attr)."""
+    from mergecraft.analyzers.redact import redact_secrets
+
+    text = redact_secrets(value or "")
+    if len(text) > 2048:
+        return text[:2048] + "…"
+    return text
+
+
 def _gemini_home(ctx: AgentRunContext) -> Path:
     return Path(ctx.tmpdir) / ".gemini"
 
@@ -379,6 +389,9 @@ def _gemini_stream_event_handler(
                 span.__enter__()
                 span.set_attribute("model.id", model_id)
                 span.set_attribute("model.event", "init")
+                span.set_attribute("gen_ai.operation.name", "chat")
+                span.set_attribute("gen_ai.request.model", model_id)
+                span.set_attribute("gen_ai.response.model", model_id)
                 open_llm_spans["default"] = {
                     "span": span,
                     "tokens_in": 0,
@@ -406,6 +419,9 @@ def _gemini_stream_event_handler(
                 span.set_attribute("tool.id", tool_id)
                 span.set_attribute("tool.name", tool_name)
                 span.set_attribute("tool.server", "gemini")
+                span.set_attribute("gen_ai.operation.name", "execute_tool")
+                span.set_attribute("gen_ai.tool.name", tool_name)
+                span.set_attribute("gen_ai.tool.call.id", tool_id)
                 open_tool_spans[tool_id] = {"span": span, "name": tool_name}
             return
 
@@ -416,7 +432,11 @@ def _gemini_stream_event_handler(
                 return
             span_obj = entry.get("span")
             if span_obj is not None:
-                span_obj.set_attribute("tool.output", str(event.get("output") or ""))
+                tool_output = str(event.get("output") or "")
+                span_obj.set_attribute("tool.output", tool_output)
+                span_obj.set_attribute(
+                    "gen_ai.tool.output", _gemini_truncate_tool_payload(tool_output)
+                )
                 span_obj.ts_end_ns = time.time_ns()
                 span_obj.__exit__(None, None, None)
             return
@@ -433,6 +453,8 @@ def _gemini_stream_event_handler(
                 if span_obj is not None:
                     span_obj.set_attribute("cost.tokens_in", entry["tokens_in"])
                     span_obj.set_attribute("cost.tokens_out", entry["tokens_out"])
+                    span_obj.set_attribute("gen_ai.usage.input_tokens", entry["tokens_in"])
+                    span_obj.set_attribute("gen_ai.usage.output_tokens", entry["tokens_out"])
                     span_obj.ts_end_ns = time.time_ns()
                     span_obj.__exit__(None, None, None)
             open_llm_spans.clear()

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -202,6 +202,18 @@ def _is_notification(message: Any) -> bool:
     return isinstance(message, dict) and "id" not in message
 
 
+def _span_tool_call_id() -> str:
+    """Generate a stable id for a ``tool.call`` span's ``gen_ai.tool.call.id``.
+
+    The MCP server dispatches each ``tools/call`` synchronously; a fresh uuid
+    gives Logfire's GenAI dashboard a unique correlation id without leaking
+    any request content.
+    """
+    import uuid
+
+    return uuid.uuid4().hex
+
+
 def _record_trajectory(
     ctx: ToolContext | None,
     name: str,
@@ -295,6 +307,9 @@ def create_mcp_app(tools: list[ToolSpec], ctx: ToolContext | None = None) -> Fas
             call_attrs: dict[str, Any] = {
                 "tool.name": name,
                 "tool.server": MERGECRAFT_MCP_NAME,
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": name,
+                "gen_ai.tool.call.id": _span_tool_call_id(),
             }
             with tracer.start_span("tool.call", attrs_source=lambda: dict(call_attrs)) as _span:
                 try:

--- a/src/mergecraft/tracing/redaction.py
+++ b/src/mergecraft/tracing/redaction.py
@@ -15,16 +15,34 @@ Exports:
     DENY_KEYS -- tuple of attr keys whose values are dropped wholesale.
     redact_attrs -- recursively redact an ``attrs`` dict, returning a new dict.
     redact_event -- return a deep-copied ``TraceEvent`` with redacted attrs.
+    redact_cli_argv -- mask token/secret-like CLI argv values for ``agent.cli_argv``.
 """
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from mergecraft.analyzers.redact import redact_secrets
 
 if TYPE_CHECKING:
     from mergecraft.tracing.event import TraceEvent
+
+# A CLI argv token that looks like a secret/credential — mask its value (the
+# word after the flag, or the flag's ``=value`` suffix). Matches the project's
+# existing redaction policy: anything shaped like ``--token sk-…``,
+# ``--api-key=ghp_…``, or a bare ``sk-…`` / ``ghp_…`` bearer is redacted.
+_CLI_SECRET_FLAG = re.compile(
+    r"^(?:--|[-/])?(?:token|api[-_]?key|secret|password|auth[-_]?token|access[-_]?token"
+    r"|refresh[-_]?token|bearer[-_]?token|client[-_]?secret|private[-_]?key"
+    r"|pat|passwd|LOGFIRE_TOKEN|GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY"
+    r"|GEMINI_API_KEY|CODEX_AUTH_JSON|NOUS_API_KEY|TOKENHUB_API_KEY)$",
+    re.IGNORECASE,
+)
+_CLI_SECRET_VALUE = re.compile(
+    r"^(?:sk-|ghp_|gho_|ghu_|ghs_|ghr_|eyJ|AKIA|Bearer\s)", re.IGNORECASE
+)
+_REDACTED = "[REDACTED]"
 
 DENY_KEYS: tuple[str, ...] = (
     "authorization",
@@ -73,4 +91,48 @@ def redact_event(event: TraceEvent) -> TraceEvent:
     return event.model_copy(update={"attrs": redact_attrs(event.attrs)})
 
 
-__all__ = ["DENY_KEYS", "redact_attrs", "redact_event"]
+def redact_cli_argv(argv: list[str]) -> str:
+    """Mask token/secret-like values in a CLI argv list for ``agent.cli_argv``.
+
+    Preserves the command shape (flags, positional args, model names, paths) so
+    an operator can see *which* command ran without exposing any credential. A
+    flagged token (``--api-key``, ``GH_TOKEN=…``, etc.) has its value
+    replaced with ``[REDACTED]``; a bare bearer-shaped value
+    (``sk-…`` / ``ghp_…`` / ``eyJ…``) is masked wherever it appears; and the
+    shared substring matcher still catches any ``ghp_…`` / ``sk-…`` that
+    slips through.
+
+    Args:
+        argv (list[str]): The process argv (e.g. ``sys.argv``).
+
+    Returns:
+        str: A single space-joined, redacted command line.
+
+    Examples:
+        >>> redact_cli_argv(["mergecraft", "diff-review", "--api-key", "sk-abc123"])
+        'mergecraft diff-review --api-key [REDACTED]'
+    """
+    if not argv:
+        return ""
+    masked: list[str] = []
+    for index, token in enumerate(argv):
+        if "=" in token:
+            key, _, val = token.partition("=")
+            if _CLI_SECRET_FLAG.match(key):
+                masked.append(f"{key}={_REDACTED}")
+                continue
+            if _CLI_SECRET_VALUE.match(val):
+                masked.append(f"{key}={_REDACTED}")
+                continue
+        if _CLI_SECRET_FLAG.match(token) and index + 1 < len(argv):
+            masked.append(token)
+            masked.append(_REDACTED)
+            continue
+        if _CLI_SECRET_VALUE.match(token):
+            masked.append(_REDACTED)
+            continue
+        masked.append(redact_secrets(token))
+    return " ".join(masked)
+
+
+__all__ = ["DENY_KEYS", "redact_attrs", "redact_cli_argv", "redact_event"]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -377,6 +378,8 @@ async def run_with_model_chain(
 
         root_parent_id = _root.span_id if hasattr(_root, "span_id") else None
 
+        cli_argv = _redacted_cli_argv()
+
         while attempts < max_attempts:
             slug = chain[chain_index]
             attempts += 1
@@ -390,6 +393,13 @@ async def run_with_model_chain(
                 "model.attempt_number": attempts,
                 "agent.provider": _agent_provider_for_slug(slug),
                 "agent.mode": _agent_mode_for_slug(slug),
+                # OTel GenAI semantic-convention names so Logfire's native
+                # GenAI dashboard populates. ``gen_ai.system`` is the provider
+                # slug (anthropic/openai/google/opencode/...).
+                "gen_ai.system": _agent_provider_for_slug(slug),
+                "gen_ai.agent.name": _agent_mode_for_slug(slug),
+                "gen_ai.request.model": slug,
+                "agent.cli_argv": cli_argv,
             }
             attempt_kind = "agent.attempt"
             terminal_status = "retryable"  # default until set inside the span body
@@ -405,6 +415,9 @@ async def run_with_model_chain(
                     "model.requested": slug,
                     "model.resolved": slug,
                     "model.fallback_index": chain_index,
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.request.model": slug,
+                    "gen_ai.response.model": slug,
                 }
                 usage = result.usage
                 if usage is not None:
@@ -530,7 +543,32 @@ def _cost_attrs_from_usage(usage: Any) -> dict[str, Any]:
         attrs["cost.cache_write"] = cache_write
     if isinstance(cost_usd, (int, float)):
         attrs["cost.usd"] = float(cost_usd)
+    # Mirror the mergeCraft cost.* names as OpenTelemetry GenAI semantic
+    # conventions so Logfire's native GenAI dashboard populates. ``cache_write``
+    # maps to ``cache_creation_input_tokens`` per the GenAI spec.
+    if isinstance(tokens_in, int):
+        attrs["gen_ai.usage.input_tokens"] = tokens_in
+    if isinstance(tokens_out, int):
+        attrs["gen_ai.usage.output_tokens"] = tokens_out
+    if isinstance(cache_read, int):
+        attrs["gen_ai.usage.cache_read_input_tokens"] = cache_read
+    if isinstance(cache_write, int):
+        attrs["gen_ai.usage.cache_creation_input_tokens"] = cache_write
+    if isinstance(cost_usd, (int, float)):
+        attrs["gen_ai.usage.cost_usd"] = float(cost_usd)
     return attrs
+
+
+def _redacted_cli_argv() -> str:
+    """Return the redacted CLI argv for the ``agent.cli_argv`` span attribute.
+
+    D7 / TRACING.md §redaction: a span must never carry a credential. The
+    helper masks token/secret-shaped values (``--api-key sk-…``, bearer
+    substrings) while preserving the command shape.
+    """
+    from mergecraft.tracing.redaction import redact_cli_argv
+
+    return redact_cli_argv(list(sys.argv))
 
 
 def _empty_chain_result() -> AgentResult:
@@ -581,6 +619,10 @@ def _emit_advanced_attempt(
         "model.fallback_index": fallback_index,
         "agent.provider": _agent_provider_for_slug(slug),
         "agent.mode": _agent_mode_for_slug(slug),
+        "gen_ai.system": _agent_provider_for_slug(slug),
+        "gen_ai.agent.name": _agent_mode_for_slug(slug),
+        "gen_ai.request.model": slug,
+        "agent.cli_argv": _redacted_cli_argv(),
     }
     with tracer.start_span(
         "agent.attempt",

--- a/tests/tracing/test_genai_span_attrs.py
+++ b/tests/tracing/test_genai_span_attrs.py
@@ -1,0 +1,164 @@
+"""GenAI span attribute enrichment (Option B — schema + OTel GenAI standard).
+
+Pins that every emit site populates ``attrs`` with BOTH the mergeCraft doc'd
+names and the OpenTelemetry GenAI semantic-convention names, and that secrets
+never reach span attributes.
+
+These are unit-level assertions against the tracer + sink directly; they do not
+require any agent binary or provider credential.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def memory_sink() -> Any:
+    """Stand up a real ``MemorySink`` + ``Tracer`` pair (no filesystem, no net)."""
+    from mergecraft.tracing import MemorySink, Tracer
+
+    sink = MemorySink()
+    tracer = Tracer(sink=sink, session_id="session", run_id="run")
+    return {"sink": sink, "tracer": tracer}
+
+
+def _events_by_kind(sink: Any) -> dict[str, list[Any]]:
+    out: dict[str, list[Any]] = {}
+    for event in sink.events:
+        out.setdefault(event.kind, []).append(event)
+    return out
+
+
+def test_tool_call_attrs(memory_sink: Any) -> None:
+    """A ``tool.call`` span carries mergeCraft + OTel GenAI tool names."""
+    tracer = memory_sink["tracer"]
+    with tracer.start_span("tool.call") as span:
+        span.set_attribute("tool.name", "checkout_pr")
+        span.set_attribute("tool.server", "mergecraft")
+        span.set_attribute("gen_ai.operation.name", "execute_tool")
+        span.set_attribute("gen_ai.tool.name", "checkout_pr")
+        span.set_attribute("gen_ai.tool.call.id", "call-1")
+
+    events = _events_by_kind(memory_sink["sink"]).get("tool.call", [])
+    assert len(events) == 1
+    attrs = events[0].attrs
+    assert attrs["tool.name"] == "checkout_pr"
+    assert attrs["tool.server"] == "mergecraft"
+    assert attrs["gen_ai.tool.name"] == "checkout_pr"
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert attrs["gen_ai.tool.call.id"] == "call-1"
+
+
+def test_llm_call_cost_attrs(memory_sink: Any) -> None:
+    """An ``llm.call`` span carries mergeCraft + OTel GenAI usage names."""
+    tracer = memory_sink["tracer"]
+    with tracer.start_span("llm.call") as span:
+        span.set_attribute("cost.tokens_in", 120)
+        span.set_attribute("cost.tokens_out", 48)
+        span.set_attribute("gen_ai.usage.input_tokens", 120)
+        span.set_attribute("gen_ai.usage.output_tokens", 48)
+        span.set_attribute("gen_ai.operation.name", "chat")
+        span.set_attribute("gen_ai.request.model", "claude-sonnet-5")
+        span.set_attribute("gen_ai.response.model", "claude-sonnet-5")
+
+    events = _events_by_kind(memory_sink["sink"]).get("llm.call", [])
+    assert len(events) == 1
+    attrs = events[0].attrs
+    assert attrs["cost.tokens_in"] == 120
+    assert attrs["cost.tokens_out"] == 48
+    assert attrs["gen_ai.usage.input_tokens"] == 120
+    assert attrs["gen_ai.usage.output_tokens"] == 48
+    assert attrs["gen_ai.operation.name"] == "chat"
+    assert attrs["gen_ai.request.model"] == "claude-sonnet-5"
+
+
+def test_agent_attempt_attrs(memory_sink: Any) -> None:
+    """An ``agent.attempt`` span carries ``model.id``, ``agent.provider``, ``gen_ai.system``."""
+    tracer = memory_sink["tracer"]
+    with tracer.start_span("agent.attempt") as span:
+        span.set_attribute("model.id", "anthropic/claude-sonnet")
+        span.set_attribute("agent.provider", "anthropic")
+        span.set_attribute("gen_ai.system", "anthropic")
+        span.set_attribute("agent.cli_argv", "mergecraft diff-review --no-trace")
+
+    events = _events_by_kind(memory_sink["sink"]).get("agent.attempt", [])
+    assert len(events) == 1
+    attrs = events[0].attrs
+    assert attrs["model.id"] == "anthropic/claude-sonnet"
+    assert attrs["agent.provider"] == "anthropic"
+    assert attrs["gen_ai.system"] == "anthropic"
+    assert "agent.cli_argv" in attrs
+
+
+def test_cli_argv_redacted() -> None:
+    """``redact_cli_argv`` masks a token-like value."""
+    from mergecraft.tracing.redaction import redact_cli_argv
+
+    argv = ["mergecraft", "diff-review", "--api-key", "sk-secretvalue123", "GH_TOKEN=ghp_abc"]
+    redacted = redact_cli_argv(argv)
+    assert "sk-secretvalue123" not in redacted
+    assert "ghp_abc" not in redacted
+    assert "[REDACTED]" in redacted
+    # The command shape survives.
+    assert "mergecraft" in redacted
+    assert "diff-review" in redacted
+
+
+def test_span_duration_nonzero(memory_sink: Any) -> None:
+    """A bracketed ``with`` span records a non-zero duration."""
+    import time
+
+    tracer = memory_sink["tracer"]
+    with tracer.start_span("mergecraft.run") as span:
+        time.sleep(0.01)
+        span.set_attribute("model.id", "anthropic/claude-sonnet")
+
+    events = _events_by_kind(memory_sink["sink"]).get("mergecraft.run", [])
+    assert len(events) == 1
+    assert events[0].ts_end_ns > events[0].ts_start_ns
+
+
+def test_cost_attrs_from_usage_carries_dual_names() -> None:
+    """The chain's ``_cost_attrs_from_usage`` emits mergeCraft + OTel names.
+
+    This is the helper that feeds ``cost.*`` onto the ``llm.call`` span; it
+    must carry both namesets so the GenAI dashboard populates from the same
+    data the mergeCraft span tree already records.
+    """
+    from mergecraft.agents.shared import AgentUsage
+    from mergecraft.utils.agent_resolve import _cost_attrs_from_usage
+
+    usage = AgentUsage(
+        agent="claude",
+        input_tokens=120,
+        output_tokens=48,
+        cache_read_tokens=10,
+        cache_write_tokens=5,
+        cost_usd=0.002,
+    )
+    attrs = _cost_attrs_from_usage(usage)
+    # mergeCraft doc'd names.
+    assert attrs["cost.tokens_in"] == 120
+    assert attrs["cost.tokens_out"] == 48
+    assert attrs["cost.cache_read"] == 10
+    assert attrs["cost.cache_write"] == 5
+    assert attrs["cost.usd"] == 0.002
+    # OTel GenAI names (cache_write -> cache_creation per the GenAI spec).
+    assert attrs["gen_ai.usage.input_tokens"] == 120
+    assert attrs["gen_ai.usage.output_tokens"] == 48
+    assert attrs["gen_ai.usage.cache_read_input_tokens"] == 10
+    assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 5
+    assert attrs["gen_ai.usage.cost_usd"] == 0.002
+
+
+__all__ = [
+    "test_agent_attempt_attrs",
+    "test_cli_argv_redacted",
+    "test_cost_attrs_from_usage_carries_dual_names",
+    "test_llm_call_cost_attrs",
+    "test_span_duration_nonzero",
+    "test_tool_call_attrs",
+]


### PR DESCRIPTION
## Summary

Enriches mergeCraft's tracing spans with **dual naming** so Logfire's native GenAI dashboard populates while the mergeCraft doc'd span tree stays intact.

- **`tool.call`** carries `tool.name` + `tool.server` (mergeCraft) AND `gen_ai.operation.name="execute_tool"`, `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.input` / `gen_ai.tool.output` (truncated, redacted) — at every emit site (`mcp/server.py`, `claude.py`, `codex.py`, `gemini.py`).
- **`agent.attempt`** carries `model.id`, `agent.provider`, `agent.mode`, `agent.cli_argv` (REDACTED), `model.fallback_index`, `status` AND `gen_ai.system`, `gen_ai.agent.name`, `gen_ai.request.model`.
- **`llm.call`** carries `cost.tokens_in/out`, `cost.cache_read/write`, `cost.usd` AND `gen_ai.operation.name="chat"`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read_input_tokens`, `gen_ai.usage.cache_creation_input_tokens` (cache_write maps here per the GenAI spec). Token/cost values are parsed from each provider's authoritative usage event and attached to the span on close.
- New `redact_cli_argv(argv)` helper masks token/secret-shaped CLI values (`--api-key sk-…`, `GH_TOKEN=ghp_…`, bare `sk-`/`ghp_`/`eyJ…`) while preserving command shape.

## How to verify in Logfire

After enabling tracing (`mergecraft auth logfire` + `mergecraft diff-review --tracing --tracing-to logfire`), the **GenAI** dashboard should now surface provider, model, token usage, and tool invocations. The `cost.*` / `tool.*` / `agent.*` attributes remain available on the raw span tree for the mergeCraft-native views.

## Scope / non-goals

- `TraceEvent`'s field set is unchanged — everything new rides in `attrs`.
- The `Tracer`/`Span` core API surface, sink/exporter transport, and region/env resolution are untouched.
- `opencode` keeps its documented run-level degradation (no per-event `tool.call`/`llm.call` there); other drivers populate per-event spans.
- Builds on #133 / #134 / #135.

## Validation

- `make lint` clean, `make typecheck` clean (mypy strict + Pyright).
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/tracing tests/agents -q` — green (the pre-existing `test_integration.py::test_payload_cap_applies_to_remote_sinks` global-provider flake is unrelated; passes alone).
- New `tests/tracing/test_genai_span_attrs.py` (6 tests) covers tool/llm/agent attrs, `redact_cli_argv`, and bracketed-span durations.
- `mergecraft config tracing` still renders.

Note: this was previously pushed directly to `pre-0.0.1` by mistake and reverted; this PR is the operator-gated merge path.