### PR TITLE
feat(mcp): add submit_review_verdict as the typed terminal review operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added: `submit_review_verdict` — a typed MCP operation that records a review's terminal verdict
+  (`approve` / `request_changes`), summary and structured findings. Unknown fields and invalid
+  verdict values are rejected; an identical re-submission is idempotent, a conflicting one is an
+  error. Not yet enforced — the run outcome is unchanged in this release
 - `mergecraft tracing logfire wire-workflow` / `unwire-workflow` — surgical
   YAML mutation of `.github/workflows/*.yml` to wire (or strip) the four
   Logfire keys (`tracing: "true"`, `tracing-to: logfire`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `submit_review_verdict` now rejects non-list `findings` (including `{}`, `false`,
+  and `0`) instead of recording them as an empty list, hashes the validated payload
+  so omitting `findings` matches `findings: []`, and scopes the recorded submit to
+  the active model-chain attempt so a fallback cannot inherit or conflict-reject
+  the failed attempt's verdict
 - `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real
   registered command is `mergecraft traces show <run-id>` — the stale
   invocation is now generated from the live CLI app instead of hand-maintained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `submit_review_verdict` now rejects non-list `findings` (including `{}`, `false`,
-  and `0`) instead of recording them as an empty list, hashes the validated payload
-  so omitting `findings` matches `findings: []`, and scopes the recorded submit to
-  the active model-chain attempt so a fallback cannot inherit or conflict-reject
-  the failed attempt's verdict
+- `submit_review_verdict` now rejects non-list `findings` and severities outside
+  the review taxonomy, hashes the validated payload so omitting `findings` matches
+  `findings: []`, keeps a conflict flag sticky for the attempt, and scopes the
+  recorded submit to the active model-chain attempt so a fallback cannot inherit
+  or conflict-reject the failed attempt's verdict
 - `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real
   registered command is `mergecraft traces show <run-id>` — the stale
   invocation is now generated from the live CLI app instead of hand-maintained

--- a/docs/test-plans/review-integrity-vp1.md
+++ b/docs/test-plans/review-integrity-vp1.md
@@ -1,0 +1,56 @@
+# Review integrity VP1 — `submit_review_verdict` terminal tool — test plan (VP1.1 RED)
+
+Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md`
+Worktree: `mergecraft-vp1-terminal-tool` @ `wave/vp1-terminal-tool`
+
+## xfail schedule
+
+| Wave | Test files | Marker |
+|------|------------|--------|
+| **VP1.2** | `tests/mcp/test_submit_review_verdict.py` (all 9) | `green after VP1.2: submit_review_verdict` |
+| **VP1.2** | `tests/agents/test_agent_result_terminal_fields.py::test_fields_populate_from_tool_state` | same |
+
+All cross-wave markers use `strict=False`. `test_defaults_preserve_existing_behaviour` is **not** xfailing — it is a V2 regression pin that must pass against current `AgentResult` and keep passing after the new fields land with defaults.
+
+VP1.2 removes the markers after `mergecraft.mcp.verdict` and the `AgentResult` / `ToolState` fields exist.
+
+## Named symbols this suite pins
+
+The plan's params model was unnamed in W0. This suite pins **`SubmitReviewVerdictParams`** in `src/mergecraft/mcp/verdict.py` (`extra="forbid"`; `verdict: Literal["approve", "request_changes"]`; `summary: str`; `findings: list[AgentFinding]`). `TerminalSubmission` is pinned on `src/mergecraft/mcp/tool_state.py` alongside `ReviewRecord` / `ApprovalRecord`. Canonical payload hash is SHA-256 of `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)`.
+
+| Symbol | Module | Direct test |
+|--------|--------|-------------|
+| `submit_review_verdict_tool` | `mcp/verdict.py` | every execute path in `test_submit_review_verdict.py` |
+| `SubmitReviewVerdictParams` | `mcp/verdict.py` | `test_unknown_field_is_rejected`, `test_invalid_verdict_enum_is_rejected`, `test_missing_required_field_is_rejected` |
+| `TerminalSubmission` | `mcp/tool_state.py` | `test_valid_submission_is_recorded` |
+| `ToolState.terminal_submission` | `mcp/tool_state.py` | `test_valid_submission_is_recorded` |
+| `ToolState.terminal_submission_conflict` | `mcp/tool_state.py` | `test_second_conflicting_submission_is_rejected` |
+| `AgentFinding` (D3, no parallel type) | `agents/verifier.py` | `test_findings_use_agent_finding_shape` |
+| `AgentResult.terminal_submission_received` | `agents/shared.py` | both tests in `test_agent_result_terminal_fields.py` |
+| `AgentResult.terminal_submission_id` | `agents/shared.py` | `test_fields_populate_from_tool_state` |
+| `AgentResult.diagnostics` | `agents/shared.py` | `test_fields_populate_from_tool_state` |
+| `finalize_agent_result` | `agents/post_run.py` | `test_fields_populate_from_tool_state` |
+| `build_orchestrator_tools` / `build_common_tools` | `mcp/server.py` | `test_tool_is_registered_for_orchestrator_only` |
+| `subagent_denied_tool_names` / `verifier_denied_tool_names` | `agents/gates.py`, `agents/verifier.py` | `test_tool_is_in_subagent_deny_list` |
+
+## Contract matrix
+
+| Decision | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| VP1 tool records a typed submission | Functional | Happy: well-formed `approve` + empty findings lands `TerminalSubmission` with id, hash, `submitted_at` | `test_valid_submission_is_recorded` |
+| extra="forbid" | Unit + functional | Edge/error: unrecognized key is `ValidationError` on the params model **and** `is_error` on the tool; nothing is recorded | `test_unknown_field_is_rejected` |
+| Verdict enum | Unit + functional | Error: `"lgtm"` rejected on the model and the tool | `test_invalid_verdict_enum_is_rejected` |
+| Required fields | Unit + functional | Error: absent `summary` / `verdict` (parametrized) | `test_missing_required_field_is_rejected` |
+| **D3** reuse `AgentFinding` | Integration | Happy: fingerprint + `identity()` survive round-trip; stored finding is an `AgentFinding` instance | `test_findings_use_agent_finding_shape` |
+| **D4** identical resubmit | Functional | Happy/edge: same payload hash returns the original id; still one record; conflict flag stays false | `test_second_identical_submission_is_idempotent` |
+| **D4** conflicting resubmit | Functional | Error: differing payload is an error, `terminal_submission_conflict` is true, original id remains | `test_second_conflicting_submission_is_rejected` |
+| Orchestrator-only registration | Integration | Happy: real `build_orchestrator_tools` includes the name; `build_common_tools` does not; `mutates is False` | `test_tool_is_registered_for_orchestrator_only` |
+| Deny lists (mutates=False still denied) | Integration | Guard: name is in both `subagent_denied_tool_names` and `verifier_denied_tool_names` | `test_tool_is_in_subagent_deny_list` |
+| **V2** AgentResult defaults | Unit | Regression: `AgentResult(success=True)` still constructs; `terminal_submission_received` getattr-defaults `False` | `test_defaults_preserve_existing_behaviour` |
+| Finalize copies tool state | Integration | Happy: after a recorded submission, `finalize_agent_result` sets `terminal_submission_received=True` and the id | `test_fields_populate_from_tool_state` |
+
+Registration and deny-list tests build the real toolsets from `mcp/server.py` and assert on `ToolSpec.name`. They do not grep source.
+
+## RED acceptance (VP1.1)
+
+11 collected; 1 passes (`test_defaults_preserve_existing_behaviour`); 10 xfail pending VP1.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave.

--- a/docs/test-plans/review-integrity-vp1.md
+++ b/docs/test-plans/review-integrity-vp1.md
@@ -1,4 +1,4 @@
-# Review integrity VP1 — `submit_review_verdict` terminal tool — test plan (VP1.1 RED)
+# Review integrity VP1 — `submit_review_verdict` terminal tool — test plan
 
 Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md`
 Worktree: `mergecraft-vp1-terminal-tool` @ `wave/vp1-terminal-tool`
