### PR TITLE
release: sync pre-0.0.1 to main

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -425,7 +425,22 @@ jobs:
         # initializing the Codex app-server). Fixed in #194 (prepare_workspace_for_agent()
         # chown as the last step); f5b070b is #194 merged into pre-0.0.1, synced to main
         # via #195. Lesson holds: re-bump this SHA explicitly, every time.
-        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        # 2026-08-14 (fifth bump, same day): re-bumped to 3bf6d7b — checkout_pr failed
+        # when re-run against a shared workspace within one job: a Nous review, then a
+        # Codex fallback, both call checkout_pr against the same /github/workspace, and
+        # the second call's fetch failed outright ("refusing to fetch into branch
+        # 'refs/heads/pr-<n>' checked out at '/github/workspace'"). Reproduced on both
+        # PR #201 and PR #202 — Nous timed out (Nous Portal flakiness, unrelated), the
+        # Codex fallback then hit this, and neither posted a mergecraft-approval verdict
+        # before running out of budget. Fixed in #204 (src/mergecraft/mcp/checkout.py —
+        # detach HEAD before the fetch). Unlike every prior bump above, this SHA is
+        # #204's own branch-tip commit, pinned before merge: #204 cannot review itself
+        # with its own fix (the same self-review limitation the top-of-file comment
+        # describes for mergecraft.yml edits), so bumping only after merge would need a
+        # second PR just to consume the first. 3bf6d7b survives merge intact — this repo
+        # merges PRs with a merge commit, never squash — so once #204 lands this pin is
+        # already correct; no follow-up bump needed.
+        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: 25m
@@ -518,8 +533,10 @@ jobs:
         # load-breaking `${{ secrets.X }}` in description text), then to a1c10ef (#190:
         # setpriv never resets $HOME, agent subprocess EACCES post-privilege-drop), then to
         # f5b070b (#194: $CODEX_HOME/.gemini/.claude also created root-owned before the
-        # drop, same bug shape) — see the matching comment on the Nous step above for why.
-        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        # drop, same bug shape), then to 3bf6d7b (#204: checkout_pr fetch failure on a
+        # shared workspace when Nous falls back to Codex, fixed by detaching HEAD before
+        # the fetch) — see the matching comment on the Nous step above for why.
+        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ tests/analyzers/fixtures/repo/.mergecraft/
 !/.mergecraft/learnings.md
 !/.mergecraft/xrepo-learnings.md
 !/.mergecraft/xrepo-brief.md
+
+/.agents

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "skills": {
+    "building-pydantic-ai-agents": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/building-pydantic-ai-agents/SKILL.md",
+      "computedHash": "102cbcc4b4a548464814b65c44e1bd7170ff2188d07ec830544560d54133e6e6"
+    },
+    "logfire-instrumentation": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-instrumentation/SKILL.md",
+      "computedHash": "cebf8a4a963c9d3d5c2422bd11a3ea7370e5d7c3ee67aac1443a8b90c42eec1f"
+    },
+    "logfire-query": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-query/SKILL.md",
+      "computedHash": "51ddcfa6016440895c54cb34b43b9ade73e000c0a14e092a2524b4e844cc3397"
+    },
+    "logfire-ui": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/logfire-ui/SKILL.md",
+      "computedHash": "ec9ad81fb607e771b6e21eedae39af01985fc902f8bac03b51f669ad0ddb3f97"
+    },
+    "pydantic": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/pydantic/SKILL.md",
+      "computedHash": "2f523749fc2edc5cb3b73435a282373cd69209682be7992b6cde333f30d59254"
+    },
+    "pydantic-ai-harness": {
+      "source": "pydantic/skills",
+      "sourceType": "github",
+      "skillPath": "skills/pydantic-ai-harness/SKILL.md",
+      "computedHash": "24ebd64439b138bb1f7c0fa466d0a64a9d99d36108a670673c9c75c455f9ce8d"
+    }
+  }
+}

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -157,6 +157,18 @@ def checkout_pr_tool(ctx: ToolContext):
         )
         local_branch = f"pr-{pull_number}"
 
+        # Detach HEAD before fetching into local_branch. checkout_pr can run
+        # more than once against the same shared workspace within a single
+        # job (e.g. a Nous review, then a Codex fallback both calling
+        # checkout_pr against /github/workspace) — if a prior call already
+        # left HEAD on local_branch, `git fetch ... :local_branch` fails with
+        # "refusing to fetch into branch ... checked out" and the second
+        # review never completes. Detaching first — safe, since the dirty
+        # check above already guarantees no uncommitted work to lose — means
+        # the fetch target is never the current HEAD, regardless of what an
+        # earlier checkout_pr call left behind.
+        _run_git(["checkout", "--detach", "HEAD"], cwd=cwd)
+
         # Fetch PR head via GitHub's pull/<n>/head ref
         _run_git(
             ["fetch", "--no-tags", "origin", f"pull/{pull_number}/head:{local_branch}"],

--- a/tests/mcp/test_checkout.py
+++ b/tests/mcp/test_checkout.py
@@ -227,6 +227,28 @@ async def _checkout(ctx: ToolContext) -> dict[str, Any]:
 
 
 @pytest.mark.asyncio
+async def test_checkout_pr_succeeds_when_local_branch_already_checked_out(
+    tmp_path: Path,
+) -> None:
+    """Regression: a second checkout_pr call in the same shared workspace
+    (e.g. a Nous review, then a Codex fallback, both calling checkout_pr
+    against the same /github/workspace within one job) must not fail with
+    "refusing to fetch into branch ... checked out" just because the first
+    call already left HEAD on the PR's local branch.
+    """
+    clone, _first, head = _pr_repo_with_two_commits(tmp_path)
+    github = _StubGitHub(head_sha=head, reviews=[])
+    ctx = _ctx_for(clone, github, tmp_path, mode="Review")
+
+    first = await _checkout(ctx)
+    second = await _checkout(ctx)
+
+    assert first["pullNumber"] == 1
+    assert second["pullNumber"] == 1
+    assert second["localBranch"] == "pr-1"
+
+
+@pytest.mark.asyncio
 async def test_incremental_diff_covers_only_commits_since_the_last_review(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Syncs main with pre-0.0.1's latest merges: #202 (ignore /.agents, track skills-lock.json), #204 (fix checkout_pr shared-workspace fetch failure + bump the mergecraft self-review action pin to 3bf6d7b).

Gets the checkout_pr fix and the new pin actually live for pull_request_target reviews, which resolve mergecraft.yml from main — #204 merging into pre-0.0.1 alone doesn't do that.