### PR TITLE
fix(ci): bump trivy-action to v0.36.0 (v0.65.0 release deleted)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -148,7 +148,7 @@ jobs:
           output-file: sbom-analyzers.spdx.json
           upload-artifact: false
       - name: Trivy scan slim
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ needs.build-images.outputs.slim_ref }}
           format: sarif
@@ -157,7 +157,7 @@ jobs:
           exit-code: ${{ steps.gate.outputs.exit_code }}
           ignore-unfixed: true
       - name: Trivy scan analyzers
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ needs.build-images.outputs.analyzers_ref }}
           format: sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   brackets literally. The runtime warning for a missing `[tracing]` extra uses
   `console.print(..., markup=False)` to keep the install command verbatim.
   Test: `test_auth_logfire_help_does_not_emit_unbalanced_backticks`
+- Bump `aquasecurity/trivy-action` from `v0.33.1` to `v0.36.0` (SHA
+  `ed142fd0`). The pinned `v0.33.1` defaults to Trivy `v0.65.0`, whose
+  release tag was deleted from `aquasecurity/trivy`; the action's
+  install script resolves the version from the GitHub API (success) then
+  downloads the asset (HTTP 404), failing the `SBOM + vulnerability scan`
+  job deterministically on every `pre-0.0.1` push since the T1-reconcile
+  commit. `v0.36.0` defaults to Trivy `v0.70.0`, which is still
+  published. Two-line change to `.github/workflows/ci-cd.yml`.
 
 ### Added
 


### PR DESCRIPTION
## Summary

The `SBOM + vulnerability scan` job in `ci-cd.yml` pins `aquasecurity/trivy-action@b6643a29 # v0.33.1`. That action's default Trivy version is `v0.65.0`, whose **release tag was deleted from `aquasecurity/trivy`** (the GitHub API returns `404 Not Found` for `repos/aquasecurity/trivy/releases/tags/v0.65.0`).

The action's install script resolves the version from the API (succeeds — it gets the `v0.65.0` release metadata), then attempts to download the tarball (`https://github.com/aquasecurity/trivy/releases/download/v0.65.0/trivy_0.65.0_Linux-64bit.tar.gz`) and gets **HTTP 404**. The setup step itself fails before any Trivy command runs, so the entire `SBOM + vulnerability scan` job fails deterministically on every push to `pre-0.0.1` since the T1-reconcile commit (`9021fd1`). This affects PRs #147 (W4), #148 (W5), and #149 (W6) — none of which introduced the regression.

**Fix:** bump `aquasecurity/trivy-action` from `v0.33.1` to `v0.36.0` (SHA `ed142fd0`). v0.36.0's default Trivy is `v0.70.0`, which is still published (HTTP 200, 47 MB tarball).

## Reproduction

```bash
$ curl -sL -o /dev/null -w "%{http_code}\n" \
    https://github.com/aquasecurity/trivy/releases/download/v0.65.0/trivy_0.65.0_Linux-64bit.tar.gz
404

$ curl -sL -o /dev/null -w "%{http_code}\n" \
    https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-64bit.tar.gz
200
```

The v0.33.1 action's setup step fails at `##[error]Process completed with exit code 1.` 200ms after `aquasecurity/trivy info found version: 0.65.0` — exactly when the install script's `curl` gets the 404.

## Test plan

- [x] Pre-commit `Conventional Commits` passes
- [x] Diff is 2 lines in `ci-cd.yml` + 8 lines of changelog

## Diff

```text
 .github/workflows/ci-cd.yml | 4 ++--
 CHANGELOG.md                | 8 ++++++++
 2 files changed, 10 insertions(+), 2 deletions(-)
```

Should land before #147 / #148 / #149 so those PRs can merge with a clean SBOM check.