### PR TITLE
docs: generate action + CLI reference tables with a --check gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/gen_reference_docs.py` regenerates README's `action.yml` input/output
+  tables and CLI command table from the live sources (never a subprocess — it
+  walks the live Typer `app` object) and splices them between HTML sentinel
+  comments; `make reference-docs-check` (wired into `make ci-static`) fails the
+  build on drift. Closes the audit in the issues-showcase-readiness wave plan
+  (PR G2): the README table documented 9 of 24 real `action.yml` inputs and
+  neither declared output anywhere
+
+### Fixed
+
+- `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real
+  registered command is `mergecraft traces show <run-id>` — the stale
+  invocation is now generated from the live CLI app instead of hand-maintained
+
 ### Removed
 
 - Dropped `evidence/` from the tree — it held regenerable verifier/tool-run

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 
 .PHONY: help setup install lockcheck lint format typecheck pyright test security \
 	precommit build ci ci-static ci-steps ci-resume ci-reset catalog-check docker-build clean \
-	examples example-workflows-check bench-review eval-gate eval-replay \
+	examples example-workflows-check reference-docs reference-docs-check bench-review eval-gate eval-replay \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
 	lint-ruff-advisory hook-pins-check
 
@@ -134,11 +134,17 @@ examples: ## Render example workflow YAML from templates
 example-workflows-check: ## Fail when committed example workflows drift from templates
 	$(UV) run python scripts/render_example_workflows.py --check
 
-ci-static: lockcheck lint typecheck pyright catalog-check build example-workflows-check ## Static/build tier
+reference-docs: ## Regenerate the README action + CLI reference tables
+	$(UV) run python scripts/gen_reference_docs.py
+
+reference-docs-check: ## Fail when README reference tables drift from action.yml / the CLI
+	$(UV) run python scripts/gen_reference_docs.py --check
+
+ci-static: lockcheck lint typecheck pyright catalog-check build example-workflows-check reference-docs-check ## Static/build tier
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check build example-workflows-check security coverage-gate
+CI_STEPS := lockcheck lint typecheck pyright catalog-check build example-workflows-check reference-docs-check security coverage-gate
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/README.md
+++ b/README.md
@@ -343,19 +343,62 @@ inlined into the workflow file and never logged (convention 7). For
 multi-provider setups, fall back to the indexed env-var form below —
 `with:` cannot enumerate multiple providers.
 
