### PR TITLE
chore: ignore /.agents and track skills-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ tests/analyzers/fixtures/repo/.mergecraft/
 !/.mergecraft/learnings.md
 !/.mergecraft/xrepo-learnings.md
 !/.mergecraft/xrepo-brief.md
+
+/.agents

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "skills": {
+    "building-pydantic-ai-agents": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/building-pydantic-ai-agents/SKILL.md",
+      "computedHash": "102cbcc4b4a548464814b65c44e1bd7170ff2188d07ec830544560d54133e6e6"
+    },
+    "logfire-instrumentation": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-instrumentation/SKILL.md",
+      "computedHash": "cebf8a4a963c9d3d5c2422bd11a3ea7370e5d7c3ee67aac1443a8b90c42eec1f"
+    },
+    "logfire-query": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-query/SKILL.md",
+      "computedHash": "51ddcfa6016440895c54cb34b43b9ade73e000c0a14e092a2524b4e844cc3397"
+    },
+    "logfire-ui": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-ui/SKILL.md",
+      "computedHash": "ec9ad81fb607e771b6e21eedae39af01985fc902f8bac03b51f669ad0ddb3f97"
+    },
+    "pydantic": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/pydantic/SKILL.md",
+      "computedHash": "2f523749fc2edc5cb3b73435a282373cd69209682be7992b6cde333f30d59254"
+    },
+    "pydantic-ai-harness": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/pydantic-ai-harness/SKILL.md",
+      "computedHash": "24ebd64439b138bb1f7c0fa466d0a64a9d99d36108a670673c9c75c455f9ce8d"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `/.agents` to `.gitignore` so the local machine-scoped skill cache stays out of version control.
- Track `skills-lock.json` so the set of installed skills is reproducible across clones, while leaving the cached bodies themselves off the repo.

## Why

The `.agents/` tree is operator-only state that mirrors the local skill cache used by the agent harness — it has no place in source. `skills-lock.json` is the index/lockfile for that cache; tracking it (without the bodies) keeps the set of installed skills reproducible without bloating the repo.

## Test plan

- [ ] `git status` on `pre-0.0.1` is clean after a fetch + reset.
- [ ] `.agents/` does not appear in `git ls-files` and is hidden by `git status`.
- [ ] `skills-lock.json` is present in the diff.