### PR TITLE
fix(ci): stop pre-0.0.1 from racing main for the :latest / :analyzers tags

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -345,19 +345,43 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # :latest / :analyzers are the production mutable tags — main only. A
+      # pre-release branch build must never win that race against main's own
+      # build just by finishing later (both had independent per-ref
+      # concurrency groups and no ordering guarantee between them). Actual
+      # version releases retag :latest separately via Craft (.craft.yml,
+      # triggered off refs/tags/v*), which is a distinct promotion path, not
+      # this branch-push one.
       - name: Retag slim digest → :latest
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1'
+        if: github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
           docker buildx imagetools create \
             --tag "${IMAGE_SLIM}:latest" \
             "${IMAGE_SLIM}@${{ needs.build-images.outputs.slim_digest }}"
       - name: Retag analyzers digest → :analyzers
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1'
+        if: github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
           docker buildx imagetools create \
             --tag "${IMAGE_ANALYZERS}:analyzers" \
+            "${IMAGE_ANALYZERS}@${{ needs.build-images.outputs.analyzers_digest }}"
+      # pre-0.0.1 (the active pre-release/staging branch) gets its own mutable
+      # channel instead, so pre-release testers have a moving tag to pull
+      # without ever touching the production :latest / :analyzers.
+      - name: Retag slim digest → :rc
+        if: github.ref == 'refs/heads/pre-0.0.1'
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_SLIM}:rc" \
+            "${IMAGE_SLIM}@${{ needs.build-images.outputs.slim_digest }}"
+      - name: Retag analyzers digest → :analyzers-rc
+        if: github.ref == 'refs/heads/pre-0.0.1'
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_ANALYZERS}:analyzers-rc" \
             "${IMAGE_ANALYZERS}@${{ needs.build-images.outputs.analyzers_digest }}"
       - name: Record digests for Craft SHA→version retag
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,21 @@
 # SPDX-License-Identifier: MIT
 name: Docker
 
-# Advisory/manual only on PRs (catalog F.2). Post-merge publish runs via CI/CD + workflow_dispatch.
+# Build-and-smoke-test only — NEVER pushes to the registry, on any trigger.
+# ci-cd.yml is the sole publisher of both the canonical SHA tag and every
+# mutable/channel tag (:latest, :analyzers, :rc, :analyzers-rc). This
+# workflow used to also push on `push` events; that was removed (PR #201
+# review) because docker/build-push-action's buildx provenance means two
+# independent builds of the same commit are NOT guaranteed to produce the
+# same digest, so a late push here could overwrite ci-cd.yml's SHA tag
+# in-place between its build-images and sbom-scan/sign-attest jobs — those
+# pull the SHA tag BY NAME, not by the digest build-images actually
+# captured, so the wrong image could get scanned/signed/promoted. Two
+# concurrency groups with no ordering guarantee between them (docker-*-<ref>
+# vs ci-cd-*-<ref>) means "harmless because same commit" does not hold.
+# See tests/ci/test_trivy_scan_gate.py::test_docker_yml_never_pushes_a_mutable_tag
+# for the (deliberately narrower) mutable-tag half of this contract; ci-cd.yml
+# remains the only workflow with `packages: write` at all.
 on:
   push:
     branches: [main, pre-0.0.1]
