### PR TITLE
feat(evals): F1, false-positive ledger and closed-world metrics [stacked 1/7]

### DIFF
--- a/docs/dev/test-plans/eval-benchmark-b1-metrics.md
+++ b/docs/dev/test-plans/eval-benchmark-b1-metrics.md
@@ -1,0 +1,163 @@
+# Eval benchmark B1 — F1, FP ledger, closed-world metrics test plan (RED)
+
+Wave plan: `.ignorelocal/waves/issues-eval-benchmark-numbers-wave-plan.md` — PR B1
+Worktree: `mergecraft-bench-b1-metrics` @ `wave/bench-b1-metrics`
+Anchor: `src/mergecraft/evals/scoring.py`
+
+## Design-gate findings (B1.0) — for the B1.2 implementer to confirm
+
+### 1. Category vocabulary — two vocabularies, not one, and that's correct
+
+B1.0's third bullet asks whether `review_taxonomy.py`'s category vocabulary
+aligns with `evals/benchmark.py`'s four `corpus_class_for()` buckets
+(`correctness` / `security` / `cross_file` / `adversarial_noop`).
+
+**Verified: they are answering different questions and should stay separate.**
+
+- `corpus_class_for()` classifies a **bank `Case`** (`evals/store.py::Case`,
+  used for structural decision replay in `evals/benchmark.py`) by its id
+  prefix / `case.category` field, whose values are things like
+  `false_positive`, `missed_finding`, `rejected`, `reverted` — none of which
+  come from `review_taxonomy.py` today. This is a **case-level** bucket: "what
+  kind of regression scenario is this eval-bank entry."
+- `review_taxonomy.FINDING_CATEGORIES` (`"Functional Correctness"`,
+  `"Data Integrity & Atomicity"`, `"Security & Privacy"`,
+  `"Stability & Availability"`, `"Performance & Scalability"`,
+  `"Maintainability & Code Quality"`) is a **finding-level** taxonomy — what a
+  single reported finding is *about*. `BaselineIssue.category` /
+  `ReportedFinding.category` in `scoring.py` are free-text fields that already
+  compare case-insensitively against each other, with no connection to
+  `corpus_class_for()`.
+
+B1's `by_category` breakdown (this test plan) buckets **findings**, so it
+reuses `review_taxonomy.FINDING_CATEGORIES` — pinned by
+`test_by_category_keys_use_the_review_taxonomy_vocabulary` in
+`tests/evals/test_scoring_metrics.py`, which also asserts the four
+`corpus_class_for()` bucket names never leak into `by_category`. B7's report
+template confirms both axes coexist side by side (`Detection` section's
+`by_category` breakdown vs. the separate `By class` line using the four
+buckets) — this is not a naming collision to fix, it is two legitimately
+different rollups. **No source change needed for this finding** — B1.2 should
+just use `review_taxonomy.FINDING_CATEGORIES` for `by_category` keys and leave
+`corpus_class_for()` untouched.
+
+### 2. Where `closed_world` lives — a judgment call pinned by these tests
+
+B1.0's first bullet locks "closed-world flag lives on the case, not the
+report." But `scoring.py` has no `Case` wrapper — `score_findings()` takes
+flat `list[BaselineIssue]` / `list[ReportedFinding]`, and a **clean**
+closed-world case (the exact scenario the checklist names: "0 findings ->
+`strict_precision == 1.0`") has **zero** `BaselineIssue` rows, so the flag
+cannot live on a per-issue field — there is no issue instance to carry it.
+
+**Pinned here:** `closed_world` is a keyword-only parameter on
+`score_findings()` (mirroring the existing `slack` parameter), and
+`ScoreReport` gains a `closed_world: bool = False` field that echoes the
+call-time input — not as a new independently-computed metric, but as the
+minimum state needed for `.strict_precision` to know whether it is allowed to
+answer. `AggregateScoreReport.fold_score_reports()` then reads this field off
+each per-case report to decide the closed-world subset for
+`false_positives_per_case` / `clean_case_fp_rate`. If the implementer finds a
+cleaner way to satisfy the same test assertions without a `ScoreReport.
+closed_world` field, that's a valid alternative — the tests only assert on
+`strict_precision`, `false_positives`, and `unadjudicated` values, never on
+the literal existence of a `closed_world` attribute.
+
+### 3. `false_positives_per_case` / `clean_case_fp_rate` — closed-world subset only
+
+Per D4, an open-world case can never confirm a false positive, so both
+aggregate rates are computed **only over `closed_world=True` reports** in the
+folded set. Including open-world reports (whose `false_positives` is always
+0) would dilute the rate as a function of how many open-world cases happen to
+be in the corpus, which measures corpus composition, not FP behaviour. Pinned
+by `test_fold_false_positives_per_case_averages_over_closed_world_cases_only`
+and `test_fold_clean_case_fp_rate_is_the_fraction_of_closed_cases_with_a_false_finding`
+in `tests/evals/test_scoring_aggregate.py`.
+
+## Locked decisions exercised
+
+| ID | Decision | Tests |
+|----|----------|-------|
+| **D3** | `ScoreReport` extended, never replaced; `extra="forbid"` preserved; `precision` kept as a deprecated alias | `test_score_report_still_forbids_unknown_fields`, `test_existing_precision_alias_matches_corpus_confirmed_precision`, all of `tests/cli/test_eval_score_cmd.py` |
+| **D4** | Two precision metrics — `corpus_confirmed_precision` (open-world) and `strict_precision` (closed-world only, raises otherwise) | `test_strict_precision_raises_on_an_open_world_report`, `test_clean_case_zero_findings_has_strict_precision_one`, `test_clean_case_with_false_findings_scores_strict_precision_zero` |
+| **D5** | Unmatched findings are `unadjudicated`, not `false_positive`, until judged (both reported) | `test_open_world_unmatched_findings_are_unadjudicated_not_false_positive`, `test_clean_case_with_false_findings_scores_strict_precision_zero` |
+| B1.0 bullet 2 | `f1` is `0.0`, never `NaN`, when precision and recall are both 0 | `test_f1_is_zero_not_nan_when_precision_and_recall_are_both_zero` |
+
+## xfail schedule
+
+None. Every new-contract test in this plan fails via `AttributeError` /
+`TypeError` at assertion or call time (not at collection) — see "Deferred
+imports" below — so no `xfail` marker is needed; the suite is red by ordinary
+test failure, which is the cleanest signal for the B1.2 implementer.
+
+## Deferred imports (why collection stays green)
+
+`fold_score_reports` does not exist anywhere in `scoring.py` yet. Importing it
+by name (`from mergecraft.evals.scoring import fold_score_reports`) would
+raise `ImportError` at **collection** time and fail the whole test file, not
+just the tests that use it. `tests/evals/test_scoring_aggregate.py` instead
+imports the module (`from mergecraft.evals import scoring`) and calls
+`scoring.fold_score_reports(...)` inside each test body, so the
+`AttributeError` surfaces as an ordinary per-test failure. Every other new
+symbol referenced in this plan (`ScoreReport.f1`, `.strict_precision`,
+`.by_category`, ..., `score_findings(..., closed_world=...)`) is an attribute
+or keyword access on an object/function that already exists today, so it
+naturally fails at call/assertion time without needing this treatment.
+
+## Contract matrix
+
+| Contract | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| F1 worked example (32 TP / 18 unadjudicated / 8 FN -> P 64.0% / R 80.0% / F1 71.1%) | Unit | Happy | `test_f1_matches_the_worked_example` |
+| F1 degenerate zeros | Unit | Edge | `test_f1_is_zero_not_nan_when_precision_and_recall_are_both_zero` |
+| Empty corpus | Unit | Edge | `test_empty_corpus_is_vacuously_complete` |
+| Closed-world clean case, 0 findings | Unit | Happy | `test_clean_case_zero_findings_has_strict_precision_one` |
+| Closed-world clean case, 2 false findings | Unit | Edge | `test_clean_case_with_false_findings_scores_strict_precision_zero` |
+| `strict_precision` on open-world raises | Unit | Error | `test_strict_precision_raises_on_an_open_world_report` |
+| Open-world unmatched -> `unadjudicated`, not `false_positives` | Unit | Happy | `test_open_world_unmatched_findings_are_unadjudicated_not_false_positive` |
+| `by_category` / `by_severity` sum to totals | Unit | Happy | `test_by_category_and_by_severity_sum_back_to_the_totals` |
+| `by_category` keys use `review_taxonomy`, not `corpus_class_for()` | Unit | Happy | `test_by_category_keys_use_the_review_taxonomy_vocabulary` |
+| `by_severity` keys cover `FINDING_SEVERITIES` | Unit | Happy | `test_by_severity_keys_use_the_normalized_finding_severities` |
+| `precision` deprecated alias == `corpus_confirmed_precision` | Unit | Happy | `test_existing_precision_alias_matches_corpus_confirmed_precision` |
+| `ScoreReport` still forbids unknown fields (regression) | Unit | Error | `test_score_report_still_forbids_unknown_fields` |
+| `AggregateScoreReport` folds case count | Integration | Happy | `test_fold_counts_every_report_as_one_case` |
+| `AggregateScoreReport` sums totals | Integration | Happy | `test_fold_sums_totals_across_cases` |
+| `false_positives_per_case` — closed-world subset only | Integration | Happy | `test_fold_false_positives_per_case_averages_over_closed_world_cases_only` |
+| `clean_case_fp_rate` — closed-world subset only | Integration | Happy | `test_fold_clean_case_fp_rate_is_the_fraction_of_closed_cases_with_a_false_finding` |
+| Folding zero reports doesn't divide by zero | Integration | Edge | `test_fold_of_zero_reports_does_not_divide_by_zero` |
+| Aggregate `by_category` / `by_severity` sum to totals | Integration | Happy | `test_fold_by_category_sums_back_to_the_aggregate_totals`, `test_fold_by_severity_sums_back_to_the_aggregate_totals` |
+| `mergecraft eval score --json` key set unchanged (D3) | Functional | Happy (regression) | `test_eval_score_json_output_keeps_its_existing_key_set` |
+| `mergecraft eval score --json` values unchanged (D3) | Functional | Happy (regression) | `test_eval_score_json_output_values_are_unchanged` |
+| `mergecraft eval score` human output unchanged (D3) | Functional | Happy (regression) | `test_eval_score_human_output_keeps_its_existing_lines` |
+| `--min-recall` gate unchanged (D3) | Functional | Error (regression) | `test_eval_score_min_recall_gate_is_unchanged` |
+
+## Implementation notes for B1.2
+
+- Add `closed_world: bool = False` keyword-only parameter to `score_findings()`.
+- Extend `ScoreReport` (never replace, keep `extra="forbid"`) with: `closed_world`,
+  `f1`, `corpus_confirmed_precision`, `strict_precision`, `false_positives`,
+  `unadjudicated`, `false_negatives`, `by_category`, `by_severity`. Keep
+  `precision` as a property/alias returning the same value as
+  `corpus_confirmed_precision`.
+- New small breakdown model (e.g. `CategoryBreakdown`, `extra="forbid"`) with
+  at least `total_issues: int` and `found: int` — tests only read these two
+  attributes off `by_category` / `by_severity` dict values, so additional
+  fields (e.g. per-category recall) are free to add.
+- New `AggregateScoreReport` model + `fold_score_reports(reports: list[ScoreReport]) -> AggregateScoreReport`
+  free function in `scoring.py`, exported from `evals/scoring.py` and (per the
+  existing `evals/__init__.py` re-export pattern) from `mergecraft.evals`.
+- `cli/eval_cmd.py::score` is intentionally **not** touched by B1 — its
+  `--json` dict stays hand-built from the eight existing keys. B3 is the PR
+  that will decide whether/how the new fields reach the CLI.
+- Docstrings should carry the D4/D5 tone already set by the existing
+  `precision` property docstring in `scoring.py`.
+
+## Verification
+
+- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/evals/test_scoring_metrics.py tests/evals/test_scoring_aggregate.py tests/cli/test_eval_score_cmd.py -q`
+  — collects cleanly today; all new-contract tests fail with `AttributeError`
+  / `TypeError` (not collection errors); the D3 regression-guard tests already
+  pass.
+- `make lint` — ruff check/format clean on the three new files.
+- `make typecheck` — scoped to `src/mergecraft` only (`Makefile:67`), so these
+  test files are not mypy-checked; no action needed here.

--- a/src/mergecraft/evals/__init__.py
+++ b/src/mergecraft/evals/__init__.py
@@ -22,10 +22,13 @@ network, and no module-level I/O at import time (§W11.6).
 from __future__ import annotations
 
 from mergecraft.evals.scoring import (
+    AggregateScoreReport,
     BaselineIssue,
+    Breakdown,
     Match,
     ReportedFinding,
     ScoreReport,
+    fold_score_reports,
     format_report,
     load_baseline_issues,
     load_reported_findings,
@@ -58,7 +61,9 @@ __all__ = [
     "CASE_STATUS_PASSED",
     "CASE_STATUS_REGRESSION",
     "DEFAULT_BANK_DIR",
+    "AggregateScoreReport",
     "BaselineIssue",
+    "Breakdown",
     "Case",
     "CaseFilter",
     "Match",
@@ -67,6 +72,7 @@ __all__ = [
     "ScoreReport",
     "add_case",
     "diff_cases",
+    "fold_score_reports",
     "format_report",
     "list_cases",
     "load_baseline_issues",

--- a/src/mergecraft/evals/scoring.py
+++ b/src/mergecraft/evals/scoring.py
@@ -16,31 +16,46 @@ Exports:
     BaselineIssue: One frozen expected issue.
     ReportedFinding: One finding a review run produced.
     Match: A baseline issue paired with the finding that located it.
-    ScoreReport: Recall, precision and the per-issue breakdown.
+    Breakdown: Per-category/per-severity issue and match counts.
+    ScoreReport: Recall, precision, F1, the FP ledger and the per-issue breakdown.
+    AggregateScoreReport: Many per-case ScoreReports folded into one corpus-wide report.
     load_baseline_issues: Parse baseline rows from a JSON payload.
     load_reported_findings: Parse review output from a JSON payload.
     score_findings: Match reported findings against baseline issues.
+    fold_score_reports: Fold many per-case ScoreReports into one AggregateScoreReport.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from mergecraft.review_taxonomy import FINDING_CATEGORIES, FINDING_SEVERITIES
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 __all__ = [
+    "AggregateScoreReport",
     "BaselineIssue",
+    "Breakdown",
     "Match",
     "ReportedFinding",
     "ScoreReport",
+    "fold_score_reports",
     "load_baseline_issues",
     "load_reported_findings",
     "normalize_severity",
     "score_findings",
 ]
+
+# Catch-all buckets for a category/severity that does not fall into
+# review_taxonomy's fixed vocabulary (e.g. blank, or a corpus-specific label)
+# — keeps `sum(by_category.values()) == total_issues` true unconditionally.
+_UNCATEGORIZED: Final[str] = "Uncategorized"
+_UNKNOWN_SEVERITY: Final[str] = "Unknown"
 
 # A baseline issue anchored at a single line still deserves a match when the
 # reviewer flags the statement just above or below it — reviewers legitimately
@@ -106,6 +121,15 @@ class Match(BaseModel):
     category_agrees: bool
 
 
+class Breakdown(BaseModel):
+    """Issue and match counts for one ``by_category`` / ``by_severity`` bucket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_issues: int = 0
+    found: int = 0
+
+
 class ScoreReport(BaseModel):
     """The outcome of scoring one review run against one baseline."""
 
@@ -116,6 +140,16 @@ class ScoreReport(BaseModel):
     matches: list[Match]
     missed_issue_ids: list[str]
     unmatched_finding_indexes: list[int]
+    # Echoes the `closed_world` argument `score_findings()` was called with,
+    # so `.strict_precision` knows whether every ground-truth issue in this
+    # case is known (D4). Does not change how `matches` are computed.
+    closed_world: bool = False
+    # Per-`review_taxonomy.FINDING_CATEGORIES` issue/match counts. Sums back
+    # to `total_issues` / `found` (D9 — reproducible from its parts).
+    by_category: dict[str, Breakdown] = Field(default_factory=dict)
+    # Per-`review_taxonomy.FINDING_SEVERITIES` issue/match counts. Sums back
+    # to `total_issues` / `found` (D9).
+    by_severity: dict[str, Breakdown] = Field(default_factory=dict)
 
     @property
     def found(self) -> int:
@@ -130,17 +164,68 @@ class ScoreReport(BaseModel):
         return self.found / self.total_issues
 
     @property
-    def precision(self) -> float:
+    def corpus_confirmed_precision(self) -> float:
         """Fraction of reported findings that hit a baseline issue.
 
         This is a **lower bound on usefulness, not a false-positive rate**: a
         corpus labels the issues a human chose to record, so a real defect the
         human never wrote down scores here as unmatched. Read it as "how much of
-        the output is corpus-confirmed", never as "the rest is noise".
+        the output is corpus-confirmed", never as "the rest is noise". Safe on
+        any corpus, open- or closed-world (D4).
         """
         if self.total_reported == 0:
             return 1.0
         return len(self.matches) / self.total_reported
+
+    @property
+    def precision(self) -> float:
+        """Deprecated alias for :attr:`corpus_confirmed_precision` (D3: kept
+        byte-compatible for ``mergecraft eval score`` output and older callers)."""
+        return self.corpus_confirmed_precision
+
+    @property
+    def false_negatives(self) -> int:
+        """Baseline issues no reported finding located."""
+        return len(self.missed_issue_ids)
+
+    @property
+    def false_positives(self) -> int:
+        """Unmatched findings confirmed as noise. Only nonzero on a
+        closed-world report, where every ground-truth issue is known and an
+        unmatched finding is therefore confirmed wrong, not merely unlabelled
+        (D4/D5)."""
+        return len(self.unmatched_finding_indexes) if self.closed_world else 0
+
+    @property
+    def unadjudicated(self) -> int:
+        """Unmatched findings not yet judged. The honest bucket on an
+        open-world corpus, where an unmatched finding may be a real defect the
+        human baseline simply never recorded (D5)."""
+        return 0 if self.closed_world else len(self.unmatched_finding_indexes)
+
+    @property
+    def f1(self) -> float:
+        """Harmonic mean of recall and ``corpus_confirmed_precision``. ``0.0``
+        (never ``NaN``) when both are zero."""
+        precision, recall = self.corpus_confirmed_precision, self.recall
+        if precision + recall == 0:
+            return 0.0
+        return 2 * precision * recall / (precision + recall)
+
+    @property
+    def strict_precision(self) -> float:
+        """TP / (TP + false_positives). Defined **only** on a closed-world
+        report, where every unmatched finding is a confirmed false positive
+        rather than merely unadjudicated (D4). Raises on an open-world report."""
+        if not self.closed_world:
+            raise ValueError(
+                "strict_precision is only defined on a closed-world report (D4); "
+                "call score_findings(..., closed_world=True) for a fully-labelled case"
+            )
+        denominator = self.found + self.false_positives
+        if denominator == 0:
+            return 1.0
+        return self.found / denominator
 
     @property
     def severity_agreement(self) -> float:
@@ -148,6 +233,58 @@ class ScoreReport(BaseModel):
         if not self.matches:
             return 1.0
         return sum(1 for m in self.matches if m.severity_agrees) / len(self.matches)
+
+
+class AggregateScoreReport(BaseModel):
+    """Many per-case :class:`ScoreReport`\\ s folded into one corpus-wide report.
+
+    ``false_positives_per_case`` and ``clean_case_fp_rate`` average only over
+    the closed-world subset of the folded reports: an open-world case can
+    never confirm a false positive (D4), so folding one in as a diluting zero
+    would measure corpus composition rather than false-positive behaviour.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_cases: int
+    total_issues: int
+    total_reported: int
+    found: int
+    false_negatives: int
+    unadjudicated: int
+    false_positives: int
+    # Mean `false_positives` across the closed-world subset only. `0.0` when
+    # the fold has no closed-world case (D4).
+    false_positives_per_case: float
+    # Fraction of closed-world cases with at least one false positive. `0.0`
+    # when the fold has no closed-world case (D4).
+    clean_case_fp_rate: float
+    by_category: dict[str, Breakdown] = Field(default_factory=dict)
+    by_severity: dict[str, Breakdown] = Field(default_factory=dict)
+
+    @property
+    def recall(self) -> float:
+        """Fraction of baseline issues located, across every folded case."""
+        if self.total_issues == 0:
+            return 1.0
+        return self.found / self.total_issues
+
+    @property
+    def corpus_confirmed_precision(self) -> float:
+        """Fraction of reported findings that hit a baseline issue, across
+        every folded case. See :attr:`ScoreReport.corpus_confirmed_precision`."""
+        if self.total_reported == 0:
+            return 1.0
+        return self.found / self.total_reported
+
+    @property
+    def f1(self) -> float:
+        """Harmonic mean of ``recall`` and ``corpus_confirmed_precision``.
+        ``0.0`` (never ``NaN``) when both are zero."""
+        precision, recall = self.corpus_confirmed_precision, self.recall
+        if precision + recall == 0:
+            return 0.0
+        return 2 * precision * recall / (precision + recall)
 
 
 # Benchmark corpora record severity in their own vocabulary. tripll's
@@ -285,11 +422,53 @@ def _distance(issue: BaselineIssue, finding: ReportedFinding) -> int:
     return 0
 
 
+def _empty_breakdowns() -> tuple[dict[str, Breakdown], dict[str, Breakdown]]:
+    """Pre-seed one zero-count bucket per known category and severity.
+
+    Every ``review_taxonomy`` value is present up front (even at zero) so a
+    corpus that happens to use every category still reports exactly that
+    vocabulary — see ``test_by_category_keys_use_the_review_taxonomy_vocabulary``.
+    """
+    by_category = {category: Breakdown() for category in FINDING_CATEGORIES}
+    by_severity = {severity: Breakdown() for severity in FINDING_SEVERITIES}
+    return by_category, by_severity
+
+
+def _record_issue(
+    issue: BaselineIssue,
+    *,
+    matched: bool,
+    by_category: dict[str, Breakdown],
+    by_severity: dict[str, Breakdown],
+) -> None:
+    """Tally one baseline issue into its category and severity buckets.
+
+    A category/severity outside the known vocabulary (including blank) falls
+    into a catch-all bucket rather than being dropped, so the totals invariant
+    (``sum(by_category.values()) == total_issues``) holds unconditionally.
+    """
+    category_key = issue.category if issue.category in FINDING_CATEGORIES else _UNCATEGORIZED
+    category_bucket = by_category.setdefault(category_key, Breakdown())
+    category_bucket.total_issues += 1
+    if matched:
+        category_bucket.found += 1
+
+    normalized_severity = normalize_severity(issue.severity)
+    severity_key = (
+        normalized_severity if normalized_severity in FINDING_SEVERITIES else _UNKNOWN_SEVERITY
+    )
+    severity_bucket = by_severity.setdefault(severity_key, Breakdown())
+    severity_bucket.total_issues += 1
+    if matched:
+        severity_bucket.found += 1
+
+
 def score_findings(
     issues: list[BaselineIssue],
     findings: list[ReportedFinding],
     *,
     slack: int = DEFAULT_LINE_SLACK,
+    closed_world: bool = False,
 ) -> ScoreReport:
     """Match reported findings against baseline issues by file and line overlap.
 
@@ -297,6 +476,12 @@ def score_findings(
     the closest not-yet-claimed finding that overlaps it. One finding therefore
     cannot satisfy two baseline issues, so a single sprawling comment covering a
     whole file scores one match rather than all of them.
+
+    ``closed_world`` marks this case as fully labelled — every issue a human
+    would flag is already in ``issues`` — so an unmatched finding is a
+    confirmed false positive rather than merely unadjudicated (D4/D5). It
+    lives here, not on ``BaselineIssue``, because a clean closed-world case
+    has zero baseline issues to carry a per-issue flag.
     """
     claimed: set[int] = set()
     matches: list[Match] = []
@@ -324,12 +509,25 @@ def score_findings(
             )
         )
 
+    matched_ids = {match.issue_id for match in matches}
+    by_category, by_severity = _empty_breakdowns()
+    for issue in issues:
+        _record_issue(
+            issue,
+            matched=issue.id in matched_ids,
+            by_category=by_category,
+            by_severity=by_severity,
+        )
+
     return ScoreReport(
         total_issues=len(issues),
         total_reported=len(findings),
         matches=matches,
         missed_issue_ids=missed,
         unmatched_finding_indexes=[index for index in range(len(findings)) if index not in claimed],
+        closed_world=closed_world,
+        by_category=by_category,
+        by_severity=by_severity,
     )
 
 
@@ -349,3 +547,52 @@ def format_report(report: ScoreReport, *, corpus: Path | str = "") -> str:
     if report.missed_issue_ids:
         lines.append(f"  missed           : {', '.join(report.missed_issue_ids)}")
     return "\n".join(lines)
+
+
+def _merge_breakdowns(breakdowns: Iterable[dict[str, Breakdown]]) -> dict[str, Breakdown]:
+    """Sum per-case ``by_category`` / ``by_severity`` dicts into one corpus-wide dict."""
+    merged: dict[str, Breakdown] = {}
+    for per_case in breakdowns:
+        for key, value in per_case.items():
+            bucket = merged.setdefault(key, Breakdown())
+            bucket.total_issues += value.total_issues
+            bucket.found += value.found
+    return merged
+
+
+def fold_score_reports(reports: list[ScoreReport]) -> AggregateScoreReport:
+    """Fold many per-case :class:`ScoreReport`\\ s into one corpus-wide report.
+
+    Each report counts as exactly one case. ``false_positives_per_case`` and
+    ``clean_case_fp_rate`` are averaged over the closed-world subset only
+    (D4): an open-world case's ``false_positives`` is always ``0``, so
+    including it would dilute the rate by corpus composition rather than
+    measure false-positive behaviour. Folding an empty list is well-defined
+    and never divides by zero.
+    """
+    closed_world_reports = [report for report in reports if report.closed_world]
+
+    if closed_world_reports:
+        false_positives_per_case = sum(
+            report.false_positives for report in closed_world_reports
+        ) / len(closed_world_reports)
+        clean_case_fp_rate = sum(
+            1 for report in closed_world_reports if report.false_positives > 0
+        ) / len(closed_world_reports)
+    else:
+        false_positives_per_case = 0.0
+        clean_case_fp_rate = 0.0
+
+    return AggregateScoreReport(
+        total_cases=len(reports),
+        total_issues=sum(report.total_issues for report in reports),
+        total_reported=sum(report.total_reported for report in reports),
+        found=sum(report.found for report in reports),
+        false_negatives=sum(report.false_negatives for report in reports),
+        unadjudicated=sum(report.unadjudicated for report in reports),
+        false_positives=sum(report.false_positives for report in reports),
+        false_positives_per_case=false_positives_per_case,
+        clean_case_fp_rate=clean_case_fp_rate,
+        by_category=_merge_breakdowns(report.by_category for report in reports),
+        by_severity=_merge_breakdowns(report.by_severity for report in reports),
+    )

--- a/src/mergecraft/evals/scoring.py
+++ b/src/mergecraft/evals/scoring.py
@@ -428,6 +428,16 @@ def _empty_breakdowns() -> tuple[dict[str, Breakdown], dict[str, Breakdown]]:
     Every ``review_taxonomy`` value is present up front (even at zero) so a
     corpus that happens to use every category still reports exactly that
     vocabulary — see ``test_by_category_keys_use_the_review_taxonomy_vocabulary``.
+
+    B1.0 design-gate reconciliation: this is deliberately a different, orthogonal
+    vocabulary from ``benchmark.py``'s ``corpus_class_for()`` four buckets
+    (``correctness`` / ``security`` / ``cross_file`` / ``adversarial_noop``).
+    ``FINDING_CATEGORIES`` classifies an individual finding (this module operates
+    at finding granularity and has no notion of a benchmark *case*);
+    ``corpus_class_for()`` classifies a whole bank case by its
+    ``bench-<class>-<slug>`` id prefix, for decision-replay gate metrics (B2). A
+    published report shows both side by side (B7's "Detection" vs "By class"
+    sections) rather than merging them into one taxonomy.
     """
     by_category = {category: Breakdown() for category in FINDING_CATEGORIES}
     by_severity = {severity: Breakdown() for severity in FINDING_SEVERITIES}

--- a/tests/cli/test_eval_score_cmd.py
+++ b/tests/cli/test_eval_score_cmd.py
@@ -1,0 +1,116 @@
+"""`mergecraft eval score` output stays byte-compatible under B1 (D3 regression guard).
+
+B1 extends ``ScoreReport`` with a large new metric surface (`f1`,
+`corpus_confirmed_precision`, `strict_precision`, the FP ledger, `by_category`
+/ `by_severity`, ...). ``cli/eval_cmd.py::score`` builds its ``--json`` output
+from a hand-picked dict of eight named keys rather than
+``report.model_dump()``, and the human-readable path goes through
+``format_report()`` unchanged — so new fields on the model must not change
+what this command emits today.
+
+These tests exercise only the *existing*, unmodified code path, so they
+already pass before B1.2 lands and must keep passing unchanged afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip Rich's ANSI styling so line-content assertions survive highlighting."""
+    return _ANSI_RE.sub("", text)
+
+
+_EXPECTED_ISSUES = [
+    {"id": "x-1", "path": "src/app.py", "start_line": 10, "end_line": 12, "severity": "high"}
+]
+_ACTUAL_FINDINGS = [
+    {
+        "path": "src/app.py",
+        "start_line": 11,
+        "end_line": 11,
+        "severity": "Major",
+        "message": "totally different wording",
+    }
+]
+
+
+def _write_json(tmp_path: Path, name: str, rows: list[dict[str, object]]) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(rows))
+    return path
+
+
+def test_eval_score_json_output_keeps_its_existing_key_set(tmp_path: Path) -> None:
+    actual = _write_json(tmp_path, "actual.json", _ACTUAL_FINDINGS)
+    expected = _write_json(tmp_path, "expected.json", _EXPECTED_ISSUES)
+
+    result = runner.invoke(app, ["eval", "score", str(actual), str(expected), "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "total_issues",
+        "total_reported",
+        "found",
+        "recall",
+        "precision",
+        "severity_agreement",
+        "missed_issue_ids",
+        "matches",
+    }
+
+
+def test_eval_score_json_output_values_are_unchanged(tmp_path: Path) -> None:
+    actual = _write_json(tmp_path, "actual.json", _ACTUAL_FINDINGS)
+    expected = _write_json(tmp_path, "expected.json", _EXPECTED_ISSUES)
+
+    result = runner.invoke(app, ["eval", "score", str(actual), str(expected), "--json"])
+
+    payload = json.loads(result.stdout)
+    assert payload["total_issues"] == 1
+    assert payload["total_reported"] == 1
+    assert payload["found"] == 1
+    assert payload["recall"] == 1.0
+    assert payload["precision"] == 1.0
+    assert payload["missed_issue_ids"] == []
+    assert payload["matches"][0]["issue_id"] == "x-1"
+
+
+def test_eval_score_human_output_keeps_its_existing_lines(tmp_path: Path) -> None:
+    actual = _write_json(tmp_path, "actual.json", _ACTUAL_FINDINGS)
+    expected = _write_json(tmp_path, "expected.json", _EXPECTED_ISSUES)
+
+    result = runner.invoke(app, ["eval", "score", str(actual), str(expected)])
+    output = _plain(result.stdout)
+
+    assert result.exit_code == 0, result.stdout
+    assert "baseline issues : 1" in output
+    assert "findings reported: 1" in output
+    assert "located          : 1" in output
+    assert "recall           : 100.00%" in output
+    assert "corpus-confirmed : 100.00%" in output
+
+
+def test_eval_score_min_recall_gate_is_unchanged(tmp_path: Path) -> None:
+    actual = _write_json(tmp_path, "actual.json", [])
+    expected = _write_json(tmp_path, "expected.json", _EXPECTED_ISSUES)
+
+    result = runner.invoke(
+        app, ["eval", "score", str(actual), str(expected), "--min-recall", "0.5"]
+    )
+    output = _plain(result.stdout)
+
+    assert result.exit_code == 1
+    assert "recall 0.00% is below the required 50.00%" in output

--- a/tests/evals/test_scoring_aggregate.py
+++ b/tests/evals/test_scoring_aggregate.py
@@ -1,0 +1,133 @@
+"""AggregateScoreReport — folding many per-case ScoreReports (#140, B1, RED wave).
+
+A single `score_findings()` call scores one case. #140's headline numbers
+(false positives / case, clean-case FP rate, corpus-wide P/R/F1) are computed
+over an entire corpus of cases, so B1.2 adds `fold_score_reports()` to reduce
+many per-case `ScoreReport`s into one `AggregateScoreReport`.
+
+Only `closed_world=True` cases can ever populate `false_positives` (D4), so
+both `false_positives_per_case` and `clean_case_fp_rate` are averaged over the
+closed-world subset only — an open-world case contributing a diluting zero
+would make the metric drift with corpus composition rather than measure
+anything. This is a design choice pinned here for B1.2; see
+`docs/dev/test-plans/eval-benchmark-b1-metrics.md` for the rationale.
+
+None of this exists yet — every test is expected to fail (AttributeError on
+`scoring.fold_score_reports`, or TypeError on the new `closed_world` keyword)
+until B1.2 lands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `fold_score_reports` does not exist yet (B1.2). Importing the module rather
+# than the name keeps collection green — the AttributeError then surfaces
+# inside each test body, as a real per-test failure, instead of aborting
+# collection for the whole file.
+from mergecraft.evals import scoring
+from mergecraft.evals.scoring import BaselineIssue, ReportedFinding, ScoreReport, score_findings
+
+
+def _clean_report(*, false_findings: int) -> ScoreReport:
+    """A closed-world case with no baseline issues and ``false_findings`` bogus
+    findings (0 -> a spotless run, >0 -> genuine false positives, D4)."""
+    findings = [
+        ReportedFinding(path="src/a.py", start_line=10 * i + 1, end_line=10 * i + 2)
+        for i in range(false_findings)
+    ]
+    return score_findings([], findings, closed_world=True)
+
+
+def _open_world_report() -> ScoreReport:
+    issue = BaselineIssue(
+        id="o-1",
+        path="src/b.py",
+        start_line=5,
+        end_line=6,
+        category="Security & Privacy",
+        severity="Critical",
+    )
+    matched = ReportedFinding(path="src/b.py", start_line=5, end_line=6, severity="Critical")
+    unadjudicated = ReportedFinding(path="src/b.py", start_line=900, end_line=901)
+    return score_findings([issue], [matched, unadjudicated])
+
+
+def test_fold_counts_every_report_as_one_case() -> None:
+    reports = [
+        _clean_report(false_findings=0),
+        _clean_report(false_findings=2),
+        _open_world_report(),
+    ]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert aggregate.total_cases == 3
+
+
+def test_fold_sums_totals_across_cases() -> None:
+    reports = [
+        _clean_report(false_findings=0),
+        _clean_report(false_findings=2),
+        _open_world_report(),
+    ]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert aggregate.total_issues == sum(r.total_issues for r in reports)
+    assert aggregate.total_reported == sum(r.total_reported for r in reports)
+    assert aggregate.found == sum(r.found for r in reports)
+
+
+def test_fold_false_positives_per_case_averages_over_closed_world_cases_only() -> None:
+    # Two closed-world cases (0 and 2 false findings) + one open-world case that
+    # must not dilute the denominator (D4: it cannot confirm a false positive).
+    reports = [
+        _clean_report(false_findings=0),
+        _clean_report(false_findings=2),
+        _open_world_report(),
+    ]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert aggregate.false_positives_per_case == pytest.approx(1.0)  # (0 + 2) / 2
+
+
+def test_fold_clean_case_fp_rate_is_the_fraction_of_closed_cases_with_a_false_finding() -> None:
+    reports = [
+        _clean_report(false_findings=0),
+        _clean_report(false_findings=2),
+        _open_world_report(),
+    ]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert aggregate.clean_case_fp_rate == pytest.approx(0.5)  # 1 of 2 closed-world cases
+
+
+def test_fold_of_zero_reports_does_not_divide_by_zero() -> None:
+    aggregate = scoring.fold_score_reports([])
+
+    assert aggregate.total_cases == 0
+    assert aggregate.false_positives_per_case == 0.0
+    assert aggregate.clean_case_fp_rate == 0.0
+    assert aggregate.recall == 1.0
+    assert aggregate.corpus_confirmed_precision == 1.0
+
+
+def test_fold_by_category_sums_back_to_the_aggregate_totals() -> None:
+    reports = [_clean_report(false_findings=0), _open_world_report()]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert sum(v.total_issues for v in aggregate.by_category.values()) == aggregate.total_issues
+    assert sum(v.found for v in aggregate.by_category.values()) == aggregate.found
+
+
+def test_fold_by_severity_sums_back_to_the_aggregate_totals() -> None:
+    reports = [_clean_report(false_findings=0), _open_world_report()]
+
+    aggregate = scoring.fold_score_reports(reports)
+
+    assert sum(v.total_issues for v in aggregate.by_severity.values()) == aggregate.total_issues
+    assert sum(v.found for v in aggregate.by_severity.values()) == aggregate.found

--- a/tests/evals/test_scoring_metrics.py
+++ b/tests/evals/test_scoring_metrics.py
@@ -1,0 +1,250 @@
+"""F1, closed-world strict precision, and the FP ledger (#140, B1, RED wave).
+
+`evals/scoring.py` currently reports recall/precision/severity_agreement only.
+B1 extends `score_findings()`/`ScoreReport` with:
+
+- `f1` — harmonic mean of recall and `corpus_confirmed_precision`, `0.0` (never
+  `NaN`) when both are zero.
+- `corpus_confirmed_precision` — the open-world-safe rename of today's
+  `precision`; `precision` stays as a deprecated alias with the same value
+  (D3: extend, never replace).
+- `closed_world` — a per-call flag on `score_findings()` (there is no `Case`
+  object in this module's flat issues/findings API, and a clean case has zero
+  `BaselineIssue` rows to carry a per-issue flag, so the call site is the only
+  place that can say "this corpus entry is fully labelled"). `ScoreReport`
+  echoes it so `strict_precision` knows whether it is allowed to answer.
+- `false_positives` / `unadjudicated` — the D5 three-state ledger. Unmatched
+  findings are `false_positives` only when `closed_world=True`; otherwise they
+  are `unadjudicated`, never asserted as noise (D4/D5).
+- `strict_precision` — TP / (TP + false_positives), defined **only** on
+  closed-world reports; raises on an open-world one (D4).
+- `by_category` / `by_severity` — per-key breakdowns that sum back to the
+  report's totals. Categories reuse `review_taxonomy.FINDING_CATEGORIES` (the
+  finding-level taxonomy) — deliberately **not**
+  `evals.benchmark.corpus_class_for()`'s four case-level buckets
+  (`correctness`/`security`/`cross_file`/`adversarial_noop`), which classify a
+  bank *case* for decision replay, not a finding's subject matter. See
+  `docs/dev/test-plans/eval-benchmark-b1-metrics.md` for the reconciliation.
+
+None of this exists yet — every test below is expected to fail (ImportError /
+AttributeError) until B1.2 lands, except `test_score_report_still_forbids_
+unknown_fields`, which exercises only today's shape and is a regression guard:
+it already passes and must keep passing unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.evals.scoring import (
+    BaselineIssue,
+    ReportedFinding,
+    ScoreReport,
+    score_findings,
+)
+from mergecraft.review_taxonomy import FINDING_CATEGORIES, FINDING_SEVERITIES
+
+
+def _issue(
+    identifier: str = "b-1",
+    *,
+    path: str = "src/app.py",
+    start: int = 10,
+    end: int = 20,
+    severity: str = "high",
+    category: str = "",
+) -> BaselineIssue:
+    return BaselineIssue(
+        id=identifier,
+        path=path,
+        start_line=start,
+        end_line=end,
+        severity=severity,
+        category=category,
+    )
+
+
+def _finding(
+    *,
+    path: str = "src/app.py",
+    start: int = 12,
+    end: int = 14,
+    severity: str = "Major",
+    category: str = "",
+) -> ReportedFinding:
+    return ReportedFinding(
+        path=path, start_line=start, end_line=end, severity=severity, category=category
+    )
+
+
+def _spaced_issue(index: int, *, path: str = "src/bench.py") -> BaselineIssue:
+    """A baseline issue on its own 10-line block, far enough apart that the
+    default ±3 line slack can never bleed into a neighbour."""
+    line = index * 10 + 1
+    return BaselineIssue(id=f"bench-{index:03d}", path=path, start_line=line, end_line=line + 1)
+
+
+def _spaced_finding(index: int, *, path: str = "src/bench.py", offset: int = 0) -> ReportedFinding:
+    line = offset + index * 10 + 1
+    return ReportedFinding(path=path, start_line=line, end_line=line + 1)
+
+
+# ── F1 — worked example (B1.1) ──────────────────────────────────────────────
+
+
+def test_f1_matches_the_worked_example() -> None:
+    """32 TP / 18 unadjudicated / 8 FN -> P 64.0%, R 80.0%, F1 71.1%."""
+    issues = [_spaced_issue(i) for i in range(40)]
+    matched_findings = [_spaced_finding(i) for i in range(32)]
+    extra_findings = [_spaced_finding(i, offset=10_000) for i in range(18)]
+
+    report = score_findings(issues, matched_findings + extra_findings)
+
+    assert report.found == 32
+    assert report.false_negatives == 8
+    assert report.unadjudicated == 18
+    assert report.false_positives == 0, "open-world: unmatched findings are never false_positives"
+    assert report.recall == pytest.approx(0.8)
+    assert report.corpus_confirmed_precision == pytest.approx(0.64)
+    assert report.f1 == pytest.approx(0.711111, abs=1e-5)
+
+
+def test_f1_is_zero_not_nan_when_precision_and_recall_are_both_zero() -> None:
+    issues = [_issue(f"b-{i}", start=i * 100, end=i * 100 + 1) for i in range(3)]
+    findings = [_finding(start=i * 100 + 900, end=i * 100 + 901) for i in range(2)]
+
+    report = score_findings(issues, findings)
+
+    assert report.recall == 0.0
+    assert report.corpus_confirmed_precision == 0.0
+    assert not math.isnan(report.f1)
+    assert report.f1 == 0.0
+
+
+def test_empty_corpus_is_vacuously_complete() -> None:
+    report = score_findings([], [])
+
+    assert report.recall == 1.0
+    assert report.corpus_confirmed_precision == 1.0
+    assert report.f1 == pytest.approx(1.0)
+    assert report.false_negatives == 0
+    assert report.unadjudicated == 0
+    assert report.false_positives == 0
+
+
+# ── closed-world ledger (D4/D5) ─────────────────────────────────────────────
+
+
+def test_clean_case_zero_findings_has_strict_precision_one() -> None:
+    report = score_findings([], [], closed_world=True)
+
+    assert report.strict_precision == 1.0
+    assert report.false_positives == 0
+    assert report.unadjudicated == 0
+
+
+def test_clean_case_with_false_findings_scores_strict_precision_zero() -> None:
+    findings = [_finding(start=10, end=10), _finding(start=50, end=50)]
+
+    report = score_findings([], findings, closed_world=True)
+
+    assert report.strict_precision == 0.0
+    assert report.false_positives == 2
+    assert report.unadjudicated == 0, "closed-world unmatched findings are never unadjudicated"
+
+
+def test_strict_precision_raises_on_an_open_world_report() -> None:
+    report = score_findings([_issue()], [_finding()])  # closed_world defaults False
+
+    with pytest.raises(ValueError, match=r"(?i)closed.world"):
+        _ = report.strict_precision
+
+
+def test_open_world_unmatched_findings_are_unadjudicated_not_false_positive() -> None:
+    findings = [_finding(start=12, end=14), _finding(start=900, end=901)]
+
+    report = score_findings([_issue()], findings)
+
+    assert report.found == 1
+    assert report.unadjudicated == 1
+    assert report.false_positives == 0
+
+
+# ── by_category / by_severity (B1.1) ────────────────────────────────────────
+
+
+def test_by_category_and_by_severity_sum_back_to_the_totals() -> None:
+    issues = [
+        _issue("a", category="Functional Correctness", severity="Critical"),
+        _issue("b", category="Functional Correctness", severity="Major", start=200, end=201),
+        _issue("c", category="Security & Privacy", severity="Critical", start=400, end=401),
+        _issue("d", category="Security & Privacy", severity="Minor", start=600, end=601),
+    ]
+    # Only "a" and "c" get a matching finding — "b" and "d" are missed.
+    findings = [
+        _finding(severity="Critical", start=10, end=20),
+        _finding(severity="Critical", start=400, end=401),
+    ]
+
+    report = score_findings(issues, findings)
+
+    assert sum(v.total_issues for v in report.by_category.values()) == report.total_issues
+    assert sum(v.found for v in report.by_category.values()) == report.found
+    assert sum(v.total_issues for v in report.by_severity.values()) == report.total_issues
+    assert sum(v.found for v in report.by_severity.values()) == report.found
+
+    assert report.by_category["Functional Correctness"].total_issues == 2
+    assert report.by_category["Functional Correctness"].found == 1
+    assert report.by_category["Security & Privacy"].total_issues == 2
+    assert report.by_category["Security & Privacy"].found == 1
+
+
+def test_by_category_keys_use_the_review_taxonomy_vocabulary() -> None:
+    """by_category groups by review_taxonomy.FINDING_CATEGORIES — the
+    finding-level taxonomy — never `corpus_class_for()`'s case-level buckets."""
+    issues = [
+        _issue(f"i-{i}", category=category, start=i * 100, end=i * 100 + 1)
+        for i, category in enumerate(FINDING_CATEGORIES)
+    ]
+
+    report = score_findings(issues, [])
+
+    assert set(report.by_category) == set(FINDING_CATEGORIES)
+    for corpus_class in ("correctness", "security", "cross_file", "adversarial_noop"):
+        assert corpus_class not in report.by_category
+
+
+def test_by_severity_keys_use_the_normalized_finding_severities() -> None:
+    issues = [
+        _issue(f"s-{i}", severity=severity, start=i * 100, end=i * 100 + 1)
+        for i, severity in enumerate(FINDING_SEVERITIES)
+    ]
+
+    report = score_findings(issues, [])
+
+    assert set(report.by_severity) == set(FINDING_SEVERITIES)
+
+
+# ── D3: deprecated alias (new contract — red until B1.2) ────────────────────
+
+
+def test_existing_precision_alias_matches_corpus_confirmed_precision() -> None:
+    """`precision` (D3: extended, never replaced) must still exist and equal
+    the new canonical `corpus_confirmed_precision`."""
+    report = score_findings([_issue()], [_finding(start=900, end=901)])
+
+    assert report.precision == report.corpus_confirmed_precision
+
+
+# ── D3 regression guard — passes today already, must keep passing ──────────
+
+
+def test_score_report_still_forbids_unknown_fields() -> None:
+    payload = score_findings([], []).model_dump()
+    payload["bogus_field"] = True
+
+    with pytest.raises(ValidationError):
+        ScoreReport.model_validate(payload)


### PR DESCRIPTION
## Summary

PR B1 of 7 in the eval-benchmark stacked plan (`.ignorelocal/waves/issues-eval-benchmark-numbers-wave-plan.md`), spinning out of #140. Extends `evals/scoring.py`'s `ScoreReport` with the F1 / false-positive ledger and closed-world metrics needed before any downstream PR (gate metrics, live-run join, corpus growth, publication) can proceed.

- `f1` (harmonic mean of recall/`corpus_confirmed_precision`, `0.0` not `NaN` on double-zero), matching the plan's worked example: 32 TP / 18 unadjudicated / 8 FN → P 64.0%, R 80.0%, F1 71.1%.
- `corpus_confirmed_precision` — `precision` kept as a deprecated alias, byte-compatible with existing `mergecraft eval score` output.
- `strict_precision` — closed-world only, raises on an open-world report (an open-world corpus only labels what a human recorded, so "false positive" can't be asserted there — D4).
- Three-state ledger: `false_positives` / `unadjudicated` / `false_negatives` — unmatched findings on an open-world case are `unadjudicated`, not assumed `false_positive`, until judged (D5).
- `false_positives_per_case`, `clean_case_fp_rate` (averaged over the closed-world subset only).
- `by_category` / `by_severity` breakdowns (pinned to `review_taxonomy.FINDING_CATEGORIES`, an intentionally orthogonal axis from `benchmark.py`'s case-level `corpus_class_for()` buckets — reconciled per B1.0's design-gate bullet).
- `AggregateScoreReport` / `fold_score_reports()` folding many per-case reports — not yet consumed anywhere (expected; B2/B3 wire it in).
- `closed_world` keyword-only param on `score_findings()` (a clean closed-world case has zero `BaselineIssue` rows to carry a per-issue flag).

`ScoreReport` stays `extra="forbid"` and byte-compatible with existing CLI output (D3).

## Verification

- Authored RED (test-creator) → implemented GREEN (wave-plan-executor) → verified (wave-verifier), per the plan's owner-agent split.
- `wave-verifier` independently recomputed the worked example against the live code (not the test file), confirmed `strict_precision`'s raise/1.0/0.0 behavior by direct call, diffed `mergecraft eval score` CLI output byte-for-byte against `origin/pre-0.0.1`, and spot-checked pre-existing unrelated test failures against a clean worktree.
- One verifier finding (category-vocabulary reconciliation, B1.0) addressed in a follow-up docstring-only commit; re-confirmed 132 passed / 1 xfailed after the fix.
- `make lint typecheck pyright` clean. `make ci` green except 4 pre-existing failures (3× `test_eval_list_*`, 1× `test_models_show_prints_config_order_with_env_override`) — all Rich-ANSI-digit-splitting issues, confirmed identical on a clean `origin/pre-0.0.1` worktree, unrelated to this diff.

## Test plan

- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/evals tests/cli/test_eval_score_cmd.py -q` — 132 passed, 1 xfailed
- [x] `make lint typecheck pyright` clean
- [x] `make ci` — green modulo the 4 pre-existing unrelated failures noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)