### PR TITLE
security: fail-closed container privilege drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aborts as `configuration_error` instead of silently executing the agent as
   root — previously that degradation was logged at `debug` and the review
   continued. The image build now asserts both are present.
+- Fixed: the privilege drop also rejects the resolved user when its UID/GID is
+  0 — the username is not the security boundary, so `MERGECRAFT_AGENT_USER=root`
+  (or any user mapped to uid 0) can no longer silently run the agent as root
+- Fixed: `prepare_workspace_for_agent` is now guarded at its `main()` call site,
+  so a missing/UID-0 agent user surfaces as `RunOutcome.configuration_error`
+  instead of escaping as an uncaught traceback
 - Trust tier is derived before any repo-controlled git setup or `setupScript`;
   untrusted events skip operator scripts instead of running them first
 - Agent CLI subprocesses receive an explicit credential allowlist — no ambient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Fixed: the agent privilege drop now fails closed. When the action image runs
+  as root and `setpriv` or the `mergecraft` user is unavailable, the run
+  aborts as `configuration_error` instead of silently executing the agent as
+  root — previously that degradation was logged at `debug` and the review
+  continued. The image build now asserts both are present.
 - Trust tier is derived before any repo-controlled git setup or `setupScript`;
   untrusted events skip operator scripts instead of running them first
 - Agent CLI subprocesses receive an explicit credential allowlist — no ambient

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,10 @@ RUN uv sync --frozen --no-dev \
     && rm -f /opt/mergecraft/.venv/lib/python3.14/site-packages/merge_craft-*.dist-info/uv_cache.json \
     && sed -i '/uv_cache\.json/d' \
         /opt/mergecraft/.venv/lib/python3.14/site-packages/merge_craft-*.dist-info/RECORD \