@@ -17,7 +31,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
@@ -31,65 +44,29 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Resolve slim image tags
-        id: slim-tags
-        # Never a mutable/channel tag (:latest, :rc, …) here — ci-cd.yml's
-        # promote job is the sole owner of those (build once → SBOM → scan →
-        # sign → attest → promote). This step only pushes the immutable SHA
-        # tag, which ci-cd.yml's own build-images job also pushes with
-        # identical content — redundant but harmless, unlike a mutable tag
-        # duplicated across two unsynchronized pipelines.
-        run: |
-          {
-            echo 'tags<<EOF'
-            echo "ghcr.io/alexhawat/mergecraft:${GITHUB_SHA}"
-            if [ "${{ github.event_name }}" != "push" ]; then
-              echo 'mergecraft:ci'
-            fi
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
       - name: Build slim
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
-          push: ${{ github.event_name == 'push' }}
-          load: ${{ github.event_name != 'push' }}
-          tags: ${{ steps.slim-tags.outputs.tags }}
+          push: false
+          load: true
+          tags: mergecraft:ci
           cache-from: type=gha,scope=mergeCraft-slim
           cache-to: type=gha,mode=max,scope=mergeCraft-slim
-      - name: Resolve analyzers image tags
-        id: analyzers-tags
-        # Same "SHA tag only, no mutable channel" rule as the slim tags above.
-        run: |
-          {
-            echo 'tags<<EOF'
-            echo "ghcr.io/alexhawat/mergecraft:analyzers-${GITHUB_SHA}"
-            if [ "${{ github.event_name }}" != "push" ]; then
-              echo 'mergecraft-analyzers:ci'
-            fi
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
       - name: Build analyzers
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.analyzers
-          push: ${{ github.event_name == 'push' }}
-          load: ${{ github.event_name != 'push' }}
-          tags: ${{ steps.analyzers-tags.outputs.tags }}
+          push: false
+          load: true
+          tags: mergecraft-analyzers:ci
           cache-from: type=gha,scope=mergeCraft-analyzers
           cache-to: type=gha,mode=max,scope=mergeCraft-analyzers
       - name: Entrypoint smoke (slim)
-        if: github.event_name != 'push'
         run: docker run --rm mergecraft:ci --help
       - name: Entrypoint smoke (analyzers)
-        if: github.event_name != 'push'
         run: |
           docker run --rm mergecraft-analyzers:ci --help
           docker run --rm --entrypoint /bin/sh mergecraft-analyzers:ci -c "which actionlint zizmor shellcheck hadolint"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,10 +38,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve slim image tags
         id: slim-tags
+        # :latest is the production mutable tag — main only. pre-0.0.1 (the
+        # active pre-release/staging branch) gets :rc instead, so this build
+        # can never win a same-tag race against main's own build just by
+        # finishing later — mirrors ci-cd.yml's promote job, which is the
+        # authoritative signed/scanned publish path for the same two tags.
         run: |
           {
             echo 'tags<<EOF'
-            echo 'ghcr.io/alexhawat/mergecraft:latest'
+            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+              echo 'ghcr.io/alexhawat/mergecraft:latest'
+            elif [ "${GITHUB_REF}" = "refs/heads/pre-0.0.1" ]; then
+              echo 'ghcr.io/alexhawat/mergecraft:rc'
+            fi
             echo "ghcr.io/alexhawat/mergecraft:${GITHUB_SHA}"
             if [ "${{ github.event_name }}" != "push" ]; then
               echo 'mergecraft:ci'
@@ -60,10 +69,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=mergeCraft-slim
       - name: Resolve analyzers image tags
         id: analyzers-tags
+        # Same main-vs-pre-0.0.1 channel split as the slim tags above.
         run: |
           {
             echo 'tags<<EOF'
-            echo 'ghcr.io/alexhawat/mergecraft:analyzers'
+            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+              echo 'ghcr.io/alexhawat/mergecraft:analyzers'
+            elif [ "${GITHUB_REF}" = "refs/heads/pre-0.0.1" ]; then
+              echo 'ghcr.io/alexhawat/mergecraft:analyzers-rc'
+            fi
             echo "ghcr.io/alexhawat/mergecraft:analyzers-${GITHUB_SHA}"
             if [ "${{ github.event_name }}" != "push" ]; then
               echo 'mergecraft-analyzers:ci'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,9 +13,8 @@ name: Docker
 # captured, so the wrong image could get scanned/signed/promoted. Two
 # concurrency groups with no ordering guarantee between them (docker-*-<ref>
 # vs ci-cd-*-<ref>) means "harmless because same commit" does not hold.
-# See tests/ci/test_trivy_scan_gate.py::test_docker_yml_never_pushes_a_mutable_tag
-# for the (deliberately narrower) mutable-tag half of this contract; ci-cd.yml
-# remains the only workflow with `packages: write` at all.
+# Enforced by tests/ci/test_trivy_scan_gate.py::test_docker_yml_never_pushes_to_the_registry;
+# ci-cd.yml remains the only workflow with `packages: write` at all.
 on:
   push:
     branches: [main, pre-0.0.1]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,19 +38,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve slim image tags
         id: slim-tags
-        # :latest is the production mutable tag — main only. pre-0.0.1 (the
-        # active pre-release/staging branch) gets :rc instead, so this build
-        # can never win a same-tag race against main's own build just by
-        # finishing later — mirrors ci-cd.yml's promote job, which is the
-        # authoritative signed/scanned publish path for the same two tags.
+        # Never a mutable/channel tag (:latest, :rc, …) here — ci-cd.yml's
+        # promote job is the sole owner of those (build once → SBOM → scan →
+        # sign → attest → promote). This step only pushes the immutable SHA
+        # tag, which ci-cd.yml's own build-images job also pushes with
+        # identical content — redundant but harmless, unlike a mutable tag
+        # duplicated across two unsynchronized pipelines.
         run: |
           {
             echo 'tags<<EOF'
-            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              echo 'ghcr.io/alexhawat/mergecraft:latest'
-            elif [ "${GITHUB_REF}" = "refs/heads/pre-0.0.1" ]; then
-              echo 'ghcr.io/alexhawat/mergecraft:rc'
-            fi
             echo "ghcr.io/alexhawat/mergecraft:${GITHUB_SHA}"
             if [ "${{ github.event_name }}" != "push" ]; then
               echo 'mergecraft:ci'
@@ -69,15 +65,10 @@ jobs:
           cache-to: type=gha,mode=max,scope=mergeCraft-slim
       - name: Resolve analyzers image tags
         id: analyzers-tags
-        # Same main-vs-pre-0.0.1 channel split as the slim tags above.
+        # Same "SHA tag only, no mutable channel" rule as the slim tags above.
         run: |
           {
             echo 'tags<<EOF'
-            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              echo 'ghcr.io/alexhawat/mergecraft:analyzers'
-            elif [ "${GITHUB_REF}" = "refs/heads/pre-0.0.1" ]; then
-              echo 'ghcr.io/alexhawat/mergecraft:analyzers-rc'
-            fi
             echo "ghcr.io/alexhawat/mergecraft:analyzers-${GITHUB_SHA}"
             if [ "${{ github.event_name }}" != "push" ]; then
               echo 'mergecraft-analyzers:ci'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,10 @@ Add repository secrets for Craft publish: `TWINE_USERNAME`, `TWINE_PASSWORD`.
      `release/**` and `v*` tags); uploads `image-scan-reports`
    - cosign keyless-signs both digests and attaches build-provenance + SBOM
      attestations
-   - on `main` / `pre-0.0.1`, promotes `:latest` / `:analyzers` by **retagging
-     the same digests** (no second rebuild)
+   - on `main`, promotes `:latest` / `:analyzers` by **retagging the same
+     digests** (no second rebuild); on `pre-0.0.1`, promotes to `:rc` /
+     `:analyzers-rc` instead, so a pre-release build can never win the
+     `:latest` / `:analyzers` tags just by finishing later
 
 **Release preconditions** (must be green or an explicit documented skip before
 `craft publish`):

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -1,8 +1,9 @@
 # Supply chain — image scans and vulnerability waivers
 
 mergeCraft publishes container images from [`.github/workflows/ci-cd.yml`](../.github/workflows/ci-cd.yml).
-The `sbom-scan` job runs Trivy on every digest that can be promoted to `:latest` or
-`:analyzers`, and **HIGH/CRITICAL findings block the pipeline** unless explicitly waived.
+The `sbom-scan` job runs Trivy on every digest that can be promoted to `:latest` /
+`:analyzers` (main) or `:rc` / `:analyzers-rc` (pre-0.0.1), and **HIGH/CRITICAL
+findings block the pipeline** unless explicitly waived.
 
 This policy is part of the [0.0.1 distribution checklist](https://github.com/alexhawat/mergeCraft/issues/141).
 

--- a/tests/ci/test_trivy_scan_gate.py
+++ b/tests/ci/test_trivy_scan_gate.py
@@ -75,40 +75,32 @@ def test_promote_latest_channel_is_main_only() -> None:
     assert "refs/heads/main" not in analyzers_rc
 
 
-def _docker_tag_script(step_name: str) -> str:
-    content = read_text(".github/workflows/docker.yml")
-    match = re.search(
-        rf"name:\s*{re.escape(step_name)}.*?run:\s*\|\s*\n(?P<script>.*?)(?:\n      - name:|\Z)",
-        content,
-        re.DOTALL,
-    )
-    assert match is not None, f"{step_name!r} step not found in docker.yml"
-    return match.group("script")
+def test_docker_yml_never_pushes_to_the_registry() -> None:
+    """PR #201 follow-up (finding 6736461a / 661a2231) — docker.yml must be a
+    pure build-and-smoke-test workflow, never a second registry writer, on
+    any trigger.
 
-
-def test_docker_yml_never_pushes_a_mutable_tag() -> None:
-    """PR #201 follow-up — ci-cd.yml's promote job is the sole owner of every
-    mutable/channel tag (:latest, :analyzers, :rc, :analyzers-rc). docker.yml
-    is a second, unsynchronized pipeline; it may only push the immutable SHA
-    tag, never duplicate a moving one alongside ci-cd.yml's promote job.
+    ci-cd.yml's build-images/promote jobs are the sole publishers of the
+    canonical SHA tag and every mutable/channel tag. docker/build-push-action
+    adds buildx provenance by default, so two independent builds of the same
+    commit are not guaranteed the same digest — a second pusher here could
+    silently replace the SHA tag ci-cd.yml's sbom-scan/sign-attest jobs pull
+    BY NAME (not by the digest build-images actually captured), between two
+    workflows with no ordering guarantee (separate concurrency groups).
     """
-    for step_name, mutable_tags in (
-        (
-            "Resolve slim image tags",
-            ("ghcr.io/alexhawat/mergecraft:latest", "ghcr.io/alexhawat/mergecraft:rc"),
-        ),
-        (
-            "Resolve analyzers image tags",
-            (
-                "ghcr.io/alexhawat/mergecraft:analyzers'",
-                "ghcr.io/alexhawat/mergecraft:analyzers-rc",
-            ),
-        ),
-    ):
-        script = _docker_tag_script(step_name)
-        for tag in mutable_tags:
-            assert tag not in script, f"{step_name!r} still pushes mutable tag {tag!r}"
-        assert "${GITHUB_SHA}" in script, f"{step_name!r} lost its SHA tag"
+    doc = load_workflow("docker.yml")
+    permissions = doc.get("permissions") or {}
+    assert "packages" not in permissions, (
+        "docker.yml must not declare packages: write — it never pushes"
+    )
+
+    build = job(doc, "build")
+    for step_name in ("Build slim", "Build analyzers"):
+        step = _step(build, step_name)
+        with_block = step.get("with") or {}
+        assert with_block.get("push") is False, f"{step_name!r} must set push: false"
+        tags = str(with_block.get("tags", ""))
+        assert "ghcr.io" not in tags, f"{step_name!r} still tags for the registry: {tags!r}"
 
 
 def test_scan_gate_blocks_every_ref_that_can_publish() -> None:

--- a/tests/ci/test_trivy_scan_gate.py
+++ b/tests/ci/test_trivy_scan_gate.py
@@ -26,12 +26,89 @@ def _scan_gate_script() -> str:
     return match.group("script")
 
 
+def _step(job_dict: dict[str, Any], name: str) -> dict[str, Any]:
+    for step in job_dict.get("steps", []):
+        if step.get("name") == name:
+            return step
+    names = [step.get("name") for step in job_dict.get("steps", [])]
+    raise AssertionError(f"step {name!r} not found; have {names}")
+
+
 def test_promote_still_fires_on_main_and_pre_001() -> None:
-    """D6 — do not strip ``:latest`` from main/pre-0.0.1; tighten the scan instead."""
+    """D6 — the promote JOB (build → SBOM → scan → sign → attest) still runs
+    for both main and pre-0.0.1, so the scan gate stays blocking on both —
+    tighten which mutable TAG each branch gets instead (see
+    test_promote_latest_channel_is_main_only), not whether the job fires.
+    """
     promote = job(load_workflow("ci-cd.yml"), "promote")
     condition = str(promote.get("if", ""))
     assert "refs/heads/main" in condition
     assert "refs/heads/pre-0.0.1" in condition
+
+
+def test_promote_latest_channel_is_main_only() -> None:
+    """PR #201 — :latest/:analyzers must never come from pre-0.0.1.
+
+    Two unsynchronized pipelines (main's and pre-0.0.1's) racing for the same
+    mutable tag meant whichever finished last silently became the public
+    production image. pre-0.0.1 gets its own :rc / :analyzers-rc channel
+    instead — this pins that split so a regression that re-adds pre-0.0.1 to
+    the :latest/:analyzers steps (or drops it from the :rc/:analyzers-rc
+    steps) fails loudly.
+    """
+    promote = job(load_workflow("ci-cd.yml"), "promote")
+
+    latest = str(_step(promote, "Retag slim digest → :latest").get("if", ""))
+    assert "refs/heads/main" in latest
+    assert "refs/heads/pre-0.0.1" not in latest
+
+    analyzers = str(_step(promote, "Retag analyzers digest → :analyzers").get("if", ""))
+    assert "refs/heads/main" in analyzers
+    assert "refs/heads/pre-0.0.1" not in analyzers
+
+    rc = str(_step(promote, "Retag slim digest → :rc").get("if", ""))
+    assert "refs/heads/pre-0.0.1" in rc
+    assert "refs/heads/main" not in rc
+
+    analyzers_rc = str(_step(promote, "Retag analyzers digest → :analyzers-rc").get("if", ""))
+    assert "refs/heads/pre-0.0.1" in analyzers_rc
+    assert "refs/heads/main" not in analyzers_rc
+
+
+def _docker_tag_script(step_name: str) -> str:
+    content = read_text(".github/workflows/docker.yml")
+    match = re.search(
+        rf"name:\s*{re.escape(step_name)}.*?run:\s*\|\s*\n(?P<script>.*?)(?:\n      - name:|\Z)",
+        content,
+        re.DOTALL,
+    )
+    assert match is not None, f"{step_name!r} step not found in docker.yml"
+    return match.group("script")
+
+
+def test_docker_yml_never_pushes_a_mutable_tag() -> None:
+    """PR #201 follow-up — ci-cd.yml's promote job is the sole owner of every
+    mutable/channel tag (:latest, :analyzers, :rc, :analyzers-rc). docker.yml
+    is a second, unsynchronized pipeline; it may only push the immutable SHA
+    tag, never duplicate a moving one alongside ci-cd.yml's promote job.
+    """
+    for step_name, mutable_tags in (
+        (
+            "Resolve slim image tags",
+            ("ghcr.io/alexhawat/mergecraft:latest", "ghcr.io/alexhawat/mergecraft:rc"),
+        ),
+        (
+            "Resolve analyzers image tags",
+            (
+                "ghcr.io/alexhawat/mergecraft:analyzers'",
+                "ghcr.io/alexhawat/mergecraft:analyzers-rc",
+            ),
+        ),
+    ):
+        script = _docker_tag_script(step_name)
+        for tag in mutable_tags:
+            assert tag not in script, f"{step_name!r} still pushes mutable tag {tag!r}"
+        assert "${GITHUB_SHA}" in script, f"{step_name!r} lost its SHA tag"
 
 
 def test_scan_gate_blocks_every_ref_that_can_publish() -> None:


### PR DESCRIPTION
## Summary
- `ci-cd.yml`'s `promote` job and `docker.yml` both retagged/pushed `:latest` and `:analyzers` on every push to **either** `main` or `pre-0.0.1`, each in its own per-ref concurrency group with no ordering guarantee between the two branches' pipelines. Whichever finished last silently became the public production image — a pre-release branch build could clobber `main`'s image.
- `ci-cd.yml`'s `promote` job now restricts `:latest` / `:analyzers` to `main` only (version releases via `refs/tags/v*` still get `:latest` separately through Craft, unaffected). `pre-0.0.1` now promotes to its own `:rc` / `:analyzers-rc` channel instead.
- `docker.yml` is now genuinely smoke-only — `push: false` unconditionally, on every trigger. It no longer pushes any tag, mutable or immutable, to the registry. `ci-cd.yml` is the sole publisher of the canonical SHA tag and every mutable/channel tag, closing a subtler race the review caught: buildx provenance means two independent builds of the same commit aren't guaranteed the same digest, so a second pusher here could have silently replaced ci-cd.yml's SHA tag between its `build-images` job (which captures a specific digest) and its `sbom-scan`/`sign-attest` jobs (which pull that tag *by name*).
- Regression tests added/updated in `tests/ci/test_trivy_scan_gate.py`: `test_promote_latest_channel_is_main_only`, `test_docker_yml_never_pushes_to_the_registry`, and a stale docstring fix on the pre-existing `test_promote_still_fires_on_main_and_pre_001`.
- Fixed two stale doc references (`CONTRIBUTING.md`, `docs/supply-chain.md`) that still described `pre-0.0.1` as promoting `:latest`/`:analyzers`.

## Test plan
- [x] `actionlint` clean on both workflow files
- [x] `zizmor` clean at High/Medium (0 high; medium count unchanged from baseline)
- [x] YAML parses
- [x] `tests/ci` suite green (148 passed)
- [x] `ruff check` / `ruff format --check` clean
- [ ] Watch the next `main` push and the next `pre-0.0.1` push confirm `:latest`/`:analyzers` and `:rc`/`:analyzers-rc` land correctly, and that `docker.yml`'s run never touches the registry (can't fully verify without a live push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)