### PR TITLE
release: sync pre-0.0.1 to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
 # Every path requires review from the owner before merge.
 # The ruleset "protect-main" enforces code-owner review on the default branch.
-* @alexhawat
+# sevn-one is the distinct GitHub identity mergeCraft's own self-review job
+# authenticates as (fix/reviewer-identity) — the default github.token cannot
+# submit an "Approve" review (GitHub platform restriction), so a genuinely
+# separate account is required for a clean self-review to satisfy
+# required_approving_review_count with require_code_owner_review intact.
+* @alexhawat @sevn-one

--- a/.github/workflows/mergecraft-approve.yml
+++ b/.github/workflows/mergecraft-approve.yml
@@ -1,0 +1,110 @@
+# mergeCraft self-review — privileged same-repo approval (D14 gate 3, PR #200).
+#
+# Companion to mergecraft.yml. That workflow's own reviewing agent can never
+# submit a real GitHub APPROVE under pull_request_target: derive_trust_tier()
+# (src/mergecraft/analyzers/trust.py) hardcodes pull_request_target to
+# "untrusted" unconditionally, regardless of fork status, by design (D14) —
+# because the agent reads PR-authored content as part of reviewing it, so its
+# own approved:true output can never be trusted as the thing that unlocks a
+# real approval, same-repo PR or not.
+#
+# This workflow is a SEPARATE, privileged path that never re-reads PR content
+# and never re-invokes the agent. It only reads the mergecraft-approval
+# check-run mergecraft.yml already posted — which decide_approval()
+# (src/mergecraft/agents/gates.py) computes as a pure function of Finding
+# severities (W7.1/W7.2 of docs/dev/test-plans/security-structural-approval.md),
+# immune to whatever the agent's own narrative says — and, only when that
+# conclusion is "success", submits a PAT-backed APPROVE as @sevn-one (the
+# distinct CODEOWNER identity from PR #196/#200; the default GITHUB_TOKEN is
+# silently downgraded to a comment on any approve attempt, a GitHub platform
+# restriction unrelated to PR authorship).
+#
+# Why workflow_run instead of a step inside mergecraft.yml's own
+# pull_request_target job: a `workflow_run` trigger's definition is ALWAYS read
+# from the repository default branch (even more unconditionally than
+# pull_request_target's Nov-2025-policy guarantee) and runs on its own runner
+# with no PR checkout at all — real privilege separation from whatever the
+# reviewing agent touched, not just "same trigger type, different job".
+# `workflow_run.pull_requests` is documented to be empty for fork PRs, so this
+# workflow naturally never fires for them without any manual fork check.
+#
+# 2026-08-14: an earlier version of this fix added a `pull_request` trigger to
+# mergecraft.yml itself to earn a "trusted" tier for same-repo PRs. That got a
+# same-day CHANGES_REQUESTED revert on PR #200: `pull_request` resolves the
+# workflow *definition* from the PR's own branch, so it would have handed
+# MERGECRAFT_REVIEWER_PAT, provider credentials, OIDC, and a write-scoped token
+# to PR-controlled code. See the "bootstrap pull_request trigger" comment near
+# the top of mergecraft.yml. Do not reintroduce that shape here either — this
+# file must stay workflow_run-only.
+name: mergecraft-approve
+
+on:
+  workflow_run:
+    workflows: [mergecraft]
+    types: [completed]
+
+permissions:
+  contents: read
+  checks: read
+
+jobs:
+  approve:
+    name: mergecraft privileged approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # workflow_run.pull_requests is populated only for same-repo PRs (empty for
+    # forks) — this is the fork exclusion, not a manual repo-name comparison.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request_target' &&
+      github.event.workflow_run.pull_requests[0] != null
+    steps:
+      - name: Check the structural mergecraft-approval verdict
+        id: verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          conclusion=""; queried=""
+          for attempt in $(seq 1 3); do
+            if conclusion="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+              | sort_by(.completed_at // .started_at) | last | .conclusion // ""')"; then
+              queried="yes"; break
+            fi
+            echo "check-runs query failed (attempt ${attempt}/3); retrying in 3s…" >&2
+            sleep 3
+          done
+          if [ -z "${queried}" ]; then
+            echo "check-runs API unreachable after retries — not approving." >&2
+            echo "conclusion=" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "mergecraft-approval conclusion for ${HEAD_SHA}: ${conclusion:-none}"
+          echo "conclusion=${conclusion}" >> "${GITHUB_OUTPUT}"
+
+      - name: Submit privileged APPROVE
+        if: steps.verdict.outputs.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.MERGECRAFT_REVIEWER_PAT }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "MERGECRAFT_REVIEWER_PAT not configured — nothing to submit with."
+            exit 0
+          fi
+          # commit_id pins the review to the exact reviewed SHA — GitHub rejects
+          # the call if the PR has since moved to a new head, so a stale verdict
+          # can never approve a commit it never actually saw.
+          gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            -X POST \
+            -f event=APPROVE \
+            -f commit_id="${HEAD_SHA}" \
+            -f body="Approved by mergeCraft (@sevn-one) — clean structural verdict on ${HEAD_SHA}." \
+            >/dev/null
+          echo "Submitted PAT-backed APPROVE for PR #${PR_NUMBER} @ ${HEAD_SHA}."

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -57,8 +57,10 @@
 # NOUS_API_KEY the primary is inert and Codex is the only reviewer; without
 # CODEX_AUTH_JSON / OPENAI_API_KEY, Nous is the only reviewer.
 #
