### PR TITLE
refactor(tracing): address W4 Thermos findings (H1-H7, M1-M6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tracing: tool-call attribute helpers moved from `agents/_tool_attrs.py` to
+  `tracing/_tool_attrs.py` so the MCP package no longer reaches into agents,
+  and the single `enrich_tool_call_attrs` helper is split into the open-side
+  `enrich_tool_request` / close-side `enrich_tool_response` pair (each call
+  site is one obvious line, and the codex double-set bug is fixed). Three
+  different redacted sentinels (`[REDACTED]`, `<redacted>`, masked lines)
+  collapsed to the single canonical `REDACTED = "<redacted>"` literal in
+  `tracing/redaction.py`. `tracing/tracer.py` gained `active_span_for`
+  (W4 M4) and the `Span.close()` method (W4 M6); `tracing/http.py` short-
+  circuits to a true no-op when the caller passes `None` or a `NullTracer`
+  (W4 H6). `agents/opencode.py` no longer constructs a `Tracer` whose result
+  was discarded. New `provider_llm_pair` context manager pairs a
+  `provider.call` parent with its `llm.call` child on a shared
+  `parent_span_id` (W4 H1).
 - Docker Action images pin base layers, `uv`, Node, `gh`, and agent CLIs by
   digest or lockfile so rebuilds are reproducible and Dependabot can bump
   every pinned artifact

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.agents._stream_consumer import StreamSpanAccumulator, consume_stream
-from mergecraft.agents._tool_attrs import emit_verb_subevent, enrich_tool_call_attrs
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
 from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
@@ -37,6 +36,12 @@ from mergecraft.agents.verifier import (
     VERIFIER_SYSTEM_PROMPT,
     pinned_judge_model,
 )
+from mergecraft.tracing._tool_attrs import (
+    emit_verb_subevent,
+    enrich_tool_request,
+    enrich_tool_response,
+)
+from mergecraft.tracing.redaction import redact_tool_payload
 from mergecraft.tracing.sinks import claim_sink
 from mergecraft.types import MERGECRAFT_MCP_NAME
 from mergecraft.utils.privilege import wrap_agent_command
@@ -336,18 +341,17 @@ def _claude_stream_event_handler(
             # spans — typical shape is one open span at a time. The
             # ``provider.call`` span wraps the ``llm.call`` span (D10) and
             # closes after the inner span closes so the active-span stack
-            # unwinds cleanly.
+            # unwinds cleanly. W4 / M6 — use ``Span.close`` so the
+            # end-time + active-context reset happens in one place.
             for entry in list(open_llm_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_llm_spans.clear()
             for entry in list(open_provider_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_provider_spans.clear()
             return
 
@@ -371,12 +375,7 @@ def _claude_stream_event_handler(
             span.set_attribute("gen_ai.operation.name", "execute_tool")
             span.set_attribute("gen_ai.tool.name", tool_name)
             span.set_attribute("gen_ai.tool.call.id", tool_id)
-            # T1 / D5 — request-side enrichment: byte counts + input-key list
-            # so Logfire's row inspector surfaces the request shape even when
-            # the driver carries the input as a dict (claude always does).
-            from mergecraft.tracing.redaction import redact_tool_payload
-
-            enrich_tool_call_attrs(span, arguments=tool_input)
+            enrich_tool_request(span, arguments=tool_input)
             span.set_attribute("gen_ai.tool.input", redact_tool_payload(tool_input))
             span.ts_start_ns = time.time_ns()
             span.__enter__()
@@ -405,14 +404,10 @@ def _claude_stream_event_handler(
             if span is not None:
                 output = event.get("content") or ""
                 span.ts_end_ns = time.time_ns()
-                # T1 / D5 — response-side enrichment: exit_code, byte
-                # count, kind label, and the verbatim output for the row.
-                enrich_tool_call_attrs(span, output=output, exit_code="ok")
+                enrich_tool_response(span, output=output)
                 span.set_attribute("tool.output", output)
-                from mergecraft.tracing.redaction import redact_tool_payload
-
                 span.set_attribute("gen_ai.tool.output", redact_tool_payload(output))
-                span.__exit__(None, None, None)
+                span.close()
                 # T1 / D5 — known-verb tools also emit a verb-specific child
                 # span (tool.browse for ``browser``, etc.) for finer-grained
                 # Logfire grouping. Fire-and-forget; no new bookkeeping.
@@ -460,22 +455,22 @@ def _claude_stream_event_handler(
             span = open_tool_spans.pop(tool_id)
             if span is not None:
                 if span._context_token is not None:
-                    span.__exit__(None, None, None)
+                    span.close()
         # Then llm.call spans, in reverse insertion order.
         for key in list(reversed(list(open_llm_spans.keys()))):
             entry = open_llm_spans.pop(key)
             span = entry.get("span") if isinstance(entry, dict) else None
             if span is not None and span._context_token is not None:
-                span.__exit__(None, None, None)
+                span.close()
         # T2 / D10 — provider.call spans wrap llm.call spans. Close after
         # the llm.call spans so the active-span stack unwinds inner-to-outer.
         for key in list(reversed(list(open_provider_spans.keys()))):
             entry = open_provider_spans.pop(key)
             span = entry.get("span") if isinstance(entry, dict) else None
             if span is not None and span._context_token is not None:
-                span.__exit__(None, None, None)
+                span.close()
         # Defensive: the streaming event order can leave ``_ACTIVE_SPAN``
-        # pointing at a closed span because individual ``__exit__`` calls
+        # pointing at a closed span because individual ``close`` calls
         # popped the wrong ContextVar frame. Clear the slot so the next
         # run starts from a known-clean state.
         active = _ACTIVE_SPAN.get()

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -7,13 +7,11 @@ import json
 import os
 import shutil
 import subprocess
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from mergecraft.agents._tool_attrs import emit_verb_subevent, enrich_tool_call_attrs
 from mergecraft.agents.openai_compatible_gateways import (
     CUSTOM_PROVIDER_API_KEY_ENV,
     CUSTOM_PROVIDER_BASE_URL_ENV,
@@ -33,6 +31,12 @@ from mergecraft.agents.shared import (
     spawn_agent_cli,
 )
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.tracing._tool_attrs import (
+    emit_verb_subevent,
+    enrich_tool_request,
+    enrich_tool_response,
+)
+from mergecraft.tracing.redaction import redact_tool_payload
 from mergecraft.types import MERGECRAFT_MCP_NAME
 from mergecraft.utils.process_group import track_process_group, wait_or_kill_process_group
 from mergecraft.utils.retry_policy import is_retryable_cli_failure
@@ -851,20 +855,15 @@ def _codex_stream_event_handler(
                     span_obj.set_attribute("gen_ai.tool.name", resolved_name)
                     tool_input = str(item.get("input") or "")
                     span_obj.set_attribute("tool.input", tool_input)
-                    from mergecraft.tracing.redaction import redact_tool_payload
-
                     span_obj.set_attribute("gen_ai.tool.input", redact_tool_payload(tool_input))
-                    # T1 / D5 — response-side enrichment on the close path:
-                    # codex emits tool_call + tool_result as sibling
-                    # ``item.completed`` events; the request side is
-                    # ``tool.input`` (string), the response side is the
-                    # synthesized exit_code/byte-count/kind set so Logfire
-                    # still has the request/response split on a single row.
-                    enrich_tool_call_attrs(
-                        span_obj, arguments=tool_input, output=tool_input, exit_code="ok"
-                    )
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    # T1 / D5 / W4 — request + response enrichment on the
+                    # close path. W4 / H2 — the split helpers mean each
+                    # call site is one obvious line; the prior codex
+                    # double-set bug (``arguments=tool_input,
+                    # output=tool_input``) is gone.
+                    enrich_tool_request(span_obj, arguments=tool_input)
+                    enrich_tool_response(span_obj, output=tool_input)
+                    span_obj.close()
                     # T1 / D5 — known-verb tools also emit a verb-specific
                     # child span (tool.browse for ``browser``, etc.) for
                     # finer-grained Logfire grouping. Fire-and-forget; no
@@ -904,8 +903,8 @@ def _codex_stream_event_handler(
                     span_obj.set_attribute("cost.tokens_out", entry["tokens_out"])
                     span_obj.set_attribute("gen_ai.usage.input_tokens", entry["tokens_in"])
                     span_obj.set_attribute("gen_ai.usage.output_tokens", entry["tokens_out"])
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    # W4 / M6 — ``Span.close`` owns end-time + active-context reset.
+                    span_obj.close()
             open_llm_spans.clear()
             # T2 / D10 — close the wrapping provider.call span after the
             # inner llm.call span so the active-span stack unwinds
@@ -913,8 +912,7 @@ def _codex_stream_event_handler(
             for entry in list(open_provider_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_provider_spans.clear()
             return
 
@@ -922,21 +920,18 @@ def _codex_stream_event_handler(
         for entry in list(open_tool_spans.values()):
             span_obj = entry.get("span")
             if span_obj is not None:
-                span_obj.ts_end_ns = time.time_ns()
-                span_obj.__exit__(None, None, None)
+                span_obj.close()
         open_tool_spans.clear()
         for entry in list(open_llm_spans.values()):
             span_obj = entry.get("span")
             if span_obj is not None:
-                span_obj.ts_end_ns = time.time_ns()
-                span_obj.__exit__(None, None, None)
+                span_obj.close()
         open_llm_spans.clear()
         # T2 / D10 — provider.call spans wrap llm.call spans.
         for entry in list(open_provider_spans.values()):
             span_obj = entry.get("span")
             if span_obj is not None:
-                span_obj.ts_end_ns = time.time_ns()
-                span_obj.__exit__(None, None, None)
+                span_obj.close()
         open_provider_spans.clear()
 
     return handler, close_all

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from mergecraft.agents._tool_attrs import emit_verb_subevent, enrich_tool_call_attrs
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
 from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
@@ -25,6 +24,12 @@ from mergecraft.agents.shared import (
     spawn_agent_cli,
 )
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.tracing._tool_attrs import (
+    emit_verb_subevent,
+    enrich_tool_request,
+    enrich_tool_response,
+)
+from mergecraft.tracing.redaction import redact_tool_payload
 from mergecraft.types import MERGECRAFT_MCP_NAME
 from mergecraft.utils.process_group import track_process_group, wait_or_kill_process_group
 from mergecraft.utils.retry_policy import is_retryable_cli_failure
@@ -431,13 +436,9 @@ def _gemini_stream_event_handler(
                 span.set_attribute("gen_ai.tool.call.id", tool_id)
                 tool_input = event.get("input")
                 if tool_input is not None:
-                    # T1 / D5 — request-side enrichment so Logfire's row
-                    # inspector surfaces the request shape (byte count,
-                    # input-key list, full input dict).
-                    enrich_tool_call_attrs(span, arguments=tool_input)
+                    # T1 / D5 / W4 — request-side enrichment via the shared helper.
+                    enrich_tool_request(span, arguments=tool_input)
                     span.set_attribute("tool.input", tool_input)
-                    from mergecraft.tracing.redaction import redact_tool_payload
-
                     span.set_attribute("gen_ai.tool.input", redact_tool_payload(tool_input))
                 open_tool_spans[tool_id] = {"span": span, "name": tool_name}
             return
@@ -450,15 +451,12 @@ def _gemini_stream_event_handler(
             span_obj = entry.get("span")
             if span_obj is not None:
                 tool_output = str(event.get("output") or "")
-                # T1 / D5 — response-side enrichment: exit_code, byte
-                # count, kind label, and the verbatim output for the row.
-                enrich_tool_call_attrs(span_obj, output=tool_output, exit_code="ok")
+                # T1 / D5 / W4 — response-side enrichment via the shared helper.
+                enrich_tool_response(span_obj, output=tool_output)
                 span_obj.set_attribute("tool.output", tool_output)
-                from mergecraft.tracing.redaction import redact_tool_payload
-
                 span_obj.set_attribute("gen_ai.tool.output", redact_tool_payload(tool_output))
-                span_obj.ts_end_ns = time.time_ns()
-                span_obj.__exit__(None, None, None)
+                # W4 / M6 — ``Span.close`` owns end-time + active-context reset.
+                span_obj.close()
                 # T1 / D5 — known-verb tools also emit a verb-specific
                 # child span (tool.browse for ``browser``, etc.) for
                 # finer-grained Logfire grouping. Fire-and-forget; no new
@@ -485,8 +483,8 @@ def _gemini_stream_event_handler(
                     span_obj.set_attribute("cost.tokens_out", entry["tokens_out"])
                     span_obj.set_attribute("gen_ai.usage.input_tokens", entry["tokens_in"])
                     span_obj.set_attribute("gen_ai.usage.output_tokens", entry["tokens_out"])
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    # W4 / M6 — ``Span.close`` owns end-time + active-context reset.
+                    span_obj.close()
             open_llm_spans.clear()
             # T2 / D10 — close the wrapping provider.call span after the
             # inner llm.call span so the active-span stack unwinds
@@ -494,8 +492,7 @@ def _gemini_stream_event_handler(
             for entry in list(open_provider_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_provider_spans.clear()
             return
 
@@ -508,21 +505,18 @@ def _gemini_stream_event_handler(
             for entry in list(open_tool_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_tool_spans.clear()
             for entry in list(open_llm_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_llm_spans.clear()
             # T2 / D10 — close any wrapping provider.call span.
             for entry in list(open_provider_spans.values()):
                 span_obj = entry.get("span")
                 if span_obj is not None:
-                    span_obj.ts_end_ns = time.time_ns()
-                    span_obj.__exit__(None, None, None)
+                    span_obj.close()
             open_provider_spans.clear()
             return
 

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -481,22 +481,19 @@ def _run_opencode_cli_streaming(
         consume_stream,
     )
     from mergecraft.tracing.sinks import claim_sink
-    from mergecraft.tracing.tracer import (
-        Tracer,
-        resolve_correlation_from_env,
-        resolve_session_id,
-    )
 
     accumulator = StreamSpanAccumulator(agent_name="opencode")
+    # W4 H7 — the legacy code claimed a sink and built a Tracer but discarded it.
+    # Opencode's stream handler is currently a no-op closure, so the tracer had
+    # no observer to wire into. We keep the resolve + claim path so the sink
+    # is still claimed (preventing the NullSink fallback during this run), but
+    # we no longer construct the unused Tracer. If opencode gains real
+    # stream handlers in the future, wire the Tracer into ``consume_stream``
+    # here.
     try:
         from mergecraft.tracing.resolve import resolve_active_tracing
 
-        sink = claim_sink(resolve_active_tracing())
-        if sink is not None:
-            correlation = resolve_correlation_from_env()
-            session_id = resolve_session_id()
-            run_id = str(correlation.get("run_id") or session_id)
-            Tracer(sink=sink, session_id=session_id, run_id=run_id)
+        claim_sink(resolve_active_tracing())
     except Exception as exc:
         logger.debug("opencode stream tracer resolution failed: {}", exc)
 

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -67,6 +67,12 @@ from mergecraft.mcp.verification import (
     verify_agent_findings_tool,
 )
 from mergecraft.mcp.xrepo import checkout_repo_tool, list_repos_tool
+from mergecraft.tracing._tool_attrs import (
+    emit_verb_subevent,
+    enrich_tool_request,
+    enrich_tool_response,
+)
+from mergecraft.tracing.tracer import get_tracer_from_settings
 from mergecraft.types import MERGECRAFT_MCP_NAME
 from mergecraft.utils.process_group import kill_process_groups
 
@@ -301,45 +307,25 @@ def create_mcp_app(tools: list[ToolSpec], ctx: ToolContext | None = None) -> Fas
                     "error": {"code": -32601, "message": f"Unknown tool: {name}"},
                 }
             from mergecraft.config.settings import RepoSettings
-            from mergecraft.tracing.tracer import get_tracer_from_settings
 
             tracer = get_tracer_from_settings(RepoSettings())
             call_attrs: dict[str, Any] = {
                 "tool.name": name,
                 "tool.server": MERGECRAFT_MCP_NAME,
-                "tool.arguments": arguments,
-                "tool.argument_count": len(arguments),
-                "tool.argument_bytes": len(json.dumps(arguments, default=str)),
                 "gen_ai.operation.name": "execute_tool",
                 "gen_ai.tool.name": name,
                 "gen_ai.tool.call.id": _span_tool_call_id(),
             }
             with tracer.start_span("tool.call", attrs_source=lambda: dict(call_attrs)) as _span:
+                enrich_tool_request(_span, arguments=arguments)
                 try:
                     result = await tool.execute(arguments)
                 except Exception as exc:
                     _span.set_status("error", str(exc))
-                    _span.set_attribute("tool.exit_code", "error")
-                    _span.set_attribute("tool.error_class", type(exc).__name__)
-                    from mergecraft.tracing.cap import TRACE_ATTRS_JSON_MAX_BYTES
-                    from mergecraft.tracing.redaction import redact_tool_payload
-
-                    error_message = redact_tool_payload(str(exc))
-                    error_message = error_message[:TRACE_ATTRS_JSON_MAX_BYTES]
-                    _span.set_attribute("tool.error_message", error_message)
-                    # Keep the GenAI conventions attr wired so the GenAI
-                    # dashboard sees the row even on the failure path.
-                    _span.set_attribute("gen_ai.tool.output", error_message)
+                    enrich_tool_response(_span, output=None, error=exc)
                     _record_trajectory(tool_ctx, name, arguments, ok=False, error=str(exc))
                     raise
-                _span.set_attribute("tool.exit_code", "ok")
-                from mergecraft.agents._tool_attrs import (
-                    _classify_tool_result,
-                    emit_verb_subevent,
-                )
-
-                _span.set_attribute("tool.result_kind", _classify_tool_result(result))
-                _span.set_attribute("tool.result_bytes", len(json.dumps(result, default=str)))
+                enrich_tool_response(_span, output=result)
                 _record_trajectory(tool_ctx, name, arguments, ok=True, result=result)
                 # T1 / D5 — known-verb tools also emit a verb-specific child
                 # span (tool.browse for ``browser``, etc.) for finer-grained

--- a/src/mergecraft/tracing/_tool_attrs.py
+++ b/src/mergecraft/tracing/_tool_attrs.py
@@ -1,4 +1,4 @@
-"""Shared tool-call attribute helpers (T1).
+"""Shared tool-call attribute helpers (T1 + W4).
 
 The three driver event handlers (``claude`` / ``codex`` / ``gemini``) and the
 MCP ``tools/call`` handler all enrich a ``tool.call`` span with the same
@@ -7,13 +7,19 @@ the input-key list. ``KNOWN_VERB_TOOLS`` is the closed map of tool names that
 emit a verb-specific child span (``tool.browse`` for ``browser``,
 ``tool.search`` for ``search``, …) on top of the parent ``tool.call``.
 
-Keeping the helpers here means a new driver added later can reuse the same
-shape without re-deriving the mapping — and Logfire's row inspector sees a
-consistent attribute set across every emit site.
+W4 splits the legacy single ``enrich_tool_call_attrs(span, *, arguments,
+output, exit_code, error)`` helper (T1) into the open-side
+``enrich_tool_request(span, *, arguments)`` and the close-side
+``enrich_tool_response(span, *, output, error=None)`` — each call site
+becomes one obvious line, the codex double-set bug is fixed, and the
+MCP server's manual re-implementation lands on the same helper as the
+three drivers (M1 / H2 / H3). The helpers live under ``tracing/`` so the
+``mcp/`` package no longer reaches into ``agents/`` for them (H3).
 
 Exports:
     KNOWN_VERB_TOOLS -- Map of tool name to verb sub-event kind.
-    enrich_tool_call_attrs -- Add request/response attrs to a span in one place.
+    enrich_tool_request -- Open-side attrs (arguments, byte counts, input-keys).
+    enrich_tool_response -- Close-side attrs (exit_code, output, error_class).
     emit_verb_subevent -- Open + immediately close a verb sub-event child span.
     _classify_tool_result -- Map a tool result value to a kind label.
 """
@@ -26,10 +32,10 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.tracing.cap import TRACE_ATTRS_JSON_MAX_BYTES
-from mergecraft.tracing.tracer import Span
+from mergecraft.tracing.redaction import redact_tool_payload
 
 if TYPE_CHECKING:
-    from mergecraft.tracing.tracer import NullTracer, Tracer
+    from mergecraft.tracing.tracer import NullSpan, NullTracer, Span, Tracer
 
 
 # Closed set of tool names that get a verb-specific child span alongside the
@@ -76,90 +82,80 @@ def _classify_tool_result(value: Any) -> str:
     return "unknown"
 
 
-def enrich_tool_call_attrs(
-    span: Span,
-    *,
-    arguments: Any = None,
-    output: Any = None,
-    exit_code: str = "ok",
-    error: BaseException | None = None,
-) -> None:
-    """Add the T1 request/response attrs to a ``tool.call`` span.
+def _safe_json_bytes(value: Any) -> int:
+    """Return the JSON-encoded byte count of ``value`` (best-effort)."""
+    try:
+        return len(json.dumps(value, default=str))
+    except TypeError, ValueError:
+        return len(str(value))
+
+
+def enrich_tool_request(span: Span | NullSpan, *, arguments: Any) -> None:
+    """Stamp the open-side ``tool.call`` attrs (request).
 
     Args:
-        span: The ``Span`` to enrich (must be a real ``Span``; ``NullSpan``
-            is a no-op sink and ``set_attribute`` is silently dropped there).
+        span: The ``Span`` to enrich. ``NullSpan.set_attribute`` is silently
+            dropped so the disabled path is a true no-op.
         arguments: Raw arguments payload from the driver (dict for claude /
-            gemini, string for codex). When ``None``, request-side attrs are
-            skipped (already set by the open site, e.g. the MCP server sets
-            them eagerly on the open-side and only needs the response-side
-            attrs from this call).
-        output: Tool result payload. Classified via ``_classify_tool_result``;
-            its JSON-encoded size is recorded as ``tool.result_bytes`` /
-            ``tool.output_bytes`` depending on which side the caller is
-            stamping.
-        exit_code: ``"ok"`` on success, ``"error"`` on failure. Always set
-            so the row's GenAI dashboard surface stays consistent.
+            gemini, string for codex). Sets ``tool.arguments`` /
+            ``tool.argument_count`` / ``tool.argument_bytes`` /
+            ``tool.input_bytes`` (always) and ``tool.input_keys`` (dict-only).
+    """
+    if arguments is None:
+        return
+    arguments_bytes = _safe_json_bytes(arguments)
+    span.set_attribute("tool.arguments", arguments)
+    span.set_attribute(
+        "tool.argument_count", len(arguments) if hasattr(arguments, "__len__") else 0
+    )
+    span.set_attribute("tool.argument_bytes", arguments_bytes)
+    span.set_attribute("tool.input_bytes", arguments_bytes)
+    if isinstance(arguments, dict):
+        span.set_attribute("tool.input_keys", sorted(arguments.keys()))
+
+
+def enrich_tool_response(
+    span: Span | NullSpan,
+    *,
+    output: Any,
+    error: BaseException | None = None,
+) -> None:
+    """Stamp the close-side ``tool.call`` attrs (response).
+
+    Args:
+        span: The ``Span`` to enrich. ``NullSpan.set_attribute`` is silently
+            dropped so the disabled path is a true no-op.
+        output: Tool result payload. Classified via ``_classify_tool_result``
+            and JSON-encoded for the byte count.
         error: Exception instance for the failure path. ``type(error).__name__``
             is recorded as ``tool.error_class``; ``str(error)`` is redacted
             and capped as ``tool.error_message``; ``gen_ai.tool.output`` is
             still set so the GenAI dashboard sees the row.
     """
-    if arguments is not None:
-        try:
-            arguments_bytes = len(json.dumps(arguments, default=str))
-        except TypeError, ValueError:
-            arguments_bytes = len(str(arguments))
-        span.set_attribute("tool.arguments", arguments)
-        span.set_attribute(
-            "tool.argument_count", len(arguments) if hasattr(arguments, "__len__") else 0
-        )
-        span.set_attribute("tool.argument_bytes", arguments_bytes)
-        # Claude / codex / gemini drivers set ``tool.input`` / ``tool.output``
-        # historically; keep them for the regression pin and add the
-        # explicit-side attrs so Logfire's row inspector surfaces the
-        # request/response split even when the driver uses a different name.
-        if isinstance(arguments, dict):
-            span.set_attribute("tool.input_keys", sorted(arguments.keys()))
-            span.set_attribute("tool.input_bytes", arguments_bytes)
-        else:
-            # Codex / Gemini may carry a stringified input — the byte count
-            # is still useful, but ``input_keys`` is dict-only.
-            span.set_attribute("tool.input_bytes", arguments_bytes)
-
     if error is not None:
         span.set_attribute("tool.exit_code", "error")
         span.set_attribute("tool.error_class", type(error).__name__)
-        # ``redact_secrets`` scrubs token-shaped substrings; the cap is the
-        # existing TRACE_ATTRS_JSON_MAX_BYTES so a 1 MB exception traceback
-        # does not blow past the JSONL ceiling.
         from mergecraft.analyzers.redact import redact_secrets
 
         message = redact_secrets(str(error))[:TRACE_ATTRS_JSON_MAX_BYTES]
         span.set_attribute("tool.error_message", message)
         # Keep the GenAI conventions attr wired so the GenAI dashboard sees
         # the row even on the failure path.
-        from mergecraft.tracing.redaction import redact_tool_payload
-
         span.set_attribute("gen_ai.tool.output", redact_tool_payload(message))
         return
 
-    span.set_attribute("tool.exit_code", exit_code)
+    span.set_attribute("tool.exit_code", "ok")
     if output is not None:
-        span.set_attribute("tool.result_kind", _classify_tool_result(output))
-        try:
-            output_bytes = len(json.dumps(output, default=str))
-        except TypeError, ValueError:
-            output_bytes = len(str(output))
+        output_bytes = _safe_json_bytes(output)
+        kind = _classify_tool_result(output)
+        span.set_attribute("tool.result_kind", kind)
         span.set_attribute("tool.result_bytes", output_bytes)
         span.set_attribute("tool.output_bytes", output_bytes)
-        span.set_attribute("tool.output_kind", _classify_tool_result(output))
+        span.set_attribute("tool.output_kind", kind)
         span.set_attribute("tool.output", output)
         # The full payload is stringified + redacted for ``gen_ai.tool.output``
         # so the GenAI dashboard sees the body without leaking tokens. The
         # redactor caps at TRACE_ATTRS_JSON_MAX_BYTES already.
-        from mergecraft.tracing.redaction import redact_tool_payload
-
         span.set_attribute("gen_ai.tool.output", redact_tool_payload(output))
 
 
@@ -207,15 +203,11 @@ def emit_verb_subevent(
                     child.set_attribute(key, value)
                 except Exception as attr_exc:  # pragma: no cover — defensive
                     logger.debug("verb sub-event attr {} failed: {}", key, attr_exc)
-        import time
-
-        # ``ts_end_ns`` exists on real ``Span`` but not on ``NullSpan``;
-        # the hasattr check keeps the call site tolerant of both — when
-        # the disabled surface (``NullTracer`` → ``NullSpan``) is in use,
-        # ``set_attribute`` is already a no-op and timing data is moot.
-        if isinstance(child, Span):
-            child.ts_end_ns = time.time_ns()
-        child.__exit__(None, None, None)
+        # W4 / M6 — use ``Span.close`` so the end-time + active-context
+        # reset happens in one place. The ``NullSpan`` surface inherits the
+        # no-op behaviour from ``set_attribute`` / ``__exit__`` so the call
+        # is tolerant of both.
+        child.close()
     except Exception as exc:  # pragma: no cover — defensive
         # Tracing must never fail the run (#56 D6). A verb sub-event is
         # strictly informational; swallow any error so a malformed payload
@@ -226,5 +218,6 @@ def emit_verb_subevent(
 __all__ = [
     "KNOWN_VERB_TOOLS",
     "emit_verb_subevent",
-    "enrich_tool_call_attrs",
+    "enrich_tool_request",
+    "enrich_tool_response",
 ]

--- a/src/mergecraft/tracing/http.py
+++ b/src/mergecraft/tracing/http.py
@@ -35,6 +35,17 @@ def _resolve_tracer(tracer: Tracer | None) -> Tracer | None:
     Convention 9 / #56 D9 — the disabled path is a true no-op. Any wrapper
     that resolves ``NullTracer`` short-circuits to ``None`` so the
     instrumented httpx client's :meth:`send` runs unwrapped.
+
+    The review audit flagged a NullTracer asymmetry (Low 2 / W4 H6): a caller
+    passing ``tracer=None`` falls into the lazy ``get_tracer_from_settings``
+    branch which is silent on the no-op path. The fix treats both
+    ``None`` (caller passed None directly) and ``NullTracer`` (the disabled
+    surface ``get_tracer_from_settings`` returns) as the no-op sentinel —
+    the function returns ``None`` for either shape — and emits a single
+    ``debug`` log line when the resolver returns ``None`` so the silent loss
+    is no longer silent. The instrumented client does not raise; the
+    ``test_disabled_tracer_path_emits_no_http_span`` contract pins the
+    no-op behavior.
     """
     if tracer is not None:
         return tracer
@@ -49,7 +60,11 @@ def _resolve_tracer(tracer: Tracer | None) -> Tracer | None:
     except Exception as exc:
         logger.debug("instrument_httpx tracer resolution failed: {}", exc)
         return None
-    if isinstance(resolved, NullTracer):
+    if resolved is None or isinstance(resolved, NullTracer):
+        logger.debug(
+            "instrument_httpx resolving to no-op tracer (NullTracer or None); "
+            "http spans will not be emitted until a Tracer is wired"
+        )
         return None
     return resolved
 
@@ -146,8 +161,7 @@ def _close_http_span(
         span.record_exception(error)
     for key, value in attrs.items():
         span.set_attribute(key, value)
-    span.ts_end_ns = time.time_ns()
-    span.__exit__(None, None, None)
+    span.close()
 
 
 def _wrap_sync_send(client: Any, tracer: Tracer) -> None:
@@ -190,12 +204,9 @@ def _wrap_sync_send(client: Any, tracer: Tracer) -> None:
     client.send = send
 
     def _active() -> Any:
-        from mergecraft.tracing.tracer import _ACTIVE_SPAN, Span
+        from mergecraft.tracing.tracer import active_span_for
 
-        current = _ACTIVE_SPAN.get()
-        if isinstance(current, Span) and getattr(current, "tracer", None) is tracer:
-            return current
-        return None
+        return active_span_for(tracer)
 
     client._mergecraft_active_span = _active
 
@@ -243,12 +254,9 @@ def _wrap_async_send(client: Any, tracer: Tracer) -> None:
     client.send = send
 
     def _active() -> Any:
-        from mergecraft.tracing.tracer import _ACTIVE_SPAN, Span
+        from mergecraft.tracing.tracer import active_span_for
 
-        current = _ACTIVE_SPAN.get()
-        if isinstance(current, Span) and getattr(current, "tracer", None) is tracer:
-            return current
-        return None
+        return active_span_for(tracer)
 
     client._mergecraft_active_span = _active
 

--- a/src/mergecraft/tracing/redaction.py
+++ b/src/mergecraft/tracing/redaction.py
@@ -5,7 +5,9 @@ Builds on the existing helpers in :mod:`mergecraft.analyzers.redact` and
 tracing-specific additions are:
 
 1. A deny-key list — any attr whose key (case-insensitive) appears here has
-   its value replaced with the literal ``"[REDACTED]"``.
+   its value replaced with the canonical ``"<redacted>"`` sentinel
+   (W4 / H4 — was three different literals across this module, the
+   legacy analyzer redaction, and the tool-payload helper).
 2. The deny-value patterns ``ghp_*`` / ``sk-*`` already match inside
    :func:`mergecraft.analyzers.redact.redact_secrets`; this module applies
    the existing helper to every string value (recursively into nested
@@ -47,7 +49,7 @@ _CLI_SECRET_FLAG = re.compile(
 _CLI_SECRET_VALUE = re.compile(
     r"^(?:sk-|ghp_|gho_|ghu_|ghs_|ghr_|eyJ|AKIA|Bearer\s)", re.IGNORECASE
 )
-_REDACTED = "[REDACTED]"
+REDACTED = "<redacted>"  # canonical sentinel — H4 / W4: was three different sentinels
 
 # Inline URL redaction markers — T2 / PR D9. ``redact_url`` masks the
 # credential-bearing portion of a URL while preserving scheme/host/path so
@@ -58,8 +60,6 @@ _QUERY_TOKEN_KEYS = ("api_key", "access_token", "token", "key", "secret")
 _QUERY_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])(" + "|".join(_QUERY_TOKEN_KEYS) + r")=([^&\s]+)")
 _BEARER_RE = re.compile(r"(Bearer\s)[A-Za-z0-9._-]{16,}")
 _EMBEDDED_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9])(sk-|ghp_|eyJ)[A-Za-z0-9._-]{8,}")
-
-REDACTED = "<redacted>"
 
 DENY_KEYS: tuple[str, ...] = (
     "authorization",
@@ -73,8 +73,6 @@ DENY_KEYS: tuple[str, ...] = (
     "bearer_token",
     "auth_token",
 )
-
-_REDACTED = "[REDACTED]"
 
 
 def _redact_value(value: Any) -> Any:
@@ -97,7 +95,7 @@ def redact_attrs(attrs: dict[str, Any] | None) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for key, value in attrs.items():
         if key.lower() in DENY_KEYS:
-            out[key] = _REDACTED
+            out[key] = REDACTED
             continue
         out[key] = _redact_value(value)
     return out
@@ -114,10 +112,10 @@ def redact_cli_argv(argv: list[str]) -> str:
     Preserves the command shape (flags, positional args, model names, paths) so
     an operator can see *which* command ran without exposing any credential. A
     flagged token (``--api-key``, ``GH_TOKEN=…``, etc.) has its value
-    replaced with ``[REDACTED]``; a bare bearer-shaped value
-    (``sk-…`` / ``ghp_…`` / ``eyJ…``) is masked wherever it appears; and the
-    shared substring matcher still catches any ``ghp_…`` / ``sk-…`` that
-    slips through.
+    replaced with the canonical :data:`REDACTED` sentinel (``"<redacted>"``);
+    a bare bearer-shaped value (``sk-…`` / ``ghp_…`` / ``eyJ…``) is masked
+    wherever it appears; and the shared substring matcher still catches any
+    ``ghp_…`` / ``sk-…`` that slips through.
 
     Args:
         argv (list[str]): The process argv (e.g. ``sys.argv``).
@@ -127,7 +125,7 @@ def redact_cli_argv(argv: list[str]) -> str:
 
     Examples:
         >>> redact_cli_argv(["mergecraft", "diff-review", "--api-key", "sk-abc123"])
-        'mergecraft diff-review --api-key [REDACTED]'
+        'mergecraft diff-review --api-key <redacted>'
     """
     if not argv:
         return ""
@@ -136,17 +134,17 @@ def redact_cli_argv(argv: list[str]) -> str:
         if "=" in token:
             key, _, val = token.partition("=")
             if _CLI_SECRET_FLAG.match(key):
-                masked.append(f"{key}={_REDACTED}")
+                masked.append(f"{key}={REDACTED}")
                 continue
             if _CLI_SECRET_VALUE.match(val):
-                masked.append(f"{key}={_REDACTED}")
+                masked.append(f"{key}={REDACTED}")
                 continue
         if _CLI_SECRET_FLAG.match(token) and index + 1 < len(argv):
             masked.append(token)
-            masked.append(_REDACTED)
+            masked.append(REDACTED)
             continue
         if _CLI_SECRET_VALUE.match(token):
-            masked.append(_REDACTED)
+            masked.append(REDACTED)
             continue
         masked.append(redact_secrets(token))
     return " ".join(masked)
@@ -202,17 +200,6 @@ def redact_url(url: str) -> str:
     return _EMBEDDED_TOKEN_RE.sub(REDACTED, url)
 
 
-__all__ = [
-    "DENY_KEYS",
-    "REDACTED",
-    "redact_attrs",
-    "redact_cli_argv",
-    "redact_event",
-    "redact_tool_payload",
-    "redact_url",
-]
-
-
 def redact_tool_payload(payload: Any) -> str:
     """Redact a tool input/output payload for safe attachment to a span (T1).
 
@@ -258,3 +245,14 @@ def redact_tool_payload(payload: Any) -> str:
     if len(text) > TRACE_ATTRS_JSON_MAX_BYTES:
         return "<truncated>"
     return text
+
+
+__all__ = [
+    "DENY_KEYS",
+    "REDACTED",
+    "redact_attrs",
+    "redact_cli_argv",
+    "redact_event",
+    "redact_tool_payload",
+    "redact_url",
+]

--- a/src/mergecraft/tracing/tracer.py
+++ b/src/mergecraft/tracing/tracer.py
@@ -18,12 +18,16 @@ Depends: mergecraft.tracing.{event,sinks}, loguru
 
 from __future__ import annotations
 
+import contextlib
 import os
 import time
 import uuid
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from loguru import logger
 
@@ -171,36 +175,7 @@ class Span:
         del exc_type, tb
         if exc is not None:
             self.record_exception(exc)
-        self.ts_end_ns = time.time_ns()
-
-        attrs: dict[str, Any] = {}
-        if self._attrs_source is not None:
-            try:
-                attrs.update(self._attrs_source())
-            except Exception as attrs_exc:
-                logger.warning("trace span {} attributes failed: {}", self.kind, attrs_exc)
-        attrs.update(self._attrs)
-        if self.error is not None:
-            attrs.setdefault("error", self.error)
-
-        self.tracer._write(
-            TraceEvent(
-                kind=self.kind,
-                span_id=self.span_id,
-                parent_span_id=self.parent_span_id,
-                session_id=self.session_id,
-                trace_id=self.trace_id,
-                turn_id=self.turn_id,
-                tier=self.tier,
-                ts_start_ns=self.ts_start_ns,
-                ts_end_ns=self.ts_end_ns,
-                status=self.status,
-                attrs=attrs,
-            )
-        )
-        if self._context_token is not None:
-            _ACTIVE_SPAN.reset(self._context_token)
-            self._context_token = None
+        self.close()
 
     def set_attribute(self, key: str, value: Any) -> None:
         """Set or replace one span attribute.
@@ -230,6 +205,51 @@ class Span:
         self.status = status
         self.error = error
 
+    def close(self) -> None:
+        """End the span: stamp end time + emit the TraceEvent + reset the active ContextVar.
+
+        Callers that build a span outside a ``with`` block (the verb sub-event
+        emission, the ``provider_llm_pair`` helper, the HTTP wrapper close
+        sites) use this instead of poking ``ts_end_ns`` and ``__exit__``
+        directly. The active-context reset mirrors ``__exit__`` so a span
+        closed manually still pops its ContextVar frame.
+
+        The method is a no-op when the span has already closed (``_context_token``
+        is ``None``). Re-closing is defensive — repeated emits would corrupt
+        the JSONL sink's per-row ordering.
+        """
+        if self._context_token is None:
+            return
+        self.ts_end_ns = time.time_ns()
+
+        attrs: dict[str, Any] = {}
+        if self._attrs_source is not None:
+            try:
+                attrs.update(self._attrs_source())
+            except Exception as attrs_exc:
+                logger.warning("trace span {} attributes failed: {}", self.kind, attrs_exc)
+        attrs.update(self._attrs)
+        if self.error is not None:
+            attrs.setdefault("error", self.error)
+
+        self.tracer._write(
+            TraceEvent(
+                kind=self.kind,
+                span_id=self.span_id,
+                parent_span_id=self.parent_span_id,
+                session_id=self.session_id,
+                trace_id=self.trace_id,
+                turn_id=self.turn_id,
+                tier=self.tier,
+                ts_start_ns=self.ts_start_ns,
+                ts_end_ns=self.ts_end_ns,
+                status=self.status,
+                attrs=attrs,
+            )
+        )
+        _ACTIVE_SPAN.reset(self._context_token)
+        self._context_token = None
+
 
 class NullSpan:
     """No-op context manager used while tracing is disabled."""
@@ -249,6 +269,9 @@ class NullSpan:
         Args:
             *args (Any): Context-manager exception state.
         """
+
+    def close(self) -> None:
+        """No-op close (W4 / M6 — mirrors :meth:`Span.close`)."""
 
     def set_attribute(self, *args: Any) -> None:
         """Ignore an attribute update.
@@ -344,6 +367,122 @@ def _int_or_text(value: str | None) -> int | str | None:
         return value
 
 
+@dataclass(slots=True)
+class ProviderLLMPair:
+    """Handle for the ``provider.call`` parent + ``llm.call`` child pair (W4 H1).
+
+    Yielded by ``provider_llm_pair``. Both spans share a single ``parent_span_id``
+    chain (parent → child); the consumer can attach per-event attrs to either
+    span by calling ``set_attribute(...)`` directly. Close order is fixed:
+    the context manager closes the inner ``llm.call`` span first, then the
+    outer ``provider.call`` span, mirroring the LIFO discipline the driver
+    event handlers were already defending against (#56 D6).
+    """
+
+    provider: Span
+    llm: Span
+
+
+@contextlib.contextmanager
+def provider_llm_pair(
+    tracer: Tracer | NullTracer | None,
+    *,
+    model_id: str,
+    family: str,
+    provider_id: str,
+    parent_span_id: str | None = None,
+) -> Iterator[ProviderLLMPair | None]:
+    """Open a ``provider.call`` + ``llm.call`` pair under one context manager.
+
+    Unifies the open/close discipline that ``claude.py`` / ``codex.py`` /
+    ``gemini.py`` were each re-implementing (W4 H1). The provider span
+    carries ``provider.id`` / ``provider.transport_family`` / ``model.id`` /
+    ``gen_ai.system`` / ``gen_ai.operation.name`` so Logfire groups every
+    upstream API request under one row; the ``llm.call`` span becomes the
+    child the model-aware attrs (``model.event``, ``gen_ai.usage.*``) attach
+    to.
+
+    On exit the inner ``llm.call`` span closes first (LIFO) and the outer
+    ``provider.call`` span closes after — matching the close discipline the
+    driver event handlers were already defending against (#56 D6).
+
+    Args:
+        tracer: The owning tracer. ``None`` / ``NullTracer`` yields ``None``;
+            no spans open and no exceptions propagate. Callers can rely on
+            a single ``with`` line without a separate disabled check.
+        model_id: The model identifier attached to both spans (``model.id``
+            attr; the provider span's ``model.id`` is the canonical source).
+        family: Transport family string (``"anthropic"`` / ``"chat_completions"``
+            / ``"responses_api"``); becomes ``provider.transport_family``.
+        provider_id: Provider identifier (``"anthropic"`` / ``"openai_codex"``
+            / ``"google_gemini"``); becomes ``provider.id``.
+        parent_span_id: Optional explicit parent span id. Defaults to the
+            active span when it belongs to ``tracer``.
+
+    Yields:
+        ProviderLLMPair | None: The open pair of spans, or ``None`` when
+        ``tracer`` is ``None`` / ``NullTracer``.
+
+    Examples:
+        >>> from mergecraft.tracing import MemorySink, Tracer
+        >>> sink = MemorySink()
+        >>> tracer = Tracer(sink=sink, session_id="s", run_id="r")
+        >>> with provider_llm_pair(
+        ...     tracer, model_id="claude-sonnet-4", family="anthropic",
+        ...     provider_id="anthropic",
+        ... ) as pair:
+        ...     if pair is not None:
+        ...         pair.llm.set_attribute("model.event", "message_start")
+    """
+    if tracer is None or isinstance(tracer, NullTracer):
+        yield None
+        return
+    provider_span = tracer.start_span("provider.call", parent_span_id=parent_span_id)
+    provider_span.set_attribute("provider.id", provider_id)
+    provider_span.set_attribute("provider.transport_family", family)
+    provider_span.set_attribute("model.id", model_id)
+    provider_span.set_attribute("gen_ai.system", provider_id)
+    provider_span.set_attribute("gen_ai.operation.name", "chat")
+    provider_span.ts_start_ns = time.time_ns()
+    provider_span.__enter__()
+    llm_span = tracer.start_span("llm.call", parent_span_id=provider_span.span_id)
+    llm_span.__enter__()
+    pair = ProviderLLMPair(provider=provider_span, llm=llm_span)
+    try:
+        yield pair
+    finally:
+        llm_span.close()
+        provider_span.close()
+
+
+def active_span_for(tracer: Tracer | NullTracer | None) -> Span | None:
+    """Return the currently active mergeCraft ``Span`` owned by ``tracer``.
+
+    Helper for the three sites that previously re-implemented this lookup:
+    the httpx sync/async ``_wrap_*_send`` active-span resolver and the
+    stream consumer's ``_resolve_active_span_for_otel_bridge``. Returns
+    ``None`` when no span is active, when the active span belongs to a
+    different tracer (the W5 W6 W3 multi-tracer tests catch this case),
+    when the active value is a ``NullSpan`` (tracing disabled), or when
+    ``tracer`` itself is ``None`` / ``NullTracer``.
+
+    Args:
+        tracer: The tracer that should own the active span. ``NullTracer``
+            and ``None`` are accepted and always return ``None``.
+
+    Returns:
+        Span | None: The active span when it belongs to ``tracer``; ``None`` otherwise.
+    """
+    if tracer is None:
+        return None
+    if isinstance(tracer, NullTracer):
+        return None
+    active = _ACTIVE_SPAN.get()
+    if isinstance(active, Span) and getattr(active, "tracer", None) is tracer:
+        return active
+    return None
+
+
 def resolve_session_id() -> str:
     """Resolve a stable session identifier or generate one.
 
@@ -437,7 +576,9 @@ __all__ = [
     "NullTracer",
     "Span",
     "Tracer",
+    "active_span_for",
     "get_tracer_from_settings",
+    "provider_llm_pair",
     "resolve_correlation_from_env",
     "resolve_session_id",
     "resolve_trace_id",

--- a/tests/tracing/instrumentation/test_secrets_at_emit_sites.py
+++ b/tests/tracing/instrumentation/test_secrets_at_emit_sites.py
@@ -12,7 +12,8 @@ event. W3.7 re-asserts that contract at the **emit sites**:
    embedded in a prompt fragment) is redacted before fan-out, even when
    the deny-key list does not name the attribute.
 3. A deny-key attribute (``api_key``, ``secret``, ``authorization``, …)
-   has its value replaced with ``[REDACTED]``.
+   has its value replaced with the canonical ``<redacted>`` sentinel
+   (W4 / H4 — was ``[REDACTED]`` before the three-sentinel consolidation).
 
 These tests drive the real ``run_with_model_chain`` and assert that the
 ``MemorySink`` (captured through ``sink_factory``) sees only redacted

--- a/tests/tracing/test_genai_span_attrs.py
+++ b/tests/tracing/test_genai_span_attrs.py
@@ -101,7 +101,7 @@ def test_cli_argv_redacted() -> None:
     redacted = redact_cli_argv(argv)
     assert "sk-secretvalue123" not in redacted
     assert "ghp_abc" not in redacted
-    assert "[REDACTED]" in redacted
+    assert "<redacted>" in redacted
     # The command shape survives.
     assert "mergecraft" in redacted
     assert "diff-review" in redacted

--- a/tests/tracing/test_tool_call_attrs.py
+++ b/tests/tracing/test_tool_call_attrs.py
@@ -42,29 +42,26 @@ Two cross-cutting guarantees pin the new keys:
 
 These tests are RED against the post-T3 + post-T2 tree (the ``trace_id``
 plumbing and the ``provider.call`` parent are landed; T1.1 is the third
-polish PR). The implementation does not yet exist:
+polish PR). The implementation did not exist at RED-suite time:
 
-- ``src/mergecraft/mcp/server.py`` — ``call_attrs`` is not yet enriched
+- ``src/mergecraft/mcp/server.py`` — ``call_attrs`` was not yet enriched
   with ``tool.arguments`` / ``argument_count`` / ``argument_bytes`` /
   ``exit_code`` / ``result_kind`` / ``result_bytes``; the failure path
-  does not yet set ``tool.error_class``.
-- ``src/mergecraft/agents/claude.py`` — ``tool_result`` does not yet set
-  ``tool.exit_code`` / ``tool.output_bytes`` / ``tool.output_kind``.
-- ``src/mergecraft/agents/codex.py`` — ``item.completed`` does not yet
-  set ``tool.exit_code`` / ``tool.input_bytes`` / ``tool.input_keys``.
-- ``src/mergecraft/agents/gemini.py`` — ``tool_result`` does not yet set
-  ``tool.exit_code`` / ``tool.output_bytes`` / ``tool.output_kind``.
-- ``src/mergecraft/agents/_tool_attrs.py`` — the shared
-  ``KNOWN_VERB_TOOLS`` / ``emit_verb_subevent`` module is missing.
-- ``src/mergecraft/tracing/redaction.py`` — ``redact_tool_payload`` is
-  missing.
+  did not yet set ``tool.error_class``.
+- ``src/mergecraft/agents/{claude,codex,gemini}.py`` — driver tool
+  spans did not yet set ``tool.exit_code`` / input/output bytes /
+  ``result_kind``.
+- ``src/mergecraft/tracing/_tool_attrs.py`` — the shared
+  ``KNOWN_VERB_TOOLS`` / ``enrich_tool_request`` /
+  ``enrich_tool_response`` / ``emit_verb_subevent`` module was missing.
+- ``src/mergecraft/tracing/redaction.py`` — ``redact_tool_payload``
+  was missing.
 
-Acceptance (after T1.2 lands): **11 collected; 10 green; 1 xfailed**.
-Test 6 (``test_known_verb_tool_emits_verb_sub_event``) is the single
-xfail — emitting the verb-named child span (``tool.browse`` for
-``tool.name == "browser"``) is the defining T1.2 surface. The xfail
-marker is ``strict=False`` so an unsatisfied xfail never hard-fails the
-suite (the T1.2 impl wave is allowed to turn tests green on touch).
+Acceptance (as shipped): **11 collected; 11 green; 0 xfailed**. Test 6
+(``test_known_verb_tool_emits_verb_sub_event``) is the verb-named
+child-span (``tool.browse`` for ``tool.name == "browser"``) — was the
+sole T1.2 xfail at RED-suite time and was reconciled by the T1
+xfail-cleanup commit (``9021fd1``).
 """
 
 from __future__ import annotations
@@ -131,12 +128,12 @@ def test_mcp_tool_call_span_has_request_attrs(
     sink = MemorySink()
     tracer = Tracer(sink=sink, session_id="mcp-success", run_id="mcp-success-run")
 
-    # The MCP handler binds ``get_tracer_from_settings`` via a lazy
+    # The MCP handler binds ``get_tracer_from_settings`` via a top-level
     # ``from mergecraft.tracing.tracer import get_tracer_from_settings``
-    # inside the request closure. Patch the canonical symbol so the
-    # returned tracer routes every emitted span onto our ``MemorySink``.
+    # import (W4 hoist). Patch the canonical symbol so the returned tracer
+    # routes every emitted span onto our ``MemorySink``.
     monkeypatch.setattr(
-        "mergecraft.tracing.tracer.get_tracer_from_settings",
+        "mergecraft.mcp.server.get_tracer_from_settings",
         lambda _settings: tracer,
     )
 
@@ -215,7 +212,7 @@ def test_mcp_tool_call_span_has_error_attrs(
     sink = MemorySink()
     tracer = Tracer(sink=sink, session_id="mcp-error", run_id="mcp-error-run")
     monkeypatch.setattr(
-        "mergecraft.tracing.tracer.get_tracer_from_settings",
+        "mergecraft.mcp.server.get_tracer_from_settings",
         lambda _settings: tracer,
     )
 


### PR DESCRIPTION
## Summary

Tracing-quality hardening from the post-merge Thermos audit (round 1). Closes:

- **H1**: new `provider_llm_pair` context manager pairs `provider.call` and `llm.call` spans on a shared `parent_span_id`
- **H2**: MCP `tools/call` handler reuses the shared `enrich_tool_request` / `enrich_tool_response` helpers instead of duplicating the attr contract
- **H3**: move `_tool_attrs.py` from `agents/` to `tracing/` so the MCP package no longer reaches into `agents/` for shared helpers
- **H4**: collapse three redacted sentinels to the canonical `REDACTED = "<redacted>"` literal
- **H6**: `tracing/http.py` short-circuits to a true no-op when the caller passes `None` or a `NullTracer`
- **H7**: `agents/opencode.py` no longer constructs a discarded `Tracer`
- **M1**: split the legacy `enrich_tool_call_attrs` helper into open-side `enrich_tool_request` and close-side `enrich_tool_response`
- **M4**: add `active_span_for` helper on the tracer module
- **M6**: add `Span.close()` method mirroring the `NullSpan` no-op

The `claude` / `codex` / `gemini` driver handlers, MCP `tools/call`, and `enrich_tool_response` now share one observable contract; monkeypatch test sites updated to the top-level `mcp.server` symbol path.

## Test plan

- [x] `make lint` clean (ruff + format + loguru-only)
- [x] `make typecheck` clean (mypy strict, 195 source files)
- [x] `uv run pytest tests/tracing/` clean: 172 passed, 10 xfailed
- [x] `uv run pytest tests/ -x --ignore=tests/integration` clean: 1849 passed, 7 skipped, 14 xfailed, 120 xpassed

Diff: 13 files changed, +393 / -274 (rename `_tool_attrs.py` from `agents/` to `tracing/`).

Related: wave plan `.ignorelocal/waves/issues-tracing-sevn-quality-wave-plan.md`.