### PR TITLE
config: strict (extra=forbid) _OPTIONAL_FEATURE parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unparseable Action `timeout` input fails closed as `configuration_error`
   (keep `--notimeout` to disable); dependency-install failure maps the run to
   `inconclusive` rather than a silent continue
+- Changed: unknown keys in optional-feature config blocks (`staticChecks`,
+  `ciEvidence`, custom mode definitions, tracing sink entries) are now
+  configuration errors instead of being silently ignored — the one-release
+  warning shim has ended. Security and runtime blocks were already strict.
+  A syntactically broken `.mergecraft/config.yaml` still falls back to
+  defaults.
 - Tracing `enabled` is tri-state (`true` / `false` / unset); Action
   `tracing` input no longer collapses unset to false, and is wired into the
   live Action path (input > env > YAML > default)

--- a/docs/config-failure-policy.md
+++ b/docs/config-failure-policy.md
@@ -19,6 +19,7 @@ Surfaces in this class (Pydantic `extra="forbid"`):
 | `GatesSettings` | Gate mode / override vocabulary |
 | `AnalyzersSettings` | Analyzer enablement and trust-adjacent toggles |
 | `TracingSettings` | Whether reviewed-repo content may leave the runner |
+| Optional-feature blocks (`StaticCheckDefinition`, `CiEvidenceSettings`, `ModeDefinition`, `TraceSinkEntry`) | **Flipped to `forbid` at pre-0.0.1 (D8).** The one-release warning shim has ended — an unknown key now fails closed the same way the security/runtime blocks do, so a typo on a `staticChecks` / `ciEvidence` / `modes` / `tracing.sinks` entry aborts instead of silently dropping |
 
 Invalid enum values on `push` / `shell`, unknown keys on those models, and
 unparseable Action inputs that drive runtime (`timeout`) all fail closed.
@@ -36,8 +37,7 @@ Examples:
 
 | Surface | Behaviour |
 |---------|-----------|
-| Syntactically broken `.mergecraft/config.yaml` | Warn, fall back to `default_settings()` |
-| Nested informational blocks (`staticChecks`, `ciEvidence`, mode defs, sink entries, …) | Unknown keys warn for one release (`extra="ignore"` + warning shim), then flip to `forbid` |
+| Syntactically broken `.mergecraft/config.yaml` | Warn, fall back to `default_settings()` (D9 — broken YAML is **not** fail-closed) |
 | Trusted-tier `setupScript` non-zero exit | Warn-only; the run continues (untrusted tiers never execute it — trust ordering) |
 | Learnings seed / bundled-skills install failure | Warn and continue without that feature |
 

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -24,15 +24,21 @@ from mergecraft.types import PushPermission, ShellPermission  # noqa: TC001
 AccountPlan = Literal["none", "payg"]
 HeadingDepth = Literal[1, 2, 3, 4, 5, 6]
 
-# D4 / W6.2 — security/runtime models use ``extra="forbid"``; optional-feature
-# models keep ``extra="ignore"`` for one release with a warning shim. See
-# ``docs/config-failure-policy.md``.
+# D4 / D8 / W6.2 — security/runtime and optional-feature models both use
+# ``extra="forbid"``. The optional-feature one-release warning shim has ended
+# (D8 flipped at pre-0.0.1; see ``docs/config-failure-policy.md``).
 _SECURITY_RUNTIME_EXTRA: Literal["forbid"] = "forbid"
-_OPTIONAL_FEATURE_EXTRA: Literal["ignore"] = "ignore"
+_OPTIONAL_FEATURE_EXTRA: Literal["forbid"] = "forbid"
 
 
 def _warn_unknown_config_keys(model_name: str, data: object, fields: dict[str, Any]) -> object:
-    """Warn on unknown keys for optional-feature models (D4 one-release shim)."""
+    """Warn on unknown keys for optional-feature models (D4 one-release shim).
+
+    The shim was retired in D8 (``_OPTIONAL_FEATURE_EXTRA = "forbid"``); the
+    helper is preserved as a direct symbol anchor for tests that still assert
+    it warns when called, and as a fallback for any future caller that wants
+    to surface a soft warning before raising.
+    """
     if not isinstance(data, dict):
         return data
     known: set[str] = set()
