### PR TITLE
docs(ci): scope the conflicted-PR rationale in the live workflow

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -58,9 +58,18 @@
 # CODEX_AUTH_JSON / OPENAI_API_KEY, Nous is the only reviewer.
 #
 # Trigger: pull_request_target (not pull_request). GitHub skips pull_request
-# workflows when refs/pull/N/merge cannot be built (merge conflicts), which
-# leaves ruleset require-mergecraft-review with a permanently missing check.
-# pull_request_target always fires on synchronize even with merge conflicts.
+# workflows when refs/pull/N/merge cannot be built (merge conflicts), so the
+# ruleset check require-mergecraft-review sits unreported for as long as the
+# conflict lasts. pull_request_target always fires on synchronize even with
+# merge conflicts, so the review still lands while the PR is conflicted.
+#
+# That gap is the conflicted window, not a permanent block: pushing the conflict
+# fix to the PR branch fires synchronize and would clear a pull_request check
+# too. It outlasts the conflict only when the conflict disappears WITHOUT a push
+# to the head branch (the base moved), because nothing then re-triggers the run.
+# A conflicted PR is unmergeable on its own account anyway, so weigh this
+# against running with repository secrets in scope rather than treating it as
+# decisive. Full rationale: README "Workflow-placement gotchas".
 #
 # Workflow resolution (GitHub Nov 2025 policy, effective 2025-12-08): pull_request_target
 # definitions are read from the repository default branch (`main`), not the PR base.


### PR DESCRIPTION
## Why

Follow-up to #167, and found by our own reviewer. While reviewing that PR, the Nous pass flagged a fourth copy of a claim #167 was correcting everywhere else:

> the repo's own live workflow `.github/workflows/mergecraft.yml:60-63` still says a conflicted `pull_request` run "leaves ruleset `require-mergecraft-review` with a permanently missing check" — the very overstatement this PR corrects elsewhere.

It's right, and this is the copy that matters most: it's the header on the definition that actually runs.

## The correction

"Permanently missing" overstates it. Resolving a merge conflict normally means pushing to the PR head branch, which fires `synchronize`, rebuilds `refs/pull/N/merge`, and lets the `pull_request` run report — clearing the check. The block lasts only while the PR stays conflicted.

It outlives the conflict in exactly one narrow case: the conflict disappears *without* a push to the head branch (the base moved), so nothing re-triggers the run.

The header now says that, keeps the real benefit (`pull_request_target` still fires on `synchronize`, so the review lands while the PR is conflicted), and adds the point that makes the argument honest — a conflicted PR is unmergeable on its own account, so this is a factor to weigh against running with repository secrets in scope, not a decisive one.

## Why it wasn't in #167

#167 targets `pre-0.0.1` and fixed `README.md`, `scripts/example_workflows/hardened.yml.tpl`, and `docs/artifacts/dogfood-mergecraft.yml`. This file couldn't have been fixed from that branch regardless: it's the live `pull_request_target` definition, which GitHub resolves from the **default branch** — precisely the placement rule #167 documents. So it needs its own PR against `main`.

## Scope

Comment-only. The trigger, the concurrency group, the same-repo guard, and every job are untouched — `git diff` is 12 insertions / 3 deletions, all in the header block.

## Verification

- `actionlint .github/workflows/mergecraft.yml` → clean
- YAML parses
- `make workflow-lint` skips its actionlint/zizmor bootstrap on darwin (linux-only in CI), so zizmor runs here for the first time in CI

Note: since this edits the workflow on the default branch, the change takes effect for the *next* PR after merge, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)