-# Trigger: pull_request_target (not pull_request). GitHub skips pull_request
-# workflows when refs/pull/N/merge cannot be built (merge conflicts), so the
+# Trigger: pull_request_target for fork PRs, pull_request for same-repo PRs
+# (see the D14 gate-3 note near the bottom of this comment block for why both
+# now exist). GitHub skips pull_request workflows when refs/pull/N/merge
+# cannot be built (merge conflicts), so the
 # ruleset check require-mergecraft-review sits unreported for as long as the
 # conflict lasts. pull_request_target always fires on synchronize even with
 # merge conflicts, so the review still lands while the PR is conflicted.
@@ -76,10 +78,24 @@
 # Therefore a PR that edits this file cannot review itself with its own changes;
 # they take effect on the next PR after merge.
 #
-# The bootstrap `pull_request` trigger has been removed: running BOTH triggers made
-# each synchronize fire two runs that resolved to the SAME concurrency group (see
-# below) — with cancel-in-progress they cancelled each other, and a cancelled
-# `mergecraft review` is a non-success on the required check. Do not re-add it.
+# A `pull_request` trigger returned (PR #200 / D14 gate 3): self-review needs a
+# genuine non-fork `pull_request` event for derive_trust_tier() (src/mergecraft/
+# analyzers/trust.py) to legitimately return "trusted" — pull_request_target is
+# hardcoded "untrusted" regardless of fork status, by design (D14), so no same-repo
+# PR could ever earn a real APPROVE while pull_request_target was the only trigger.
+#
+# This is NOT the same shape as the bootstrap trigger removed below: that removal
+# was never about pull_request being unsafe to trigger on — it was that BOTH
+# triggers shared ONE concurrency group, so `cancel-in-progress` force-cancelled
+# whichever run lost the race, and a cancelled `mergecraft review` is a non-success
+# on the required check. This return avoids that by (1) keying the concurrency
+# group on `github.event_name` too, so the two triggers' runs never share a group
+# and never cancel each other, and (2) gating the `review` (and `wait-for-ci`) job
+# so pull_request_target only does real work for fork PRs and pull_request only for
+# same-repo PRs — the "wrong" lane's job cleanly SKIPS rather than races, and a
+# skipped required check does not block merges. Both triggers still fire on every
+# push regardless of fork status (GitHub does not support conditional trigger
+# registration); the mutual exclusivity lives entirely in the job-level `if`s.
 #
 # Same-repo guard below keeps fork PRs from receiving secrets (prior pull_request
 # behavior). mergeCraft uses checkout_pr + API with push/shell disabled — no
@@ -114,6 +130,12 @@ on:
     # .coderabbit.yaml `pre-.*` coverage).
     branches: [main, develop, test-pre, "pre-*"]
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+    # Same-repo PRs only in practice — the `review` / `wait-for-ci` job `if`s
+    # skip this lane for forks. Exists so derive_trust_tier() sees a genuine
+    # non-fork `pull_request` event (D14 gate 3). See the trigger comment above.
+    branches: [main, develop, test-pre, "pre-*"]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       prompt:
@@ -127,7 +149,10 @@ permissions:
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
   # so concurrent reviews do not cancel each other (GitHub Nov 2025 policy).