@@ -53,14 +59,9 @@ def _warn_unknown_config_keys(model_name: str, data: object, fields: dict[str, A
 
 
 class _OptionalFeatureModel(BaseModel):
-    """Optional-feature config models: ``extra="ignore"`` + unknown-key warning."""
+    """Optional-feature config models: ``extra="forbid"`` (D8)."""
 
     model_config = ConfigDict(extra=_OPTIONAL_FEATURE_EXTRA, populate_by_name=True)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _warn_extras(cls, data: object) -> object:
-        return _warn_unknown_config_keys(cls.__name__, data, cls.model_fields)
 
 
 class ModeDefinition(_OptionalFeatureModel):

--- a/tests/config/test_extra_forbid.py
+++ b/tests/config/test_extra_forbid.py
@@ -1,13 +1,18 @@
-"""Plan W6.2 — ``extra="forbid"`` on security/runtime settings models (D4, ``#16``).
+"""Plan W6.2 — ``extra="forbid"`` on settings models (D4, D8, ``#16``).
 
 Contracts:
 
 - Security/runtime settings models reject unknown keys with an *actionable*
   error naming the offending key (fail closed).
-- Non-security surfaces keep ``ignore`` + warning for one release (D4), so
-  this suite pins the flip per-model: ``RepoSettings`` and the nested
-  security/runtime blocks must forbid; purely informational blocks are
-  asserted separately in ``test_config_failure_policy.py``.
+- Optional-feature settings models also reject unknown keys (D8; the
+  one-release warning shim has ended). The strict policy for the
+  optional-feature blocks (``staticChecks``, ``ciEvidence``, custom mode
+  definitions, tracing sink entries) is asserted separately in
+  ``test_optional_feature_strictness.py``.
+- The historical warn-shim helper ``_warn_unknown_config_keys`` remains
+  importable as a symbol anchor — direct calls still warn — but it is no
+  longer wired into the model-validator path. This suite pins that
+  contract so the helper cannot be silently deleted or repurposed.
 """
 
 from __future__ import annotations
@@ -79,23 +84,24 @@ def test_load_repo_settings_fails_closed_on_unknown_key(tmp_path) -> None:
 
 
 def test_warn_unknown_config_keys_logs_for_optional_models() -> None:
-    """W6.2 / D4 — optional-feature models warn on unknown keys (one-release shim).
+    """W6.2 / D4 / D8 — ``_warn_unknown_config_keys`` warns when called directly.
 
-    Direct coverage for ``_warn_unknown_config_keys``: deleting the shim (or
-    switching optional models to silent ``extra="ignore"`` without a warning)
-    must break this test.
+    The shim was retired in D8 (``_OPTIONAL_FEATURE_EXTRA = "forbid"``), so
+    the model-validator path no longer calls this helper — that policy is
+    pinned separately by
+    ``tests/config/test_optional_feature_strictness.py``. This test keeps the
+    helper anchored as an importable symbol: deleting the function (or
+    silently swallowing its log call) must break this test.
     """
     messages: list[str] = []
     sink_id = logger.add(lambda record: messages.append(record.record["message"]), level="WARNING")
     try:
-        # Call the helper directly (symbol anchor).
+        # Direct symbol anchor — only this path still applies post-D8.
         _warn_unknown_config_keys(
             "ModeDefinition",
             {"id": "x", "name": "n", "description": "d", "mysteryKey": 1},
             ModeDefinition.model_fields,
         )
-        # And through the model validator path operators actually hit.
-        ModeDefinition.model_validate({"id": "x", "name": "n", "description": "d", "mysteryKey": 1})
     finally:
         logger.remove(sink_id)
     joined = "\n".join(messages)

--- a/tests/config/test_optional_feature_strictness.py
+++ b/tests/config/test_optional_feature_strictness.py
@@ -1,0 +1,253 @@
+"""Plan W6.3 — ``extra="forbid"`` on optional-feature config models (D8, F5).
+
+Contracts (D8, D9):
+
+- Optional-feature config models reject unknown keys with a
+  ``ValidationError`` — same fail-closed posture as security/runtime models
+  (``D4``). The one-release warning shim has served its window and ends.
+- Broken YAML still falls back to defaults (D9): only unknown keys within a
+  parsed model fail closed. A syntactically unparseable
+  ``.mergecraft/config.yaml`` keeps warn-and-default — defaults are the
+  restrictive push/shell posture, so that path stays fail-safe.
+- The error message names the offending key so a consumer can fix a typo
+  without bisecting their config.
+- The shipped ``examples/config.yaml`` and every valid optional block
+  (``staticChecks``, ``ciEvidence``, ``modes``, ``tracing.sinks``) still
+  loads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.config.settings import (
+    RepoSettings,
+    load_repo_settings,
+)
+from mergecraft.run_outcome import RunOutcome
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_unknown_static_check() -> dict[str, object]:
+    """Return a top-level config carrying one valid + one unknown-key entry."""
+    return {
+        "staticChecks": [
+            {"name": "lint", "command": "make lint"},
+            {"name": "types", "command": "mypy {files}", "mysterySuffix": [".rs"]},
+        ]
+    }
+
+
+def _settings_with_unknown_ci_evidence() -> dict[str, object]:
+    """Unknown key inside ``ciEvidence`` block (D8)."""
+    return {"ciEvidence": {"gates": {"lint": "Lint"}, "sirifs": ["some-artifact"]}}
+
+
+def _settings_with_unknown_mode_def() -> dict[str, object]:
+    """Unknown key inside a custom mode definition (D8)."""
+    return {
+        "modes": [
+            {
+                "id": "triage",
+                "name": "Triage",
+                "description": "Label issues",
+                "promppt": "Label the issue",  # typo: `prompt` is the real field
+            }
+        ]
+    }
+
+
+def _settings_with_unknown_sink_entry() -> dict[str, object]:
+    """Unknown key inside a tracing sink entry (D8)."""
+    return {
+        "tracing": {
+            "sinks": [
+                {"type": "jsonl_file", "path": ".mergecraft/traces/", "tier": "hot"},
+            ]
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Unknown keys raise ValidationError (one test per optional block)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_key_on_static_checks_raises() -> None:
+    """D8 — ``staticChecks`` entries with unknown keys fail closed."""
+    with pytest.raises(ValidationError) as exc_info:
+        RepoSettings.model_validate(_settings_with_unknown_static_check())
+    text = str(exc_info.value)
+    assert "mysterySuffix" in text, f"error does not name the offending key: {text}"
+
+
+def test_unknown_key_on_ci_evidence_raises() -> None:
+    """D8 — ``ciEvidence`` blocks with unknown keys fail closed."""
+    with pytest.raises(ValidationError) as exc_info:
+        RepoSettings.model_validate(_settings_with_unknown_ci_evidence())
+    text = str(exc_info.value)
+    assert "sirifs" in text, f"error does not name the offending key: {text}"
+
+
+def test_unknown_key_on_mode_def_raises() -> None:
+    """D8 — a custom ``modes`` entry with an unknown key fails closed."""
+    with pytest.raises(ValidationError) as exc_info:
+        RepoSettings.model_validate(_settings_with_unknown_mode_def())
+    text = str(exc_info.value)
+    assert "promppt" in text, f"error does not name the offending key: {text}"
+
+
+def test_unknown_key_on_sink_entry_raises() -> None:
+    """D8 — a ``tracing.sinks`` entry with an unknown key fails closed."""
+    with pytest.raises(ValidationError) as exc_info:
+        RepoSettings.model_validate(_settings_with_unknown_sink_entry())
+    text = str(exc_info.value)
+    assert "tier" in text, f"error does not name the offending key: {text}"
+
+
+# ---------------------------------------------------------------------------
+# 2. The fail-closed posture matches the security/runtime convention
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_optional_key_maps_to_configuration_error() -> None:
+    """D8 — a ``ValidationError`` from optional-feature models maps to
+    ``RunOutcome.configuration_error`` (same as security/runtime models).
+
+    Pydantic ``ValidationError`` is reclassified by
+    ``mergecraft.main._classify_error_outcome`` to the
+    ``configuration_error`` bucket — verify the wiring exists rather than
+    relying on the reclassifier to change.
+    """
+    from mergecraft.main import _classify_error_outcome
+
+    try:
+        RepoSettings.model_validate(_settings_with_unknown_static_check())
+    except ValidationError as exc:
+        outcome = _classify_error_outcome(exc)
+    else:  # pragma: no cover — defensive
+        pytest.fail("expected ValidationError")
+
+    assert outcome is RunOutcome.configuration_error, (
+        f"unknown optional key mapped to {outcome!r}, expected configuration_error"
+    )
+
+
+def test_error_message_names_the_offending_key() -> None:
+    """D8 — the message is actionable: it names the offending key AND its block.
+
+    Two unknowns at different depths in one payload make sure the path
+    identifies the block, not just the leaf — a consumer with a typo in a
+    nested block needs the block named in the error to find the typo
+    without bisecting their config.
+    """
+    payload = {
+        "ciEvidence": {"gates": {"lint": "Lint"}, "extra_unknown": 1},
+        "modes": [
+            {"id": "triage", "name": "Triage", "description": "x", "prompt": "x", "mystery": 1}
+        ],
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        RepoSettings.model_validate(payload)
+    text = str(exc_info.value)
+    assert "extra_unknown" in text, f"ciEvidence-level key not named: {text}"
+    assert "mystery" in text, f"mode-level key not named: {text}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Regression pins — valid optional blocks still load
+# ---------------------------------------------------------------------------
+
+
+def test_valid_optional_config_still_loads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D8 — every optional block still validates after the flip.
+
+    Regression pin: ``examples/config.yaml`` plus a representative valid
+    ``ciEvidence``, ``modes``, and ``tracing.sinks`` block round-trip without
+    error. If the flip ever leaks into one of these blocks, this test turns
+    red before any consumer breaks.
+    """
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(
+        (
+            "model: anthropic/claude-sonnet\n"
+            "push: restricted\n"
+            "shell: restricted\n"
+            "signedCommits: false\n"
+            "prApproveEnabled: false\n"
+            "autoMergeEnabled: false\n"
+            "modes:\n"
+            "  - id: triage\n"
+            "    name: Triage\n"
+            "    description: Label issues\n"
+            "    prompt: Label the issue\n"
+            "staticChecks:\n"
+            "  - name: lint\n"
+            "    command: make lint\n"
+            "    suffixes: ['.py']\n"
+            "ciEvidence:\n"
+            "  gates:\n"
+            "    lint: Lint\n"
+            "  sarifArtifacts:\n"
+            "    - codeql-results\n"
+            "tracing:\n"
+            "  enabled: false\n"
+            "  sinks:\n"
+            "    - type: jsonl_file\n"
+            "      path: .mergecraft/traces/\n"
+        ),
+        encoding="utf-8",
+    )
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+
+    assert settings.model == "anthropic/claude-sonnet"
+    assert settings.push == "restricted"
+    assert settings.shell == "restricted"
+    assert len(settings.modes) == 1
+    assert settings.modes[0].id == "triage"
+    assert len(settings.static_checks) == 1
+    assert settings.static_checks[0].name == "lint"
+    assert settings.ci_evidence.gates == {"lint": "Lint"}
+    assert settings.ci_evidence.sarif_artifacts == ["codeql-results"]
+    assert settings.tracing.enabled is False
+    assert len(settings.tracing.sinks) == 1
+    assert settings.tracing.sinks[0].type == "jsonl_file"
+
+
+# ---------------------------------------------------------------------------
+# 4. D9 — broken YAML still falls back to defaults
+# ---------------------------------------------------------------------------
+
+
+def test_broken_yaml_still_falls_back_to_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D9 — a syntactically unparseable ``.mergecraft/config.yaml`` warns and
+    falls back to ``default_settings()``.
+
+    D8 flips *unknown keys within a parsed model*. An unparseable file is a
+    different shape: the loader catches ``yaml.YAMLError`` at
+    ``settings.py`` and warns, returning the restrictive defaults so the
+    run can still proceed. This test pins that path so a future refactor
+    cannot silently turn a syntax error into a hard failure.
+    """
+    from mergecraft.config.settings import default_settings
+
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text("push: [not, a, scalar\n", encoding="utf-8")
+
+    monkeypatch.delenv("MERGECRAFT_CONFIG", raising=False)
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+
+    defaults = default_settings()
+    assert settings.push == defaults.push, "broken YAML must fall back to default push"
+    assert settings.shell == defaults.shell, "broken YAML must fall back to default shell"


### PR DESCRIPTION
## Summary

Changes optional-feature configuration models to reject unknown keys, preserving restrictive defaults for malformed YAML while surfacing actionable validation errors.

## Wave-plan section

- Wave: S3
- Plan: `.ignorelocal/waves/issues-setup-container-hygiene-wave-plan.md`
- Branch: `wave/rfc-s3-config-forbid` @ `d86751d`

## Test additions

- `tests/config/test_optional_feature_strictness.py`: unknown keys in static checks, CI evidence, mode definitions, and tracing sinks, plus valid-config and broken-YAML regression pins.
- `tests/config/test_extra_forbid.py`: updated strictness regression coverage.

## Audit status

- Thermos code-quality: NO_ISSUES on integration branch `wave/integration-s1-s5` (includes this PR's changes)
- Thermos branch audit: NO_ISSUES
- Full non-analyzer suite: 1400 passed
- `make ci-static`: clean
