### PR TITLE
fix(action): stop action.yml description text from breaking as an expression

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,8 +98,11 @@ inputs:
       and exposes it to the harness as `MERGECRAFT_CUSTOM_PROVIDER_API_KEY`.
       Never inline the API key value here — reference the env-var *name*
       only (convention 7). Wire the secret via the workflow's `env:` block
-      from a GitHub Actions secret (`${{ secrets.MY_PROVIDER_API_KEY }}`).
-      See issue #71.
+      from a GitHub Actions secret named `MY_PROVIDER_API_KEY` (interpolated
+      in your workflow YAML, not written literally here — a literal
+      `secrets.*` expression inside this file's own description text fails
+      action.yml validation, since `secrets` isn't a valid context for a
+      composite action's metadata). See issue #71.
     required: false
   output_schema:
     description: "JSON Schema (draft-07) for structured output validation."
@@ -128,16 +131,16 @@ inputs:
     description: |
       Tracing shorthand (W8.5 / W7.7): ``local_files`` / ``logfire`` /
       ``otel``. Wins over the config block. ``logfire`` requires the
-      optional ``[tracing]`` extra plus ``${{ secrets.LOGFIRE_TOKEN }}``;
-      ``otel`` requires an ``otel-endpoint``.
+      optional ``[tracing]`` extra plus a `LOGFIRE_TOKEN` secret wired via
+      `logfire-token` below; ``otel`` requires an ``otel-endpoint``.
     required: false
     default: ""
   logfire-token:
     description: |
-      Direct logfire token (W8.5 / W7.7). Wire as
-      ``${{ secrets.LOGFIRE_TOKEN }}`` so the secret never appears in
-      the workflow file. Held at runtime only; never inlined into
-      config dumps.
+      Direct logfire token (W8.5 / W7.7). Wire from a `LOGFIRE_TOKEN`
+      GitHub Actions secret (interpolated in your workflow YAML, not written
+      literally here) so the secret never appears in the workflow file.
+      Held at runtime only; never inlined into config dumps.
     required: false
     default: ""
   otel-endpoint:

--- a/tests/action/test_action_yml_contract.py
+++ b/tests/action/test_action_yml_contract.py
@@ -271,3 +271,21 @@ class TestActionYmlHygiene:
             assert expr.startswith("${{"), (
                 f"{env_var} hard-codes a value instead of referencing inputs.*: {expr!r}"
             )
+
+    def test_no_secrets_expression_in_manifest_text(self) -> None:
+        """A ``${{ secrets.* }}`` expression anywhere in action.yml fails to load.
+
+        GitHub evaluates ``${{ ... }}`` wherever it appears lexically in a
+        composite action's YAML — including inside plain ``description:``
+        prose meant only as a consumer-facing example — and ``secrets`` is
+        not a valid named-value in a composite action's own metadata scope.
+        This previously broke every consumer pinning past a specific commit
+        with "Unrecognized named-value: 'secrets'" at action-load time, not
+        at review time, so it surfaced only when something (a self-review
+        pin bump) finally pinned past the offending commit. Parsed YAML
+        loses the literal ``${{ }}`` text once it's inside a string value,
+        so this greps the raw file rather than the parsed dict.
+        """
+        raw = _ACTION_YML.read_text(encoding="utf-8")
+        offending = [line for line in raw.splitlines() if "${{" in line and "secrets." in line]
+        assert not offending, f"literal secrets.* expression(s) in action.yml: {offending}"


### PR DESCRIPTION
## What broke

Three input `description:` fields in `action.yml` (`provider_api_key_env`, `tracing-to`, `logfire-token`) embedded literal example text like `` `${{ secrets.MY_PROVIDER_API_KEY }}` `` -- meant purely as documentation showing a consumer how to write their own workflow. GitHub Actions evaluates `${{ ... }}` wherever it appears lexically in an action's YAML, including inside plain description prose, not just executable fields. `secrets` is not a valid named-value in a composite action's own metadata scope, so this failed the action's *load* step entirely:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.MY_PROVIDER_API_KEY
Failed to load alexhawat/mergeCraft/<sha>/action.yml
```

This is a load-time failure, not a review-time one -- it breaks **every consumer pinning past the commit that introduced these description strings**, not just mergeCraft's own self-review. It stayed latent for months because mergeCraft's self-review workflow was pinned to an older commit (deliberately, for an unrelated reason -- see #177) and nothing had pinned past the offending commit until today's bump.

## Fix

Reworded all three descriptions to name the secret without the `${{ }}` wrapper -- the semantic content (which secret name to reference) doesn't need the literal expression syntax to be useful documentation.

Added a regression test: `tests/action/test_action_yml_contract.py::TestActionYmlHygiene::test_no_secrets_expression_in_manifest_text`. It greps the raw file text rather than the parsed YAML, since the literal `${{` token disappears once it's inside a parsed string value -- a `yaml.safe_load`-based test would not have caught this.

## Validation

- Confirmed the regression test's grep pattern matches all three lines on the pre-fix content and zero lines on the fix -- verified against `git show` of both states, not just against the working tree.
- `make lint` / `make typecheck` clean.
- `make ci-resume`: all 9 steps passed, 2116 passed / 0 failed, coverage ratchet OK (71.85% within [70%, 75%]).

## Follow-up

A broader prevention pass (repo-local pre-commit hook, a mergeCraft analyzer/pattern-scanner rule so this class of bug is caught in every repo mergeCraft reviews, a coding-standards.md note, and local agent-instruction updates) is in progress as a separate PR.

🤖 Generated with Claude Code.