### PR TITLE
feat(analyzers): add change-impact extraction (impactPath) for review prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(analyzers): add change-impact extraction (impactPath) for review prompts` — new
+  `analyzers.impact` setting (default off) enables declaration-level reference-lead
+  extraction from the diff. When enabled and the diff touches files with recognised
+  extensions, `checkout_pr` returns an `impactPath` JSON file listing every declaration
+  the diff touches, grouped by language, capped at 24 declarations. Defaults to off
+  pending eval-bank measurement. (#94)
 - `feat(findings): carry unresolved review findings past the merge` — a merged PR
   keeps its inline comments forever but nobody re-opens one, so findings the
   author never fixed or rebutted were lost to attention. `mergecraft findings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ dev = [
     "pytest-randomly==4.1.0",
     "pytest-split==0.11.0",
     "types-aiofiles==25.1.0.20251011",
+    # Pinned to the version in analyzers/catalog/ast-grep.yaml so dev/test
+    # runs exercise the same declaration-node kinds as the managed binary
+    # impact.py resolves at review time.
+    "ast-grep-cli==0.44.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/mergecraft/analyzers/catalog/impact-declarations/c.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/c.yml
@@ -1,0 +1,18 @@
+id: impact-decl-c
+language: c
+rule:
+  any:
+    - kind: function_definition
+      has:
+        field: declarator
+        has: { field: declarator, pattern: $NAME }
+    - kind: declaration
+      has:
+        field: declarator
+        has: { field: declarator, pattern: $NAME }
+    - kind: struct_specifier
+      has: { field: name, pattern: $NAME }
+    - kind: union_specifier
+      has: { field: name, pattern: $NAME }
+    - kind: enum_specifier
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/cpp.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/cpp.yml
@@ -1,0 +1,24 @@
+id: impact-decl-cpp
+language: cpp
+rule:
+  any:
+    - kind: function_definition
+      has:
+        field: declarator
+        has: { field: declarator, pattern: $NAME }
+    - kind: declaration
+      has:
+        field: declarator
+        has: { field: declarator, pattern: $NAME }
+    - kind: field_declaration
+      has:
+        field: declarator
+        has: { field: declarator, pattern: $NAME }
+    - kind: class_specifier
+      has: { field: name, pattern: $NAME }
+    - kind: struct_specifier
+      has: { field: name, pattern: $NAME }
+    - kind: union_specifier
+      has: { field: name, pattern: $NAME }
+    - kind: enum_specifier
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/go.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/go.yml
@@ -1,0 +1,10 @@
+id: impact-decl-go
+language: go
+rule:
+  any:
+    - kind: function_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: method_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: type_spec
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/java.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/java.yml
@@ -1,0 +1,14 @@
+id: impact-decl-java
+language: java
+rule:
+  any:
+    - kind: class_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: interface_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: enum_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: method_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: constructor_declaration
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/javascript.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/javascript.yml
@@ -1,0 +1,18 @@
+id: impact-decl-javascript
+language: javascript
+rule:
+  any:
+    - kind: function_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: method_definition
+      has: { field: name, pattern: $NAME }
+    - kind: class_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: arrow_function }
+        - has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: function_expression }
+        - has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/python.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/python.yml
@@ -1,0 +1,8 @@
+id: impact-decl-python
+language: python
+rule:
+  any:
+    - kind: function_definition
+      has: { field: name, pattern: $NAME }
+    - kind: class_definition
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/rust.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/rust.yml
@@ -1,0 +1,18 @@
+id: impact-decl-rust
+language: rust
+rule:
+  any:
+    - kind: function_item
+      has: { field: name, pattern: $NAME }
+    - kind: function_signature_item
+      has: { field: name, pattern: $NAME }
+    - kind: struct_item
+      has: { field: name, pattern: $NAME }
+    - kind: trait_item
+      has: { field: name, pattern: $NAME }
+    - kind: enum_item
+      has: { field: name, pattern: $NAME }
+    - kind: union_item
+      has: { field: name, pattern: $NAME }
+    - kind: macro_definition
+      has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/tsx.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/tsx.yml
@@ -1,0 +1,24 @@
+id: impact-decl-tsx
+language: tsx
+rule:
+  any:
+    - kind: function_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: method_definition
+      has: { field: name, pattern: $NAME }
+    - kind: class_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: interface_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: type_alias_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: enum_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: arrow_function }
+        - has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: function_expression }
+        - has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/catalog/impact-declarations/typescript.yml
+++ b/src/mergecraft/analyzers/catalog/impact-declarations/typescript.yml
@@ -1,0 +1,24 @@
+id: impact-decl-typescript
+language: typescript
+rule:
+  any:
+    - kind: function_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: method_definition
+      has: { field: name, pattern: $NAME }
+    - kind: class_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: interface_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: type_alias_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: enum_declaration
+      has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: arrow_function }
+        - has: { field: name, pattern: $NAME }
+    - kind: variable_declarator
+      all:
+        - has: { field: value, kind: function_expression }
+        - has: { field: name, pattern: $NAME }

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -24,9 +24,12 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.manifest import TrustTier
 
 _CATALOG_DECL_DIR = Path(__file__).resolve().parent / "catalog" / "impact-declarations"
 
@@ -99,23 +102,55 @@ def _run_ast_grep(
     rule_path: Path,
     files: list[str],
     cwd: str,
+    *,
+    tier: TrustTier,
 ) -> list[dict[str, Any]]:
-    try:
-        result = subprocess.run(
-            [binary, "scan", "--json", "-r", str(rule_path), *files],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        msg = f"ast-grep invocation failed ({rule_path.name}): {exc}"
-        raise _ExtractionFailed(msg) from exc
-    if result.returncode != 0:
-        msg = f"ast-grep exited {result.returncode} ({rule_path.name}): {result.stderr.strip()}"
+    """Run one ast-grep declaration scan through the shared sandbox/trust path.
+
+    ast-grep parses PR-authored source with a native parser, so it gets the same
+    isolation (D7) and env-scrubbing every other analyzer gets against untrusted
+    checkouts — never a bare ``subprocess.run`` with the parent environment.
+    Fails closed: if sandbox isolation is required (untrusted tier) and
+    unavailable, this raises rather than falling back to unsandboxed execution.
+    """
+    from mergecraft.analyzers.registry import get_manifest
+    from mergecraft.analyzers.resolve import AnalyzerPlan
+    from mergecraft.analyzers.run import run_plan
+    from mergecraft.analyzers.sandbox import plan_sandbox
+    from mergecraft.analyzers.trust import build_analyzer_env
+
+    manifest = get_manifest("ast-grep")
+    repo_root = Path(cwd)
+    scratch_dir = repo_root / ".mergecraft" / "analyzer-scratch" / "ast-grep-impact"
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    sandbox_decision = plan_sandbox(
+        manifest=manifest, tier=tier, repo_root=repo_root, scratch_dir=scratch_dir
+    )
+    if not sandbox_decision.can_run:
+        msg = sandbox_decision.skip_reason or f"ast-grep sandbox unavailable ({rule_path.name})"
         raise _ExtractionFailed(msg)
+
+    env = build_analyzer_env(tier=tier, event=None)
+    plan = AnalyzerPlan(
+        manifest_id="ast-grep-impact",
+        mode="managed",
+        argv=(binary, "scan", "--json", "-r", str(rule_path), *files),
+        cwd=repo_root,
+        env=env,
+        timeout_s=30,
+    )
+    outcome = run_plan(plan, sandbox_context=sandbox_decision.context)
+    if outcome.status != "passed":
+        msg = f"ast-grep {outcome.status} ({rule_path.name}): {outcome.output}"
+        raise _ExtractionFailed(msg)
+    raw = (
+        Path(outcome.output_path).read_text(encoding="utf-8")
+        if outcome.output_path
+        else outcome.output
+    )
     try:
-        matches = json.loads(result.stdout or "[]")
+        matches = json.loads(raw or "[]")
     except json.JSONDecodeError as exc:
         msg = f"ast-grep produced unparsable output ({rule_path.name}): {exc}"
         raise _ExtractionFailed(msg) from exc
@@ -126,6 +161,8 @@ def _find_declarations_batch(
     paths: list[str],
     cwd: str,
     ast_grep_binary: str,
+    *,
+    tier: TrustTier,
 ) -> dict[str, list[dict[str, object]]]:
     """Extract declaration-node candidates for every path, grouped by ast-grep rule.
 
@@ -147,7 +184,7 @@ def _find_declarations_batch(
     results: dict[str, list[dict[str, object]]] = {fp: [] for fp in paths}
     for rule_name, files in groups.items():
         rule_path = _CATALOG_DECL_DIR / rule_name
-        matches = _run_ast_grep(ast_grep_binary, rule_path, files, cwd)
+        matches = _run_ast_grep(ast_grep_binary, rule_path, files, cwd, tier=tier)
         label = labels[rule_name]
         for m in matches:
             name_mv = m.get("metaVariables", {}).get("single", {}).get("NAME")
@@ -207,11 +244,16 @@ def extract_impact(
     cwd: str,
     *,
     ast_grep_binary: str = "ast-grep",
+    tier: TrustTier = "untrusted",
 ) -> dict[str, object] | None:
     """Extract the change-impact artifact, or ``None`` if extraction failed outright.
 
     ``None`` means "we could not reliably determine this" — the caller must omit
-    the artifact entirely rather than publish a partial/misleading one.
+    the artifact entirely rather than publish a partial/misleading one. ``tier``
+    gates ast-grep's execution sandbox (D7) — it must reflect the *actual* trust
+    tier of this checkout (fork PR vs. same-repo), never a value read from the
+    checkout itself, since the checkout's own ``.mergecraft/config.yaml`` is
+    attacker-controlled on an untrusted PR. Defaults to the safer "untrusted".
     """
     hunks = _parse_hunks(diff_text)
     relevant_files = [fp for fp in _changed_paths(diff_text) if fp in hunks]
@@ -219,7 +261,7 @@ def extract_impact(
         return {"impactPath": [], "truncated": False, "totalDeclarations": 0}
 
     try:
-        decls_by_file = _find_declarations_batch(relevant_files, cwd, ast_grep_binary)
+        decls_by_file = _find_declarations_batch(relevant_files, cwd, ast_grep_binary, tier=tier)
 
         candidates: list[dict[str, object]] = []
         for fp in relevant_files:
@@ -272,8 +314,9 @@ def write_impact(
     pull_number: int | str,
     *,
     ast_grep_binary: str = "ast-grep",
+    tier: TrustTier = "untrusted",
 ) -> dict[str, object] | None:
-    data = extract_impact(diff_text, cwd, ast_grep_binary=ast_grep_binary)
+    data = extract_impact(diff_text, cwd, ast_grep_binary=ast_grep_binary, tier=tier)
     if data is None:
         return None
     rows = data.get("impactPath", [])

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -1,8 +1,9 @@
-"""Change-impact extraction from a diff — declaration-level reference leads.
+"""Change-impact extraction from a diff - declaration-level reference leads.
 
 Given a formatted PR diff and the checked-out files, produces a structured
-artifact (``impactPath``) listing every declaration the diff touches, grouped
-by language and ranked by severity. Default off behind ``analyzers.impact``.
+artifact (``impactPath``) listing every declaration the diff *actually touches*
+(within hunk ranges), grouped by language, with cross-file references.
+Default off behind ``analyzers.impact``.
 
 Design decisions documented at
 ``.ignorelocal/waves/evidence/s6-design-decisions.md``.
@@ -13,12 +14,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from pathlib import Path
 
-# Language → extension → declaration patterns (multiline regex).
-# Covers the 8 languages in the shipped ast-grep catalog (python, javascript,
-# typescript, go, java, rust, c, cpp).  Patterns look for the declaration
-# *headline* on its own line — class/function/interface definitions.
 _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
     "Python": {
         ".py": [
@@ -78,9 +76,7 @@ _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
         ],
     },
     "C/C++": {
-        ".c": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-        ],
+        ".c": [re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE)],
         ".h": [
             re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
             re.compile(
@@ -99,26 +95,46 @@ _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
             re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
             re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
         ],
-        ".cxx": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-        ],
+        ".cxx": [re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE)],
     },
 }
 
-
 _DIFF_FILE_RE = re.compile(r"^diff --git a/(?P<path>.+?) b/(?P<to>.+)$", re.MULTILINE)
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@")
 
-# Q3 design cap: 24 declarations per review, 8 references per decl.
+
 _MAX_DECLARATIONS: int = 24
 _MAX_REFS: int = 8
 
 
 def _changed_paths(diff_text: str) -> list[str]:
-    """Return the post-image paths named by a unified diff, in first-seen order."""
     seen: dict[str, None] = {}
     for match in _DIFF_FILE_RE.finditer(diff_text):
         seen.setdefault(match.group("to"), None)
     return list(seen)
+
+
+def _parse_hunks(diff_text: str) -> dict[str, list[tuple[int, int]]]:
+    hunks: dict[str, list[tuple[int, int]]] = {}
+    current_file: str | None = None
+    for line in diff_text.splitlines():
+        file_match = _DIFF_FILE_RE.match(line)
+        if file_match:
+            current_file = file_match.group("to")
+            continue
+        if current_file is None:
+            continue
+        hunk_match = _HUNK_RE.match(line)
+        if hunk_match:
+            start = int(hunk_match.group("start"))
+            count = int(hunk_match.group("count") or "1")
+            end = start + max(count, 1) - 1
+            hunks.setdefault(current_file, []).append((start, end))
+    return hunks
+
+
+def _intersects_hunks(line_no: int, hunk_ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= line_no <= end for start, end in hunk_ranges)
 
 
 def _extension(path: str) -> str:
@@ -127,12 +143,6 @@ def _extension(path: str) -> str:
 
 
 def _find_declarations(path: str, cwd: str) -> list[dict[str, object]]:
-    """Extract declaration names from *path* (relative to *cwd*).
-
-    Returns ``[{"name": str, "language": str, "line": int}, …]``
-    sorted by file order. Empty when the file has no recognised extension
-    or is not on disk.
-    """
     full = os.path.join(cwd, path)
     if not os.path.isfile(full):
         return []
@@ -140,7 +150,6 @@ def _find_declarations(path: str, cwd: str) -> list[dict[str, object]]:
         text = Path(full).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
-
     ext = _extension(path)
     results: list[dict[str, object]] = []
     seen_names: set[str] = set()
@@ -151,33 +160,75 @@ def _find_declarations(path: str, cwd: str) -> list[dict[str, object]]:
                 name = match.group("name")
                 if name and name not in seen_names:
                     seen_names.add(name)
-                    # Approximate line number from match position
                     line = text[: match.start()].count("\n") + 1
                     results.append({"name": name, "language": lang, "line": line})
     return results
 
 
-def extract_impact(diff_text: str, cwd: str) -> dict[str, object]:
-    """Extract impact data from *diff_text* and files checked out at *cwd*.
+def _find_references(
+    symbol: str,
+    cwd: str,
+    *,
+    exclude_file: str | None = None,
+    max_refs: int = 8,
+) -> list[dict[str, object]]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "grep", "-nw", "--no-color", "-e", symbol],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError, subprocess.TimeoutExpired, OSError:
+        return []
+    if result.returncode not in {0, 1}:
+        return []
+    refs: list[dict[str, object]] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        parts = line.split(":", 2)
+        if len(parts) < 2:
+            continue
+        ref_file = parts[0]
+        if exclude_file and ref_file == exclude_file:
+            continue
+        try:
+            ref_line = int(parts[1])
+        except ValueError, IndexError:
+            continue
+        refs.append({"file": ref_file, "line": ref_line})
+        if len(refs) >= max_refs:
+            break
+    return refs
 