-  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # event_name is also part of the key so the pull_request_target (fork) and
+  # pull_request (same-repo) lanes never share a group and never cancel each
+  # other — see the trigger comment above.
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -142,7 +167,16 @@ jobs:
   # context, which is the pre-existing behavior.
   wait-for-ci:
     name: mergecraft wait for CI
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # Same lane-exclusivity clause as the `review` job below: only the lane that
+    # will actually run a review bothers waiting for CI (avoids burning a runner
+    # on the lane that is about to skip).
+    if: >-
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 25
     outputs:
@@ -154,7 +188,7 @@ jobs:
     steps:
       - name: Wait for CI checks on the PR head SHA
         id: wait
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -238,9 +272,21 @@ jobs:
     # `always()` keeps the required check reporting even if the (fail-open) wait
     # job errors out on a runner fault; a skipped wait job still skips the review,
     # because the draft/dispatch condition below is the same one it uses.
+    #
+    # The trailing clause is the lane-exclusivity gate (D14 gate 3 / PR #200):
+    # pull_request_target only reviews fork PRs, pull_request only reviews
+    # same-repo PRs, workflow_dispatch always runs. Both triggers fire on every
+    # push regardless of fork status, so this is what keeps exactly one lane
+    # doing real work per push — see the trigger comment near the top of the
+    # file for the concurrency-group half of that story.
     if: >-
       always() &&
-      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -312,7 +358,7 @@ jobs:
           CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             text="${DISPATCH_PROMPT:-Review the current pull request.}"
           else
             # Codex presents mergeCraft MCP tools as mergecraft_. Naming the
@@ -351,7 +397,7 @@ jobs:
         if: >-
           env.HAS_NOUS == 'true' &&
           env.HAS_CODEX == 'true' &&
-          github.event_name == 'pull_request_target'
+          github.event_name != 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -445,7 +491,7 @@ jobs:
         run: |
           set -euo pipefail
           need="false"
-          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+          if [ "${EVENT_NAME}" != "workflow_dispatch" ]; then
             latest=""
             for attempt in $(seq 1 3); do
               if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
@@ -557,7 +603,7 @@ jobs:
         # Retries below only smooth over a single transient API blip; once
         # retries are exhausted without success, this step exits 1.
         if: >-
-          github.event_name == 'pull_request_target' &&
+          github.event_name != 'workflow_dispatch' &&
           env.HAS_AUTH == 'true'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -57,10 +57,8 @@
 # NOUS_API_KEY the primary is inert and Codex is the only reviewer; without
 # CODEX_AUTH_JSON / OPENAI_API_KEY, Nous is the only reviewer.
 #
-# Trigger: pull_request_target for fork PRs, pull_request for same-repo PRs
-# (see the D14 gate-3 note near the bottom of this comment block for why both
-# now exist). GitHub skips pull_request workflows when refs/pull/N/merge
-# cannot be built (merge conflicts), so the
+# Trigger: pull_request_target (not pull_request). GitHub skips pull_request
+# workflows when refs/pull/N/merge cannot be built (merge conflicts), so the
 # ruleset check require-mergecraft-review sits unreported for as long as the
 # conflict lasts. pull_request_target always fires on synchronize even with
 # merge conflicts, so the review still lands while the PR is conflicted.
@@ -78,24 +76,28 @@
 # Therefore a PR that edits this file cannot review itself with its own changes;
 # they take effect on the next PR after merge.
 #
-# A `pull_request` trigger returned (PR #200 / D14 gate 3): self-review needs a
-# genuine non-fork `pull_request` event for derive_trust_tier() (src/mergecraft/
-# analyzers/trust.py) to legitimately return "trusted" — pull_request_target is
-# hardcoded "untrusted" regardless of fork status, by design (D14), so no same-repo
-# PR could ever earn a real APPROVE while pull_request_target was the only trigger.
+# The bootstrap `pull_request` trigger has been removed: running BOTH triggers made
+# each synchronize fire two runs that resolved to the SAME concurrency group (see
+# below) — with cancel-in-progress they cancelled each other, and a cancelled
+# `mergecraft review` is a non-success on the required check. Do not re-add it.
 #