@@ -7,12 +7,16 @@ Worktree: `mergecraft-vp1-terminal-tool` @ `wave/vp1-terminal-tool`
 
 | Wave | Test files | Marker |
 |------|------------|--------|
-| **VP1.2** | `tests/mcp/test_submit_review_verdict.py` (all 9) | `green after VP1.2: submit_review_verdict` |
-| **VP1.2** | `tests/agents/test_agent_result_terminal_fields.py::test_fields_populate_from_tool_state` | same |
+| **VP1.2** | `tests/mcp/test_submit_review_verdict.py` (all 9) | *(markers removed 2026-08-15 after VP1.2)* |
+| **VP1.2** | `tests/agents/test_agent_result_terminal_fields.py::test_fields_populate_from_tool_state` | *(markers removed 2026-08-15 after VP1.2)* |
 
-All cross-wave markers use `strict=False`. `test_defaults_preserve_existing_behaviour` is **not** xfailing — it is a V2 regression pin that must pass against current `AgentResult` and keep passing after the new fields land with defaults.
+`test_defaults_preserve_existing_behaviour` was never xfailing — it is a V2 regression pin.
 
-VP1.2 removes the markers after `mergecraft.mcp.verdict` and the `AgentResult` / `ToolState` fields exist.
+### xfail reconciliation log
+
+| Date | Impl wave | Markers removed | Notes |
+|------|-----------|-----------------|-------|
+| 2026-08-15 | VP1.2 | module-level `pytestmark` on `test_submit_review_verdict.py` (9 tests) + `@pytest.mark.xfail` on `test_fields_populate_from_tool_state` | Suite is now 11/11 real passes. Direct pin added: `submit_review_verdict` is in `TERMINAL_PROTOCOL_DENIED_TOOL_NAMES` (deleting the constant/guard fails the suite). |
 
 ## Named symbols this suite pins
 
@@ -32,6 +36,7 @@ The plan's params model was unnamed in W0. This suite pins **`SubmitReviewVerdic
 | `finalize_agent_result` | `agents/post_run.py` | `test_fields_populate_from_tool_state` |
 | `build_orchestrator_tools` / `build_common_tools` | `mcp/server.py` | `test_tool_is_registered_for_orchestrator_only` |
 | `subagent_denied_tool_names` / `verifier_denied_tool_names` | `agents/gates.py`, `agents/verifier.py` | `test_tool_is_in_subagent_deny_list` |
+| `TERMINAL_PROTOCOL_DENIED_TOOL_NAMES` | `agents/gates.py` | `test_tool_is_in_subagent_deny_list` (deleting the constant fails the suite) |
 
 ## Contract matrix
 
@@ -45,7 +50,7 @@ The plan's params model was unnamed in W0. This suite pins **`SubmitReviewVerdic
 | **D4** identical resubmit | Functional | Happy/edge: same payload hash returns the original id; still one record; conflict flag stays false | `test_second_identical_submission_is_idempotent` |
 | **D4** conflicting resubmit | Functional | Error: differing payload is an error, `terminal_submission_conflict` is true, original id remains | `test_second_conflicting_submission_is_rejected` |
 | Orchestrator-only registration | Integration | Happy: real `build_orchestrator_tools` includes the name; `build_common_tools` does not; `mutates is False` | `test_tool_is_registered_for_orchestrator_only` |
-| Deny lists (mutates=False still denied) | Integration | Guard: name is in both `subagent_denied_tool_names` and `verifier_denied_tool_names` | `test_tool_is_in_subagent_deny_list` |
+| Deny lists (mutates=False still denied) | Integration | Guard: name is in `TERMINAL_PROTOCOL_DENIED_TOOL_NAMES` and both `subagent_denied_tool_names` and `verifier_denied_tool_names` | `test_tool_is_in_subagent_deny_list` |
 | **V2** AgentResult defaults | Unit | Regression: `AgentResult(success=True)` still constructs; `terminal_submission_received` getattr-defaults `False` | `test_defaults_preserve_existing_behaviour` |
 | Finalize copies tool state | Integration | Happy: after a recorded submission, `finalize_agent_result` sets `terminal_submission_received=True` and the id | `test_fields_populate_from_tool_state` |
 
@@ -54,3 +59,7 @@ Registration and deny-list tests build the real toolsets from `mcp/server.py` an
 ## RED acceptance (VP1.1)
 
 11 collected; 1 passes (`test_defaults_preserve_existing_behaviour`); 10 xfail pending VP1.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave.
