### PR TITLE
fix(tracing): coerce dict/list attrs before real OTel export

### DIFF
--- a/src/mergecraft/tracing/exporters.py
+++ b/src/mergecraft/tracing/exporters.py
@@ -422,6 +422,28 @@ def json_dumps(obj: Any) -> bytes:
     return _json.dumps(obj, default=str).encode("utf-8")
 
 
+def _otel_safe_attr_value(value: Any) -> Any:
+    """Coerce ``value`` into a type the real OTel SDK accepts for span attributes.
+
+    OTel restricts attribute values to ``bool`` / ``str`` / ``bytes`` / ``int`` /
+    ``float`` or a homogeneous sequence of those. ``TraceEvent.attrs`` is only
+    JSON-compatible, not OTel-safe — structured values like ``tool.arguments``
+    / ``tool.output`` (dicts, or lists containing them) reach here as-is and
+    the SDK rejects them outright, dropping the attribute with an "Invalid
+    type" warning instead of raising. JSON-encode anything outside the
+    accepted set so the value still reaches the exported span.
+    """
+    if isinstance(value, bool | str | bytes | int | float):
+        return value
+    if isinstance(value, list | tuple) and all(
+        isinstance(item, bool | str | bytes | int | float) for item in value
+    ):
+        return list(value)
+    import json as _json
+
+    return _json.dumps(value, default=str)
+
+
 class OTLPSink:
     """One sink class serving both ``logfire`` and ``otel`` (D5).
 
@@ -533,10 +555,16 @@ class OTLPSink:
             }
             # Forward mergeCraft attrs (gen_ai.*, model.*, …) so OTLP export
             # reaches real collectors — the in-memory recording processor is
-            # not a substitute for this boundary (#143 / W7).
+            # not a substitute for this boundary (#143 / W7). Coerced through
+            # ``_otel_safe_attr_value`` first: ``TraceEvent.attrs`` is
+            # JSON-compatible and carries structured values (``tool.arguments``,
+            # ``tool.output``, …) that the real OTel SDK rejects outright —
+            # bool/str/bytes/int/float or a homogeneous sequence of those is
+            # the full accepted type set; anything else silently drops with an
+            # "Invalid type" warning instead of raising.
             for key, value in (event.attrs or {}).items():
                 if key not in attrs:
-                    attrs[key] = value
+                    attrs[key] = _otel_safe_attr_value(value)
             # If attrs is the truncation marker, forward the marker as an
             # attribute so consumers see it (D8).
             if event.attrs.get("truncated") is True:

--- a/tests/tracing/test_exporters.py
+++ b/tests/tracing/test_exporters.py
@@ -160,6 +160,43 @@ def test_otlp_sink_maps_attrs_to_genai_conventions(trace_event_data: dict[str, A
     assert span_attrs["gen_ai.usage.output_tokens"] == 48
 
 
+def test_otlp_sink_json_encodes_dict_and_list_attrs(trace_event_data: dict[str, Any]) -> None:
+    """A dict/list-of-dict attr value is JSON-encoded before it reaches the OTel span.
+
+    ``tool.arguments`` / ``tool.output`` (``_tool_attrs.py``) carry raw dict
+    payloads through ``TraceEvent.attrs`` — JSON-compatible, but not one of
+    the types the real OTel SDK accepts for span attributes (``bool`` /
+    ``str`` / ``bytes`` / ``int`` / ``float`` or a homogeneous sequence of
+    those). Passing a dict straight through used to make the SDK log
+    "Invalid type dict for attribute" and silently drop the attribute.
+    ``OTLPSink.write`` must coerce it via ``_otel_safe_attr_value`` first. A
+    scalar-only list (``tool.input_keys``) is left untouched since OTel
+    already accepts it.
+    """
+    from mergecraft.tracing import OTLPSink, TraceEvent
+
+    trace_event_data["attrs"] = {
+        "tool.arguments": {"path": "src/foo.py", "content": "x = 1"},
+        "tool.output": [{"kind": "text", "text": "ok"}],
+        "tool.input_keys": ["content", "path"],
+    }
+    sink = OTLPSink(endpoint="http://127.0.0.1:1/canary-no-network", provider=object())
+    fake_tracer = _FakeOtelTracer()
+    sink._tracer = fake_tracer
+
+    sink.write(TraceEvent.model_validate(trace_event_data))
+
+    span_attrs = fake_tracer.calls[0]["attributes"]
+    assert isinstance(span_attrs["tool.arguments"], str)
+    assert json.loads(span_attrs["tool.arguments"]) == {
+        "path": "src/foo.py",
+        "content": "x = 1",
+    }
+    assert isinstance(span_attrs["tool.output"], str)
+    assert json.loads(span_attrs["tool.output"]) == [{"kind": "text", "text": "ok"}]
+    assert span_attrs["tool.input_keys"] == ["content", "path"]
+
+
 def test_sink_write_failure_never_propagates(trace_event_data: dict[str, Any]) -> None:
     """A raising inner sink is swallowed by ``RedactingSink`` and logged at ``warning``.
 
@@ -223,6 +260,7 @@ __all__ = [
     "test_attrs_over_cap_are_truncated_not_dropped",
     "test_jsonl_sink_redacts_on_write_and_on_read",
     "test_jsonl_sink_round_trips_every_field",
+    "test_otlp_sink_json_encodes_dict_and_list_attrs",
     "test_otlp_sink_maps_attrs_to_genai_conventions",
     "test_sink_write_failure_never_propagates",
 ]


### PR DESCRIPTION
## What?

Fixes tool-call span attributes (`tool.arguments`, `tool.output`) silently disappearing from exported traces when a real OTel-backed sink (Logfire, OTLP) is configured.

## Why?

`OTLPSink.write` forwards every `TraceEvent` attr straight onto the real OTel span. mergeCraft's own attrs are only JSON-compatible, not OTel-safe: the SDK accepts `bool`/`str`/`bytes`/`int`/`float` or a homogeneous sequence of those, and dict-valued attrs like `tool.arguments`/`tool.output` fall outside that set. The SDK doesn't raise, it logs `Invalid type dict for attribute '...' value` and drops the attribute, so every tool call span shipped without its request/response payload.

This stayed invisible because the degraded `NullSink` (used when the `[tracing]` extra isn't installed) accepts anything without validation — it only surfaces once a real sink is wired up.

## Test plan

- `make lint` / `make typecheck` on the touched files
- `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/tracing -q` — same pre-existing failures with and without this change (confirmed via `git stash` comparison): 4 need `MERGECRAFT_OTEL_COLLECTOR_DUMP`, 1 is documented order-dependent flakiness from shared `TracerProvider` state