-# This is NOT the same shape as the bootstrap trigger removed below: that removal
-# was never about pull_request being unsafe to trigger on — it was that BOTH
-# triggers shared ONE concurrency group, so `cancel-in-progress` force-cancelled
-# whichever run lost the race, and a cancelled `mergecraft review` is a non-success
-# on the required check. This return avoids that by (1) keying the concurrency
-# group on `github.event_name` too, so the two triggers' runs never share a group
-# and never cancel each other, and (2) gating the `review` (and `wait-for-ci`) job
-# so pull_request_target only does real work for fork PRs and pull_request only for
-# same-repo PRs — the "wrong" lane's job cleanly SKIPS rather than races, and a
-# skipped required check does not block merges. Both triggers still fire on every
-# push regardless of fork status (GitHub does not support conditional trigger
-# registration); the mutual exclusivity lives entirely in the job-level `if`s.
+# 2026-08-14 (PR #200): a same-repo `pull_request` trigger was tried here as a way
+# to earn derive_trust_tier() == "trusted" for self-review (D14 gate 3) and got a
+# same-day CHANGES_REQUESTED revert: `pull_request` resolves the workflow
+# *definition* from the PR's own branch (unlike pull_request_target, which always
+# reads it from the default branch), so that lane would have handed
+# MERGECRAFT_REVIEWER_PAT, provider credentials, OIDC, and a write-scoped token to
+# PR-controlled code — any same-repo collaborator could edit this file on their
+# branch to self-approve or exfiltrate the PAT. Do not re-add a `pull_request`
+# trigger to this workflow for that purpose. The actual fix lives in the sibling
+# `mergecraft-approve.yml` workflow: a `workflow_run` trigger, which (like
+# pull_request_target, and more unconditionally so) always resolves its
+# definition from the default branch, runs on its own runner with no PR checkout
+# at all, and — via `workflow_run.pull_requests` being empty for forks by
+# GitHub's own documented behavior — naturally never fires for fork PRs. It only
+# reads the already-posted `mergecraft-approval` check-run conclusion (a pure
+# function of Finding severities, immune to the agent's own narrative) and, if
+# it is "success", submits the PAT-backed APPROVE itself.
 #
 # Same-repo guard below keeps fork PRs from receiving secrets (prior pull_request
 # behavior). mergeCraft uses checkout_pr + API with push/shell disabled — no
@@ -130,12 +132,6 @@ on:
     # .coderabbit.yaml `pre-.*` coverage).
     branches: [main, develop, test-pre, "pre-*"]
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request:
-    # Same-repo PRs only in practice — the `review` / `wait-for-ci` job `if`s
-    # skip this lane for forks. Exists so derive_trust_tier() sees a genuine
-    # non-fork `pull_request` event (D14 gate 3). See the trigger comment above.
-    branches: [main, develop, test-pre, "pre-*"]
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       prompt:
@@ -149,10 +145,7 @@ permissions:
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
   # so concurrent reviews do not cancel each other (GitHub Nov 2025 policy).
-  # event_name is also part of the key so the pull_request_target (fork) and
-  # pull_request (same-repo) lanes never share a group and never cancel each
-  # other — see the trigger comment above.
-  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
+  group: mergecraft-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -167,16 +160,7 @@ jobs:
   # context, which is the pre-existing behavior.
   wait-for-ci:
     name: mergecraft wait for CI
-    # Same lane-exclusivity clause as the `review` job below: only the lane that
-    # will actually run a review bothers waiting for CI (avoids burning a runner
-    # on the lane that is about to skip).
-    if: >-
-      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      )
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 25
     outputs:
@@ -188,7 +172,7 @@ jobs:
     steps:
       - name: Wait for CI checks on the PR head SHA
         id: wait
-        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -272,21 +256,9 @@ jobs:
     # `always()` keeps the required check reporting even if the (fail-open) wait
     # job errors out on a runner fault; a skipped wait job still skips the review,
     # because the draft/dispatch condition below is the same one it uses.
-    #
-    # The trailing clause is the lane-exclusivity gate (D14 gate 3 / PR #200):
-    # pull_request_target only reviews fork PRs, pull_request only reviews
-    # same-repo PRs, workflow_dispatch always runs. Both triggers fire on every
-    # push regardless of fork status, so this is what keeps exactly one lane
-    # doing real work per push — see the trigger comment near the top of the
-    # file for the concurrency-group half of that story.
     if: >-
       always() &&
-      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      )
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -358,7 +330,7 @@ jobs:
           CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
             text="${DISPATCH_PROMPT:-Review the current pull request.}"
           else
             # Codex presents mergeCraft MCP tools as mergecraft_. Naming the
@@ -397,7 +369,7 @@ jobs:
         if: >-
           env.HAS_NOUS == 'true' &&
           env.HAS_CODEX == 'true' &&
-          github.event_name != 'workflow_dispatch'
+          github.event_name == 'pull_request_target'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -491,7 +463,7 @@ jobs:
         run: |
           set -euo pipefail
           need="false"
