### PR TITLE
fix(mcp): detach HEAD before checkout_pr fetches into the local PR branch

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -425,7 +425,22 @@ jobs:
         # initializing the Codex app-server). Fixed in #194 (prepare_workspace_for_agent()
         # chown as the last step); f5b070b is #194 merged into pre-0.0.1, synced to main
         # via #195. Lesson holds: re-bump this SHA explicitly, every time.
-        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        # 2026-08-14 (fifth bump, same day): re-bumped to 3bf6d7b — checkout_pr failed
+        # when re-run against a shared workspace within one job: a Nous review, then a
+        # Codex fallback, both call checkout_pr against the same /github/workspace, and
+        # the second call's fetch failed outright ("refusing to fetch into branch
+        # 'refs/heads/pr-<n>' checked out at '/github/workspace'"). Reproduced on both
+        # PR #201 and PR #202 — Nous timed out (Nous Portal flakiness, unrelated), the
+        # Codex fallback then hit this, and neither posted a mergecraft-approval verdict
+        # before running out of budget. Fixed in #204 (src/mergecraft/mcp/checkout.py —
+        # detach HEAD before the fetch). Unlike every prior bump above, this SHA is
+        # #204's own branch-tip commit, pinned before merge: #204 cannot review itself
+        # with its own fix (the same self-review limitation the top-of-file comment
+        # describes for mergecraft.yml edits), so bumping only after merge would need a
+        # second PR just to consume the first. 3bf6d7b survives merge intact — this repo
+        # merges PRs with a merge commit, never squash — so once #204 lands this pin is
+        # already correct; no follow-up bump needed.
+        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: 25m
@@ -518,8 +533,10 @@ jobs:
         # load-breaking `${{ secrets.X }}` in description text), then to a1c10ef (#190:
         # setpriv never resets $HOME, agent subprocess EACCES post-privilege-drop), then to
         # f5b070b (#194: $CODEX_HOME/.gemini/.claude also created root-owned before the
-        # drop, same bug shape) — see the matching comment on the Nous step above for why.
-        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        # drop, same bug shape), then to 3bf6d7b (#204: checkout_pr fetch failure on a
+        # shared workspace when Nous falls back to Codex, fixed by detaching HEAD before
+        # the fetch) — see the matching comment on the Nous step above for why.
+        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -157,6 +157,18 @@ def checkout_pr_tool(ctx: ToolContext):
         )
         local_branch = f"pr-{pull_number}"
 
+        # Detach HEAD before fetching into local_branch. checkout_pr can run
+        # more than once against the same shared workspace within a single
+        # job (e.g. a Nous review, then a Codex fallback both calling
+        # checkout_pr against /github/workspace) — if a prior call already
+        # left HEAD on local_branch, `git fetch ... :local_branch` fails with
+        # "refusing to fetch into branch ... checked out" and the second
+        # review never completes. Detaching first — safe, since the dirty
+        # check above already guarantees no uncommitted work to lose — means
+        # the fetch target is never the current HEAD, regardless of what an
+        # earlier checkout_pr call left behind.
+        _run_git(["checkout", "--detach", "HEAD"], cwd=cwd)
+
         # Fetch PR head via GitHub's pull/<n>/head ref
         _run_git(
             ["fetch", "--no-tags", "origin", f"pull/{pull_number}/head:{local_branch}"],

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -227,6 +227,28 @@ async def _checkout(ctx: ToolContext) -> dict[str, Any]:
 
 
 @pytest.mark.asyncio
+async def test_checkout_pr_succeeds_when_local_branch_already_checked_out(
+    tmp_path: Path,
+) -> None:
+    """Regression: a second checkout_pr call in the same shared workspace
+    (e.g. a Nous review, then a Codex fallback, both calling checkout_pr
+    against the same /github/workspace within one job) must not fail with
+    "refusing to fetch into branch ... checked out" just because the first
+    call already left HEAD on the PR's local branch.
+    """
+    clone, _first, head = _pr_repo_with_two_commits(tmp_path)
+    github = _StubGitHub(head_sha=head, reviews=[])
+    ctx = _ctx_for(clone, github, tmp_path, mode="Review")
+
+    first = await _checkout(ctx)
+    second = await _checkout(ctx)
+
+    assert first["pullNumber"] == 1
+    assert second["pullNumber"] == 1
+    assert second["localBranch"] == "pr-1"
+
+
+@pytest.mark.asyncio
 async def test_incremental_diff_covers_only_commits_since_the_last_review(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `checkout_pr` can run more than once against the same shared workspace within a single review job — a Nous review, then a Codex fallback, both call `checkout_pr` against the same `/github/workspace`. The first call leaves HEAD on the PR's local branch (`pr-<n>`); the second call's fetch then fails outright: `fatal: refusing to fetch into branch 'refs/heads/pr-<n>' checked out at '/github/workspace'`.
- Reproduced this on **both** PR #201 and PR #202: Nous timed out (unrelated Nous Portal flakiness), the Codex fallback then hit this exact error, spent several minutes working around it via ad hoc git surgery (stash, detach, retry), and still failed to post a `mergecraft-approval` verdict before running out of budget.
- Also reproduced on **#204's own first review** — confirms the bug is real and not this PR's diff.
- Fix: detach HEAD before the fetch, unconditionally. Safe — the dirty-tree check a few lines above already guarantees nothing uncommitted would be lost.
- Also bumps `mergecraft.yml`'s self-review action pin to this PR's own branch-tip commit (`3bf6d7b`), since #204 can't review itself with its own fix otherwise (the review runs the SHA-pinned image, not the PR's live source — same limitation this file's header already documents). This survives merge since the repo uses merge commits, not squash, so no follow-up bump PR is needed once #204 lands.

## Test plan
- [x] New regression test `test_checkout_pr_succeeds_when_local_branch_already_checked_out` — confirmed it reproduces the exact failure without the fix, and passes with it.
- [x] `tests/mcp` suite green (81 passed)
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` strict clean on `checkout.py`
- [x] `actionlint` / `zizmor` clean on the pin bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)