-    Returns ``{"impactPath": […], "truncated": bool, "totalDeclarations": int}``.
-    """
+
+def extract_impact(diff_text: str, cwd: str) -> dict[str, object]:
+    hunks = _parse_hunks(diff_text)
     rows: list[dict[str, object]] = []
     for fp in _changed_paths(diff_text):
+        file_hunks = hunks.get(fp)
+        if not file_hunks:
+            continue
         decls = _find_declarations(fp, cwd)
         for d in decls:
+            line_val = d["line"]
+            assert isinstance(line_val, int)
+            if not _intersects_hunks(line_val, file_hunks):
+                continue
+            name_val = d["name"]
+            assert isinstance(name_val, str)
+            refs = _find_references(name_val, cwd, exclude_file=fp)
             rows.append(
                 {
                     "file": fp,
                     "declaration": d["name"],
                     "language": d["language"],
                     "line": d["line"],
+                    "references": refs,
                 }
             )
-
-    # Sort: language → file → line
     rows.sort(key=lambda r: (r["language"], r["file"], r["line"]))
-
     capped = rows[:_MAX_DECLARATIONS]
     return {
         "impactPath": capped,
@@ -192,19 +243,12 @@ def write_impact(
     tmpdir: str,
     pull_number: int | str,
 ) -> dict[str, object] | None:
-    """Write the impact-path JSON artifact to disk.
-
-    Returns ``None`` when there are zero declarations, so the caller omits
-    the ``impactPath`` key entirely (same convention as ``incrementalDiffPath``).
-    """
     data = extract_impact(diff_text, cwd)
     rows = data.get("impactPath", [])
     if not rows:
         return None
-
     path = str(Path(tmpdir) / f"pr-{pull_number}-impact.json")
     Path(path).write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-
     return {
         "impactPath": path,
         "impactTruncated": data["truncated"],

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -20,8 +20,8 @@ from pathlib import Path
 _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
     "Python": {
         ".py": [
-            re.compile(r"^def\s+(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)\s*[(:]", re.MULTILINE),
+            re.compile(r"^[ \t]*def\s+(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^[ \t]*class\s+(?P<name>[a-zA-Z_]\w*)\s*[(:]", re.MULTILINE),
         ],
     },
     "JavaScript/TypeScript": {
@@ -40,9 +40,30 @@ _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
             re.compile(
                 r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
             ),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(r"^interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(r"^type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:default\s+)?class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(
+                r"^(?:export\s+)?(?:default\s+)?interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(r"^(?:export\s+)?type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:)]", re.MULTILINE
+            ),
+            re.compile(r"^enum\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+        ],
+        ".tsx": [
+            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(
+                r"^(?:export\s+)?(?:default\s+)?class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(
+                r"^(?:export\s+)?(?:default\s+)?interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(r"^(?:export\s+)?type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
             re.compile(
                 r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:)]", re.MULTILINE
             ),
@@ -52,6 +73,7 @@ _LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
     "Go": {
         ".go": [
             re.compile(r"^func\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
+            re.compile(r"^func\s+\([^)]*\)\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
             re.compile(r"^type\s+(?P<name>[a-zA-Z_]\w+)\s+(?:struct|interface)\b", re.MULTILINE),
         ],
     },
@@ -174,7 +196,7 @@ def _find_references(
 ) -> list[dict[str, object]]:
     try:
         result = subprocess.run(
-            ["git", "-C", cwd, "grep", "-nw", "--no-color", "-e", symbol],
+            ["git", "-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol],
             capture_output=True,
             text=True,
             timeout=15,
@@ -205,35 +227,42 @@ def _find_references(
 
 def extract_impact(diff_text: str, cwd: str) -> dict[str, object]:
     hunks = _parse_hunks(diff_text)
-    rows: list[dict[str, object]] = []
+    candidates: list[dict[str, object]] = []
     for fp in _changed_paths(diff_text):
         file_hunks = hunks.get(fp)
         if not file_hunks:
             continue
-        decls = _find_declarations(fp, cwd)
-        for d in decls:
+        for d in _find_declarations(fp, cwd):
             line_val = d["line"]
             assert isinstance(line_val, int)
             if not _intersects_hunks(line_val, file_hunks):
                 continue
-            name_val = d["name"]
-            assert isinstance(name_val, str)
-            refs = _find_references(name_val, cwd, exclude_file=fp)
-            rows.append(
-                {
-                    "file": fp,
-                    "declaration": d["name"],
-                    "language": d["language"],
-                    "line": d["line"],
-                    "references": refs,
-                }
+            candidates.append(
+                {"file": fp, "name": d["name"], "language": d["language"], "line": d["line"]}
             )
-    rows.sort(key=lambda r: (r["language"], r["file"], r["line"]))
-    capped = rows[:_MAX_DECLARATIONS]
+    total = len(candidates)
+    candidates.sort(key=lambda r: (r["language"], r["file"], r["line"]))
+    capped = candidates[:_MAX_DECLARATIONS]
+    rows: list[dict[str, object]] = []
+    for c in capped:
+        name_val = c["name"]
+        assert isinstance(name_val, str)
+        fp_val = c["file"]
+        assert isinstance(fp_val, str)
+        refs = _find_references(name_val, cwd, exclude_file=fp_val)
+        rows.append(
+            {
+                "file": c["file"],
+                "declaration": c["name"],
+                "language": c["language"],
+                "line": c["line"],
+                "references": refs,
+            }
+        )
     return {
-        "impactPath": capped,
-        "truncated": len(rows) > _MAX_DECLARATIONS,
-        "totalDeclarations": len(rows),
+        "impactPath": rows,
+        "truncated": total > _MAX_DECLARATIONS,
+        "totalDeclarations": total,
     }
 
 

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -5,6 +5,14 @@ artifact (``impactPath``) listing every declaration the diff *actually touches*
 (within hunk ranges), grouped by language, with cross-file references.
 Default off behind ``analyzers.impact``.
 
+Declaration nodes are extracted through the shipped ``ast-grep`` catalog entry
+(``analyzers/catalog/ast-grep.yaml``) rather than hand-rolled regexes, using the
+kind-based rules in ``analyzers/catalog/impact-declarations/``. Any extraction
+failure (subprocess error, timeout, unexpected exit) suppresses the whole
+artifact instead of publishing a partial result — a partial ``impactPath`` with
+silently-empty references would read as "no other usages" when the truth is
+"we couldn't check".
+
 Design decisions documented at
 ``.ignorelocal/waves/evidence/s6-design-decisions.md``.
 """
@@ -16,109 +24,27 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any, cast
 