-          if [ "${EVENT_NAME}" != "workflow_dispatch" ]; then
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
             latest=""
             for attempt in $(seq 1 3); do
               if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
@@ -603,7 +575,7 @@ jobs:
         # Retries below only smooth over a single transient API blip; once
         # retries are exhausted without success, this step exits 1.
         if: >-
-          github.event_name != 'workflow_dispatch' &&
+          github.event_name == 'pull_request_target' &&
           env.HAS_AUTH == 'true'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -250,6 +250,13 @@ jobs:
       HAS_CODEX: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
       HAS_NOUS: ${{ secrets.NOUS_API_KEY != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
       HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # The default github.token cannot submit an "Approve" review — GitHub
+      # silently downgrades any attempt to a comment (a documented platform
+      # restriction, independent of PR author). A PAT from a genuinely
+      # distinct account (sevn-one, a collaborator + CODEOWNERS entry) can.
+      # Only used for same-repo runs — fork PRs still rely purely on the
+      # review's findings, never on an approval identity to route around.
+      HAS_BOT_TOKEN: ${{ secrets.MERGECRAFT_REVIEWER_PAT != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -410,6 +417,9 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
+          # See HAS_BOT_TOKEN above — falls back to github.token when the PAT
+          # isn't configured (e.g. a fork of this repo without the secret).
+          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
         env:
           MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
           MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
@@ -503,6 +513,8 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
+          # See the matching comment on the Nous step above.
+          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,16 @@ tests/analyzers/fixtures/repo/.mergecraft/
 # checkout instead of alongside it (backstop; operator removes them with
 # `git worktree remove`, this just keeps them out of `git status`/`find`).
 /mergecraft-*/
+
+# mergeCraft's own runtime cache/scratch state, provisioned into <repo>/.mergecraft/
+# on every self-review run (analyzer-cache/, analyzer-scratch/, analyzer-runs/,
+# analyzers.lock, .provision.lock, traces/) — regenerated every run, never source
+# of truth. Without this it shows up as untracked and dirties the working tree on
+# every self-review, which can also trip checkout_pr's clean-tree guard
+# (src/mergecraft/mcp/checkout.py) on a second checkout in the same job. Repo-authored
+# content under .mergecraft/ stays tracked via the negations below.
+/.mergecraft/*
+!/.mergecraft/config.yaml
+!/.mergecraft/learnings.md
+!/.mergecraft/xrepo-learnings.md
+!/.mergecraft/xrepo-brief.md

--- a/.mergecraft/config.yaml
+++ b/.mergecraft/config.yaml
@@ -1,0 +1,11 @@
+# mergeCraft repo-config for this repo's own self-review consumer workflow
+# (.github/workflows/mergecraft.yml). See docs/REVIEW-DOCTRINE.md.
+#
+# prApproveEnabled alone does not let self-review submit a real GitHub APPROVE
+# (D14, PR #200): create_pull_request_review_tool also requires the agent's own
+# approved=true AND ctx.trust_tier == "trusted", which derive_trust_tier()
+# (src/mergecraft/analyzers/trust.py) only grants to a genuine non-fork
+# `pull_request` event or workflow_dispatch — never to pull_request_target,
+# regardless of fork status. See the mergecraft.yml trigger comment for how the
+# workflow now earns that "trusted" tier for same-repo PRs.
+prApproveEnabled: true

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -21,3 +21,11 @@ rules:
       # number reaches the CLI via `env:`, not a `run:` interpolation.
       # Authorization = the merge itself.
       - findings-carryover.yml
+      # Submits a privileged PR approval as the distinct @sevn-one identity
+      # (D14 gate 3, PR #200). No checkout of any kind — only a read of the
+      # already-posted mergecraft-approval check-run conclusion (a pure
+      # function of Finding severities, not the reviewing agent's narrative)
+      # and, if it is "success", a `gh api` POST to /pulls/{n}/reviews pinned
+      # to that exact commit_id. pull_requests[0] is empty for fork PRs by
+      # GitHub's own documented behavior, so this never fires for them.
+      - mergecraft-approve.yml


### PR DESCRIPTION
Syncs main with pre-0.0.1's latest merge: #200 (distinct-identity self-review approval, adds .github/workflows/mergecraft-approve.yml).

This specifically gets mergecraft-approve.yml onto the default branch — its workflow_run trigger only registers once the file exists on main, which is why #202's approval gate is still unresolved despite #200 already being merged into pre-0.0.1.