### PR TITLE
fix(analyzers): retry trivy on unparsable output from a DB-fetch race

### DIFF
--- a/src/mergecraft/analyzers/supply_chain.py
+++ b/src/mergecraft/analyzers/supply_chain.py
@@ -6,9 +6,10 @@ import json
 import re
 import shutil
 import tempfile
+import time
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 from loguru import logger
 
@@ -25,6 +26,7 @@ from mergecraft.analyzers.sandbox import plan_sandbox
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
     from mergecraft.analyzers.manifest import AnalyzerManifest
+    from mergecraft.analyzers.sandbox import SandboxContext
 
 TrustTier = Literal["trusted", "untrusted"]
 
@@ -310,6 +312,62 @@ def _run_osv_scan(
     return enriched, None
 
 
+# Trivy fetches its vulnerability DB over the network on every invocation (no
+# offline/cached-DB mode is wired up here) — a slow or interrupted download
+# can leave stdout without a valid JSON object at all (ghcr.io / trivy-db.
+# github.io / mirror.gcr.io per the catalog's network_allowlist), which is a
+# different failure than a legitimately clean scan: a clean scan is still
+# valid JSON, just with an empty ``Results``, and never raises. Only the
+# unparsable case is retried — an empty-but-valid result is never retried
+# into a different answer.
+_TRIVY_MAX_ATTEMPTS: Final[int] = 3
+_TRIVY_RETRY_DELAY_S: Final[float] = 3.0
+
+
+def _run_trivy_and_parse(
+    finalized: AnalyzerPlan,
+    *,
+    manifest: AnalyzerManifest,
+    repo_root: Path,
+    sandbox_context: SandboxContext | None,
+) -> tuple[list[Finding], str, str | None]:
+    """Run trivy and parse its output, retrying only on unparsable output.
+
+    Returns ``(findings, raw_output, error)``. ``error`` is set only for a
+    process-level failure (``outcome.ran is False``); a parse failure that
+    survives every retry is re-raised, matching the pre-retry contract.
+    """
+    last_error: ValueError | None = None
+    for attempt in range(1, _TRIVY_MAX_ATTEMPTS + 1):
+        outcome = run_plan(finalized, sandbox_context=sandbox_context)
+        if not outcome.ran:
+            return [], "", outcome.output
+
+        raw = (
+            Path(outcome.output_path).read_text(encoding="utf-8")
+            if outcome.output_path
+            else outcome.output
+        )
+        try:
+            findings = parse_output(raw, manifest=manifest, repo_root=repo_root)
+        except ValueError as exc:
+            last_error = exc
+            logger.warning(
+                "{}: unparsable output on attempt {}/{}: {}",
+                manifest.id,
+                attempt,
+                _TRIVY_MAX_ATTEMPTS,
+                exc,
+            )
+            if attempt < _TRIVY_MAX_ATTEMPTS:
+                time.sleep(_TRIVY_RETRY_DELAY_S)
+            continue
+        return findings, raw, None
+
+    assert last_error is not None, "loop always assigns last_error before exhausting attempts"
+    raise last_error
+
+
 def _run_trivy_fs(
     *,
     manifest: AnalyzerManifest,
@@ -360,16 +418,15 @@ def _run_trivy_fs(
     if not sandbox.can_run:
         return [], sandbox.skip_reason
 
-    outcome = run_plan(finalized, sandbox_context=sandbox.context)
-    if not outcome.ran:
-        return [], outcome.output
-
-    raw = (
-        Path(outcome.output_path).read_text(encoding="utf-8")
-        if outcome.output_path
-        else outcome.output
+    findings, raw, error = _run_trivy_and_parse(
+        finalized,
+        manifest=manifest,
+        repo_root=repo_root,
+        sandbox_context=sandbox.context,
     )
-    findings = parse_output(raw, manifest=manifest, repo_root=repo_root)
+    if error is not None:
+        return [], error
+
     return (
         _enrich_trivy_findings(
             findings,
@@ -444,16 +501,15 @@ def _run_trivy_config(
     if not sandbox.can_run:
         return [], sandbox.skip_reason
 
-    outcome = run_plan(finalized, sandbox_context=sandbox.context)
-    if not outcome.ran:
-        return [], outcome.output
-
-    raw = (
-        Path(outcome.output_path).read_text(encoding="utf-8")
-        if outcome.output_path
-        else outcome.output
+    findings, _raw, error = _run_trivy_and_parse(
+        finalized,
+        manifest=manifest,
+        repo_root=repo_root,
+        sandbox_context=sandbox.context,
     )
-    return parse_output(raw, manifest=manifest, repo_root=repo_root), None
+    if error is not None:
+        return [], error
+    return findings, None
 
 
 def _scan_side(

--- a/tests/analyzers/test_trivy_retry.py
+++ b/tests/analyzers/test_trivy_retry.py
@@ -1,0 +1,147 @@
+"""Retry-on-unparsable-output for trivy's live vulnerability-DB dependency.
+
+trivy fetches its DB over the network on every invocation (no offline/cached
+mode wired up), so a slow or interrupted download can leave stdout without a
+valid JSON object at all — distinct from a legitimately clean scan, which is
+still valid JSON with an empty ``Results``. These tests mock ``run_plan`` so
+they are deterministic and never depend on network access or the real
+``trivy`` binary.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from mergecraft.analyzers import supply_chain
+from mergecraft.analyzers.registry import get_manifest
+from mergecraft.analyzers.resolve import AnalyzerPlan
+from mergecraft.analyzers.run import AnalyzerOutcome
+
+_MALFORMED_OUTPUT = "INFO: fetching vulnerability database...\n"
+_VALID_EMPTY_OUTPUT = '{"Results": []}'
+_VALID_FINDING_OUTPUT = (
+    '{"Results": [{"Target": "requirements.txt", "Vulnerabilities": '
+    '[{"VulnerabilityID": "CVE-2024-0001", "Severity": "HIGH", "Title": "x"}]}]}'
+)
+
+
+def _plan() -> AnalyzerPlan:
+    return AnalyzerPlan(manifest_id="trivy", mode="managed", argv=("trivy",))
+
+
+def _outcome(output: str) -> AnalyzerOutcome:
+    return AnalyzerOutcome(name="trivy", command="trivy", status="passed", output=output)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+
+def test_recovers_from_transient_unparsable_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two malformed attempts (DB not ready yet) then a valid one still succeeds."""
+    outputs = iter([_MALFORMED_OUTPUT, _MALFORMED_OUTPUT, _VALID_FINDING_OUTPUT])
+    calls = 0
+
+    def fake_run_plan(
+        _plan: AnalyzerPlan, *, sandbox_context: object | None = None
+    ) -> AnalyzerOutcome:
+        nonlocal calls
+        calls += 1
+        return _outcome(next(outputs))
+
+    monkeypatch.setattr(supply_chain, "run_plan", fake_run_plan)
+
+    findings, raw, error = supply_chain._run_trivy_and_parse(
+        _plan(),
+        manifest=get_manifest("trivy"),
+        repo_root=Path("/tmp"),
+        sandbox_context=None,
+    )
+
+    assert error is None
+    assert calls == 3
+    assert raw == _VALID_FINDING_OUTPUT
+    assert len(findings) == 1
+    assert findings[0].rule_id == "CVE-2024-0001"
+
+
+def test_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistently malformed output re-raises the parse error, not silently skipped."""
+    calls = 0
+
+    def fake_run_plan(
+        _plan: AnalyzerPlan, *, sandbox_context: object | None = None
+    ) -> AnalyzerOutcome:
+        nonlocal calls
+        calls += 1
+        return _outcome(_MALFORMED_OUTPUT)
+
+    monkeypatch.setattr(supply_chain, "run_plan", fake_run_plan)
+
+    with pytest.raises(ValueError, match="trivy JSON output must be an object"):
+        supply_chain._run_trivy_and_parse(
+            _plan(),
+            manifest=get_manifest("trivy"),
+            repo_root=Path("/tmp"),
+            sandbox_context=None,
+        )
+
+    assert calls == supply_chain._TRIVY_MAX_ATTEMPTS
+
+
+def test_valid_empty_results_is_never_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A legitimately clean scan (valid JSON, zero findings) is not retried."""
+    calls = 0
+
+    def fake_run_plan(
+        _plan: AnalyzerPlan, *, sandbox_context: object | None = None
+    ) -> AnalyzerOutcome:
+        nonlocal calls
+        calls += 1
+        return _outcome(_VALID_EMPTY_OUTPUT)
+
+    monkeypatch.setattr(supply_chain, "run_plan", fake_run_plan)
+
+    findings, raw, error = supply_chain._run_trivy_and_parse(
+        _plan(),
+        manifest=get_manifest("trivy"),
+        repo_root=Path("/tmp"),
+        sandbox_context=None,
+    )
+
+    assert error is None
+    assert calls == 1, "a valid-but-empty result must not be retried"
+    assert raw == _VALID_EMPTY_OUTPUT
+    assert findings == []
+
+
+def test_process_failure_short_circuits_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``outcome.ran is False`` (e.g. provisioning/timeout) is not a parse failure and is not retried."""
+    calls = 0
+
+    def fake_run_plan(
+        _plan: AnalyzerPlan, *, sandbox_context: object | None = None
+    ) -> AnalyzerOutcome:
+        nonlocal calls
+        calls += 1
+        return AnalyzerOutcome(
+            name="trivy", command="trivy", status="unavailable", output="trivy binary not found"
+        )
+
+    monkeypatch.setattr(supply_chain, "run_plan", fake_run_plan)
+
+    findings, raw, error = supply_chain._run_trivy_and_parse(
+        _plan(),
+        manifest=get_manifest("trivy"),
+        repo_root=Path("/tmp"),
+        sandbox_context=None,
+    )
+
+    assert calls == 1, "a process-level failure must not be retried"
+    assert findings == []
+    assert raw == ""
+    assert error == "trivy binary not found"


### PR DESCRIPTION
## Summary
- trivy fetches its vulnerability DB over the network on every invocation (no offline/cached-DB mode wired up — `network_allowlist` in the catalog manifest is `ghcr.io` / `trivy-db.github.io` / `mirror.gcr.io`). A slow or interrupted download can leave stdout without a valid JSON object at all.
- Observed both failure shapes on the same CI test (`test_newly_introduced_cve_reported_with_fix_and_transitive_status[trivy]`) across consecutive reruns of the same job: once as zero findings, once as `ValueError: trivy JSON output must be an object` — consistent with the live DB fetch racing differently each run.
- Adds `_run_trivy_and_parse()`: retries the whole trivy invocation (not just the parse) up to 3 attempts, only on that specific `ValueError`. A legitimately clean scan (valid JSON, empty `Results`) never raises, so it's never retried into a different answer. Wired into both `_run_trivy_fs()` and `_run_trivy_config()`, which shared this exact pattern.

## Test plan
- [x] New tests in `tests/analyzers/test_trivy_retry.py` mock `run_plan` for determinism (no live network/trivy binary dependency): recovers after 2 malformed attempts, gives up and re-raises after exhausting retries, never retries a valid-but-empty result, never retries a process-level failure.
- [x] `tests/analyzers` suite green (527 passed)
- [x] `ruff check` / `ruff format --check` / `mypy` strict / `pyright` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)