+<!-- BEGIN:action-inputs -->
 The full input list:
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `model` | _(empty)_ | Pass-through model slug. Resolved against the configured provider chain. |
-| `provider_base_url` | _(empty)_ | OpenAI-compatible base URL for the singleton provider. |
-| `provider_api_key_env` | _(empty)_ | **Env-var name** that holds the API key (never the key value itself). |
-| `tracing` | _(unset)_ | `true` enables telemetry; unset defers to the next precedence layer. |
-| `tracing-to` | _(empty)_ | `local_files` / `logfire` / `otel` — telemetry sink. |
-| `logfire-token` | _(empty)_ | Logfire auth token (W8.5). |
-| `otel-endpoint` | _(empty)_ | OTLP collector URL (W8.5 / W7.7). |
-| `setup_failure_policy` | `inconclusive` | S1 / D10 — what a trusted-tier `setupScript` failure (non-zero exit **or** timeout) maps to: `inconclusive` (default — neutral check conclusion, the run is no-verdict), `fail` (configuration_error), or `warn` (run continues; prompt still carries the failure text). Closed vocabulary — unknown values fail closed as `configuration_error` before the run starts. |
-| `setup_timeout` | `10m` | S1 / F6 — wall-clock budget for `setupScript` (e.g. `5m`, `30s`, `1h`). A hanging install stalls the run otherwise. Reuses the same duration grammar as `timeout`. The setup runs as a session leader so a TERM → grace → KILL on the deadline reaches the whole process tree. |
+| `allow_pr_target_comments` | `false` | Opt-in to comment-driven invocation under `pull_request_target`. Default: false (refused). When set to `true`, comments from authors in {OWNER, MEMBER, COLLABORATOR} dispatch the agent even under `pull_request_target`. Set this only on workflows whose `if:` already gates comment triggers to trusted authors; leave it off everywhere else. See issue #72 / D6. |
+| `analyzers` | `auto` | Analyzer execution tier: off (disabled), auto (detect + provision), full (baked image tools), or untrusted-only (trust-aware: run only analyzers that need no secrets, no network and no PR-authored command construction — trusted-tier and repo-native manifests are skipped with a named reason rather than failing). Under `pull_request_target` and fork-head pull requests, `auto` resolves to `untrusted-only`. An unrecognised value also resolves to `untrusted-only`, with a warning. Default: auto |
+| `codex_sandbox` | _(unset)_ | Codex platform-sandbox policy. Leave unset (default) to keep Codex's own bubblewrap/Landlock sandbox. Set to `danger-full-access` ONLY when the runner is already an ephemeral, isolated container — inside a Docker container action, bubblewrap cannot create a nested user namespace and every Codex call fails before doing work. mergeCraft's own shell/push controls are unaffected either way. See issue #70. |
+| `cwd` | _(unset)_ | Working directory for the agent (defaults to GITHUB_WORKSPACE) |
+| `logfire-token` | _(empty)_ | Direct logfire token (W8.5 / W7.7). Wire from a `LOGFIRE_TOKEN` GitHub Actions secret (interpolated in your workflow YAML, not written literally here) so the secret never appears in the workflow file. Held at runtime only; never inlined into config dumps. |
+| `model` | _(unset)_ | Model to use — a curated slug (e.g. anthropic/claude-opus, tokenhub/hy3, nous/deepseek/deepseek-v4-flash) or a raw models.dev specifier. Overrides repo settings. OpenAI-compatible gateways: set NOUS_API_KEY or TOKENHUB_API_KEY (or MERGECRAFT_CUSTOM_PROVIDER_*). Default behaviour (#37 / W4): the supplied `model:` becomes the **head** of the configured chain — the repo's `models:` list (and any `modelFallbacks:`) is retained as the tail and walked on credential miss or retryable failure. To restore the legacy "use exactly this model, suppress the chain" semantics, set `model_pin: enabled`. |
+| `model_pin` | `disabled` | #37 / W4 / D8 — opt into the legacy "use exactly this model" semantics for the `model:` input. Default `disabled`: `model:` becomes the chain head; the configured `models:` / `modelFallbacks:` tail is walked on credential miss or retryable failure. Set to `enabled` to collapse the chain to `[model]` (suppress fallbacks). Wire this through `.mergecraft/ config.yaml`'s `modelPin: true` for repo-wide default; the action input wins. |
+| `otel-endpoint` | _(empty)_ | OTLP collector URL (W8.5 / W7.7): e.g. `http://127.0.0.1:4318/v1/traces`. Wins over the config block. |
+| `output_schema` | _(unset)_ | JSON Schema (draft-07) for structured output validation. |
+| `prompt` | _(unset)_ | Prompt to send to the agent (string or JSON payload) |
+| `prompt_file` | _(unset)_ | Path to a file (relative to GITHUB_WORKSPACE) whose contents are used as the prompt. Set exactly one of prompt or prompt_file. |
+| `provider_api_key_env` | _(unset)_ | Name of an environment variable that holds the singleton provider's API key (e.g. `MY_PROVIDER_API_KEY`). mergeCraft reads this env var's value and exposes it to the harness as `MERGECRAFT_CUSTOM_PROVIDER_API_KEY`. Never inline the API key value here — reference the env-var *name* only (convention 7). Wire the secret via the workflow's `env:` block from a GitHub Actions secret named `MY_PROVIDER_API_KEY` (interpolated in your workflow YAML, not written literally here — a literal `secrets.*` expression inside this file's own description text fails action.yml validation, since `secrets` isn't a valid context for a composite action's metadata). See issue #71. |
+| `provider_base_url` | _(unset)_ | Custom OpenAI-compatible base URL for the singleton provider (`MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`, PR #79 / D7). Use this to point Codex or OpenCode at a third-party OpenAI-compatible gateway without committing env-var names in workflow YAML. The indexed multi-provider form (`MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>` for `N >= 1`) is env-only and not exposed here — that path is for advanced multi-provider setups where `with:` cannot enumerate multiple entries. See issue #71. |
+| `push` | _(unset)_ | Git push permission: disabled, restricted, or enabled. Default: restricted |
+| `sarif_upload` | `disabled` | Upload catalog-analyzer findings to GitHub code scanning as SARIF 2.1.0: disabled (default) or enabled. Complementary evidence for when the review narrative is thin or findings overflow the inline comment budget — never a gate: an upload failure is logged and the run still completes. Requires `security-events: write` on the job, and code scanning to be available on the repository. Only findings from catalog analyzers that this run's trust tier, shell policy and `analyzers:` mode actually admitted are uploaded, after secret redaction. CI-sourced and agent-sourced findings are never uploaded. An unrecognised value resolves to disabled, with a warning. When unset, `.mergecraft/config.yaml`'s `analyzers.sarifUpload` decides (default false). See issue #39. |
+| `setup_failure_policy` | _(empty)_ | S1 / D10 — what happens when a trusted-tier `setupScript` fails (non-zero exit) or times out. `inconclusive` (default) maps the run to `RunOutcome.inconclusive` (a `neutral` check conclusion) — the run is treated as no-verdict, never a passing review of an under-provisioned tree. `fail` aborts the run as `RunOutcome.configuration_error` (the consumer has declared the failure is unrecoverable). `warn` reproduces the legacy continue-on-failure behaviour; the prompt still carries the failure text so the reviewing agent knows its tree may be partially provisioned. Unknown values fail closed as `configuration_error` (this is a security/runtime surface — `extra="forbid"` semantics). |
+| `setup_timeout` | _(empty)_ | S1 / F6 — maximum wall-clock duration for `setupScript` (e.g. `5m`, `30s`, `1h`). A hanging install stalls the run otherwise. The setup runs as a session leader so its whole process tree is TERM→KILLed on timeout. Reusing `resolve_timeout_ms` — the same parser the `timeout` input uses. Default `10m` applies even when `timeout` is unset or `--notimeout`; setup never consumes the whole run budget. Note: `setupTimeout` must be strictly less than `timeout` (or the run aborts as `configuration_error`). Equal / larger budgets would let the setup script eat the whole run deadline; the agent is then given ≈1 ms and a setup timeout surfaces as `timed_out` instead of the `inconclusive` / `configuration_error` the setup policy was supposed to produce. Lower `setupTimeout` or raise `timeout` to satisfy the guard — see `docs/config-failure-policy.md` for the runtime reason text. |
+| `shell` | _(unset)_ | Shell permission: disabled, restricted, or enabled. |
+| `status_checks` | _(unset)_ | Post mergecraft and mergecraft-approval commit-status checks: disabled (default) or enabled. |
+| `suggest_eval_add` | `disabled` | Opt-in (W12.4 / #44): when enabled, log a logger.info suggestion to add the run to the eval bank when the run produced no positive findings, the trust tier is trusted, and the trigger is a re-review (not a fresh PR). Accepts disabled\|enabled (also true/false aliases). Default: disabled; mergeCraft never auto-adds. |
+| `timeout` | _(unset)_ | Maximum run duration (e.g., 10m, 1h30m). Default: 1h |
+| `token` | `${{ github.token }}` | GitHub-provided token with job-scoped permissions. |
+| `tracing` | _(empty)_ | Tracing enablement (W8.5 / W7.7): true / false. Wins over the .mergecraft/config.yaml `tracing.enabled` block when set. Unset defers to the config (default off). |
+| `tracing-to` | _(empty)_ | Tracing shorthand (W8.5 / W7.7): `local_files` / `logfire` / `otel`. Wins over the config block. `logfire` requires the optional `[tracing]` extra plus a `LOGFIRE_TOKEN` secret wired via `logfire-token` below; `otel` requires an `otel-endpoint`. |
+<!-- END:action-inputs -->
+
+Behavioural note: `setup_failure_policy`'s and `setup_timeout`'s literal
+`action.yml` default is an empty string (unset defers to the S1/D10 policy
+described below); the *effective* runtime default when left unset is
+`inconclusive` and `10m` respectively.
+
+- S1 / D10 — what a trusted-tier `setupScript` failure (non-zero exit **or**
+  timeout) maps to: `inconclusive` (effective default — neutral check
+  conclusion, the run is no-verdict), `fail` (`configuration_error`), or
+  `warn` (run continues; prompt still carries the failure text). Closed
+  vocabulary — unknown values fail closed as `configuration_error` before the
+  run starts.
+- S1 / F6 — `setup_timeout`'s effective default (`10m`) is the wall-clock
+  budget for `setupScript` (e.g. `5m`, `30s`, `1h`). A hanging install stalls
+  the run otherwise. Reuses the same duration grammar as `timeout`. The setup
+  runs as a session leader so a TERM → grace → KILL on the deadline reaches
+  the whole process tree.
+
+#### Action outputs
+
+<!-- BEGIN:action-outputs -->
+| Output | Description |
+|--------|-------------|
+| `evidence_packet` | JSON body of this run's Merge Evidence Packet (#47) — the versioned, structured record of the findings, deterministic checks, blast-radius lane, self-assessment, and decision behind the review. Emitted via `$GITHUB_OUTPUT` as multiline JSON (not a filesystem path). Empty when the run had no pull request to attest to. To upload as an artifact, write the output to a file in a later step. Schema: `docs/evidence-packet.md`. |
+| `result` | Set when the prompt requests it; required when output_schema is provided. |
+<!-- END:action-outputs -->
 
 #### Worked example — Nous-hosted DeepSeek V4 Flash
 
@@ -492,17 +535,58 @@ A workflow that used to dual-step (`if: HAS_CLAUDE` → one review, else
 
 ## 🧰 CLI
 
-| Command | Purpose |
-|---------|---------|
-| `mergecraft init` | Scaffold `.mergecraft/config.yaml` + example workflow |
-| `mergecraft auth <provider>` | Save a credential via `gh secret set` (`claude`, `codex`, `gemini`, `nous`, `tokenhub`, `cursor`, `logfire`) |
-| `mergecraft models list / set / show` | Curated slugs, ordered preference list, effective winner |
-| `mergecraft diff-review` | Offline local git/patch review (`--dry-run`, `--json`) |
-| `mergecraft watch --pr N` | Stream PR/issue timeline as JSONL |
-| `mergecraft learnings active / staging / influence` | Audit memory entries and their provenance |
-| `mergecraft traces <run-id>` | Read back local tracing spans (re-redacted) |
-| `mergecraft config tracing` | Render resolved tracing state (token redacted) |
-| `mergecraft gha` | Action runtime entry (Docker action) |
+The full command list (one row per real leaf command — pass `--help` to any
+of them for its full flag set):
+
+<!-- BEGIN:cli-commands -->
+| Command | Description |
+|---------|-------------|
+| `mergecraft analyzers detect` | Show analyzers that would run for changed paths in this repo. |
+| `mergecraft analyzers docs` | Regenerate `docs/ANALYZERS.md` from manifests. |
+| `mergecraft analyzers explain <analyzer-id>` | Print manifest fields and notes for one analyzer. |
+| `mergecraft analyzers export <analyzer-id>` | Run one analyzer and export findings as SARIF. |
+| `mergecraft analyzers list` | List catalog analyzers and whether they would enable here. |
+| `mergecraft analyzers lock` | Write or refresh `.mergecraft/analyzers.lock` for managed tools. |
+| `mergecraft analyzers run <analyzer-id>` | Execute one analyzer against the working tree. |
+| `mergecraft auth claude` | Save a Claude Code OAuth token as CLAUDE_CODE_OAUTH_TOKEN. |
+| `mergecraft auth codex` | Mint a Codex subscription credential and save it as CODEX_AUTH_JSON. |
+| `mergecraft auth cursor` | Save a Cursor API key as CURSOR_API_KEY. |
+| `mergecraft auth gemini` | Save a Gemini API key as GEMINI_API_KEY. |
+| `mergecraft auth logfire` | Save a Logfire write token + project for the `logfire` tracing sink. |
+| `mergecraft auth minimax` | Save a MiniMax API key as MERGECRAFT_CUSTOM_PROVIDER_API_KEY. |
+| `mergecraft auth nous` | Save a Nous Portal API key as NOUS_API_KEY. |
+| `mergecraft auth tokenhub` | Save a Tencent TokenHub API key as TOKENHUB_API_KEY. |
+| `mergecraft config tracing` | Render the resolved tracing config — sinks, retention, redaction, token redacted. |
+| `mergecraft diff-review` | Review a local git diff offline (no GitHub Action / PR posting). |
+| `mergecraft eval add` | Add a case to the bank. |
+| `mergecraft eval gate` | Check the eval bank's integrity — the CI-safe half of the eval loop. |
+| `mergecraft eval list` | List cases in the bank. |
+| `mergecraft eval promote <case-id>` | Promote a case into a permanent pytest test file (#44, W12.1). |
+| `mergecraft eval replay <case-id>` | Replay a case and report the diff. |
+| `mergecraft eval replay-bank` | Replay the eval bank and write a versioned benchmark result set (#140). |
+| `mergecraft eval score <actual> <expected>` | Score review findings against a frozen benchmark baseline. |
+| `mergecraft findings carryover --pr N` | File one issue per unresolved mergeCraft finding. Dry run unless `--apply`. |
+| `mergecraft findings export --pr N` | Print the findings a merge would bury. Never writes anything. |
+| `mergecraft gha token` | Acquire a GitHub App installation token, or revoke it with `--post`. |
+| `mergecraft init` | Scaffold `.mergecraft/config.yaml` and an example workflow (local, no API). |
+| `mergecraft learnings active` | List only the active (promoted) learning entries. |
+| `mergecraft learnings influence` | List active + staging learning entries with their provenance. |
+| `mergecraft learnings staging` | List only the staging (quarantined) learning entries. |
+| `mergecraft models list` | List curated model slugs and whether credentials are detected locally. |
+| `mergecraft models set <slugs>` | Write an ordered `models:` list to `.mergecraft/config.yaml`. |
+| `mergecraft models show` | Show effective model order, env override, and the slug that would win now. |
+| `mergecraft traces show <run-id>` | Read back the local JSONL traces for the given run id (re-redacts on render). |
+| `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
+| `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
+| `mergecraft version` | Show the mergeCraft package version. |
+| `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |
+<!-- END:cli-commands -->
+
+The bare `gha` group invocation (no subcommand) is the Docker action's
+runtime entry point — it is a Typer group callback, not a
+`registered_commands` leaf itself, so it is described here in prose rather
+than as its own table row; `gha token` above is the one real leaf command
+under that group.
 
 ## 🔒 Security model
 
@@ -530,6 +614,9 @@ A workflow that used to dual-step (`if: HAS_CLAUDE` → one review, else
   ``0o600`` inside a ``0o700`` credentials directory the agent cannot read.
   Run temp dirs and registered leak-surface paths are removed on success and
   failure; ``wipe_runner_leak_surface`` only unlinks mergeCraft-owned paths.
+- **`push` / `shell` value semantics are defined in the action-inputs
+  table** — see [Action inputs (`with:`)](#action-inputs-with) above for the
+  `disabled` / `restricted` / `enabled` vocabulary both inputs share.
 - **Containment hardening** — ``safe.directory`` is scoped to
   ``$GITHUB_WORKSPACE`` and registered cross-repo checkout roots (no wildcard).
   Git hooks run only when ``shell: enabled``; ``restricted`` and ``disabled``

--- a/scripts/gen_reference_docs.py
+++ b/scripts/gen_reference_docs.py
@@ -234,20 +234,19 @@ def _render_cli_table(commands: list[tuple[CommandPath, Any]]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _splice(text: str, begin: str, end: str, content: str, *, required: bool) -> str:
+def _splice(text: str, begin: str, end: str, content: str) -> str:
     """Replace the text between a ``<!-- BEGIN:x -->`` / ``<!-- END:x -->`` pair.
 
-    When ``required`` is False and the sentinel pair is absent, ``text`` is
-    returned unchanged — used for the action-outputs table, which is not part
-    of the generator's frozen scratch-fixture contract (``README.md`` in the
-    real repo carries the sentinel; ad-hoc scratch fixtures may not).
+    Every sentinel pair is mandatory: a removed pair must fail the generator
+    loudly (``--check`` as well as default/write mode), not silently leave a
+    now-unmanaged table in place. A table that survives sentinel removal
+    would still contain the right substrings today, so ``--check`` would
+    report clean even though nothing regenerates or verifies it anymore.
     """
     pattern = re.compile(re.escape(begin) + r"\n.*?" + re.escape(end), re.DOTALL)
     if not pattern.search(text):
-        if required:
-            msg = f"{README_PATH}: sentinel pair not found: {begin} / {end}"
-            raise SystemExit(msg)
-        return text
+        msg = f"{README_PATH}: sentinel pair not found: {begin} / {end}"
+        raise SystemExit(msg)
     replacement = f"{begin}\n{content}{end}"
     return pattern.sub(lambda _match: replacement, text, count=1)
 
@@ -258,19 +257,11 @@ def _generate(
     inputs = dict(action_data.get("inputs") or {})
     outputs = dict(action_data.get("outputs") or {})
     text = readme_text
+    text = _splice(text, _ACTION_INPUTS_BEGIN, _ACTION_INPUTS_END, _render_action_inputs(inputs))
     text = _splice(
-        text, _ACTION_INPUTS_BEGIN, _ACTION_INPUTS_END, _render_action_inputs(inputs), required=True
+        text, _ACTION_OUTPUTS_BEGIN, _ACTION_OUTPUTS_END, _render_action_outputs(outputs)
     )
-    text = _splice(
-        text,
-        _ACTION_OUTPUTS_BEGIN,
-        _ACTION_OUTPUTS_END,
-        _render_action_outputs(outputs),
-        required=False,
-    )
-    return _splice(
-        text, _CLI_COMMANDS_BEGIN, _CLI_COMMANDS_END, _render_cli_table(commands), required=True
-    )
+    return _splice(text, _CLI_COMMANDS_BEGIN, _CLI_COMMANDS_END, _render_cli_table(commands))
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/gen_reference_docs.py
+++ b/scripts/gen_reference_docs.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Regenerate README's action-input, action-output, and CLI reference tables.
+
+Module: scripts.gen_reference_docs
+Depends: argparse, difflib, inspect, re, sys, typing, pathlib, yaml,
+    mergecraft.cli.app
+
+The two reference tables in ``README.md`` (the ``action.yml`` "full input
+list" and the ``## CLI`` command table) are hand-maintained prose that drifts
+from the live sources — see the ``issues-showcase-readiness`` wave plan, PR
+G2. This script derives both from the live sources (``action.yml`` for
+inputs/outputs, the live Typer ``app`` object for CLI commands — never a
+subprocess) and splices them into ``README.md`` between HTML sentinel
+comments, so the tables can be regenerated (default) or checked for drift
+(``--check``) without hand-editing.
+
+Exports:
+    main — regenerate (default) or ``--check`` the README reference tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import inspect
+import re
+import sys
+import typing
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTION_YML_PATH = REPO_ROOT / "action.yml"
+README_PATH = REPO_ROOT / "README.md"
+
+_ACTION_INPUTS_BEGIN = "<!-- BEGIN:action-inputs -->"
+_ACTION_INPUTS_END = "<!-- END:action-inputs -->"
+_ACTION_OUTPUTS_BEGIN = "<!-- BEGIN:action-outputs -->"
+_ACTION_OUTPUTS_END = "<!-- END:action-outputs -->"
+_CLI_COMMANDS_BEGIN = "<!-- BEGIN:cli-commands -->"
+_CLI_COMMANDS_END = "<!-- END:cli-commands -->"
+
+CommandPath = tuple[str, ...]
+
+# ---------------------------------------------------------------------------
+# shared text helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_paragraph(text: str) -> str:
+    """Return the first blank-line-delimited paragraph of ``text``, collapsed to one line."""
+    paragraph = text.strip().split("\n\n", 1)[0]
+    return " ".join(paragraph.split())
+
+
+def _md_cell(text: str) -> str:
+    """Make ``text`` safe as one markdown table cell: single backticks, no bare pipes."""
+    collapsed = _first_paragraph(text).replace("``", "`")
+    return collapsed.replace("|", "\\|")
+
+
+# ---------------------------------------------------------------------------
+# action.yml -> action-inputs / action-outputs tables
+# ---------------------------------------------------------------------------
+
+
+def _load_action_yml() -> dict[str, Any]:
+    data = yaml.safe_load(ACTION_YML_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        msg = f"{ACTION_YML_PATH}: did not parse as a mapping"
+        raise TypeError(msg)
+    return data
+
+
+def _render_default_cell(spec: dict[str, Any]) -> str:
+    """Render the literal ``action.yml`` ``default:`` value, not any behavioural default.
+
+    ``_(unset)_`` means the input has no ``default:`` key at all (required prose
+    default lives only in the description, if anywhere). ``_(empty)_`` means an
+    explicit ``default: ""`` — distinct from having no default key.
+    """
+    if "default" not in spec:
+        return "_(unset)_"
+    default = str(spec["default"])
+    if default == "":
+        return "_(empty)_"
+    return f"`{default}`"
+
+
+def _render_action_inputs(inputs: dict[str, dict[str, Any]]) -> str:
+    lines = [
+        "The full input list:",
+        "",
+        "| Input | Default | Description |",
+        "|-------|---------|-------------|",
+    ]
+    for name in sorted(inputs):
+        spec = inputs[name] or {}
+        default_cell = _render_default_cell(spec)
+        description = _md_cell(str(spec.get("description", "")))
+        lines.append(f"| `{name}` | {default_cell} | {description} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_action_outputs(outputs: dict[str, dict[str, Any]]) -> str:
+    lines = [
+        "| Output | Description |",
+        "|--------|-------------|",
+    ]
+    for name in sorted(outputs):
+        spec = outputs[name] or {}
+        description = _md_cell(str(spec.get("description", "")))
+        lines.append(f"| `{name}` | {description} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# live Typer app -> CLI command table
+# ---------------------------------------------------------------------------
+
+
+def _walk_typer_commands(
+    app: typer.Typer, prefix: CommandPath = ()
+) -> list[tuple[CommandPath, Any]]:
+    """Recursively collect every leaf command's path + callback from a Typer app.
+
+    Mirrors ``tests/docs/test_reference_docs.py::_walk_typer_commands`` (never
+    invoke the CLI as a subprocess to discover commands — walk the live
+    ``registered_commands`` / ``registered_groups`` objects).
+    """
+    commands: list[tuple[CommandPath, Any]] = []
+    for command in app.registered_commands:
+        name = command.name
+        if name is None and command.callback is not None:
+            name = command.callback.__name__.replace("_", "-")
+        if not name:
+            msg = f"unnamed command under {prefix}"
+            raise ValueError(msg)
+        commands.append(((*prefix, name), command.callback))
+    for group in app.registered_groups:
+        if not group.name or group.typer_instance is None:
+            msg = f"malformed group under {prefix}: {group.name!r}"
+            raise ValueError(msg)
+        commands.extend(_walk_typer_commands(group.typer_instance, (*prefix, group.name)))
+    return commands
+
+
+def _typer_info(param: inspect.Parameter, hint: Any) -> Any:
+    """Return the ``ArgumentInfo``/``OptionInfo`` behind a Typer parameter.
+
+    Handles both the legacy ``name: T = typer.Option(...)`` style (the info
+    object *is* the parameter default) and the modern
+    ``name: Annotated[T, typer.Option(...)]`` style (the info object is
+    embedded in the annotation's metadata instead — ``hint`` is the
+    *resolved* annotation from ``typing.get_type_hints``, since
+    ``from __future__ import annotations`` leaves ``param.annotation`` as an
+    unresolved string in some, but not all, observed cases).
+    """
+    if isinstance(param.default, (typer.models.ArgumentInfo, typer.models.OptionInfo)):
+        return param.default
+    for arg in typing.get_args(hint):
+        if isinstance(arg, (typer.models.ArgumentInfo, typer.models.OptionInfo)):
+            return arg
+    return None
+
+
+def _is_required(param: inspect.Parameter, info: Any) -> bool:
+    if param.default is inspect.Parameter.empty:
+        return True
+    return bool(
+        isinstance(info, (typer.models.ArgumentInfo, typer.models.OptionInfo))
+        and info.default is ...
+    )
+
+
+def _invocation_suffix(callback: Any) -> str:
+    """Best-effort trailing placeholder tokens for a command's required params.
+
+    Only ever appends a token pattern the README test's parser
+    (``_parse_cli_invocation``) can strip back off cleanly: a run of required
+    positional ``<placeholder>`` tokens, or a single ``--flag PLACEHOLDER``
+    when there is exactly one required option and no required positional
+    argument. Commands with several required options (e.g. ``eval add``) are
+    documented bare — the parser only strips *one* trailing flag+value pair,
+    so chaining several would leave a bogus token stuck to the command path.
+    """
+    sig = inspect.signature(callback)
+    try:
+        hints = typing.get_type_hints(callback, include_extras=True)
+    except Exception:  # pragma: no cover - defensive; every real command resolves cleanly
+        hints = {}
+    arg_placeholders: list[str] = []
+    required_options: list[tuple[Any, inspect.Parameter, Any]] = []
+    for name, param in sig.parameters.items():
+        hint = hints.get(name, param.annotation)
+        info = _typer_info(param, hint)
+        if info is None or not _is_required(param, info):
+            continue
+        if isinstance(info, typer.models.ArgumentInfo):
+            arg_placeholders.append(f"<{name.replace('_', '-')}>")
+        else:
+            required_options.append((info, param, hint))
+    if arg_placeholders:
+        return " " + " ".join(arg_placeholders)
+    if len(required_options) == 1:
+        info, param, hint = required_options[0]
+        flag = info.param_decls[0] if info.param_decls else f"--{param.name.replace('_', '-')}"
+        placeholder = "N" if "int" in str(hint) else param.name.upper()
+        return f" {flag} {placeholder}"
+    return ""
+
+
+def _cli_row(path: CommandPath, callback: Any) -> str:
+    invocation = "mergecraft " + " ".join(path) + _invocation_suffix(callback)
+    summary = _md_cell(callback.__doc__ or "") if callback is not None else ""
+    return f"| `{invocation}` | {summary} |"
+
+
+def _render_cli_table(commands: list[tuple[CommandPath, Any]]) -> str:
+    lines = ["| Command | Description |", "|---------|-------------|"]
+    for path, callback in sorted(commands, key=lambda item: item[0]):
+        lines.append(_cli_row(path, callback))
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# sentinel splicing
+# ---------------------------------------------------------------------------
+
+
+def _splice(text: str, begin: str, end: str, content: str, *, required: bool) -> str:
+    """Replace the text between a ``<!-- BEGIN:x -->`` / ``<!-- END:x -->`` pair.
+
+    When ``required`` is False and the sentinel pair is absent, ``text`` is
+    returned unchanged — used for the action-outputs table, which is not part
+    of the generator's frozen scratch-fixture contract (``README.md`` in the
+    real repo carries the sentinel; ad-hoc scratch fixtures may not).
+    """
+    pattern = re.compile(re.escape(begin) + r"\n.*?" + re.escape(end), re.DOTALL)
+    if not pattern.search(text):
+        if required:
+            msg = f"{README_PATH}: sentinel pair not found: {begin} / {end}"
+            raise SystemExit(msg)
+        return text
+    replacement = f"{begin}\n{content}{end}"
+    return pattern.sub(lambda _match: replacement, text, count=1)
+
+
+def _generate(
+    action_data: dict[str, Any], readme_text: str, commands: list[tuple[CommandPath, Any]]
+) -> str:
+    inputs = dict(action_data.get("inputs") or {})
+    outputs = dict(action_data.get("outputs") or {})
+    text = readme_text
+    text = _splice(
+        text, _ACTION_INPUTS_BEGIN, _ACTION_INPUTS_END, _render_action_inputs(inputs), required=True
+    )
+    text = _splice(
+        text,
+        _ACTION_OUTPUTS_BEGIN,
+        _ACTION_OUTPUTS_END,
+        _render_action_outputs(outputs),
+        required=False,
+    )
+    return _splice(
+        text, _CLI_COMMANDS_BEGIN, _CLI_COMMANDS_END, _render_cli_table(commands), required=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Regenerate (default) or ``--check`` README's action/CLI reference tables."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero (with a unified diff) when README drifts from action.yml / the live CLI.",
+    )
+    args = parser.parse_args(argv)
+
+    # Imported here (not at module scope) so ``--check``/write always reflect
+    # whatever ``mergecraft.cli.app`` looks like right now — and so a bare
+    # ``python -c "import scripts.gen_reference_docs"`` never has an import-time
+    # side effect of loading the whole CLI app.
+    from mergecraft.cli.app import app as root_app
+
+    action_data = _load_action_yml()
+    commands = _walk_typer_commands(root_app)
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    generated = _generate(action_data, readme_text, commands)
+
+    if args.check:
+        if generated == readme_text:
+            print(f"{README_PATH.name}: reference tables match action.yml / the live CLI")
+            return 0
+        diff = difflib.unified_diff(
+            readme_text.splitlines(keepends=True),
+            generated.splitlines(keepends=True),
+            fromfile=str(README_PATH),
+            tofile=f"{README_PATH} (generated)",
+        )
+        sys.stdout.writelines(diff)
+        print(
+            f"{README_PATH.name}: reference tables drifted from action.yml / the live CLI"
+            " (run: make reference-docs)",
+            file=sys.stderr,
+        )
+        return 1
+
+    README_PATH.write_text(generated, encoding="utf-8")
+    print(f"wrote {README_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/docs/test_reference_docs.py
+++ b/tests/docs/test_reference_docs.py
@@ -23,6 +23,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import pytest
 import yaml
 
 from mergecraft.cli.app import app as root_app
@@ -30,7 +31,6 @@ from mergecraft.cli.auth_cmd import app as auth_app
 from tests.ci.workflow_support import REPO_ROOT
 
 if TYPE_CHECKING:
-    import pytest
     import typer
 
 ACTION_YML = REPO_ROOT / "action.yml"
@@ -242,6 +242,11 @@ _SCRATCH_README = """\
 
 <!-- BEGIN:action-inputs -->
 <!-- END:action-inputs -->
+
+#### Action outputs
+
+<!-- BEGIN:action-outputs -->
+<!-- END:action-outputs -->
 """
 
 
@@ -398,3 +403,28 @@ def test_generator_check_mode_detects_drift(
         "--check must emit a unified diff (lines starting with ---/+++/@@) on drift, "
         f"not just a terse message; got:\n{output}"
     )
+
+
+def test_generator_fails_when_a_sentinel_pair_is_removed(tmp_path: Path) -> None:
+    """A removed sentinel pair must fail loudly, not silently orphan that table.
+
+    If a sentinel pair is deleted (e.g. by a careless hand-edit) but the table
+    content it used to wrap is left behind, that table still contains the
+    right substrings — so a content-presence check alone would stay green
+    while the table quietly stops being regenerated or verified. Every
+    sentinel pair must therefore be mandatory: removing one must raise, in
+    both write and ``--check`` mode.
+    """
+    module = _load_gen_reference_docs()
+    _, readme = _write_scratch_repo(tmp_path, module)
+
+    text = readme.read_text(encoding="utf-8")
+    assert "<!-- BEGIN:action-outputs -->" in text
+    stripped = text.replace("<!-- BEGIN:action-outputs -->\n<!-- END:action-outputs -->\n", "", 1)
+    assert stripped != text, "fixture sentinel pair not found; cannot remove it"
+    readme.write_text(stripped, encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        module.main([])
+    with pytest.raises(SystemExit):
+        module.main(["--check"])

--- a/tests/docs/test_reference_docs.py
+++ b/tests/docs/test_reference_docs.py
@@ -1,0 +1,400 @@
+"""G2 — README action/CLI reference tables vs. live ``action.yml``/CLI app (RED, G2.1).
+
+Three separate audits found README/action.yml/CLI drift (issues-showcase-readiness
+wave plan, PR G2): the README's "full input list" table documents 9 of 24 real
+``action.yml`` inputs, neither declared output is documented anywhere, the CLI
+table documents ``mergecraft traces <run-id>`` when the real registered command is
+``mergecraft traces show <run-id>``, and whole CLI groups (``analyzers``, ``eval``,
+``findings``, ``version``, ``gha token``, ``tracing logfire enable/disable``) are
+undocumented. G2.2 (a later wave) adds ``scripts/gen_reference_docs.py`` to
+regenerate both tables from the live sources between HTML sentinel comments and
+wires a ``--check`` gate into ``make ci-static``; this suite is the RED contract
+that wave implements against.
+
+Every assertion here reads the *live* ``action.yml`` / live Typer ``app`` object
+rather than hard-coding today's counts, so the suite stays correct as the code
+evolves instead of re-encoding today's drift as magic numbers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from mergecraft.cli.app import app as root_app
+from mergecraft.cli.auth_cmd import app as auth_app
+from tests.ci.workflow_support import REPO_ROOT
+
+if TYPE_CHECKING:
+    import pytest
+    import typer
+
+ACTION_YML = REPO_ROOT / "action.yml"
+README = REPO_ROOT / "README.md"
+
+# ---------------------------------------------------------------------------
+# action.yml helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_action_yml() -> dict[str, Any]:
+    data = yaml.safe_load(ACTION_YML.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "action.yml did not parse as a mapping"
+    return data
+
+
+def _action_inputs() -> dict[str, dict[str, Any]]:
+    return dict(_load_action_yml().get("inputs") or {})
+
+
+def _action_outputs() -> dict[str, dict[str, Any]]:
+    return dict(_load_action_yml().get("outputs") or {})
+
+
+def _readme_action_input_table() -> dict[str, str]:
+    """Parse README's ``| Input | Default | Description |`` table.
+
+    Returns ``{input_name: raw_default_cell_text}`` (the ``Default`` column,
+    backticks and placeholder prose like ``_(empty)_`` left un-normalised —
+    callers normalise per their own needs).
+    """
+    text = README.read_text(encoding="utf-8")
+    match = re.search(r"The full input list:\n\n(\|.*\n(?:\|.*\n)+)", text)
+    assert match, "README.md: could not locate 'The full input list:' action-input table"
+    rows = match.group(1).splitlines()[2:]  # drop header + separator rows
+    documented: dict[str, str] = {}
+    for row in rows:
+        cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        name = cells[0].strip("`")
+        documented[name] = cells[1]
+    return documented
+
+
+# ---------------------------------------------------------------------------
+# CLI-app helpers
+# ---------------------------------------------------------------------------
+
+
+def _walk_typer_commands(app: typer.Typer, prefix: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
+    """Recursively collect every leaf command's full path from a Typer app.
+
+    Walks ``registered_commands`` (leaves) and ``registered_groups``
+    (``add_typer`` sub-apps, nested arbitrarily deep — e.g. ``tracing`` ->
+    ``logfire`` -> ``enable``/``disable`` is 3 levels).
+    """
+    paths: set[tuple[str, ...]] = set()
+    for command in app.registered_commands:
+        name = command.name
+        if name is None and command.callback is not None:
+            name = command.callback.__name__.replace("_", "-")
+        assert name, f"unnamed command under {prefix}"
+        paths.add((*prefix, name))
+    for group in app.registered_groups:
+        assert group.name, f"unnamed group under {prefix}"
+        assert group.typer_instance is not None, f"group {group.name!r} has no typer_instance"
+        paths |= _walk_typer_commands(group.typer_instance, (*prefix, group.name))
+    return paths
+
+
+_PLACEHOLDER = re.compile(r"^<[^>]+>$")
+_BRACKET = re.compile(r"^\[[^\]]+\]$")
+_INVOCATION = re.compile(r"`(mergecraft [^`]+)`")
+_CLI_HEADING = "## \U0001f9f0 CLI"
+
+
+def _parse_cli_invocation(invocation: str) -> list[tuple[str, ...]]:
+    """Parse one backtick-quoted ``mergecraft ...`` string into command-path tuples.
+
+    Honours the README's `` / `` shorthand for sibling subcommands (e.g.
+    ``models list / set / show`` -> ``("models","list")``, ``("models","set")``,
+    ``("models","show")``) and strips a single trailing positional-argument or
+    option-flag token (``<placeholder>``, ``[placeholder]``, a bare upper-case
+    value placeholder like ``N``, or a ``--flag``). This is a literal parse of
+    what the row actually says — it does not infer a "corrected" form, which is
+    exactly why ``mergecraft traces <run-id>`` parses to ``("traces",)`` (not a
+    real leaf command; the real leaf is ``("traces","show")``) while
+    ``mergecraft auth <provider>`` parses to ``("auth",)`` — also not a leaf,
+    since ``auth`` only has named-provider children.
+    """
+    text = invocation.strip()
+    if not text.startswith("mergecraft"):
+        return []
+    text = text[len("mergecraft") :].strip()
+    if not text:
+        return []
+    branches = [branch.strip() for branch in text.split(" / ")]
+    first_tokens = branches[0].split()
+    group = first_tokens[0] if first_tokens else ""
+    paths: list[tuple[str, ...]] = []
+    for index, branch in enumerate(branches):
+        tokens = branch.split()
+        if index > 0 and tokens and tokens[0] != group:
+            tokens = [group, *tokens]
+        while tokens and (
+            _PLACEHOLDER.match(tokens[-1]) or _BRACKET.match(tokens[-1]) or tokens[-1].isupper()
+        ):
+            tokens.pop()
+        while tokens and tokens[-1].startswith("--"):
+            tokens.pop()
+        if tokens:
+            paths.append(tuple(tokens))
+    return paths
+
+
+def _readme_cli_section() -> str:
+    text = README.read_text(encoding="utf-8")
+    start = text.index(_CLI_HEADING)
+    rest = text[start + len(_CLI_HEADING) :]
+    end_match = re.search(r"\n## ", rest)
+    return rest[: end_match.start()] if end_match else rest
+
+
+def _readme_documented_cli_paths() -> set[tuple[str, ...]]:
+    documented: set[tuple[str, ...]] = set()
+    for match in _INVOCATION.finditer(_readme_cli_section()):
+        documented.update(_parse_cli_invocation(match.group(1)))
+    return documented
+
+
+def _auth_registry_providers() -> set[str]:
+    providers: set[str] = set()
+    for command in auth_app.registered_commands:
+        assert command.name, "unnamed command under auth"
+        providers.add(command.name)
+    return providers
+
+
+def _readme_auth_providers() -> set[str]:
+    """Return the provider names README documents for ``mergecraft auth``.
+
+    Handles today's shorthand row (``mergecraft auth <provider>`` followed by a
+    parenthetical comma list) and, as a fallback, a future table shape where the
+    reference-doc generator expands each provider into its own
+    ``mergecraft auth <name>`` row instead of the shorthand.
+    """
+    text = README.read_text(encoding="utf-8")
+    row_match = re.search(r"^\|\s*`mergecraft auth <provider>`.*$", text, re.MULTILINE)
+    if row_match:
+        paren_match = re.search(r"\(([^)]*)\)", row_match.group(0))
+        assert paren_match, (
+            f"README auth row has no parenthetical provider list: {row_match.group(0)!r}"
+        )
+        return {name.strip().strip("`") for name in paren_match.group(1).split(",") if name.strip()}
+    documented_paths = _readme_documented_cli_paths()
+    return {path[1] for path in documented_paths if len(path) >= 2 and path[0] == "auth"}
+
+
+# ---------------------------------------------------------------------------
+# generator-script loader (scripts/gen_reference_docs.py does not exist until G2.2)
+# ---------------------------------------------------------------------------
+
+
+def _load_gen_reference_docs() -> Any:
+    """Load ``scripts/gen_reference_docs.py`` per-test (never at module import time).
+
+    A missing script must fail exactly the tests that need it, not blow up
+    collection for the whole file — mirrors ``tests/ci/test_hook_pins.py`` and
+    ``tests/ci/test_action_yml_hygiene.py``.
+    """
+    path = REPO_ROOT / "scripts" / "gen_reference_docs.py"
+    assert path.is_file(), "scripts/gen_reference_docs.py missing (lands in G2.2)"
+    spec = importlib.util.spec_from_file_location("gen_reference_docs", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Design note: no pre-existing sentinel convention exists anywhere in this repo
+# (confirmed via grep) — these markers are this generator's own contract, first
+# defined here; G2.2 must match them exactly.
+_SCRATCH_ACTION_YML = """\
+inputs:
+  prompt:
+    description: "Prompt text"
+    required: false
+  model_pin:
+    description: "Pin the model"
+    required: false
+    default: "disabled"
+outputs:
+  result:
+    description: "Result output"
+    value: ${{ steps.run.outputs.result }}
+"""
+
+_SCRATCH_README = """\
+# Scratch
+
+## \U0001f9f0 CLI
+
+<!-- BEGIN:cli-commands -->
+<!-- END:cli-commands -->
+
+#### Action inputs (`with:`)
+
+<!-- BEGIN:action-inputs -->
+<!-- END:action-inputs -->
+"""
+
+
+def _write_scratch_repo(tmp_path: Path, module: Any) -> tuple[Path, Path]:
+    """Point the loaded module's path-level constants at a scratch copy.
+
+    Only ``action.yml``/``README.md`` are scratch files — the CLI table half
+    of the generator imports the real ``mergecraft.cli.app`` object (there is
+    no file to substitute for a live Python object; the generator will import
+    the real app in production too).
+    """
+    action_yml = tmp_path / "action.yml"
+    readme = tmp_path / "README.md"
+    action_yml.write_text(_SCRATCH_ACTION_YML, encoding="utf-8")
+    readme.write_text(_SCRATCH_README, encoding="utf-8")
+    module.ACTION_YML_PATH = action_yml
+    module.README_PATH = readme
+    return action_yml, readme
+
+
+# ---------------------------------------------------------------------------
+# 1. action inputs
+# ---------------------------------------------------------------------------
+
+
+def test_every_action_input_is_documented() -> None:
+    real = set(_action_inputs())
+    documented = set(_readme_action_input_table())
+    assert documented == real, (
+        f"README action-input table drift — missing: {sorted(real - documented)}, "
+        f"stale/extra: {sorted(documented - real)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. action outputs
+# ---------------------------------------------------------------------------
+
+
+def test_both_action_outputs_are_documented() -> None:
+    outputs = set(_action_outputs())
+    assert outputs, "action.yml declares no outputs — nothing to check against"
+    text = README.read_text(encoding="utf-8")
+    missing = sorted(name for name in outputs if f"`{name}`" not in text)
+    assert not missing, f"action.yml outputs undocumented anywhere in README.md: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 3. action input defaults
+# ---------------------------------------------------------------------------
+
+
+def test_action_input_defaults_match_yaml() -> None:
+    inputs = _action_inputs()
+    documented = _readme_action_input_table()
+    mismatches: list[str] = []
+    for name, spec in inputs.items():
+        if "default" not in spec:
+            # No default key at all in action.yml — distinct from an explicit
+            # empty-string default; nothing to compare here.
+            continue
+        if name not in documented:
+            # Presence is test_every_action_input_is_documented's job.
+            continue
+        real_default = str(spec["default"])
+        doc_cell = documented[name]
+        normalized = doc_cell.strip("`")
+        if normalized in {"_(empty)_", "_(unset)_"}:
+            normalized = ""
+        if real_default != normalized:
+            mismatches.append(
+                f"{name}: action.yml default={real_default!r}, README says {doc_cell!r}"
+            )
+    assert not mismatches, "\n".join(mismatches)
+
+
+# ---------------------------------------------------------------------------
+# 4/5. CLI commands vs. README's CLI table (both directions)
+# ---------------------------------------------------------------------------
+
+
+def test_every_cli_command_is_documented() -> None:
+    real = _walk_typer_commands(root_app)
+    documented = _readme_documented_cli_paths()
+    missing = sorted(real - documented)
+    assert not missing, f"CLI commands missing from README's CLI table: {missing}"
+
+
+def test_documented_cli_commands_all_exist() -> None:
+    real = _walk_typer_commands(root_app)
+    documented = _readme_documented_cli_paths()
+    bogus = sorted(documented - real)
+    assert not bogus, (
+        f"README documents CLI invocations that don't resolve to a real registered "
+        f"command: {bogus} (e.g. `mergecraft traces <run-id>` parses to ('traces',), "
+        f"but the real leaf command is ('traces','show'))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. auth provider list
+# ---------------------------------------------------------------------------
+
+
+def test_auth_provider_list_matches_registry() -> None:
+    real = _auth_registry_providers()
+    documented = _readme_auth_providers()
+    assert documented == real, (
+        f"README auth provider list drift — missing: {sorted(real - documented)}, "
+        f"stale: {sorted(documented - real)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7/8. scripts/gen_reference_docs.py --check behaviour (RED until G2.2)
+# ---------------------------------------------------------------------------
+
+
+def test_generator_check_mode_is_idempotent(tmp_path: Path) -> None:
+    module = _load_gen_reference_docs()
+    _write_scratch_repo(tmp_path, module)
+
+    write_exit = module.main([])
+    assert write_exit == 0, "default (write) mode must exit 0"
+
+    check_exit = module.main(["--check"])
+    assert check_exit == 0, "--check must exit 0 immediately after a write pass (idempotent)"
+
+
+def test_generator_check_mode_detects_drift(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_gen_reference_docs()
+    _, readme = _write_scratch_repo(tmp_path, module)
+    assert module.main([]) == 0
+
+    generated = readme.read_text(encoding="utf-8")
+    mutated = generated.replace(
+        "<!-- END:action-inputs -->",
+        "| `bogus_input` | `nope` | drift injected by test_generator_check_mode_detects_drift |\n"
+        "<!-- END:action-inputs -->",
+    )
+    assert mutated != generated, "fixture sentinel marker not found; cannot inject drift"
+    readme.write_text(mutated, encoding="utf-8")
+
+    capsys.readouterr()  # drain any output from the write pass above
+    check_exit = module.main(["--check"])
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+
+    assert check_exit != 0, "--check must exit non-zero when README drifts from action.yml"
+    diff_lines = [line for line in output.splitlines() if line.startswith(("---", "+++", "@@"))]
+    assert diff_lines, (
+        "--check must emit a unified diff (lines starting with ---/+++/@@) on drift, "
+        f"not just a terse message; got:\n{output}"
+    )


### PR DESCRIPTION
## Summary

Three separate audits have found README/`action.yml`/CLI drift (PR G2 of the `issues-showcase-readiness` wave plan, G-F4). This adds a generator + `--check` gate so the drift class can't recur, mirroring the existing `render_example_workflows.py --check` pattern already wired into `make ci-static`.

- `scripts/gen_reference_docs.py` (new) regenerates two README tables from live sources — never a subprocess:
  - The action inputs/outputs tables from `action.yml` (24 inputs, 2 outputs — the README table previously documented 9/24 inputs and neither output anywhere).
  - The CLI command table by walking the live `mergecraft.cli.app.app` Typer object (`registered_commands` + `registered_groups`, recursively) — 39 real leaf commands. Whole groups were previously undocumented: `analyzers` (7), `eval` (7), `findings` (2), `version`, `gha token`, `config tracing`, `tracing logfire enable`/`disable`.
- Both tables are spliced into `README.md` between HTML sentinel comments (`<!-- BEGIN:... -->`/`<!-- END:... -->`) so the surrounding prose stays hand-written and the tables become machine-owned.
- `make reference-docs` / `make reference-docs-check` (the latter wired into `ci-static` and `CI_STEPS`, immediately after `example-workflows-check`).
- Fixes `mergecraft traces <run-id>` → `mergecraft traces show <run-id>` by construction (the old form isn't a real registered leaf command).
- Fixes a subtler drift: `setup_failure_policy`/`setup_timeout` were documented with their *effective* runtime defaults (`inconclusive`/`10m`) even though `action.yml`'s literal `default:` field for both is `""` — the generator now renders the literal YAML default and states the effective default separately in prose.
- Adds a one-line cross-reference from the Security-model section to the new inputs table for `push`/`shell` semantics.

## Test plan

- [x] `tests/docs/test_reference_docs.py` — 8 new tests, written tests-first (confirmed 0/8 passing against `action.yml`/README/live CLI app before this PR's implementation commit; all failures were genuine drift, not placeholders). 8/8 green now.
- [x] `make reference-docs-check` clean.
- [x] `make ci-static` passes with the new step included.
- [x] Behavioural proof beyond the structural tests: all 39 documented commands run with `mergecraft ... --help` at exit 0 (scripted, not spot-checked).
- [x] `make ci-resume` clean — all 10 steps (lockcheck, lint, typecheck, pyright, catalog-check, build, example-workflows-check, reference-docs-check, security, coverage-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)