### PR TITLE
fix(ci): bump the mergecraft self-review pin past the action.yml load bug

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -102,7 +102,8 @@
 # `MERGECRAFT_REF` together there — a one-sided bump in this file is
 # invisible to that gate.
 # 2026-08-07: rolled back from 88c6f419 to 8d747f39 — Codex stdin hang regression. See PR #246.
-# 2026-08-14: re-bumped to 0ab5388 (pre-0.0.1 tip) — see the per-step comments below for why.
+# 2026-08-14: re-bumped to 0ab5388 (pre-0.0.1 tip), then to f951af0 (#186: action.yml
+# load-breaking secrets.* expression in description text) — see the per-step comments below.
 name: mergecraft
 
 on:
@@ -373,10 +374,17 @@ jobs:
         # the review before it could post a mergecraft-approval verdict at all. The Codex
         # stdin-hang class of bug this pin originally dodged was traced to blocking I/O in
         # the Codex driver; 889c1f0 (`feat(agents): migrate codex driver to streaming NDJSON
-        # read loop`) replaced that read path months ago, well before this SHA. Watch the
-        # first few post-bump runs' Codex step for a hang regardless — revert to a known-good
-        # SHA between 8d747f39 and here if one appears.
-        uses: alexhawat/mergeCraft@0ab538803bae60eaf83ee070532670e215249f14 # pre-0.0.1
+        # read loop`) replaced that read path months ago, well before this SHA.
+        # 2026-08-14 (later same day): re-bumped again to f951af0. 0ab5388's action.yml had
+        # an unrelated, more severe bug: three input `description:` fields contained a
+        # literal `${{ secrets.X }}` example, which GitHub evaluates wherever it lexically
+        # appears — including inside plain documentation prose — and `secrets` is not a
+        # valid named-value in a composite action's own metadata. That failed the action's
+        # *load* step outright ("Unrecognized named-value: 'secrets'") for every consumer
+        # pinning past 0ab5388, self-review included. Fixed in #186; f951af0 is #186 merged
+        # into pre-0.0.1. See tests/action/test_action_yml_contract.py::TestActionYmlHygiene
+        # ::test_no_secrets_expression_in_manifest_text for the regression guard.
+        uses: alexhawat/mergeCraft@f951af0553e934530ee69e6a1c8a641b602ca5c3 # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: 25m
@@ -462,9 +470,10 @@ jobs:
         # together; if a future `MERGECRAFT_REF` parity rule is added to this
         # repo's Makefile, bump that var in unison.
         # 2026-08-07: rolled back from 88c6f419 to 8d747f39 — Codex stdin hang regression. See PR #246.
-        # 2026-08-14: re-bumped to pre-0.0.1 tip (0ab5388) — see the matching comment on the
-        # Nous step above for why.
-        uses: alexhawat/mergeCraft@0ab538803bae60eaf83ee070532670e215249f14 # pre-0.0.1
+        # 2026-08-14: re-bumped to pre-0.0.1 tip (0ab5388), then again to f951af0 (#186:
+        # action.yml load-breaking `${{ secrets.X }}` in description text) — see the matching
+        # comment on the Nous step above for why.
+        uses: alexhawat/mergeCraft@f951af0553e934530ee69e6a1c8a641b602ca5c3 # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job


### PR DESCRIPTION
The pin bumped in #177 (\`0ab5388\`) has #186's now-fixed \`\${{ secrets.X }}\`-in-description bug baked into its immutable history — that specific commit's \`action.yml\` will always fail to load, no matter what merges on top of it later. Merging #186 into \`pre-0.0.1\`, or syncing \`pre-0.0.1\` into \`main\` again, does **not** fix this: the pin is a literal SHA, and only pointing it at a *later* commit that contains the fix does.

Re-bumps both self-review steps' pin from \`0ab5388\` to \`f951af0\` (#186 merged into \`pre-0.0.1\`), whose \`action.yml\` is confirmed clean (verified no \`\${{ secrets.* }}\` or any other invalid-context expression via \`git show f951af0:action.yml\`).

## Validation
- YAML syntax valid.
- Confirmed \`f951af0\`'s \`action.yml\` has zero \`\${{ secrets.* }}\` occurrences and every remaining \`\${{ }}\` expression uses a valid context (\`github.token\`, \`steps.*.outputs.*\`, \`inputs.*\`).

## Next step after this merges
Same as #177 → #178: this alone does **not** fix self-review, since \`pull_request_target\` resolves the workflow file (and this pin) from \`main\`, not from a PR's base branch. Needs a follow-up "release: sync pre-0.0.1 to main" once this merges.

🤖 Generated with Claude Code.