### PR TITLE
feat(evals): join finding-location scoring to the benchmark result set [stacked 3/7 — on top of #212]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 .PHONY: help setup install lockcheck lint format typecheck pyright test security \
 	precommit build ci ci-static ci-steps ci-resume ci-reset catalog-check docker-build clean \
 	examples example-workflows-check reference-docs reference-docs-check bench-review eval-gate eval-replay \
+	bench-detect \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
 	lint-ruff-advisory hook-pins-check
 
@@ -177,6 +178,9 @@ eval-gate: ## Check eval-bank integrity (structural; see 'mergecraft eval gate -
 
 eval-replay: ## Replay eval bank; write versioned result set (operator-triggered; needs live keys for F1)
 	$(UV) run mergecraft eval replay-bank
+
+bench-detect: ## Join structural replay + live finding-location detection (#140, B3; needs live keys)
+	$(UV) run mergecraft eval bench
 
 docker-build: ## Build action Docker image
 	docker build -t mergeCraft:local -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ of them for its full flag set):
 | `mergecraft config tracing` | Render the resolved tracing config — sinks, retention, redaction, token redacted. |
 | `mergecraft diff-review` | Review a local git diff offline (no GitHub Action / PR posting). |
 | `mergecraft eval add` | Add a case to the bank. |