+
+## Reconciliation (post-VP1.2)
+
+11 collected; 11 passed; 0 xfail; 0 xpass. `TERMINAL_PROTOCOL_DENIED_TOOL_NAMES` now has a direct `tests/` reference. VP1 Final checkboxes are not flipped here.

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -52,6 +52,9 @@ GIT_NATIVE_READ_DENY_CLAUDE: list[str] = [f"{tool}(.git/config)" for tool in CLA
 # one source of truth.
 BLOCKING_SEVERITIES: Final[frozenset[str]] = frozenset({"Critical", "Major"})
 
+# Terminal-protocol tools are orchestrator-only even when ``mutates=False``.
+TERMINAL_PROTOCOL_DENIED_TOOL_NAMES: Final[frozenset[str]] = frozenset({"submit_review_verdict"})
+
 
 def subagent_denied_tool_names(
     ctx: ToolContext,
@@ -59,6 +62,9 @@ def subagent_denied_tool_names(
 ) -> list[str]:
     """Canonical bare names of every state-mutating MCP tool for this run."""
     names = [t.name for t in build_orchestrator_tools(ctx, output_schema) if t.mutates]
+    for terminal_name in TERMINAL_PROTOCOL_DENIED_TOOL_NAMES:
+        if terminal_name not in names:
+            names.append(terminal_name)
     if not names:
         msg = (
             "subagent deny list derived empty — no MCP tool is marked mutates=True. "

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -175,10 +176,23 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
     return f"{base}\n\nThis is a reflection turn — address the issues above, then stop."
 
 
+def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
+    submission = ctx.tool_state.terminal_submission
+    if submission is None:
+        return False, None, {}
+    return True, submission.id, {}
+
+
 async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> AgentResult:
     """Terminal hard-fail if stopHook / unsubmittedReview still open."""
+    received, submission_id, diagnostics = _terminal_submission_fields(ctx)
     if not result.success:
-        return result
+        return replace(
+            result,
+            terminal_submission_received=received,
+            terminal_submission_id=submission_id,
+            diagnostics=diagnostics,
+        )
     issues = await collect_post_run_issues(ctx, skip_summary_stale=True)
     if issues.unsubmitted_review:
         expected = (
@@ -186,17 +200,27 @@ async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> Ag
             if issues.unsubmitted_review == "Review"
             else "create_pull_request_review or report_progress"
         )
-        return AgentResult(
-            success=False,
-            output=result.output,
-            error=(
-                f"post-run gate failed: selected {issues.unsubmitted_review} mode but "
-                f"never called {expected}"
+        return replace(
+            AgentResult(
+                success=False,
+                output=result.output,
+                error=(
+                    f"post-run gate failed: selected {issues.unsubmitted_review} mode but "
+                    f"never called {expected}"
+                ),
+                usage=result.usage,
+                metadata=result.metadata,
             ),
-            usage=result.usage,
-            metadata=result.metadata,
+            terminal_submission_received=received,
+            terminal_submission_id=submission_id,
+            diagnostics=diagnostics,
         )
-    return result
+    return replace(
+        result,
+        terminal_submission_received=received,
+        terminal_submission_id=submission_id,
+        diagnostics=diagnostics,
+    )
 
 
 async def run_post_run_retry_loop(

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -177,10 +177,16 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
 
 
 def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
+    """Copy the recorded terminal submission onto ``AgentResult``.
+
+    Diagnostics stay thin in VP1: ``attempt_id`` is the only field the
+    submission carries that finalize does not already promote as a first-class
+    attribute. VP3 fills the rest of the attempt envelope.
+    """
     submission = ctx.tool_state.terminal_submission
     if submission is None:
         return False, None, {}
-    return True, submission.id, {}
+    return True, submission.id, {"attempt_id": submission.attempt_id}
 
 
 async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> AgentResult:

--- a/src/mergecraft/agents/shared.py
+++ b/src/mergecraft/agents/shared.py
@@ -131,6 +131,9 @@ class AgentResult:
     error: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     usage: AgentUsage | None = None
+    terminal_submission_received: bool = False
+    terminal_submission_id: str | None = None
+    diagnostics: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -1064,6 +1064,7 @@ async def _run_agent_task_with_deadline(ctx: RunContext) -> tuple[str | None, Ag
                 run_once=_run_agent_once,
                 head=model_head,
                 pin=model_pin,
+                tool_state=tool_state,
             )
             return winning_slug, chain_result
         return selected_slug, await agent.run(run_ctx)

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -62,6 +62,7 @@ from mergecraft.mcp.shared import JsonSchema, ToolResult, ToolSpec
 from mergecraft.mcp.shell import kill_background_tool, shell_tool
 from mergecraft.mcp.static_checks import run_static_checks_tool
 from mergecraft.mcp.upload import upload_file_tool
+from mergecraft.mcp.verdict import submit_review_verdict_tool
 from mergecraft.mcp.verification import (
     record_finding_verdict_tool,
     verify_agent_findings_tool,
@@ -143,6 +144,7 @@ def build_orchestrator_tools(
         *build_common_tools(ctx, output_schema),
         report_progress_tool(ctx),
         select_mode_tool(ctx),
+        submit_review_verdict_tool(ctx),
         push_branch_tool(ctx),
         push_tags_tool(ctx),
         delete_branch_tool(ctx),

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -86,6 +86,23 @@ class ProgressComment:
 
 
 @dataclass(slots=True)
+class TerminalSubmission:
+    """Recorded terminal review verdict for a run (VP1).
+
+    Findings are ``AgentFinding`` instances at runtime; typed as ``Any`` here
+    to keep this module free of the verifier import cycle.
+    """
+
+    id: str
+    verdict: Literal["approve", "request_changes"]
+    summary: str
+    findings: list[Any]
+    payload_hash: str
+    submitted_at: str
+    attempt_id: int
+
+
+@dataclass(slots=True)
 class ReviewRecord:
     id: int
     node_id: str
@@ -192,6 +209,8 @@ class ToolState:
     # live path always sets this.
     modes: list[Mode] = field(default_factory=list)
     review: ReviewRecord | None = None
+    terminal_submission: TerminalSubmission | None = None
+    terminal_submission_conflict: bool = False
     approval: ApprovalRecord | None = None
     review_replies: dict[int, ReviewReplyRecord] = field(default_factory=dict)
     dependency_installation: DependencyInstallationState | None = None

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import TerminalSubmission
+from mergecraft.review_taxonomy import FINDING_SEVERITIES
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -45,12 +46,16 @@ class SubmitReviewVerdictParams(BaseModel):
         coerced: list[Any] = []
         for item in value:
             if isinstance(item, AgentFinding):
-                coerced.append(item)
+                finding = item
             elif isinstance(item, dict):
-                coerced.append(AgentFinding.model_validate(item))
+                finding = AgentFinding.model_validate(item)
             else:
                 msg = "each finding must be an object"
                 raise ValueError(msg)
+            if finding.severity not in FINDING_SEVERITIES:
+                msg = f"severity must be one of {FINDING_SEVERITIES!r}, got {finding.severity!r}"
+                raise ValueError(msg)
+            coerced.append(finding)
         return coerced
 
 
@@ -62,7 +67,9 @@ def submit_review_verdict_tool(ctx: ToolContext):
 
         if existing is not None:
             if existing.payload_hash == payload_hash:
-                ctx.tool_state.terminal_submission_conflict = False
+                # Conflict stays sticky for this attempt. VP2 treats the flag as
+                # "this attempt is unusable"; a later identical replay must not
+                # wash that out. `_prepare_chain_attempt` is the only reset.
                 return {
                     "recorded": True,
                     "id": existing.id,
@@ -124,7 +131,7 @@ def submit_review_verdict_tool(ctx: ToolContext):
                             "line": {"type": "number"},
                             "severity": {
                                 "type": "string",
-                                "enum": ["Critical", "Major", "Minor", "Trivial"],
+                                "enum": list(FINDING_SEVERITIES),
                             },
                             "body": {"type": "string"},
                             "fingerprint": {"type": "string"},

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -1,0 +1,147 @@
+"""Terminal review verdict MCP tool (VP1).
+
+Records a typed terminal submission on ``ToolState`` without publishing to
+GitHub. Enforcement and outcome wiring land in VP2; this module is inert for
+run outcomes until then.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from mergecraft.mcp.shared import execute, tool
+from mergecraft.mcp.tool_state import TerminalSubmission
+
+if TYPE_CHECKING:
+    from mergecraft.mcp.context import ToolContext
+
+
+def _canonical_payload_hash(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class SubmitReviewVerdictParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: Literal["approve", "request_changes"]
+    summary: str
+    findings: list[Any] = Field(default_factory=list)
+
+    @field_validator("findings", mode="before")
+    @classmethod
+    def _coerce_findings(cls, value: object) -> list[Any]:
+        from mergecraft.agents.verifier import AgentFinding
+
+        if not value:
+            return []
+        if not isinstance(value, list):
+            msg = "findings must be a list"
+            raise TypeError(msg)
+        coerced: list[Any] = []
+        for item in value:
+            if isinstance(item, AgentFinding):
+                coerced.append(item)
+            elif isinstance(item, dict):
+                coerced.append(AgentFinding.model_validate(item))
+            else:
+                msg = "each finding must be an object"
+                raise TypeError(msg)
+        return coerced
+
+
+def submit_review_verdict_tool(ctx: ToolContext):
+    async def _run(params: dict[str, Any]) -> dict[str, Any]:
+        validated = SubmitReviewVerdictParams.model_validate(params)
+        payload_hash = _canonical_payload_hash(dict(params))
+        existing = ctx.tool_state.terminal_submission
+
+        if existing is not None:
+            if existing.payload_hash == payload_hash:
+                ctx.tool_state.terminal_submission_conflict = False
+                return {
+                    "recorded": True,
+                    "id": existing.id,
+                    "verdict": existing.verdict,
+                    "replayed": True,
+                }
+            ctx.tool_state.terminal_submission_conflict = True
+            msg = (
+                "terminal submission conflict: a different verdict payload was already "
+                "recorded for this run"
+            )
+            raise ValueError(msg)
+
+        submission = TerminalSubmission(
+            id=uuid.uuid4().hex,
+            verdict=validated.verdict,
+            summary=validated.summary,
+            findings=list(validated.findings),
+            payload_hash=payload_hash,
+            submitted_at=datetime.now(UTC).isoformat(),
+            attempt_id=ctx.tool_state.fallback_index,
+        )
+        ctx.tool_state.terminal_submission = submission
+        ctx.tool_state.terminal_submission_conflict = False
+        return {
+            "recorded": True,
+            "id": submission.id,
+            "verdict": submission.verdict,
+            "replayed": False,
+        }
+
+    return tool(
+        name="submit_review_verdict",
+        description=(
+            "Record the terminal review verdict for this run: approve or request_changes, "
+            "a summary, and structured findings. Identical re-submissions are idempotent; "
+            "conflicting payloads are rejected. Does not publish to GitHub — call "
+            "create_pull_request_review separately when publication is required."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "verdict": {
+                    "type": "string",
+                    "enum": ["approve", "request_changes"],
+                    "description": "Structural terminal verdict for this review run.",
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "Short summary of the review outcome.",
+                },
+                "findings": {
+                    "type": "array",
+                    "description": "Structured findings backing a request_changes verdict.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "line": {"type": "number"},
+                            "severity": {
+                                "type": "string",
+                                "enum": ["Critical", "Major", "Minor", "Trivial"],
+                            },
+                            "body": {"type": "string"},
+                            "fingerprint": {"type": "string"},
+                        },
+                        "required": ["path", "body", "severity"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["verdict", "summary"],
+            "additionalProperties": False,
+        },
+        mutates=False,
+        execute=execute(_run, "submit_review_verdict"),
+    )
+
+
+__all__ = ["SubmitReviewVerdictParams", "submit_review_verdict_tool"]

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -39,11 +39,9 @@ class SubmitReviewVerdictParams(BaseModel):
     def _coerce_findings(cls, value: object) -> list[Any]:
         from mergecraft.agents.verifier import AgentFinding
 
-        if not value:
-            return []
         if not isinstance(value, list):
             msg = "findings must be a list"
-            raise TypeError(msg)
+            raise ValueError(msg)
         coerced: list[Any] = []
         for item in value:
             if isinstance(item, AgentFinding):
@@ -52,14 +50,14 @@ class SubmitReviewVerdictParams(BaseModel):
                 coerced.append(AgentFinding.model_validate(item))
             else:
                 msg = "each finding must be an object"
-                raise TypeError(msg)
+                raise ValueError(msg)
         return coerced
 
 
 def submit_review_verdict_tool(ctx: ToolContext):
     async def _run(params: dict[str, Any]) -> dict[str, Any]:
         validated = SubmitReviewVerdictParams.model_validate(params)
-        payload_hash = _canonical_payload_hash(dict(params))
+        payload_hash = _canonical_payload_hash(validated.model_dump(mode="json"))
         existing = ctx.tool_state.terminal_submission
 
         if existing is not None:

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -439,6 +439,15 @@ def promote_model_evidence(
         )
 
 
+def _prepare_chain_attempt(tool_state: ToolState | None, fallback_index: int) -> None:
+    """Stamp the active chain index and drop any prior attempt's terminal submit."""
+    if tool_state is None:
+        return
+    tool_state.fallback_index = fallback_index
+    tool_state.terminal_submission = None
+    tool_state.terminal_submission_conflict = False
+
+
 async def run_with_model_chain(
     *,
     settings: RepoSettings,
@@ -447,6 +456,7 @@ async def run_with_model_chain(
     correlation: dict[str, Any] | None = None,
     head: str | None = None,
     pin: bool = False,
+    tool_state: ToolState | None = None,
 ) -> tuple[str, AgentResult]:
     """Walk the model chain, advancing on retryable failures.
 
@@ -476,6 +486,10 @@ async def run_with_model_chain(
         pin (bool, optional): #37 / W4 — collapse to ``[head]`` (or the first
             configured entry) and skip the fallback tail. The escape hatch for
             operators who explicitly want "use exactly this model".
+        tool_state (ToolState | None, optional): Shared MCP state for this run.
+            When supplied, ``fallback_index`` is updated *before* ``run_once``
+            and any terminal submission from a prior chain entry is cleared so
+            a fallback cannot inherit or conflict-reject the failed attempt.
 
     Returns:
         tuple[str, AgentResult]: The winning slug and its agent result.
@@ -517,6 +531,7 @@ async def run_with_model_chain(
         while attempts < max_attempts:
             slug = chain[chain_index]
             attempts += 1
+            _prepare_chain_attempt(tool_state, chain_index)
             logger.info("» model chain attempt {}/{} slug={}", attempts, max_attempts, slug)
 
             attempt_attrs = {

--- a/tests/agents/test_agent_result_terminal_fields.py
+++ b/tests/agents/test_agent_result_terminal_fields.py
@@ -1,0 +1,98 @@
+"""AgentResult fields that record whether a terminal verdict was submitted (VP1 / V2).
+
+``test_defaults_preserve_existing_behaviour`` is a regression pin: it must
+pass against current ``AgentResult`` (no new fields required) and keep
+passing after VP1.2 adds defaults. ``test_fields_populate_from_tool_state``
+is RED until VP1.2 populates the fields from ``ctx.tool_state``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.post_run import finalize_agent_result
+from mergecraft.agents.shared import AgentResult, AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _tool_ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def test_defaults_preserve_existing_behaviour() -> None:
+    """V2 regression pin: existing ``AgentResult`` constructions still work."""
+    result = AgentResult(success=True)
+    assert result.success is True
+    assert result.output is None
+    assert result.error is None
+    assert result.metadata == {}
+    assert result.usage is None
+    assert getattr(result, "terminal_submission_received", False) is False
+    assert getattr(result, "terminal_submission_id", None) is None
+
+    populated = AgentResult(success=True, output="done", metadata={"k": "v"})
+    assert populated.output == "done"
+    assert populated.metadata == {"k": "v"}
+    assert getattr(populated, "terminal_submission_received", False) is False
+
+
+@pytest.mark.xfail(reason="green after VP1.2: submit_review_verdict", strict=False)
+@pytest.mark.asyncio
+async def test_fields_populate_from_tool_state(tmp_path: Path) -> None:
+    """After a recorded submission, finalize copies the flag and id onto ``AgentResult``."""
+    from mergecraft.mcp.verdict import submit_review_verdict_tool
+
+    tool_ctx = _tool_ctx(tmp_path)
+    recorded = await submit_review_verdict_tool(tool_ctx).execute(
+        {
+            "verdict": "approve",
+            "summary": "No blocking issues in the diff.",
+            "findings": [],
+        }
+    )
+    assert recorded.is_error is False
+    submission = tool_ctx.tool_state.terminal_submission
+    assert submission is not None
+    submission_id = submission.id
+
+    run_ctx = AgentRunContext(
+        payload=tool_ctx.payload,
+        mcp_server_url=tool_ctx.mcp_server_url,
+        tmpdir=tool_ctx.tmpdir,
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(),
+        tool_state=tool_ctx.tool_state,
+    )
+    finalized = await finalize_agent_result(run_ctx, AgentResult(success=True))
+    assert finalized.terminal_submission_received is True
+    assert finalized.terminal_submission_id == submission_id
+    diagnostics: dict[str, Any] = finalized.diagnostics
+    assert isinstance(diagnostics, dict)

--- a/tests/agents/test_agent_result_terminal_fields.py
+++ b/tests/agents/test_agent_result_terminal_fields.py
@@ -94,3 +94,4 @@ async def test_fields_populate_from_tool_state(tmp_path: Path) -> None:
     assert finalized.terminal_submission_id == submission_id
     diagnostics: dict[str, Any] = finalized.diagnostics
     assert isinstance(diagnostics, dict)
+    assert diagnostics.get("attempt_id") == submission.attempt_id

--- a/tests/agents/test_agent_result_terminal_fields.py
+++ b/tests/agents/test_agent_result_terminal_fields.py
@@ -1,9 +1,8 @@
 """AgentResult fields that record whether a terminal verdict was submitted (VP1 / V2).
 
-``test_defaults_preserve_existing_behaviour`` is a regression pin: it must
-pass against current ``AgentResult`` (no new fields required) and keep
-passing after VP1.2 adds defaults. ``test_fields_populate_from_tool_state``
-is RED until VP1.2 populates the fields from ``ctx.tool_state``.
+``test_defaults_preserve_existing_behaviour`` is a V2 regression pin.
+``test_fields_populate_from_tool_state`` was xfail until VP1.2; the marker
+was removed after that wave populated the fields from ``ctx.tool_state``.
 """
 
 from __future__ import annotations
@@ -64,7 +63,6 @@ def test_defaults_preserve_existing_behaviour() -> None:
     assert getattr(populated, "terminal_submission_received", False) is False
 
 
-@pytest.mark.xfail(reason="green after VP1.2: submit_review_verdict", strict=False)
 @pytest.mark.asyncio
 async def test_fields_populate_from_tool_state(tmp_path: Path) -> None:
     """After a recorded submission, finalize copies the flag and id onto ``AgentResult``."""

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -110,7 +110,9 @@ async def test_valid_submission_is_recorded(tmp_path: Path) -> None:
     assert recorded.verdict == "approve"
     assert recorded.summary == payload["summary"]
     assert recorded.findings == []
-    assert recorded.payload_hash == _canonical_payload_hash(payload)
+    assert recorded.payload_hash == _canonical_payload_hash(
+        _params_model().model_validate(payload).model_dump(mode="json")
+    )
     assert recorded.submitted_at
     assert hasattr(recorded, "attempt_id")
 
@@ -257,3 +259,99 @@ def test_tool_is_in_subagent_deny_list(tmp_path: Path) -> None:
     assert _TOOL_NAME in TERMINAL_PROTOCOL_DENIED_TOOL_NAMES
     assert _TOOL_NAME in subagent_denied_tool_names(ctx)
     assert _TOOL_NAME in verifier_denied_tool_names(ctx)
+
+
+@pytest.mark.parametrize("value", [{}, False, 0, "", None])
+def test_non_list_findings_are_rejected(value: object) -> None:
+    """Malformed falsy findings must not canonicalize to an empty list."""
+    payload = {**_valid_payload(), "findings": value}
+    with pytest.raises(ValidationError) as excinfo:
+        _params_model().model_validate(payload)
+    assert "findings" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [{}, False, 0, "", None])
+async def test_non_list_findings_are_rejected_at_the_tool(tmp_path: Path, value: object) -> None:
+    """MCP dispatch does not schema-validate arguments — the tool must still reject."""
+    ctx = _ctx(tmp_path)
+    result = await _submit(ctx, {**_valid_payload(), "findings": value})
+    assert result.is_error is True
+    assert "findings" in _error_text(result).lower()
+    assert getattr(ctx.tool_state, "terminal_submission", None) is None
+
+
+@pytest.mark.asyncio
+async def test_omitted_findings_matches_empty_list_idempotency(tmp_path: Path) -> None:
+    """D4: omitting ``findings`` and sending ``findings: []`` are the same payload."""
+    ctx = _ctx(tmp_path)
+    omitted = {"verdict": "approve", "summary": "No blocking issues in the diff."}
+    first = await _submit(ctx, omitted)
+    assert first.is_error is False
+    original_id = ctx.tool_state.terminal_submission.id  # type: ignore[union-attr]
+
+    second = await _submit(ctx, {**omitted, "findings": []})
+    assert second.is_error is False
+    replayed = ctx.tool_state.terminal_submission
+    assert replayed is not None
+    assert replayed.id == original_id
+    assert ctx.tool_state.terminal_submission_conflict is False
+
+
+@pytest.mark.asyncio
+async def test_model_chain_resets_terminal_submission_on_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retryable first attempt's submit must not conflict-reject the fallback."""
+    from mergecraft.agents.shared import AgentResult
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.utils.agent_resolve import run_with_model_chain
+
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+    ctx = _ctx(tmp_path)
+    seen_indexes: list[int] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        seen_indexes.append(ctx.tool_state.fallback_index)
+        if slug.startswith("openai/"):
+            recorded = await _submit(ctx, _valid_payload())
+            assert recorded.is_error is False
+            assert ctx.tool_state.fallback_index == 0
+            return AgentResult(
+                success=False,
+                error="provider rate limited",
+                metadata={"retryable": True},
+            )
+        assert ctx.tool_state.fallback_index == 1
+        assert ctx.tool_state.terminal_submission is None
+        assert ctx.tool_state.terminal_submission_conflict is False
+        recorded = await _submit(
+            ctx,
+            {**_valid_payload(), "summary": "Fallback model recorded the verdict."},
+        )
+        assert recorded.is_error is False
+        return AgentResult(success=True, output="review complete")
+
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    winning_slug, result = await run_with_model_chain(
+        settings=settings,
+        run_once=run_once,
+        tool_state=ctx.tool_state,
+    )
+
+    assert seen_indexes == [0, 1]
+    assert winning_slug == "google/gemini-3.1-pro-preview"
+    assert result.success is True
+    recorded = ctx.tool_state.terminal_submission
+    assert recorded is not None
+    assert recorded.attempt_id == 1
+    assert recorded.summary == "Fallback model recorded the verdict."
+    assert ctx.tool_state.terminal_submission_conflict is False

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -203,6 +203,49 @@ async def test_findings_use_agent_finding_shape(tmp_path: Path) -> None:
     assert round_tripped.line == finding.line
 
 
+def test_unknown_finding_severity_is_rejected() -> None:
+    """Terminal findings must use the closed taxonomy, not a free-form string."""
+    payload = {
+        "verdict": "request_changes",
+        "summary": "One finding stands.",
+        "findings": [
+            {
+                "path": "src/app.py",
+                "body": "token logged in plaintext",
+                "severity": "Blocker",
+            }
+        ],
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        _params_model().model_validate(payload)
+    message = str(excinfo.value)
+    assert "Blocker" in message
+    assert "severity" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_finding_severity_is_rejected_at_the_tool(tmp_path: Path) -> None:
+    """MCP dispatch does not schema-validate arguments — the tool must still reject."""
+    ctx = _ctx(tmp_path)
+    result = await _submit(
+        ctx,
+        {
+            "verdict": "request_changes",
+            "summary": "One finding stands.",
+            "findings": [
+                {
+                    "path": "src/app.py",
+                    "body": "token logged in plaintext",
+                    "severity": "Blocker",
+                }
+            ],
+        },
+    )
+    assert result.is_error is True
+    assert "blocker" in _error_text(result).lower()
+    assert getattr(ctx.tool_state, "terminal_submission", None) is None
+
+
 @pytest.mark.asyncio
 async def test_second_identical_submission_is_idempotent(tmp_path: Path) -> None:
     """D4: the same payload hash returns the original id; no second record."""
@@ -240,6 +283,27 @@ async def test_second_conflicting_submission_is_rejected(tmp_path: Path) -> None
     assert ctx.tool_state.terminal_submission_conflict is True
     assert ctx.tool_state.terminal_submission is not None
     assert ctx.tool_state.terminal_submission.id == original_id
+
+
+@pytest.mark.asyncio
+async def test_conflict_flag_stays_set_after_identical_replay(tmp_path: Path) -> None:
+    """A → conflict B → A must leave the attempt marked unusable for VP2."""
+    ctx = _ctx(tmp_path)
+    first = await _submit(ctx, _valid_payload())
+    assert first.is_error is False
+    original_id = ctx.tool_state.terminal_submission.id  # type: ignore[union-attr]
+
+    conflicting = {**_valid_payload(), "summary": "Actually this needs changes."}
+    second = await _submit(ctx, conflicting)
+    assert second.is_error is True
+    assert ctx.tool_state.terminal_submission_conflict is True
+
+    third = await _submit(ctx, _valid_payload())
+    assert third.is_error is False
+    replayed = ctx.tool_state.terminal_submission
+    assert replayed is not None
+    assert replayed.id == original_id
+    assert ctx.tool_state.terminal_submission_conflict is True
 
 
 def test_tool_is_registered_for_orchestrator_only(tmp_path: Path) -> None:

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -1,0 +1,262 @@
+"""RED suite for ``submit_review_verdict`` — the typed terminal review operation (VP1).
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP1.1).
+Implementation lands in VP1.2 (``mergecraft.mcp.verdict``); every test here is
+non-strict xfail until then. Imports of that module stay inside helpers so
+collection does not fail while the module is absent.
+
+Pinned contracts (W0):
+    D3 — submission findings are ``AgentFinding``, not a parallel type.
+    D4 — identical resubmit is idempotent; a conflicting payload rejects the
+         attempt and sets ``terminal_submission_conflict``.
+    extra="forbid" on the params model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.agents.gates import subagent_denied_tool_names
+from mergecraft.agents.verifier import AgentFinding, verifier_denied_tool_names
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.server import build_common_tools, build_orchestrator_tools
+from mergecraft.mcp.shared import ToolResult
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.xfail(
+    reason="green after VP1.2: submit_review_verdict",
+    strict=False,
+)
+
+_TOOL_NAME = "submit_review_verdict"
+_UNEXPECTED_FIELD = "unexpected_field"
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def _valid_payload() -> dict[str, Any]:
+    return {
+        "verdict": "approve",
+        "summary": "No blocking issues in the diff.",
+        "findings": [],
+    }
+
+
+def _canonical_payload_hash(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _params_model() -> type[Any]:
+    """Pinned name: the plan did not lock a class, the suite does."""
+    from mergecraft.mcp.verdict import SubmitReviewVerdictParams
+
+    return SubmitReviewVerdictParams
+
+
+async def _submit(ctx: ToolContext, payload: dict[str, Any]) -> ToolResult:
+    from mergecraft.mcp.verdict import submit_review_verdict_tool
+
+    return await submit_review_verdict_tool(ctx).execute(payload)
+
+
+def _error_text(result: ToolResult) -> str:
+    return result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_valid_submission_is_recorded(tmp_path: Path) -> None:
+    """A well-formed submission lands a ``TerminalSubmission`` on ``ToolState`` with an id."""
+    from mergecraft.mcp.tool_state import TerminalSubmission
+
+    ctx = _ctx(tmp_path)
+    payload = _valid_payload()
+    result = await _submit(ctx, payload)
+
+    assert result.is_error is False
+    recorded = ctx.tool_state.terminal_submission
+    assert recorded is not None
+    assert isinstance(recorded, TerminalSubmission)
+    assert isinstance(recorded.id, str)
+    assert recorded.id
+    assert recorded.verdict == "approve"
+    assert recorded.summary == payload["summary"]
+    assert recorded.findings == []
+    assert recorded.payload_hash == _canonical_payload_hash(payload)
+    assert recorded.submitted_at
+    assert hasattr(recorded, "attempt_id")
+
+
+@pytest.mark.asyncio
+async def test_unknown_field_is_rejected(tmp_path: Path) -> None:
+    """``extra="forbid"``: an unrecognized key is a validation error, not a silent drop."""
+    params_cls = _params_model()
+    assert params_cls.model_config.get("extra") == "forbid"
+
+    payload = {**_valid_payload(), _UNEXPECTED_FIELD: "nope"}
+    with pytest.raises(ValidationError) as excinfo:
+        params_cls.model_validate(payload)
+    assert _UNEXPECTED_FIELD in str(excinfo.value)
+
+    ctx = _ctx(tmp_path)
+    result = await _submit(ctx, payload)
+    assert result.is_error is True
+    assert _UNEXPECTED_FIELD in _error_text(result)
+    assert getattr(ctx.tool_state, "terminal_submission", None) is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_verdict_enum_is_rejected(tmp_path: Path) -> None:
+    """``\"lgtm\"`` is not a verdict — only ``approve`` / ``request_changes``."""
+    payload = {**_valid_payload(), "verdict": "lgtm"}
+    with pytest.raises(ValidationError) as excinfo:
+        _params_model().model_validate(payload)
+    message = str(excinfo.value)
+    assert "lgtm" in message
+    assert "verdict" in message.lower()
+
+    ctx = _ctx(tmp_path)
+    result = await _submit(ctx, payload)
+    assert result.is_error is True
+    assert "lgtm" in _error_text(result)
+    assert getattr(ctx.tool_state, "terminal_submission", None) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_required_field_is_rejected(tmp_path: Path) -> None:
+    """Absent ``summary`` / ``verdict`` is a validation error, not a defaulted record."""
+    params_cls = _params_model()
+    for omit in ("summary", "verdict"):
+        payload = _valid_payload()
+        del payload[omit]
+        with pytest.raises(ValidationError) as excinfo:
+            params_cls.model_validate(payload)
+        assert omit in str(excinfo.value)
+
+        ctx = _ctx(tmp_path)
+        result = await _submit(ctx, payload)
+        assert result.is_error is True
+        assert omit in _error_text(result).lower()
+        assert getattr(ctx.tool_state, "terminal_submission", None) is None
+
+
+@pytest.mark.asyncio
+async def test_findings_use_agent_finding_shape(tmp_path: Path) -> None:
+    """D3: a submission finding round-trips through ``AgentFinding`` (fingerprint + identity)."""
+    finding = AgentFinding(
+        path="src/app.py",
+        body="token logged in plaintext",
+        severity="Critical",
+        line=12,
+        fingerprint="fp-explicit-identity",
+    )
+    ctx = _ctx(tmp_path)
+    result = await _submit(
+        ctx,
+        {
+            "verdict": "request_changes",
+            "summary": "One critical finding stands.",
+            "findings": [finding.model_dump()],
+        },
+    )
+    assert result.is_error is False
+    recorded = ctx.tool_state.terminal_submission
+    assert recorded is not None
+    assert len(recorded.findings) == 1
+    round_tripped = recorded.findings[0]
+    assert isinstance(round_tripped, AgentFinding)
+    assert round_tripped.fingerprint == finding.fingerprint
+    assert round_tripped.identity() == finding.identity()
+    assert round_tripped.path == finding.path
+    assert round_tripped.body == finding.body
+    assert round_tripped.severity == finding.severity
+    assert round_tripped.line == finding.line
+
+
+@pytest.mark.asyncio
+async def test_second_identical_submission_is_idempotent(tmp_path: Path) -> None:
+    """D4: the same payload hash returns the original id; no second record."""
+    ctx = _ctx(tmp_path)
+    payload = _valid_payload()
+    first = await _submit(ctx, payload)
+    assert first.is_error is False
+    original = ctx.tool_state.terminal_submission
+    assert original is not None
+    original_id = original.id
+    original_hash = original.payload_hash
+
+    second = await _submit(ctx, payload)
+    assert second.is_error is False
+    replayed = ctx.tool_state.terminal_submission
+    assert replayed is not None
+    assert replayed.id == original_id
+    assert replayed.payload_hash == original_hash
+    assert replayed is original
+    assert ctx.tool_state.terminal_submission_conflict is False
+
+
+@pytest.mark.asyncio
+async def test_second_conflicting_submission_is_rejected(tmp_path: Path) -> None:
+    """D4: a differing payload is an error and marks the attempt unusable."""
+    ctx = _ctx(tmp_path)
+    first = await _submit(ctx, _valid_payload())
+    assert first.is_error is False
+    original_id = ctx.tool_state.terminal_submission.id  # type: ignore[union-attr]
+
+    conflicting = {**_valid_payload(), "summary": "Actually this needs changes."}
+    second = await _submit(ctx, conflicting)
+    assert second.is_error is True
+    assert "conflict" in _error_text(second).lower()
+    assert ctx.tool_state.terminal_submission_conflict is True
+    assert ctx.tool_state.terminal_submission is not None
+    assert ctx.tool_state.terminal_submission.id == original_id
+
+
+def test_tool_is_registered_for_orchestrator_only(tmp_path: Path) -> None:
+    """Present on the orchestrator toolset; absent from the read-only common set."""
+    ctx = _ctx(tmp_path)
+    orchestrator = {spec.name: spec for spec in build_orchestrator_tools(ctx)}
+    common_names = {spec.name for spec in build_common_tools(ctx)}
+
+    assert _TOOL_NAME in orchestrator
+    assert orchestrator[_TOOL_NAME].mutates is False
+    assert _TOOL_NAME not in common_names
+
+
+def test_tool_is_in_subagent_deny_list(tmp_path: Path) -> None:
+    """Terminal-protocol tools are denied to subagents and the verifier even when mutates=False."""
+    ctx = _ctx(tmp_path)
+    assert _TOOL_NAME in subagent_denied_tool_names(ctx)
+    assert _TOOL_NAME in verifier_denied_tool_names(ctx)

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -1,9 +1,7 @@
-"""RED suite for ``submit_review_verdict`` — the typed terminal review operation (VP1).
+"""Suite for ``submit_review_verdict`` — the typed terminal review operation (VP1).
 
-Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP1.1).
-Implementation lands in VP1.2 (``mergecraft.mcp.verdict``); every test here is
-non-strict xfail until then. Imports of that module stay inside helpers so
-collection does not fail while the module is absent.
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP1.1 RED, VP1.2
+impl). xfail markers were removed after VP1.2.
 
 Pinned contracts (W0):
     D3 — submission findings are ``AgentFinding``, not a parallel type.
@@ -21,7 +19,10 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from pydantic import ValidationError
 
-from mergecraft.agents.gates import subagent_denied_tool_names
+from mergecraft.agents.gates import (
+    TERMINAL_PROTOCOL_DENIED_TOOL_NAMES,
+    subagent_denied_tool_names,
+)
 from mergecraft.agents.verifier import AgentFinding, verifier_denied_tool_names
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -37,11 +38,6 @@ from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-pytestmark = pytest.mark.xfail(
-    reason="green after VP1.2: submit_review_verdict",
-    strict=False,
-)
 
 _TOOL_NAME = "submit_review_verdict"
 _UNEXPECTED_FIELD = "unexpected_field"
@@ -258,5 +254,6 @@ def test_tool_is_registered_for_orchestrator_only(tmp_path: Path) -> None:
 def test_tool_is_in_subagent_deny_list(tmp_path: Path) -> None:
     """Terminal-protocol tools are denied to subagents and the verifier even when mutates=False."""
     ctx = _ctx(tmp_path)
+    assert _TOOL_NAME in TERMINAL_PROTOCOL_DENIED_TOOL_NAMES
     assert _TOOL_NAME in subagent_denied_tool_names(ctx)
     assert _TOOL_NAME in verifier_denied_tool_names(ctx)


### PR DESCRIPTION
## Summary
- Adds `submit_review_verdict` as the typed terminal review operation, with `TerminalSubmission` on tool state and matching fields on `AgentResult`
- The tool is inert on its own: nothing fail-closes on a missing verdict yet (that is VP2)

## Test plan
- [x] `make lint` / `make typecheck`
- [x] `make ci-resume` (VP1 Final)
- [ ] CI on this PR