-_LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
-    "Python": {
-        ".py": [
-            re.compile(r"^[ \t]*def\s+(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^[ \t]*class\s+(?P<name>[a-zA-Z_]\w*)\s*[(:]", re.MULTILINE),
-        ],
-    },
-    "JavaScript/TypeScript": {
-        ".js": [
-            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:]", re.MULTILINE
-            ),
-        ],
-        ".ts": [
-            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(
-                r"^(?:export\s+)?(?:default\s+)?class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(
-                r"^(?:export\s+)?(?:default\s+)?interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(r"^(?:export\s+)?type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:)]", re.MULTILINE
-            ),
-            re.compile(r"^enum\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-        ],
-        ".tsx": [
-            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(
-                r"^(?:export\s+)?(?:default\s+)?class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(
-                r"^(?:export\s+)?(?:default\s+)?interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
-            ),
-            re.compile(r"^(?:export\s+)?type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
-            re.compile(
-                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:)]", re.MULTILINE
-            ),
-            re.compile(r"^enum\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
-        ],
-    },
-    "Go": {
-        ".go": [
-            re.compile(r"^func\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
-            re.compile(r"^func\s+\([^)]*\)\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
-            re.compile(r"^type\s+(?P<name>[a-zA-Z_]\w+)\s+(?:struct|interface)\b", re.MULTILINE),
-        ],
-    },
-    "Java": {
-        ".java": [
-            re.compile(r"^(?:\w+\s+)*class\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
-            re.compile(r"^(?:\w+\s+)*interface\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
-            re.compile(r"^(?:\w+\s+)*\w+\s+(?P<name>[a-z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^enum\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
-        ],
-    },
-    "Rust": {
-        ".rs": [
-            re.compile(r"^fn\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
-            re.compile(
-                r"^(?:pub\s+)?(?:struct|trait|enum|union)\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE
-            ),
-            re.compile(
-                r"^(?:pub\s+)?(?:async\s+|unsafe\s+)?fn\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE
-            ),
-            re.compile(r"^macro_rules!\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE),
-        ],
-    },
-    "C/C++": {
-        ".c": [re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE)],
-        ".h": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(
-                r"^(?:typedef\s+)?(?:struct|union|enum)\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE
-            ),
-        ],
-        ".cpp": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
-        ],
-        ".hpp": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
-        ],
-        ".cc": [
-            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
-            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
-        ],
-        ".cxx": [re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE)],
-    },
+from loguru import logger
+
+_CATALOG_DECL_DIR = Path(__file__).resolve().parent / "catalog" / "impact-declarations"
+
+# extension -> (friendly language label, ast-grep rule file under _CATALOG_DECL_DIR)
+_EXTENSION_RULES: dict[str, tuple[str, str]] = {
+    ".py": ("Python", "python.yml"),
+    ".js": ("JavaScript/TypeScript", "javascript.yml"),
+    ".ts": ("JavaScript/TypeScript", "typescript.yml"),
+    ".tsx": ("JavaScript/TypeScript", "tsx.yml"),
+    ".go": ("Go", "go.yml"),
+    ".java": ("Java", "java.yml"),
+    ".rs": ("Rust", "rust.yml"),
+    ".c": ("C/C++", "c.yml"),
+    ".h": ("C/C++", "c.yml"),
+    ".cpp": ("C/C++", "cpp.yml"),
+    ".hpp": ("C/C++", "cpp.yml"),
+    ".cc": ("C/C++", "cpp.yml"),
+    ".cxx": ("C/C++", "cpp.yml"),
 }
 
 _DIFF_FILE_RE = re.compile(r"^diff --git a/(?P<path>.+?) b/(?P<to>.+)$", re.MULTILINE)
@@ -127,6 +53,10 @@ _HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @
 
 _MAX_DECLARATIONS: int = 24
 _MAX_REFS: int = 8
+
+
+class _ExtractionFailed(RuntimeError):
+    """Internal signal: a subprocess call failed outright (not just "no matches")."""
 
 
 def _changed_paths(diff_text: str) -> list[str]:
@@ -164,26 +94,69 @@ def _extension(path: str) -> str:
     return dot.lower()
 
 
-def _find_declarations(path: str, cwd: str) -> list[dict[str, object]]:
-    full = os.path.join(cwd, path)
-    if not os.path.isfile(full):
-        return []
+def _run_ast_grep(
+    binary: str,
+    rule_path: Path,
+    files: list[str],
+    cwd: str,
+) -> list[dict[str, Any]]:
     try:
-        text = Path(full).read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return []
-    ext = _extension(path)
-    results: list[dict[str, object]] = []
-    seen_names: set[str] = set()
-    for lang, entries in _LANG_PATTERNS.items():
-        patterns = entries.get(ext, [])
-        for pat in patterns:
-            for match in pat.finditer(text):
-                name = match.group("name")
-                if name and name not in seen_names:
-                    seen_names.add(name)
-                    line = text[: match.start()].count("\n") + 1
-                    results.append({"name": name, "language": lang, "line": line})
+        result = subprocess.run(
+            [binary, "scan", "--json", "-r", str(rule_path), *files],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        msg = f"ast-grep invocation failed ({rule_path.name}): {exc}"
+        raise _ExtractionFailed(msg) from exc
+    if result.returncode != 0:
+        msg = f"ast-grep exited {result.returncode} ({rule_path.name}): {result.stderr.strip()}"
+        raise _ExtractionFailed(msg)
+    try:
+        matches = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        msg = f"ast-grep produced unparsable output ({rule_path.name}): {exc}"
+        raise _ExtractionFailed(msg) from exc
+    return cast("list[dict[str, Any]]", matches)
+
+
+def _find_declarations_batch(
+    paths: list[str],
+    cwd: str,
+    ast_grep_binary: str,
+) -> dict[str, list[dict[str, object]]]:
+    """Extract declaration-node candidates for every path, grouped by ast-grep rule.
+
+    Raises ``_ExtractionFailed`` if any batch's ast-grep invocation fails outright.
+    A path that does not exist on disk (deleted file, etc.) is skipped, not a failure.
+    """
+    groups: dict[str, list[str]] = {}
+    labels: dict[str, str] = {}
+    for fp in paths:
+        if not os.path.isfile(os.path.join(cwd, fp)):
+            continue
+        rule = _EXTENSION_RULES.get(_extension(fp))
+        if rule is None:
+            continue
+        label, rule_name = rule
+        groups.setdefault(rule_name, []).append(fp)
+        labels[rule_name] = label
+
+    results: dict[str, list[dict[str, object]]] = {fp: [] for fp in paths}
+    for rule_name, files in groups.items():
+        rule_path = _CATALOG_DECL_DIR / rule_name
+        matches = _run_ast_grep(ast_grep_binary, rule_path, files, cwd)
+        label = labels[rule_name]
+        for m in matches:
+            name_mv = m.get("metaVariables", {}).get("single", {}).get("NAME")
+            name = name_mv.get("text") if name_mv else None
+            file_field = m.get("file")
+            if not name or file_field not in results:
+                continue
+            line = int(m["range"]["start"]["line"]) + 1
+            results[file_field].append({"name": name, "language": label, "line": line})
     return results
 
 
@@ -192,8 +165,9 @@ def _find_references(
     cwd: str,
     *,
     exclude_file: str | None = None,
-    max_refs: int = 8,
-) -> list[dict[str, object]]:
+    max_refs: int = _MAX_REFS,
+) -> tuple[list[dict[str, object]], bool]:
+    """Return (capped references, whether more references existed than the cap)."""
     try:
         result = subprocess.run(
             ["git", "-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol],
@@ -201,11 +175,14 @@ def _find_references(
             text=True,
             timeout=15,
         )
-    except FileNotFoundError, subprocess.TimeoutExpired, OSError:
-        return []
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        msg = f"git grep failed for {symbol!r}: {exc}"
+        raise _ExtractionFailed(msg) from exc
     if result.returncode not in {0, 1}:
-        return []
+        msg = f"git grep exited {result.returncode} for {symbol!r}: {result.stderr.strip()}"
+        raise _ExtractionFailed(msg)
     refs: list[dict[str, object]] = []
+    total = 0
     for line in result.stdout.splitlines():
         if not line:
             continue
@@ -219,46 +196,68 @@ def _find_references(
             ref_line = int(parts[1])
         except ValueError, IndexError:
             continue
-        refs.append({"file": ref_file, "line": ref_line})
-        if len(refs) >= max_refs:
-            break
-    return refs
+        total += 1
+        if len(refs) < max_refs:
+            refs.append({"file": ref_file, "line": ref_line})
+    return refs, total > max_refs
 
 
-def extract_impact(diff_text: str, cwd: str) -> dict[str, object]:
+def extract_impact(
+    diff_text: str,
+    cwd: str,
+    *,
+    ast_grep_binary: str = "ast-grep",
+) -> dict[str, object] | None:
+    """Extract the change-impact artifact, or ``None`` if extraction failed outright.
+
+    ``None`` means "we could not reliably determine this" — the caller must omit
+    the artifact entirely rather than publish a partial/misleading one.
+    """
     hunks = _parse_hunks(diff_text)
-    candidates: list[dict[str, object]] = []
-    for fp in _changed_paths(diff_text):
-        file_hunks = hunks.get(fp)
-        if not file_hunks:
-            continue
-        for d in _find_declarations(fp, cwd):
-            line_val = d["line"]
-            assert isinstance(line_val, int)
-            if not _intersects_hunks(line_val, file_hunks):
-                continue
-            candidates.append(
-                {"file": fp, "name": d["name"], "language": d["language"], "line": d["line"]}
+    relevant_files = [fp for fp in _changed_paths(diff_text) if fp in hunks]
+    if not relevant_files:
+        return {"impactPath": [], "truncated": False, "totalDeclarations": 0}
+
+    try:
+        decls_by_file = _find_declarations_batch(relevant_files, cwd, ast_grep_binary)
+
+        candidates: list[dict[str, object]] = []
+        for fp in relevant_files:
+            file_hunks = hunks[fp]
+            for d in decls_by_file.get(fp, []):
+                line_val = d["line"]
+                assert isinstance(line_val, int)
+                if not _intersects_hunks(line_val, file_hunks):
+                    continue
+                candidates.append(
+                    {"file": fp, "name": d["name"], "language": d["language"], "line": d["line"]}
+                )
+
+        total = len(candidates)
+        candidates.sort(key=lambda r: (r["language"], r["file"], r["line"]))
+        capped = candidates[:_MAX_DECLARATIONS]
+
+        rows: list[dict[str, object]] = []
+        for c in capped:
+            name_val = c["name"]
+            assert isinstance(name_val, str)
+            fp_val = c["file"]
+            assert isinstance(fp_val, str)
+            refs, refs_truncated = _find_references(name_val, cwd, exclude_file=fp_val)
+            rows.append(
+                {
+                    "file": c["file"],
+                    "declaration": c["name"],
+                    "language": c["language"],
+                    "line": c["line"],
+                    "references": refs,
+                    "referencesTruncated": refs_truncated,
+                }
             )
-    total = len(candidates)
-    candidates.sort(key=lambda r: (r["language"], r["file"], r["line"]))
-    capped = candidates[:_MAX_DECLARATIONS]
-    rows: list[dict[str, object]] = []
-    for c in capped:
-        name_val = c["name"]
-        assert isinstance(name_val, str)
-        fp_val = c["file"]
-        assert isinstance(fp_val, str)
-        refs = _find_references(name_val, cwd, exclude_file=fp_val)
-        rows.append(
-            {
-                "file": c["file"],
-                "declaration": c["name"],
-                "language": c["language"],
-                "line": c["line"],
-                "references": refs,
-            }
-        )
+    except _ExtractionFailed as exc:
+        logger.info("impact extraction failed, suppressing artifact: {}", exc)
+        return None
+
     return {
         "impactPath": rows,
         "truncated": total > _MAX_DECLARATIONS,
@@ -271,8 +270,12 @@ def write_impact(
     cwd: str,
     tmpdir: str,
     pull_number: int | str,
+    *,
+    ast_grep_binary: str = "ast-grep",
 ) -> dict[str, object] | None:
-    data = extract_impact(diff_text, cwd)
+    data = extract_impact(diff_text, cwd, ast_grep_binary=ast_grep_binary)
+    if data is None:
+        return None
     rows = data.get("impactPath", [])
     if not rows:
         return None
@@ -283,3 +286,38 @@ def write_impact(
         "impactTruncated": data["truncated"],
         "impactDeclarationCount": data["totalDeclarations"],
     }
+
+
+def resolve_ast_grep_binary(repo_root: Path) -> str | None:
+    """Resolve the pinned, managed ``ast-grep`` binary (D10) for impact extraction.
+
+    Returns ``None`` when it cannot be resolved (unsupported platform, network
+    unavailable, checksum mismatch) — callers should skip emitting ``impactPath``
+    rather than fall back to an unpinned binary found on ``PATH``.
+    """
+    from mergecraft.analyzers.execution import provision_platform_key
+    from mergecraft.analyzers.provision import (
+        ProvisionError,
+        resolve_baked_binary,
+        resolve_with_lock,
+    )
+    from mergecraft.analyzers.registry import get_manifest
+
+    manifest = get_manifest("ast-grep")
+    baked = resolve_baked_binary(manifest)
+    if baked is not None:
+        return str(baked)
+
+    cache_dir = repo_root / ".mergecraft" / "analyzer-cache"
+    lock_path = repo_root / ".mergecraft" / "analyzers.lock"
+    try:
+        result = resolve_with_lock(
+            manifest=manifest,
+            lock_path=lock_path,
+            cache_dir=cache_dir,
+            platform=provision_platform_key(),
+        )
+    except ProvisionError as exc:
+        logger.info("impact: could not resolve managed ast-grep binary: {}", exc)
+        return None
+    return str(result.resolved_path)

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -168,11 +168,22 @@ def _find_declarations_batch(
 
     Raises ``_ExtractionFailed`` if any batch's ast-grep invocation fails outright.
     A path that does not exist on disk (deleted file, etc.) is skipped, not a failure.
+    Paths are resolved and checked for containment within ``cwd`` before use —
+    a PR can add a symlink pointing outside the checkout, and ``os.path.isfile``
+    follows symlinks, so an unresolved check would hand ast-grep a target
+    outside the repo (matching the containment check ``expand_analyzer_argv``
+    already applies to manifest-driven analyzer argv).
     """
     groups: dict[str, list[str]] = {}
     labels: dict[str, str] = {}
+    repo_root = Path(cwd).resolve()
     for fp in paths:
-        if not os.path.isfile(os.path.join(cwd, fp)):
+        try:
+            resolved = (repo_root / fp).resolve()
+            resolved.relative_to(repo_root)
+        except OSError, ValueError:
+            continue
+        if not resolved.is_file():
             continue
         rule = _EXTENSION_RULES.get(_extension(fp))
         if rule is None:
@@ -331,12 +342,20 @@ def write_impact(
     }
 
 
-def resolve_ast_grep_binary(repo_root: Path) -> str | None:
+def resolve_ast_grep_binary() -> str | None:
     """Resolve the pinned, managed ``ast-grep`` binary (D10) for impact extraction.
 
     Returns ``None`` when it cannot be resolved (unsupported platform, network
     unavailable, checksum mismatch) — callers should skip emitting ``impactPath``
     rather than fall back to an unpinned binary found on ``PATH``.
+
+    The managed cache and lock live under the user cache dir, never under the
+    PR checkout: ``resolve_with_lock`` trusts an existing cached executable
+    whenever its hash matches its *own* lock entry, without re-checking either
+    against the manifest's pinned provenance. A PR that committed a binary at
+    the checkout-relative cache path plus a matching lock entry would have
+    that binary accepted as "managed" and executed. Caching outside the
+    checkout removes that attacker-controlled surface entirely.
     """
     from mergecraft.analyzers.execution import provision_platform_key
     from mergecraft.analyzers.provision import (
@@ -351,8 +370,9 @@ def resolve_ast_grep_binary(repo_root: Path) -> str | None:
     if baked is not None:
         return str(baked)
 
-    cache_dir = repo_root / ".mergecraft" / "analyzer-cache"
-    lock_path = repo_root / ".mergecraft" / "analyzers.lock"
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "mergecraft"
+    cache_dir = cache_root / "analyzer-cache"
+    lock_path = cache_root / "analyzers.lock"
     try:
         result = resolve_with_lock(
             manifest=manifest,

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -1,0 +1,212 @@
+"""Change-impact extraction from a diff — declaration-level reference leads.
+
+Given a formatted PR diff and the checked-out files, produces a structured
+artifact (``impactPath``) listing every declaration the diff touches, grouped
+by language and ranked by severity. Default off behind ``analyzers.impact``.
+
+Design decisions documented at
+``.ignorelocal/waves/evidence/s6-design-decisions.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+# Language → extension → declaration patterns (multiline regex).
+# Covers the 8 languages in the shipped ast-grep catalog (python, javascript,
+# typescript, go, java, rust, c, cpp).  Patterns look for the declaration
+# *headline* on its own line — class/function/interface definitions.
+_LANG_PATTERNS: dict[str, dict[str, list[re.Pattern[str]]]] = {
+    "Python": {
+        ".py": [
+            re.compile(r"^def\s+(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)\s*[(:]", re.MULTILINE),
+        ],
+    },
+    "JavaScript/TypeScript": {
+        ".js": [
+            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:]", re.MULTILINE
+            ),
+        ],
+        ".ts": [
+            re.compile(r"^function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE
+            ),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(r"^interface\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+            re.compile(r"^type\s+(?P<name>[a-zA-Z_$\w]+)\s*=", re.MULTILINE),
+            re.compile(
+                r"^(?:export\s+)?(?:const|let|var)\s+(?P<name>[a-zA-Z_$\w]+)\s*[=(:)]", re.MULTILINE
+            ),
+            re.compile(r"^enum\s+(?P<name>[a-zA-Z_$\w]+)", re.MULTILINE),
+        ],
+    },
+    "Go": {
+        ".go": [
+            re.compile(r"^func\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
+            re.compile(r"^type\s+(?P<name>[a-zA-Z_]\w+)\s+(?:struct|interface)\b", re.MULTILINE),
+        ],
+    },
+    "Java": {
+        ".java": [
+            re.compile(r"^(?:\w+\s+)*class\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
+            re.compile(r"^(?:\w+\s+)*interface\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
+            re.compile(r"^(?:\w+\s+)*\w+\s+(?P<name>[a-z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^enum\s+(?P<name>[A-Za-z_]\w*)", re.MULTILINE),
+        ],
+    },
+    "Rust": {
+        ".rs": [
+            re.compile(r"^fn\s+(?P<name>[a-zA-Z_]\w+)\s*\(", re.MULTILINE),
+            re.compile(
+                r"^(?:pub\s+)?(?:struct|trait|enum|union)\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE
+            ),
+            re.compile(
+                r"^(?:pub\s+)?(?:async\s+|unsafe\s+)?fn\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE
+            ),
+            re.compile(r"^macro_rules!\s+(?P<name>[a-zA-Z_]\w+)", re.MULTILINE),
+        ],
+    },
+    "C/C++": {
+        ".c": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+        ],
+        ".h": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(
+                r"^(?:typedef\s+)?(?:struct|union|enum)\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE
+            ),
+        ],
+        ".cpp": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
+        ],
+        ".hpp": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
+        ],
+        ".cc": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+            re.compile(r"^class\s+(?P<name>[a-zA-Z_]\w*)", re.MULTILINE),
+        ],
+        ".cxx": [
+            re.compile(r"^(?:\w+\s+)+\s*(?P<name>[a-zA-Z_]\w*)\s*\(", re.MULTILINE),
+        ],
+    },
+}
+
+
+_DIFF_FILE_RE = re.compile(r"^diff --git a/(?P<path>.+?) b/(?P<to>.+)$", re.MULTILINE)
+
+# Q3 design cap: 24 declarations per review, 8 references per decl.
+_MAX_DECLARATIONS: int = 24
+_MAX_REFS: int = 8
+
+
+def _changed_paths(diff_text: str) -> list[str]:
+    """Return the post-image paths named by a unified diff, in first-seen order."""
+    seen: dict[str, None] = {}
+    for match in _DIFF_FILE_RE.finditer(diff_text):
+        seen.setdefault(match.group("to"), None)
+    return list(seen)
+
+
+def _extension(path: str) -> str:
+    _, dot = os.path.splitext(path)
+    return dot.lower()
+
+
+def _find_declarations(path: str, cwd: str) -> list[dict[str, object]]:
+    """Extract declaration names from *path* (relative to *cwd*).
+
+    Returns ``[{"name": str, "language": str, "line": int}, …]``
+    sorted by file order. Empty when the file has no recognised extension
+    or is not on disk.
+    """
+    full = os.path.join(cwd, path)
+    if not os.path.isfile(full):
+        return []
+    try:
+        text = Path(full).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    ext = _extension(path)
+    results: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    for lang, entries in _LANG_PATTERNS.items():
+        patterns = entries.get(ext, [])
+        for pat in patterns:
+            for match in pat.finditer(text):
+                name = match.group("name")
+                if name and name not in seen_names:
+                    seen_names.add(name)
+                    # Approximate line number from match position
+                    line = text[: match.start()].count("\n") + 1
+                    results.append({"name": name, "language": lang, "line": line})
+    return results
+
+
+def extract_impact(diff_text: str, cwd: str) -> dict[str, object]:
+    """Extract impact data from *diff_text* and files checked out at *cwd*.
+
+    Returns ``{"impactPath": […], "truncated": bool, "totalDeclarations": int}``.
+    """
+    rows: list[dict[str, object]] = []
+    for fp in _changed_paths(diff_text):
+        decls = _find_declarations(fp, cwd)
+        for d in decls:
+            rows.append(
+                {
+                    "file": fp,
+                    "declaration": d["name"],
+                    "language": d["language"],
+                    "line": d["line"],
+                }
+            )
+
+    # Sort: language → file → line
+    rows.sort(key=lambda r: (r["language"], r["file"], r["line"]))
+
+    capped = rows[:_MAX_DECLARATIONS]
+    return {
+        "impactPath": capped,
+        "truncated": len(rows) > _MAX_DECLARATIONS,
+        "totalDeclarations": len(rows),
+    }
+
+
+def write_impact(
+    diff_text: str,
+    cwd: str,
+    tmpdir: str,
+    pull_number: int | str,
+) -> dict[str, object] | None:
+    """Write the impact-path JSON artifact to disk.
+
+    Returns ``None`` when there are zero declarations, so the caller omits
+    the ``impactPath`` key entirely (same convention as ``incrementalDiffPath``).
+    """
+    data = extract_impact(diff_text, cwd)
+    rows = data.get("impactPath", [])
+    if not rows:
+        return None
+
+    path = str(Path(tmpdir) / f"pr-{pull_number}-impact.json")
+    Path(path).write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+
+    return {
+        "impactPath": path,
+        "impactTruncated": data["truncated"],
+        "impactDeclarationCount": data["totalDeclarations"],
+    }

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -179,6 +179,12 @@ class AnalyzersSettings(BaseModel):
     # before the upload can succeed. The `sarif_upload` action input overrides
     # this in both directions when it is set (`resolve_sarif_upload_enabled`).
     sarif_upload: bool = Field(default=False, alias="sarifUpload")
+    # #94 / S6 — change-impact extraction (impactPath), default off.
+    # Produces a declaration-level reference-lead table for the diff at
+    # review time. Off by default until the eval-bank corpus (#140) measures
+    # its cost-to-benefit ratio (see S6 design at
+    # .ignorelocal/waves/issues-setup-container-hygiene-wave-plan.md).
+    impact: bool = Field(default=False, alias="impact")
 
 
 # D5 / D9 / D15 — `tracing` block on `RepoSettings`. Additive-only, default off.

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from mergecraft.analyzers.impact import write_impact
+from mergecraft.analyzers.impact import resolve_ast_grep_binary, write_impact
 from mergecraft.config.settings import load_repo_settings
 from mergecraft.mcp.git import _git_env, _run_git
 from mergecraft.mcp.shared import execute, tool
@@ -268,18 +268,27 @@ def checkout_pr_tool(ctx: ToolContext):
             repo_root = Path(cwd)
             settings_obj = load_repo_settings(root=repo_root, load_learnings_files=False)
             if settings_obj.analyzers.impact:
-                impact_result = write_impact(diff, cwd, temp, pull_number)
-                if impact_result is not None:
-                    result["impactPath"] = impact_result["impactPath"]
-                    result["impactTruncated"] = impact_result["impactTruncated"]
-                    result["impactDeclarationCount"] = impact_result["impactDeclarationCount"]
+                ast_grep_binary = resolve_ast_grep_binary(repo_root)
+                if ast_grep_binary is None:
                     logger.info(
-                        "impactPath for PR #{} -> {} ({} declarations, truncated={})",
+                        "impactPath skipped for PR #{}: managed ast-grep binary unavailable",
                         pull_number,
-                        impact_result["impactPath"],
-                        impact_result["impactDeclarationCount"],
-                        impact_result["impactTruncated"],
                     )
+                else:
+                    impact_result = write_impact(
+                        diff, cwd, temp, pull_number, ast_grep_binary=ast_grep_binary
+                    )
+                    if impact_result is not None:
+                        result["impactPath"] = impact_result["impactPath"]
+                        result["impactTruncated"] = impact_result["impactTruncated"]
+                        result["impactDeclarationCount"] = impact_result["impactDeclarationCount"]
+                        logger.info(
+                            "impactPath for PR #{} -> {} ({} declarations, truncated={})",
+                            pull_number,
+                            impact_result["impactPath"],
+                            impact_result["impactDeclarationCount"],
+                            impact_result["impactTruncated"],
+                        )
         except Exception as imp_err:
             logger.info("impact extraction soft-failed: {}", imp_err)
 

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.analyzers.impact import resolve_ast_grep_binary, write_impact
+from mergecraft.analyzers.trust import analyzers_enabled
 from mergecraft.config.settings import load_repo_settings
 from mergecraft.mcp.git import _git_env, _run_git
 from mergecraft.mcp.shared import execute, tool
@@ -264,15 +265,19 @@ def checkout_pr_tool(ctx: ToolContext):
         # S6 #94 — impact-path extraction (default off behind analyzers.impact).
         # Emitted only when enabled; returns None (-> no key) when the diff
         # has zero declarations, matching the incrementalDiffPath convention.
-        # The impact.impact toggle is read from the PR's own checkout (fine —
-        # repo config is safe to *read* regardless of trust tier), but ast-grep
-        # execution itself is gated on ctx.trust_tier inside write_impact, which
-        # fails closed (omits impactPath) when sandbox isolation for an
-        # untrusted checkout isn't available (D7).
+        # The analyzers.impact toggle is read from the PR's own checkout (fine —
+        # repo config is safe to *read* regardless of trust tier), but gated
+        # behind analyzers_enabled(ctx) first so the operator's effective
+        # policy (analyzers: off, or analyzers.enabled: false) always wins over
+        # whatever a PR sets in its own config — mirrors run_analyzers_tool's
+        # gate (mcp/analyzers.py). ast-grep execution itself is further gated
+        # on ctx.trust_tier inside write_impact, which fails closed (omits
+        # impactPath) when sandbox isolation for an untrusted checkout isn't
+        # available (D7).
         try:
             repo_root = Path(cwd)
             settings_obj = load_repo_settings(root=repo_root, load_learnings_files=False)
-            if settings_obj.analyzers.impact:
+            if analyzers_enabled(ctx) and settings_obj.analyzers.impact:
                 ast_grep_binary = resolve_ast_grep_binary(repo_root)
                 if ast_grep_binary is None:
                     logger.info(

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -278,7 +278,7 @@ def checkout_pr_tool(ctx: ToolContext):
             repo_root = Path(cwd)
             settings_obj = load_repo_settings(root=repo_root, load_learnings_files=False)
             if analyzers_enabled(ctx) and settings_obj.analyzers.impact:
-                ast_grep_binary = resolve_ast_grep_binary(repo_root)
+                ast_grep_binary = resolve_ast_grep_binary()
                 if ast_grep_binary is None:
                     logger.info(
                         "impactPath skipped for PR #{}: managed ast-grep binary unavailable",

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -264,6 +264,11 @@ def checkout_pr_tool(ctx: ToolContext):
         # S6 #94 — impact-path extraction (default off behind analyzers.impact).
         # Emitted only when enabled; returns None (-> no key) when the diff
         # has zero declarations, matching the incrementalDiffPath convention.
+        # The impact.impact toggle is read from the PR's own checkout (fine —
+        # repo config is safe to *read* regardless of trust tier), but ast-grep
+        # execution itself is gated on ctx.trust_tier inside write_impact, which
+        # fails closed (omits impactPath) when sandbox isolation for an
+        # untrusted checkout isn't available (D7).
         try:
             repo_root = Path(cwd)
             settings_obj = load_repo_settings(root=repo_root, load_learnings_files=False)
@@ -276,7 +281,12 @@ def checkout_pr_tool(ctx: ToolContext):
                     )
                 else:
                     impact_result = write_impact(
-                        diff, cwd, temp, pull_number, ast_grep_binary=ast_grep_binary
+                        diff,
+                        cwd,
+                        temp,
+                        pull_number,
+                        ast_grep_binary=ast_grep_binary,
+                        tier=ctx.trust_tier,
                     )
                     if impact_result is not None:
                         result["impactPath"] = impact_result["impactPath"]

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from mergecraft.analyzers.impact import write_impact
+from mergecraft.config.settings import load_repo_settings
 from mergecraft.mcp.git import _git_env, _run_git
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import StoredPushDest, primary_repo_state
@@ -259,6 +261,28 @@ def checkout_pr_tool(ctx: ToolContext):
                         len(changed),
                     )
 
+        # S6 #94 — impact-path extraction (default off behind analyzers.impact).
+        # Emitted only when enabled; returns None (-> no key) when the diff
+        # has zero declarations, matching the incrementalDiffPath convention.
+        try:
+            repo_root = Path(cwd)
+            settings_obj = load_repo_settings(root=repo_root, load_learnings_files=False)
+            if settings_obj.analyzers.impact:
+                impact_result = write_impact(diff, cwd, temp, pull_number)
+                if impact_result is not None:
+                    result["impactPath"] = impact_result["impactPath"]
+                    result["impactTruncated"] = impact_result["impactTruncated"]
+                    result["impactDeclarationCount"] = impact_result["impactDeclarationCount"]
+                    logger.info(
+                        "impactPath for PR #{} -> {} ({} declarations, truncated={})",
+                        pull_number,
+                        impact_result["impactPath"],
+                        impact_result["impactDeclarationCount"],
+                        impact_result["impactTruncated"],
+                    )
+        except Exception as imp_err:
+            logger.info("impact extraction soft-failed: {}", imp_err)
+
         logger.info("checked out PR #{} -> {}", pull_number, local_branch)
         return result
 
@@ -270,7 +294,9 @@ def checkout_pr_tool(ctx: ToolContext):
             "Checkout a pull request branch locally. Returns diffPath pointing to the "
             "formatted diff file, plus incrementalDiffPath (changes since the last "
             "mergeCraft review) on a re-review when a prior reviewed commit is "
-            "recoverable and the range is non-empty."
+            "recoverable and the range is non-empty. When the repo config enables "
+            "analyzers.impact, also returns impactPath pointing to a JSON file listing "
+            "declaration-level reference leads for the changed files."
         ),
         input_schema={
             "type": "object",

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -1,0 +1,151 @@
+"""Tests for change-impact extraction (S6 / #94).
+
+Covers the ``analyzers.impact`` config toggle, the declaration-extraction
+logic, and the ``impactPath`` artifact contract.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from mergecraft.analyzers.impact import _changed_paths, extract_impact, write_impact
+
+# A minimal diff that touches two files with known declarations.
+_SAMPLE_DIFF = """diff --git a/src/example.py b/src/example.py
+index abc..def 100644
+--- a/src/example.py
++++ b/src/example.py
+@@ -1,3 +1,4 @@
+ def existing_func():
+     pass
++
++def new_func():
++    return 42
+diff --git a/src/util.ts b/src/util.ts
+index 111..222 100644
+--- a/src/util.ts
++++ b/src/util.ts
+@@ -1,2 +1,5 @@
+ export const CONSTANT = 1
++
++export function helper(): string {
++    return "hello"
++}
+diff --git a/README.md b/README.md
+index 000..111 100644
+--- /dev/null
++++ b/README.md
+@@ -0,0 +1 @@
++# my project
+"""
+
+
+def test_changed_paths_extracts_post_image_paths() -> None:
+    paths = _changed_paths(_SAMPLE_DIFF)
+    assert paths == ["src/example.py", "src/util.ts", "README.md"]
+
+
+def test_extract_impact_returns_declarations() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "example.py").write_text(
+            "def existing_func():\n    pass\n\n\ndef new_func():\n    return 42\n"
+        )
+        (src / "util.ts").write_text(
+            'export const CONSTANT = 1\n\n\nexport function helper(): string {\n    return "hello"\n}\n'
+        )
+
+        result = extract_impact(_SAMPLE_DIFF, tmp)
+        rows = result["impactPath"]
+        assert isinstance(rows, list)
+        # Should find: existing_func, new_func (python), CONSTANT, helper (ts)
+        names = {(r["file"], r["declaration"]) for r in rows}
+        assert ("src/example.py", "existing_func") in names, names
+        assert ("src/example.py", "new_func") in names, names
+        assert ("src/util.ts", "CONSTANT") in names
+        assert ("src/util.ts", "helper") in names
+        assert result["totalDeclarations"] == 4
+        assert result["truncated"] is False
+
+
+def test_extract_impact_readme_has_no_declarations() -> None:
+    """Markdown files have no recognised patterns and contribute zero rows."""
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "example.py").write_text("def f():\n    pass\n")
+        result = extract_impact(
+            "diff --git a/README.md b/README.md\nindex a..b 100644\n--- /dev/null\n+++ b/README.md\n@@ -0,0 +1 @@\n+# readme\n",
+            tmp,
+        )
+        rows = result["impactPath"]
+        assert isinstance(rows, list)
+        assert len(rows) == 0, "README.md should contribute no declarations"
+        assert result["totalDeclarations"] == 0
+
+
+def test_extract_impact_empty_diff_returns_empty() -> None:
+    result = extract_impact("", "/tmp")
+    assert result["totalDeclarations"] == 0
+    assert result["impactPath"] == []
+
+
+def test_write_impact_returns_none_when_empty() -> None:
+    assert write_impact("", "/tmp", "/tmp", 1) is None
+
+
+def test_write_impact_writes_json_when_nonempty() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "example.py").write_text("def f():\n    pass\n")
+        diff = "diff --git a/src/example.py b/src/example.py\nindex a..b 100644\n--- a/src/example.py\n+++ b/src/example.py\n@@ -1 +1,2 @@\n def f():\n+    pass\n"
+
+        written = write_impact(diff, tmp, tmp, 42)
+        assert written is not None
+        assert written["impactPath"].endswith("pr-42-impact.json")
+        assert written["impactDeclarationCount"] == 1
+        assert written["impactTruncated"] is False
+
+        data = json.loads(Path(written["impactPath"]).read_text(encoding="utf-8"))
+        assert len(data["impactPath"]) == 1
+        assert data["impactPath"][0]["declaration"] == "f"
+
+
+def test_extract_impact_respects_max_declarations() -> None:
+    """When more than _MAX_DECLARATIONS declarations exist, truncated is True."""
+    from mergecraft.analyzers.impact import _MAX_DECLARATIONS
+
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        lines: list[str] = []
+        diff_parts: list[str] = []
+        for i in range(_MAX_DECLARATIONS + 5):
+            lines.append(f"def func_{i}():\n    pass\n")
+            diff_parts.append(
+                f"diff --git a/src/mod_{i}.py b/src/mod_{i}.py\n"
+                f"index a..b 100644\n"
+                f"--- /dev/null\n"
+                f"+++ b/src/mod_{i}.py\n"
+                f"@@ -0,0 +1,2 @@\n"
+                f"+def func_{i}():\n+    pass\n"
+            )
+            (src / f"mod_{i}.py").write_text(f"def func_{i}():\n    pass\n")
+
+        diff = "\n".join(diff_parts)
+        result = extract_impact(diff, tmp)
+        assert result["truncated"] is True
+        assert len(result["impactPath"]) == _MAX_DECLARATIONS
+        assert result["totalDeclarations"] == _MAX_DECLARATIONS + 5
+
+
+def test_extract_impact_missing_file_does_not_crash() -> None:
+    """A diff referencing a file not checked out should be skipped, not crash."""
+    diff = "diff --git a/phantom.py b/phantom.py\nindex a..b 100644\n--- /dev/null\n+++ b/phantom.py\n@@ -0,0 +1 @@\n+def phantom():\n+    pass\n"
+    result = extract_impact(diff, "/tmp/nonexistent")
+    assert result["totalDeclarations"] == 0
+    assert result["impactPath"] == []

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -436,3 +436,71 @@ def test_write_impact_omits_key_for_untrusted_tier_without_sandbox(tmp_path: Pat
     repo = _git_repo(tmp_path)
     _write_and_commit(repo, {"src/example.py": "def existing_func():\n    pass\n"})
     assert write_impact(_SAMPLE_DIFF, str(repo), str(tmp_path), 7, tier="untrusted") is None
+
+
+def test_declaration_scan_rejects_symlink_escaping_the_checkout(tmp_path: Path) -> None:
+    """A PR can add a symlink whose target lives outside the checkout.
+    ``os.path.isfile`` follows symlinks, so an unresolved containment check
+    would hand ast-grep a path outside the repo to parse. The declaration
+    (only reachable via the symlink target) must never appear."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("def outside_secret():\n    pass\n")
+
+    repo = _git_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "escape.py").symlink_to(outside / "secret.py")
+    subprocess.run(["git", "add", "-f", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add symlink"], cwd=repo, check=True, capture_output=True
+    )
+
+    diff = _added_file_diff("src/escape.py", "def outside_secret():\n    pass\n")
+    result = extract_impact(diff, str(repo), tier="trusted")
+    assert result is not None
+    decl_names = {r["declaration"] for r in result["impactPath"]}
+    assert "outside_secret" not in decl_names
+
+
+def test_resolve_ast_grep_binary_uses_cache_outside_any_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The managed binary cache/lock must never live under a PR checkout.
+
+    ``resolve_with_lock`` trusts an existing cached executable whenever its
+    hash matches its *own* lock entry, without re-checking either against the
+    manifest's pinned provenance — so a checkout-relative cache is poisonable
+    by the PR itself (commit a binary plus a matching lock entry at the known
+    path). Caching under the user cache dir instead removes that surface."""
+    from mergecraft.analyzers import provision as provision_module
+    from mergecraft.analyzers.impact import resolve_ast_grep_binary
+
+    fake_cache_home = tmp_path / "isolated-cache-home"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(fake_cache_home))
+    monkeypatch.delenv("MERGECRAFT_ANALYZERS", raising=False)
+
+    # Simulate a PR that committed a poisoned binary + lock entry at the old,
+    # vulnerable, checkout-relative cache path.
+    poisoned_checkout = tmp_path / "checkout"
+    poisoned_cache = poisoned_checkout / ".mergecraft" / "analyzer-cache"
+    poisoned_cache.mkdir(parents=True)
+    (poisoned_cache / "ast-grep").write_text("not a real binary")
+
+    seen: dict[str, Path] = {}
+
+    def _fake_resolve_with_lock(
+        *, manifest: object, lock_path: Path, cache_dir: Path, platform: str
+    ) -> object:
+        seen["lock_path"] = lock_path
+        seen["cache_dir"] = cache_dir
+        raise provision_module.ProvisionError("stub: no network in test")
+
+    monkeypatch.setattr(provision_module, "resolve_with_lock", _fake_resolve_with_lock)
+
+    result = resolve_ast_grep_binary()
+
+    assert result is None
+    assert str(seen["cache_dir"]).startswith(str(fake_cache_home))
+    assert str(seen["lock_path"]).startswith(str(fake_cache_home))
+    assert "checkout" not in str(seen["cache_dir"])
+    assert "checkout" not in str(seen["lock_path"])

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -172,3 +172,90 @@ def test_extract_impact_missing_file_does_not_crash() -> None:
     result = extract_impact(diff, "/tmp/nonexistent")
     assert result["totalDeclarations"] == 0
     assert result["impactPath"] == []
+
+
+def test_cross_file_references_include_usages_in_git_repo(tmp_path: Path) -> None:
+    """A real git repo: usages of a changed declaration in other files appear.
+
+    Guards the ``git grep`` subprocess path (path:line:content parsing,
+    exclude_file filtering, and the -w word match). The declaration file
+    itself is excluded; cross-file usages are kept."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "dev@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Dev"], cwd=repo, check=True, capture_output=True)
+
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("def changed():\n    return True\n")
+    (repo / "src" / "consumer.py").write_text("from app import changed\nresult = changed()\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    diff = """diff --git a/src/app.py b/src/app.py
+index a..b 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1,2 @@
+ def changed():
++    return True
+"""
+
+    result = extract_impact(diff, str(repo))
+    rows = result["impactPath"]
+    app_row = next(r for r in rows if r["file"] == "src/app.py")
+    assert app_row["declaration"] == "changed"
+    ref_files = [ref["file"] for ref in app_row["references"]]
+    assert "src/consumer.py" in ref_files, f"expected consumer.py ref in {ref_files}"
+    assert "src/app.py" not in ref_files, "declaration file must be excluded from references"
+    ref = next(ref for ref in app_row["references"] if ref["file"] == "src/consumer.py")
+    assert ref["line"] == 1, f"expected line 1 (from app import changed) but got {ref}"
+    ref_lines = [ref["line"] for ref in app_row["references"] if ref["file"] == "src/consumer.py"]
+    assert 1 in ref_lines, f"expected import usage (line 1) in {ref_lines}"
+    assert 2 in ref_lines, f"expected call usage (line 2) in {ref_lines}"
+
+
+def test_cross_file_references_word_match_excludes_substrings(tmp_path: Path) -> None:
+    """-w word match: a declaration name must not match inside a longer identifier."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "dev@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Dev"], cwd=repo, check=True, capture_output=True)
+
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("def run():\n    return 1\n")
+    (repo / "src" / "runner.py").write_text("def runner():\n    return run()\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    diff = """diff --git a/src/app.py b/src/app.py
+index a..b 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1,2 @@
+ def run():
++    return 1
+"""
+
+    result = extract_impact(diff, str(repo))
+    rows = result["impactPath"]
+    app_row = next(r for r in rows if r["file"] == "src/app.py")
+    assert app_row["declaration"] == "run"
+    # "runner" contains "run" but -w must exclude it; only "return run()" matches.
+    ref_lines = [ref["line"] for ref in app_row["references"]]
+    assert ref_lines == [2], f"expected only the exact-symbol reference at line 2, got {ref_lines}"

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -1,16 +1,30 @@
 """Tests for change-impact extraction (S6 / #94).
 
-Covers declaration extraction, hunk filtering, cross-file references,
-and the ``impactPath`` artifact contract.
+Covers declaration extraction via the shipped ast-grep catalog entry, hunk
+filtering, cross-file references, reference/declaration truncation, extraction-
+failure propagation, and the ``impactPath`` artifact contract.
+
+Declaration extraction always needs the managed ``ast-grep`` binary; the dev
+extra pins ``ast-grep-cli`` to the same version as
+``analyzers/catalog/ast-grep.yaml`` so it is on ``PATH`` under ``uv run``.
+Reference lookup shells out to ``git grep``, so any test that expects
+declarations to resolve references needs a real (committed) git repo — a bare
+temp dir makes ``git grep`` fail, which is itself exercised as the
+extraction-failure path below.
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from mergecraft.analyzers.impact import (
+    _MAX_DECLARATIONS,
+    _MAX_REFS,
     _changed_paths,
     _intersects_hunks,
     _parse_hunks,
@@ -47,6 +61,46 @@ index 000..111 100644
 """
 
 
+def _git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "dev@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Dev"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def _write_and_commit(repo: Path, files: dict[str, str]) -> None:
+    for relpath, content in files.items():
+        path = repo / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add files"], cwd=repo, check=True, capture_output=True
+    )
+
+
+def _added_file_diff(path: str, content: str) -> str:
+    """A minimal diff that adds ``path`` wholesale, so every declaration in it
+    falls within the (single, whole-file) hunk range."""
+    lines = content.splitlines()
+    hunk_body = "\n".join(f"+{line}" for line in lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "index a..b 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{hunk_body}\n"
+    )
+
+
 def test_changed_paths_extracts_post_image_paths() -> None:
     paths = _changed_paths(_SAMPLE_DIFF)
     assert paths == ["src/example.py", "src/util.ts", "README.md"]
@@ -72,22 +126,21 @@ def test_intersects_hunks() -> None:
     assert not _intersects_hunks(31, ranges)
 
 
-def test_extract_impact_returns_declarations_within_hunks() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        src = Path(tmp) / "src"
-        src.mkdir()
-        # existing_func @ line 1, new_func @ line 7. Hunk range 1-4.
-        txt = "def existing_func():\n    pass\n\n\n\n\ndef new_func():\n    return 42\n"
-        (src / "example.py").write_text(txt)
-        result = extract_impact(_SAMPLE_DIFF, tmp)
-        rows = result["impactPath"]
-        decl_names = [r["declaration"] for r in rows if r["file"] == "src/example.py"]
-        assert "existing_func" in decl_names, "Missing existing_func"
-        assert "new_func" not in decl_names, "new_func should be excluded"
-        assert result["totalDeclarations"] > 0
+def test_extract_impact_returns_declarations_within_hunks(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    # existing_func @ line 1, new_func @ line 7. Hunk range 1-4.
+    txt = "def existing_func():\n    pass\n\n\n\n\ndef new_func():\n    return 42\n"
+    _write_and_commit(repo, {"src/example.py": txt})
+    result = extract_impact(_SAMPLE_DIFF, str(repo))
+    assert result is not None
+    rows = result["impactPath"]
+    decl_names = [r["declaration"] for r in rows if r["file"] == "src/example.py"]
+    assert "existing_func" in decl_names, "Missing existing_func"
+    assert "new_func" not in decl_names, "new_func should be excluded"
+    assert result["totalDeclarations"] > 0
 
 
-def test_hunk_filter_excludes_unchanged_declarations() -> None:
+def test_hunk_filter_excludes_unchanged_declarations(tmp_path: Path) -> None:
     diff = """diff --git a/src/app.py b/src/app.py
 index a..b 100644
 --- a/src/app.py
@@ -99,21 +152,21 @@ index a..b 100644
 +def changed():
 +    return True
 """
-    with tempfile.TemporaryDirectory() as tmp:
-        src = Path(tmp) / "src"
-        src.mkdir()
-        txt = "def stale():\n    pass\n\n\ndef unchanged():\n    pass\n\n\ndef updated():\n    return 42\n\n\ndef changed():\n    return True\n"
-        (src / "app.py").write_text(txt)
-        result = extract_impact(diff, tmp)
-        decl_names = {r["declaration"] for r in result["impactPath"]}
-        assert "changed" in decl_names
-        assert "stale" not in decl_names
-        assert "unchanged" not in decl_names
-        assert "updated" not in decl_names
+    repo = _git_repo(tmp_path)
+    txt = "def stale():\n    pass\n\n\ndef unchanged():\n    pass\n\n\ndef updated():\n    return 42\n\n\ndef changed():\n    return True\n"
+    _write_and_commit(repo, {"src/app.py": txt})
+    result = extract_impact(diff, str(repo))
+    assert result is not None
+    decl_names = {r["declaration"] for r in result["impactPath"]}
+    assert "changed" in decl_names
+    assert "stale" not in decl_names
+    assert "unchanged" not in decl_names
+    assert "updated" not in decl_names
 
 
 def test_empty_diff_returns_empty() -> None:
     result = extract_impact("", "/tmp")
+    assert result is not None
     assert result["totalDeclarations"] == 0
     assert result["impactPath"] == []
 
@@ -122,54 +175,56 @@ def test_write_impact_returns_none_when_empty() -> None:
     assert write_impact("", "/tmp", "/tmp", 1) is None
 
 
-def test_write_impact_writes_json_when_nonempty() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        src = Path(tmp) / "src"
-        src.mkdir()
-        (src / "example.py").write_text("def f():\n    pass\n")
-        diff_parts = ["diff --git a/src/example.py b/src/example.py"]
-        diff_parts.append("index a..b 100644")
-        diff_parts.append("--- a/src/example.py")
-        diff_parts.append("+++ b/src/example.py")
-        diff_parts.append("@@ -1 +1,2 @@")
-        diff_parts.append(" def f():")
-        diff_parts.append("+    pass")
-        diff = "\n".join(diff_parts)
-        written = write_impact(diff, tmp, tmp, 42)
-        assert written is not None
-        assert written["impactPath"].endswith("pr-42-impact.json")
-        assert written["impactDeclarationCount"] == 1
-        data = json.loads(Path(written["impactPath"]).read_text())
-        assert data["impactPath"][0]["declaration"] == "f"
+def test_write_impact_writes_json_when_nonempty(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    _write_and_commit(repo, {"src/example.py": "def f():\n    pass\n"})
+    diff_parts = [
+        "diff --git a/src/example.py b/src/example.py",
+        "index a..b 100644",
+        "--- a/src/example.py",
+        "+++ b/src/example.py",
+        "@@ -1 +1,2 @@",
+        " def f():",
+        "+    pass",
+    ]
+    diff = "\n".join(diff_parts)
+    written = write_impact(diff, str(repo), str(tmp_path), 42)
+    assert written is not None
+    assert written["impactPath"].endswith("pr-42-impact.json")
+    assert written["impactDeclarationCount"] == 1
+    data = json.loads(Path(written["impactPath"]).read_text())
+    assert data["impactPath"][0]["declaration"] == "f"
 
 
-def test_extract_impact_respects_max_declarations() -> None:
-    from mergecraft.analyzers.impact import _MAX_DECLARATIONS
-
-    with tempfile.TemporaryDirectory() as tmp:
-        src = Path(tmp) / "src"
-        src.mkdir()
-        diff_parts = []
-        for i in range(_MAX_DECLARATIONS + 5):
-            mod_parts = [f"diff --git a/src/mod_{i}.py b/src/mod_{i}.py"]
-            mod_parts.append("index a..b 100644")
-            mod_parts.append("--- /dev/null")
-            mod_parts.append(f"+++ b/src/mod_{i}.py")
-            mod_parts.append("@@ -0,0 +1,2 @@")
-            mod_parts.append(f"+def func_{i}():")
-            mod_parts.append("+    pass")
-            diff_parts.append("\n".join(mod_parts))
-            (src / f"mod_{i}.py").write_text(f"def func_{i}():\n    pass\n")
-        diff = "\n".join(diff_parts)
-        result = extract_impact(diff, tmp)
-        assert result["truncated"] is True
-        assert len(result["impactPath"]) == _MAX_DECLARATIONS
-        assert result["totalDeclarations"] == _MAX_DECLARATIONS + 5
+def test_extract_impact_respects_max_declarations(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    diff_parts = []
+    files: dict[str, str] = {}
+    for i in range(_MAX_DECLARATIONS + 5):
+        mod_parts = [
+            f"diff --git a/src/mod_{i}.py b/src/mod_{i}.py",
+            "index a..b 100644",
+            "--- /dev/null",
+            f"+++ b/src/mod_{i}.py",
+            "@@ -0,0 +1,2 @@",
+            f"+def func_{i}():",
+            "+    pass",
+        ]
+        diff_parts.append("\n".join(mod_parts))
+        files[f"src/mod_{i}.py"] = f"def func_{i}():\n    pass\n"
+    _write_and_commit(repo, files)
+    diff = "\n".join(diff_parts)
+    result = extract_impact(diff, str(repo))
+    assert result is not None
+    assert result["truncated"] is True
+    assert len(result["impactPath"]) == _MAX_DECLARATIONS
+    assert result["totalDeclarations"] == _MAX_DECLARATIONS + 5
 
 
 def test_extract_impact_missing_file_does_not_crash() -> None:
     diff = "diff --git a/phantom.py b/phantom.py\nindex a..b 100644\n--- /dev/null\n+++ b/phantom.py\n@@ -0,0 +1 @@\n+def phantom():\n+    pass\n"
     result = extract_impact(diff, "/tmp/nonexistent")
+    assert result is not None
     assert result["totalDeclarations"] == 0
     assert result["impactPath"] == []
 
@@ -180,24 +235,14 @@ def test_cross_file_references_include_usages_in_git_repo(tmp_path: Path) -> Non
     Guards the ``git grep`` subprocess path (path:line:content parsing,
     exclude_file filtering, and the -w word match). The declaration file
     itself is excluded; cross-file usages are kept."""
-    import subprocess
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "dev@example.com"],
-        cwd=repo,
-        check=True,
-        capture_output=True,
+    repo = _git_repo(tmp_path)
+    _write_and_commit(
+        repo,
+        {
+            "src/app.py": "def changed():\n    return True\n",
+            "src/consumer.py": "from app import changed\nresult = changed()\n",
+        },
     )
-    subprocess.run(["git", "config", "user.name", "Dev"], cwd=repo, check=True, capture_output=True)
-
-    (repo / "src").mkdir()
-    (repo / "src" / "app.py").write_text("def changed():\n    return True\n")
-    (repo / "src" / "consumer.py").write_text("from app import changed\nresult = changed()\n")
-    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
 
     diff = """diff --git a/src/app.py b/src/app.py
 index a..b 100644
@@ -209,14 +254,14 @@ index a..b 100644
 """
 
     result = extract_impact(diff, str(repo))
+    assert result is not None
     rows = result["impactPath"]
     app_row = next(r for r in rows if r["file"] == "src/app.py")
     assert app_row["declaration"] == "changed"
+    assert app_row["referencesTruncated"] is False
     ref_files = [ref["file"] for ref in app_row["references"]]
     assert "src/consumer.py" in ref_files, f"expected consumer.py ref in {ref_files}"
     assert "src/app.py" not in ref_files, "declaration file must be excluded from references"
-    ref = next(ref for ref in app_row["references"] if ref["file"] == "src/consumer.py")
-    assert ref["line"] == 1, f"expected line 1 (from app import changed) but got {ref}"
     ref_lines = [ref["line"] for ref in app_row["references"] if ref["file"] == "src/consumer.py"]
     assert 1 in ref_lines, f"expected import usage (line 1) in {ref_lines}"
     assert 2 in ref_lines, f"expected call usage (line 2) in {ref_lines}"
@@ -224,24 +269,14 @@ index a..b 100644
 
 def test_cross_file_references_word_match_excludes_substrings(tmp_path: Path) -> None:
     """-w word match: a declaration name must not match inside a longer identifier."""
-    import subprocess
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "dev@example.com"],
-        cwd=repo,
-        check=True,
-        capture_output=True,
+    repo = _git_repo(tmp_path)
+    _write_and_commit(
+        repo,
+        {
+            "src/app.py": "def run():\n    return 1\n",
+            "src/runner.py": "def runner():\n    return run()\n",
+        },
     )
-    subprocess.run(["git", "config", "user.name", "Dev"], cwd=repo, check=True, capture_output=True)
-
-    (repo / "src").mkdir()
-    (repo / "src" / "app.py").write_text("def run():\n    return 1\n")
-    (repo / "src" / "runner.py").write_text("def runner():\n    return run()\n")
-    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
 
     diff = """diff --git a/src/app.py b/src/app.py
 index a..b 100644
@@ -253,9 +288,131 @@ index a..b 100644
 """
 
     result = extract_impact(diff, str(repo))
+    assert result is not None
     rows = result["impactPath"]
     app_row = next(r for r in rows if r["file"] == "src/app.py")
     assert app_row["declaration"] == "run"
     # "runner" contains "run" but -w must exclude it; only "return run()" matches.
     ref_lines = [ref["line"] for ref in app_row["references"]]
     assert ref_lines == [2], f"expected only the exact-symbol reference at line 2, got {ref_lines}"
+
+
+def test_reference_truncation_flag_set_when_capped(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    files = {"src/app.py": "def shared():\n    return 1\n"}
+    for i in range(_MAX_REFS + 4):
+        files[f"src/consumer_{i}.py"] = "from app import shared\nresult = shared()\n"
+    _write_and_commit(repo, files)
+
+    diff = """diff --git a/src/app.py b/src/app.py
+index a..b 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1,2 @@
+ def shared():
++    return 1
+"""
+    result = extract_impact(diff, str(repo))
+    assert result is not None
+    app_row = next(r for r in result["impactPath"] if r["file"] == "src/app.py")
+    assert app_row["referencesTruncated"] is True
+    assert len(app_row["references"]) == _MAX_REFS
+
+
+def test_extract_impact_returns_none_when_repo_unavailable_for_references() -> None:
+    """No git repo present: declarations resolve fine but git grep cannot run at
+    all (not just "no matches"). The whole artifact must be suppressed rather
+    than published with silently-empty references (#94 / review finding)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "example.py").write_text("def existing_func():\n    pass\n")
+        result = extract_impact(_SAMPLE_DIFF, tmp)
+        assert result is None
+
+
+def test_write_impact_omits_key_when_reference_lookup_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        src.mkdir()
+        (src / "example.py").write_text("def existing_func():\n    pass\n")
+        assert write_impact(_SAMPLE_DIFF, tmp, tmp, 7) is None
+
+
+def test_extract_impact_returns_none_when_ast_grep_binary_missing(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    _write_and_commit(repo, {"src/example.py": "def existing_func():\n    pass\n"})
+    result = extract_impact(
+        _SAMPLE_DIFF, str(repo), ast_grep_binary="/nonexistent/ast-grep-binary-xyz"
+    )
+    assert result is None
+
+
+_LANGUAGE_FORMS: list[tuple[str, str, set[str]]] = [
+    (
+        "src/mod.py",
+        "class Foo:\n    def method_one(self):\n        pass\n\n\ndef top_level():\n    pass\n",
+        {"Foo", "method_one", "top_level"},
+    ),
+    (
+        "src/mod.js",
+        "function topFn(x) {\n  return x;\n}\n\nclass Widget {\n  render() {\n    return null;\n  }\n}\n\nconst arrow = (x) => x + 1;\n",
+        {"topFn", "Widget", "render", "arrow"},
+    ),
+    (
+        "src/mod.ts",
+        "export default class DefaultWidget {\n}\n\nexport interface Props {\n  name: string;\n}\n\nconst arrow = (x: number) => x + 1;\n",
+        {"DefaultWidget", "Props", "arrow"},
+    ),
+    (
+        "src/mod.tsx",
+        "export function Comp(props: Props) {\n  return null;\n}\n\ninterface Props {\n  name: string;\n}\n",
+        {"Comp", "Props"},
+    ),
+    (
+        "src/mod.go",
+        "package main\n\nfunc TopFunc(x int) int {\n\treturn x\n}\n\ntype Widget struct {\n\tName string\n}\n\nfunc (w *Widget) Render() string {\n\treturn w.Name\n}\n",
+        {"TopFunc", "Widget", "Render"},
+    ),
+    (
+        "src/Mod.java",
+        "public class Sample {\n    public void doThing(int x) {\n        System.out.println(x);\n    }\n\n    static class Inner {\n        void innerMethod() {}\n    }\n}\n",
+        {"Sample", "doThing", "Inner", "innerMethod"},
+    ),
+    (
+        "src/mod.rs",
+        "pub fn top_fn(x: i32) -> i32 {\n    x\n}\n\npub struct Widget {\n    name: String,\n}\n\npub trait Shape {\n    fn area(&self) -> f64;\n}\n",
+        {"top_fn", "Widget", "Shape", "area"},
+    ),
+    (
+        "src/mod.c",
+        "int top_func(int x) {\n    return x;\n}\n\nstruct Point {\n    int x;\n    int y;\n};\n",
+        {"top_func", "Point"},
+    ),
+    (
+        "src/mod.h",
+        "int top_func(int x);\n\nstruct Point {\n    int x;\n};\n",
+        {"top_func", "Point"},
+    ),
+    (
+        "src/mod.cpp",
+        "class Widget {\npublic:\n    void render() {\n    }\n};\n\nstruct Point {\n    int x;\n};\n",
+        {"Widget", "render", "Point"},
+    ),
+]
+
+
+@pytest.mark.parametrize(("relpath", "content", "expected"), _LANGUAGE_FORMS)
+def test_declaration_extraction_covers_representative_forms(
+    tmp_path: Path, relpath: str, content: str, expected: set[str]
+) -> None:
+    """Guards the ast-grep kind-based rules against the forms that tripped up
+    the earlier hand-rolled regex table: indented Java methods, Go receiver
+    methods, TS export-default classes, .tsx, and Rust trait signatures."""
+    repo = _git_repo(tmp_path)
+    _write_and_commit(repo, {relpath: content})
+    diff = _added_file_diff(relpath, content)
+    result = extract_impact(diff, str(repo))
+    assert result is not None
+    names = {r["declaration"] for r in result["impactPath"]}
+    assert expected <= names, f"missing {expected - names} for {relpath}: got {names}"

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -1,7 +1,7 @@
 """Tests for change-impact extraction (S6 / #94).
 
-Covers the ``analyzers.impact`` config toggle, the declaration-extraction
-logic, and the ``impactPath`` artifact contract.
+Covers declaration extraction, hunk filtering, cross-file references,
+and the ``impactPath`` artifact contract.
 """
 
 from __future__ import annotations
@@ -10,9 +10,14 @@ import json
 import tempfile
 from pathlib import Path
 
-from mergecraft.analyzers.impact import _changed_paths, extract_impact, write_impact
+from mergecraft.analyzers.impact import (
+    _changed_paths,
+    _intersects_hunks,
+    _parse_hunks,
+    extract_impact,
+    write_impact,
+)
 
-# A minimal diff that touches two files with known declarations.
 _SAMPLE_DIFF = """diff --git a/src/example.py b/src/example.py
 index abc..def 100644
 --- a/src/example.py
@@ -20,7 +25,7 @@ index abc..def 100644
 @@ -1,3 +1,4 @@
  def existing_func():
      pass
-+
+
 +def new_func():
 +    return 42
 diff --git a/src/util.ts b/src/util.ts
@@ -29,7 +34,7 @@ index 111..222 100644
 +++ b/src/util.ts
 @@ -1,2 +1,5 @@
  export const CONSTANT = 1
-+
+
 +export function helper(): string {
 +    return "hello"
 +}
@@ -47,47 +52,67 @@ def test_changed_paths_extracts_post_image_paths() -> None:
     assert paths == ["src/example.py", "src/util.ts", "README.md"]
 
 
-def test_extract_impact_returns_declarations() -> None:
+def test_parse_hunks_extracts_ranges() -> None:
+    hunks = _parse_hunks(_SAMPLE_DIFF)
+    assert "src/example.py" in hunks
+    assert "src/util.ts" in hunks
+    assert "README.md" in hunks
+    assert hunks["src/example.py"] == [(1, 4)]
+    assert hunks["src/util.ts"] == [(1, 5)]
+    assert hunks["README.md"] == [(1, 1)]
+
+
+def test_intersects_hunks() -> None:
+    ranges = [(5, 10), (20, 30)]
+    assert _intersects_hunks(5, ranges)
+    assert _intersects_hunks(10, ranges)
+    assert _intersects_hunks(7, ranges)
+    assert not _intersects_hunks(4, ranges)
+    assert not _intersects_hunks(11, ranges)
+    assert not _intersects_hunks(31, ranges)
+
+
+def test_extract_impact_returns_declarations_within_hunks() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         src = Path(tmp) / "src"
         src.mkdir()
-        (src / "example.py").write_text(
-            "def existing_func():\n    pass\n\n\ndef new_func():\n    return 42\n"
-        )
-        (src / "util.ts").write_text(
-            'export const CONSTANT = 1\n\n\nexport function helper(): string {\n    return "hello"\n}\n'
-        )
-
+        # existing_func @ line 1, new_func @ line 5. Hunk range 1-4.
+        txt = "def existing_func():\n    pass\n\n\ndef new_func():\n    return 42\n"
+        (src / "example.py").write_text(txt)
         result = extract_impact(_SAMPLE_DIFF, tmp)
         rows = result["impactPath"]
-        assert isinstance(rows, list)
-        # Should find: existing_func, new_func (python), CONSTANT, helper (ts)
-        names = {(r["file"], r["declaration"]) for r in rows}
-        assert ("src/example.py", "existing_func") in names, names
-        assert ("src/example.py", "new_func") in names, names
-        assert ("src/util.ts", "CONSTANT") in names
-        assert ("src/util.ts", "helper") in names
-        assert result["totalDeclarations"] == 4
-        assert result["truncated"] is False
+        decl_names = [r["declaration"] for r in rows if r["file"] == "src/example.py"]
+        assert "existing_func" in decl_names, "Missing existing_func"
+        assert "new_func" not in decl_names, "new_func should be excluded"
+        assert result["totalDeclarations"] > 0
 
 
-def test_extract_impact_readme_has_no_declarations() -> None:
-    """Markdown files have no recognised patterns and contribute zero rows."""
+def test_hunk_filter_excludes_unchanged_declarations() -> None:
+    diff = """diff --git a/src/app.py b/src/app.py
+index a..b 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -10,3 +10,4 @@
+ def unchanged():
+     pass
+
++def changed():
++    return True
+"""
     with tempfile.TemporaryDirectory() as tmp:
         src = Path(tmp) / "src"
         src.mkdir()
-        (src / "example.py").write_text("def f():\n    pass\n")
-        result = extract_impact(
-            "diff --git a/README.md b/README.md\nindex a..b 100644\n--- /dev/null\n+++ b/README.md\n@@ -0,0 +1 @@\n+# readme\n",
-            tmp,
-        )
-        rows = result["impactPath"]
-        assert isinstance(rows, list)
-        assert len(rows) == 0, "README.md should contribute no declarations"
-        assert result["totalDeclarations"] == 0
+        txt = "def stale():\n    pass\n\n\ndef unchanged():\n    pass\n\n\ndef updated():\n    return 42\n\n\ndef changed():\n    return True\n"
+        (src / "app.py").write_text(txt)
+        result = extract_impact(diff, tmp)
+        decl_names = {r["declaration"] for r in result["impactPath"]}
+        assert "changed" in decl_names
+        assert "stale" not in decl_names
+        assert "unchanged" not in decl_names
+        assert "updated" not in decl_names
 
 
-def test_extract_impact_empty_diff_returns_empty() -> None:
+def test_empty_diff_returns_empty() -> None:
     result = extract_impact("", "/tmp")
     assert result["totalDeclarations"] == 0
     assert result["impactPath"] == []
@@ -102,40 +127,39 @@ def test_write_impact_writes_json_when_nonempty() -> None:
         src = Path(tmp) / "src"
         src.mkdir()
         (src / "example.py").write_text("def f():\n    pass\n")
-        diff = "diff --git a/src/example.py b/src/example.py\nindex a..b 100644\n--- a/src/example.py\n+++ b/src/example.py\n@@ -1 +1,2 @@\n def f():\n+    pass\n"
-
+        diff_parts = ["diff --git a/src/example.py b/src/example.py"]
+        diff_parts.append("index a..b 100644")
+        diff_parts.append("--- a/src/example.py")
+        diff_parts.append("+++ b/src/example.py")
+        diff_parts.append("@@ -1 +1,2 @@")
+        diff_parts.append(" def f():")
+        diff_parts.append("+    pass")
+        diff = "\n".join(diff_parts)
         written = write_impact(diff, tmp, tmp, 42)
         assert written is not None
         assert written["impactPath"].endswith("pr-42-impact.json")
         assert written["impactDeclarationCount"] == 1
-        assert written["impactTruncated"] is False
-
-        data = json.loads(Path(written["impactPath"]).read_text(encoding="utf-8"))
-        assert len(data["impactPath"]) == 1
+        data = json.loads(Path(written["impactPath"]).read_text())
         assert data["impactPath"][0]["declaration"] == "f"
 
 
 def test_extract_impact_respects_max_declarations() -> None:
-    """When more than _MAX_DECLARATIONS declarations exist, truncated is True."""
     from mergecraft.analyzers.impact import _MAX_DECLARATIONS
 
     with tempfile.TemporaryDirectory() as tmp:
         src = Path(tmp) / "src"
         src.mkdir()
-        lines: list[str] = []
-        diff_parts: list[str] = []
+        diff_parts = []
         for i in range(_MAX_DECLARATIONS + 5):
-            lines.append(f"def func_{i}():\n    pass\n")
-            diff_parts.append(
-                f"diff --git a/src/mod_{i}.py b/src/mod_{i}.py\n"
-                f"index a..b 100644\n"
-                f"--- /dev/null\n"
-                f"+++ b/src/mod_{i}.py\n"
-                f"@@ -0,0 +1,2 @@\n"
-                f"+def func_{i}():\n+    pass\n"
-            )
+            mod_parts = [f"diff --git a/src/mod_{i}.py b/src/mod_{i}.py"]
+            mod_parts.append("index a..b 100644")
+            mod_parts.append("--- /dev/null")
+            mod_parts.append(f"+++ b/src/mod_{i}.py")
+            mod_parts.append("@@ -0,0 +1,2 @@")
+            mod_parts.append(f"+def func_{i}():")
+            mod_parts.append("+    pass")
+            diff_parts.append("\n".join(mod_parts))
             (src / f"mod_{i}.py").write_text(f"def func_{i}():\n    pass\n")
-
         diff = "\n".join(diff_parts)
         result = extract_impact(diff, tmp)
         assert result["truncated"] is True
@@ -144,7 +168,6 @@ def test_extract_impact_respects_max_declarations() -> None:
 
 
 def test_extract_impact_missing_file_does_not_crash() -> None:
-    """A diff referencing a file not checked out should be skipped, not crash."""
     diff = "diff --git a/phantom.py b/phantom.py\nindex a..b 100644\n--- /dev/null\n+++ b/phantom.py\n@@ -0,0 +1 @@\n+def phantom():\n+    pass\n"
     result = extract_impact(diff, "/tmp/nonexistent")
     assert result["totalDeclarations"] == 0

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -131,7 +131,7 @@ def test_extract_impact_returns_declarations_within_hunks(tmp_path: Path) -> Non
     # existing_func @ line 1, new_func @ line 7. Hunk range 1-4.
     txt = "def existing_func():\n    pass\n\n\n\n\ndef new_func():\n    return 42\n"
     _write_and_commit(repo, {"src/example.py": txt})
-    result = extract_impact(_SAMPLE_DIFF, str(repo))
+    result = extract_impact(_SAMPLE_DIFF, str(repo), tier="trusted")
     assert result is not None
     rows = result["impactPath"]
     decl_names = [r["declaration"] for r in rows if r["file"] == "src/example.py"]
@@ -155,7 +155,7 @@ index a..b 100644
     repo = _git_repo(tmp_path)
     txt = "def stale():\n    pass\n\n\ndef unchanged():\n    pass\n\n\ndef updated():\n    return 42\n\n\ndef changed():\n    return True\n"
     _write_and_commit(repo, {"src/app.py": txt})
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     decl_names = {r["declaration"] for r in result["impactPath"]}
     assert "changed" in decl_names
@@ -188,7 +188,7 @@ def test_write_impact_writes_json_when_nonempty(tmp_path: Path) -> None:
         "+    pass",
     ]
     diff = "\n".join(diff_parts)
-    written = write_impact(diff, str(repo), str(tmp_path), 42)
+    written = write_impact(diff, str(repo), str(tmp_path), 42, tier="trusted")
     assert written is not None
     assert written["impactPath"].endswith("pr-42-impact.json")
     assert written["impactDeclarationCount"] == 1
@@ -214,7 +214,7 @@ def test_extract_impact_respects_max_declarations(tmp_path: Path) -> None:
         files[f"src/mod_{i}.py"] = f"def func_{i}():\n    pass\n"
     _write_and_commit(repo, files)
     diff = "\n".join(diff_parts)
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     assert result["truncated"] is True
     assert len(result["impactPath"]) == _MAX_DECLARATIONS
@@ -253,7 +253,7 @@ index a..b 100644
 +    return True
 """
 
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     rows = result["impactPath"]
     app_row = next(r for r in rows if r["file"] == "src/app.py")
@@ -287,7 +287,7 @@ index a..b 100644
 +    return 1
 """
 
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     rows = result["impactPath"]
     app_row = next(r for r in rows if r["file"] == "src/app.py")
@@ -312,7 +312,7 @@ index a..b 100644
  def shared():
 +    return 1
 """
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     app_row = next(r for r in result["impactPath"] if r["file"] == "src/app.py")
     assert app_row["referencesTruncated"] is True
@@ -327,7 +327,7 @@ def test_extract_impact_returns_none_when_repo_unavailable_for_references() -> N
         src = Path(tmp) / "src"
         src.mkdir()
         (src / "example.py").write_text("def existing_func():\n    pass\n")
-        result = extract_impact(_SAMPLE_DIFF, tmp)
+        result = extract_impact(_SAMPLE_DIFF, tmp, tier="trusted")
         assert result is None
 
 
@@ -336,14 +336,17 @@ def test_write_impact_omits_key_when_reference_lookup_fails() -> None:
         src = Path(tmp) / "src"
         src.mkdir()
         (src / "example.py").write_text("def existing_func():\n    pass\n")
-        assert write_impact(_SAMPLE_DIFF, tmp, tmp, 7) is None
+        assert write_impact(_SAMPLE_DIFF, tmp, tmp, 7, tier="trusted") is None
 
 
 def test_extract_impact_returns_none_when_ast_grep_binary_missing(tmp_path: Path) -> None:
     repo = _git_repo(tmp_path)
     _write_and_commit(repo, {"src/example.py": "def existing_func():\n    pass\n"})
     result = extract_impact(
-        _SAMPLE_DIFF, str(repo), ast_grep_binary="/nonexistent/ast-grep-binary-xyz"
+        _SAMPLE_DIFF,
+        str(repo),
+        ast_grep_binary="/nonexistent/ast-grep-binary-xyz",
+        tier="trusted",
     )
     assert result is None
 
@@ -412,7 +415,24 @@ def test_declaration_extraction_covers_representative_forms(
     repo = _git_repo(tmp_path)
     _write_and_commit(repo, {relpath: content})
     diff = _added_file_diff(relpath, content)
-    result = extract_impact(diff, str(repo))
+    result = extract_impact(diff, str(repo), tier="trusted")
     assert result is not None
     names = {r["declaration"] for r in result["impactPath"]}
     assert expected <= names, f"missing {expected - names} for {relpath}: got {names}"
+
+
+def test_extract_impact_fails_closed_for_untrusted_tier_without_sandbox(tmp_path: Path) -> None:
+    """A fork PR (untrusted tier) has no sandbox isolation available outside CI,
+    so ast-grep must not fall back to running unsandboxed against
+    attacker-controlled source — the whole artifact is suppressed rather than
+    silently executing without isolation (D7 / review finding)."""
+    repo = _git_repo(tmp_path)
+    _write_and_commit(repo, {"src/example.py": "def existing_func():\n    pass\n"})
+    result = extract_impact(_SAMPLE_DIFF, str(repo), tier="untrusted")
+    assert result is None
+
+
+def test_write_impact_omits_key_for_untrusted_tier_without_sandbox(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    _write_and_commit(repo, {"src/example.py": "def existing_func():\n    pass\n"})
+    assert write_impact(_SAMPLE_DIFF, str(repo), str(tmp_path), 7, tier="untrusted") is None

--- a/tests/analyzers/test_impact.py
+++ b/tests/analyzers/test_impact.py
@@ -76,8 +76,8 @@ def test_extract_impact_returns_declarations_within_hunks() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         src = Path(tmp) / "src"
         src.mkdir()
-        # existing_func @ line 1, new_func @ line 5. Hunk range 1-4.
-        txt = "def existing_func():\n    pass\n\n\ndef new_func():\n    return 42\n"
+        # existing_func @ line 1, new_func @ line 7. Hunk range 1-4.
+        txt = "def existing_func():\n    pass\n\n\n\n\ndef new_func():\n    return 42\n"
         (src / "example.py").write_text(txt)
         result = extract_impact(_SAMPLE_DIFF, tmp)
         rows = result["impactPath"]

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -311,7 +311,7 @@ async def test_impact_path_present_when_enabled_and_binary_resolves(
 
     repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
     monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
-    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda: "ast-grep")
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review")
 
@@ -332,7 +332,7 @@ async def test_impact_path_omitted_when_ast_grep_binary_unavailable(
 
     repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
     monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
-    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: None)
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda: None)
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review")
 
@@ -353,7 +353,7 @@ async def test_impact_path_omitted_for_untrusted_checkout_without_sandbox(
 
     repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
     monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
-    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda: "ast-grep")
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review", trust_tier="untrusted")
 
@@ -373,7 +373,7 @@ async def test_impact_path_omitted_when_operator_disables_analyzers(
 
     repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
     monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
-    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda: "ast-grep")
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review", analyzers_mode="off")
 

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -153,6 +153,36 @@ def _pr_repo_with_two_commits(tmp_path: Path) -> tuple[Path, str, str]:
     return clone, first, head
 
 
+def _pr_repo_with_impact_enabled(tmp_path: Path) -> tuple[Path, str]:
+    """Build an origin whose PR branch enables ``analyzers.impact`` and adds a
+    declaration, for exercising the ``impactPath`` wiring in ``checkout_pr``."""
+    origin = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init")
+    _git(work, "config", "user.email", "test@example.com")
+    _git(work, "config", "user.name", "Test")
+    (work / "README.md").write_text("base\n", encoding="utf-8")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-m", "base")
+    _git(work, "branch", "-M", "base")
+    _git(work, "checkout", "-b", "feature")
+    (work / ".mergecraft").mkdir()
+    (work / ".mergecraft" / "config.yaml").write_text(
+        "analyzers:\n  impact: true\n", encoding="utf-8"
+    )
+    (work / "src").mkdir()
+    (work / "src" / "app.py").write_text("def changed():\n    return True\n", encoding="utf-8")
+    _git(work, "add", ".")
+    _git(work, "commit", "-m", "enable impact + add app.py")
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=work, text=True).strip()
+    _git(work, "clone", "--bare", str(work), str(origin))
+    _git(work, "push", str(origin), "feature:refs/pull/1/head")
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", str(origin), str(clone))
+    return clone, head
+
+
 def _read(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
@@ -261,3 +291,41 @@ async def test_incremental_key_is_omitted_when_the_prior_sha_is_unreachable(
     payload = await _checkout(ctx)
 
     assert "incrementalDiffPath" not in payload
+
+
+@pytest.mark.asyncio
+async def test_impact_path_present_when_enabled_and_binary_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mergecraft.mcp import checkout as checkout_module
+
+    repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    github = _StubGitHub(head_sha=head_sha, reviews=[])
+    ctx = _ctx_for(repo, github, tmp_path, mode="Review")
+
+    payload = await _checkout(ctx)
+
+    assert "impactPath" in payload
+    assert _exists(payload["impactPath"])
+    data = json.loads(_read(payload["impactPath"]))
+    decl_names = {r["declaration"] for r in data["impactPath"]}
+    assert "changed" in decl_names
+
+
+@pytest.mark.asyncio
+async def test_impact_path_omitted_when_ast_grep_binary_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mergecraft.mcp import checkout as checkout_module
+
+    repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: None)
+    github = _StubGitHub(head_sha=head_sha, reviews=[])
+    ctx = _ctx_for(repo, github, tmp_path, mode="Review")
+
+    payload = await _checkout(ctx)
+
+    assert "impactPath" not in payload

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -198,6 +198,7 @@ def _ctx_for(
     *,
     mode: str,
     trust_tier: Literal["trusted", "untrusted"] = "trusted",
+    analyzers_mode: Literal["off", "auto", "full", "untrusted-only"] = "auto",
 ) -> ToolContext:
     state = init_tool_state(owner="acme", name="demo", dir=str(repo))
     state.selected_mode = mode
@@ -211,6 +212,7 @@ def _ctx_for(
         git_token="",
         api_token="",
         trust_tier=trust_tier,
+        analyzers_mode=analyzers_mode,
         modes=compute_modes("claude"),
         tool_state=state,
         mcp_server_url="",
@@ -354,6 +356,26 @@ async def test_impact_path_omitted_for_untrusted_checkout_without_sandbox(
     monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review", trust_tier="untrusted")
+
+    payload = await _checkout(ctx)
+
+    assert "impactPath" not in payload
+
+
+@pytest.mark.asyncio
+async def test_impact_path_omitted_when_operator_disables_analyzers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The operator's effective analyzer policy (analyzers: off) must win over
+    whatever a PR sets in its own analyzers.impact — a PR cannot self-enable
+    ast-grep execution once the operator has switched analyzers off."""
+    from mergecraft.mcp import checkout as checkout_module
+
+    repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    github = _StubGitHub(head_sha=head_sha, reviews=[])
+    ctx = _ctx_for(repo, github, tmp_path, mode="Review", analyzers_mode="off")
 
     payload = await _checkout(ctx)
 

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -191,7 +191,14 @@ def _exists(path: str) -> bool:
     return Path(path).is_file()
 
 
-def _ctx_for(repo: Path, github: GitHubClient, tmp_path: Path, *, mode: str) -> ToolContext:
+def _ctx_for(
+    repo: Path,
+    github: GitHubClient,
+    tmp_path: Path,
+    *,
+    mode: str,
+    trust_tier: Literal["trusted", "untrusted"] = "trusted",
+) -> ToolContext:
     state = init_tool_state(owner="acme", name="demo", dir=str(repo))
     state.selected_mode = mode
     (tmp_path / "artifacts").mkdir(parents=True, exist_ok=True)
@@ -203,6 +210,7 @@ def _ctx_for(repo: Path, github: GitHubClient, tmp_path: Path, *, mode: str) -> 
         github_installation_token="",
         git_token="",
         api_token="",
+        trust_tier=trust_tier,
         modes=compute_modes("claude"),
         tool_state=state,
         mcp_server_url="",
@@ -325,6 +333,27 @@ async def test_impact_path_omitted_when_ast_grep_binary_unavailable(
     monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: None)
     github = _StubGitHub(head_sha=head_sha, reviews=[])
     ctx = _ctx_for(repo, github, tmp_path, mode="Review")
+
+    payload = await _checkout(ctx)
+
+    assert "impactPath" not in payload
+
+
+@pytest.mark.asyncio
+async def test_impact_path_omitted_for_untrusted_checkout_without_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fork PR (untrusted trust tier) enabling analyzers.impact in its own
+    checked-out config must not get ast-grep run unsandboxed against its own
+    source — outside CI there is no sandbox isolation available, so the
+    artifact is suppressed rather than executed without isolation (D7)."""
+    from mergecraft.mcp import checkout as checkout_module
+
+    repo, head_sha = _pr_repo_with_impact_enabled(tmp_path)
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    monkeypatch.setattr(checkout_module, "resolve_ast_grep_binary", lambda repo_root: "ast-grep")
+    github = _StubGitHub(head_sha=head_sha, reviews=[])
+    ctx = _ctx_for(repo, github, tmp_path, mode="Review", trust_tier="untrusted")
 
     payload = await _checkout(ctx)
 

--- a/tests/test_prompt_artifact_contracts.py
+++ b/tests/test_prompt_artifact_contracts.py
@@ -63,6 +63,9 @@ def test_mcp_layer_produces_the_known_diff_artifacts() -> None:
     produced = _keys_produced_by_mcp_tools()
     assert "diffPath" in produced
     assert "incrementalDiffPath" in produced
+    assert "impactPath" in produced, (
+        "impactPath landed in checkout_pr but was not detected; rerun drift check"
+    )
 
 
 def test_every_prompt_artifact_key_is_returned_by_some_mcp_tool() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-grep-cli"
+version = "0.44.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/b6/700b2a79eed7be029d3885ae2dda638604ee34970fc14ec154f5084915b7/ast_grep_cli-0.44.1.tar.gz", hash = "sha256:391e9d60f118d0a15c905b2de1287a162d1891c2f05d94919a37784230fab559", size = 278332, upload-time = "2026-07-04T14:13:29.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/50/94f0654fe86cff7ac2f52b94a417c9918632f324cada4a7b02d07906934e/ast_grep_cli-0.44.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:34fd5494fed41e5461e46a7932cd9a3e8c42136dd6b040ccc5ceca00c1c2e553", size = 16058060, upload-time = "2026-07-04T14:13:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/53/2e/185dff98167af423436556267af472674d400154a238141b4ba2f8f42e35/ast_grep_cli-0.44.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ce408938e3e4ba8570102a5a54a674dc18b8fa21bc9560dc859a66f7c96a4291", size = 8034861, upload-time = "2026-07-04T14:13:20.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/30/6f1e5a379854a1be22983f964572a20d2229d695a63c5d6fd03570d7eab2/ast_grep_cli-0.44.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:54c21864c497275ed99c5fd9cf605aa9758cc3f21fc769fcde8c5ebc7c25d87d", size = 7882812, upload-time = "2026-07-04T14:13:21.819Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/84/1ff86aded236180eedc3c3a3ec4edb2fed13c1928104432501e21a4f2efb/ast_grep_cli-0.44.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ad11a5eb8d7bd557754b21a360a3be1bc1b19e7f4bed95b444ffc25b9451844f", size = 8184902, upload-time = "2026-07-04T14:13:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7a/796166f5ed48e2f665a85d62e260a209beef8a597ea4dd36129e5ef1452b/ast_grep_cli-0.44.1-py3-none-win32.whl", hash = "sha256:47356ab8eef7fb269e63a944427765d642bd93af20bdb966587fd706da0a61bb", size = 7716418, upload-time = "2026-07-04T14:13:25.123Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f8/cbf9f39ec10be756bafc5f9def09083b6d4c3833f87a2d6818ffd2a53c48/ast_grep_cli-0.44.1-py3-none-win_amd64.whl", hash = "sha256:43dd6a281bf55269ad101460f291e7447f4dbfced794f92ced896610e5bfa589", size = 8212412, upload-time = "2026-07-04T14:13:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a7/e078c3c4a200984ac91590fc42f3c51418d02d168dbdb5a96148b11309c7/ast_grep_cli-0.44.1-py3-none-win_arm64.whl", hash = "sha256:ce18f7f13aee07e9ec169122458ce241910c876ef5536f9115d6fec8c42a4d86", size = 7937089, upload-time = "2026-07-04T14:13:28.224Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1107,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "ast-grep-cli" },
     { name = "bandit" },
     { name = "basedpyright" },
     { name = "mypy" },
@@ -1124,6 +1140,7 @@ tracing = [
 requires-dist = [
     { name = "aiofiles", specifier = "==25.1.0" },
     { name = "anyio", specifier = "==4.11.0" },
+    { name = "ast-grep-cli", marker = "extra == 'dev'", specifier = "==0.44.1" },
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = "==1.9.4" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = "==1.39.9" },
     { name = "fastapi", specifier = "==0.139.2" },


### PR DESCRIPTION
## Summary

- Adds `analyzers.impact` setting (default `false`) to enable declaration-level reference-lead extraction from the PR diff
- Creates `src/mergecraft/analyzers/impact.py` — extracts function/class/interface/type declarations from changed files (via the shipped `ast-grep` catalog entry, kind-based rules per language), groups by language, caps at 24 declarations, with capped cross-file references (`git grep`)
- Wires `impactPath` into `checkout_pr` tool result behind the config toggle, gated on the operator's effective analyzer policy (`analyzers: off` always wins over a PR's own config) and executed through mergeCraft's existing sandbox/trust path (D7) rather than a bare subprocess
- Adds drift-test guard for `impactPath` key
- Extensive unit tests: hunk filtering, cross-file references in real git repos, representative declaration forms across all 8 languages, reference/declaration truncation metadata, extraction-failure propagation (sandbox unavailable, missing binary, no git repo), symlink-escape rejection, and cache/lock isolation from the checkout
- Producer-side groundwork for #94 — does **not** close it

## Design

Design decisions (Q1–Q4) locked during S6.0 and recorded at `.ignorelocal/waves/evidence/s6-design-decisions.md`:

- **Languages:** 8 languages in the ast-grep catalog — Python, JS/TS, Go, Java, Rust, C/C++
- **Symbol extraction:** Declaration nodes only (function/class/interface/type definitions), extracted through the shipped ast-grep catalog entry rather than a hand-rolled parser
- **Ranking + truncation:** Language → file path, cap at 24 declarations per review; references capped at 8 per declaration with a `referencesTruncated` flag
- **Cost:** Default off until eval-bank measurement (Q5 — blocked on #140 corpus)
- **Prompt integration:** Deliberately **not** wired into prompts in this PR. #94 asked for the review/mode prompts to consume `impactPath` with an "explicitly incomplete reference leads" framing — that's real prompt-engineering work with its own cost/eval question (Q5, blocked on #140), so it's out of scope here. This PR is the producer half only: `checkout_pr` can emit a correct, safely-extracted `impactPath` behind the toggle; no reviewing agent reads it yet. A follow-up issue will wire the prompt consumer once the eval-bank corpus lands.

## Security

- ast-grep execution runs through `plan_sandbox` / `build_analyzer_env` / `run_plan` — the same isolation and env-scrubbing every other analyzer gets against untrusted PR checkouts, not a bare `subprocess.run`.
- The trust tier passed to the sandbox comes from `ctx.trust_tier` (derived from the GitHub event), never from the PR's own checked-out config.
- Impact extraction is gated on `analyzers_enabled(ctx)` first — the operator's `analyzers: off` / `analyzers.enabled: false` always wins over whatever a PR's own `.mergecraft/config.yaml` requests.
- The managed ast-grep binary's cache/lock live under the user cache dir, never under the PR checkout, so a PR can't poison `resolve_with_lock`'s cache-hit path by committing a binary + matching lock entry at a predictable path.
- Declaration-scan candidate paths are resolved and containment-checked against the checkout root before use, so a symlink committed by the PR can't point ast-grep at a file outside the checkout.

## Test plan

- [x] `make lint` clean
- [x] `mypy` + `pyright` clean on touched paths
- [x] `uv run pytest tests/analyzers/test_impact.py -v` — all green
- [x] `uv run pytest tests/mcp/test_checkout.py -v` — all green
- [x] `uv run pytest tests/test_prompt_artifact_contracts.py -v` — 2/2 green (drift check includes `impactPath`)
- [x] `make test` — full unit suite green
