### PR TITLE
security: trust-tier fall-through defaults to untrusted

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -20,4 +20,8 @@ jobs:
   changelog-preview:
     # Pin: getsentry/craft changelog-preview@v2 → 2.30.1; dependabot owns bumps.
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@cd1e8294061fd970b40d98b77aaa109cb1e00e78 # v2
+    # Pin the craft binary too: the upstream default ("latest") queries
+    # api.github.com unauthenticated, which 403s on rate-limit and fails the job.
+    with:
+      craft-version: 2.30.1
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Askpass helpers are written then immediately shredded after git setup
   (auth is brokered via MCP `http.extraHeader`, never ambient `GIT_ASKPASS`);
   runner-temp wipe only removes mergeCraft-registered paths
+- Fixed: `derive_trust_tier` now returns `untrusted` for unrecognized or
+  malformed GitHub event shapes instead of defaulting to `trusted`.
+  Previously an unknown event type received the most permissive tier. The
+  events that must stay trusted (`workflow_dispatch`, `pull_request_target`,
+  fork / same-repo `pull_request`) have explicit branches and are unaffected.
+  Comment / schedule / `workflow_call` / `workflow_run` / `merge_group` /
+  `push` / `release` / empty `GITHUB_EVENT_NAME` all resolve to `untrusted`.
+  (#144)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: `derive_trust_tier` now returns `untrusted` for unrecognized or
   malformed GitHub event shapes instead of defaulting to `trusted`.
   Previously an unknown event type received the most permissive tier. The
-  events that must stay trusted (`workflow_dispatch`, `pull_request_target`,
-  fork / same-repo `pull_request`) have explicit branches and are unaffected.
+  `pull_request` dict branch is gated on `GITHUB_EVENT_NAME == "pull_request"`
+  and only a same-repo shape (`fork is False`) earns the trusted tier; an
+  unknown event name with a PR-shaped payload, or a `pull_request` payload
+  with missing or wrong-typed nested fields, fails closed to `untrusted`.
   Comment / schedule / `workflow_call` / `workflow_run` / `merge_group` /
   `push` / `release` / empty `GITHUB_EVENT_NAME` all resolve to `untrusted`.
   (#144)

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -78,22 +78,24 @@ def derive_trust_tier(
     if event_name == "pull_request_target":
         return "untrusted"
 
-    pull_request = event.get("pull_request")
-    if isinstance(pull_request, dict):
-        head = pull_request.get("head")
-        if isinstance(head, dict):
-            repo = head.get("repo")
-            if isinstance(repo, dict) and repo.get("fork") is True:
-                return "untrusted"
-        return "trusted"
+    if event_name == "pull_request":
+        pull_request = event.get("pull_request")
+        if isinstance(pull_request, dict):
+            head = pull_request.get("head")
+            if isinstance(head, dict):
+                repo = head.get("repo")
+                if isinstance(repo, dict) and repo.get("fork") is False:
+                    return "trusted"
+        return "untrusted"
 
     # Fail closed (#144): an unrecognised event shape is more restricted, never
     # more permissive. Convention 5 / D7 — matches ``UNKNOWN_MODE_FALLBACK``
     # above. Comment / schedule / workflow_call / workflow_run / merge_group /
     # push / release / empty ``GITHUB_EVENT_NAME`` all land here and resolve to
-    # ``untrusted``; events that must stay trusted (``workflow_dispatch``,
-    # ``pull_request_target``, fork / same-repo ``pull_request``) have explicit
-    # branches above.
+    # ``untrusted``. The events with explicit branches — ``workflow_dispatch``
+    # (trusted), ``pull_request_target`` (untrusted), and same-repo
+    # ``pull_request`` (trusted via the gated branch above) — never fall
+    # through to this default.
     return "untrusted"
 
 

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -87,7 +87,14 @@ def derive_trust_tier(
                 return "untrusted"
         return "trusted"
 
-    return "trusted"
+    # Fail closed (#144): an unrecognised event shape is more restricted, never
+    # more permissive. Convention 5 / D7 — matches ``UNKNOWN_MODE_FALLBACK``
+    # above. Comment / schedule / workflow_call / workflow_run / merge_group /
+    # push / release / empty ``GITHUB_EVENT_NAME`` all land here and resolve to
+    # ``untrusted``; events that must stay trusted (``workflow_dispatch``,
+    # ``pull_request_target``, fork / same-repo ``pull_request``) have explicit
+    # branches above.
+    return "untrusted"
 
 
 def build_analyzer_env(

--- a/tests/analyzers/test_adapters_supply_chain.py
+++ b/tests/analyzers/test_adapters_supply_chain.py
@@ -117,12 +117,15 @@ def test_trufflehog_never_emits_secret_value(adapter_fixture_repo: Path) -> None
             assert PLANTED_AWS_SECRET not in cleaned
 
 
-def test_trufflehog_verification_off_on_fork(adapter_fixture_repo: Path) -> None:
+def test_trufflehog_verification_off_on_fork(
+    adapter_fixture_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     tool_id = "trufflehog"
     if tool_id not in _catalog_ids():
         pytest.fail(f"{tool_id} manifest missing from catalog")
 
     trust = import_module("mergecraft.analyzers.trust")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     tier = trust.derive_trust_tier(FORK_PULL_REQUEST_EVENT)
     assert tier == "untrusted"
 

--- a/tests/analyzers/test_trust.py
+++ b/tests/analyzers/test_trust.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -15,20 +16,29 @@ from mergecraft.modes import compute_modes
 from mergecraft.utils.github import GitHubClient
 from tests.analyzers.support import import_module
 
+if TYPE_CHECKING:
+    import pytest
+
 
 def test_missing_github_event_defaults_untrusted() -> None:
     trust = import_module("mergecraft.analyzers.trust")
     assert trust.derive_trust_tier(event=None, shell="restricted") == "untrusted"
 
 
-def test_same_repo_pull_request_is_trusted(same_repo_event: dict[str, object]) -> None:
+def test_same_repo_pull_request_is_trusted(
+    monkeypatch: pytest.MonkeyPatch, same_repo_event: dict[str, object]
+) -> None:
     trust = import_module("mergecraft.analyzers.trust")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     tier = trust.derive_trust_tier(event=same_repo_event, shell="restricted")
     assert tier == "trusted"
 
 
-def test_fork_pull_request_is_untrusted(fork_pr_event: dict[str, object]) -> None:
+def test_fork_pull_request_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch, fork_pr_event: dict[str, object]
+) -> None:
     trust = import_module("mergecraft.analyzers.trust")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     tier = trust.derive_trust_tier(event=fork_pr_event, shell="restricted")
     assert tier == "untrusted"
 
@@ -88,8 +98,11 @@ def test_shell_disabled_keeps_the_analyzer_surface(tmp_path: Path) -> None:
     assert trust.analyzers_enabled(ctx) is True
 
 
-def test_w0_probe_event_shape_matches_trusted(same_repo_event: dict[str, object]) -> None:
+def test_w0_probe_event_shape_matches_trusted(
+    monkeypatch: pytest.MonkeyPatch, same_repo_event: dict[str, object]
+) -> None:
     """W0.4 probe: ``pull_request`` same-repo PR #1, ``fork=false``."""
     trust = import_module("mergecraft.analyzers.trust")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     assert same_repo_event["pull_request"]["head"]["repo"]["fork"] is False  # type: ignore[index]
     assert trust.derive_trust_tier(event=same_repo_event, shell="restricted") == "trusted"

--- a/tests/analyzers/test_trust_aware_analyzer_mode.py
+++ b/tests/analyzers/test_trust_aware_analyzer_mode.py
@@ -331,19 +331,31 @@ def test_event_trust_analyzers_matrix(
 
 
 @pytest.mark.parametrize(
-    ("event", "expected_tier"),
+    ("event", "event_payload", "expected_tier"),
     [
-        ("pull_request_target", "untrusted"),
-        ("workflow_dispatch", "trusted"),
-        ("pull_request", "trusted"),
+        ("pull_request_target", {"pull_request": {}}, "untrusted"),
+        ("workflow_dispatch", {"action": "workflow_dispatch"}, "trusted"),
+        (
+            "pull_request",
+            {"pull_request": {"head": {"repo": {"fork": False}}}},
+            "trusted",
+        ),
     ],
 )
 def test_event_axis_derives_the_expected_tier(
-    monkeypatch: pytest.MonkeyPatch, event: str, expected_tier: str
+    monkeypatch: pytest.MonkeyPatch,
+    event: str,
+    event_payload: dict[str, Any],
+    expected_tier: str,
 ) -> None:
-    """Pin the event -> tier edge the matrix's tier axis stands on."""
+    """Pin the event -> tier edge the matrix's tier axis stands on.
+
+    ``pull_request`` uses a well-formed same-repo shape (``fork is False``):
+    an empty ``pull_request`` dict now fails closed to ``untrusted`` (the
+    empty-dict case is pinned by the S4.1 regression suite).
+    """
     monkeypatch.setenv("GITHUB_EVENT_NAME", event)
-    assert derive_trust_tier(event={"pull_request": {}}, shell="restricted") == expected_tier
+    assert derive_trust_tier(event=event_payload, shell="restricted") == expected_tier
 
 
 def test_offline_event_is_trusted() -> None:

--- a/tests/security/test_trust_fallthrough.py
+++ b/tests/security/test_trust_fallthrough.py
@@ -7,14 +7,15 @@ including the empty event, an unrecognised ``GITHUB_EVENT_NAME``, and a
 malformed payload missing the keys the recognised branches read.
 
 This suite pins the **post-flip** contract: the fall-through resolves to
-``"untrusted"`` in every case the prior default silently trusted. The four
-regression pins keep the recognised branches locked down so the flip cannot
-move them by accident. The caller-tolerance test enumerates the single
-production call site (``main.py``'s ``derive_trust_tier``) and asserts the
-downstream helpers consume the untrusted result without raising.
-
-The four RED tests will go green in PR S4.2 (wave-runner implementation
-wave); the four regression pins must stay green throughout.
+``"untrusted"`` in every case the prior default silently trusted. The PR-shaped
+``pull_request`` branch is gated on ``GITHUB_EVENT_NAME == "pull_request"`` and
+only a same-repo shape (``fork is False``) earns the trusted tier; unknown
+event names, and ``pull_request`` payloads with missing or wrong-typed nested
+fields, all fail closed to ``"untrusted"``. The regression pins keep the
+recognised branches locked down so the flip cannot move them by accident. The
+caller-tolerance test enumerates the single production call site (``main.py``'s
+``derive_trust_tier``) and asserts the downstream helpers consume the untrusted
+result without raising.
 """
 
 from __future__ import annotations
@@ -78,6 +79,79 @@ def test_empty_event_name_is_untrusted(
     """
     monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
     tier = derive_trust_tier(event={"some": "payload"})
+    assert tier == "untrusted"
+
+
+def test_unknown_event_name_with_pr_shaped_payload_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — an unrecognised event name with a PR-shaped payload stays untrusted.
+
+    The P1 regression: the ``pull_request`` dict branch is gated on
+    ``GITHUB_EVENT_NAME == "pull_request"``, so an arbitrary event name cannot
+    reach the same-repo ``"trusted"`` return by smuggling a PR-shaped payload.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "totally_unrecognised_event")
+    tier = derive_trust_tier(event={"pull_request": {"head": {"repo": {"fork": False}}}})
+    assert tier == "untrusted"
+
+
+def test_pull_request_empty_dict_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — ``pull_request`` with an empty dict resolves to ``"untrusted"``.
+
+    The P1 regression: a ``pull_request`` whose ``head`` is missing used to
+    fall out of the nested lookups and hit the permissive ``return "trusted"``.
+    Only ``fork is False`` earns the trusted tier now.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"pull_request": {}})
+    assert tier == "untrusted"
+
+
+def test_pull_request_missing_head_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — ``pull_request`` with a non-dict ``head`` resolves to ``"untrusted"``."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"pull_request": {"head": "not-a-dict"}})
+    assert tier == "untrusted"
+
+
+def test_pull_request_missing_repo_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — ``pull_request.head`` with a non-dict ``repo`` resolves to ``"untrusted"``."""
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"pull_request": {"head": {"repo": "not-a-dict"}}})
+    assert tier == "untrusted"
+
+
+def test_pull_request_missing_fork_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — ``pull_request.head.repo`` without ``fork`` resolves to ``"untrusted"``.
+
+    The P1 regression: a missing ``fork`` key used to fall through to the
+    permissive ``return "trusted"``; only an explicit ``fork is False``
+    (same-repo) earns the trusted tier.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"pull_request": {"head": {"repo": {}}}})
+    assert tier == "untrusted"
+
+
+def test_pull_request_wrong_typed_fork_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — a wrong-typed ``fork`` value resolves to ``"untrusted"``.
+
+    ``fork`` is compared with ``is False``, so a truthy or non-boolean value
+    cannot accidentally land on the same-repo trusted branch.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"pull_request": {"head": {"repo": {"fork": "false"}}}})
     assert tier == "untrusted"
 
 

--- a/tests/security/test_trust_fallthrough.py
+++ b/tests/security/test_trust_fallthrough.py
@@ -1,0 +1,189 @@
+"""PR S4 — fail-closed default for ``derive_trust_tier`` (#144).
+
+The third fail-open default in ``analyzers/trust.py`` sits at the bottom of
+:func:`mergecraft.analyzers.trust.derive_trust_tier`: today every event shape
+that does not match a recognised branch falls through to ``"trusted"`` —
+including the empty event, an unrecognised ``GITHUB_EVENT_NAME``, and a
+malformed payload missing the keys the recognised branches read.
+
+This suite pins the **post-flip** contract: the fall-through resolves to
+``"untrusted"`` in every case the prior default silently trusted. The four
+regression pins keep the recognised branches locked down so the flip cannot
+move them by accident. The caller-tolerance test enumerates the single
+production call site (``main.py``'s ``derive_trust_tier``) and asserts the
+downstream helpers consume the untrusted result without raising.
+
+The four RED tests will go green in PR S4.2 (wave-runner implementation
+wave); the four regression pins must stay green throughout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mergecraft.analyzers.trust import (
+    allow_repo_command_overrides,
+    build_analyzer_env,
+    derive_trust_tier,
+    evaluate_manifest_for_tier,
+    resolve_selection_tier,
+)
+from tests.analyzers.support import (
+    FORK_PULL_REQUEST_EVENT,
+    SAME_REPO_PULL_REQUEST_EVENT,
+    import_module,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_unknown_event_name_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — an unrecognised ``GITHUB_EVENT_NAME`` resolves to ``"untrusted"``.
+
+    None of the recognised branches (``workflow_dispatch``, ``pull_request_target``,
+    the ``pull_request`` dict shape) match an arbitrary event name. Under the
+    post-flip contract the fall-through returns ``"untrusted"``.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "totally_unrecognised_event")
+    tier = derive_trust_tier(event={"some": "payload"})
+    assert tier == "untrusted"
+
+
+def test_malformed_payload_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — a payload missing the keys the recognised branches read resolves
+    to ``"untrusted"`` without raising.
+
+    The fall-through must not crash on a payload with no ``pull_request`` key
+    and no other recognised shape, and must not silently upgrade to trusted.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event={"unrelated": "shape"})
+    assert tier == "untrusted"
+
+
+def test_empty_event_name_is_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — ``GITHUB_EVENT_NAME`` unset or empty resolves to ``"untrusted"``.
+
+    An Action without ``GITHUB_EVENT_NAME`` set (or with it cleared) used to
+    fall through to ``"trusted"`` once the ``event`` dict was non-empty;
+    after S4.2 the same input resolves to ``"untrusted"``.
+    """
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    tier = derive_trust_tier(event={"some": "payload"})
+    assert tier == "untrusted"
+
+
+def test_workflow_dispatch_remains_trusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 regression pin — ``workflow_dispatch`` keeps the trusted tier.
+
+    The flip must not move the explicit ``workflow_dispatch`` branch.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
+    tier = derive_trust_tier(event={"action": "workflow_dispatch"})
+    assert tier == "trusted"
+
+
+def test_pull_request_target_tier_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 regression pin — ``pull_request_target`` keeps the untrusted tier.
+
+    The flip must not move the explicit ``pull_request_target`` branch.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_target")
+    tier = derive_trust_tier(event={"pull_request": {"head": {"repo": {"fork": False}}}})
+    assert tier == "untrusted"
+
+
+def test_fork_head_pull_request_remains_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 regression pin — fork-head ``pull_request`` keeps the untrusted tier.
+
+    The flip must not move the fork detection branch — a fork PR is the
+    canonical untrusted shape and must not be silently promoted.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event=FORK_PULL_REQUEST_EVENT)
+    assert tier == "untrusted"
+
+
+def test_same_repo_pull_request_tier_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 regression pin — same-repo ``pull_request`` keeps the trusted tier.
+
+    The branch most at risk of collateral damage from the fall-through flip:
+    a same-repo PR with a dict-shaped ``pull_request`` resolves to
+    ``"trusted"`` via the explicit dict branch, *not* via the fall-through.
+    This pin guards against a refactor that loses the dict branch on the way
+    to changing the fall-through default.
+    """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    tier = derive_trust_tier(event=SAME_REPO_PULL_REQUEST_EVENT)
+    assert tier == "trusted"
+
+
+def test_every_caller_tolerates_untrusted_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S4.1 — the production caller chain tolerates the post-flip untrusted
+    default rather than crashing.
+
+    Per the S4.2 caller audit, the single production call site is
+    ``src/mergecraft/main.py`` (``trust_tier = derive_trust_tier(event=...)``);
+    that return value gates ``setup_script`` execution (``main.py:368``), the
+    analyzer env builder, the manifest tier gate, the command-overrides gate,
+    and the selection-tier resolver. For an unrecognised event shape all of
+    these must consume the untrusted result without raising and without
+    expanding what the run is allowed to see.
+
+    This test does not import ``main.py`` (its full flow is covered by
+    ``test_trust_ordering.py``); it exercises the downstream helpers directly
+    with the untrusted result, and asserts both the tier returned by
+    ``derive_trust_tier`` and that every helper handles it cleanly.
+    """
+    manifest_mod = import_module("mergecraft.analyzers.manifest")
+    raw = Path("tests/analyzers/fixtures/manifests/valid-actionlint.yaml").read_text(
+        encoding="utf-8"
+    )
+    trusted_only_manifest = manifest_mod.load_manifest_yaml(
+        raw.replace("trust: untrusted", "trust: trusted")
+    )
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "totally_unrecognised_event")
+    tier = derive_trust_tier(event={"some": "payload"})
+    assert tier == "untrusted"
+
+    # Analyzer env builder must scrub secrets on the untrusted tier
+    # (build_analyzer_env is a pure function: it returns a dict, never raises
+    # on the untrusted branch).
+    env = build_analyzer_env(event={"some": "payload"}, tier=tier, repo_env={})
+    assert isinstance(env, dict)
+    assert "GITHUB_TOKEN" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+    # Manifest tier gate must produce a deterministic decision on untrusted,
+    # not raise.
+    decision = evaluate_manifest_for_tier(manifest=trusted_only_manifest, tier=tier)
+    assert decision.skipped is True
+    assert decision.reason is not None
+
+    # Command-overrides gate must refuse on untrusted (never raise).
+    assert allow_repo_command_overrides(tier) is False
+
+    # Selection-tier resolver must stay at-or-stricter-than the derived tier
+    # on untrusted, regardless of the requested mode (never raise).
+    assert resolve_selection_tier(mode="auto", tier=tier) == "untrusted"
+    assert resolve_selection_tier(mode="full", tier=tier) == "untrusted"
+    assert resolve_selection_tier(mode="untrusted-only", tier=tier) == "untrusted"

--- a/tests/status_checks/test_status_checks_enforce.py
+++ b/tests/status_checks/test_status_checks_enforce.py
@@ -30,6 +30,8 @@ from mergecraft.analyzers.trust import derive_trust_tier
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 
 # ---------------------------------------------------------------------------
 # Module-availability helpers — same pattern as test_decide_approval.py.
@@ -231,6 +233,7 @@ async def test_report_status_checks_surfaces_neutral_for_crashed_run(
 
 def test_fork_pr_cannot_self_approve_at_decision_layer(
     blocked_pr_event: dict,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``derive_trust_tier()`` returns ``"untrusted"`` for a fork PR, and
     ``prApproveEnabled=true`` ⇒ no approval, regardless of config (D14).
@@ -241,6 +244,7 @@ def test_fork_pr_cannot_self_approve_at_decision_layer(
     ``"neutral"`` (the exact shape is W8's call; the contract is *not*
     success).
     """
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     tier = derive_trust_tier(blocked_pr_event)
     assert tier == "untrusted", (
         "sanity: a fork PR event must be tier='untrusted' before we assert the inert path"

--- a/tests/utils/test_fence.py
+++ b/tests/utils/test_fence.py
@@ -247,7 +247,7 @@ def test_untrusted_text_appears_only_inside_fence() -> None:
 # ── W3.5 — fence carries author + trust tier. ───────────────────────────────
 
 
-def test_fence_carries_author_and_trust_tier() -> None:
+def test_fence_carries_author_and_trust_tier(monkeypatch: pytest.MonkeyPatch) -> None:
     """The fence block names its author login and the trust tier
     (`derive_trust_tier`'s return value) so a reviewer can weight it
     per `docs/REVIEW-DOCTRINE.md` (D7 last clause)."""
@@ -261,6 +261,7 @@ def test_fence_carries_author_and_trust_tier() -> None:
             "head": {"repo": {"fork": True}},
         },
     }
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     tier = derive_trust_tier(fork_event)
     assert tier == "untrusted", (
         "test fixture drifted: fork head must derive `untrusted`; check analyzers/trust.py:30-58"

--- a/tests/utils/test_meat_harness.py
+++ b/tests/utils/test_meat_harness.py
@@ -218,7 +218,7 @@ def _event_for(trust: str) -> dict[str, Any] | None:
     raise AssertionError(msg)
 
 
-def test_meat_is_inert_on_untrusted_tier(tmp_path: Path) -> None:
+def test_meat_is_inert_on_untrusted_tier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``derive_trust_tier()`` returning ``untrusted`` → harness not invoked.
 
     Even when the binary is on PATH and the opt-in flag is set, the
@@ -227,6 +227,7 @@ def test_meat_is_inert_on_untrusted_tier(tmp_path: Path) -> None:
     the load-bearing security test for the spike batch.
     """
     # Sanity-check the fixture: this branch of D7 is what the plan locks.
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     assert derive_trust_tier(_event_for("untrusted")) == "untrusted"
 
     # Place a real-sounding fake so a bug in the trust gate would

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.409" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
@@ -1160,7 +1160,7 @@ requires-dist = [
     { name = "typer", specifier = "==0.25.1" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20251011" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = "==4.25.1.20250822" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "==6.0.12.20260510" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "==6.0.12.20260724" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
 provides-extras = ["harbor", "tracing", "dev"]
@@ -1732,15 +1732,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -2379,11 +2379,11 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260510"
+version = "6.0.12.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Changes unrecognized or malformed GitHub event shapes to resolve to the untrusted trust tier, closing the permissive default in `derive_trust_tier` and pinning known behavior with regression tests.

Follow-up commit `c919dae` addresses the P1 review: the `pull_request` dict branch is now gated on `GITHUB_EVENT_NAME == "pull_request"` and only returns `trusted` when `fork is False`. An unknown event name with a PR-shaped payload, or a `pull_request` payload with missing or wrong-typed nested fields, fails closed to `untrusted` instead of reaching the permissive `return "trusted"`.

## Wave-plan section

- Wave: S4
- Plan: `.ignorelocal/waves/issues-setup-container-hygiene-wave-plan.md`
- Branch: `wave/rfc-s4-trust-failclosed` @ `c919dae`

## Test additions

- `tests/security/test_trust_fallthrough.py`: unknown, malformed, and empty event fallthrough cases, plus recognized-tier and caller-tolerance regression pins — including new P1 regression cases for unknown event names with a PR-shaped payload and `pull_request` payloads with missing/wrong-typed nested fields.

## Audit status

- Thermos code-quality: NO_ISSUES on integration branch `wave/integration-s1-s5` (includes this PR's changes)
- Thermos branch audit: NO_ISSUES
- Full non-analyzer suite: 1400 passed
- `make ci-static`: clean