-    && rm -rf /root/.cache/uv /tmp/*
+    && rm -rf /root/.cache/uv /tmp/* \
+    && command -v setpriv >/dev/null \
+    && getent passwd mergecraft >/dev/null \
+    || { echo "FATAL: privilege drop unavailable (setpriv or mergecraft user missing)"; exit 1; }
 
 COPY docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -211,7 +211,19 @@ async def main() -> MainResult:
     ensure_github_workspace_registered()
     workspace = os.environ.get("GITHUB_WORKSPACE", "").strip()
     if workspace:
-        prepare_workspace_for_agent(workspace)
+        # Guard the workspace prep at its call site so a missing/UID-0 agent
+        # user surfaces as a structured ``RunOutcome.configuration_error``
+        # rather than escaping as an uncaught traceback. The outer ``try/except``
+        # below is reached only after this block returns, so we route through
+        # the same classification the outer handler would have used.
+        try:
+            prepare_workspace_for_agent(workspace)
+        except _ConfigurationError as exc:
+            return MainResult(
+                success=False,
+                error=str(exc),
+                outcome=_classify_error_outcome(exc),
+            )
     stop_mcp = None
     github: GitHubClient | None = None
     token_ref = None

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -2,9 +2,12 @@
 
 When the action image runs as root the agent subprocess must drop to the
 unprivileged ``mergecraft`` user via ``setpriv``. If the boundary is missing
-(``setpriv`` not on PATH, or the user not in the passwd database) the run
-aborts as a configuration error rather than silently executing the agent as
-root — that fallback is the F4' defect and it must not regress.
+(``setpriv`` not on PATH, the user not in the passwd database, or the resolved
+user has UID/GID 0) the run aborts as a configuration error rather than
+silently executing the agent as root — that fallback is the F4' defect and it
+must not regress. UID/GID 0 is the security boundary, not the username: a
+configured user that happens to resolve to ``root`` would still spawn the
+agent as root.
 """
 
 from __future__ import annotations
@@ -49,7 +52,10 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
 
     Fails closed with ``main._ConfigurationError`` if ``setpriv`` or the agent
     user is unavailable — never silently returns the unwrapped command (the
-    F4' fail-open default this contract replaces).
+    F4' fail-open default this contract replaces). Resolves the user record via
+    ``pwd.getpwnam`` and additionally rejects UID/GID 0 — the username is not
+    the security boundary; a configured user that happens to resolve to ``root``
+    would still spawn the agent as root, defeating the privilege drop.
     """
     if os.getuid() != 0:
         return list(cmd)
@@ -67,18 +73,8 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
     try:
         import pwd
 
-        pwd.getpwnam(user)
-    except (ImportError, KeyError) as exc:
-        if isinstance(exc, KeyError):
-            logger.error(
-                "agent user {!r} is not in /etc/passwd; refusing to run the agent "
-                "subprocess as root — Dockerfile must useradd this uid before shipping",
-                user,
-            )
-            raise _raise_configuration_error(
-                f"agent user {user!r} does not exist in /etc/passwd inside the action "
-                f"image; the privilege drop cannot land and the run cannot proceed as root"
-            ) from exc
+        entry = pwd.getpwnam(user)
+    except ImportError as exc:
         # ``ImportError`` on a non-POSIX platform — the action image is Linux,
         # so this branch cannot fire there; surface as a config error rather than
         # silently continuing, since it would otherwise look identical to the
@@ -87,6 +83,29 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
         raise _raise_configuration_error(
             f"pwd module unavailable; cannot verify agent user {user!r} on this platform"
         ) from exc
+    except KeyError as exc:
+        logger.error(
+            "agent user {!r} is not in /etc/passwd; refusing to run the agent "
+            "subprocess as root — Dockerfile must useradd this uid before shipping",
+            user,
+        )
+        raise _raise_configuration_error(
+            f"agent user {user!r} does not exist in /etc/passwd inside the action "
+            f"image; the privilege drop cannot land and the run cannot proceed as root"
+        ) from exc
+    if entry.pw_uid == 0 or entry.pw_gid == 0:
+        logger.error(
+            "agent user {!r} resolves to uid={} gid={}; refusing to run the agent "
+            "subprocess as root — privilege drop requires a non-zero uid/gid",
+            entry.pw_name,
+            entry.pw_uid,
+            entry.pw_gid,
+        )
+        raise _raise_configuration_error(
+            f"agent user {entry.pw_name!r} resolves to uid={entry.pw_uid} gid={entry.pw_gid} "
+            f"inside the action image; the privilege drop cannot land onto a root account "
+            f"and the run cannot proceed"
+        )
     return ["setpriv", f"--reuid={user}", f"--regid={user}", "--init-groups", *cmd]
 
 
@@ -98,7 +117,10 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     ``pwd`` module **is** importable but the user genuinely does not exist, the
     run fails closed as a configuration error — the previous
     ``except (ImportError, KeyError): return`` collapsed the two and let a
-    missing user pass silently.
+    missing user pass silently. Resolves the user record and additionally
+    rejects UID/GID 0: a configured user that maps to ``root`` would still
+    leave the chown at uid 0, which is not the privilege drop this helper
+    exists to perform.
     """
     if os.getuid() != 0:
         return
@@ -120,6 +142,19 @@ def prepare_workspace_for_agent(workspace: str) -> None:
             f"agent user {user!r} does not exist in /etc/passwd inside the action image; "
             f"prepare_workspace_for_agent cannot chown {workspace!r} for the privilege drop"
         ) from exc
+    if pw.pw_uid == 0 or pw.pw_gid == 0:
+        logger.error(
+            "agent user {!r} resolves to uid={} gid={}; refusing to chown the workspace "
+            "for a root account — privilege drop requires a non-zero uid/gid",
+            pw.pw_name,
+            pw.pw_uid,
+            pw.pw_gid,
+        )
+        raise _raise_configuration_error(
+            f"agent user {pw.pw_name!r} resolves to uid={pw.pw_uid} gid={pw.pw_gid} "
+            f"inside the action image; prepare_workspace_for_agent cannot chown "
+            f"{workspace!r} onto a root account"
+        )
     target = workspace.strip()
     if not target:
         return

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -1,14 +1,28 @@
-"""Drop agent subprocess privileges while keeping the action entrypoint root (W3.4)."""
+"""Drop agent subprocess privileges while keeping the action entrypoint root (W3.4).
+
+When the action image runs as root the agent subprocess must drop to the
+unprivileged ``mergecraft`` user via ``setpriv``. If the boundary is missing
+(``setpriv`` not on PATH, or the user not in the passwd database) the run
+aborts as a configuration error rather than silently executing the agent as
+root — that fallback is the F4' defect and it must not regress.
+"""
 
 from __future__ import annotations
 
 import os
 import shutil
 import subprocess
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
 _DEFAULT_AGENT_USER = "mergecraft"
+
+if TYPE_CHECKING:
+    # Imported lazily inside the failure paths to avoid a circular import:
+    # ``mergecraft.main`` already imports ``prepare_workspace_for_agent`` from
+    # this module, so the class symbol is looked up at raise-time only.
+    from mergecraft.main import _ConfigurationError
 
 
 def agent_user_name() -> str:
@@ -17,19 +31,75 @@ def agent_user_name() -> str:
     )
 
 
+def _raise_configuration_error(message: str) -> _ConfigurationError:
+    """Return a ``main._ConfigurationError`` instance, importing lazily.
+
+    The deferred import keeps the dependency direction one-way
+    (``main`` → ``utils``) while letting the failure surface the same
+    exception type ``_classify_error_outcome`` already maps to
+    ``RunOutcome.configuration_error``.
+    """
+    from mergecraft.main import _ConfigurationError
+
+    return _ConfigurationError(message)
+
+
 def wrap_agent_command(cmd: list[str]) -> list[str]:
-    """Prefix ``cmd`` with ``setpriv`` when running as root in the action image."""
+    """Prefix ``cmd`` with ``setpriv`` when running as root in the action image.
+
+    Fails closed with ``main._ConfigurationError`` if ``setpriv`` or the agent
+    user is unavailable — never silently returns the unwrapped command (the
+    F4' fail-open default this contract replaces).
+    """
     if os.getuid() != 0:
         return list(cmd)
     user = agent_user_name()
     if shutil.which("setpriv") is None:
-        logger.debug("setpriv unavailable; agent subprocess runs as uid {}", os.getuid())
-        return list(cmd)
+        logger.error(
+            "setpriv unavailable on PATH; refusing to run the agent subprocess as root "
+            "(uid={}) — image must ship setpriv so the privilege drop can land",
+            os.getuid(),
+        )
+        raise _raise_configuration_error(
+            "setpriv is not on PATH inside the action image; the agent privilege drop "
+            "is unavailable and the run cannot proceed as root"
+        )
+    try:
+        import pwd
+
+        pwd.getpwnam(user)
+    except (ImportError, KeyError) as exc:
+        if isinstance(exc, KeyError):
+            logger.error(
+                "agent user {!r} is not in /etc/passwd; refusing to run the agent "
+                "subprocess as root — Dockerfile must useradd this uid before shipping",
+                user,
+            )
+            raise _raise_configuration_error(
+                f"agent user {user!r} does not exist in /etc/passwd inside the action "
+                f"image; the privilege drop cannot land and the run cannot proceed as root"
+            ) from exc
+        # ``ImportError`` on a non-POSIX platform — the action image is Linux,
+        # so this branch cannot fire there; surface as a config error rather than
+        # silently continuing, since it would otherwise look identical to the
+        # fail-open case to anyone reading logs.
+        logger.error("pwd module unavailable; cannot verify agent user {} on this platform", user)
+        raise _raise_configuration_error(
+            f"pwd module unavailable; cannot verify agent user {user!r} on this platform"
+        ) from exc
     return ["setpriv", f"--reuid={user}", f"--regid={user}", "--init-groups", *cmd]
 
 
 def prepare_workspace_for_agent(workspace: str) -> None:
-    """``chown`` the checkout workspace so the unprivileged agent user can operate (W3.4)."""
+    """``chown`` the checkout workspace so the unprivileged agent user can operate (W3.4).
+
+    On non-POSIX hosts (where ``pwd`` cannot be imported at all) the action
+    image cannot be running, so the missing-user branch is silent. When the
+    ``pwd`` module **is** importable but the user genuinely does not exist, the
+    run fails closed as a configuration error — the previous
+    ``except (ImportError, KeyError): return`` collapsed the two and let a
+    missing user pass silently.
+    """
     if os.getuid() != 0:
         return
     user = agent_user_name()
@@ -37,9 +107,19 @@ def prepare_workspace_for_agent(workspace: str) -> None:
         import pwd
 
         pw = pwd.getpwnam(user)
-    except ImportError, KeyError:
-        logger.debug("agent user {!r} not found; skipping workspace chown", user)
+    except ImportError:
+        logger.debug("pwd module unavailable; skipping workspace chown on this platform")
         return
+    except KeyError as exc:
+        logger.error(
+            "agent user {!r} is not in /etc/passwd; cannot chown the workspace for the "
+            "privilege drop — aborting instead of running the agent as root",
+            user,
+        )
+        raise _raise_configuration_error(
+            f"agent user {user!r} does not exist in /etc/passwd inside the action image; "
+            f"prepare_workspace_for_agent cannot chown {workspace!r} for the privilege drop"
+        ) from exc
     target = workspace.strip()
     if not target:
         return

--- a/tests/security/test_privilege_fail_closed.py
+++ b/tests/security/test_privilege_fail_closed.py
@@ -1,0 +1,324 @@
+"""PR S2 — privilege drop fails closed when the boundary is unavailable.
+
+Contracts:
+
+- When the action runs as root inside the image, the agent subprocess must drop
+  to the unprivileged ``mergecraft`` user via ``setpriv``. If either
+  ``setpriv`` or the agent user is missing, the run must abort as a
+  configuration error — silently executing the agent as root would silently
+  disable the security boundary (F4').
+- The build image must itself refuse to build when either artifact is absent
+  (D11), so a tampered image never reaches a runner.
+- Non-root invocations must continue to work unchanged (D12); the boundary only
+  applies inside the action image.
+
+These tests run as non-root in CI; the root path is simulated by monkeypatching
+``os.getuid``, ``shutil.which``, and ``pwd.getpwnam`` — never by adding a
+production-side test hook (convention 10).
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import shutil
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from mergecraft.main import _classify_error_outcome, _ConfigurationError
+from mergecraft.run_outcome import RunOutcome
+from mergecraft.utils import privilege
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "Dockerfile"
+
+
+class _FakePwnam:
+    """Stand-in for ``pwd.struct_passwd`` carrying only the fields the code reads."""
+
+    def __init__(self, pw_name: str, pw_uid: int = 10001, pw_gid: int = 10001) -> None:
+        self.pw_name = pw_name
+        self.pw_uid = pw_uid
+        self.pw_gid = pw_gid
+
+
+def _force_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every branch in ``wrap_agent_command``/``prepare_workspace_for_agent``
+    see the action-image root path, regardless of the host's real uid."""
+    monkeypatch.setattr(os, "getuid", lambda: 0)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_user_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``agent_user_name`` deterministic across tests — the default unless a
+    specific case overrides it. ``monkeypatch`` is autouse so the env var never
+    leaks across tests."""
+    monkeypatch.delenv("MERGECRAFT_AGENT_USER", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# wrap_agent_command
+# ---------------------------------------------------------------------------
+
+
+def test_root_without_setpriv_raises_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root + no ``setpriv`` on PATH → abort, not an unwrapped command."""
+    # Arrange — pretend we're root, and that setpriv does not exist anywhere on PATH.
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: None if name == "setpriv" else f"/usr/bin/{name}"
+    )
+
+    # Act + Assert — the boundary has to fail closed as the same exception type
+    # ``main._classify_error_outcome`` maps to ``RunOutcome.configuration_error``.
+    with pytest.raises(_ConfigurationError, match="setpriv"):
+        privilege.wrap_agent_command(["claude", "--help"])
+
+
+def test_root_without_agent_user_raises_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setpriv`` present but the agent user missing → abort at the wrap site,
+    not at ``prepare_workspace_for_agent`` further down."""
+    # Arrange — root + setpriv available, but the user does not exist.
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+
+    def _raise_keyerror(_name: str) -> _FakePwnam:
+        raise KeyError(_name)
+
+    monkeypatch.setattr(pwd, "getpwnam", _raise_keyerror)
+
+    # Act + Assert — fail closed with the configuration-error type.
+    with pytest.raises(_ConfigurationError, match="mergecraft"):
+        privilege.wrap_agent_command(["claude", "--help"])
+
+
+def test_root_with_setpriv_and_user_wraps_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy-path pin: argv must be exactly the ``setpriv`` invocation contract.
+
+    Fails if any flag regresses (e.g. ``--reuid`` dropped, ``--init-groups``
+    removed) or if the drop stops happening on the root path.
+    """
+    # Arrange — root + setpriv + the mergecraft user all resolve cleanly.
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+    monkeypatch.setattr(pwd, "getpwnam", lambda _name: _FakePwnam(_name))
+
+    # Act
+    wrapped = privilege.wrap_agent_command(["claude", "--help"])
+
+    # Assert — pin the exact argv shape; any drift here is a regression on the
+    # privilege drop contract (the verifier reads uid from inside the child).
+    assert wrapped == [
+        "setpriv",
+        "--reuid=mergecraft",
+        "--regid=mergecraft",
+        "--init-groups",
+        "claude",
+        "--help",
+    ]
+
+
+def test_non_root_returns_command_unwrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D12 — outside the action image, ``wrap_agent_command`` is a no-op even
+    if the rest of the boundary tools happen to exist (a developer running
+    ``mergecraft diff-review`` on a workstation)."""
+    # Arrange — non-root, but setpriv *is* available, so we know the function
+    # short-circuited before reaching the wrap branch.
+    monkeypatch.setattr(os, "getuid", lambda: 1000)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+
+    # Act
+    out = privilege.wrap_agent_command(["claude", "--help"])
+
+    # Assert — unchanged argv, no raise, no list aliasing.
+    assert out == ["claude", "--help"]
+
+
+def test_custom_agent_user_via_env_is_honoured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``MERGECRAFT_AGENT_USER`` is respected on the happy path; a nonexistent
+    custom user still fails closed at the wrap site."""
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+
+    # Case 1: env var honoured.
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "reviewer")
+    monkeypatch.setattr(pwd, "getpwnam", lambda name: _FakePwnam(name))
+    wrapped = privilege.wrap_agent_command(["claude", "--help"])
+    assert wrapped[1] == "--reuid=reviewer"
+    assert wrapped[2] == "--regid=reviewer"
+
+    # Case 2: env var names a user that doesn't exist → fail closed.
+    monkeypatch.setattr(pwd, "getpwnam", lambda _name: (_ for _ in ()).throw(KeyError(_name)))
+    with pytest.raises(_ConfigurationError, match="reviewer"):
+        privilege.wrap_agent_command(["claude", "--help"])
+
+
+def test_failure_is_logged_at_error_not_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the drop is unavailable, the log record must be ``ERROR`` — the old
+    ``debug`` log line is exactly what let the failure pass unnoticed."""
+    # Arrange — root + no setpriv, so the failure path runs.
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: None if name == "setpriv" else f"/usr/bin/{name}"
+    )
+
+    records: list[tuple[str, str]] = []
+
+    def _capture(record: object) -> None:
+        entry = record.record  # type: ignore[attr-defined]
+        records.append((entry["level"].name, entry["message"]))
+
+    sink_id = logger.add(_capture, level="DEBUG")
+    try:
+        with pytest.raises(_ConfigurationError):
+            privilege.wrap_agent_command(["claude", "--help"])
+    finally:
+        logger.remove(sink_id)
+
+    # Assert — at least one ERROR record, and nothing dropped the failure at DEBUG.
+    error_records = [msg for level, msg in records if level == "ERROR"]
+    assert error_records, "privilege-drop failure must log at ERROR, got: " + ", ".join(
+        f"{lvl}:{msg!r}" for lvl, msg in records
+    )
+    debug_records = [msg for level, msg in records if level == "DEBUG"]
+    assert not any("setpriv" in m.lower() for m in debug_records), (
+        "the old debug line for setpriv absence must be gone: " + ", ".join(debug_records)
+    )
+
+
+# ---------------------------------------------------------------------------
+# prepare_workspace_for_agent
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_workspace_missing_user_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When running as root, the silently-``return`` branch at the old
+    ``except ImportError, KeyError:`` must be split: ``KeyError`` is a real
+    failure and must raise the configuration-error type. ``ImportError`` on
+    ``pwd`` (non-POSIX) is the one we still tolerate."""
+    _force_root(monkeypatch)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    # Case 1 — KeyError on getpwnam: must raise, not silently return.
+    def _raise_keyerror(_name: str) -> _FakePwnam:
+        raise KeyError(_name)
+
+    monkeypatch.setattr(pwd, "getpwnam", _raise_keyerror)
+    with pytest.raises(_ConfigurationError, match="mergecraft"):
+        privilege.prepare_workspace_for_agent(str(workspace))
+
+    # Case 2 — ImportError on the pwd import: non-POSIX host, action image
+    # cannot be running here; the legacy silent-return behaviour is preserved.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _import_blocking_pwd(name: str, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        if name == "pwd":
+            raise ImportError("pwd unavailable on this platform")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import_blocking_pwd)
+    # Should not raise.
+    privilege.prepare_workspace_for_agent(str(workspace))
+
+
+# ---------------------------------------------------------------------------
+# main._classify_error_outcome wires the abort into the right outcome bucket
+# ---------------------------------------------------------------------------
+
+
+def test_abort_maps_to_configuration_error_outcome() -> None:
+    """The ``_ConfigurationError`` raised by ``wrap_agent_command`` must reach
+    ``_classify_error_outcome`` as ``RunOutcome.configuration_error``, so the
+    GitHub check conclusion is ``neutral`` rather than an uncaught crash."""
+    outcome = _classify_error_outcome(_ConfigurationError("setpriv unavailable"))
+    assert outcome is RunOutcome.configuration_error
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile build-time assertion (D11)
+# ---------------------------------------------------------------------------
+
+
+def _dockerfile_run_lines(dockerfile_text: str) -> list[str]:
+    """Concatenate every ``RUN`` instruction body in source order.
+
+    The Dockerfile uses line-continuation backslashes inside ``RUN``, so a
+    naive split-on-``\n`` will fragment the body. This walks the file once,
+    tracking line continuations, and returns the joined instruction body for
+    each ``RUN`` line. Comment-only lines (``#``) inside a ``RUN`` survive the
+    parse because they are not stripped by the Dockerfile parser either —
+    what matters for the assertion is that the **tokens** ``command``,
+    ``getent``, and ``mergecraft`` appear together in at least one ``RUN``.
+    """
+    bodies: list[str] = []
+    buffer: list[str] = []
+    in_run = False
+    for raw in dockerfile_text.splitlines():
+        stripped = raw.strip()
+        if in_run:
+            buffer.append(raw)
+            if stripped.endswith("\\"):
+                continue
+            bodies.append("\n".join(buffer))
+            buffer = []
+            in_run = False
+            continue
+        if stripped.startswith("RUN "):
+            buffer = [raw]
+            in_run = True
+            if stripped.endswith("\\"):
+                continue
+            bodies.append(raw)
+            buffer = []
+            in_run = False
+    # Flush a trailing unterminated continuation, in case the file ends mid-RUN.
+    if in_run and buffer:
+        bodies.append("\n".join(buffer))
+    return bodies
+
+
+def test_dockerfile_asserts_setpriv_and_agent_user() -> None:
+    """D11 — the image must refuse to build when ``setpriv`` or the agent user
+    is missing. The assertion is parsed out of the ``RUN`` instruction set, not
+    string-matched against a comment, so reformatting comments cannot silently
+    regress the contract."""
+    assert _DOCKERFILE.exists(), f"missing {_DOCKERFILE}"
+    text = _DOCKERFILE.read_text(encoding="utf-8")
+    run_bodies = _dockerfile_run_lines(text)
+
+    matching = [
+        body
+        for body in run_bodies
+        if "setpriv" in body and "mergecraft" in body and "exit 1" in body
+    ]
+    assert matching, (
+        "Dockerfile must contain a RUN instruction that asserts setpriv + "
+        "mergecraft user are present and exits 1 otherwise; none found."
+    )

--- a/tests/security/test_privilege_fail_closed.py
+++ b/tests/security/test_privilege_fail_closed.py
@@ -209,6 +209,66 @@ def test_failure_is_logged_at_error_not_debug(
 
 
 # ---------------------------------------------------------------------------
+# UID 0 reject — fail closed when the resolved user has UID/GID 0
+# ---------------------------------------------------------------------------
+
+
+def test_root_user_rejected_by_uid_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pwd.getpwnam`` returning ``pw_uid=0``/``pw_gid=0`` is a fail-open hole:
+    ``setpriv --reuid=root`` would run the agent as root, defeating the drop.
+    The username is not the security boundary — the UID is — so a record whose
+    ``pw_name`` is anything (including ``root``) but whose ``pw_uid`` is 0
+    must be rejected with a message that names the UID, not just "user missing".
+    """
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+    monkeypatch.setattr(pwd, "getpwnam", lambda name: _FakePwnam(name, pw_uid=0, pw_gid=0))
+
+    with pytest.raises(_ConfigurationError, match="uid=0"):
+        privilege.wrap_agent_command(["claude", "--help"])
+
+
+def test_zero_uid_rejected_even_when_username_is_not_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured user named anything but ``root`` that happens to resolve to
+    UID 0 must still be rejected. The username is a hint; the UID is the
+    boundary. Without this check, a misconfigured image that maps e.g.
+    ``reviewer`` to ``uid=0`` would silently run the agent as root.
+    """
+    _force_root(monkeypatch)
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/setpriv" if name == "setpriv" else None
+    )
+    monkeypatch.setattr(pwd, "getpwnam", lambda _name: _FakePwnam("notroot", pw_uid=0, pw_gid=0))
+
+    with pytest.raises(_ConfigurationError, match="notroot"):
+        privilege.wrap_agent_command(["claude", "--help"])
+
+
+def test_zero_uid_rejected_in_prepare_workspace_too(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The same UID 0 check must guard ``prepare_workspace_for_agent`` —
+    otherwise the chown helper would silently ``chown -R … 0:0 …`` and the
+    agent process would land on a root-owned workspace. The guard at the wrap
+    site is not enough; both call sites must fail closed.
+    """
+    _force_root(monkeypatch)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    monkeypatch.setattr(pwd, "getpwnam", lambda name: _FakePwnam(name, pw_uid=0, pw_gid=0))
+
+    with pytest.raises(_ConfigurationError, match="uid=0"):
+        privilege.prepare_workspace_for_agent(str(workspace))
+
+
+# ---------------------------------------------------------------------------
 # prepare_workspace_for_agent
 # ---------------------------------------------------------------------------
 

--- a/tests/test_run_outcome.py
+++ b/tests/test_run_outcome.py
@@ -170,6 +170,55 @@ async def test_configuration_error_outcome_on_bad_timeout(
     assert getattr(rec.result, "outcome", None) == run_outcome_cls.configuration_error
 
 
+async def test_configuration_error_outcome_on_uid_zero_agent_user(
+    run_outcome_cls: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """N2 — ``prepare_workspace_for_agent`` runs ahead of the outer
+    ``try/except`` in ``main()``. Without an explicit guard the missing-user /
+    UID-0 failure escapes as an uncaught traceback instead of landing in
+    ``RunOutcome.configuration_error``. Drives the real ``main()`` with the
+    agent user resolving to UID/GID 0 and asserts the structured outcome plus
+    a clean (non-raised) return.
+    """
+    import os as _os
+    import pwd as _pwd
+
+    import mergecraft.utils.privilege as privilege_mod
+
+    # Force the root path so ``prepare_workspace_for_agent`` is exercised and
+    # patch ``pwd.getpwnam`` so the agent user resolves to UID/GID 0 — the
+    # hole the N1 fix plugs.
+    monkeypatch.setattr(_os, "getuid", lambda: 0)
+    monkeypatch.setattr(
+        privilege_mod.pwd if hasattr(privilege_mod, "pwd") else _pwd,
+        "getpwnam",
+        lambda _name: type(
+            "_Pw",
+            (),
+            {"pw_name": "root", "pw_uid": 0, "pw_gid": 0},
+        )(),
+    )
+
+    rec = await run_main_for_test(monkeypatch=monkeypatch, tmp_path=tmp_path)
+
+    # The exception must NOT escape ``main()`` — the bug fixed in N2 was that
+    # the call ran outside the outer handler.
+    assert rec.raised is None, (
+        f"_ConfigurationError escaped main(): {rec.raised!r}; main() must guard "
+        f"prepare_workspace_for_agent at its call site"
+    )
+    assert rec.result is not None
+    assert not rec.result.success
+    outcome = getattr(rec.result, "outcome", None)
+    assert outcome == run_outcome_cls.configuration_error, (
+        f"UID-0 agent user mapped to {outcome!r}; must be configuration_error so "
+        f"the GitHub check concludes neutral rather than crashing the runner"
+    )
+    # Structured failure reason — the operator needs to know *what* failed,
+    # not just that it failed.
+    assert rec.result.error, "structured failure reason must be carried on MainResult.error"
+
+
 async def test_inconclusive_outcome_on_prep_failure(
     run_outcome_cls: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/utils/test_privilege.py
+++ b/tests/utils/test_privilege.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import pytest
+
 import mergecraft.utils.privilege as privilege
 from mergecraft.agents.shared import wrap_agent_subprocess
 from mergecraft.utils.privilege import (
@@ -47,6 +49,15 @@ def test_wrap_agent_command_prefixes_setpriv_when_root(
     Fails if the privilege drop is deleted: returned argv equals the bare cmd.
     Runtime UID≠0 proof stays deferred to W11 in-image; this pins structure.
     """
+    import sys
+
+    class _Pw:
+        pw_uid = 1001
+        pw_gid = 1001
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
     monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
     monkeypatch.setattr(privilege.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
@@ -61,11 +72,18 @@ def test_wrap_agent_command_prefixes_setpriv_when_root(
 def test_wrap_agent_command_skips_setpriv_when_missing(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """Direct ``wrap_agent_command`` — root without setpriv returns bare cmd."""
+    """Direct ``wrap_agent_command`` — root without setpriv fails closed (F4' fix).
+
+    Previously this test pinned the fail-open default (returning the bare
+    command so the agent ran as root). S2 inverts that: a missing ``setpriv``
+    is now a configuration error, surfaced via ``main._ConfigurationError``.
+    """
+    from mergecraft.main import _ConfigurationError
+
     monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
     monkeypatch.setattr(privilege.shutil, "which", lambda _name: None)
-    cmd = ["gemini", "run"]
-    assert wrap_agent_command(cmd) == cmd
+    with pytest.raises(_ConfigurationError, match="setpriv"):
+        wrap_agent_command(["gemini", "run"])
 
 
 def test_wrap_agent_subprocess_delegates_to_wrap_agent_command(
@@ -75,6 +93,15 @@ def test_wrap_agent_subprocess_delegates_to_wrap_agent_command(
 
     Fails if the shared wrapper is deleted or bypasses ``wrap_agent_command``.
     """
+    import sys
+
+    class _Pw:
+        pw_uid = 1001
+        pw_gid = 1001
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
     monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
     monkeypatch.setattr(privilege.shutil, "which", lambda name: f"/usr/bin/{name}")
     wrapped = wrap_agent_subprocess(["opencode", "serve"])

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.409" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
@@ -1160,7 +1160,7 @@ requires-dist = [
     { name = "typer", specifier = "==0.25.1" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20251011" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = "==4.25.1.20250822" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "==6.0.12.20260510" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "==6.0.12.20260724" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
 provides-extras = ["harbor", "tracing", "dev"]
@@ -1732,15 +1732,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -2379,11 +2379,11 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260510"
+version = "6.0.12.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Makes the container privilege boundary fail closed by aborting when root cannot drop to the configured agent user and asserts `setpriv` and user availability during the image build.

## Wave-plan section

- Wave: S2
- Plan: `.ignorelocal/waves/issues-setup-container-hygiene-wave-plan.md`
- Branch: `wave/rfc-s2-privilege` @ `10e02c8`

## Test additions

- `tests/security/test_privilege_fail_closed.py`: root, `setpriv`, agent-user, custom-user, logging, workspace-preparation, outcome, and Dockerfile assertion coverage.
- `tests/utils/test_privilege.py`: updated privilege-drop regression coverage.

## Audit status

- Thermos code-quality: NO_ISSUES on integration branch `wave/integration-s1-s5` (includes this PR's changes)
- Thermos branch audit: NO_ISSUES
- Full non-analyzer suite: 1400 passed
- `make ci-static`: clean
