### PR TITLE
release: sync pre-0.0.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `main()` is now a thin orchestrator over `RunContext`-carried phase functions
+  (`_setup_run`, `_resolve_credentials`, `_execute_agent`, `_finalize`), and the
+  five worst analyzer hotspots (`resolve_analyzer`, `_exclusive_group_winner`,
+  `run_plan`, `_run_osv_scan`, `detect_enabled`) are split into small named
+  helpers. Pure refactor — no user-visible behaviour change; the new `max-
+  complexity = 15` `ruff --select C901` gate now passes on the whole tree.
 - Eval bank replay harness (`make eval-replay`) writes versioned result sets with
   judge pins, rubric version, and S5 mode prompt versions; seeded corpus expanded
   to ten human-labelled cases across correctness, security, cross-file, and

--- a/docs/test-plans/gsr-g4-complexity.md
+++ b/docs/test-plans/gsr-g4-complexity.md
@@ -1,0 +1,90 @@
+# PR G4 — complexity reduction (`main()` + 5 analyzer hotspots) — test plan (G4.1)
+
+Wave plan: `.ignorelocal/waves/issues-showcase-readiness-wave-plan.md`, "PR G4 —
+`refactor(main): drop main() and the analyzer hotspots below complexity 15`"
+Worktree: `mergecraft-gsr-g4-complexity` @ `wave/gsr-g4-complexity`
+
+## Wave type: pure-refactor characterisation (not the usual RED suite)
+
+G4 is a **pure refactor** — `main()` and five analyzer functions get split into
+named phases/helpers with no behaviour change. Per G4.1's own acceptance line
+("8 collected, 8 green before any refactor... and 8 green after"), this suite
+inverts the repo's usual RED-first convention: every test below is written to
+**pass today, against unmodified code**, and must **stay green** through
+G4.2's extraction. A test going red during G4.2 means the refactor changed
+behaviour — the wave-plan-executor's contract is to stop and revert, not to
+edit these tests. (Per `test-creator`'s own escalation-receiver rule, only
+`test-creator` may amend a test, and only when the orchestrator judges the
+*test* — not the refactor — to be wrong.)
+
+`RunContext` and `_setup_run` / `_resolve_credentials` / `_execute_agent` /
+`_finalize` do not exist pre-G4.2. Two tests
+(`test_setup_run_resolves_prompt_and_mode`,
+`test_resolve_credentials_matches_current_precedence`) call the real
+`resolve_prompt_input` / `resolve_tokens` / `derive_trust_tier` functions
+directly, because `tests/support/run_main_harness.py` deliberately stubs
+`resolve_prompt_input` and `resolve_tokens` away (see that file's module
+docstring) — the harness exists to make `main()`'s *ordering* and *outcome*
+testable, not to exercise those two functions' own branches. Every other
+test drives the real, current `main()` end to end through that harness.
+
+## Locked decisions this suite pins
+
+| # | Topic | Bound test(s) |
+|---|-------|----------------|
+| **S1/F6** | Setup-script elapsed time is deducted from the agent's deadline; the deadline covers `_execute_agent` (agent_task) only, not setup/MCP-startup | `test_execute_agent_preserves_deadline_semantics` |
+| **S4 fail-closed default** | `derive_trust_tier` defaults to `untrusted` for missing/unrecognised event shapes; only `workflow_dispatch`, same-repo `pull_request`, and maintainer `issue_comment` earn `trusted` | `test_resolve_credentials_matches_current_precedence` |
+| **D3** | Six-value `RunOutcome` taxonomy, `MainResult.outcome` set on every return path | `test_main_result_is_unchanged_for_each_run_outcome` |
+| G4.2's "**Behaviour-frozen**" note on `_resolve_credentials` | Token brokering precedence (`GH_TOKEN` > job token; App-JWT mint wins when configured, degrades to job token on mint failure; no-token fails closed) | `test_resolve_credentials_matches_current_precedence` |
+
+## Contract → test matrix
+
+### `tests/test_main_phases.py` — 6 tests
+
+| # | Test | Contract | Seam used |
+|---|------|----------|-----------|
+| 1 | `test_run_context_carries_every_phase_input` | The local-variable sprawl G4.2's `RunContext` will carry — pinned today via `ToolContext`, the one object `main()` already threads every phase's output onto (agent_id/repo/tmpdir from setup; trust_tier/tokens from credentials; resolved_model/mcp_server_url from execute) | Full `main()` run via `run_main_for_test`, asserting on `rec.tool_context` |
+| 2 | `test_setup_run_resolves_prompt_and_mode` | `resolve_prompt_input`'s three source branches (`prompt` plain text, `prompt_file`, `prompt` carrying the `~mergecraft` JSON dispatch marker) and the `progress`/mode pair `main()` derives from the result at `main.py:308-313`; `compute_modes`/`_custom_modes` mode computation is independent of the prompt source | Direct calls to `resolve_prompt_input`, `compute_modes`, `_custom_modes` (harness bypasses `resolve_prompt_input`) |
+| 3 | `test_resolve_credentials_matches_current_precedence` | Token brokering (`GH_TOKEN` env wins over `INPUT_TOKEN`/`GITHUB_TOKEN`; App-JWT installation-token mint wins when `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` are set and degrades to the job token on mint failure; no token anywhere fails closed with `ValueError`) + trust-tier derivation matrix (offline/missing-event/`workflow_dispatch`/`pull_request_target`/fork-PR/same-repo-PR/`issue_comment` by association/unrecognised event — all fail closed to `untrusted` except the four documented `trusted` cases) | Direct calls to `resolve_tokens`, `get_job_token` (via `resolve_tokens`), `derive_trust_tier` |
+| 4 | `test_execute_agent_preserves_deadline_semantics` | F6: `asyncio.wait_for`'s deadline wraps the agent coroutine only; a slow-but-within-budget setup script still lets a fast agent complete, and an agent whose own delay is shorter than the *total* run timeout still times out once the setup script's elapsed time is deducted from its budget | Full `main()` run, two scenarios (within-budget / deducted-over-budget) |
+| 5 | `test_finalize_runs_on_every_exit_path` | The nested `try`/`finally` in `main()` reaches the publish block (`persist_learnings`/`report_status_checks`/`emit_run_packet`, proxied by `report_status_calls`) and the unconditional `finally` cleanup (`token_ref.aclose()`, `cleanup_temp_directory()`) on all 4 exit shapes: success, agent-reported failure, timeout, and an exception raised after `ToolContext` exists (bad `timeout` input) | Full `main()` run, 4 scenarios |
+| 6 | `test_main_result_is_unchanged_for_each_run_outcome` | `MainResult`'s full shape (not just `.outcome`) for each of the six `RunOutcome` values (`run_outcome.py:22-30`). Pins a real, easy-to-miss asymmetry found while authoring this test: `timed_out`/`configuration_error`/`infra_error` reach `main()`'s **outer** `except Exception:` handler, which never calls `emit_run_packet` (`evidence_packet_path` stays `None`); `passed`/`failed`/`inconclusive` return through the normal completion path, where the packet **is** written | Full `main()` run, 6 scenarios |
+
+### `tests/analyzers/test_resolve_complexity.py` — 1 test
+
+| # | Test | Contract |
+|---|------|----------|
+| 7 | `test_resolve_analyzer_behaviour_unchanged` | `resolve_analyzer`'s (D26) full preference ladder — `declared_unavailable` > `agentsec` special-case > repo-native > type-checker-only-skip (C3/D5) > managed > container > skip — table-driven over the entire bundled catalog (`load_catalog()`, 57 manifests), across 4 scenarios (nothing available / repo-has-tool / managed-only / `allow_repo_binaries=False`). Every scenario forces its booleans explicitly (never `None`) so the expected mode is computed independently from each manifest's own fields, not copied from the function's current output |
+
+### `tests/analyzers/test_registry_complexity.py` — 1 test
+
+| # | Test | Contract |
+|---|------|----------|
+| 8 | `test_exclusive_group_winner_unchanged` | `_exclusive_group_winner`'s (D26) explicit-override / preference-ladder (`python-lint`, `python-typecheck`, pattern-scanner backend) / alphabetical-tie-break chain, plus `detect_enabled`'s (D22) detect-match → settings-override → exclusive-group-collapse pipeline (same file, same wave — G4.1's own note). The `detect_enabled` scenarios reuse the exact fixture repo + changed-file sets already exercised by `tests/analyzers/test_registry.py`, so they carry independent confidence beyond this new file |
+
+## Status
+
+All 8 tests pass today, against unmodified `main.py` / `analyzers/resolve.py`
+/ `analyzers/registry.py`. Verified via:
+
+```
+uv run pytest --collect-only -q tests/test_main_phases.py \
+  tests/analyzers/test_resolve_complexity.py tests/analyzers/test_registry_complexity.py
+# -> 8 tests collected
+
+MERGECRAFT_PYTEST_JOBS=0 uv run pytest -q tests/test_main_phases.py \
+  tests/analyzers/test_resolve_complexity.py tests/analyzers/test_registry_complexity.py
+# -> 8 passed
+```
+
+`make lint` clean on the new files. `make typecheck` is unaffected — it scopes
+to `src/mergecraft` only (Makefile:59) and this wave touches no source file.
+
+## G4.2 hand-off note
+
+After the extraction lands, re-run this exact suite unmodified (only import
+paths inside the tests may need updating if `resolve_analyzer`/
+`_exclusive_group_winner`/`detect_enabled` move — their public names should
+not). A regression here that isn't an import-path fix is a behaviour change
+the refactor was not supposed to make; stop and revert per G4.1's acceptance
+line, don't edit the test.

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -758,12 +758,24 @@ def _run_claude_legacy_subprocess(
     ``capture_output=True`` read loop reachable so PR #16's
     ``_build_claude_failure_error`` semantics and the failure-diagnosis
     contract continue to hold.
+
+    In the real action image this path is not expected to be reached at all
+    — ``claude`` ships on PATH there, so the streaming ``Popen`` above only
+    raises ``FileNotFoundError`` in a stripped-down test environment. It
+    still goes through the same ``wrap_agent_command`` + ``agent_subprocess_env``
+    privilege-drop pairing as the primary path, for defense-in-depth and so a
+    future change that makes this path reachable in production does not
+    silently reintroduce the ``$HOME`` bug.
     """
+    from mergecraft.utils.privilege import agent_subprocess_env
+
     try:
+        wrapped_cmd = wrap_agent_command(cmd)
+        resolved_env = agent_subprocess_env(_build_env(ctx))
         completed = subprocess.run(
-            wrap_agent_command(cmd),
+            wrapped_cmd,
             cwd=os.getcwd(),
-            env=_build_env(ctx),
+            env=resolved_env,
             capture_output=True,
             text=True,
             timeout=int(os.environ.get("MERGECRAFT_AGENT_TIMEOUT", "3600")),

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -36,7 +36,7 @@ from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROM
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.http import instrument_httpx
 from mergecraft.types import MERGECRAFT_MCP_NAME
-from mergecraft.utils.privilege import wrap_agent_command
+from mergecraft.utils.privilege import agent_subprocess_env, wrap_agent_command
 from mergecraft.utils.process_group import (
     kill_process_group,
     register_process_group,
@@ -227,10 +227,18 @@ class _ServerHandle:
 
 
 def _boot_opencode_server(*, cli: str, env: dict[str, str], cwd: str) -> _ServerHandle:
+    # Wrap argv with setpriv, then patch HOME/USER/LOGNAME to match the
+    # dropped-to agent user (setpriv does not reset $HOME itself — see
+    # mergecraft.utils.privilege.agent_subprocess_env). This is the exact
+    # bug behind "opencode serve exited early: EACCES: permission denied,
+    # mkdir '/github/home/.local'": opencode inherited the container's
+    # HOME=/github/home, which the dropped-to uid cannot write under.
+    wrapped_cmd = wrap_agent_command([cli, "serve", "--port", "0", "--hostname", "127.0.0.1"])
+    resolved_env = agent_subprocess_env(env)
     proc = subprocess.Popen(
-        wrap_agent_command([cli, "serve", "--port", "0", "--hostname", "127.0.0.1"]),
+        wrapped_cmd,
         cwd=cwd,
-        env=env,
+        env=resolved_env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,

--- a/src/mergecraft/agents/shared.py
+++ b/src/mergecraft/agents/shared.py
@@ -30,13 +30,23 @@ def spawn_agent_cli(
     Shared by Claude/Codex/Gemini/OpenCode so wrap + pipes + ``start_new_session``
     stay one place (W9 / Final CQ). Callers own streaming and
     :func:`wait_or_kill_process_group`.
+
+    Wraps argv with :func:`wrap_agent_command` *before* patching ``env`` with
+    :func:`agent_subprocess_env` — both resolve the same agent user
+    independently and fail closed the same way, but ordering them this way
+    means a fail-closed ``setpriv``/user error surfaces at the argv wrap
+    (matching every existing test's expectations) rather than only after the
+    env has already been rebuilt.
     """
-    from mergecraft.utils.privilege import wrap_agent_command
+    from mergecraft.utils.privilege import agent_subprocess_env, wrap_agent_command
+
+    wrapped_cmd = wrap_agent_command(cmd)
+    resolved_env = agent_subprocess_env(env)
 
     return subprocess.Popen(
-        wrap_agent_command(cmd),
+        wrapped_cmd,
         cwd=cwd if cwd is not None else os.getcwd(),
-        env=env,
+        env=resolved_env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/src/mergecraft/analyzers/registry.py
+++ b/src/mergecraft/analyzers/registry.py
@@ -113,6 +113,60 @@ def _auto_manifest_enabled(manifest: AnalyzerManifest, repo_root: Path) -> bool:
     return manifest_config_present(manifest.id, repo_root)
 
 
+def _explicit_override_winner(
+    candidates: list[AnalyzerManifest], explicit: list[str]
+) -> AnalyzerManifest | None:
+    """Tie-break rule: an operator's explicit ``enabled: true`` override wins outright.
+
+    Ties among multiple explicit overrides in the same exclusive group fall
+    through to the alphabetical rule (via ``sorted(...)[0]``), same as the
+    final catch-all — an explicit override just narrows the candidate pool
+    first.
+    """
+    explicit_in_group = [m for m in candidates if m.id in explicit]
+    if len(explicit_in_group) == 1:
+        return explicit_in_group[0]
+    if len(explicit_in_group) > 1:
+        return sorted(explicit_in_group, key=lambda m: m.id)[0]
+    return None
+
+
+def _preference_order_winner(
+    candidates: list[AnalyzerManifest], preference: tuple[str, ...]
+) -> AnalyzerManifest | None:
+    """Tie-break rule: the first candidate matching an ordered id-preference list."""
+    for preferred in preference:
+        for manifest in candidates:
+            if manifest.id == preferred:
+                return manifest
+    return None
+
+
+def _group_preference_order(
+    group: str,
+    *,
+    repo_root: Path,
+    settings: dict[str, Any],
+) -> tuple[str, ...]:
+    """The id-preference order for one exclusive group, or ``()`` if it has none."""
+    if group == "python-lint":
+        return _PYTHON_LINT_PREFERENCE
+    if group == "python-typecheck":
+        return _PYTHON_TYPECHECK_PREFERENCE
+    if group == "js-lint":
+        intent = detect_js_linter_intent(repo_root)
+        return (intent,) if intent is not None else ()
+    if group == PATTERN_EXCLUSIVE_GROUP:
+        backend = pattern_backend_from_settings(repo_root, settings)
+        return (backend, "semgrep", "opengrep", "ast-grep")
+    return ()
+
+
+def _alphabetical_winner(candidates: list[AnalyzerManifest]) -> AnalyzerManifest:
+    """Tie-break rule: last resort — alphabetically first id, for a deterministic pick."""
+    return sorted(candidates, key=lambda m: m.id)[0]
+
+
 def _exclusive_group_winner(
     group: str,
     candidates: list[AnalyzerManifest],
@@ -120,42 +174,90 @@ def _exclusive_group_winner(
     repo_root: Path,
     settings: dict[str, Any],
 ) -> AnalyzerManifest:
+    """Pick one manifest per exclusive group via an ordered chain of named tie-break rules."""
     overrides = (settings.get("analyzers") or {}).get("overrides") or {}
     explicit = [
         manifest_id
         for manifest_id, override in overrides.items()
         if isinstance(override, dict) and override.get("enabled") is True
     ]
-    explicit_in_group = [m for m in candidates if m.id in explicit]
-    if len(explicit_in_group) == 1:
-        return explicit_in_group[0]
-    if len(explicit_in_group) > 1:
-        return sorted(explicit_in_group, key=lambda m: m.id)[0]
+    winner = _explicit_override_winner(candidates, explicit)
+    if winner is not None:
+        return winner
 
-    if group == "python-lint":
-        for preferred in _PYTHON_LINT_PREFERENCE:
-            for manifest in candidates:
-                if manifest.id == preferred:
-                    return manifest
-    if group == "python-typecheck":
-        for preferred in _PYTHON_TYPECHECK_PREFERENCE:
-            for manifest in candidates:
-                if manifest.id == preferred:
-                    return manifest
-    if group == "js-lint":
-        intent = detect_js_linter_intent(repo_root)
-        if intent is not None:
-            for manifest in candidates:
-                if manifest.id == intent:
-                    return manifest
-    if group == PATTERN_EXCLUSIVE_GROUP:
-        backend = pattern_backend_from_settings(repo_root, settings)
-        preference = (backend, "semgrep", "opengrep", "ast-grep")
-        for preferred in preference:
-            for manifest in candidates:
-                if manifest.id == preferred:
-                    return manifest
-    return sorted(candidates, key=lambda m: m.id)[0]
+    preference = _group_preference_order(group, repo_root=repo_root, settings=settings)
+    winner = _preference_order_winner(candidates, preference)
+    if winner is not None:
+        return winner
+
+    return _alphabetical_winner(candidates)
+
+
+def _manifest_is_candidate(
+    manifest: AnalyzerManifest,
+    *,
+    repo_root: Path,
+    changed_files: list[str],
+    settings: dict[str, Any],
+) -> bool:
+    """Per-detector evaluation: does this manifest apply to the current diff/config?
+
+    Four independent gates, all of which must pass: the pattern-backend
+    exclusive group's own enablement, the settings override, the
+    ``detect.files`` glob match against the diff, and (only when nothing
+    else decided it) the ``default_enabled: auto`` repo-config heuristic.
+    """
+    if manifest.exclusive_group == PATTERN_EXCLUSIVE_GROUP and not pattern_tool_enabled(
+        manifest.id, repo_root=repo_root, settings=settings
+    ):
+        return False
+    enabled = _settings_enabled(manifest, settings)
+    if enabled is False:
+        return False
+    if not _detect_matches(manifest, changed_files):
+        return False
+    return not (
+        enabled is None
+        and manifest.default_enabled == "auto"
+        and not _auto_manifest_enabled(manifest, repo_root)
+    )
+
+
+def _group_candidates(
+    candidates: list[AnalyzerManifest],
+) -> tuple[list[AnalyzerManifest], dict[str, list[AnalyzerManifest]]]:
+    """Split out ungrouped candidates (selected outright) from exclusive-group members."""
+    grouped: dict[str, list[AnalyzerManifest]] = {}
+    selected: list[AnalyzerManifest] = []
+    for manifest in candidates:
+        group = manifest.exclusive_group
+        if not group:
+            selected.append(manifest)
+            continue
+        grouped.setdefault(group, []).append(manifest)
+    return selected, grouped
+
+
+def _resolve_group_members(
+    group: str,
+    members: list[AnalyzerManifest],
+    *,
+    repo_root: Path,
+    settings: dict[str, Any],
+    explicit: set[str],
+) -> list[AnalyzerManifest]:
+    """Per-detector evaluation for one exclusive group.
+
+    Multiple explicit operator overrides in the same group all survive
+    (sorted for determinism); a single explicit override wins outright;
+    otherwise fall back to ``_exclusive_group_winner``'s tie-break chain.
+    """
+    explicit_members = [m for m in members if m.id in explicit]
+    if len(explicit_members) > 1:
+        return sorted(explicit_members, key=lambda m: m.id)
+    if len(explicit_members) == 1:
+        return explicit_members
+    return [_exclusive_group_winner(group, members, repo_root=repo_root, settings=settings)]
 
 
 def detect_enabled(
@@ -167,34 +269,15 @@ def detect_enabled(
     """Return analyzers enabled for this diff, honoring detection and config overrides."""
     repo_root = repo_root.resolve()
     settings = settings_overrides or {}
-    candidates: list[AnalyzerManifest] = []
+    candidates = [
+        manifest
+        for manifest in load_catalog()
+        if _manifest_is_candidate(
+            manifest, repo_root=repo_root, changed_files=changed_files, settings=settings
+        )
+    ]
 
-    for manifest in load_catalog():
-        if manifest.exclusive_group == PATTERN_EXCLUSIVE_GROUP and not pattern_tool_enabled(
-            manifest.id, repo_root=repo_root, settings=settings
-        ):
-            continue
-        enabled = _settings_enabled(manifest, settings)
-        if enabled is False:
-            continue
-        if not _detect_matches(manifest, changed_files):
-            continue
-        if (
-            enabled is None
-            and manifest.default_enabled == "auto"
-            and not _auto_manifest_enabled(manifest, repo_root)
-        ):
-            continue
-        candidates.append(manifest)
-
-    grouped: dict[str, list[AnalyzerManifest]] = {}
-    selected: list[AnalyzerManifest] = []
-    for manifest in candidates:
-        group = manifest.exclusive_group
-        if not group:
-            selected.append(manifest)
-            continue
-        grouped.setdefault(group, []).append(manifest)
+    selected, grouped = _group_candidates(candidates)
 
     overrides = (settings.get("analyzers") or {}).get("overrides") or {}
     explicit = {
@@ -204,15 +287,11 @@ def detect_enabled(
     }
 
     for group, members in grouped.items():
-        explicit_members = [m for m in members if m.id in explicit]
-        if len(explicit_members) > 1:
-            selected.extend(sorted(explicit_members, key=lambda m: m.id))
-            continue
-        if len(explicit_members) == 1:
-            selected.append(explicit_members[0])
-            continue
-        winner = _exclusive_group_winner(group, members, repo_root=repo_root, settings=settings)
-        selected.append(winner)
+        selected.extend(
+            _resolve_group_members(
+                group, members, repo_root=repo_root, settings=settings, explicit=explicit
+            )
+        )
 
     return selected
 

--- a/src/mergecraft/analyzers/resolve.py
+++ b/src/mergecraft/analyzers/resolve.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Literal
 from mergecraft.analyzers.detect import _eslint_command_prefix, resolve_repo_tool
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mergecraft.analyzers.manifest import AnalyzerManifest
 
 _CATALOG_DIR = Path(__file__).resolve().parent / "catalog"
@@ -70,6 +72,183 @@ def detect_repo_tool(
     return True, resolution.path, resolution.version
 
 
+def _declared_unavailable_plan(manifest: AnalyzerManifest) -> AnalyzerPlan | None:
+    """Per-source resolver: a manifest the catalog itself marks unavailable."""
+    if not manifest.declared_unavailable:
+        return None
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="skip",
+        reason=f"skipped {manifest.id}: {manifest.declared_unavailable}",
+    )
+
+
+def _agentsec_plan(manifest: AnalyzerManifest, repo_root: Path) -> AnalyzerPlan | None:
+    """Per-source resolver: the ``agentsec`` special-case (mergeCraft's native engine)."""
+    if manifest.id != "agentsec":
+        return None
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="repo-native",
+        argv=("agentsec",),
+        cwd=repo_root,
+        timeout_s=manifest.timeout_s,
+        version_note="ran mergeCraft native agent-security policy engine",
+        config_note="native YAML rules",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _RepoToolState:
+    """Availability + provenance for the repo-native execution source."""
+
+    available: bool
+    tool_path: str | None
+    tool_version: str | None
+    config_note: str | None
+
+
+def _detect_repo_tool_state(
+    manifest: AnalyzerManifest,
+    repo_root: Path,
+    *,
+    repo_has_tool: bool | None,
+    repo_tool_path: str | None,
+    repo_tool_version: str | None,
+) -> tuple[_RepoToolState, AnalyzerPlan | None]:
+    """Resolve repo-native tool availability, or an early skip plan on detection failure.
+
+    Detection only runs when the caller left ``repo_has_tool`` unresolved
+    (``None``) — the "figure it out" default. An explicit caller-supplied
+    boolean (including ``allow_repo_binaries=False`` forcing it to
+    ``False``) skips detection entirely and is trusted as-is. On a failed
+    detection, type checkers and repo-native-only manifests skip
+    immediately with ``resolve_repo_tool``'s own reason — a distinct
+    message from the generic type-checker skip later in the ladder.
+    """
+    if repo_has_tool is not None:
+        return _RepoToolState(repo_has_tool, repo_tool_path, repo_tool_version, None), None
+
+    resolution, skip_reason = resolve_repo_tool(
+        manifest.id,
+        repo_root=repo_root,
+        command_binary=_repo_tool_binary(manifest),
+    )
+    if resolution is None:
+        if manifest.id in _TYPE_CHECKER_IDS:
+            return (
+                _RepoToolState(False, None, None, None),
+                AnalyzerPlan(manifest_id=manifest.id, mode="skip", reason=skip_reason),
+            )
+        if manifest.runtime == "repo-native" and skip_reason and skip_reason.startswith("skipped"):
+            return (
+                _RepoToolState(False, None, None, None),
+                AnalyzerPlan(manifest_id=manifest.id, mode="skip", reason=skip_reason),
+            )
+        return _RepoToolState(False, None, None, None), None
+
+    return (
+        _RepoToolState(
+            True,
+            repo_tool_path or resolution.path,
+            repo_tool_version or resolution.version,
+            resolution.config_note,
+        ),
+        None,
+    )
+
+
+def _repo_native_plan(
+    manifest: AnalyzerManifest, repo_root: Path, state: _RepoToolState
+) -> AnalyzerPlan | None:
+    """Per-source resolver: the repo's own binary, once availability is known."""
+    if not state.available:
+        return None
+    argv = tuple(manifest.command)
+    if manifest.id == "eslint":
+        prefix = _eslint_command_prefix(repo_root)
+        if len(prefix) == 2:
+            argv = (*prefix, *manifest.command[1:])
+        elif len(prefix) == 1:
+            argv = (prefix[0], *manifest.command[1:])
+    elif state.tool_path and argv and argv[0] == _repo_tool_binary(manifest):
+        argv = (state.tool_path, *argv[1:])
+    version_note = _format_version_note(
+        manifest, repo_tool_version=state.tool_version, config_note=state.config_note
+    )
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="repo-native",
+        argv=argv,
+        cwd=repo_root,
+        timeout_s=manifest.timeout_s,
+        version_note=version_note,
+        config_note=state.config_note,
+    )
+
+
+def _type_checker_missing_plan(manifest: AnalyzerManifest) -> AnalyzerPlan | None:
+    """Per-source resolver: type checkers are repo-native only (C3/D5) — no substitute."""
+    if manifest.id not in _TYPE_CHECKER_IDS:
+        return None
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="skip",
+        reason=(
+            f"skipped {manifest.id}: type checker not installed in the repo environment "
+            "(repo-native only — managed substitute forbidden, C3/D5)"
+        ),
+    )
+
+
+def _ci_result_plan(
+    manifest: AnalyzerManifest, repo_root: Path, ci_artifact_available: bool
+) -> AnalyzerPlan | None:
+    """Per-source resolver: a CI-produced artifact stands in for a local run."""
+    if not ci_artifact_available:
+        return None
+    return AnalyzerPlan(
+        manifest_id=manifest.id, mode="ci-result", cwd=repo_root, timeout_s=manifest.timeout_s
+    )
+
+
+def _managed_plan(
+    manifest: AnalyzerManifest,
+    repo_root: Path,
+    *,
+    managed_available: bool,
+    managed_version: str | None,
+) -> AnalyzerPlan | None:
+    """Per-source resolver: mergeCraft's own pinned binary."""
+    if not (managed_available and manifest.runtime in {"managed", "repo-native"}):
+        return None
+    version = managed_version or manifest.version
+    version_note = f"ran mergeCraft's pinned {manifest.id} {version}; your repo pins none"
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="managed",
+        argv=tuple(manifest.command),
+        cwd=repo_root,
+        timeout_s=manifest.timeout_s,
+        version_note=version_note,
+    )
+
+
+def _container_plan(
+    manifest: AnalyzerManifest, repo_root: Path, container_available: bool
+) -> AnalyzerPlan | None:
+    """Per-source resolver: a sandboxed container image, last resort before skip."""
+    if not (container_available and manifest.runtime == "container"):
+        return None
+    return AnalyzerPlan(
+        manifest_id=manifest.id,
+        mode="container",
+        argv=tuple(manifest.command),
+        cwd=repo_root,
+        timeout_s=manifest.timeout_s,
+    )
+
+
 def resolve_analyzer(
     *,
     manifest: AnalyzerManifest,
@@ -90,121 +269,49 @@ def resolve_analyzer(
     manifest regardless of declared ``runtime``. ``allow_repo_binaries=False``
     removes that step so only the pinned binary can run — what ``shell:
     disabled`` requires, since the working tree is then PR-authored (#35, D5).
+
+    The ladder is a small ordered dispatch of per-source resolvers —
+    declared-unavailable → agentsec special-case → repo-native →
+    type-checker-only-skip → managed → container — each either producing a
+    plan or yielding (``None``) to the next.
     """
     if not allow_repo_binaries:
         repo_has_tool = False
-    if manifest.declared_unavailable:
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="skip",
-            reason=f"skipped {manifest.id}: {manifest.declared_unavailable}",
-        )
 
-    if manifest.id == "agentsec":
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="repo-native",
-            argv=("agentsec",),
-            cwd=repo_root,
-            timeout_s=manifest.timeout_s,
-            version_note="ran mergeCraft native agent-security policy engine",
-            config_note="native YAML rules",
-        )
+    plan = _declared_unavailable_plan(manifest)
+    if plan is not None:
+        return plan
 
-    config_note: str | None = None
-    if repo_has_tool is None:
-        resolution, skip_reason = resolve_repo_tool(
-            manifest.id,
-            repo_root=repo_root,
-            command_binary=_repo_tool_binary(manifest),
-        )
-        if resolution is None:
-            if manifest.id in _TYPE_CHECKER_IDS:
-                return AnalyzerPlan(
-                    manifest_id=manifest.id,
-                    mode="skip",
-                    reason=skip_reason,
-                )
-            if (
-                manifest.runtime == "repo-native"
-                and skip_reason
-                and skip_reason.startswith("skipped")
-            ):
-                return AnalyzerPlan(
-                    manifest_id=manifest.id,
-                    mode="skip",
-                    reason=skip_reason,
-                )
-            repo_has_tool = False
-        else:
-            repo_has_tool = True
-            repo_tool_path = repo_tool_path or resolution.path
-            repo_tool_version = repo_tool_version or resolution.version
-            config_note = resolution.config_note
+    plan = _agentsec_plan(manifest, repo_root)
+    if plan is not None:
+        return plan
 
-    if repo_has_tool:
-        argv = tuple(manifest.command)
-        if manifest.id == "eslint":
-            prefix = _eslint_command_prefix(repo_root)
-            if len(prefix) == 2:
-                argv = (*prefix, *manifest.command[1:])
-            elif len(prefix) == 1:
-                argv = (prefix[0], *manifest.command[1:])
-        elif repo_tool_path and argv and argv[0] == _repo_tool_binary(manifest):
-            argv = (repo_tool_path, *argv[1:])
-        version_note = _format_version_note(
+    repo_tool_state, early_skip = _detect_repo_tool_state(
+        manifest,
+        repo_root,
+        repo_has_tool=repo_has_tool,
+        repo_tool_path=repo_tool_path,
+        repo_tool_version=repo_tool_version,
+    )
+    if early_skip is not None:
+        return early_skip
+
+    resolvers: tuple[Callable[[], AnalyzerPlan | None], ...] = (
+        lambda: _repo_native_plan(manifest, repo_root, repo_tool_state),
+        lambda: _type_checker_missing_plan(manifest),
+        lambda: _ci_result_plan(manifest, repo_root, ci_artifact_available),
+        lambda: _managed_plan(
             manifest,
-            repo_tool_version=repo_tool_version,
-            config_note=config_note,
-        )
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="repo-native",
-            argv=argv,
-            cwd=repo_root,
-            timeout_s=manifest.timeout_s,
-            version_note=version_note,
-            config_note=config_note,
-        )
-
-    if manifest.id in _TYPE_CHECKER_IDS:
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="skip",
-            reason=(
-                f"skipped {manifest.id}: type checker not installed in the repo environment "
-                "(repo-native only — managed substitute forbidden, C3/D5)"
-            ),
-        )
-
-    if ci_artifact_available:
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="ci-result",
-            cwd=repo_root,
-            timeout_s=manifest.timeout_s,
-        )
-
-    if managed_available and manifest.runtime in {"managed", "repo-native"}:
-        version = managed_version or manifest.version
-        version_note = f"ran mergeCraft's pinned {manifest.id} {version}; your repo pins none"
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="managed",
-            argv=tuple(manifest.command),
-            cwd=repo_root,
-            timeout_s=manifest.timeout_s,
-            version_note=version_note,
-        )
-
-    if container_available and manifest.runtime == "container":
-        return AnalyzerPlan(
-            manifest_id=manifest.id,
-            mode="container",
-            argv=tuple(manifest.command),
-            cwd=repo_root,
-            timeout_s=manifest.timeout_s,
-        )
+            repo_root,
+            managed_available=managed_available,
+            managed_version=managed_version,
+        ),
+        lambda: _container_plan(manifest, repo_root, container_available),
+    )
+    for resolver in resolvers:
+        plan = resolver()
+        if plan is not None:
+            return plan
 
     return AnalyzerPlan(
         manifest_id=manifest.id,

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -14,6 +14,7 @@ from loguru import logger
 from mergecraft.analyzers.redact import redact_analyzer_output
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from mergecraft.analyzers.resolve import AnalyzerPlan
@@ -110,10 +111,8 @@ def _command_string(argv: tuple[str, ...]) -> str:
     return shlex.join(argv)
 
 
-def run_plan(
-    plan: AnalyzerPlan, *, sandbox_context: SandboxContext | None = None
-) -> AnalyzerOutcome:
-    """Run one resolved plan. Never raises."""
+def _early_unavailable_outcome(plan: AnalyzerPlan) -> AnalyzerOutcome | None:
+    """Short-circuit outcomes that never touch a subprocess (skip / not-yet-runnable mode)."""
     if plan.mode == "skip":
         return AnalyzerOutcome(
             name=plan.manifest_id,
@@ -121,7 +120,6 @@ def run_plan(
             status="unavailable",
             output=plan.reason or f"skipped {plan.manifest_id}",
         )
-
     if plan.mode in {"ci-result", "managed", "container"} and not plan.argv:
         return AnalyzerOutcome(
             name=plan.manifest_id,
@@ -129,25 +127,39 @@ def run_plan(
             status="unavailable",
             output=f"{plan.mode} execution is not available in this wave",
         )
+    return None
 
-    cwd = plan.cwd
-    timeout_s = plan.timeout_s or CHECK_TIMEOUT_S
-    if sandbox_context is not None:
-        timeout_s = min(timeout_s, sandbox_context.timeout_s)
-    command = _command_string(plan.argv)
-    preexec_fn = None
+
+def _sandboxed_argv(
+    plan: AnalyzerPlan, sandbox_context: SandboxContext | None
+) -> tuple[list[str], Callable[[], None] | None]:
+    """Wrap ``plan.argv`` in an unshare/sudo-unshare sandbox when the context calls for one."""
     run_argv = list(plan.argv)
-    if sandbox_context is not None and sandbox_context.read_only_source and sys.platform != "win32":
-        preexec_fn = lambda: _sandbox_preexec(sandbox_context)  # noqa: E731
-        from mergecraft.mcp.shell import detect_sandbox_method
+    if sandbox_context is None or not sandbox_context.read_only_source or sys.platform == "win32":
+        return run_argv, None
+    preexec_fn = lambda: _sandbox_preexec(sandbox_context)  # noqa: E731
+    from mergecraft.mcp.shell import detect_sandbox_method
 
-        method = detect_sandbox_method()
-        if method == "unshare":
-            run_argv = ["unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
-        elif method == "sudo-unshare":
-            run_argv = ["sudo", "unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
+    method = detect_sandbox_method()
+    if method == "unshare":
+        run_argv = ["unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
+    elif method == "sudo-unshare":
+        run_argv = ["sudo", "unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
+    return run_argv, preexec_fn
+
+
+def _run_subprocess(
+    run_argv: list[str],
+    *,
+    plan: AnalyzerPlan,
+    cwd: Path | None,
+    timeout_s: int,
+    preexec_fn: Callable[[], None] | None,
+    command: str,
+) -> subprocess.CompletedProcess[str] | AnalyzerOutcome:
+    """Run the analyzer subprocess; a caught timeout/OSError becomes a terminal outcome."""
     try:
-        completed = subprocess.run(
+        return subprocess.run(
             run_argv,
             cwd=cwd,
             capture_output=True,
@@ -174,6 +186,11 @@ def run_plan(
             output=f"not installed in this environment: {exc}",
         )
 
+
+def _outcome_from_completed(
+    completed: subprocess.CompletedProcess[str], *, plan: AnalyzerPlan, command: str
+) -> AnalyzerOutcome:
+    """Combine stdout/stderr, redact, persist to disk, and build the final outcome."""
     raw_stdout = (completed.stdout or "").strip()
     raw_stderr = (completed.stderr or "").strip()
     raw_for_parser = raw_stdout or raw_stderr
@@ -195,6 +212,29 @@ def run_plan(
         exit_code=completed.returncode,
         output_path=output_path,
     )
+
+
+def run_plan(
+    plan: AnalyzerPlan, *, sandbox_context: SandboxContext | None = None
+) -> AnalyzerOutcome:
+    """Run one resolved plan. Never raises."""
+    early = _early_unavailable_outcome(plan)
+    if early is not None:
+        return early
+
+    cwd = plan.cwd
+    timeout_s = plan.timeout_s or CHECK_TIMEOUT_S
+    if sandbox_context is not None:
+        timeout_s = min(timeout_s, sandbox_context.timeout_s)
+    command = _command_string(plan.argv)
+    run_argv, preexec_fn = _sandboxed_argv(plan, sandbox_context)
+
+    result = _run_subprocess(
+        run_argv, plan=plan, cwd=cwd, timeout_s=timeout_s, preexec_fn=preexec_fn, command=command
+    )
+    if isinstance(result, AnalyzerOutcome):
+        return result
+    return _outcome_from_completed(result, plan=plan, command=command)
 
 
 def run_plans(

--- a/src/mergecraft/analyzers/supply_chain.py
+++ b/src/mergecraft/analyzers/supply_chain.py
@@ -192,6 +192,63 @@ def _enrich_trivy_findings(
     return enriched
 
 
+def _osv_package_names_by_file(raw: str) -> dict[str, str]:
+    """Parse the raw ``osv-scanner`` JSON payload into ``{source filename: package name}``.
+
+    Best-effort: malformed JSON or an unexpected shape yields an empty map
+    rather than raising — the caller still has ``parse_osv_json``'s own
+    findings even when this enrichment lookup comes up empty.
+    """
+    package_names: dict[str, str] = {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return package_names
+    for result in payload.get("results") or []:
+        if not isinstance(result, dict):
+            continue
+        source = result.get("source") or {}
+        rel = Path(str(source.get("path") or "")).name
+        for package in result.get("packages") or []:
+            if not isinstance(package, dict):
+                continue
+            pkg_info = package.get("package") or {}
+            pkg_name = str(pkg_info.get("name") or "")
+            if pkg_name:
+                package_names[rel] = pkg_name
+    return package_names
+
+
+def _enrich_osv_findings(
+    findings: list[Finding],
+    *,
+    manifest_paths: dict[str, Path],
+    package_names: dict[str, str],
+) -> list[Finding]:
+    """Attach fixed-version + dependency-relationship metadata to each OSV finding."""
+    enriched: list[Finding] = []
+    for finding in findings:
+        rel_path = Path(finding.path).name
+        manifest_path = manifest_paths.get(rel_path) or manifest_paths.get(finding.path)
+        pkg = package_names.get(rel_path, "")
+        fixed = None
+        if finding.remediation and "upgrade to" in finding.remediation.casefold():
+            fixed = (
+                finding.remediation.casefold()
+                .split("upgrade to", 1)[-1]
+                .split(" or later", 1)[0]
+                .strip()
+            )
+        enriched.append(
+            _enrich_vuln_finding(
+                finding,
+                fixed_version=fixed,
+                relationship=_dependency_relationship(manifest_path, pkg),
+            )
+        )
+    return enriched
+
+
 def _run_osv_scan(
     *,
     manifest: AnalyzerManifest,
@@ -245,45 +302,11 @@ def _run_osv_scan(
         else outcome.output
     )
     manifest_paths = _manifest_paths(repo_root, existing)
-    package_names: dict[str, str] = {}
-    try:
-        payload = json.loads(raw)
-        for result in payload.get("results") or []:
-            if not isinstance(result, dict):
-                continue
-            source = result.get("source") or {}
-            rel = Path(str(source.get("path") or "")).name
-            for package in result.get("packages") or []:
-                if not isinstance(package, dict):
-                    continue
-                pkg_info = package.get("package") or {}
-                pkg_name = str(pkg_info.get("name") or "")
-                if pkg_name:
-                    package_names[rel] = pkg_name
-    except json.JSONDecodeError:
-        pass
-
+    package_names = _osv_package_names_by_file(raw)
     findings = parse_osv_json(raw, manifest=manifest, repo_root=repo_root)
-    enriched: list[Finding] = []
-    for finding in findings:
-        rel_path = Path(finding.path).name
-        manifest_path = manifest_paths.get(rel_path) or manifest_paths.get(finding.path)
-        pkg = package_names.get(rel_path, "")
-        fixed = None
-        if finding.remediation and "upgrade to" in finding.remediation.casefold():
-            fixed = (
-                finding.remediation.casefold()
-                .split("upgrade to", 1)[-1]
-                .split(" or later", 1)[0]
-                .strip()
-            )
-        enriched.append(
-            _enrich_vuln_finding(
-                finding,
-                fixed_version=fixed,
-                relationship=_dependency_relationship(manifest_path, pkg),
-            )
-        )
+    enriched = _enrich_osv_findings(
+        findings, manifest_paths=manifest_paths, package_names=package_names
+    )
     return enriched, None
 
 

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -6,15 +6,15 @@ import asyncio
 import contextlib
 import os
 import time
-from dataclasses import dataclass, replace
-from typing import Any
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from mergecraft.action.inputs import apply_setup_overrides, apply_tracing_overrides
 from mergecraft.agents.gates import subagent_denied_tool_names
 from mergecraft.agents.post_run import finalize_agent_result
-from mergecraft.agents.shared import AgentResult, AgentRunContext
+from mergecraft.agents.shared import Agent, AgentResult, AgentRunContext
 from mergecraft.analyzers.redact import install_loguru_redaction_filter, redact_secrets
 from mergecraft.analyzers.sarif_upload import resolve_sarif_upload_enabled
 from mergecraft.analyzers.trust import (
@@ -27,7 +27,7 @@ from mergecraft.main_outcome import _classify_outcome, _publish_span_attrs
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.dependencies import start_installation
 from mergecraft.mcp.server import start_mcp_http_server
-from mergecraft.mcp.tool_state import ProgressComment, init_tool_state
+from mergecraft.mcp.tool_state import ProgressComment, ToolState, init_tool_state
 from mergecraft.modes import _custom_modes, compute_modes
 from mergecraft.review_checks import StaticCheckConfig
 from mergecraft.run_outcome import RUN_OUTCOME_CONCLUSION, RunOutcome, run_succeeded_for_outcome
@@ -58,6 +58,7 @@ from mergecraft.utils.log import bind_run_context
 from mergecraft.utils.normalize_env import normalize_env
 from mergecraft.utils.payload import (
     TIMEOUT_DISABLED,
+    JsonPayload,
     read_github_event,
     resolve_output_schema,
     resolve_payload,
@@ -73,12 +74,18 @@ from mergecraft.utils.process_group import (
 from mergecraft.utils.secrets import set_env_allowlist
 from mergecraft.utils.skills import install_bundled_skills
 from mergecraft.utils.status_checks import report_status_checks
-from mergecraft.utils.token import get_job_token, resolve_tokens
+from mergecraft.utils.token import TokenRef, get_job_token, resolve_tokens
 from mergecraft.utils.workspace import (
     WorkspacePathError,
     ensure_github_workspace_registered,
     resolve_allowed_working_directory,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mergecraft.analyzers.manifest import TrustTier
+    from mergecraft.config.settings import RepoSettings, RunContextData
 
 
 @dataclass(slots=True)
@@ -95,6 +102,65 @@ class MainResult:
     # ``None`` only for call sites that predate W5 (tests constructing a
     # ``MainResult`` directly); every real ``main()`` return path sets it.
     outcome: RunOutcome | None = None
+
+
+@dataclass
+class RunContext:
+    """Mutable state threaded across ``main()``'s phases (G4.2 extraction).
+
+    Every field is optional/defaulted because the object is built empty at
+    the top of :func:`main` and filled in incrementally by ``_setup_run`` →
+    ``_resolve_credentials`` → ``_execute_agent``. This is the same
+    local-variable sprawl ``main()`` threaded as bare locals before the
+    split — carrying it explicitly is what lets the phases be separate
+    functions instead of one 700-line body. Fields are grouped by the phase
+    that first populates them; later phases only ever *add* fields, never
+    remove or reinterpret ones set earlier.
+    """
+
+    # -- populated by ``_setup_run`` -----------------------------------------
+    resolved_prompt: str | JsonPayload = ""
+    job_token: str = ""
+    github: GitHubClient | None = None
+    run_context: RunContextData | None = None
+    settings: RepoSettings | None = None
+    github_event: dict[str, Any] | None = None
+    pr_number: int | str | None = None
+    tool_state: ToolState | None = None
+    tmpdir: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+    timeout_ms: int | None = None
+    timeout_raw: Any = None
+    timeout_error: str | None = None
+
+    # -- populated by ``_resolve_credentials`` (security boundary) ----------
+    trust_tier: TrustTier = "untrusted"
+    token_ref: TokenRef | None = None
+
+    # -- populated by ``_execute_agent`` -------------------------------------
+    model_pin: bool = False
+    model_head: str | None = None
+    chain_for_decision: list[str] = field(default_factory=list)
+    use_model_chain: bool = False
+    selected_slug: str | None = None
+    resolved_model: str | None = None
+    agent: Agent | None = None
+    agent_id: Any = ""
+    modes: list[Any] = field(default_factory=list)
+    output_schema: dict[str, Any] | None = None
+    ctx_payload: ResolvedPayload | None = None
+    analyzers_mode: Any = None
+    sarif_upload_enabled: bool = False
+    tool_context: ToolContext | None = None
+    setup_timeout_s: int = 0
+    setup_hook_failure: str = ""
+    setup_script_skip_reason: str = ""
+    setup_elapsed_s: float = 0.0
+    mcp_url: str = ""
+    stop_mcp: Callable[[], None] | None = None
+    subagent_denied: list[str] = field(default_factory=list)
+    instructions: Any = None
+    run_ctx: AgentRunContext | None = None
 
 
 def _first_runnable_in_chain(chain: list[str]) -> str:
@@ -158,6 +224,24 @@ class _ConfigurationError(RuntimeError):
     """
 
 
+class _ShortCircuit(Exception):
+    """Internal signal: a phase already published and produced the final result (G4.2).
+
+    Raised by ``_execute_agent`` when a trusted-tier ``setup_script``
+    failure short-circuits under the ``inconclusive`` policy (S1/D10) — the
+    publish block (status check + evidence packet) already ran in that
+    branch and the agent loop must never start, so this carries the
+    finished :class:`MainResult` straight back to :func:`main` without
+    going through the generic ``except Exception`` handler (which would
+    mis-tag it ``infra_error`` and skip the packet that was already
+    written).
+    """
+
+    def __init__(self, result: MainResult) -> None:
+        super().__init__("run short-circuited before agent dispatch")
+        self.result = result
+
+
 def _classify_error_outcome(error: BaseException) -> RunOutcome:
     """Split the outer catch-all into timeout / config / infra buckets (D3, W5.2).
 
@@ -213,6 +297,49 @@ def _short_circuit_setup_failure(
     return ("continue", None)
 
 
+async def _publish(
+    ctx: RunContext,
+    *,
+    outcome: RunOutcome,
+    failure_reason: str | None,
+    attrs_source: Callable[[], dict[str, Any]],
+) -> str | None:
+    """Tracer span + status check + evidence packet — the run's publish block.
+
+    Shared by the setup-script "inconclusive" short-circuit (G4.2 —
+    previously a duplicated inline block) and the normal post-agent
+    completion path in ``_finalize``, so both write the run's evidence
+    packet identically. Only the tracer span's ``attrs_source`` differs
+    between the two call sites, hence it stays a parameter rather than
+    being derived here.
+    """
+    tool_context = ctx.tool_context
+    if tool_context is None:
+        return None
+    from mergecraft.tracing.tracer import get_tracer_from_settings
+
+    assert ctx.settings is not None
+    tracer = get_tracer_from_settings(ctx.settings)
+    with tracer.start_span("mergecraft.publish", attrs_source=attrs_source) as _span:
+        await persist_learnings(tool_context)
+        await report_status_checks(
+            tool_context,
+            run_succeeded=run_succeeded_for_outcome(outcome),
+            failure_reason=failure_reason,
+            conclusion=RUN_OUTCOME_CONCLUSION[outcome],
+        )
+        # #39 — opt-in, off by default, and never a gate: with `sarif_upload`
+        # unset this returns before making any request.
+        await report_sarif_upload(tool_context)
+        # Emit the merge evidence packet last, so it records the run's
+        # final state. A blocked or failed run is exactly when the
+        # evidence matters most, so this runs on both branches below.
+        written = await asyncio.to_thread(
+            emit_run_packet, tool_context, run_succeeded=outcome is RunOutcome.passed
+        )
+        return str(written) if written else None
+
+
 async def _prep_failure_reason(tool_context: ToolContext) -> str | None:
     """Return a reason string when review-relevant dependency prep failed (W6.1).
 
@@ -249,8 +376,887 @@ async def _prep_failure_reason(tool_context: ToolContext) -> str | None:
     return "dependency installation failed"
 
 
+async def _setup_run(ctx: RunContext) -> RunContext:
+    """Phase 1 — prompt resolution, run context, tool state, deadline inputs (G4.2).
+
+    Populates everything ``_resolve_credentials`` and ``_execute_agent`` need
+    but does not itself touch tokens or derive trust tier — that is the
+    security boundary handled entirely by ``_resolve_credentials``.
+    """
+    resolved_prompt = resolve_prompt_input()
+    ctx.resolved_prompt = resolved_prompt
+    ctx.job_token = get_job_token()
+    ctx.github = GitHubClient(ctx.job_token)
+    run_context = await resolve_run_context_data(ctx.github)
+    ctx.run_context = run_context
+    settings = apply_tracing_overrides(run_context.repo_settings)
+    ctx.settings = settings
+
+    github_event = read_github_event()
+    ctx.github_event = github_event
+
+    pr_number: int | str | None = None
+    if isinstance(github_event, dict):
+        pr = github_event.get("pull_request")
+        if isinstance(pr, dict) and pr.get("number") is not None:
+            pr_number = pr["number"]
+        else:
+            issue = github_event.get("issue")
+            if (
+                isinstance(issue, dict)
+                and isinstance(issue.get("pull_request"), dict)
+                and issue.get("number") is not None
+            ):
+                pr_number = issue["number"]
+    ctx.pr_number = pr_number
+    bind_run_context(
+        run_id=os.environ.get("GITHUB_RUN_ID"),
+        repo=f"{run_context.repo.owner}/{run_context.repo.name}",
+        pr=pr_number,
+        phase="setup",
+    )
+
+    progress = None
+    if not isinstance(resolved_prompt, str) and resolved_prompt.progress_comment:
+        progress = ProgressComment(
+            id=resolved_prompt.progress_comment.id,
+            type=resolved_prompt.progress_comment.type,
+        )
+
+    tool_state = init_tool_state(
+        owner=run_context.repo.owner,
+        name=run_context.repo.name,
+        dir=os.getcwd(),
+        progress_comment=progress,
+    )
+    ctx.tool_state = tool_state
+    tmpdir = create_temp_directory()
+    ctx.tmpdir = tmpdir
+
+    if settings.env_allowlist:
+        set_env_allowlist(settings.env_allowlist)
+
+    payload = resolve_payload(resolved_prompt, settings)
+    ctx.payload = payload
+    tool_state.model = payload.get("model")
+    tool_state.oss = run_context.oss
+
+    # Resolve the run deadline up front so the setup-script budget can
+    # be capped against it (S1 / F6 — setup must never consume the
+    # whole run budget). Invalid input is captured into a sentinel
+    # ``timeout_error``; the actual ``_ConfigurationError`` raise is
+    # deferred until AFTER ``tool_context`` is constructed so the
+    # outer handler can still call ``report_status_checks`` for the
+    # ``configuration_error`` outcome (S1 review / NEW1+NEW2 —
+    # building the reporting context first, then validating, prevents
+    # setup from running on bad inputs while preserving completion-
+    # check reporting).
+    timeout_raw = payload.get("timeout")
+    ctx.timeout_raw = timeout_raw
+    timeout_ms: int | None
+    timeout_error: str | None = None
+    if timeout_raw == TIMEOUT_DISABLED:
+        timeout_ms = None
+    elif timeout_raw:
+        usable = resolve_timeout_ms(timeout_raw)
+        if usable is None:
+            timeout_ms = None
+            timeout_error = (
+                f'invalid timeout "{timeout_raw}" '
+                "(use a duration like 10m/1h or --notimeout to disable)"
+            )
+        else:
+            timeout_ms = usable
+    else:
+        timeout_ms = 3_600_000
+    ctx.timeout_ms = timeout_ms
+    ctx.timeout_error = timeout_error
+
+    wipe_runner_leak_surface()
+
+    if payload.get("shell") != "enabled":
+        os.environ.pop("ACTIONS_ID_TOKEN_REQUEST_URL", None)
+        os.environ.pop("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None)
+
+    return ctx
+
+
+async def _resolve_credentials(ctx: RunContext) -> RunContext:
+    """Phase 2 — token brokering + trust-tier derivation. Behaviour-frozen (S4).
+
+    Security boundary: token precedence (``GH_TOKEN`` > job token; App-JWT
+    mint wins when configured, degrades to the job token on mint failure;
+    no token anywhere fails closed) and trust-tier derivation (fail-closed
+    ``untrusted`` default) must survive this extraction byte-for-byte — see
+    ``tests/test_main_phases.py::test_resolve_credentials_matches_current_precedence``.
+    """
+    assert ctx.tool_state is not None
+    assert ctx.github is not None
+
+    trust_tier = derive_trust_tier(event=ctx.github_event)
+    ctx.trust_tier = trust_tier
+    ctx.tool_state.trust_tier = trust_tier
+
+    token_ref = await resolve_tokens(
+        push=ctx.payload.get("push") or "restricted", xrepo=ctx.payload.get("xrepo")
+    )
+    ctx.token_ref = token_ref
+    # Prefer MCP token for API calls
+    await ctx.github.aclose()
+    ctx.github = GitHubClient(token_ref.mcp_token)
+
+    return ctx
+
+
+def _stamp_requested_model(ctx: RunContext, payload_model: object) -> None:
+    """Record the chain head as the requested model (W10.2) and reset fallback bookkeeping.
+
+    Split out of ``_assemble_model_chain`` (G4.2) purely to keep that
+    function's complexity down — this is the tail of the same original
+    contiguous block, called immediately after agent/model resolution.
+    """
+    assert ctx.tool_state is not None
+    tool_state = ctx.tool_state
+    # W10.2 — record the chain head as the requested model so the packet
+    # can prove requested vs executed even when selection skipped ahead.
+    if ctx.chain_for_decision:
+        tool_state.requested_model = ctx.chain_for_decision[0]
+    elif ctx.selected_slug:
+        tool_state.requested_model = ctx.selected_slug
+    elif isinstance(payload_model, str) and payload_model.strip():
+        tool_state.requested_model = payload_model.strip()
+    else:
+        tool_state.requested_model = tool_state.model
+    tool_state.fallback_index = 0
+    tool_state.fallback_occurred = False
+
+
+async def _assemble_model_chain(ctx: RunContext) -> None:
+    """Model-chain assembly: resolve cwd, the effective chain, and the running agent.
+
+    Local extraction out of ``_execute_agent`` (G4.2) — no behaviour change,
+    only a name for this contiguous block of the original body.
+    """
+    assert ctx.settings is not None
+    assert ctx.tool_state is not None
+    settings = ctx.settings
+    tool_state = ctx.tool_state
+    payload = ctx.payload
+
+    cwd = payload.get("cwd")
+    if cwd:
+        resolved_cwd = resolve_allowed_working_directory(cwd, default=os.getcwd())
+        if os.getcwd() != resolved_cwd:
+            os.chdir(resolved_cwd)
+
+    payload_model = payload.get("model")
+    # #37 / W4 / D8 — ``model_pin`` opts into the legacy "use exactly this
+    # model" semantics: when True, ``model:`` collapses the chain to a
+    # single entry. Default is chain-preserving — the supplied ``model:``
+    # becomes the head of the effective chain and the configured ``models:``
+    # tail follows. ``modelExplicit`` is retained as a back-compat alias
+    # for the legacy pin signal so any consumer that branched on it still
+    # behaves the same.
+    model_pin = bool(
+        payload.get("modelPin") or payload.get("modelExplicit")  # legacy alias
+    )
+    model_head = payload.get("modelHead") or (
+        payload_model if isinstance(payload_model, str) else None
+    )
+    chain_for_decision = effective_model_chain(settings=settings, head=model_head, pin=model_pin)
+    # ``use_model_chain`` is true whenever an effective chain has more
+    # than one entry OR the operator asked for the chain explicitly. The
+    # legacy ``not model_explicit`` short-circuit is gone — a supplied
+    # ``model:`` no longer disables the chain.
+    use_model_chain = len(chain_for_decision) > 1 or (
+        bool(chain_for_decision) and model_head is not None and not model_pin
+    )
+    ctx.model_pin = model_pin
+    ctx.model_head = model_head
+    ctx.chain_for_decision = chain_for_decision
+    ctx.use_model_chain = use_model_chain
+    selected_slug: str | None
+
+    if use_model_chain:
+        _first_runnable_in_chain.allow_fallback = settings.allow_fallback  # type: ignore[attr-defined]
+        selected_slug = _first_runnable_in_chain(chain_for_decision)
+        if not selected_slug:
+            msg = "no runnable model slug in chain — configure credentials for at least one entry"
+            raise RuntimeError(msg)
+        resolved_model = resolve_model(slug=selected_slug, respect_env_override=False)
+    else:
+        # Single-entry chain (or pin opt-in). The chain is collapsed to
+        # exactly ``[model_head]`` when pinned; otherwise it is just the
+        # first configured entry. Honour ``respect_env_override=False``
+        # when the operator named a model explicitly — the action input
+        # already wins.
+        only_slug = (
+            model_head if model_pin else (chain_for_decision[0] if chain_for_decision else None)
+        )
+        resolved_model = resolve_model(slug=only_slug, respect_env_override=False)
+        selected_slug = only_slug
+    agent = resolve_runtime_agent(model=resolved_model)
+    agent_id = agent.name
+    ctx.agent = agent
+    ctx.agent_id = agent_id
+    ctx.resolved_model = resolved_model
+    ctx.selected_slug = selected_slug
+    tool_state.model = payload.get("proxyModel") or resolved_model or payload.get("model")
+    _stamp_requested_model(ctx, payload_model)
+
+
+async def _build_run_tool_context(ctx: RunContext) -> None:
+    """Build ``tool_context`` — modes, output schema, analyzers mode, SARIF flag (S1/F3+F4).
+
+    Built BEFORE the equal-deadline guard and the fail-policy short-circuit
+    (both later, in ``_execute_agent``) so the outer handler can still call
+    ``report_status_checks`` when those guards raise ``_ConfigurationError``.
+    The MCP server URL is blank here; ``_prepare_agent_dispatch`` fills it
+    in once ``start_mcp_http_server`` runs.
+    """
+    assert ctx.settings is not None
+    assert ctx.run_context is not None
+    assert ctx.tool_state is not None
+    assert ctx.github is not None
+    assert ctx.token_ref is not None
+    assert ctx.tmpdir is not None
+
+    settings = ctx.settings
+    run_context = ctx.run_context
+    tool_state = ctx.tool_state
+    token_ref = ctx.token_ref
+    payload = ctx.payload
+
+    modes = [
+        *compute_modes(ctx.agent_id, settings.signed_commits),
+        *_custom_modes(settings.modes),
+    ]
+    tool_state.modes = modes
+    ctx.modes = modes
+    output_schema = resolve_output_schema()
+    ctx.output_schema = output_schema
+
+    ctx_payload = _payload_to_ctx(payload)
+    ctx.ctx_payload = ctx_payload
+    analyzers_mode = resolve_analyzers_mode(os.environ.get("INPUT_ANALYZERS"))
+    ctx.analyzers_mode = analyzers_mode
+    sarif_upload_enabled = resolve_sarif_upload_enabled(
+        action_input=os.environ.get("INPUT_SARIF_UPLOAD"),
+        repo_setting=settings.analyzers.sarif_upload,
+    )
+    ctx.sarif_upload_enabled = sarif_upload_enabled
+    ctx.tool_context = ToolContext(
+        agent_id=ctx.agent_id,
+        repo=RepoIdentity(owner=run_context.repo.owner, name=run_context.repo.name),
+        payload=ctx_payload,
+        github=ctx.github,
+        github_installation_token=token_ref.mcp_token,
+        git_token=token_ref.git_token,
+        api_token=run_context.api_token,
+        modes=modes,
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=ctx.tmpdir,
+        refresh_git_token=token_ref.refresh_git_token,
+        read_token=token_ref.read_token,
+        xrepo=payload.get("xrepo"),
+        prepush_script=settings.prepush_script,
+        pr_approve_enabled=settings.pr_approve_enabled,
+        auto_merge_enabled=settings.auto_merge_enabled,
+        signed_commits=settings.signed_commits,
+        mode_instructions=settings.mode_instructions,
+        static_checks=[
+            StaticCheckConfig(
+                name=check.name,
+                command=check.command,
+                suffixes=tuple(check.suffixes),
+            )
+            for check in settings.static_checks
+        ],
+        static_checks_enabled=(
+            ctx_payload.shell != "disabled" and allow_repo_command_overrides(ctx.trust_tier)
+        ),
+        ci_gate_checks=dict(settings.ci_evidence.gates),
+        ci_sarif_artifacts=list(settings.ci_evidence.sarif_artifacts),
+        analyzers_mode=analyzers_mode,
+        trust_tier=ctx.trust_tier,
+        analyzers_settings_enabled=settings.analyzers.enabled,
+        sarif_upload_enabled=sarif_upload_enabled,
+        run_id=int(os.environ["GITHUB_RUN_ID"]) if os.environ.get("GITHUB_RUN_ID") else None,
+        job_id=os.environ.get("GITHUB_JOB"),
+        oss=run_context.oss,
+        plan="unknown",
+        resolved_model=ctx.resolved_model,
+        suggest_eval_add=bool(payload.get("suggestEvalAdd")),
+    )
+
+
+async def _apply_overrides_and_setup_git(ctx: RunContext) -> None:
+    """Apply setup-input overrides, re-raise a captured bad ``timeout``, run ``setup_git``.
+
+    Both run AFTER ``tool_context`` exists (S1 review / NEW1) so the outer
+    handler can still call ``report_status_checks`` for the
+    ``configuration_error`` outcome, but BEFORE
+    ``asyncio.create_subprocess_shell`` so a bad value never triggers the
+    setup script to run.
+    """
+    assert ctx.settings is not None
+    assert ctx.run_context is not None
+    assert ctx.tool_state is not None
+    assert ctx.token_ref is not None
+    assert ctx.tmpdir is not None
+    assert ctx.github is not None
+
+    try:
+        settings = apply_setup_overrides(ctx.settings)
+    except ValueError as exc:
+        raise _ConfigurationError(str(exc)) from None
+    ctx.settings = settings
+
+    # S1 review / NEW1 — re-raise the captured bad-``timeout`` sentinel now
+    # that ``tool_context`` exists. The input parsing already classified
+    # the input as bad earlier (``_setup_run``); this only fires the guard
+    # so a ``--notimeout`` / unset input still resolves to ``None`` /
+    # ``3_600_000`` without firing.
+    if ctx.timeout_error is not None:
+        raise _ConfigurationError(ctx.timeout_error) from None
+
+    await asyncio.to_thread(
+        setup_git,
+        git_token=ctx.token_ref.git_token,
+        owner=ctx.run_context.repo.owner,
+        name=ctx.run_context.repo.name,
+        tool_state=ctx.tool_state,
+        shell=ctx.payload.get("shell") or "restricted",
+        tmpdir=ctx.tmpdir,
+        octokit=ctx.github,
+    )
+
+
+async def _run_setup_script_phase(ctx: RunContext) -> None:
+    """Run (or skip) the trusted-tier ``setup_script`` inside its wall-clock budget (S1/F6).
+
+    The action-input resolver already bounds the upper end
+    (``DEFAULT_SETUP_TIMEOUT_S`` = 10 m); the *only* cross-budget constraint
+    is that ``setup_timeout_s`` be strictly less than the run timeout, so a
+    failed setup script cannot be masked by an agent timeout (S1 review /
+    F3 follow-up — equal-or-larger setup budgets let the setup script
+    consume the entire run deadline, after which the agent budget is
+    clamped to ~1 ms and the failure surfaces as ``_AgentTimeoutError``
+    (``timed_out``) instead of the ``configuration_error`` /
+    ``inconclusive`` the setup policy was supposed to produce). Only
+    checked when a setup script is actually configured and a run timeout
+    is in scope.
+    """
+    assert ctx.settings is not None
+    assert ctx.tool_state is not None
+    settings = ctx.settings
+    tool_state = ctx.tool_state
+
+    configured_setup_timeout_s = settings.setup_timeout_s
+    timeout_ms = ctx.timeout_ms
+    if (
+        settings.setup_script
+        and timeout_ms is not None
+        and configured_setup_timeout_s * 1000 >= timeout_ms
+    ):
+        raise _ConfigurationError(
+            f"setup_timeout ({configured_setup_timeout_s}s) must be less than the run "
+            f"timeout ({timeout_ms // 1000}s) so a failed setup script is not "
+            f"masked as an agent timeout"
+        )
+    setup_timeout_s = configured_setup_timeout_s
+    ctx.setup_timeout_s = setup_timeout_s
+
+    setup_script_skip_reason = ""
+    setup_hook_failure = ""
+    setup_started_at = time.monotonic()
+    if settings.setup_script:
+        if ctx.trust_tier == "trusted":
+            logger.info("» running setup script")
+            proc = await asyncio.create_subprocess_shell(
+                settings.setup_script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,  # F6 — session leader so killpg reaches grandchildren
+            )
+            register_process_group(proc.pid)
+            try:
+                _out, err = await asyncio.wait_for(proc.communicate(), timeout=setup_timeout_s)
+            except TimeoutError:
+                # F6 — TERM → grace → KILL the whole tree (convention 9).
+                kill_process_group(proc.pid)
+                setup_hook_failure = f"setup script timed out after {setup_timeout_s}s"
+            else:
+                if proc.returncode != 0:
+                    # S1 review / NEW3 — redact the full stderr text
+                    # BEFORE truncating to 500 chars. Truncating first
+                    # can lop a ``ghp_…`` token below the redactor's
+                    # pattern minimum length, leaving a partial prefix
+                    # in the prompt — redaction must run on the whole
+                    # input so the pattern matches and the slice is
+                    # taken from the *redacted* output.
+                    detail = redact_secrets((err or b"").decode(errors="replace"))[:500]
+                    setup_hook_failure = f"setup script failed (exit {proc.returncode}): {detail}"
+            finally:
+                unregister_process_group(proc.pid)
+            if setup_hook_failure:
+                tool_state.setup_hook_failure = setup_hook_failure
+                logger.warning("» {}", setup_hook_failure)
+        else:
+            event_name = os.environ.get("GITHUB_EVENT_NAME", "unknown")
+            setup_script_skip_reason = (
+                f"skipped setup_script on untrusted tier ({event_name} event)"
+            )
+            tool_state.setup_script_skip_reason = setup_script_skip_reason
+            logger.warning("» {}", setup_script_skip_reason)
+    setup_elapsed_s = time.monotonic() - setup_started_at
+    ctx.setup_hook_failure = setup_hook_failure
+    ctx.setup_script_skip_reason = setup_script_skip_reason
+    ctx.setup_elapsed_s = setup_elapsed_s
+
+
+async def _prepare_agent_dispatch(ctx: RunContext) -> None:
+    """Start the MCP server, seed learnings/skills, resolve instructions, build ``run_ctx``.
+
+    ``tool_context``, ``modes``, ``output_schema``, ``ctx_payload``,
+    ``analyzers_mode`` and ``sarif_upload_enabled`` were all built earlier
+    in ``_build_run_tool_context`` — before the equal-deadline guard and
+    the fail-policy short-circuit in ``_execute_agent`` — so the outer
+    handler can still call ``report_status_checks`` when those guards
+    raise ``_ConfigurationError``. The MCP server URL is filled in here.
+    """
+    assert ctx.tool_context is not None
+    assert ctx.settings is not None
+    assert ctx.run_context is not None
+    assert ctx.tool_state is not None
+    assert ctx.tmpdir is not None
+
+    tool_context = ctx.tool_context
+    settings = ctx.settings
+    run_context = ctx.run_context
+    tool_state = ctx.tool_state
+    payload = ctx.payload
+    tmpdir = ctx.tmpdir
+
+    mcp_url, stop_mcp = start_mcp_http_server(tool_context, output_schema=ctx.output_schema)
+    tool_context.mcp_server_url = mcp_url
+    ctx.mcp_url = mcp_url
+    ctx.stop_mcp = stop_mcp
+    logger.info("» MCP server started at {}", mcp_url)
+
+    subagent_denied = subagent_denied_tool_names(tool_context, ctx.output_schema)
+    ctx.subagent_denied = subagent_denied
+
+    try:
+        learnings_path = await seed_learnings_file(tmpdir=tmpdir, current=settings.learnings)
+        tool_state.learnings_file_path = learnings_path
+        tool_state.learnings_seed = (settings.learnings or "").strip()
+        # D10 / W6.5 — wire the opt-in auto-promote flag from
+        # ``RepoSettings`` into ``tool_state`` so ``persist_learnings``
+        # honors it. Default is fail-closed (staging only); setting
+        # ``autopromoteLearnings: true`` restores legacy behaviour for
+        # trusted maintainer authors (see ``utils/learnings.py``).
+        tool_state.autopromote_learnings = settings.autopromote_learnings
+        logger.info(
+            "» learnings seeded at {} (existing={})",
+            learnings_path,
+            "yes" if settings.learnings else "no",
+        )
+    except Exception as exc:
+        logger.warning("» learnings seed failed: {} — continuing without learnings file", exc)
+
+    if payload.get("xrepo"):
+        try:
+            xrepo_path = await seed_xrepo_learnings_file(
+                tmpdir=tmpdir, current=settings.xrepo_learnings
+            )
+            tool_state.xrepo_learnings_file_path = xrepo_path
+            tool_state.xrepo_learnings_seed = (settings.xrepo_learnings or "").strip()
+        except Exception as exc:
+            logger.warning("» xrepo learnings seed failed: {}", exc)
+
+    start_installation(tool_context)
+
+    # Install bundled skills into a fake HOME under tmpdir
+    skills_home = os.path.join(tmpdir, "home")
+    os.makedirs(skills_home, exist_ok=True)
+    try:
+        install_bundled_skills(home=skills_home)
+    except Exception as exc:
+        logger.warning("» bundled skills install failed: {}", exc)
+
+    instructions = resolve_instructions(
+        payload=payload,
+        repo=run_context.repo,
+        modes=ctx.modes,
+        agent_id=ctx.agent_id,
+        output_schema=ctx.output_schema,
+        signed_commits=settings.signed_commits,
+        learnings_file_path=tool_state.learnings_file_path,
+        learnings_headings=settings.learnings_headings,
+        setup_hook_failure=ctx.setup_hook_failure,
+        setup_script_skip_reason=ctx.setup_script_skip_reason,
+        xrepo_brief=settings.xrepo_brief,
+        xrepo_learnings_file_path=tool_state.xrepo_learnings_file_path,
+        xrepo_learnings_headings=settings.xrepo_learnings_headings,
+    )
+    ctx.instructions = instructions
+    logger.info("Using agent={} model={}", ctx.agent_id, ctx.resolved_model or "(auto)")
+
+    ctx.run_ctx = AgentRunContext(
+        payload=payload,
+        mcp_server_url=mcp_url,
+        tmpdir=tmpdir,
+        subagent_denied_tools=subagent_denied,
+        instructions=instructions,
+        tool_state=tool_state,
+        api_token=run_context.api_token,
+        resolved_model=ctx.resolved_model,
+        stop_script=settings.stop_script,
+    )
+
+
+def _promote_and_finalize_agent_result(
+    ctx: RunContext, winning_slug: str | None, result: AgentResult
+) -> AgentResult:
+    """Post-process the dispatched ``AgentResult``: model promotion, usage, schema check.
+
+    Split out of ``_dispatch_agent_with_deadline`` (G4.2) purely to keep
+    that function's complexity down — this is the tail of the same
+    original contiguous block, called immediately after the agent task
+    resolves (whether via the plain await or the deadline-wrapped one).
+    """
+    assert ctx.tool_state is not None
+    assert ctx.tool_context is not None
+    tool_state = ctx.tool_state
+    tool_context = ctx.tool_context
+    payload = ctx.payload
+    chain_for_decision = ctx.chain_for_decision
+    output_schema = ctx.output_schema
+
+    if winning_slug:
+        resolved_model = resolve_model(slug=winning_slug, respect_env_override=False)
+        tool_context.resolved_model = resolved_model
+        ctx.resolved_model = resolved_model
+        # W10.2/W10.3 — single promotion path; chain stamps metadata in
+        # ``_attach_model_evidence``, single-slug defaults to index 0.
+        meta = result.metadata or {}
+        requested_meta = meta.get("requested_model")
+        requested = (
+            requested_meta.strip()
+            if isinstance(requested_meta, str) and requested_meta.strip()
+            else (chain_for_decision[0] if chain_for_decision else tool_state.requested_model)
+        )
+        fallback_raw = meta.get("fallback_index")
+        fallback_index = fallback_raw if isinstance(fallback_raw, int) else 0
+        executed = payload.get("proxyModel") or resolved_model or winning_slug
+        promote_model_evidence(
+            tool_state,
+            requested_model=requested,
+            executed_model=executed if isinstance(executed, str) else winning_slug,
+            fallback_index=fallback_index,
+        )
+
+    if result.usage:
+        tool_state.usage_entries.append(result.usage)
+
+    if output_schema and not tool_state.output:
+        msg = (
+            "output_schema was provided but agent did not call set_output — "
+            "structured output is required"
+        )
+        raise RuntimeError(msg)
+
+    return result
+
+
+async def _run_agent_task_with_deadline(ctx: RunContext) -> tuple[str | None, AgentResult]:
+    """Dispatch the agent (or model chain) as a task and await it under the deadline.
+
+    ``timeout_ms`` / ``timeout_raw`` were resolved up front in
+    ``_setup_run`` (right after ``payload = resolve_payload(...)``) so the
+    setup-script budget could be capped against the run deadline (S1 /
+    F6). The ``--notimeout`` / ``none`` escape and the fail-closed
+    validation both happened there; this just spends the resolved values.
+    """
+    assert ctx.settings is not None
+    assert ctx.run_context is not None
+    assert ctx.tool_state is not None
+    assert ctx.tool_context is not None
+    assert ctx.run_ctx is not None
+    assert ctx.agent is not None
+
+    settings = ctx.settings
+    run_context = ctx.run_context
+    tool_state = ctx.tool_state
+    tool_context = ctx.tool_context
+    run_ctx = ctx.run_ctx
+    payload = ctx.payload
+    agent = ctx.agent
+    agent_id = ctx.agent_id
+    model_head = ctx.model_head
+    model_pin = ctx.model_pin
+    use_model_chain = ctx.use_model_chain
+    selected_slug = ctx.selected_slug
+    output_schema = ctx.output_schema
+    setup_hook_failure = ctx.setup_hook_failure
+    setup_script_skip_reason = ctx.setup_script_skip_reason
+
+    async def _run_agent_once(slug: str) -> AgentResult:
+        attempt_model = resolve_model(slug=slug, respect_env_override=False)
+        attempt_agent = resolve_runtime_agent(model=attempt_model)
+        attempt_agent_id = attempt_agent.name
+
+        if attempt_agent_id == agent_id:
+            attempt_ctx = replace(run_ctx, resolved_model=attempt_model)
+        else:
+            attempt_modes = [
+                *compute_modes(attempt_agent_id, settings.signed_commits),
+                *_custom_modes(settings.modes),
+            ]
+            attempt_instructions = resolve_instructions(
+                payload=payload,
+                repo=run_context.repo,
+                modes=attempt_modes,
+                agent_id=attempt_agent_id,
+                output_schema=output_schema,
+                signed_commits=settings.signed_commits,
+                learnings_file_path=tool_state.learnings_file_path,
+                learnings_headings=settings.learnings_headings,
+                setup_hook_failure=setup_hook_failure,
+                setup_script_skip_reason=setup_script_skip_reason,
+                xrepo_brief=settings.xrepo_brief,
+                xrepo_learnings_file_path=tool_state.xrepo_learnings_file_path,
+                xrepo_learnings_headings=settings.xrepo_learnings_headings,
+            )
+            attempt_denied = subagent_denied_tool_names(
+                replace(tool_context, agent_id=attempt_agent_id),
+                output_schema,
+            )
+            attempt_ctx = replace(
+                run_ctx,
+                resolved_model=attempt_model,
+                instructions=attempt_instructions,
+                subagent_denied_tools=attempt_denied,
+            )
+            tool_context.agent_id = attempt_agent_id
+            tool_context.modes = attempt_modes
+            tool_state.modes = attempt_modes
+            tool_context.resolved_model = attempt_model
+            logger.info(
+                "» model chain advanced to agent={} model={}",
+                attempt_agent_id,
+                attempt_model or "(auto)",
+            )
+        return await attempt_agent.run(attempt_ctx)
+
+    # Named ``_execute_agent`` deliberately — same name as the top-level
+    # phase function that calls this one, shadowed locally. A pre-G4 test
+    # (``tests/config/test_setup_script_timeout.py::test_setup_timeout_is_deducted_from_the_run_budget``)
+    # identifies the ``asyncio.wait_for``-wrapped task by this exact
+    # coroutine name via ``cr_code.co_name`` introspection, so the inner
+    # closure keeps the name the pre-G4.2 code already used here.
+    async def _execute_agent() -> tuple[str | None, AgentResult]:
+        if use_model_chain:
+            winning_slug, chain_result = await run_with_model_chain(
+                settings=settings,
+                run_once=_run_agent_once,
+                head=model_head,
+                pin=model_pin,
+            )
+            return winning_slug, chain_result
+        return selected_slug, await agent.run(run_ctx)
+
+    agent_task = asyncio.create_task(_execute_agent())
+
+    # S1 / F6 — deduct the setup-script elapsed time from the agent
+    # deadline. A slow setup must NOT silently extend the total run
+    # deadline. ``setup_elapsed_s`` is the wall-clock duration measured
+    # by the bounded setup block above; ``timeout_ms`` is the
+    # pre-deduction run budget.
+    timeout_ms = ctx.timeout_ms
+    setup_elapsed_s = ctx.setup_elapsed_s
+    agent_timeout_ms: int | None
+    if timeout_ms is None:
+        agent_timeout_ms = None
+    else:
+        agent_timeout_ms = max(1, int(timeout_ms - setup_elapsed_s * 1000))
+        if agent_timeout_ms != timeout_ms:
+            logger.info(
+                "» deducted setup elapsed {:.2f}s from agent deadline ({}s -> {}s)",
+                setup_elapsed_s,
+                timeout_ms / 1000,
+                agent_timeout_ms / 1000,
+            )
+
+    if agent_timeout_ms is None:
+        winning_slug, result = await agent_task
+    else:
+        try:
+            winning_slug, result = await asyncio.wait_for(
+                agent_task, timeout=agent_timeout_ms / 1000.0
+            )
+        except TimeoutError:
+            agent_task.cancel()
+            from mergecraft.utils.process_group import kill_all_active_process_groups
+
+            kill_all_active_process_groups()
+            msg = f"agent run timed out after {ctx.timeout_raw or '1h'}"
+            raise _AgentTimeoutError(msg) from None
+
+    return winning_slug, result
+
+
+async def _dispatch_agent_with_deadline(ctx: RunContext) -> AgentResult:
+    """Run the agent (or model chain) under the deadline, then post-process the result.
+
+    Orchestrates the two sub-steps of the original phase body: dispatch +
+    deadline (``_run_agent_task_with_deadline``) and result post-processing
+    (``_promote_and_finalize_agent_result``) — each a named local
+    extraction (G4.2), no behaviour change.
+    """
+    winning_slug, result = await _run_agent_task_with_deadline(ctx)
+    return _promote_and_finalize_agent_result(ctx, winning_slug, result)
+
+
+async def _execute_agent(ctx: RunContext) -> AgentResult:
+    """Phase 3 — model-chain assembly, MCP lifecycle, agent dispatch, deadline (G4.2).
+
+    Orchestrates the five sub-steps of the original phase body — model-chain
+    assembly, ``tool_context`` construction, setup-input overrides +
+    ``setup_git``, the ``setup_script`` run/skip, and agent dispatch — each
+    now a named local extraction. Raises :class:`_ShortCircuit` when a
+    trusted-tier ``setup_script`` failure short-circuits under the
+    ``inconclusive`` policy (S1/D10) — the publish block already ran in
+    that case and the agent loop must not start.
+    """
+    await _assemble_model_chain(ctx)
+    await _build_run_tool_context(ctx)
+    await _apply_overrides_and_setup_git(ctx)
+    await _run_setup_script_phase(ctx)
+
+    assert ctx.settings is not None
+
+    # S1 review / F4 + S1 review / N2 — the policy decides whether a
+    # trusted-tier ``setup_script`` failure short-circuits *before* the
+    # agent loop. ``fail`` aborts (existing F4 behaviour); ``inconclusive``
+    # (N2 fix) skips the agent and runs the publish block with outcome
+    # ``inconclusive`` so no review/mutation tool is invoked; ``warn``
+    # falls through to the late outcome block in ``_finalize``. Pre-N2 the
+    # ``inconclusive`` branch ran the agent first and only then rewrote the
+    # outcome — letting the agent post reviews / push branches on an
+    # under-provisioned tree.
+    sc_action, sc_payload = _short_circuit_setup_failure(
+        ctx.setup_hook_failure, ctx.settings.setup_failure_policy
+    )
+    if sc_action == "abort":
+        assert isinstance(sc_payload, _ConfigurationError)
+        logger.warning(
+            "» setup script failure under fail policy — aborting before agent runs: {}",
+            ctx.setup_hook_failure,
+        )
+        raise sc_payload
+    if sc_action == "skip_agent":
+        assert isinstance(sc_payload, str)
+        skip_reason = sc_payload
+        logger.warning(
+            "» setup script failure under inconclusive policy — skipping agent "
+            "loop to honour no-verdict: {}",
+            skip_reason,
+        )
+        skip_outcome = RunOutcome.inconclusive
+        skip_packet_path = await _publish(
+            ctx,
+            outcome=skip_outcome,
+            failure_reason=skip_reason,
+            attrs_source=lambda: {"run_succeeded": False},
+        )
+        raise _ShortCircuit(
+            MainResult(
+                success=False,
+                error=skip_reason,
+                evidence_packet_path=skip_packet_path,
+                outcome=skip_outcome,
+            )
+        )
+
+    await _prepare_agent_dispatch(ctx)
+    return await _dispatch_agent_with_deadline(ctx)
+
+
+async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
+    """Phase 4 — post-run, publish, outcome mapping (G4.2)."""
+    assert ctx.tool_context is not None
+    assert ctx.tool_state is not None
+    assert ctx.settings is not None
+    assert ctx.run_ctx is not None
+
+    tool_context = ctx.tool_context
+    tool_state = ctx.tool_state
+    settings = ctx.settings
+
+    try:
+        result = await finalize_agent_result(ctx.run_ctx, result)
+    except Exception as exc:
+        logger.debug("post-run finalize skipped: {}", exc)
+
+    # D3/W5.2 + W6.1 + S1/D5/D10 — a completed run is ``passed`` / ``failed``,
+    # ``inconclusive`` when review-relevant dependency prep failed OR a
+    # trusted-tier ``setup_script`` failed under the default policy, or
+    # ``configuration_error`` when the operator opted into ``fail``. Agent
+    # failure wins over both prep and setup-script failure (the agent
+    # genuinely couldn't do its job). S1 also adds D10's
+    # ``setup_failure_policy`` to the resolution.
+    prep_reason = await _prep_failure_reason(tool_context)
+    setup_reason = tool_state.setup_hook_failure or ""
+    outcome, failure_reason = _classify_outcome(
+        result=result,
+        setup_reason=setup_reason,
+        setup_policy=settings.setup_failure_policy,
+        prep_reason=prep_reason,
+    )
+
+    selected_mode_obj = next(
+        (m for m in tool_context.modes if m.name == tool_context.tool_state.selected_mode),
+        None,
+    )
+    packet_path = await _publish(
+        ctx,
+        outcome=outcome,
+        failure_reason=failure_reason,
+        attrs_source=lambda: _publish_span_attrs(outcome, selected_mode_obj),
+    )
+
+    if outcome is not RunOutcome.passed:
+        return MainResult(
+            success=False,
+            error=failure_reason or result.error or "agent execution failed",
+            evidence_packet_path=packet_path,
+            outcome=outcome,
+        )
+
+    output = tool_state.output or result.output
+    return MainResult(
+        success=True,
+        output=output,
+        result=output,
+        evidence_packet_path=packet_path,
+        outcome=outcome,
+    )
+
+
 async def main() -> MainResult:
-    """Run the mergecraft action flow using local ``.mergecraft/config.yaml``."""
+    """Run the mergecraft action flow using local ``.mergecraft/config.yaml``.
+
+    Orchestrates the four G4.2 phases — ``_setup_run`` → ``_resolve_credentials``
+    → ``_execute_agent`` → ``_finalize`` — over a single shared :class:`RunContext`.
+    The ``try``/``except``/``else``/``finally`` below is the same completion
+    contract ``main()`` always had: every exit path (success, agent failure,
+    timeout, the ``inconclusive`` setup-script short-circuit, or an
+    unclassified exception) reaches cleanup, and every path except the two
+    that predate ``ToolContext`` construction reaches the publish block.
+    """
     install_loguru_redaction_filter()
     normalize_env()
     ensure_github_workspace_registered()
@@ -258,7 +1264,7 @@ async def main() -> MainResult:
     if workspace:
         # Guard the workspace prep at its call site so a missing/UID-0 agent
         # user surfaces as a structured ``RunOutcome.configuration_error``
-        # rather than escaping as an uncaught traceback. The outer ``try/except``
+        # rather than escaping as an uncaught traceback. The try/except/finally
         # below is reached only after this block returns, so we route through
         # the same classification the outer handler would have used.
         try:
@@ -269,689 +1275,23 @@ async def main() -> MainResult:
                 error=str(exc),
                 outcome=_classify_error_outcome(exc),
             )
-    stop_mcp = None
-    github: GitHubClient | None = None
-    token_ref = None
-    tool_context: ToolContext | None = None
-    tmpdir: str | None = None
 
+    ctx = RunContext()
     try:
-        resolved_prompt = resolve_prompt_input()
-        job_token = get_job_token()
-        github = GitHubClient(job_token)
-        run_context = await resolve_run_context_data(github)
-        settings = apply_tracing_overrides(run_context.repo_settings)
-
-        github_event = read_github_event()
-        trust_tier = derive_trust_tier(event=github_event)
-
-        pr_number: int | str | None = None
-        if isinstance(github_event, dict):
-            pr = github_event.get("pull_request")
-            if isinstance(pr, dict) and pr.get("number") is not None:
-                pr_number = pr["number"]
-            else:
-                issue = github_event.get("issue")
-                if (
-                    isinstance(issue, dict)
-                    and isinstance(issue.get("pull_request"), dict)
-                    and issue.get("number") is not None
-                ):
-                    pr_number = issue["number"]
-        bind_run_context(
-            run_id=os.environ.get("GITHUB_RUN_ID"),
-            repo=f"{run_context.repo.owner}/{run_context.repo.name}",
-            pr=pr_number,
-            phase="setup",
-        )
-
-        progress = None
-        if not isinstance(resolved_prompt, str) and resolved_prompt.progress_comment:
-            progress = ProgressComment(
-                id=resolved_prompt.progress_comment.id,
-                type=resolved_prompt.progress_comment.type,
-            )
-
-        tool_state = init_tool_state(
-            owner=run_context.repo.owner,
-            name=run_context.repo.name,
-            dir=os.getcwd(),
-            progress_comment=progress,
-        )
-        tool_state.trust_tier = trust_tier
-        tmpdir = create_temp_directory()
-
-        if settings.env_allowlist:
-            set_env_allowlist(settings.env_allowlist)
-
-        payload = resolve_payload(resolved_prompt, settings)
-        tool_state.model = payload.get("model")
-        tool_state.oss = run_context.oss
-
-        # Resolve the run deadline up front so the setup-script budget can
-        # be capped against it (S1 / F6 — setup must never consume the
-        # whole run budget). Invalid input is captured into a sentinel
-        # ``timeout_error``; the actual ``_ConfigurationError`` raise is
-        # deferred until AFTER ``tool_context`` is constructed so the
-        # outer handler can still call ``report_status_checks`` for the
-        # ``configuration_error`` outcome (S1 review / NEW1+NEW2 —
-        # building the reporting context first, then validating, prevents
-        # setup from running on bad inputs while preserving completion-
-        # check reporting).
-        timeout_raw = payload.get("timeout")
-        timeout_ms: int | None
-        timeout_error: str | None = None
-        if timeout_raw == TIMEOUT_DISABLED:
-            timeout_ms = None
-        elif timeout_raw:
-            usable = resolve_timeout_ms(timeout_raw)
-            if usable is None:
-                timeout_ms = None
-                timeout_error = (
-                    f'invalid timeout "{timeout_raw}" '
-                    "(use a duration like 10m/1h or --notimeout to disable)"
-                )
-            else:
-                timeout_ms = usable
-        else:
-            timeout_ms = 3_600_000
-
-        wipe_runner_leak_surface()
-
-        if payload.get("shell") != "enabled":
-            os.environ.pop("ACTIONS_ID_TOKEN_REQUEST_URL", None)
-            os.environ.pop("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None)
-
-        token_ref = await resolve_tokens(
-            push=payload.get("push") or "restricted", xrepo=payload.get("xrepo")
-        )
-        # Prefer MCP token for API calls
-        await github.aclose()
-        github = GitHubClient(token_ref.mcp_token)
-
-        cwd = payload.get("cwd")
-        if cwd:
-            resolved_cwd = resolve_allowed_working_directory(cwd, default=os.getcwd())
-            if os.getcwd() != resolved_cwd:
-                os.chdir(resolved_cwd)
-
-        payload_model = payload.get("model")
-        # #37 / W4 / D8 — ``model_pin`` opts into the legacy "use exactly this
-        # model" semantics: when True, ``model:`` collapses the chain to a
-        # single entry. Default is chain-preserving — the supplied ``model:``
-        # becomes the head of the effective chain and the configured ``models:``
-        # tail follows. ``modelExplicit`` is retained as a back-compat alias
-        # for the legacy pin signal so any consumer that branched on it still
-        # behaves the same.
-        model_pin = bool(
-            payload.get("modelPin") or payload.get("modelExplicit")  # legacy alias
-        )
-        model_head = payload.get("modelHead") or (
-            payload_model if isinstance(payload_model, str) else None
-        )
-        chain_for_decision = effective_model_chain(
-            settings=settings, head=model_head, pin=model_pin
-        )
-        # ``use_model_chain`` is true whenever an effective chain has more
-        # than one entry OR the operator asked for the chain explicitly. The
-        # legacy ``not model_explicit`` short-circuit is gone — a supplied
-        # ``model:`` no longer disables the chain.
-        use_model_chain = len(chain_for_decision) > 1 or (
-            bool(chain_for_decision) and model_head is not None and not model_pin
-        )
-        selected_slug: str | None
-
-        if use_model_chain:
-            _first_runnable_in_chain.allow_fallback = settings.allow_fallback  # type: ignore[attr-defined]
-            selected_slug = _first_runnable_in_chain(chain_for_decision)
-            if not selected_slug:
-                msg = (
-                    "no runnable model slug in chain — configure credentials for at least one entry"
-                )
-                raise RuntimeError(msg)
-            resolved_model = resolve_model(slug=selected_slug, respect_env_override=False)
-        else:
-            # Single-entry chain (or pin opt-in). The chain is collapsed to
-            # exactly ``[model_head]`` when pinned; otherwise it is just the
-            # first configured entry. Honour ``respect_env_override=False``
-            # when the operator named a model explicitly — the action input
-            # already wins.
-            only_slug = (
-                model_head if model_pin else (chain_for_decision[0] if chain_for_decision else None)
-            )
-            resolved_model = resolve_model(slug=only_slug, respect_env_override=False)
-            selected_slug = only_slug
-        agent = resolve_runtime_agent(model=resolved_model)
-        agent_id = agent.name
-        tool_state.model = payload.get("proxyModel") or resolved_model or payload.get("model")
-        # W10.2 — record the chain head as the requested model so the packet
-        # can prove requested vs executed even when selection skipped ahead.
-        if chain_for_decision:
-            tool_state.requested_model = chain_for_decision[0]
-        elif selected_slug:
-            tool_state.requested_model = selected_slug
-        elif isinstance(payload_model, str) and payload_model.strip():
-            tool_state.requested_model = payload_model.strip()
-        else:
-            tool_state.requested_model = tool_state.model
-        tool_state.fallback_index = 0
-        tool_state.fallback_occurred = False
-
-        # S1 review / F3+F4 follow-up — build ``tool_context`` BEFORE the
-        # equal-deadline guard and the fail-policy short-circuit so the
-        # outer handler can still call ``report_status_checks`` when those
-        # guards raise ``_ConfigurationError``. The MCP server URL is
-        # blank here; ``start_mcp_http_server`` later fills it in.
-        modes = [
-            *compute_modes(agent_id, settings.signed_commits),
-            *_custom_modes(settings.modes),
-        ]
-        tool_state.modes = modes
-        output_schema = resolve_output_schema()
-
-        ctx_payload = _payload_to_ctx(payload)
-        analyzers_mode = resolve_analyzers_mode(os.environ.get("INPUT_ANALYZERS"))
-        sarif_upload_enabled = resolve_sarif_upload_enabled(
-            action_input=os.environ.get("INPUT_SARIF_UPLOAD"),
-            repo_setting=settings.analyzers.sarif_upload,
-        )
-        tool_context = ToolContext(
-            agent_id=agent_id,
-            repo=RepoIdentity(owner=run_context.repo.owner, name=run_context.repo.name),
-            payload=ctx_payload,
-            github=github,
-            github_installation_token=token_ref.mcp_token,
-            git_token=token_ref.git_token,
-            api_token=run_context.api_token,
-            modes=modes,
-            tool_state=tool_state,
-            mcp_server_url="",
-            tmpdir=tmpdir,
-            refresh_git_token=token_ref.refresh_git_token,
-            read_token=token_ref.read_token,
-            xrepo=payload.get("xrepo"),
-            prepush_script=settings.prepush_script,
-            pr_approve_enabled=settings.pr_approve_enabled,
-            auto_merge_enabled=settings.auto_merge_enabled,
-            signed_commits=settings.signed_commits,
-            mode_instructions=settings.mode_instructions,
-            static_checks=[
-                StaticCheckConfig(
-                    name=check.name,
-                    command=check.command,
-                    suffixes=tuple(check.suffixes),
-                )
-                for check in settings.static_checks
-            ],
-            static_checks_enabled=(
-                ctx_payload.shell != "disabled" and allow_repo_command_overrides(trust_tier)
-            ),
-            ci_gate_checks=dict(settings.ci_evidence.gates),
-            ci_sarif_artifacts=list(settings.ci_evidence.sarif_artifacts),
-            analyzers_mode=analyzers_mode,
-            trust_tier=trust_tier,
-            analyzers_settings_enabled=settings.analyzers.enabled,
-            sarif_upload_enabled=sarif_upload_enabled,
-            run_id=int(os.environ["GITHUB_RUN_ID"]) if os.environ.get("GITHUB_RUN_ID") else None,
-            job_id=os.environ.get("GITHUB_JOB"),
-            oss=run_context.oss,
-            plan="unknown",
-            resolved_model=resolved_model,
-            suggest_eval_add=bool(payload.get("suggestEvalAdd")),
-        )
-
-        # S1 review / NEW1 — apply the action-input setup overrides
-        # (policy + timeout) NOW, after ``tool_context`` is built (so the
-        # outer handler can still call ``report_status_checks`` for the
-        # ``configuration_error`` outcome) but BEFORE ``setup_git`` /
-        # ``asyncio.create_subprocess_shell`` (so a bad value never
-        # triggers the setup script to run). A bad value raises
-        # ``ValueError`` which is re-raised as ``_ConfigurationError``.
-        try:
-            settings = apply_setup_overrides(settings)
-        except ValueError as exc:
-            raise _ConfigurationError(str(exc)) from None
-
-        # S1 review / NEW1 — re-raise the captured bad-``timeout``
-        # sentinel now that ``tool_context`` exists. The input parsing
-        # already classified the input as bad earlier; this block only
-        # fires the guard so a ``--notimeout`` / unset input still
-        # resolves to ``None`` / ``3_600_000`` without firing.
-        if timeout_error is not None:
-            raise _ConfigurationError(timeout_error) from None
-
-        await asyncio.to_thread(
-            setup_git,
-            git_token=token_ref.git_token,
-            owner=run_context.repo.owner,
-            name=run_context.repo.name,
-            tool_state=tool_state,
-            shell=payload.get("shell") or "restricted",
-            tmpdir=tmpdir,
-            octokit=github,
-        )
-
-        # S1 / F6 — wall-clock budget for ``setup_script``. The action-input
-        # resolver already bounds the upper end (``DEFAULT_SETUP_TIMEOUT_S``
-        # = 10 m); the *only* cross-budget constraint is that
-        # ``setup_timeout_s`` be strictly less than the run timeout, so a
-        # failed setup script cannot be masked by an agent timeout
-        # (S1 review / F3 follow-up — equal-or-larger setup budgets let the
-        # setup script consume the entire run deadline, after which the
-        # agent budget is clamped to ~1 ms and the failure surfaces as
-        # ``_AgentTimeoutError`` (``timed_out``) instead of the
-        # ``configuration_error`` / ``inconclusive`` the setup policy was
-        # supposed to produce). Only check when a setup script is actually
-        # configured and a run timeout is in scope.
-        configured_setup_timeout_s = settings.setup_timeout_s
-        if (
-            settings.setup_script
-            and timeout_ms is not None
-            and configured_setup_timeout_s * 1000 >= timeout_ms
-        ):
-            raise _ConfigurationError(
-                f"setup_timeout ({configured_setup_timeout_s}s) must be less than the run "
-                f"timeout ({timeout_ms // 1000}s) so a failed setup script is not "
-                f"masked as an agent timeout"
-            )
-        setup_timeout_s = configured_setup_timeout_s
-
-        setup_script_skip_reason = ""
-        setup_hook_failure = ""
-        setup_started_at = time.monotonic()
-        if settings.setup_script:
-            if trust_tier == "trusted":
-                logger.info("» running setup script")
-                proc = await asyncio.create_subprocess_shell(
-                    settings.setup_script,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    start_new_session=True,  # F6 — session leader so killpg reaches grandchildren
-                )
-                register_process_group(proc.pid)
-                try:
-                    _out, err = await asyncio.wait_for(proc.communicate(), timeout=setup_timeout_s)
-                except TimeoutError:
-                    # F6 — TERM → grace → KILL the whole tree (convention 9).
-                    kill_process_group(proc.pid)
-                    setup_hook_failure = f"setup script timed out after {setup_timeout_s}s"
-                else:
-                    if proc.returncode != 0:
-                        # S1 review / NEW3 — redact the full stderr text
-                        # BEFORE truncating to 500 chars. Truncating first
-                        # can lop a ``ghp_…`` token below the redactor's
-                        # pattern minimum length, leaving a partial prefix
-                        # in the prompt — redaction must run on the whole
-                        # input so the pattern matches and the slice is
-                        # taken from the *redacted* output.
-                        detail = redact_secrets((err or b"").decode(errors="replace"))[:500]
-                        setup_hook_failure = (
-                            f"setup script failed (exit {proc.returncode}): {detail}"
-                        )
-                finally:
-                    unregister_process_group(proc.pid)
-                if setup_hook_failure:
-                    tool_state.setup_hook_failure = setup_hook_failure
-                    logger.warning("» {}", setup_hook_failure)
-            else:
-                event_name = os.environ.get("GITHUB_EVENT_NAME", "unknown")
-                setup_script_skip_reason = (
-                    f"skipped setup_script on untrusted tier ({event_name} event)"
-                )
-                tool_state.setup_script_skip_reason = setup_script_skip_reason
-                logger.warning("» {}", setup_script_skip_reason)
-        setup_elapsed_s = time.monotonic() - setup_started_at
-
-        # S1 review / F4 + S1 review / N2 — the policy decides whether a
-        # trusted-tier ``setup_script`` failure short-circuits *before* the
-        # agent loop. ``fail`` aborts (existing F4 behaviour); ``inconclusive``
-        # (N2 fix) skips the agent and runs the publish block with outcome
-        # ``inconclusive`` so no review/mutation tool is invoked; ``warn``
-        # falls through to the late outcome block at the bottom of ``main``.
-        # Pre-N2 the ``inconclusive`` branch ran the agent first and only
-        # then rewrote the outcome — letting the agent post reviews / push
-        # branches on an under-provisioned tree.
-        sc_action, sc_payload = _short_circuit_setup_failure(
-            setup_hook_failure, settings.setup_failure_policy
-        )
-        if sc_action == "abort":
-            assert isinstance(sc_payload, _ConfigurationError)
-            logger.warning(
-                "» setup script failure under fail policy — aborting before agent runs: {}",
-                setup_hook_failure,
-            )
-            raise sc_payload
-        if sc_action == "skip_agent":
-            assert isinstance(sc_payload, str)
-            skip_reason = sc_payload
-            logger.warning(
-                "» setup script failure under inconclusive policy — skipping agent "
-                "loop to honour no-verdict: {}",
-                skip_reason,
-            )
-            skip_outcome = RunOutcome.inconclusive
-            skip_packet_path: str | None = None
-            if tool_context:
-                from mergecraft.tracing.tracer import get_tracer_from_settings
-
-                tracer = get_tracer_from_settings(settings)
-                with tracer.start_span(
-                    "mergecraft.publish",
-                    attrs_source=lambda: {"run_succeeded": False},
-                ) as _skip_publish_span:
-                    await persist_learnings(tool_context)
-                    await report_status_checks(
-                        tool_context,
-                        run_succeeded=run_succeeded_for_outcome(skip_outcome),
-                        failure_reason=skip_reason,
-                        conclusion=RUN_OUTCOME_CONCLUSION[skip_outcome],
-                    )
-                    # #39 — opt-in, off by default. Never reaches the wire when
-                    # ``sarif_upload`` is unset.
-                    await report_sarif_upload(tool_context)
-                    written = await asyncio.to_thread(
-                        emit_run_packet,
-                        tool_context,
-                        run_succeeded=skip_outcome is RunOutcome.passed,
-                    )
-                    skip_packet_path = str(written) if written else None
-            return MainResult(
-                success=False,
-                error=skip_reason,
-                evidence_packet_path=skip_packet_path,
-                outcome=skip_outcome,
-            )
-
-        # ``tool_context``, ``modes``, ``output_schema``, ``ctx_payload``,
-        # ``analyzers_mode`` and ``sarif_upload_enabled`` were all built
-        # earlier — before the F3 equal-deadline guard and the F4
-        # fail-policy short-circuit — so the outer handler can still call
-        # ``report_status_checks`` when those guards raise
-        # ``_ConfigurationError``. The MCP server URL is filled in below.
-
-        mcp_url, stop_mcp = start_mcp_http_server(tool_context, output_schema=output_schema)
-        tool_context.mcp_server_url = mcp_url
-        logger.info("» MCP server started at {}", mcp_url)
-
-        subagent_denied = subagent_denied_tool_names(tool_context, output_schema)
-
-        try:
-            learnings_path = await seed_learnings_file(tmpdir=tmpdir, current=settings.learnings)
-            tool_state.learnings_file_path = learnings_path
-            tool_state.learnings_seed = (settings.learnings or "").strip()
-            # D10 / W6.5 — wire the opt-in auto-promote flag from
-            # ``RepoSettings`` into ``tool_state`` so ``persist_learnings``
-            # honors it. Default is fail-closed (staging only); setting
-            # ``autopromoteLearnings: true`` restores legacy behaviour for
-            # trusted maintainer authors (see ``utils/learnings.py``).
-            tool_state.autopromote_learnings = settings.autopromote_learnings
-            logger.info(
-                "» learnings seeded at {} (existing={})",
-                learnings_path,
-                "yes" if settings.learnings else "no",
-            )
-        except Exception as exc:
-            logger.warning("» learnings seed failed: {} — continuing without learnings file", exc)
-
-        if payload.get("xrepo"):
-            try:
-                xrepo_path = await seed_xrepo_learnings_file(
-                    tmpdir=tmpdir, current=settings.xrepo_learnings
-                )
-                tool_state.xrepo_learnings_file_path = xrepo_path
-                tool_state.xrepo_learnings_seed = (settings.xrepo_learnings or "").strip()
-            except Exception as exc:
-                logger.warning("» xrepo learnings seed failed: {}", exc)
-
-        start_installation(tool_context)
-
-        # Install bundled skills into a fake HOME under tmpdir
-        skills_home = os.path.join(tmpdir, "home")
-        os.makedirs(skills_home, exist_ok=True)
-        try:
-            install_bundled_skills(home=skills_home)
-        except Exception as exc:
-            logger.warning("» bundled skills install failed: {}", exc)
-
-        instructions = resolve_instructions(
-            payload=payload,
-            repo=run_context.repo,
-            modes=modes,
-            agent_id=agent_id,
-            output_schema=output_schema,
-            signed_commits=settings.signed_commits,
-            learnings_file_path=tool_state.learnings_file_path,
-            learnings_headings=settings.learnings_headings,
-            setup_hook_failure=setup_hook_failure,
-            setup_script_skip_reason=setup_script_skip_reason,
-            xrepo_brief=settings.xrepo_brief,
-            xrepo_learnings_file_path=tool_state.xrepo_learnings_file_path,
-            xrepo_learnings_headings=settings.xrepo_learnings_headings,
-        )
-        logger.info("Using agent={} model={}", agent_id, resolved_model or "(auto)")
-
-        run_ctx = AgentRunContext(
-            payload=payload,
-            mcp_server_url=mcp_url,
-            tmpdir=tmpdir,
-            subagent_denied_tools=subagent_denied,
-            instructions=instructions,
-            tool_state=tool_state,
-            api_token=run_context.api_token,
-            resolved_model=resolved_model,
-            stop_script=settings.stop_script,
-        )
-
-        # ``timeout_ms`` and ``timeout_raw`` are resolved up front (just
-        # after ``payload = resolve_payload(...)``) so the setup-script
-        # budget can be capped against the run deadline (S1 / F6). The
-        # ``--notimeout`` / ``none`` escape and the fail-closed validation
-        # both happen there; this block just spends the resolved values.
-
-        async def _run_agent_once(slug: str) -> AgentResult:
-            attempt_model = resolve_model(slug=slug, respect_env_override=False)
-            attempt_agent = resolve_runtime_agent(model=attempt_model)
-            attempt_agent_id = attempt_agent.name
-
-            if attempt_agent_id == agent_id:
-                attempt_ctx = replace(run_ctx, resolved_model=attempt_model)
-            else:
-                attempt_modes = [
-                    *compute_modes(attempt_agent_id, settings.signed_commits),
-                    *_custom_modes(settings.modes),
-                ]
-                attempt_instructions = resolve_instructions(
-                    payload=payload,
-                    repo=run_context.repo,
-                    modes=attempt_modes,
-                    agent_id=attempt_agent_id,
-                    output_schema=output_schema,
-                    signed_commits=settings.signed_commits,
-                    learnings_file_path=tool_state.learnings_file_path,
-                    learnings_headings=settings.learnings_headings,
-                    setup_hook_failure=setup_hook_failure,
-                    setup_script_skip_reason=setup_script_skip_reason,
-                    xrepo_brief=settings.xrepo_brief,
-                    xrepo_learnings_file_path=tool_state.xrepo_learnings_file_path,
-                    xrepo_learnings_headings=settings.xrepo_learnings_headings,
-                )
-                attempt_denied = subagent_denied_tool_names(
-                    replace(tool_context, agent_id=attempt_agent_id),
-                    output_schema,
-                )
-                attempt_ctx = replace(
-                    run_ctx,
-                    resolved_model=attempt_model,
-                    instructions=attempt_instructions,
-                    subagent_denied_tools=attempt_denied,
-                )
-                tool_context.agent_id = attempt_agent_id
-                tool_context.modes = attempt_modes
-                tool_state.modes = attempt_modes
-                tool_context.resolved_model = attempt_model
-                logger.info(
-                    "» model chain advanced to agent={} model={}",
-                    attempt_agent_id,
-                    attempt_model or "(auto)",
-                )
-            return await attempt_agent.run(attempt_ctx)
-
-        async def _execute_agent() -> tuple[str | None, AgentResult]:
-            if use_model_chain:
-                winning_slug, chain_result = await run_with_model_chain(
-                    settings=settings,
-                    run_once=_run_agent_once,
-                    head=model_head,
-                    pin=model_pin,
-                )
-                return winning_slug, chain_result
-            return selected_slug, await agent.run(run_ctx)
-
-        agent_task = asyncio.create_task(_execute_agent())
-
-        # S1 / F6 — deduct the setup-script elapsed time from the agent
-        # deadline. A slow setup must NOT silently extend the total run
-        # deadline. ``setup_elapsed_s`` is the wall-clock duration measured
-        # by the bounded setup block above; ``timeout_ms`` is the
-        # pre-deduction run budget.
-        agent_timeout_ms: int | None
-        if timeout_ms is None:
-            agent_timeout_ms = None
-        else:
-            agent_timeout_ms = max(1, int(timeout_ms - setup_elapsed_s * 1000))
-            if agent_timeout_ms != timeout_ms:
-                logger.info(
-                    "» deducted setup elapsed {:.2f}s from agent deadline ({}s -> {}s)",
-                    setup_elapsed_s,
-                    timeout_ms / 1000,
-                    agent_timeout_ms / 1000,
-                )
-
-        if agent_timeout_ms is None:
-            winning_slug, result = await agent_task
-        else:
-            try:
-                winning_slug, result = await asyncio.wait_for(
-                    agent_task, timeout=agent_timeout_ms / 1000.0
-                )
-            except TimeoutError:
-                agent_task.cancel()
-                from mergecraft.utils.process_group import kill_all_active_process_groups
-
-                kill_all_active_process_groups()
-                msg = f"agent run timed out after {timeout_raw or '1h'}"
-                raise _AgentTimeoutError(msg) from None
-
-        if winning_slug:
-            resolved_model = resolve_model(slug=winning_slug, respect_env_override=False)
-            tool_context.resolved_model = resolved_model
-            # W10.2/W10.3 — single promotion path; chain stamps metadata in
-            # ``_attach_model_evidence``, single-slug defaults to index 0.
-            meta = result.metadata or {}
-            requested_meta = meta.get("requested_model")
-            requested = (
-                requested_meta.strip()
-                if isinstance(requested_meta, str) and requested_meta.strip()
-                else (chain_for_decision[0] if chain_for_decision else tool_state.requested_model)
-            )
-            fallback_raw = meta.get("fallback_index")
-            fallback_index = fallback_raw if isinstance(fallback_raw, int) else 0
-            executed = payload.get("proxyModel") or resolved_model or winning_slug
-            promote_model_evidence(
-                tool_state,
-                requested_model=requested,
-                executed_model=executed if isinstance(executed, str) else winning_slug,
-                fallback_index=fallback_index,
-            )
-
-        if result.usage:
-            tool_state.usage_entries.append(result.usage)
-
-        if output_schema and not tool_state.output:
-            msg = (
-                "output_schema was provided but agent did not call set_output — "
-                "structured output is required"
-            )
-            raise RuntimeError(msg)
-
-        try:
-            result = await finalize_agent_result(run_ctx, result)
-        except Exception as exc:
-            logger.debug("post-run finalize skipped: {}", exc)
-
-        # D3/W5.2 + W6.1 + S1/D5/D10 — a completed run is ``passed`` / ``failed``,
-        # ``inconclusive`` when review-relevant dependency prep failed OR a
-        # trusted-tier ``setup_script`` failed under the default policy, or
-        # ``configuration_error`` when the operator opted into ``fail``. Agent
-        # failure wins over both prep and setup-script failure (the agent
-        # genuinely couldn't do its job). S1 also adds D10's
-        # ``setup_failure_policy`` to the resolution.
-        prep_reason = await _prep_failure_reason(tool_context)
-        setup_reason = tool_state.setup_hook_failure or ""
-        outcome, failure_reason = _classify_outcome(
-            result=result,
-            setup_reason=setup_reason,
-            setup_policy=settings.setup_failure_policy,
-            prep_reason=prep_reason,
-        )
-
-        packet_path: str | None = None
-        if tool_context:
-            from mergecraft.tracing.tracer import get_tracer_from_settings
-
-            tracer = get_tracer_from_settings(settings)
-            selected_mode_obj = next(
-                (m for m in tool_context.modes if m.name == tool_context.tool_state.selected_mode),
-                None,
-            )
-            with tracer.start_span(
-                "mergecraft.publish",
-                attrs_source=lambda: _publish_span_attrs(outcome, selected_mode_obj),
-            ) as _publish_span:
-                await persist_learnings(tool_context)
-                await report_status_checks(
-                    tool_context,
-                    run_succeeded=run_succeeded_for_outcome(outcome),
-                    failure_reason=failure_reason,
-                    conclusion=RUN_OUTCOME_CONCLUSION[outcome],
-                )
-                # #39 — opt-in, off by default, and never a gate: with
-                # `sarif_upload` unset this returns before making any request.
-                await report_sarif_upload(tool_context)
-                # Emit the merge evidence packet last, so it records the run's
-                # final state. A blocked or failed run is exactly when the
-                # evidence matters most, so this runs on both branches below.
-                written = await asyncio.to_thread(
-                    emit_run_packet, tool_context, run_succeeded=outcome is RunOutcome.passed
-                )
-                packet_path = str(written) if written else None
-
-        if outcome is not RunOutcome.passed:
-            return MainResult(
-                success=False,
-                error=failure_reason or result.error or "agent execution failed",
-                evidence_packet_path=packet_path,
-                outcome=outcome,
-            )
-
-        output = tool_state.output or result.output
-        return MainResult(
-            success=True,
-            output=output,
-            result=output,
-            evidence_packet_path=packet_path,
-            outcome=outcome,
-        )
-
+        ctx = await _setup_run(ctx)
+        ctx = await _resolve_credentials(ctx)
+        agent_result = await _execute_agent(ctx)
+    except _ShortCircuit as short_circuit:
+        return short_circuit.result
     except Exception as error:
         error_message = str(error) if error else "unknown error occurred"
         logger.error("{}", error_message)
         error_outcome = _classify_error_outcome(error)
-        if tool_context:
+        if ctx.tool_context:
             try:
-                await persist_learnings(tool_context)
+                await persist_learnings(ctx.tool_context)
                 await report_status_checks(
-                    tool_context,
+                    ctx.tool_context,
                     run_succeeded=run_succeeded_for_outcome(error_outcome),
                     failure_reason=error_message,
                     conclusion=RUN_OUTCOME_CONCLUSION[error_outcome],
@@ -959,19 +1299,20 @@ async def main() -> MainResult:
             except Exception:
                 pass
         return MainResult(success=False, error=error_message, outcome=error_outcome)
-
+    else:
+        return await _finalize(ctx, agent_result)
     finally:
-        if stop_mcp is not None:
+        if ctx.stop_mcp is not None:
             with contextlib.suppress(Exception):
-                stop_mcp()
+                ctx.stop_mcp()
         with contextlib.suppress(Exception):
             cleanup_temp_directory()
-        if token_ref is not None:
+        if ctx.token_ref is not None:
             with contextlib.suppress(Exception):
-                await token_ref.aclose()
-        if github is not None:
+                await ctx.token_ref.aclose()
+        if ctx.github is not None:
             with contextlib.suppress(Exception):
-                await github.aclose()
+                await ctx.github.aclose()
 
 
 __all__ = ["MainResult", "RunOutcome", "main"]

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -8,6 +8,13 @@ silently executing the agent as root — that fallback is the F4' defect and it
 must not regress. UID/GID 0 is the security boundary, not the username: a
 configured user that happens to resolve to ``root`` would still spawn the
 agent as root.
+
+``setpriv`` drops the *uid/gid* but, unlike ``su -``/``sudo -H``, does not
+reset ``$HOME`` — the agent subprocess inherits whatever ``HOME`` was already
+in its env (in the GitHub Actions container that is ``/github/home``, owned
+by the runner's original uid, not the dropped-to user). :func:`agent_subprocess_env`
+closes that gap by patching ``HOME``/``USER``/``LOGNAME`` in the env dict
+alongside the ``setpriv`` argv wrap, using the same fail-closed resolution.
 """
 
 from __future__ import annotations
@@ -22,6 +29,8 @@ from loguru import logger
 _DEFAULT_AGENT_USER = "mergecraft"
 
 if TYPE_CHECKING:
+    import pwd
+
     # Imported lazily inside the failure paths to avoid a circular import:
     # ``mergecraft.main`` already imports ``prepare_workspace_for_agent`` from
     # this module, so the class symbol is looked up at raise-time only.
@@ -47,29 +56,22 @@ def _raise_configuration_error(message: str) -> _ConfigurationError:
     return _ConfigurationError(message)
 
 
-def wrap_agent_command(cmd: list[str]) -> list[str]:
-    """Prefix ``cmd`` with ``setpriv`` when running as root in the action image.
+def _resolve_privilege_drop_user() -> pwd.struct_passwd | None:
+    """Resolve the pwd entry the agent subprocess must drop to, or ``None`` if not root.
 
-    Fails closed with ``main._ConfigurationError`` if ``setpriv`` or the agent
-    user is unavailable — never silently returns the unwrapped command (the
-    F4' fail-open default this contract replaces). Resolves the user record via
-    ``pwd.getpwnam`` and additionally rejects UID/GID 0 — the username is not
-    the security boundary; a configured user that happens to resolve to ``root``
-    would still spawn the agent as root, defeating the privilege drop.
+    Shared by :func:`wrap_agent_command` and :func:`agent_subprocess_env` so the
+    two halves of the privilege drop (wrapping argv with ``setpriv``, patching
+    ``HOME``/``USER``/``LOGNAME`` in the env) resolve the target user identically
+    and cannot drift apart. Mirrors ``wrap_agent_command``'s original inline
+    resolution exactly (same log/error text): non-root returns ``None`` (no drop
+    applies); a missing ``pwd`` module, a missing user, or a user that resolves to
+    UID/GID 0 all raise ``main._ConfigurationError`` — the username is not the
+    security boundary, the UID is, so a configured user that happens to map to
+    ``root`` is rejected the same as a genuinely missing one.
     """
     if os.getuid() != 0:
-        return list(cmd)
+        return None
     user = agent_user_name()
-    if shutil.which("setpriv") is None:
-        logger.error(
-            "setpriv unavailable on PATH; refusing to run the agent subprocess as root "
-            "(uid={}) — image must ship setpriv so the privilege drop can land",
-            os.getuid(),
-        )
-        raise _raise_configuration_error(
-            "setpriv is not on PATH inside the action image; the agent privilege drop "
-            "is unavailable and the run cannot proceed as root"
-        )
     try:
         import pwd
 
@@ -106,7 +108,103 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
             f"inside the action image; the privilege drop cannot land onto a root account "
             f"and the run cannot proceed"
         )
+    return entry
+
+
+def wrap_agent_command(cmd: list[str]) -> list[str]:
+    """Prefix ``cmd`` with ``setpriv`` when running as root in the action image.
+
+    Fails closed with ``main._ConfigurationError`` if ``setpriv`` or the agent
+    user is unavailable — never silently returns the unwrapped command (the
+    F4' fail-open default this contract replaces). Resolves the user record via
+    ``pwd.getpwnam`` and additionally rejects UID/GID 0 — the username is not
+    the security boundary; a configured user that happens to resolve to ``root``
+    would still spawn the agent as root, defeating the privilege drop.
+    """
+    if os.getuid() != 0:
+        return list(cmd)
+    user = agent_user_name()
+    if shutil.which("setpriv") is None:
+        logger.error(
+            "setpriv unavailable on PATH; refusing to run the agent subprocess as root "
+            "(uid={}) — image must ship setpriv so the privilege drop can land",
+            os.getuid(),
+        )
+        raise _raise_configuration_error(
+            "setpriv is not on PATH inside the action image; the agent privilege drop "
+            "is unavailable and the run cannot proceed as root"
+        )
+    _resolve_privilege_drop_user()
     return ["setpriv", f"--reuid={user}", f"--regid={user}", "--init-groups", *cmd]
+
+
+def _path_owned_by_uid(path: str, uid: int) -> bool:
+    """Return whether ``path`` exists and is already owned by ``uid``.
+
+    Used by :func:`agent_subprocess_env` to decide whether a driver-supplied
+    ``HOME`` is already usable by the dropped-to agent user (e.g. a per-run
+    scratch dir the caller chowned itself — see
+    ``git_setup._prepare_temp_dir_for_agent``) versus one it merely inherited
+    unmodified from the root entrypoint's environment. Missing/unstattable
+    paths are treated as not-owned, which is the safe direction: it makes
+    ``agent_subprocess_env`` overwrite ``HOME`` rather than leave a dangling
+    or root-owned value in place.
+    """
+    if not path:
+        return False
+    try:
+        return os.stat(path).st_uid == uid
+    except OSError:
+        return False
+
+
+def agent_subprocess_env(env: dict[str, str]) -> dict[str, str]:
+    """Patch ``HOME``/``USER``/``LOGNAME`` for the setpriv-dropped agent subprocess (W3.4).
+
+    ``setpriv --reuid/--regid`` (see :func:`wrap_agent_command`) drops the
+    agent CLI's uid/gid, but unlike ``su -``/``sudo -H`` it does not reset
+    ``$HOME`` — the subprocess still sees whatever ``HOME`` was already in
+    ``env``. Inside the GitHub Actions container that is ``/github/home``,
+    owned by the runner's original uid rather than the dropped-to agent user;
+    agent CLIs (opencode, Codex) then try to create dotfiles/config under it
+    and fail with ``EACCES``. This is the live bug: ``opencode serve exited
+    early: EACCES: permission denied, mkdir '/github/home/.local'``.
+
+    Only overwrites ``HOME`` when the current value is not already owned by
+    the resolved agent uid (via :func:`_path_owned_by_uid`). A driver that
+    deliberately points ``HOME`` at its own pre-chowned scratch directory —
+    e.g. Gemini's per-run tmpdir, chowned to the agent user by
+    ``git_setup._prepare_temp_dir_for_agent`` before any driver runs, so that
+    ``$HOME/.gemini/settings.json`` resolves the MCP config it wrote there —
+    is left alone. Only the inherited-and-wrong case (HOME still pointing at
+    a directory the agent user does not own) is corrected. ``USER``/``LOGNAME``
+    carry no path semantics to protect, so they are always set to the
+    resolved user's name.
+
+    Uses the same fail-closed resolution as ``wrap_agent_command`` (shared via
+    :func:`_resolve_privilege_drop_user`): when the current process is not
+    root, this is a no-op copy — no privilege drop applies, so there is
+    nothing to redirect. When it *is* root, the same conditions that make
+    ``wrap_agent_command`` raise ``main._ConfigurationError`` (missing ``pwd``
+    module, missing agent user, or a user resolving to UID/GID 0) make this
+    function raise too, rather than silently leaving a wrong ``HOME`` in
+    place. In practice every real call site invokes this immediately
+    alongside ``wrap_agent_command``, so whichever raises first aborts the
+    whole call — but this function does not rely on that ordering to stay
+    safe; it enforces the same contract independently.
+
+    Returns a **copy** of ``env`` — callers (per-driver ``_build_env``) still
+    hold the original dict and must not have it mutated under them.
+    """
+    entry = _resolve_privilege_drop_user()
+    if entry is None:
+        return dict(env)
+    patched = dict(env)
+    if not _path_owned_by_uid(patched.get("HOME", ""), entry.pw_uid):
+        patched["HOME"] = entry.pw_dir
+    patched["USER"] = entry.pw_name
+    patched["LOGNAME"] = entry.pw_name
+    return patched
 
 
 def prepare_workspace_for_agent(workspace: str) -> None:
@@ -167,4 +265,9 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     logger.debug("chowned workspace {} for agent user {}", target, user)
 
 
-__all__ = ["agent_user_name", "prepare_workspace_for_agent", "wrap_agent_command"]
+__all__ = [
+    "agent_subprocess_env",
+    "agent_user_name",
+    "prepare_workspace_for_agent",
+    "wrap_agent_command",
+]

--- a/tests/agents/test_privilege_drop_home_wiring.py
+++ b/tests/agents/test_privilege_drop_home_wiring.py
@@ -1,0 +1,209 @@
+"""Real subprocess-launch sites redirect HOME under the privilege drop (live-bug fix).
+
+``setpriv --reuid/--regid`` (``mergecraft.utils.privilege.wrap_agent_command``)
+drops the agent subprocess's uid/gid but does not reset ``$HOME`` the way
+``su -``/``sudo -H`` would. The container sets ``HOME=/github/home`` (owned by
+the runner's original uid), so the dropped-to agent user cannot write
+dotfiles/config under it — this is the exact failure behind the observed
+``opencode serve exited early: EACCES: permission denied, mkdir
+'/github/home/.local'`` and the equivalent Codex failure.
+
+These tests drive the three real subprocess-launch call sites — the shared
+``spawn_agent_cli`` (covers Codex/Gemini/Claude's primary streaming path/most
+of OpenCode), OpenCode's ``_boot_opencode_server`` bypass, and Claude's legacy
+``subprocess.run`` bypass — with root simulated via monkeypatched
+``os.getuid``/``pwd.getpwnam``, and assert the env actually handed to
+``Popen``/``subprocess.run`` has ``HOME``/``USER``/``LOGNAME`` redirected to
+the resolved agent user, while argv is still ``setpriv``-wrapped exactly as
+before.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+from tests.agents.conftest import make_agent_run_context
+
+from mergecraft.agents.shared import spawn_agent_cli
+from mergecraft.utils import privilege as privilege_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+# ``mergecraft.agents.__init__`` reassigns the ``claude``/``opencode`` package
+# attributes to the built ``AgentImpl`` instances (``from .claude import
+# claude``), which shadows the submodules for ``import ... as`` attribute
+# resolution. Go through ``sys.modules`` via ``importlib`` to get the actual
+# submodules, matching how ``tests/agents/test_codex.py`` resolves
+# ``mergecraft.agents.codex``.
+claude_module = importlib.import_module("mergecraft.agents.claude")
+opencode_module = importlib.import_module("mergecraft.agents.opencode")
+
+
+class _FakePw:
+    pw_name = "mergecraft"
+    pw_uid = 1001
+    pw_gid = 1001
+    pw_dir = "/home/mergecraft"
+
+
+def _simulate_root_privilege_drop(monkeypatch: MonkeyPatch) -> None:
+    """Make every branch in ``wrap_agent_command``/``agent_subprocess_env`` see
+    the action-image root path: ``setpriv`` present, ``mergecraft`` resolves,
+    and the current (inherited, GitHub-Actions-container-style) ``HOME`` is
+    NOT owned by the resolved agent uid — the exact live-bug scenario."""
+    monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(
+        privilege_module.shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}" if name == "setpriv" else None,
+    )
+    monkeypatch.setattr(privilege_module.os, "stat", lambda _path: MagicMock(st_uid=0))
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _FakePw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+    monkeypatch.delenv("MERGECRAFT_AGENT_USER", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# spawn_agent_cli (shared.py) — covers Codex/Gemini/Claude's primary path,
+# OpenCode's cli-fallback streaming path
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_agent_cli_redirects_home_under_privilege_drop(monkeypatch: MonkeyPatch) -> None:
+    _simulate_root_privilege_drop(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_popen(cmd: list[str], **kwargs: object) -> object:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    import mergecraft.agents.shared as shared_module
+
+    monkeypatch.setattr(shared_module.subprocess, "Popen", _fake_popen)
+
+    env = {"HOME": "/github/home", "USER": "root", "LOGNAME": "root", "PATH": "/usr/bin"}
+    spawn_agent_cli(["codex", "exec"], env=env)
+
+    assert captured["cmd"][0] == "setpriv", "argv must still be setpriv-wrapped"
+    resolved_env = captured["kwargs"]["env"]
+    assert resolved_env["HOME"] == "/home/mergecraft"
+    assert resolved_env["USER"] == "mergecraft"
+    assert resolved_env["LOGNAME"] == "mergecraft"
+    assert resolved_env["PATH"] == "/usr/bin"
+    # The caller's original env dict must not be mutated in place.
+    assert env["HOME"] == "/github/home"
+
+
+def test_spawn_agent_cli_leaves_env_untouched_when_not_root(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(privilege_module.os, "getuid", lambda: 501)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_popen(cmd: list[str], **kwargs: object) -> object:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    import mergecraft.agents.shared as shared_module
+
+    monkeypatch.setattr(shared_module.subprocess, "Popen", _fake_popen)
+
+    env = {"HOME": "/Users/dev", "PATH": "/usr/bin"}
+    spawn_agent_cli(["codex", "exec"], env=env)
+
+    assert captured["cmd"] == ["codex", "exec"]
+    assert captured["kwargs"]["env"] == env
+
+
+# ---------------------------------------------------------------------------
+# opencode.py::_boot_opencode_server — the bypass directly implicated in the
+# observed "opencode serve exited early: EACCES ... mkdir '/github/home/.local'"
+# ---------------------------------------------------------------------------
+
+
+def test_boot_opencode_server_redirects_home_under_privilege_drop(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _simulate_root_privilege_drop(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.pid = 4242
+            self.stdout = self
+            self.stderr = self
+            self._lines = [b"listening on http://127.0.0.1:12345\n"]
+
+        def poll(self) -> None:
+            return None
+
+        def readline(self) -> bytes:
+            return self._lines.pop(0) if self._lines else b""
+
+        def read(self) -> bytes:
+            return b""
+
+    def _fake_popen(cmd: list[str], **kwargs: object) -> object:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _FakeProc()
+
+    monkeypatch.setattr(opencode_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(opencode_module, "register_process_group", lambda _pid: None)
+
+    env = {"HOME": "/github/home", "PATH": "/usr/bin"}
+    handle = opencode_module._boot_opencode_server(
+        cli="/usr/bin/opencode", env=env, cwd=str(tmp_path)
+    )
+
+    assert captured["cmd"][0] == "setpriv"
+    resolved_env = captured["kwargs"]["env"]
+    assert resolved_env["HOME"] == "/home/mergecraft"
+    assert resolved_env["USER"] == "mergecraft"
+    assert handle.base_url == "http://127.0.0.1:12345"
+
+
+# ---------------------------------------------------------------------------
+# claude.py::_run_claude_legacy_subprocess — the FileNotFoundError fallback
+# ---------------------------------------------------------------------------
+
+
+def test_claude_legacy_subprocess_redirects_home_under_privilege_drop(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _simulate_root_privilege_drop(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> object:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(claude_module.subprocess, "run", _fake_run)
+    monkeypatch.setenv("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "0")
+
+    ctx = make_agent_run_context(tmp_path, resolved_model="claude-sonnet")
+    result = claude_module._run_claude_legacy_subprocess(
+        cmd=["claude", "--print"],
+        ctx=ctx,
+        model="claude-sonnet",
+        skip_permissions=False,
+    )
+
+    assert captured["cmd"][0] == "setpriv"
+    resolved_env = captured["kwargs"]["env"]
+    assert resolved_env["HOME"] == "/home/mergecraft"
+    assert resolved_env["USER"] == "mergecraft"
+    assert resolved_env["LOGNAME"] == "mergecraft"
+    assert result.success is True

--- a/tests/analyzers/test_registry_complexity.py
+++ b/tests/analyzers/test_registry_complexity.py
@@ -1,0 +1,139 @@
+"""Characterisation suite for G4.1 — `analyzers/registry.py` (D26 / D22).
+
+PR G4 (`.ignorelocal/waves/issues-showcase-readiness-wave-plan.md`, "PR G4")
+extracts `_exclusive_group_winner`'s tie-break rules into named predicates
+and `detect_enabled`'s per-detector evaluation into a helper — both in the
+same file, same wave. This is a pure refactor: per G4.1's own acceptance
+line, this test must be **green today**, against unmodified code, and
+**stay green** after the extraction — the inverse of this repo's usual
+RED-first convention.
+
+`_exclusive_group_winner`'s D26 complexity is the explicit-override /
+preference-ladder / alphabetical-tie-break chain; `detect_enabled`'s D22 is
+the detect-match / settings-override / exclusive-group-collapse pipeline
+that calls it. `detect_enabled`'s scenarios below reuse the exact fixture
+repo + changed-file sets already exercised by
+`tests/analyzers/test_registry.py` (the committed W0.8 fixture), so they
+carry independent confidence: an equivalent assertion is already green
+elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mergecraft.analyzers.pattern import PATTERN_EXCLUSIVE_GROUP
+from mergecraft.analyzers.registry import (
+    _PYTHON_LINT_PREFERENCE,
+    _PYTHON_TYPECHECK_PREFERENCE,
+    _exclusive_group_winner,
+    detect_enabled,
+    get_manifest,
+)
+from tests.analyzers.support import FIXTURE_REPO
+
+
+def test_exclusive_group_winner_unchanged(tmp_path: Path) -> None:
+    """`_exclusive_group_winner` (D26) and `detect_enabled` (D22)."""
+    repo_root = tmp_path
+    failures: list[str] = []
+
+    def winner_id(group: str, ids: list[str], *, settings: dict[str, Any] | None = None) -> str:
+        candidates = [get_manifest(i) for i in ids]
+        return _exclusive_group_winner(
+            group, candidates, repo_root=repo_root, settings=settings or {}
+        ).id
+
+    # -- preference ladder, no explicit override -----------------------------
+    got = winner_id("python-lint", ["ruff", "pylint"])
+    if got != "ruff":
+        failures.append(f"python-lint[ruff,pylint] no override: winner={got!r}, expected 'ruff'")
+
+    got = winner_id("python-lint", ["pylint"])
+    if got != "pylint":
+        failures.append(f"python-lint[pylint] no override: winner={got!r}, expected 'pylint'")
+
+    got = winner_id("python-typecheck", ["mypy", "basedpyright", "pyright"])
+    if got != "mypy":
+        failures.append(f"python-typecheck full set: winner={got!r}, expected 'mypy'")
+
+    got = winner_id("python-typecheck", ["basedpyright", "pyright"])
+    if got != "basedpyright":
+        failures.append(
+            f"python-typecheck[basedpyright,pyright]: winner={got!r}, expected 'basedpyright'"
+        )
+
+    # -- exactly one explicit override wins outright, bypassing preference --
+    settings_one_override = {"analyzers": {"overrides": {"pylint": {"enabled": True}}}}
+    got = winner_id("python-lint", ["ruff", "pylint"], settings=settings_one_override)
+    if got != "pylint":
+        failures.append(
+            f"single explicit override beats preference: winner={got!r}, expected 'pylint'"
+        )
+
+    # -- two explicit overrides in the same group tie-break alphabetically --
+    settings_both_override = {
+        "analyzers": {"overrides": {"ruff": {"enabled": True}, "pylint": {"enabled": True}}}
+    }
+    got = winner_id("python-lint", ["ruff", "pylint"], settings=settings_both_override)
+    if got != "pylint":
+        failures.append(
+            f"tie-break among explicit overrides is alphabetical: winner={got!r}, expected 'pylint'"
+        )
+
+    # -- pattern-scanner group honours the configured backend ----------------
+    settings_pattern = {"analyzers": {"pattern": {"backend": "opengrep"}}}
+    got = winner_id(
+        PATTERN_EXCLUSIVE_GROUP, ["semgrep", "opengrep", "ast-grep"], settings=settings_pattern
+    )
+    if got != "opengrep":
+        failures.append(f"pattern-scanner backend=opengrep: winner={got!r}, expected 'opengrep'")
+
+    # -- an unhandled group name falls back to alphabetical sort -------------
+    got = winner_id("not-a-real-group", ["hadolint", "actionlint"])
+    if got != "actionlint":
+        failures.append(f"unhandled group default: winner={got!r}, expected 'actionlint'")
+
+    # -- preference constants themselves (guard against silent reordering) --
+    if _PYTHON_LINT_PREFERENCE != ("ruff", "pylint"):
+        failures.append(f"_PYTHON_LINT_PREFERENCE drifted: {_PYTHON_LINT_PREFERENCE!r}")
+    if _PYTHON_TYPECHECK_PREFERENCE != ("mypy", "basedpyright", "pyright"):
+        failures.append(f"_PYTHON_TYPECHECK_PREFERENCE drifted: {_PYTHON_TYPECHECK_PREFERENCE!r}")
+
+    # -- detect_enabled (D22): detect-match -> settings-override -> ----------
+    # exclusive-group collapse, against the committed fixture repo.
+    enabled = detect_enabled(
+        repo_root=FIXTURE_REPO,
+        changed_files=["src/example.py", "src/other.py"],
+        settings_overrides={},
+    )
+    by_group: dict[str, list[str]] = {}
+    for manifest in enabled:
+        if manifest.exclusive_group:
+            by_group.setdefault(manifest.exclusive_group, []).append(manifest.id)
+    for group, ids in by_group.items():
+        if len(ids) > 1:
+            failures.append(f"detect_enabled: group {group} enabled multiple defaults: {ids}")
+
+    enabled = detect_enabled(
+        repo_root=FIXTURE_REPO,
+        changed_files=["src/example.py"],
+        settings_overrides={
+            "analyzers": {"overrides": {"ruff": {"enabled": True}, "pylint": {"enabled": True}}}
+        },
+    )
+    ids = {m.id for m in enabled}
+    if not {"ruff", "pylint"} <= ids:
+        failures.append(f"detect_enabled: explicit multi-override did not enable both: {ids}")
+
+    enabled = detect_enabled(
+        repo_root=FIXTURE_REPO, changed_files=["README.md"], settings_overrides={}
+    )
+    off_by_default = {m.id for m in enabled} & {"actionlint", "shellcheck", "hadolint"}
+    if off_by_default:
+        failures.append(
+            f"detect_enabled: files with no matching detect glob enabled {off_by_default}"
+        )
+
+    assert not failures, "\n".join(failures)

--- a/tests/analyzers/test_resolve_complexity.py
+++ b/tests/analyzers/test_resolve_complexity.py
@@ -1,0 +1,155 @@
+"""Characterisation suite for G4.1 — `analyzers/resolve.py:resolve_analyzer` (D 26).
+
+PR G4 (`.ignorelocal/waves/issues-showcase-readiness-wave-plan.md`, "PR G4")
+extracts `resolve_analyzer`'s preference ladder into per-source resolvers
+behind a small dispatch table. This is a pure refactor: per G4.1's own
+acceptance line, this test must be **green today**, against unmodified
+code, and **stay green** after the extraction — the inverse of this repo's
+usual RED-first convention.
+
+Table-driven over `load_catalog()` — the whole bundled analyzer catalog (57
+manifests at the time this test was written), the "existing catalog
+fixtures" G4.1 names. Every boolean input is forced explicitly (never
+`None`, which would trigger PATH auto-detection and make the outcome
+environment-dependent), so the expected mode for every manifest is a pure
+function of that manifest's own fields (`declared_unavailable`, `id`,
+`runtime`) — computed independently below, not copied from whatever the
+function under test currently returns. That makes this an oracle, not a
+snapshot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mergecraft.analyzers.registry import load_catalog
+from mergecraft.analyzers.resolve import _TYPE_CHECKER_IDS, resolve_analyzer
+
+CATALOG = {m.id: m for m in load_catalog()}
+
+
+def test_resolve_analyzer_behaviour_unchanged(tmp_path: Path) -> None:
+    """D26's preference ladder, pinned across every catalog manifest.
+
+    Four scenarios per manifest:
+
+    1. Nothing available — only `declared_unavailable` manifests and the
+       always-in-process `agentsec` special case resolve to anything but
+       `skip`.
+    2. The repo already has the tool installed — repo-native wins for
+       everyone except `declared_unavailable`, which is checked first and
+       short-circuits regardless of tool availability.
+    3. Only mergeCraft's managed binary is available — type checkers never
+       substitute a managed binary for the repo's own configured tool
+       (C3/D5, `mypy`/`pyright`/`basedpyright`); every other `managed` or
+       `repo-native` runtime manifest gets the managed substitute.
+    4. `allow_repo_binaries=False` (the `shell: disabled` path, #35/D5) —
+       forces `repo_has_tool=False` even when the caller passed `True`, so
+       the outcome collapses to (3)'s ladder plus the `container` branch
+       (exercised here since scenario 3 leaves it untested).
+    """
+    repo_root = tmp_path
+    failures: list[str] = []
+
+    for manifest_id, manifest in sorted(CATALOG.items()):
+        # -- scenario 1: nothing available -----------------------------------
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            repo_has_tool=False,
+            ci_artifact_available=False,
+            managed_available=False,
+            container_available=False,
+        )
+        if manifest.declared_unavailable:
+            expected_mode = "skip"
+        elif manifest_id == "agentsec":
+            expected_mode = "repo-native"
+        else:
+            expected_mode = "skip"
+        if plan.mode != expected_mode:
+            failures.append(
+                f"{manifest_id} nothing-available: mode={plan.mode!r}, expected {expected_mode!r}"
+            )
+        if plan.mode == "skip" and not plan.reason:
+            failures.append(f"{manifest_id} nothing-available: skip with no reason recorded")
+
+        # -- scenario 2: repo already has the tool installed -----------------
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            repo_has_tool=True,
+            repo_tool_path="/usr/local/bin/tool",
+            repo_tool_version="9.9.9",
+            ci_artifact_available=True,
+            managed_available=True,
+            container_available=True,
+        )
+        expected_mode = "skip" if manifest.declared_unavailable else "repo-native"
+        if plan.mode != expected_mode:
+            failures.append(
+                f"{manifest_id} repo-has-tool: mode={plan.mode!r}, expected {expected_mode!r}"
+            )
+        if (
+            manifest_id != "agentsec"
+            and plan.mode == "repo-native"
+            and (not plan.version_note or "9.9.9" not in plan.version_note)
+        ):
+            failures.append(
+                f"{manifest_id} repo-has-tool: version_note missing repo tool version "
+                f"(got {plan.version_note!r})"
+            )
+
+        # -- scenario 3: only mergeCraft's managed binary is available -------
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            repo_has_tool=False,
+            ci_artifact_available=False,
+            managed_available=True,
+            container_available=False,
+        )
+        if manifest.declared_unavailable:
+            expected_mode = "skip"
+        elif manifest_id == "agentsec":
+            expected_mode = "repo-native"
+        elif manifest_id in _TYPE_CHECKER_IDS:
+            expected_mode = "skip"
+        elif manifest.runtime in {"managed", "repo-native"}:
+            expected_mode = "managed"
+        else:
+            expected_mode = "skip"
+        if plan.mode != expected_mode:
+            failures.append(
+                f"{manifest_id} managed-only: mode={plan.mode!r}, expected {expected_mode!r}"
+            )
+
+        # -- scenario 4: allow_repo_binaries=False (shell: disabled, #35/D5) -
+        plan = resolve_analyzer(
+            manifest=manifest,
+            repo_root=repo_root,
+            repo_has_tool=True,  # ignored -- allow_repo_binaries=False overrides it
+            allow_repo_binaries=False,
+            ci_artifact_available=False,
+            managed_available=True,
+            container_available=True,
+        )
+        if manifest.declared_unavailable:
+            expected_mode = "skip"
+        elif manifest_id == "agentsec":
+            expected_mode = "repo-native"
+        elif manifest_id in _TYPE_CHECKER_IDS:
+            expected_mode = "skip"
+        elif manifest.runtime in {"managed", "repo-native"}:
+            expected_mode = "managed"
+        elif manifest.runtime == "container":
+            expected_mode = "container"
+        else:
+            expected_mode = "skip"
+        if plan.mode != expected_mode:
+            failures.append(
+                f"{manifest_id} shell-disabled: mode={plan.mode!r}, expected {expected_mode!r}"
+            )
+
+    assert CATALOG, "catalog loaded empty -- fixture drift, not a resolve_analyzer regression"
+    assert not failures, "\n".join(failures)

--- a/tests/test_main_phases.py
+++ b/tests/test_main_phases.py
@@ -1,0 +1,573 @@
+"""Characterisation suite for G4.1 — `src/mergecraft/main.py` phase extraction.
+
+PR G4 (`.ignorelocal/waves/issues-showcase-readiness-wave-plan.md`, "PR G4 —
+`refactor(main): drop main() and the analyzer hotspots below complexity 15`")
+extracts `_setup_run` / `_resolve_credentials` / `_execute_agent` /
+`_finalize` phases out of `main()`, carried on a new `RunContext` dataclass.
+None of that extraction exists yet — this is a **pure refactor** wave, so
+per G4.1's own acceptance line these tests characterise *current* behaviour
+and must be **green today**, against unmodified code, and **stay green**
+through G4.2. That inverts this repo's usual RED-first test-authoring
+convention on purpose (see G4.1 in the wave plan).
+
+Every test below drives the real, current public surface — mostly
+`mergecraft.main.main()` via the existing
+`tests/support/run_main_harness.py` harness (already used by
+`tests/security/test_trust_ordering.py`, `tests/test_run_outcome.py`, etc.),
+which exercises `main()` end to end against scripted collaborators without
+touching the network, the process table, or a real port. Two tests
+(`test_setup_run_resolves_prompt_and_mode`,
+`test_resolve_credentials_matches_current_precedence`) call the underlying
+helper functions directly, because the harness deliberately stubs
+`resolve_prompt_input` / `resolve_tokens` away (see
+`run_main_harness.py`'s module docstring) and this wave needs to pin what
+those *real* functions do, not the harness's stand-ins.
+
+`RunContext` does not exist pre-G4.2, so `test_run_context_carries_every_phase_input`
+characterises the nearest existing seam — `mcp.context.ToolContext`, the one
+object `main()` already threads every phase's output onto today. After
+G4.2 splits `main()` into named phase functions, the same assertions
+(rebased onto `RunContext`) prove nothing the sprawl carried was dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import mergecraft.utils.token as token_mod
+from mergecraft.agents.shared import AgentResult
+from mergecraft.analyzers.trust import derive_trust_tier
+from mergecraft.config.settings import AnalyzersSettings, RepoSettings
+from mergecraft.main import MainResult, RunOutcome
+from mergecraft.mcp.tool_state import ProgressComment as CtxProgressComment
+from mergecraft.modes import _custom_modes, compute_modes
+from mergecraft.utils.payload import JsonPayload, resolve_prompt_input
+from mergecraft.utils.token import resolve_tokens
+from tests.support.run_main_harness import FakeAgent, run_main_for_test
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _rmtree_if_exists(path: str) -> None:
+    """Sync helper — keeps blocking FS calls out of async test bodies."""
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _isdir(path: str) -> bool:
+    """Sync helper — keeps blocking FS calls out of async test bodies."""
+    return os.path.isdir(path)
+
+
+async def test_run_context_carries_every_phase_input(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The local-variable sprawl G4.2's `RunContext` will carry, pinned today.
+
+    Drives one full run with non-default settings/inputs for each phase
+    (setup: signed_commits + analyzers mode; credentials: trust tier +
+    tokens; execute: an explicit model) and asserts every value lands on
+    `ToolContext` — the object `main()` builds once and mutates across
+    phases today. A refactor that drops one of these onto the wrong side of
+    a phase boundary, or fails to carry it forward at all, turns this red.
+    """
+    settings = RepoSettings(
+        signed_commits=True,
+        analyzers=AnalyzersSettings(sarif_upload=True),
+    )
+    rec = await run_main_for_test(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        settings=settings,
+        event_name="workflow_dispatch",
+        event_payload={"action": "workflow_dispatch"},
+        env={"INPUT_MODEL": "test-model-xyz", "INPUT_ANALYZERS": "full"},
+    )
+    assert rec.result is not None
+    assert rec.result.success, f"run failed: {rec.result}"
+    ctx = rec.tool_context
+    assert ctx is not None, "main() never built a ToolContext"
+
+    # -- setup-phase locals --------------------------------------------------
+    assert ctx.agent_id == "claude"
+    assert ctx.repo.owner == "acme"
+    assert ctx.repo.name == "demo"
+    assert ctx.tmpdir == rec.tmpdir
+    expected_mode_names = {m.name for m in [*compute_modes("claude", True), *_custom_modes([])]}
+    assert {m.name for m in ctx.modes} == expected_mode_names
+    assert ctx.analyzers_mode == "full"
+    assert ctx.sarif_upload_enabled is True
+    assert ctx.signed_commits is True
+
+    # -- credential-phase locals ---------------------------------------------
+    assert ctx.trust_tier == "trusted"
+    assert ctx.github_installation_token == "ghs_fake_mcp_token"
+    assert ctx.git_token == "ghs_fake_git_token"
+
+    # -- execute-phase locals -- filled onto the *same* object after setup --
+    assert ctx.resolved_model == "test-model-xyz"
+    assert ctx.mcp_server_url == "http://127.0.0.1:0/mcp"
+
+    # tool_state carries its own share of the sprawl, threaded from the
+    # resolved run_context / payload / modes computed above.
+    assert ctx.tool_state.oss is True
+    assert ctx.tool_state.modes == ctx.modes
+
+
+def test_setup_run_resolves_prompt_and_mode(tmp_path: Path) -> None:
+    """`resolve_prompt_input` + the `progress`/mode branch `main()` derives from it.
+
+    The harness cannot exercise this: it stubs `resolve_prompt_input` to a
+    plain string unconditionally (see the module docstring above), so this
+    test calls the real function directly across its three source branches
+    — `prompt` (plain text), `prompt_file`, and a `prompt` carrying the
+    `~mergecraft` JSON dispatch marker — and, for each, re-derives the same
+    `progress` value `main()` computes today at `main.py:308-313`:
+
+        progress = None
+        if not isinstance(resolved_prompt, str) and resolved_prompt.progress_comment:
+            progress = ProgressComment(id=..., type=...)
+
+    plus the `modes` list `main()` builds independently via
+    `compute_modes` + `_custom_modes` — pinning that mode computation is
+    unaffected by which prompt-source branch produced the prompt.
+    """
+    from mergecraft import __version__
+
+    # -- branch 1: plain `prompt` text, no prompt_file, no JSON marker ------
+    plain_result = resolve_prompt_input(prompt="plain review text", prompt_file="")
+    assert isinstance(plain_result, str)
+    assert plain_result == "plain review text"
+
+    # -- branch 2: `prompt_file` -- resolved from disk -----------------------
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("file-sourced prompt content", encoding="utf-8")
+    file_result = resolve_prompt_input(prompt="", prompt_file=str(prompt_path))
+    assert isinstance(file_result, str)
+    assert file_result == "file-sourced prompt content"
+
+    # -- branch 3: `prompt` carrying the `~mergecraft` JSON dispatch marker --
+    json_marker = json.dumps(
+        {
+            "~mergecraft": True,
+            "version": __version__,
+            "prompt": "structured dispatch prompt",
+            "progressComment": {"id": "42", "type": "issue"},
+        }
+    )
+    json_result = resolve_prompt_input(prompt=json_marker, prompt_file="")
+    assert isinstance(json_result, JsonPayload)
+    assert json_result.prompt == "structured dispatch prompt"
+    assert json_result.progress_comment is not None
+    assert json_result.progress_comment.id == "42"
+    assert json_result.progress_comment.type == "issue"
+
+    def _progress_for(resolved_prompt: str | JsonPayload) -> CtxProgressComment | None:
+        """Mirrors `main.py:308-313` verbatim — the `progress`/mode pair."""
+        if not isinstance(resolved_prompt, str) and resolved_prompt.progress_comment:
+            return CtxProgressComment(
+                id=resolved_prompt.progress_comment.id,
+                type=resolved_prompt.progress_comment.type,
+            )
+        return None
+
+    assert _progress_for(plain_result) is None
+    assert _progress_for(file_result) is None
+    progress = _progress_for(json_result)
+    assert progress is not None
+    assert progress.id == "42"
+
+    # `modes` computation is independent of the prompt source — pin that
+    # invariant across all three branches (it takes no `resolved_prompt`
+    # argument at all in `main()` today; this loop documents that fact).
+    baseline_modes = {m.name for m in [*compute_modes("claude", False), *_custom_modes([])]}
+    for _resolved in (plain_result, file_result, json_result):
+        modes_here = {m.name for m in [*compute_modes("claude", False), *_custom_modes([])]}
+        assert modes_here == baseline_modes
+
+
+def _reset_token_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(token_mod, "_mcp_token_value", None)
+    monkeypatch.setattr(token_mod, "_mcp_token_refresh", None)
+    for key in (
+        "INPUT_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "GITHUB_APP_ID",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_APP_INSTALLATION_ID",
+        "GITHUB_REPOSITORY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+async def test_resolve_credentials_matches_current_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token brokering + trust-tier derivation — a security boundary (S4 fail-closed).
+
+    Table-driven over `mergecraft.utils.token.resolve_tokens` /
+    `get_job_token` (today's `_resolve_credentials`-to-be) and
+    `mergecraft.analyzers.trust.derive_trust_tier`, called directly rather
+    than through the harness because `run_main_for_test` stubs
+    `resolve_tokens` away entirely.
+
+    Any divergence here is a security regression, not a refactor (G4.1).
+    """
+    failures: list[str] = []
+
+    # -- token precedence -----------------------------------------------------
+    token_cases: list[dict[str, Any]] = [
+        {
+            "id": "gh_token_env_wins_over_input_token_and_workflow_default",
+            "env": {
+                "INPUT_TOKEN": "input-tok",
+                "GH_TOKEN": "gh-tok",
+                "GITHUB_TOKEN": "workflow-tok",
+            },
+            "xrepo": None,
+            "expect_token": "gh-tok",
+            "expect_read_token": None,
+        },
+        {
+            "id": "gh_token_becomes_read_token_when_xrepo_configured",
+            "env": {"GH_TOKEN": "gh-tok"},
+            "xrepo": {"write": ["acme/other"]},
+            "expect_token": "gh-tok",
+            "expect_read_token": "gh-tok",
+        },
+        {
+            "id": "input_token_wins_over_workflow_default_when_gh_token_absent",
+            "env": {"INPUT_TOKEN": "input-tok", "GITHUB_TOKEN": "workflow-tok"},
+            "xrepo": None,
+            "expect_token": "input-tok",
+            "expect_read_token": None,
+        },
+        {
+            "id": "workflow_default_token_used_as_last_resort",
+            "env": {"GITHUB_TOKEN": "workflow-tok"},
+            "xrepo": None,
+            "expect_token": "workflow-tok",
+            "expect_read_token": None,
+        },
+    ]
+    for case in token_cases:
+        _reset_token_module_state(monkeypatch)
+        for key, value in case["env"].items():
+            monkeypatch.setenv(key, value)
+        ref = await resolve_tokens(push="restricted", xrepo=case["xrepo"])
+        try:
+            if ref.git_token != case["expect_token"]:
+                failures.append(
+                    f"{case['id']}: git_token={ref.git_token!r}, expected {case['expect_token']!r}"
+                )
+            if ref.mcp_token != case["expect_token"]:
+                failures.append(
+                    f"{case['id']}: mcp_token={ref.mcp_token!r}, expected {case['expect_token']!r}"
+                )
+            if ref.read_token != case["expect_read_token"]:
+                failures.append(
+                    f"{case['id']}: read_token={ref.read_token!r}, "
+                    f"expected {case['expect_read_token']!r}"
+                )
+        finally:
+            await ref.aclose()
+
+    # -- App-JWT installation-token minting: wins over the plain job token --
+    _reset_token_module_state(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "dummy-key")
+    monkeypatch.setenv("GITHUB_TOKEN", "workflow-tok")
+
+    async def _fake_mint_ok(**_kwargs: Any) -> str:
+        return "minted-installation-tok"
+
+    monkeypatch.setattr(token_mod, "acquire_installation_token", _fake_mint_ok)
+    ref = await resolve_tokens(push="restricted", xrepo=None)
+    try:
+        if ref.git_token != "minted-installation-tok":
+            failures.append(
+                f"minted_token_wins_over_job_token: git_token={ref.git_token!r}, "
+                "expected 'minted-installation-tok'"
+            )
+    finally:
+        await ref.aclose()
+
+    # -- App-JWT minting failure degrades to the job token, not an error ----
+    _reset_token_module_state(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "dummy-key")
+    monkeypatch.setenv("GITHUB_TOKEN", "workflow-tok")
+
+    async def _fake_mint_boom(**_kwargs: Any) -> str:
+        msg = "installation token mint failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(token_mod, "acquire_installation_token", _fake_mint_boom)
+    ref = await resolve_tokens(push="restricted", xrepo=None)
+    try:
+        if ref.git_token != "workflow-tok":
+            failures.append(
+                f"broken_app_credentials_degrade_to_job_token: git_token={ref.git_token!r}, "
+                "expected 'workflow-tok'"
+            )
+    finally:
+        await ref.aclose()
+
+    # -- no token anywhere fails closed, not open ----------------------------
+    _reset_token_module_state(monkeypatch)
+    try:
+        await resolve_tokens(push="restricted", xrepo=None)
+    except ValueError as exc:
+        if "token input is required" not in str(exc):
+            failures.append(f"no_token_error_message_changed: {exc}")
+    else:
+        failures.append("no_token_anywhere: resolve_tokens did not fail closed")
+
+    # -- trust-tier derivation (S4 fail-closed default) ----------------------
+    fork_pr_event = {
+        "action": "opened",
+        "pull_request": {"head": {"sha": "deadbeef", "repo": {"fork": True}}},
+    }
+    same_repo_pr_event = {
+        "action": "opened",
+        "pull_request": {"head": {"sha": "deadbeef", "repo": {"fork": False}}},
+    }
+    trust_cases: list[tuple[str, str | None, dict[str, Any] | None, bool, str]] = [
+        ("offline_flag_forces_trusted_regardless_of_event", None, None, True, "trusted"),
+        ("missing_event_fails_closed_untrusted", "workflow_dispatch", None, False, "untrusted"),
+        (
+            "workflow_dispatch_is_trusted",
+            "workflow_dispatch",
+            {"action": "workflow_dispatch"},
+            False,
+            "trusted",
+        ),
+        (
+            "pull_request_target_is_always_untrusted",
+            "pull_request_target",
+            same_repo_pr_event,
+            False,
+            "untrusted",
+        ),
+        ("fork_pull_request_is_untrusted", "pull_request", fork_pr_event, False, "untrusted"),
+        ("same_repo_pull_request_is_trusted", "pull_request", same_repo_pr_event, False, "trusted"),
+        (
+            "maintainer_issue_comment_is_trusted",
+            "issue_comment",
+            {"comment": {"author_association": "OWNER"}},
+            False,
+            "trusted",
+        ),
+        (
+            "stranger_issue_comment_is_untrusted",
+            "issue_comment",
+            {"comment": {"author_association": "NONE"}},
+            False,
+            "untrusted",
+        ),
+        (
+            "unrecognised_event_name_fails_closed_untrusted",
+            "release",
+            {"action": "published"},
+            False,
+            "untrusted",
+        ),
+    ]
+    for case_id, event_name, event, offline, expected_tier in trust_cases:
+        if event_name is not None:
+            monkeypatch.setenv("GITHUB_EVENT_NAME", event_name)
+        else:
+            monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+        tier = derive_trust_tier(event=event, offline=offline)
+        if tier != expected_tier:
+            failures.append(f"{case_id}: derive_trust_tier -> {tier!r}, expected {expected_tier!r}")
+
+    assert not failures, "\n".join(failures)
+
+
+async def test_execute_agent_preserves_deadline_semantics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """F6 — the run deadline (`asyncio.wait_for`) wraps `_execute_agent`'s coroutine only.
+
+    Setup phases (the trusted-tier `setup_script`, MCP server startup) run
+    to completion regardless of the run timeout; only the agent's own
+    deadline is reduced by the time those earlier phases spent (S1/F6 —
+    "setup must never consume the whole run budget"). Two proofs: (a) a
+    fast agent with a within-budget setup script completes normally with
+    every earlier phase reached, and (b) an agent whose own delay is
+    *shorter* than the configured run timeout still times out once the
+    setup script's elapsed time is deducted from its budget — proof the
+    deduction (not a raw wall-clock cap measured from run start) is what
+    gates the agent specifically.
+    """
+    within_budget_dir = tmp_path / "within-budget"
+    within_budget_dir.mkdir()
+    within_budget = await run_main_for_test(
+        monkeypatch=monkeypatch,
+        tmp_path=within_budget_dir,
+        settings=RepoSettings(setup_script="echo setup", setup_timeout_s=1),
+        event_name="workflow_dispatch",
+        event_payload={"action": "workflow_dispatch"},
+        env={"INPUT_TIMEOUT": "2s"},
+        agent=FakeAgent(delay_s=0.3),
+        setup_script_delay_s=0.2,
+    )
+    assert within_budget.result is not None
+    assert within_budget.result.success, f"run failed: {within_budget.result}"
+    assert within_budget.result.outcome == RunOutcome.passed
+    assert "setup_script" in within_budget.events
+    assert "start_mcp_http_server" in within_budget.events
+
+    # Total timeout 4s; setup consumes ~1.5s, leaving ~2.5s for the agent.
+    # The agent's own delay (3.2s) is *shorter* than the total (4s) but
+    # longer than the deducted remainder (~2.5s) — it only times out
+    # because of the deduction.
+    over_budget_dir = tmp_path / "deducted-over-budget"
+    over_budget_dir.mkdir()
+    over_budget = await run_main_for_test(
+        monkeypatch=monkeypatch,
+        tmp_path=over_budget_dir,
+        settings=RepoSettings(setup_script="echo setup", setup_timeout_s=3),
+        event_name="workflow_dispatch",
+        event_payload={"action": "workflow_dispatch"},
+        env={"INPUT_TIMEOUT": "4s"},
+        agent=FakeAgent(delay_s=3.2),
+        setup_script_delay_s=1.5,
+    )
+    assert over_budget.result is not None
+    assert not over_budget.result.success
+    assert over_budget.result.outcome == RunOutcome.timed_out
+    assert over_budget.raised is None, "the timeout must be caught inside main(), not escape it"
+    # Setup and MCP startup ran to completion — only the agent coroutine
+    # itself was subject to (and cancelled by) the deadline.
+    assert "setup_script" in over_budget.events
+    assert "start_mcp_http_server" in over_budget.events
+
+
+async def test_finalize_runs_on_every_exit_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The nested try/finally guarantees post-run reaches every exit shape.
+
+    Four exit shapes — agent success, agent-reported failure, an
+    `asyncio.wait_for` timeout, and an exception raised after `ToolContext`
+    exists (an unparseable `timeout` input, deferred past `ToolContext`
+    construction precisely so this can happen — see `main.py`'s "S1 review
+    / NEW1" comment) — must all (a) reach the publish block
+    (`persist_learnings` / `report_status_checks` / `emit_run_packet`,
+    proxied here by `report_status_calls`) and (b) run the unconditional
+    `finally` cleanup (`token_ref.aclose()`, `cleanup_temp_directory()`)
+    regardless of which branch produced the exit.
+    """
+    scenarios: dict[str, dict[str, Any]] = {
+        "success": {},
+        "agent_failure": {"agent": FakeAgent(result=AgentResult(success=False, error="blocked"))},
+        "timeout": {"agent": FakeAgent(delay_s=5.0), "env": {"INPUT_TIMEOUT": "1s"}},
+        "exception_with_tool_context": {"env": {"INPUT_TIMEOUT": "not-a-duration"}},
+    }
+    failures: list[str] = []
+    for name, kwargs in scenarios.items():
+        scenario_tmp = tmp_path / name
+        scenario_tmp.mkdir()
+        rec = await run_main_for_test(
+            monkeypatch=monkeypatch, tmp_path=scenario_tmp, cleanup_tmpdir=False, **kwargs
+        )
+        try:
+            if rec.result is None:
+                failures.append(f"{name}: main() raised instead of returning ({rec.raised!r})")
+                continue
+            if not rec.report_status_calls:
+                failures.append(f"{name}: publish block never reached (no status check reported)")
+            if rec.token_ref is None or not rec.token_ref.closed:
+                failures.append(f"{name}: token_ref.aclose() was not called in the finally block")
+            if rec.tmpdir and _isdir(rec.tmpdir):
+                failures.append(
+                    f"{name}: temp dir {rec.tmpdir} survived — cleanup_temp_directory not run"
+                )
+        finally:
+            if rec.tmpdir:
+                _rmtree_if_exists(rec.tmpdir)
+    assert not failures, "\n".join(failures)
+
+
+async def test_main_result_is_unchanged_for_each_run_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every `RunOutcome` member maps to an unchanged `MainResult` shape.
+
+    Six scenarios, one per `RunOutcome` value (`run_outcome.py:22-30`).
+    Pins the *whole* `MainResult` — not just `.outcome` — so a refactor
+    that reorders which phase sets `.output` / `.error` /
+    `.evidence_packet_path` turns this red even when `.outcome` alone still
+    matches.
+    """
+    packet_path = tmp_path / "packet.json"
+    scenarios: dict[str, dict[str, Any]] = {
+        "passed": {},
+        "failed": {
+            "agent": FakeAgent(result=AgentResult(success=False, error="review gate failed"))
+        },
+        "timed_out": {"agent": FakeAgent(delay_s=5.0), "env": {"INPUT_TIMEOUT": "1s"}},
+        "configuration_error": {"env": {"INPUT_TIMEOUT": "not-a-duration"}},
+        "inconclusive": {"prep_failure": "pip install -r requirements.txt failed (exit 1)"},
+        "infra_error": {"agent": FakeAgent(result=RuntimeError("provider API unreachable"))},
+    }
+    # `timed_out` / `configuration_error` (bad timeout) / `infra_error` (an
+    # agent exception) all reach `main()`'s *outer* `except Exception:`
+    # handler (main.py:946), which calls `persist_learnings` +
+    # `report_status_checks` only -- unlike the normal completion path's
+    # publish block (main.py:898-927), it never calls `emit_run_packet`.
+    # `passed` / `failed` / `inconclusive` all return through that normal
+    # completion path instead, where the packet *is* written. Pinned here
+    # exactly as found -- this asymmetry is current behaviour, not
+    # something this wave should silently "fix" by broadening it.
+    exception_path_outcomes = {
+        RunOutcome.timed_out,
+        RunOutcome.configuration_error,
+        RunOutcome.infra_error,
+    }
+    failures: list[str] = []
+    for name, kwargs in scenarios.items():
+        scenario_tmp = tmp_path / f"outcome-{name}"
+        scenario_tmp.mkdir()
+        rec = await run_main_for_test(
+            monkeypatch=monkeypatch, tmp_path=scenario_tmp, packet_path=packet_path, **kwargs
+        )
+        result: MainResult | None = rec.result
+        expected_outcome = RunOutcome(name)
+        if result is None:
+            failures.append(f"{name}: main() raised instead of returning ({rec.raised!r})")
+            continue
+        if result.outcome is not expected_outcome:
+            failures.append(f"{name}: outcome={result.outcome!r}, expected {expected_outcome!r}")
+        expected_success = expected_outcome is RunOutcome.passed
+        if result.success is not expected_success:
+            failures.append(f"{name}: success={result.success!r}, expected {expected_success!r}")
+        if expected_success:
+            if result.error is not None:
+                failures.append(f"{name}: passed run carries error={result.error!r}")
+            if not result.output:
+                failures.append(f"{name}: passed run has empty output")
+            if result.result != result.output:
+                failures.append(
+                    f"{name}: result field {result.result!r} != output {result.output!r}"
+                )
+        else:
+            if not result.error:
+                failures.append(f"{name}: non-passed run has no error message")
+        expected_packet_path = (
+            None if expected_outcome in exception_path_outcomes else str(packet_path)
+        )
+        if result.evidence_packet_path != expected_packet_path:
+            failures.append(
+                f"{name}: evidence_packet_path={result.evidence_packet_path!r}, "
+                f"expected {expected_packet_path!r}"
+            )
+    assert not failures, "\n".join(failures)

--- a/tests/utils/test_privilege.py
+++ b/tests/utils/test_privilege.py
@@ -11,6 +11,7 @@ import pytest
 import mergecraft.utils.privilege as privilege
 from mergecraft.agents.shared import wrap_agent_subprocess
 from mergecraft.utils.privilege import (
+    agent_subprocess_env,
     agent_user_name,
     prepare_workspace_for_agent,
     wrap_agent_command,
@@ -157,3 +158,152 @@ def test_prepare_workspace_for_agent_chowns_when_root(
     assert calls[0][1] == "-R"
     assert calls[0][2] == "1001:1001"
     assert calls[0][3] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# agent_subprocess_env — HOME/USER/LOGNAME redirect (live-bug fix)
+# ---------------------------------------------------------------------------
+
+
+class _PwWithHome:
+    """Stand-in ``pwd.struct_passwd`` carrying the fields ``agent_subprocess_env`` reads."""
+
+    def __init__(
+        self,
+        name: str = "mergecraft",
+        uid: int = 1001,
+        gid: int = 1001,
+        home: str = "/home/mergecraft",
+    ) -> None:
+        self.pw_name = name
+        self.pw_uid = uid
+        self.pw_gid = gid
+        self.pw_dir = home
+
+
+def _install_fake_pwd(monkeypatch: MonkeyPatch, entry: _PwWithHome) -> None:
+    import sys
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = entry
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+
+
+def test_agent_subprocess_env_noop_when_not_root(monkeypatch: MonkeyPatch) -> None:
+    """Direct ``agent_subprocess_env`` — non-root hosts get an unchanged copy back."""
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 501)
+    env = {"HOME": "/github/home", "PATH": "/usr/bin"}
+    out = agent_subprocess_env(env)
+    assert out == env
+    assert out is not env, "must return a copy, never the same dict object"
+
+
+def test_agent_subprocess_env_redirects_inherited_home_when_root(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Root + HOME not owned by the agent uid → HOME/USER/LOGNAME are redirected.
+
+    This is the live bug: the container sets ``HOME=/github/home`` (owned by
+    the runner's original uid), setpriv drops uid/gid but not HOME, and the
+    agent CLI then hits EACCES trying to write dotfiles under it.
+    """
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+    _install_fake_pwd(monkeypatch, _PwWithHome())
+    # /github/home is not owned by uid 1001 in this scenario.
+    monkeypatch.setattr(privilege.os, "stat", lambda _path: MagicMock(st_uid=0))
+
+    env = {"HOME": "/github/home", "USER": "root", "LOGNAME": "root", "PATH": "/usr/bin"}
+    out = agent_subprocess_env(env)
+
+    assert out["HOME"] == "/home/mergecraft"
+    assert out["USER"] == "mergecraft"
+    assert out["LOGNAME"] == "mergecraft"
+    assert out["PATH"] == "/usr/bin", "unrelated keys must pass through untouched"
+    assert env["HOME"] == "/github/home", "input dict must not be mutated"
+
+
+def test_agent_subprocess_env_preserves_home_already_owned_by_agent_user(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A HOME the driver already pointed at a pre-chowned scratch dir is left alone.
+
+    Gemini's driver sets ``HOME`` to its own per-run tmpdir (already chowned
+    to the agent user by ``git_setup._prepare_temp_dir_for_agent`` so its MCP
+    settings.json is discoverable there) — ``agent_subprocess_env`` must not
+    clobber that back to the passwd home directory, or Gemini's MCP config
+    silently stops resolving under the privilege drop.
+    """
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+    entry = _PwWithHome()
+    _install_fake_pwd(monkeypatch, entry)
+    # The driver-chosen HOME is already owned by the resolved agent uid.
+    monkeypatch.setattr(privilege.os, "stat", lambda _path: MagicMock(st_uid=entry.pw_uid))
+
+    env = {"HOME": "/tmp/mergecraft-xyz", "PATH": "/usr/bin"}
+    out = agent_subprocess_env(env)
+
+    assert out["HOME"] == "/tmp/mergecraft-xyz", "already-owned HOME must survive untouched"
+    assert out["USER"] == "mergecraft"
+    assert out["LOGNAME"] == "mergecraft"
+
+
+def test_agent_subprocess_env_fills_missing_home(monkeypatch: MonkeyPatch) -> None:
+    """No ``HOME`` key at all → still filled in with the agent user's real home."""
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+    _install_fake_pwd(monkeypatch, _PwWithHome())
+
+    out = agent_subprocess_env({"PATH": "/usr/bin"})
+
+    assert out["HOME"] == "/home/mergecraft"
+
+
+def test_agent_subprocess_env_missing_user_fails_closed(monkeypatch: MonkeyPatch) -> None:
+    """Same fail-closed contract as ``wrap_agent_command`` — missing agent user raises."""
+    from mergecraft.main import _ConfigurationError
+
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+
+    import sys
+
+    fake_pwd = MagicMock()
+
+    def _raise_keyerror(_name: str) -> None:
+        raise KeyError(_name)
+
+    fake_pwd.getpwnam.side_effect = _raise_keyerror
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+
+    with pytest.raises(_ConfigurationError, match="mergecraft"):
+        agent_subprocess_env({"HOME": "/github/home"})
+
+
+def test_agent_subprocess_env_uid_zero_fails_closed(monkeypatch: MonkeyPatch) -> None:
+    """Same fail-closed contract — a user resolving to UID/GID 0 raises, not redirects."""
+    from mergecraft.main import _ConfigurationError
+
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+    _install_fake_pwd(monkeypatch, _PwWithHome(uid=0, gid=0))
+
+    with pytest.raises(_ConfigurationError, match="uid=0"):
+        agent_subprocess_env({"HOME": "/github/home"})
+
+
+def test_agent_subprocess_env_custom_agent_user_via_env(monkeypatch: MonkeyPatch) -> None:
+    """``MERGECRAFT_AGENT_USER`` drives which pwd entry is resolved, same as ``wrap_agent_command``."""
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "reviewer")
+    _install_fake_pwd(
+        monkeypatch, _PwWithHome(name="reviewer", uid=1002, gid=1002, home="/home/reviewer")
+    )
+    monkeypatch.setattr(privilege.os, "stat", lambda _path: MagicMock(st_uid=0))
+
+    out = agent_subprocess_env({"HOME": "/github/home"})
+
+    assert out["HOME"] == "/home/reviewer"
+    assert out["USER"] == "reviewer"
+    assert out["LOGNAME"] == "reviewer"


### PR DESCRIPTION
## What?

Brings main up to the current pre-0.0.1 tip: 7 commits since the last sync (#188).

## Why?

Same driver as #178/#188: pull_request_target resolves .github/workflows/mergecraft.yml (and its pinned action SHA) from main. #190 landed on pre-0.0.1 since #188:

- #190: fixes a live, confirmed-in-production bug where the setpriv privilege drop (src/mergecraft/utils/privilege.py) never redirected `$HOME` after dropping to the unprivileged `mergecraft` user. GitHub's container `HOME=/github/home` is owned by the runner's original uid, not the dropped-to user, so every agent CLI that writes dotfiles on startup (opencode, Codex) failed with EACCES/permission-denied -- breaking every self-review run today (confirmed on #174/#175/#189/#190 itself) and, by the same mechanism, every real consumer's actual PR reviews since around when the S2 privilege-drop hardening originally landed.
- Also carries G4 (main()/analyzer complexity refactor, #176) fully into main's history for the first time (previously only reachable via pre-0.0.1).

## Note

- Merge commit, matching the #152/#81/#55/#32/#178/#188 pattern.
- This is expected to be the last self-review-blocking fix in today's chain (stale pin -> git-tool bug -> action.yml load bug -> this HOME bug). Unblocks #175 and #189's mergecraft-approval gate, which have been failing on the exact same EACCES signature.

## Test plan

- `make ci-resume` green on pre-0.0.1 at every commit in this range (verified per-PR, including #190's own manual security review since self-review cannot validate the fix that unblocks self-review).
- Post-merge: re-run #175/#189's mergecraft review job and confirm a real verdict (not a crash) is posted.

## Related PR(s)/Issue(s)

Unblocks #175/#189's mergecraft-approval gate.