+| `mergecraft eval bench` | Join structural decision replay with a live finding-location run (#140, B3). |
 | `mergecraft eval gate` | Check the eval bank's integrity — the CI-safe half of the eval loop. |
 | `mergecraft eval list` | List cases in the bank. |
 | `mergecraft eval promote <case-id>` | Promote a case into a permanent pytest test file (#44, W12.1). |

--- a/docs/dev/test-plans/eval-benchmark-b3-live.md
+++ b/docs/dev/test-plans/eval-benchmark-b3-live.md
@@ -1,0 +1,273 @@
+# Eval benchmark B3 — live finding-location join test plan (RED)
+
+Wave plan: `.ignorelocal/waves/issues-eval-benchmark-numbers-wave-plan.md` — PR B3 ("the centre of
+the plan", N5)
+Worktree: `mergecraft-bench-b3-live` @ `wave/bench-b3-live` (parent: `wave/bench-b2-gate`)
+Anchors: `src/mergecraft/evals/benchmark.py` (`BenchmarkResultSet`, `run_structural_replay`,
+`DEFAULT_BENCHMARK_PROVIDERS`) · `src/mergecraft/evals/scoring.py` (`score_findings`,
+`fold_score_reports`, `ScoreReport`, `AggregateScoreReport`, `load_baseline_issues`,
+`load_reported_findings`) · `src/mergecraft/cli/diff_review_cmd.py` (`--json`) ·
+`src/mergecraft/harbor/agent.py` (`_PATCH_CANDIDATES`, read-only reference) ·
+`src/mergecraft/utils/agent_resolve.py` (`has_credentials_for_slug`).
+
+B3 has **no test-creator precedent** for its target shape — unlike B1/B2, none of the symbols this
+plan pins exist yet (`evals/live_run.py` is a wholly new module). Everything below is this pass's
+design proposal for the B3.2 implementer to confirm or override, exactly as B2.0's design gate did
+for the crashed-run/neutral-decision subtlety, but for a brand-new module instead of a field
+addition.
+
+## Why this needs a design pass before tests, not just tests
+
+`run_structural_replay()` (B1/B2, unchanged here) is pure, keyless, and free — it never touches a
+live provider. B3 is the first thing in this plan that runs `mergecraft diff-review` for real,
+which needs an LLM. That collides head-on with "RED tests must be local, keyless, deterministic."
+The resolution below is a **dependency-injection seam**: the pure join (case → findings → score →
+metrics) is one function that takes a findings-producing callable as a parameter; the RED suite
+drives that function with a stub callable and never invokes an agent. The seam is also exactly what
+`mergecraft eval bench` will wire a real subprocess call into in B3.2 — the tests pin the seam's
+shape, not its production implementation.
+
+## Design-gate findings (B3.0) — for the B3.2 implementer to confirm
+
+### 1. Patch filename reuse — read, not imported
+
+`harbor/agent.py:23` reads `_PATCH_CANDIDATES = ("task.patch", "changes.patch", "diff.patch",
+"review.patch")`. `evals/live_run.py` reuses this **value**, duplicated as its own
+`PATCH_CANDIDATES` constant — **not** imported from `mergecraft.harbor.agent`. Two reasons:
+
+- `harbor` is an optional extra (`pyproject.toml:39`, `harbor==0.20.0`) — **not installed in this
+  checkout** (`uv run python -c "import harbor"` → `ModuleNotFoundError`, verified live). Importing
+  `mergecraft.harbor.agent` at module level pulls in `harbor.agents.installed.base`, which does not
+  exist without the extra. B3.0's own bullet 4 says the in-repo corpus should not need Harbor at
+  all — a hard import dependency on the `harbor` extra would silently reintroduce that coupling.
+- The design gate says "reuse a patch filename … do not extend the tuple," which is a value
+  constraint, not an import-path constraint.
+
+**Locked here:** `mergecraft.evals.live_run.PATCH_CANDIDATES == ("task.patch", "changes.patch",
+"diff.patch", "review.patch")`, verbatim, defined independently of `mergecraft.harbor.agent`. Tests
+pin the tuple's value directly (hardcoded, commented with the line reference) rather than importing
+`mergecraft.harbor.agent`, so the suite collects cleanly whether or not the `harbor` extra is
+installed.
+
+### 2. Missing-credential path — typed, not zero-filled
+
+`evals/README.md`'s existing promise (`"With missing API keys the harness records skipped: no live
+credential and omits those metrics"`) becomes two fields on `BenchmarkResultSet`:
+
+```python
+detection: DetectionMetrics | None = None
+skipped_reason: str | None = None
+```
+
+Both default to `None` so an old committed result set (pre-B3, no `detection` key at all) still
+validates under `extra="forbid"` (D3) — Pydantic fills the default rather than rejecting the
+missing key. `detection` populated implies `skipped_reason is None`, and vice versa; that invariant
+is exercised through the individual test scenarios below (never both set, never both `None` after a
+real run attempt) rather than a `model_validator` this pass adds unprompted — see "not tested"
+below for why a cross-field validator is left to B3.2's judgment.
+
+### 3. Two distinct skip reasons, not one
+
+The plan calls out **two** situations that must produce `detection=None` for entirely different
+reasons, and the wave-generator prompt is explicit that conflating them is a mistake:
+
+- **No live credential** — `evals/README.md`'s documented case. A detection corpus exists, but
+  `has_credentials_for_slug(model)` (`utils/agent_resolve.py:99`, already used elsewhere in the
+  codebase — reused here rather than reinvented) is `False` for the requested model.
+- **No cases to detect on** — the corpus reality *today*: `evals/bench/mergecraft/` does not exist
+  yet (B4's job). Even with a valid credential, there is nothing to run `diff-review` against.
+
+**Locked here:**
+
+```python
+SKIP_REASON_NO_CREDENTIAL: Final[str] = "no live credential"
+SKIP_REASON_NO_CASES: Final[str] = "no patch-bearing cases"
+```
+
+**Locked precedence:** case discovery is checked *before* the credential check. An empty corpus
+short-circuits to `SKIP_REASON_NO_CASES` even when credentials are present — there is nothing
+credential-gated to report. `test_run_detection_reports_no_cases_even_with_valid_credentials` pins
+this ordering explicitly (credentials mocked present, corpus empty) so the two skip paths cannot be
+silently conflated regardless of which the implementer's real environment happens to hit first.
+
+**Implementation-assumption the tests monkeypatch against:** `evals/live_run.py` must import
+`has_credentials_for_slug` by name into its own module namespace (`from
+mergecraft.utils.agent_resolve import has_credentials_for_slug`), so the credential tests
+monkeypatch `mergecraft.evals.live_run.has_credentials_for_slug` rather than the origin module. If
+B3.2 instead calls it as `agent_resolve.has_credentials_for_slug(...)` via a module-qualified
+import, these three tests need their monkeypatch target updated to match — that is a mechanical
+fixup, not a contract change, and should be done by editing this test file's patch target only
+(still test-creator territory per the escalation-receiver rule, since it is the test that would be
+"wrong" — pinned to an implementation detail the plan does not actually require).
+
+### 4. Local `diff-review` loop, never Harbor (confirmed, matches B3.0 bullet 4)
+
+`cli/diff_review_cmd.py`'s `--json` flag (`diff_review_cmd.py:57-60`) writes structured findings to
+a file via `run_offline_diff_review(..., json_path=...)` →
+`analyzers/finding.py:write_findings_json` → `json.dumps({"findings": [Finding.model_dump(), ...]})`
+(`finding.py:168-172`, confirmed by reading the source). That envelope shape (`{"findings": [...]}`)
+is **already** one of the three keys `scoring.py`'s `_rows()` recognizes
+(`scoring.py:327`), so `load_reported_findings()` consumes a `diff-review --json` output file with
+zero adaptation. This is the concrete evidence that "drive the corpus locally" means: for each
+patch-bearing case, materialize its patch into a working tree, run
+`mergecraft diff-review --cwd <worktree> --diff <patch> --json <path>` as a subprocess (or via
+`run_offline_diff_review` directly — implementer's call), then feed the written JSON straight into
+`load_reported_findings()`. A live LLM call happens inside that subprocess and needs a real key —
+which is exactly the seam `review_fn` isolates from the RED suite (see the "Why this needs a design
+pass" section above).
+
+## The `evals/live_run.py` contract this test file pins
+
+None of these symbols exist yet — every test that imports them fails today via `ImportError`
+(module does not exist) at collection time, which is the expected and correct RED signature for
+this PR specifically (unlike B1/B2, where every referenced symbol already existed and RED came from
+`AttributeError`/`ValidationError` at call time).
+
+```python
+PATCH_CANDIDATES: Final[tuple[str, ...]]          # see finding 1
+BASELINE_FILENAME: Final[str] = "baseline.json"
+DEFAULT_DETECTION_CORPUS_DIR: Final[Path] = Path("evals/bench/mergecraft")
+SKIP_REASON_NO_CREDENTIAL: Final[str] = "no live credential"
+SKIP_REASON_NO_CASES: Final[str] = "no patch-bearing cases"
+
+class DetectionCase(BaseModel):        # extra="forbid"
+    case_id: str
+    patch_path: Path
+    baseline_path: Path
+    closed_world: bool = False
+
+class DetectionCaseResult(BaseModel):  # extra="forbid" — per-case row, mirrors
+                                        # CaseReplayRow's role in BenchmarkMetrics
+    case_id: str
+    closed_world: bool
+    total_issues: int
+    total_reported: int
+    found: int
+    recall: float
+    corpus_confirmed_precision: float
+    f1: float
+    strict_precision: float | None = None   # None on an open-world case (D4:
+                                             # ScoreReport.strict_precision raises there)
+
+class DetectionMetrics(BaseModel):     # extra="forbid"
+    provider: str
+    model: str
+    cases_run: int
+    aggregate: AggregateScoreReport
+    case_results: list[DetectionCaseResult]
+    raw_findings_dir: str
+
+ReviewFn = Callable[[DetectionCase], list[dict[str, Any]]]
+
+def discover_detection_cases(
+    corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+) -> list[DetectionCase]: ...
+
+def run_live_detection(
+    cases: list[DetectionCase],
+    *,
+    provider: str,
+    model: str,
+    review_fn: ReviewFn,
+    results_dir: Path,
+    slack: int = DEFAULT_LINE_SLACK,
+) -> DetectionMetrics: ...
+
+def run_detection(
+    *,
+    provider: str,
+    model: str,
+    corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+    results_dir: Path,
+    review_fn: ReviewFn | None = None,
+) -> tuple[DetectionMetrics | None, str | None]:
+    """Returns (metrics, None) on a real run, or (None, skip_reason) per findings 2/3."""
+
+def run_full_benchmark(
+    bank_dir: Path = DEFAULT_BANK_DIR,
+    *,
+    detection_corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+    results_dir: Path = DEFAULT_RESULTS_DIR,
+    providers: tuple[str, ...] = DEFAULT_BENCHMARK_PROVIDERS,
+    detection_provider: str = "claude",
+    detection_model: str = "claude-sonnet-5",
+    review_fn: ReviewFn | None = None,
+) -> BenchmarkResultSet:
+    """Joins run_structural_replay() (benchmark.py, unchanged) with run_detection()
+    into one result set carrying both sections."""
+```
+
+**Corpus-on-disk format this pass invents (B4 must follow it):** each case is a directory under
+`evals/bench/mergecraft/<case_id>/` containing one file named from `PATCH_CANDIDATES` (the patch)
+and a `baseline.json` shaped `{"closed_world": bool, "issues": [<BaselineIssue-compatible rows>]}`.
+The `"issues"` envelope key is one `load_baseline_issues()` already accepts (`scoring.py:327`), so
+no new parsing logic is needed on the scoring side. **This is a test-creator judgment call, not
+something the plan states explicitly** — B3.2 and B4 should treat it as the working default and
+override here (updating this doc) if a different on-disk shape proves better once real cases exist.
+
+**Not tested here (explicitly deferred to B3.2's judgment):**
+
+- A `model_validator` enforcing "`detection` and `skipped_reason` are never both set / both unset
+  after a real orchestration call" — the individual scenario tests below already pin the correct
+  value pair for each path (populated-detection, no-credential, no-cases), which is the behaviour
+  that actually matters; adding a schema-level invariant is a reasonable hardening B3.2 may choose
+  to add, but is not required to pass this suite.
+- The production (non-injected) default for `review_fn` — i.e., the actual subprocess/CLI
+  invocation of `mergecraft diff-review`. Finding 4 above pins what that path must produce
+  (`{"findings": [...]}` JSON compatible with `load_reported_findings()`), but exercising it for
+  real needs a live LLM call, which is out of scope for a keyless RED suite. No `MERGECRAFT_LIVE_E2E`
+  gate is added in this pass — B3.2 or a later wave can add one if a true integration test is
+  wanted.
+- `mergecraft eval bench` CLI wiring and `make bench-detect` / `make reference-docs` (D14) — B3.2's
+  job per the plan; this pass only pins the pure orchestration layer `live_run.py` exposes.
+
+## Locked decisions exercised
+
+| ID | Decision | Tests |
+|----|----------|-------|
+| **D3** | `BenchmarkResultSet` extended, never replaced; `extra="forbid"` preserved; an old result set without `detection`/`skipped_reason` still validates | `test_benchmark_result_set_without_a_detection_section_still_parses`, `test_full_benchmark_structural_section_matches_a_bare_structural_replay` |
+| **D4** | `strict_precision` is closed-world-only; `None` (not a raise) on `DetectionCaseResult` for an open-world case | `test_end_to_end_fixture_corpus_produces_correct_prf1`, `test_detection_case_result_omits_strict_precision_for_open_world_case` |
+| **D7** | Two corpora, two questions — bank cases (no patch) never surface as detection cases | `test_discover_detection_cases_ignores_a_directory_without_baseline_or_patch` |
+| B3.0 finding 1 | Reuse `_PATCH_CANDIDATES` verbatim, do not extend, do not hard-import `harbor` | `test_patch_candidates_matches_harbor_agent_verbatim` |
+| B3.0 finding 2/3 | Typed skip states, two distinct reasons, correct precedence | `test_run_detection_reports_no_credential`, `test_run_detection_reports_no_cases_even_with_valid_credentials`, `test_run_detection_prefers_no_cases_over_no_credential_when_both_are_true` |
+| evals/README.md promise | `skipped: no live credential`, metrics omitted never fabricated | `test_run_detection_reports_no_credential`, `test_full_benchmark_omits_detection_when_no_credential` |
+
+## xfail schedule
+
+None. Every test in `tests/evals/test_live_run.py` fails today via **collection-time `ImportError`**
+(`evals/live_run.py` does not exist) — the correct and expected RED signature for this PR, per the
+dispatch prompt's explicit note that this differs from B1/B2. No `xfail` markers are used because
+there is nothing meaningful to mark `xfail` against a module that does not exist yet; a bare
+`ImportError` already fails the whole file, which is the intended all-or-nothing RED for B3.
+
+## Contract matrix
+
+| Contract | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| Fixture corpus (1 open-world + 1 closed-world case) → detection section populated, P/R/F1 hand-computed | Functional/E2E | Happy | `test_end_to_end_fixture_corpus_produces_correct_prf1` |
+| Zero findings on a clean (closed-world) case → `strict_precision == 1.0` in the detection section | Integration | Edge | `test_end_to_end_fixture_corpus_produces_correct_prf1` (asserts on the clean case's `DetectionCaseResult`) |
+| Open-world case's `DetectionCaseResult.strict_precision` is `None`, not a raise | Unit | Edge | `test_detection_case_result_omits_strict_precision_for_open_world_case` |
+| No credentials → `detection is None`, `skipped_reason == "no live credential"`, `review_fn` never invoked | Integration | Error | `test_run_detection_reports_no_credential` |
+| No patch-bearing cases → `detection is None`, `skipped_reason == "no patch-bearing cases"`, even with valid credentials | Integration | Error | `test_run_detection_reports_no_cases_even_with_valid_credentials` |
+| Precedence: empty corpus wins over missing credential | Integration | Edge | `test_run_detection_prefers_no_cases_over_no_credential_when_both_are_true` |
+| `discover_detection_cases` skips a bank-style directory with no patch/no baseline (D7) | Unit | Edge | `test_discover_detection_cases_ignores_a_directory_without_baseline_or_patch` |
+| `discover_detection_cases` on a missing corpus dir returns `[]`, not an error | Unit | Edge | `test_discover_detection_cases_on_a_missing_dir_returns_empty` |
+| `PATCH_CANDIDATES` matches `harbor/agent.py` verbatim, not extended | Unit | Happy (regression) | `test_patch_candidates_matches_harbor_agent_verbatim` |
+| `run_full_benchmark` joins structural + detection; structural section is bit-identical to a bare `run_structural_replay()` call | Integration | Happy | `test_full_benchmark_structural_section_matches_a_bare_structural_replay` |
+| `run_full_benchmark` with no credentials still populates the structural section (join must not break B1/B2) | Integration | Error | `test_full_benchmark_omits_detection_when_no_credential` |
+| `BenchmarkResultSet` without a `detection` key still parses (D3 forward-compat) | Unit | Happy (regression) | `test_benchmark_result_set_without_a_detection_section_still_parses` |
+| Raw findings persisted under `raw_findings_dir` per case | Integration | Happy | `test_end_to_end_fixture_corpus_produces_correct_prf1` (asserts the written file exists) |
+
+## Verification
+
+- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/evals/test_live_run.py -q` — collects and fails via
+  `ImportError: No module named 'mergecraft.evals.live_run'` at collection time (confirmed: this is
+  the only new-module import in the file; every other imported symbol — `AggregateScoreReport`,
+  `BenchmarkResultSet`, `run_structural_replay`, `has_credentials_for_slug`, `add_case`, `Case` —
+  already exists and resolves cleanly).
+- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/evals --collect-only -q` — confirms the new file's
+  collection failure is isolated to itself and does not break collection of the rest of
+  `tests/evals/`.
+- `make lint` — clean.
+- `make typecheck` — mypy strict is scoped to `src/mergecraft` only (`Makefile:67`); this test file
+  is not mypy-checked, consistent with B1/B2's note.

--- a/evals/README.md
+++ b/evals/README.md
@@ -94,6 +94,39 @@ written only when a live run completes across ≥2 configured providers. With
 missing API keys the harness records `skipped: no live credential` and omits
 those metrics — do not fabricate a table in the README.
 
+### Two corpora, two questions (D7)
+
+`evals/cases/` (the bank above) and `evals/bench/mergecraft/` (below) answer
+different questions and are never conflated:
+
+| | `evals/cases/` (bank) | `evals/bench/mergecraft/` (detection corpus) |
+|---|---|---|
+| Question | *Did the gate make the right decision?* | *Did the review find the right lines?* |
+| Ground truth | `recorded_findings` + `expected_decision`, no patch | a patch + `baseline.json` (`{"closed_world": bool, "issues": [...]}`) |
+| Cost | free, keyless — `replay_case()` recomputes the verdict | needs a live provider — runs `diff-review` for real |
+| Consumer | `mergecraft eval replay-bank`, the `gate_matrix` fields | `mergecraft eval bench`, the `detection` section |
+
+A bank case cannot answer a detection question (no patch to review) and a
+detection case cannot answer a gate question (no `expected_decision`) — see
+`docs/dev/test-plans/eval-benchmark-b3-live.md` for why `discover_detection_cases`
+silently ignores anything shaped like the other corpus rather than erroring.
+
+### Live detection join (B3, #140)
+
+```bash
+make bench-detect
+# or: mergecraft eval bench --provider claude --model claude-sonnet-5 --json
+```
+
+Joins the keyless structural replay above with a live run against
+`evals/bench/mergecraft/`: each case's patch is reviewed via `diff-review`,
+scored against its `baseline.json` with `score_findings()`, and folded into
+the `detection` section of the published result set (`evals/live_run.py`).
+The structural section always populates; `detection` is `None` with a typed
+`skipped_reason` — `"no live credential"` or `"no patch-bearing cases"` — when
+it cannot run, never a fabricated zero. As of this writing the detection
+corpus is empty (B4 seeds it), so every `bench-detect` run reports the latter.
+
 ### Seeded corpus (human-labelled, W9.0)
 
 | Class | Count | Case ids |

--- a/src/mergecraft/cli/eval_cmd.py
+++ b/src/mergecraft/cli/eval_cmd.py
@@ -33,6 +33,11 @@ from mergecraft.evals.benchmark import (
     DEFAULT_BENCHMARK_PROVIDERS,
     DEFAULT_RESULTS_DIR,
     replay_bank,
+    write_result_set,
+)
+from mergecraft.evals.live_run import (
+    DEFAULT_DETECTION_CORPUS_DIR,
+    run_full_benchmark,
 )
 from mergecraft.evals.scoring import (
     DEFAULT_LINE_SLACK,
@@ -587,6 +592,79 @@ def replay_bank_cmd(
             console.print(f"  unsafe approval rate: {result.metrics.unsafe_approval_rate:.2%}")
             console.print(f"  clean block rate    : {result.metrics.clean_block_rate:.2%}")
             console.print(f"  inconclusive rate   : {result.metrics.inconclusive_rate:.2%}")
+
+
+# ── bench ──────────────────────────────────────────────────────────────
+
+
+@app.command("bench")
+def bench_cmd(
+    bank: Path | None = typer.Option(
+        None,
+        "--bank",
+        help="Bank directory for structural replay (default: evals/cases/).",
+    ),
+    detection_corpus: Path = typer.Option(
+        DEFAULT_DETECTION_CORPUS_DIR,
+        "--detection-corpus",
+        help="Patch-bearing detection-corpus directory.",
+    ),
+    results_dir: Path | None = typer.Option(
+        None,
+        "--results-dir",
+        help="Directory for result sets (default: evals/results/).",
+    ),
+    provider: str = typer.Option(
+        "claude",
+        "--provider",
+        help="Provider name recorded on the detection result (structural replay always pins both).",
+    ),
+    model: str = typer.Option(
+        "claude-sonnet-5",
+        "--model",
+        help="Model slug to check credentials for and drive live detection with.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the joined result set as JSON on stdout.",
+    ),
+) -> None:
+    """Join structural decision replay with a live finding-location run (#140, B3).
+
+    Structural replay (keyless) always runs. Live detection additionally runs
+    ``diff-review`` against the patch-bearing detection corpus, if credentials
+    for ``--model`` are available and the corpus is non-empty — otherwise the
+    ``detection`` section is omitted and the reason is reported, never
+    fabricated (see ``evals/README.md``).
+    """
+    bank_dir = _bank_dir(bank)
+    out_dir = results_dir if results_dir is not None else DEFAULT_RESULTS_DIR
+    result = run_full_benchmark(
+        bank_dir,
+        detection_corpus_dir=detection_corpus,
+        results_dir=out_dir,
+        providers=DEFAULT_BENCHMARK_PROVIDERS,
+        detection_provider=provider,
+        detection_model=model,
+    )
+    path = write_result_set(result, results_dir=out_dir)
+    if json_output:
+        typer.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
+        return
+
+    console.print(f"[green]benchmark result set[/green] → {path}")
+    console.print(f"  structural cases: {result.metrics.cases_total}")
+    console.print(f"  pass rate       : {result.metrics.decision_replay_pass_rate:.2%}")
+    if result.detection is not None:
+        det = result.detection
+        console.print(f"  detection cases : {det.cases_run}")
+        console.print(f"  recall          : {det.aggregate.recall:.2%}")
+        console.print(f"  precision       : {det.aggregate.corpus_confirmed_precision:.2%}")
+        console.print(f"  f1              : {det.aggregate.f1:.2%}")
+        console.print(f"  raw findings @  : {det.raw_findings_dir}")
+    else:
+        console.print(f"[yellow]detection skipped[/yellow]: {result.skipped_reason}")
 
 
 # ── gate ───────────────────────────────────────────────────────────────

--- a/src/mergecraft/evals/benchmark.py
+++ b/src/mergecraft/evals/benchmark.py
@@ -22,7 +22,7 @@ from mergecraft.agents.verifier import (
     judge_pin,
     pinned_judge_model,
 )
-from mergecraft.evals.scoring import DEFAULT_LINE_SLACK
+from mergecraft.evals.scoring import DEFAULT_LINE_SLACK, AggregateScoreReport
 from mergecraft.evals.store import (
     CASE_STATUS_PASSED,
     CASE_STATUS_REGRESSION,
@@ -33,7 +33,7 @@ from mergecraft.evals.store import (
 )
 from mergecraft.modes import modes
 
-RESULT_SET_SCHEMA_VERSION: Final[str] = "1.1.0"
+RESULT_SET_SCHEMA_VERSION: Final[str] = "1.2.0"
 DEFAULT_RESULTS_DIR: Final[Path] = Path("evals/results")
 
 # Providers the benchmark names by default (W9.0: ≥2 providers).
@@ -164,6 +164,55 @@ class BenchmarkMetrics(BaseModel):
     by_corpus_class: dict[str, CorpusClassRollup]
 
 
+class DetectionCase(BaseModel):
+    """One patch-bearing detection-corpus case discovered on disk (B3, N5)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    patch_path: Path
+    baseline_path: Path
+    closed_world: bool = False
+
+
+class DetectionCaseResult(BaseModel):
+    """One case's live finding-location outcome — mirrors ``CaseReplayRow``'s
+    role for structural replay, but for the detection join (B3, N5)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    closed_world: bool
+    total_issues: int
+    total_reported: int
+    found: int
+    recall: float
+    corpus_confirmed_precision: float
+    f1: float
+    # None on an open-world case — `ScoreReport.strict_precision` raises there
+    # (D4); never fabricated as a number that doesn't exist.
+    strict_precision: float | None = None
+
+
+class DetectionMetrics(BaseModel):
+    """Live finding-location metrics for one provider/model (B3, N5).
+
+    The join `run_structural_replay()`'s own docstring named as a future
+    path: corpus case → `diff-review` findings → `score_findings()` →
+    folded here. Optional on `BenchmarkResultSet` — see `skipped_reason`
+    for why a run may carry neither `detection` nor a fabricated one.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    model: str
+    cases_run: int
+    aggregate: AggregateScoreReport
+    case_results: list[DetectionCaseResult]
+    raw_findings_dir: str
+
+
 class BenchmarkResultSet(BaseModel):
     """Wire shape written under ``evals/results/``."""
 
@@ -173,6 +222,12 @@ class BenchmarkResultSet(BaseModel):
     pins: VersionPins
     metrics: BenchmarkMetrics
     case_results: list[CaseReplayRow]
+    # B3, N5: the live finding-location join. `None` when no live run
+    # attempted it yet, or when one was attempted but skipped — see
+    # `skipped_reason` for which. Both optional (default `None`) so a
+    # pre-B3 committed result set with neither key still validates (D3).
+    detection: DetectionMetrics | None = None
+    skipped_reason: str | None = None
 
 
 def corpus_class_for(case: Case) -> str:
@@ -417,6 +472,9 @@ __all__ = [
     "BenchmarkResultSet",
     "CaseReplayRow",
     "CorpusClassRollup",
+    "DetectionCase",
+    "DetectionCaseResult",
+    "DetectionMetrics",
     "GateMatrix",
     "ReviewingModelPin",
     "VersionPins",

--- a/src/mergecraft/evals/live_run.py
+++ b/src/mergecraft/evals/live_run.py
@@ -1,0 +1,264 @@
+"""Join corpus case -> diff-review findings -> score_findings() (#140, B3, N5).
+
+``evals/benchmark.py`` (structural decision replay) and ``evals/scoring.py``
+(finding-location precision/recall/F1) are two disconnected halves —
+``run_structural_replay()``'s own docstring names this join as a future
+path. This module is that join: a patch-bearing detection-corpus case is
+driven through a findings-producing callable (``ReviewFn``), scored against
+its recorded baseline via :func:`mergecraft.evals.scoring.score_findings`,
+and folded into a :class:`~mergecraft.evals.benchmark.DetectionMetrics`
+section on the published :class:`~mergecraft.evals.benchmark.BenchmarkResultSet`.
+
+The ``ReviewFn`` seam is deliberate: the pure orchestration below (case
+discovery, scoring, folding) is keyless and deterministic, while producing
+findings for real needs a live provider call. ``run_detection`` wires a
+default ``ReviewFn`` that shells out in-process to
+:func:`mergecraft.offline_review.run_offline_diff_review`; tests inject a
+stub at the same seam instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Final
+
+from mergecraft.evals.benchmark import (
+    DEFAULT_BENCHMARK_PROVIDERS,
+    DEFAULT_RESULTS_DIR,
+    BenchmarkResultSet,
+    DetectionCase,
+    DetectionCaseResult,
+    DetectionMetrics,
+    run_structural_replay,
+)
+from mergecraft.evals.scoring import (
+    DEFAULT_LINE_SLACK,
+    fold_score_reports,
+    load_baseline_issues,
+    load_reported_findings,
+    score_findings,
+)
+from mergecraft.evals.store import DEFAULT_BANK_DIR
+from mergecraft.utils.agent_resolve import has_credentials_for_slug
+
+# Verbatim from `harbor/agent.py`'s `_PATCH_CANDIDATES` — deliberately
+# duplicated, not imported, since the `harbor` extra is optional and this
+# in-repo corpus must not require it (B3.0 design-gate finding 1). Do not
+# extend this tuple; it defines the on-disk filename contract every detection
+# case must use.
+PATCH_CANDIDATES: Final[tuple[str, ...]] = (
+    "task.patch",
+    "changes.patch",
+    "diff.patch",
+    "review.patch",
+)
+BASELINE_FILENAME: Final[str] = "baseline.json"
+DEFAULT_DETECTION_CORPUS_DIR: Final[Path] = Path("evals/bench/mergecraft")
+
+# Two distinct skip reasons (B3.0 finding 3) — never conflated. Case
+# discovery is checked before credentials, so an empty corpus always reports
+# `SKIP_REASON_NO_CASES`, even when a credential is also missing.
+SKIP_REASON_NO_CREDENTIAL: Final[str] = "no live credential"
+SKIP_REASON_NO_CASES: Final[str] = "no patch-bearing cases"
+
+ReviewFn = Callable[[DetectionCase], list[dict[str, Any]]]
+
+
+def discover_detection_cases(
+    corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+) -> list[DetectionCase]:
+    """Find every patch-bearing case under ``corpus_dir``.
+
+    A subdirectory without both a recognized patch filename (from
+    ``PATCH_CANDIDATES``) and a ``baseline.json`` is silently skipped — a
+    decision-only bank case (D7) has neither and must never surface here.
+    """
+    if not corpus_dir.is_dir():
+        return []
+
+    cases: list[DetectionCase] = []
+    for case_dir in sorted(corpus_dir.iterdir()):
+        if not case_dir.is_dir():
+            continue
+        baseline_path = case_dir / BASELINE_FILENAME
+        patch_path = next(
+            (case_dir / name for name in PATCH_CANDIDATES if (case_dir / name).is_file()),
+            None,
+        )
+        if patch_path is None or not baseline_path.is_file():
+            continue
+        payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+        cases.append(
+            DetectionCase(
+                case_id=case_dir.name,
+                patch_path=patch_path,
+                baseline_path=baseline_path,
+                closed_world=bool(payload.get("closed_world", False)),
+            )
+        )
+    return cases
+
+
+def run_live_detection(
+    cases: list[DetectionCase],
+    *,
+    provider: str,
+    model: str,
+    review_fn: ReviewFn,
+    results_dir: Path,
+    slack: int = DEFAULT_LINE_SLACK,
+) -> DetectionMetrics:
+    """Drive every case through ``review_fn``, score it, and fold the results.
+
+    Raw findings are persisted per case under ``results_dir/raw-findings/`` —
+    a published number must be able to show its work (D9).
+    """
+    raw_dir = results_dir / "raw-findings"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    reports = []
+    case_results: list[DetectionCaseResult] = []
+    for case in cases:
+        baseline_payload = json.loads(case.baseline_path.read_text(encoding="utf-8"))
+        issues = load_baseline_issues(baseline_payload)
+
+        raw_rows = review_fn(case)
+        (raw_dir / f"{case.case_id}.json").write_text(
+            json.dumps({"findings": raw_rows}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        findings = load_reported_findings({"findings": raw_rows})
+
+        report = score_findings(issues, findings, slack=slack, closed_world=case.closed_world)
+        reports.append(report)
+        case_results.append(
+            DetectionCaseResult(
+                case_id=case.case_id,
+                closed_world=case.closed_world,
+                total_issues=report.total_issues,
+                total_reported=report.total_reported,
+                found=report.found,
+                recall=report.recall,
+                corpus_confirmed_precision=report.corpus_confirmed_precision,
+                f1=report.f1,
+                strict_precision=report.strict_precision if case.closed_world else None,
+            )
+        )
+
+    return DetectionMetrics(
+        provider=provider,
+        model=model,
+        cases_run=len(cases),
+        aggregate=fold_score_reports(reports),
+        case_results=case_results,
+        raw_findings_dir=str(raw_dir),
+    )
+
+
+def _default_review_fn(model: str) -> ReviewFn:
+    """Production ``ReviewFn``: run ``diff-review`` in-process for real.
+
+    Not exercised by the RED suite (needs a live provider) — the seam this
+    plugs into is what the tests inject a stub at instead (B3.0 finding 4).
+    """
+    from mergecraft.offline_review import run_offline_diff_review
+
+    def _fn(case: DetectionCase) -> list[dict[str, Any]]:
+        with tempfile.TemporaryDirectory(prefix="mergecraft-detect-") as tmp:
+            json_path = Path(tmp) / "findings.json"
+            asyncio.run(
+                run_offline_diff_review(
+                    cwd=Path.cwd(),
+                    diff_file=case.patch_path,
+                    model=model,
+                    json_path=json_path,
+                )
+            )
+            if not json_path.is_file():
+                return []
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                rows = payload.get("findings", [])
+                return [row for row in rows if isinstance(row, dict)]
+            return []
+
+    return _fn
+
+
+def run_detection(
+    *,
+    provider: str,
+    model: str,
+    corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+    results_dir: Path,
+    review_fn: ReviewFn | None = None,
+) -> tuple[DetectionMetrics | None, str | None]:
+    """Run detection if possible, or report exactly why it was skipped.
+
+    Returns ``(metrics, None)`` on a real run, or ``(None, skip_reason)``.
+    Case discovery is checked before credentials (locked precedence, B3.0
+    finding 3): an empty corpus is always the more specific diagnosis.
+    """
+    cases = discover_detection_cases(corpus_dir)
+    if not cases:
+        return None, SKIP_REASON_NO_CASES
+    if not has_credentials_for_slug(model):
+        return None, SKIP_REASON_NO_CREDENTIAL
+
+    resolved_review_fn = review_fn if review_fn is not None else _default_review_fn(model)
+    metrics = run_live_detection(
+        cases,
+        provider=provider,
+        model=model,
+        review_fn=resolved_review_fn,
+        results_dir=results_dir,
+    )
+    return metrics, None
+
+
+def run_full_benchmark(
+    bank_dir: Path = DEFAULT_BANK_DIR,
+    *,
+    detection_corpus_dir: Path = DEFAULT_DETECTION_CORPUS_DIR,
+    results_dir: Path = DEFAULT_RESULTS_DIR,
+    providers: tuple[str, ...] = DEFAULT_BENCHMARK_PROVIDERS,
+    detection_provider: str = "claude",
+    detection_model: str = "claude-sonnet-5",
+    review_fn: ReviewFn | None = None,
+) -> BenchmarkResultSet:
+    """Join structural decision replay with the live detection run.
+
+    The join is additive: the structural section (``metrics``/``pins``/
+    ``case_results``) is byte-identical to a bare ``run_structural_replay()``
+    call whether or not detection could run alongside it.
+    """
+    structural = run_structural_replay(bank_dir, providers=providers)
+    metrics, skipped_reason = run_detection(
+        provider=detection_provider,
+        model=detection_model,
+        corpus_dir=detection_corpus_dir,
+        results_dir=results_dir,
+        review_fn=review_fn,
+    )
+    return structural.model_copy(update={"detection": metrics, "skipped_reason": skipped_reason})
+
+
+__all__ = [
+    "BASELINE_FILENAME",
+    "DEFAULT_DETECTION_CORPUS_DIR",
+    "PATCH_CANDIDATES",
+    "SKIP_REASON_NO_CASES",
+    "SKIP_REASON_NO_CREDENTIAL",
+    "DetectionCase",
+    "DetectionCaseResult",
+    "DetectionMetrics",
+    "ReviewFn",
+    "discover_detection_cases",
+    "run_detection",
+    "run_full_benchmark",
+    "run_live_detection",
+]

--- a/tests/evals/test_benchmark_gate_metrics.py
+++ b/tests/evals/test_benchmark_gate_metrics.py
@@ -402,8 +402,12 @@ def test_decision_replay_pass_rate_is_unchanged_by_the_new_gate_fields(
     assert result.metrics.decision_replay_pass_rate == pytest.approx(1.0)
 
 
-def test_result_set_schema_version_bumped_to_1_1_0() -> None:
-    assert RESULT_SET_SCHEMA_VERSION == "1.1.0"
+def test_result_set_schema_version_is_at_least_1_1_0() -> None:
+    """B2 bumped 1.0.0 -> 1.1.0 for the gate-matrix fields; B3 bumped it again
+    to 1.2.0 for the detection join. Pin the floor B2 actually needs, not an
+    exact string a later PR's own version bump would otherwise break."""
+    major, minor, _ = (int(part) for part in RESULT_SET_SCHEMA_VERSION.split("."))
+    assert (major, minor) >= (1, 1)
 
 
 # ── VersionPins: N6 pin completion ──────────────────────────────────────

--- a/tests/evals/test_live_run.py
+++ b/tests/evals/test_live_run.py
@@ -1,0 +1,491 @@
+"""Join corpus case -> diff-review findings -> score_findings -> DetectionMetrics.
+
+(#140, B3, RED wave — "the centre of the plan", N5)
+
+``evals/benchmark.py`` (structural decision replay) and ``evals/scoring.py`` (finding-location
+precision/recall/F1) are two disconnected halves today; ``run_structural_replay()``'s own
+docstring says live provider finding-location metrics are "not populated." B3 is the join:
+corpus case -> ``diff-review --json`` -> findings -> ``score_findings()`` -> ``AggregateScoreReport``
+-> a new optional ``detection`` section on ``BenchmarkResultSet``.
+
+None of ``mergecraft.evals.live_run``'s symbols exist yet -- this whole file fails at **collection
+time** via ``ImportError`` today, which is the correct RED signature for this PR specifically
+(unlike B1/B2, where every referenced symbol already existed and RED came from ``AttributeError``/
+``ValidationError`` at call time -- see ``docs/dev/test-plans/eval-benchmark-b1-metrics.md`` and
+``eval-benchmark-b2-gate.md``). Every other imported symbol below (``BenchmarkResultSet``,
+``run_structural_replay``, ``has_credentials_for_slug``, ``Case``, ``add_case``,
+``AggregateScoreReport``) already exists and resolves cleanly -- confirm a red run shows exactly one
+failure reason (the missing module), not a typo against something that already exists.
+
+See ``docs/dev/test-plans/eval-benchmark-b3-live.md`` for the full design-gate resolution this file
+pins: why the join needs a dependency-injection seam (``review_fn``) to stay keyless and
+deterministic, the on-disk detection-corpus format this pass invents for B4 to follow, and the two
+distinct skip reasons (no credential vs. no patch-bearing cases) and their precedence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.evals.benchmark import (
+    DEFAULT_BENCHMARK_PROVIDERS,
+    RESULT_SET_SCHEMA_VERSION,
+    BenchmarkResultSet,
+    run_structural_replay,
+)
+from mergecraft.evals.live_run import (
+    BASELINE_FILENAME,
+    PATCH_CANDIDATES,
+    SKIP_REASON_NO_CASES,
+    SKIP_REASON_NO_CREDENTIAL,
+    DetectionCase,
+    DetectionCaseResult,
+    DetectionMetrics,
+    discover_detection_cases,
+    run_detection,
+    run_full_benchmark,
+    run_live_detection,
+)
+from mergecraft.evals.scoring import AggregateScoreReport
+from mergecraft.evals.store import Case, add_case
+from mergecraft.utils.learnings import LearningProvenance
+
+_WHEN = datetime(2026, 8, 15, 12, 0, 0, tzinfo=UTC)
+
+# Verified verbatim against `src/mergecraft/harbor/agent.py:23` (2026-08-15). Not imported from
+# `mergecraft.harbor.agent` -- that module requires the optional `harbor` extra
+# (`pyproject.toml:39`), which is not installed in this checkout (confirmed:
+# `uv run python -c "import harbor"` -> ModuleNotFoundError). See B3.0 design-gate finding 1 in
+# the test-plan doc for why `evals/live_run.py` must not hard-import it either.
+_HARBOR_PATCH_CANDIDATES = ("task.patch", "changes.patch", "diff.patch", "review.patch")
+
+
+# ── bank-case fixtures (structural replay side, unchanged B1/B2 machinery) ──
+
+
+def _provenance() -> LearningProvenance:
+    return LearningProvenance(
+        run_id="synthetic",
+        pr_number=1,
+        source_field="eval_bank",
+        author_login="synthetic",
+        author_association="OWNER",
+        trust_tier="trusted",
+        timestamp=_WHEN,
+    )
+
+
+def _bank_case(case_id: str) -> Case:
+    """A trivially-replayable bank case -- exercises the structural (B1/B2) half only."""
+    return Case(
+        id=case_id,
+        title=f"live-run fixture {case_id}",
+        category="missed_finding",
+        submitted_at=_WHEN,
+        run_id="synthetic",
+        pr_number=1,
+        failure_mode="wrong_decision",
+        expected_finding="synthetic",
+        expected_decision="neutral",
+        replay_command=f"mergecraft eval replay {case_id}",
+        provenance=_provenance(),
+        body="",
+        recorded_findings=[],
+        run_succeeded=True,
+        trust_tier="trusted",
+    )
+
+
+# ── detection-corpus fixtures (the new B3 on-disk shape, see test-plan doc) ──
+
+
+def _write_detection_case(
+    corpus_dir: Path,
+    case_id: str,
+    *,
+    issues: list[dict[str, Any]],
+    closed_world: bool,
+    patch_name: str = "task.patch",
+) -> None:
+    case_dir = corpus_dir / case_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+    (case_dir / patch_name).write_text(
+        "--- a/src/a.py\n+++ b/src/a.py\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+        encoding="utf-8",
+    )
+    (case_dir / BASELINE_FILENAME).write_text(
+        json.dumps({"closed_world": closed_world, "issues": issues}),
+        encoding="utf-8",
+    )
+
+
+def _stub_review_fn(
+    responses: dict[str, list[dict[str, Any]]],
+) -> tuple[Any, list[str]]:
+    """Return a ``review_fn`` and the list of case ids it was actually invoked for.
+
+    Standing in for a real ``mergecraft diff-review --json`` subprocess call (design-gate
+    finding 4) -- this is the dependency-injection seam that keeps the RED suite keyless and
+    deterministic. A production ``review_fn`` shells out and reads back the ``{"findings": [...]}``
+    file ``write_findings_json`` produces; this stub returns canned rows of the same shape.
+    """
+    calls: list[str] = []
+
+    def _fn(case: DetectionCase) -> list[dict[str, Any]]:
+        calls.append(case.case_id)
+        return responses.get(case.case_id, [])
+
+    return _fn, calls
+
+
+# ── B3.1 bullet 1: end-to-end on a fixture corpus, hand-computed P/R/F1 ──
+
+
+def test_end_to_end_fixture_corpus_produces_correct_prf1(tmp_path: Path) -> None:
+    """Two-case fixture corpus, hand-computed against ``score_findings``'s own rules.
+
+    Case A (open-world): 2 baseline issues, one located, one extra unmatched finding elsewhere.
+    recall = 1/2 = 0.5, corpus_confirmed_precision = 1/2 = 0.5, f1 = 0.5.
+
+    Case B (closed-world / clean): 0 baseline issues, 0 findings.
+    ``strict_precision`` denominator is 0 -> 1.0 (``ScoreReport.strict_precision``'s own rule,
+    scoring.py:225-228) -- the B3.1 "zero findings on a clean case" scenario.
+
+    Folded aggregate: total_issues=2, total_reported=2, found=1, recall=0.5,
+    corpus_confirmed_precision=0.5, f1=0.5 (``fold_score_reports`` is pure summation, already
+    covered by B1's own suite -- this test is pinning that ``live_run.py`` calls it correctly, not
+    re-deriving its arithmetic).
+    """
+    corpus = tmp_path / "detect-corpus"
+    _write_detection_case(
+        corpus,
+        "bench-detect-open-001",
+        closed_world=False,
+        issues=[
+            {"id": "issue-1", "path": "src/a.py", "start_line": 10, "end_line": 12},
+            {"id": "issue-2", "path": "src/b.py", "start_line": 20, "end_line": 22},
+        ],
+    )
+    _write_detection_case(
+        corpus,
+        "bench-detect-clean-001",
+        closed_world=True,
+        issues=[],
+    )
+
+    review_fn, calls = _stub_review_fn(
+        {
+            "bench-detect-open-001": [
+                {"path": "src/a.py", "start_line": 10, "end_line": 12, "message": "m1"},
+                {"path": "src/c.py", "start_line": 5, "end_line": 5, "message": "extra"},
+            ],
+            "bench-detect-clean-001": [],
+        }
+    )
+
+    cases = discover_detection_cases(corpus)
+    assert {c.case_id for c in cases} == {"bench-detect-open-001", "bench-detect-clean-001"}
+
+    results_dir = tmp_path / "results"
+    metrics = run_live_detection(
+        cases,
+        provider="claude",
+        model="claude-sonnet-5",
+        review_fn=review_fn,
+        results_dir=results_dir,
+    )
+
+    assert isinstance(metrics, DetectionMetrics)
+    assert sorted(calls) == ["bench-detect-clean-001", "bench-detect-open-001"]
+    assert metrics.cases_run == 2
+    assert metrics.provider == "claude"
+    assert metrics.model == "claude-sonnet-5"
+
+    agg = metrics.aggregate
+    assert isinstance(agg, AggregateScoreReport)
+    assert agg.total_issues == 2
+    assert agg.total_reported == 2
+    assert agg.found == 1
+    assert agg.recall == pytest.approx(0.5)
+    assert agg.corpus_confirmed_precision == pytest.approx(0.5)
+    assert agg.f1 == pytest.approx(0.5)
+
+    by_case = {r.case_id: r for r in metrics.case_results}
+    open_result = by_case["bench-detect-open-001"]
+    assert open_result.closed_world is False
+    assert open_result.recall == pytest.approx(0.5)
+    assert open_result.strict_precision is None
+
+    clean_result = by_case["bench-detect-clean-001"]
+    assert clean_result.closed_world is True
+    assert clean_result.total_issues == 0
+    assert clean_result.total_reported == 0
+    # The B3.1 checklist's exact scenario: zero findings on a clean case.
+    assert clean_result.strict_precision == pytest.approx(1.0)
+
+    # Raw findings persisted per case (B3.2 checklist: `evals/results/<stamp>/raw-findings/`).
+    raw_dir = Path(metrics.raw_findings_dir)
+    assert raw_dir.is_dir()
+    assert (raw_dir / "bench-detect-open-001.json").is_file()
+    assert (raw_dir / "bench-detect-clean-001.json").is_file()
+
+
+def test_detection_case_result_omits_strict_precision_for_open_world_case() -> None:
+    """Unit-level pin, independent of the fixture-corpus plumbing above: an open-world
+    ``DetectionCaseResult`` carries ``strict_precision=None``, never a raised exception bubbling
+    out of ``ScoreReport.strict_precision`` (D4) and never a fabricated number."""
+    result = DetectionCaseResult(
+        case_id="c",
+        closed_world=False,
+        total_issues=1,
+        total_reported=1,
+        found=1,
+        recall=1.0,
+        corpus_confirmed_precision=1.0,
+        f1=1.0,
+    )
+    assert result.strict_precision is None
+
+
+# ── B3.1 bullet 2: no credentials -> detection omitted, skipped recorded ──
+
+
+def test_run_detection_reports_no_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    corpus = tmp_path / "detect-corpus"
+    _write_detection_case(corpus, "bench-detect-open-001", closed_world=False, issues=[])
+    review_fn, calls = _stub_review_fn({})
+
+    monkeypatch.setattr(
+        "mergecraft.evals.live_run.has_credentials_for_slug",
+        lambda _model: False,
+    )
+
+    metrics, skipped_reason = run_detection(
+        provider="claude",
+        model="claude-sonnet-5",
+        corpus_dir=corpus,
+        results_dir=tmp_path / "results",
+        review_fn=review_fn,
+    )
+
+    assert metrics is None
+    assert skipped_reason == SKIP_REASON_NO_CREDENTIAL
+    assert skipped_reason == "no live credential"  # evals/README.md's exact promised string
+    # Metrics omitted, never fabricated -- the review path must not even run.
+    assert calls == []
+
+
+def test_run_detection_reports_no_cases_even_with_valid_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """B4 has not landed: ``evals/bench/mergecraft/`` carries zero patch-bearing cases today.
+    Distinct from the missing-credential path -- pinned with credentials mocked *present* so the
+    two skip reasons cannot be silently conflated."""
+    monkeypatch.setattr(
+        "mergecraft.evals.live_run.has_credentials_for_slug",
+        lambda _model: True,
+    )
+    empty_corpus = tmp_path / "empty-detect-corpus"
+
+    metrics, skipped_reason = run_detection(
+        provider="claude",
+        model="claude-sonnet-5",
+        corpus_dir=empty_corpus,
+        results_dir=tmp_path / "results",
+        review_fn=_stub_review_fn({})[0],
+    )
+
+    assert metrics is None
+    assert skipped_reason == SKIP_REASON_NO_CASES
+    assert skipped_reason == "no patch-bearing cases"
+
+
+def test_run_detection_prefers_no_cases_over_no_credential_when_both_are_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locked precedence (B3.0 finding 3): case discovery is checked before the credential
+    check, so an empty corpus reports ``SKIP_REASON_NO_CASES`` even when credentials are also
+    absent -- there being nothing to detect on is the more specific, more useful diagnosis."""
+    monkeypatch.setattr(
+        "mergecraft.evals.live_run.has_credentials_for_slug",
+        lambda _model: False,
+    )
+    empty_corpus = tmp_path / "empty-detect-corpus"
+
+    _, skipped_reason = run_detection(
+        provider="claude",
+        model="claude-sonnet-5",
+        corpus_dir=empty_corpus,
+        results_dir=tmp_path / "results",
+        review_fn=_stub_review_fn({})[0],
+    )
+
+    assert skipped_reason == SKIP_REASON_NO_CASES
+
+
+# ── discover_detection_cases: D7 two-corpora separation ──
+
+
+def test_discover_detection_cases_ignores_a_directory_without_baseline_or_patch(
+    tmp_path: Path,
+) -> None:
+    """D7 -- ``evals/cases/`` bank entries (decision-only, no patch) must never surface as
+    detection cases even if a stray directory of the same shape ends up under the detection
+    corpus root. A directory with neither a recognized patch filename nor ``baseline.json`` is
+    silently skipped, mirroring ``list_cases()``'s tolerant-skip behaviour in ``store.py``."""
+    corpus = tmp_path / "detect-corpus"
+    bank_like = corpus / "bench-correctness-off-by-one"
+    bank_like.mkdir(parents=True)
+    (bank_like / "notes.md").write_text("not a patch, not a baseline", encoding="utf-8")
+
+    _write_detection_case(corpus, "bench-detect-real-001", closed_world=False, issues=[])
+
+    cases = discover_detection_cases(corpus)
+
+    assert [c.case_id for c in cases] == ["bench-detect-real-001"]
+
+
+def test_discover_detection_cases_on_a_missing_dir_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    assert discover_detection_cases(missing) == []
+
+
+# ── B3.0 finding 1: patch-filename reuse, verbatim, not extended ──
+
+
+def test_patch_candidates_matches_harbor_agent_verbatim() -> None:
+    assert PATCH_CANDIDATES == _HARBOR_PATCH_CANDIDATES
+
+
+# ── B3.1 bullet 4: BenchmarkResultSet forward-compat (D3) ──
+
+
+def test_benchmark_result_set_without_a_detection_section_still_parses(tmp_path: Path) -> None:
+    """A result set shaped exactly like the ones B1/B2 already write (no ``detection`` or
+    ``skipped_reason`` key at all -- what every ``evals/results/*.json`` committed before B3
+    looks like) must still validate once those two optional fields exist.
+
+    Built from a real ``run_structural_replay()`` call so everything *but* the two new keys is
+    byte-faithful to production output, then those two keys are explicitly popped to simulate a
+    pre-B3 committed file -- a dump taken *after* the fields exist always includes them (at their
+    default), so popping is the only way to reconstruct what an old file on disk actually looked
+    like; asserting the keys are absent first documents that this is deliberate, not a fixture
+    bug.
+    """
+    bank = tmp_path / "bank"
+    add_case(bank, _bank_case("synthetic-001"))
+    old_style_dump = run_structural_replay(bank, providers=DEFAULT_BENCHMARK_PROVIDERS).model_dump(
+        mode="json"
+    )
+    old_style_dump.pop("detection", None)
+    old_style_dump.pop("skipped_reason", None)
+    assert "detection" not in old_style_dump
+    assert "skipped_reason" not in old_style_dump
+
+    restored = BenchmarkResultSet.model_validate(old_style_dump)
+
+    assert restored.detection is None
+    assert restored.skipped_reason is None
+    # Structural section is untouched by the field addition.
+    assert restored.metrics.cases_total == 1
+
+
+def test_benchmark_result_set_still_forbids_unknown_fields() -> None:
+    """D3 regression guard: adding ``detection``/``skipped_reason`` must not loosen
+    ``extra='forbid'`` for genuinely unrecognized keys."""
+    bank_result = run_structural_replay(Path("does-not-exist"))
+    payload = bank_result.model_dump(mode="json")
+    payload["not_a_real_field"] = "nope"
+    with pytest.raises(ValidationError):
+        BenchmarkResultSet.model_validate(payload)
+
+
+# ── run_full_benchmark: the join itself ──
+
+
+def test_full_benchmark_structural_section_matches_a_bare_structural_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The join must not perturb B1/B2's existing behaviour (B3.1 bullet 2's other half): the
+    ``metrics``/``pins``/``case_results`` a bare ``run_structural_replay()`` call produces are
+    identical whether or not detection ran alongside it."""
+    bank = tmp_path / "bank"
+    add_case(bank, _bank_case("synthetic-001"))
+    add_case(bank, _bank_case("synthetic-002"))
+
+    corpus = tmp_path / "detect-corpus"
+    _write_detection_case(corpus, "bench-detect-open-001", closed_world=False, issues=[])
+    monkeypatch.setattr(
+        "mergecraft.evals.live_run.has_credentials_for_slug",
+        lambda _model: True,
+    )
+
+    direct = run_structural_replay(bank, providers=DEFAULT_BENCHMARK_PROVIDERS)
+    joined = run_full_benchmark(
+        bank,
+        detection_corpus_dir=corpus,
+        results_dir=tmp_path / "results",
+        providers=DEFAULT_BENCHMARK_PROVIDERS,
+        review_fn=_stub_review_fn({})[0],
+    )
+
+    assert joined.metrics == direct.metrics
+    assert joined.case_results == direct.case_results
+    assert joined.detection is not None
+    assert joined.skipped_reason is None
+
+
+def test_full_benchmark_omits_detection_when_no_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No credentials -> ``detection`` omitted and ``skipped`` recorded; the structural section
+    still populates normally -- the join must not break B1/B2's existing behaviour when it
+    cannot run (B3.1 bullet 2, full sentence)."""
+    bank = tmp_path / "bank"
+    add_case(bank, _bank_case("synthetic-001"))
+
+    corpus = tmp_path / "detect-corpus"
+    _write_detection_case(corpus, "bench-detect-open-001", closed_world=False, issues=[])
+    monkeypatch.setattr(
+        "mergecraft.evals.live_run.has_credentials_for_slug",
+        lambda _model: False,
+    )
+
+    result = run_full_benchmark(
+        bank,
+        detection_corpus_dir=corpus,
+        results_dir=tmp_path / "results",
+        providers=DEFAULT_BENCHMARK_PROVIDERS,
+        review_fn=_stub_review_fn({})[0],
+    )
+
+    assert result.detection is None
+    assert result.skipped_reason == SKIP_REASON_NO_CREDENTIAL
+    # Structural section still populates -- the join is additive, not a gate on the rest.
+    assert result.metrics.cases_total == 1
+    assert result.metrics.cases_replayable == 1
+    assert result.pins.corpus_commit  # unchanged VersionPins machinery still runs
+
+
+def test_result_set_schema_version_bumped_to_1_2_0() -> None:
+    """B3.2 checklist: bump schema -> 1.2.0 for the detection join."""
+    assert RESULT_SET_SCHEMA_VERSION == "1.2.0"
+
+
+def test_detection_case_forbids_unknown_fields() -> None:
+    """Unit-level pin, independent of any orchestration: `extra='forbid'` on the new models."""
+    with pytest.raises(ValidationError):
+        DetectionCase(
+            case_id="c",
+            patch_path=Path("p"),
+            baseline_path=Path("b"),
+            unknown="nope",  # type: ignore[call-arg]
+        )


### PR DESCRIPTION
## Summary

PR B3 of 7 in the eval-benchmark stacked plan (`.ignorelocal/waves/issues-eval-benchmark-numbers-wave-plan.md`), spinning out of #140. Stacked on #212 (B2). **The centre of the plan (N5)**: `evals/benchmark.py` (structural decision replay, keyless) and `evals/scoring.py` (finding-location P/R/F1, B1) were two disconnected halves — `run_structural_replay()`'s own docstring names this join as a future path. This PR is that join.

- New `src/mergecraft/evals/live_run.py`: `discover_detection_cases()` finds patch-bearing cases under `evals/bench/mergecraft/<case_id>/` (patch file + `baseline.json`) → `run_live_detection()` drives each through a `ReviewFn` → scores via `score_findings()` → folds via `fold_score_reports()` → `DetectionMetrics`.
- **Dependency-injection seam**: the pure orchestration stays keyless/deterministic; the production default (`_default_review_fn`) shells into `run_offline_diff_review` in-process for a real LLM call — untested by design (needs live credentials), but verified to call that function's real signature correctly.
- Two typed skip states, never a fabricated zero: `SKIP_REASON_NO_CASES` ("no patch-bearing cases", checked first) and `SKIP_REASON_NO_CREDENTIAL` ("no live credential") — matches `evals/README.md`'s existing promise.
- `BenchmarkResultSet` gains `detection: DetectionMetrics | None` and `skipped_reason: str | None`, both optional so a pre-B3 committed result set still validates (D3).
- `mergecraft eval bench` / `make bench-detect` join structural replay with live detection. `RESULT_SET_SCHEMA_VERSION` → `1.2.0`. `evals/README.md` documents the two-corpora split (D7): bank cases (`evals/cases/`) answer gate questions, detection cases (`evals/bench/mergecraft/`, empty until B4) answer finding-location questions.

## Verification

- Authored RED (test-creator, with a full design-gate pass — no test-creator precedent existed for this shape) → implemented GREEN (directly) → verified (wave-verifier), per the plan's owner-agent split.
- The plan flags this wave specifically: *"must be verified by running it, not by reading it — a wired-but-dead join is exactly the failure mode."* `wave-verifier` built a real fixture detection corpus on disk, drove it through the actual join with a stub `review_fn`, and hand-computed P/R/F1 to cross-check the real output (not the shipped tests' own assertions). Also independently ran the CLI end-to-end against the real 10-case bank, inspected the written JSON directly, confirmed `run_full_benchmark` is genuinely wired to the new `bench` CLI command (not bypassed), and cross-checked the untested production `review_fn` path's call site against `run_offline_diff_review`'s real signature.
- **Verdict: pass, no findings.**
- `make lint typecheck pyright` clean. `make ci`: `ci-static` OK, Bandit/pip-audit clean, coverage floor passed (73.40% > 70%) — `coverage-gate`'s pytest step surfaces the same 4 pre-existing unrelated Rich-ANSI failures B1/B2 already isolated, re-confirmed here.

## Test plan

- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/evals -q` — 156 passed, 1 xfailed
- [x] `make lint typecheck pyright` clean
- [x] `make reference-docs-check` — passes (`mergecraft eval bench` is a new row in the generated CLI table)
- [x] `make ci` — green modulo the 4 pre-existing unrelated failures noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)