### PR TITLE
refactor(agents): typed ProviderConfig with declarative capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Full pre-release development history: see
 
 ### Changed
 
+- Typed `ProviderConfig` for OpenAI-compatible gateways (capabilities declarative; API keys stay in env vars). No wire-format change to generated `opencode.json`
 - **BREAKING** — `with: model:` is now the head of the effective model
   chain rather than a replacement for it; set `model_pin: enabled` (or
   `modelPin: true`) to restore the old single-model behavior

--- a/docs/test-plans/review-integrity-ha1.md
+++ b/docs/test-plans/review-integrity-ha1.md
@@ -1,0 +1,125 @@
+# Review integrity HA1 — typed `ProviderConfig` — RED test plan
+
+Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md` (PR HA1)
+Worktree: `../mergecraft-ha1-provider-config` @ `wave/ha1-provider-config`
+Authoring wave: **HA1.1** (tests-first — this file). Implementation: **HA1.2**.
+
+HA1 types the existing OpenAI-compatible provider surface. It does **not**
+change the wire contract (**D16**): `MERGECRAFT_CUSTOM_PROVIDER_*` keeps
+working exactly as documented in `README.md`, and `build_custom_provider`'s
+emitted JSON stays byte-identical to `origin/pre-0.0.1`. Capabilities are
+declarative and fail loud (**D12**): requesting an unsupported provider
+capability is a configuration error *before* agent execution.
+
+Target API (HA1.2): frozen Pydantic `ProviderConfig` on
+`src/mergecraft/agents/openai_compatible_gateways.py` — **not** the catalog
+namesake in `src/mergecraft/models.py` — with fields `provider_id`,
+`model_id`, `base_url`, `api_key_env`, `adapter`, `capabilities`,
+`extra_options`, plus `context_limit: int | None`. The resolved key is read
+through `api_key_env` at use time and is **never stored on the model**.
+`build_custom_provider` and `_custom_provider_ids` consume `ProviderConfig`
+internally.
+
+## xfail schedule
+
+All HA1.2 markers use `strict=False` (`pyproject.toml` sets `xfail_strict =
+true`; an early-passing xfail must be XPASS, not a hard failure).
+
+| Wave | Test | Marker reason |
+|------|------|---------------|
+| **HA1.2** | `test_gateway_env_pairs_produce_typed_configs` | `green after HA1.2: ProviderConfig` |
+| **HA1.2** | `test_api_key_never_appears_in_repr` | same |
+| **HA1.2** | `test_api_key_never_appears_in_json_dump` | same |
+| **HA1.2** | `test_api_key_never_reaches_trace_attrs` | same |
+| **HA1.2** | `test_api_key_never_reaches_run_packet` | same |
+| **HA1.2** | `test_unsupported_capability_is_a_configuration_error` | same |
+| **HA1.2** | `test_capability_declaration_round_trips` | same |
+| **HA1.2** | `test_custom_base_url_validates` | same |
+
+Regression pins below have **no** xfail — they must pass against current
+`resolve_gateway_endpoints` / `build_custom_provider` / `_custom_provider_ids`
+behaviour on `pre-0.0.1`.
+
+## Contract matrix
+
+| # | Decision / convention | Layer | Scenario | Primary test |
+|---|----------------------|-------|----------|--------------|
+| HA1.1a | D16 — `_N` env pairs type as `ProviderConfig` with today's ids | unit | happy: `_1` + `_2` → `provider_1`, `provider_2` | `test_gateway_env_pairs_produce_typed_configs` |
+| HA1.1b | D16 — partial pair dropped | unit | edge: only `API_KEY_1` set | `test_partial_pair_is_dropped` |
+| HA1.1c | D16 — index gaps preserved (no renumbering) | unit | edge: `_1` + `_3`, `_2` absent | `test_gaps_in_indices_are_preserved` |
+| HA1.1d | D16 — named presets | unit | happy: `nous/*` via `NOUS_API_KEY`, `tokenhub/*` via `TOKENHUB_API_KEY` | `test_named_presets_still_resolve` |
+| HA1.1e | convention 5 — key never in `repr`/`str` | unit | error: canary planted in env, absent from serialisation | `test_api_key_never_appears_in_repr` |
+| HA1.1f | convention 5 — key never in JSON dump | unit | error: `model_dump` / `model_dump_json` | `test_api_key_never_appears_in_json_dump` |
+| HA1.1g | convention 5 — key never in trace attrs | integration | construct → emit span → canary absent from event | `test_api_key_never_reaches_trace_attrs` |
+| HA1.1h | convention 5 — key never in run packet | integration | construct → `build_run_packet` → canary absent | `test_api_key_never_reaches_run_packet` |
+| HA1.1i | D12 — unsupported capability is a configuration error | unit | error: request `structured_output` when undeclared; raises `_ConfigurationError` before any agent run | `test_unsupported_capability_is_a_configuration_error` |
+| HA1.1j | D12 — declared capabilities round-trip | unit | happy: dump/validate preserves `capabilities`, `extra_options`, `context_limit` | `test_capability_declaration_round_trips` |
+| HA1.1k | malformed `base_url` rejected before execution | unit | error: `base_url="not a url"` → `ValidationError` | `test_custom_base_url_validates` |
+| HA1.1l | D16 — emitted OpenCode JSON byte-identical | functional | happy/edge: 8 env combinations vs `pre-0.0.1` snapshots | `test_emitted_opencode_config_is_byte_identical_for_existing_inputs` |
+
+## Byte-identity fixture set (HA1.1l)
+
+Snapshots captured from `build_custom_provider` at `origin/pre-0.0.1` (HEAD of
+this worktree at authoring). Canonical JSON (`sort_keys=True`, compact
+separators) is the equality form.
+
+| Label | Model | Env combination |
+|-------|-------|-----------------|
+| `indexed_pairs` | `provider_1/some-model` | `_1` + `_2` gateway pairs |
+| `named_nous` | `nous/deepseek/deepseek-v4-flash` | `NOUS_API_KEY` |
+| `named_tokenhub` | `tokenhub/hy3` | `TOKENHUB_API_KEY` |
+| `custom_singleton` | `default/some-model` | singleton `MERGECRAFT_CUSTOM_PROVIDER_{BASE_URL,API_KEY}` |
+| `custom_base_url_overrides_nous` | `nous/deepseek/deepseek-v4-flash` | singleton custom base URL overrides named preset |
+| `partial_pair` | `provider_1/some-model` | only `API_KEY_1` (emits `null`) |
+| `index_gaps` | `provider_1/some-model` | `_1` + `_3`, `_2` absent |
+| `indexed_overrides_singleton` | `provider_1/some-model` | indexed `_1` plus singleton (indexed wins) |
+
+## Guard-deletion proof (convention 5)
+
+`_assert_key_absent_from_model` fails if HA1.2's "never store the key"
+guard is deleted:
+
+- `api_key` must not be a Pydantic field or computed field
+- the planted canary (`ha1-canary-NEVER-LEAK-9f3c2a1b`, not `sk-`/`ghp_`
+  shaped so sink deny-value redaction cannot hide it) must not appear in
+  `repr`, `str`, `model_dump`, span attrs, or the run packet
+
+A test that only asserted "redaction replaced `api_key`" would pass with
+the key stored on the model — that is the defect these four tests refuse
+to protect.
+
+## Named deliverable symbols
+
+| Symbol | Direct test |
+|--------|-------------|
+| `ProviderConfig` | `test_gateway_env_pairs_produce_typed_configs` (+ credential / capability tests) |
+| `require_capabilities` | `test_unsupported_capability_is_a_configuration_error` |
+| `build_custom_provider` | `test_emitted_opencode_config_is_byte_identical_for_existing_inputs` |
+| `_custom_provider_ids` | `test_partial_pair_is_dropped`, `test_gaps_in_indices_are_preserved`, `test_named_presets_still_resolve` |
+
+## RED acceptance
+
+- `uv run pytest --collect-only -q tests/agents/test_provider_config.py` → **12**
+  collected, zero collection errors (`ProviderConfig` imports live inside
+  test bodies / helpers called only from xfailed tests).
+- File run: **4 pass** (regression pins) + **8 xfail** (typed model / D12 /
+  credential hygiene). Do not edit `src/` to make RED tests green.
+- `make lint` and `make typecheck` clean.
+
+## Implementation notes for HA1.2
+
+- Import `ProviderConfig` from `mergecraft.agents.openai_compatible_gateways`.
+  Keep `mergecraft.models.ProviderConfig` (catalog) unchanged.
+- `resolve_gateway_endpoints()` returns `dict[str, ProviderConfig]` keyed by
+  today's ids (`provider_<N>` / `default`). `api_key_env` is the env-var
+  *name*; the resolved value is read at emit time so OpenCode JSON still
+  carries `options.apiKey` (D16 / the byte-identity pin).
+- Closed capability set: `tool_calling`, `streaming`, `reasoning_controls`,
+  `structured_output`, `custom_base_url`, `openai_compatible`,
+  `native_opencode`. `context_limit: int | None` is a sibling field.
+- `require_capabilities(config, requested)` raises
+  `mergecraft.main._ConfigurationError` naming the missing capability
+  (match `structured_output`) without invoking an agent.
+- `base_url="not a url"` is a Pydantic `ValidationError` at construction.
+- Do not change tests. After HA1.2, the orchestrator re-dispatches
+  test-creator to remove the now-satisfied xfail markers.

--- a/docs/test-plans/review-integrity-ha1.md
+++ b/docs/test-plans/review-integrity-ha1.md
@@ -1,8 +1,9 @@
-# Review integrity HA1 — typed `ProviderConfig` — RED test plan
+# Review integrity HA1 — typed `ProviderConfig` — test plan
 
 Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md` (PR HA1)
 Worktree: `../mergecraft-ha1-provider-config` @ `wave/ha1-provider-config`
 Authoring wave: **HA1.1** (tests-first — this file). Implementation: **HA1.2**.
+xfail-reconciliation: **post-HA1.2** (this file).
 
 HA1 types the existing OpenAI-compatible provider surface. It does **not**
 change the wire contract (**D16**): `MERGECRAFT_CUSTOM_PROVIDER_*` keeps
@@ -22,23 +23,35 @@ internally.
 
 ## xfail schedule
 
-All HA1.2 markers use `strict=False` (`pyproject.toml` sets `xfail_strict =
-true`; an early-passing xfail must be XPASS, not a hard failure).
+All HA1.2 markers used `strict=False` (`pyproject.toml` sets `xfail_strict =
+true`; an early-passing xfail must be XPASS, not a hard failure). **Cleared
+after HA1.2** — the eight typed-model / D12 / credential-hygiene cases are
+real passes; the four regression pins were never marked.
 
-| Wave | Test | Marker reason |
-|------|------|---------------|
-| **HA1.2** | `test_gateway_env_pairs_produce_typed_configs` | `green after HA1.2: ProviderConfig` |
-| **HA1.2** | `test_api_key_never_appears_in_repr` | same |
-| **HA1.2** | `test_api_key_never_appears_in_json_dump` | same |
-| **HA1.2** | `test_api_key_never_reaches_trace_attrs` | same |
-| **HA1.2** | `test_api_key_never_reaches_run_packet` | same |
-| **HA1.2** | `test_unsupported_capability_is_a_configuration_error` | same |
-| **HA1.2** | `test_capability_declaration_round_trips` | same |
-| **HA1.2** | `test_custom_base_url_validates` | same |
+| Wave | Test | Marker reason | Status |
+|------|------|---------------|--------|
+| **HA1.2** | `test_gateway_env_pairs_produce_typed_configs` | `green after HA1.2: ProviderConfig` | cleared post-HA1.2 |
+| **HA1.2** | `test_api_key_never_appears_in_repr` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_api_key_never_appears_in_json_dump` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_api_key_never_reaches_trace_attrs` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_api_key_never_reaches_run_packet` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_unsupported_capability_is_a_configuration_error` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_capability_declaration_round_trips` | same | cleared post-HA1.2 |
+| **HA1.2** | `test_custom_base_url_validates` | same | cleared post-HA1.2 |
 
 Regression pins below have **no** xfail — they must pass against current
 `resolve_gateway_endpoints` / `build_custom_provider` / `_custom_provider_ids`
 behaviour on `pre-0.0.1`.
+
+## HA1.2 xfail reconciliation (2026-08-16)
+
+Removed `_HA1_2_XFAIL` and all eight `green after HA1.2: ProviderConfig`
+markers from `tests/agents/test_provider_config.py`. Suite is 12 real
+passes (0 xfail / 0 xpass). Added a closed-vocabulary pin:
+`CAPABILITY_VALUES == _CLOSED_CAPABILITIES` in
+`test_capability_declaration_round_trips` (deleting or widening the public
+constant fails). Private `_provider_config_from_env_pair` /
+`_api_key_from_env` remain untested by design. HA1 Final is unchanged.
 
 ## Contract matrix
 
@@ -94,17 +107,20 @@ to protect.
 |--------|-------------|
 | `ProviderConfig` | `test_gateway_env_pairs_produce_typed_configs` (+ credential / capability tests) |
 | `require_capabilities` | `test_unsupported_capability_is_a_configuration_error` |
+| `CAPABILITY_VALUES` | `test_capability_declaration_round_trips` (`== _CLOSED_CAPABILITIES`) |
 | `build_custom_provider` | `test_emitted_opencode_config_is_byte_identical_for_existing_inputs` |
 | `_custom_provider_ids` | `test_partial_pair_is_dropped`, `test_gaps_in_indices_are_preserved`, `test_named_presets_still_resolve` |
 
-## RED acceptance
+## RED acceptance (HA1.1, historical)
 
 - `uv run pytest --collect-only -q tests/agents/test_provider_config.py` → **12**
   collected, zero collection errors (`ProviderConfig` imports live inside
   test bodies / helpers called only from xfailed tests).
-- File run: **4 pass** (regression pins) + **8 xfail** (typed model / D12 /
-  credential hygiene). Do not edit `src/` to make RED tests green.
+- File run at HA1.1: **4 pass** (regression pins) + **8 xfail** (typed model /
+  D12 / credential hygiene). Do not edit `src/` to make RED tests green.
 - `make lint` and `make typecheck` clean.
+
+Post-HA1.2 reconciliation: **12 passed**, 0 xfail, 0 xpass, 0 fail.
 
 ## Implementation notes for HA1.2
 
@@ -121,5 +137,5 @@ to protect.
   `mergecraft.main._ConfigurationError` naming the missing capability
   (match `structured_output`) without invoking an agent.
 - `base_url="not a url"` is a Pydantic `ValidationError` at construction.
-- Do not change tests. After HA1.2, the orchestrator re-dispatches
-  test-creator to remove the now-satisfied xfail markers.
+- Tests are owned by test-creator. HA1.2 xfails were cleared in the
+  post-impl reconciliation pass; HA1 Final is unchanged.

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -104,6 +104,11 @@ class ProviderConfig(BaseModel):
 
     API keys are read through ``api_key_env`` at emit/use time and are never
     stored on this model (convention 5 / HA1).
+
+    ``model_id``, ``adapter``, ``extra_options``, and ``context_limit`` are
+    declared target-API fields. The env-derived constructors currently leave
+    them at defaults; ``require_capabilities`` is the D12 fail-closed gate and
+    is not yet called from a production harness path.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -129,7 +134,11 @@ class ProviderConfig(BaseModel):
 
 
 def require_capabilities(config: ProviderConfig, required: frozenset[str]) -> None:
-    """Fail closed when ``config`` lacks a declared capability (D12)."""
+    """Fail closed when ``config`` lacks a declared capability (D12).
+
+    Production harnesses do not call this yet; HA1 lands the gate so a later
+    wiring wave can require capabilities at resolve time without a new type.
+    """
     from mergecraft.main import _ConfigurationError
 
     missing = required - config.capabilities
@@ -147,25 +156,6 @@ class GatewayPreset:
     api_key_env: str
     base_url_env: str
     default_base_url: str
-
-
-@dataclass(frozen=True, slots=True)
-class ProviderRecord:
-    """One configured OpenAI-compatible provider, sourced from env vars.
-
-    Carries the env-var names (``base_url_env`` / ``api_key_env``) that sourced
-    the resolved values so loguru redaction can target the env-var *names*
-    rather than the resolved key values (convention 7 / D11). The resolved
-    ``api_key`` is never logged by the harness writers — this record exists so
-    the writers can pass the env-var name to a redactor and still call the
-    resolved value to populate a generated config file.
-    """
-
-    provider_id: str
-    base_url: str
-    api_key: str
-    base_url_env: str
-    api_key_env: str
 
 
 GATEWAY_PRESETS: dict[str, GatewayPreset] = {
@@ -371,7 +361,6 @@ __all__ = [
     "TOKENHUB_BASE_URL_ENV",
     "GatewayPreset",
     "ProviderConfig",
-    "ProviderRecord",
     "has_custom_provider_env",
     "has_gateway_credentials",
     "require_capabilities",

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from typing import Annotated, Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic.functional_serializers import PlainSerializer
+from pydantic.functional_validators import BeforeValidator
 
 NOUS_API_KEY_ENV = "NOUS_API_KEY"
 NOUS_BASE_URL_ENV = "NOUS_BASE_URL"
@@ -51,6 +57,86 @@ INDEXED_CUSTOM_PROVIDER_API_KEY_RE = re.compile(r"^MERGECRAFT_CUSTOM_PROVIDER_AP
 # indexed pairs; ``"default"`` for the singleton back-compat alias.
 INDEXED_PROVIDER_ID_FMT = "provider_{n}"
 SINGLETON_PROVIDER_ID = "default"
+
+# Closed capability vocabulary (HA1 / D12). ``context_limit`` is a sibling
+# field on ``ProviderConfig``, not a set member.
+CAPABILITY_VALUES: frozenset[str] = frozenset(
+    {
+        "tool_calling",
+        "streaming",
+        "reasoning_controls",
+        "structured_output",
+        "custom_base_url",
+        "openai_compatible",
+        "native_opencode",
+    }
+)
+
+_DEFAULT_GATEWAY_CAPABILITIES: frozenset[str] = frozenset(
+    {"openai_compatible", "custom_base_url", "tool_calling", "streaming"}
+)
+
+
+def _coerce_capabilities(value: object) -> frozenset[str]:
+    if isinstance(value, frozenset):
+        items = value
+    elif isinstance(value, (list, set, tuple)):
+        items = frozenset(str(item) for item in value)
+    else:
+        msg = "capabilities must be a frozenset or JSON list of capability names"
+        raise TypeError(msg)
+    unknown = items - CAPABILITY_VALUES
+    if unknown:
+        msg = f"unknown capabilities: {', '.join(sorted(unknown))}"
+        raise ValueError(msg)
+    return items
+
+
+CapabilitiesField = Annotated[
+    frozenset[str],
+    BeforeValidator(_coerce_capabilities),
+    PlainSerializer(lambda value: sorted(value), return_type=list[str]),
+]
+
+
+class ProviderConfig(BaseModel):
+    """One configured OpenAI-compatible provider, typed for harness use.
+
+    API keys are read through ``api_key_env`` at emit/use time and are never
+    stored on this model (convention 5 / HA1).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    provider_id: str
+    model_id: str = ""
+    base_url: str
+    api_key_env: str
+    adapter: str = "openai-compatible"
+    capabilities: CapabilitiesField = Field(default_factory=lambda: _DEFAULT_GATEWAY_CAPABILITIES)
+    extra_options: dict[str, Any] = Field(default_factory=dict)
+    context_limit: int | None = None
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url(cls, value: str) -> str:
+        stripped = value.strip()
+        parsed = urlparse(stripped)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            msg = "base_url must be an http(s) URL"
+            raise ValueError(msg)
+        return stripped
+
+
+def require_capabilities(config: ProviderConfig, required: frozenset[str]) -> None:
+    """Fail closed when ``config`` lacks a declared capability (D12)."""
+    from mergecraft.main import _ConfigurationError
+
+    missing = required - config.capabilities
+    if missing:
+        names = ", ".join(sorted(missing))
+        msg = f"provider {config.provider_id!r} missing required capabilities: {names}"
+        raise _ConfigurationError(msg)
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,7 +254,20 @@ def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
     return provider_id, base_url, api_key
 
 
-def _resolve_indexed_providers() -> dict[str, ProviderRecord]:
+def _provider_config_from_env_pair(
+    *,
+    provider_id: str,
+    base_url: str,
+    api_key_env: str,
+) -> ProviderConfig:
+    return ProviderConfig(
+        provider_id=provider_id,
+        base_url=base_url,
+        api_key_env=api_key_env,
+    )
+
+
+def _resolve_indexed_providers() -> dict[str, ProviderConfig]:
     """Enumerate ``MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`` pairs.
 
     Returns a dict keyed by provider id (``"provider_<N>"``). Both halves of a
@@ -195,24 +294,22 @@ def _resolve_indexed_providers() -> dict[str, ProviderRecord]:
                 continue
             base_url, api_key = by_index.get(n, ("", ""))
             by_index[n] = (base_url, stripped)
-    out: dict[str, ProviderRecord] = {}
+    out: dict[str, ProviderConfig] = {}
     for n in sorted(by_index):
         base_url, api_key = by_index[n]
         if not base_url or not api_key:
             # Partial pair — drop silently.
             continue
         provider_id = INDEXED_PROVIDER_ID_FMT.format(n=n)
-        out[provider_id] = ProviderRecord(
+        out[provider_id] = _provider_config_from_env_pair(
             provider_id=provider_id,
             base_url=base_url,
-            api_key=api_key,
-            base_url_env=f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}",
             api_key_env=f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}",
         )
     return out
 
 
-def _resolve_singleton_provider() -> ProviderRecord | None:
+def _resolve_singleton_provider() -> ProviderConfig | None:
     """Back-compat alias for a single ``default`` provider.
 
     Returns ``None`` if either half of the singleton pair is missing or empty.
@@ -221,16 +318,14 @@ def _resolve_singleton_provider() -> ProviderRecord | None:
     api_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()
     if not base_url or not api_key:
         return None
-    return ProviderRecord(
+    return _provider_config_from_env_pair(
         provider_id=SINGLETON_PROVIDER_ID,
         base_url=base_url,
-        api_key=api_key,
-        base_url_env=CUSTOM_PROVIDER_BASE_URL_ENV,
         api_key_env=CUSTOM_PROVIDER_API_KEY_ENV,
     )
 
 
-def resolve_gateway_endpoints() -> dict[str, ProviderRecord]:
+def resolve_gateway_endpoints() -> dict[str, ProviderConfig]:
     """Return every configured OpenAI-compatible provider, keyed by provider id.
 
     Multi-provider resolver (W3 / issue #71). The returned dict carries all
@@ -260,6 +355,7 @@ def resolve_gateway_endpoints() -> dict[str, ProviderRecord]:
 
 
 __all__ = [
+    "CAPABILITY_VALUES",
     "CUSTOM_PROVIDER_API_KEY_ENV",
     "CUSTOM_PROVIDER_BASE_URL_ENV",
     "DEFAULT_MINIMAX_BASE_URL",
@@ -274,9 +370,11 @@ __all__ = [
     "TOKENHUB_API_KEY_ENV",
     "TOKENHUB_BASE_URL_ENV",
     "GatewayPreset",
+    "ProviderConfig",
     "ProviderRecord",
     "has_custom_provider_env",
     "has_gateway_credentials",
+    "require_capabilities",
     "resolve_gateway_endpoint",
     "resolve_gateway_endpoints",
 ]

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -61,6 +61,11 @@ class ProviderTimeoutError(RuntimeError):
     """
 
 
+def _api_key_from_env(api_key_env: str) -> str:
+    """Read a provider API key from the environment at emit time (HA1 / D16)."""
+    return os.environ.get(api_key_env, "").strip()
+
+
 def build_custom_provider(model: str | None) -> dict[str, object] | None:
     """Describe an OpenAI-compatible provider (or several) for opencode.
 
@@ -105,7 +110,7 @@ def build_custom_provider(model: str | None) -> dict[str, object] | None:
                     "name": record.provider_id,
                     "options": {
                         "baseURL": record.base_url,
-                        "apiKey": record.api_key,
+                        "apiKey": _api_key_from_env(record.api_key_env),
                     },
                     "models": models,
                 }

--- a/tests/agents/test_openai_compatible_gateways.py
+++ b/tests/agents/test_openai_compatible_gateways.py
@@ -63,7 +63,7 @@ def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.xfail(
     reason="green after W3: shared helper exposes a multi-provider resolver "
-    "(dict/sequence of ProviderRecord keyed by provider id)",
+    "(dict of ProviderConfig keyed by provider id)",
     strict=False,
 )
 def test_shared_helper_exposes_multi_provider_resolver() -> None:
@@ -71,7 +71,7 @@ def test_shared_helper_exposes_multi_provider_resolver() -> None:
 
     Today the module exposes ``resolve_gateway_endpoint(model) -> tuple | None``
     (a singleton). W3 must add a multi-provider resolver. Acceptable shapes:
-    ``dict[str, ProviderRecord]`` or a sequence of records; the test asserts
+    ``dict[str, ProviderConfig]`` or a sequence of records; the test asserts
     either, by name, is importable from the module.
     """
     gateways = _load_gateways_module()
@@ -326,36 +326,21 @@ def test_both_harnesses_consume_the_shared_helper() -> None:
     assert "openai_compatible_gateways" in codex_src
 
 
-# -- W1.4 (structural): ProviderRecord exposes fields for log redaction -----
+# -- W1.4 (structural): ProviderConfig exposes fields for log redaction -----
 #
-# The helper's record must carry the env-var names that sourced it so the
-# harness can pass them to loguru's redactor without ever emitting the
-# resolved value. W3 lands a typed record (e.g. ``ProviderRecord``) with
-# those fields; today no such type exists, so the import is xfailed.
+# The helper's record must carry the env-var *name* that sourced the key so
+# the harness can pass it to loguru's redactor without ever storing the
+# resolved value (convention 5 / HA1).
 
 
-@pytest.mark.xfail(
-    reason="green after W3: shared helper exposes a typed ProviderRecord with env-var provenance",
-    strict=False,
-)
-def test_provider_record_carries_env_var_provenance() -> None:
-    """A typed ``ProviderRecord`` (or equivalent) must carry the env-var
-    names that sourced ``base_url`` and ``api_key`` — required for log
-    redaction (convention 7).
-    """
-    gateways = _load_gateways_module()
-    record_type = getattr(gateways, "ProviderRecord", None)
-    assert record_type is not None, (
-        "shared helper must expose a typed ProviderRecord with env-var provenance"
-    )
+def test_provider_config_carries_env_var_provenance() -> None:
+    """``ProviderConfig`` carries ``api_key_env``, never a resolved ``api_key``."""
+    from mergecraft.agents.openai_compatible_gateways import ProviderConfig
 
-    fields = getattr(record_type, "__dataclass_fields__", None) or getattr(
-        record_type, "model_fields", None
-    )
-    assert fields is not None, "ProviderRecord must be a dataclass or pydantic model"
-    names = set(fields.keys())
-    for required in ("provider_id", "base_url", "api_key", "base_url_env", "api_key_env"):
-        assert required in names, f"ProviderRecord must carry field {required!r}"
+    names = set(ProviderConfig.model_fields)
+    for required in ("provider_id", "base_url", "api_key_env"):
+        assert required in names, f"ProviderConfig must carry field {required!r}"
+    assert "api_key" not in names
 
 
 # Avoid unused-import warning when TYPE_CHECKING is collapsed.

--- a/tests/agents/test_opencode_custom_provider.py
+++ b/tests/agents/test_opencode_custom_provider.py
@@ -172,7 +172,7 @@ INDEXED_BASE_URL_FMT = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}"
 
 
 @pytest.mark.xfail(
-    reason="green after W3: indexed env-var pairs populate a dict[str, ProviderRecord]",
+    reason="green after W3: indexed env-var pairs populate a dict[str, ProviderConfig]",
     strict=False,
 )
 def test_opencode_emits_provider_blocks_for_each_indexed_pair(

--- a/tests/agents/test_provider_config.py
+++ b/tests/agents/test_provider_config.py
@@ -1,0 +1,556 @@
+"""HA1 RED suite — typed ``ProviderConfig`` with declarative capabilities.
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (PR HA1).
+Locked decisions: **D12** (capabilities are declarative and fail loud) and
+**D16** (the ``MERGECRAFT_CUSTOM_PROVIDER_*`` env-var surface is preserved;
+HA1 types what already exists and does not change the wire contract).
+
+``ProviderConfig`` lands in HA1.2 as a frozen Pydantic model on
+``mergecraft.agents.openai_compatible_gateways`` — **not** the catalog
+``mergecraft.models.ProviderConfig``. The key is read through ``api_key_env``
+at use time and is never stored on the model (convention 5 / HA1 File 1).
+``build_custom_provider`` and ``_custom_provider_ids`` consume the typed
+records internally; emitted OpenCode JSON is byte-identical to
+``origin/pre-0.0.1``.
+
+Cross-wave markers use ``strict=False`` so an early-passing xfail is XPASS,
+not a hard failure (``xfail_strict = true`` in ``pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mergecraft.agents.openai_compatible_gateways import resolve_gateway_endpoints
+from mergecraft.agents.opencode import _custom_provider_ids, build_custom_provider
+
+# -- env-var surface (D16 / README "Custom OpenAI-compatible provider") ------
+
+INDEXED_API_KEY_FMT = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}"
+INDEXED_BASE_URL_FMT = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}"
+SINGLETON_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
+SINGLETON_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
+
+PROVIDER_1_ID = "provider_1"
+PROVIDER_2_ID = "provider_2"
+PROVIDER_3_ID = "provider_3"
+
+NOUS_MODEL = "nous/deepseek/deepseek-v4-flash"
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+TOKENHUB_MODEL = "tokenhub/hy3"
+TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+
+# Unique canary — deliberately *not* ``sk-`` / ``ghp_`` shaped so sink
+# deny-value redaction cannot hide a stored key. Guard-deletion proof:
+# adding ``api_key`` to the model makes this value show up in repr / dump.
+CANARY_API_KEY = "ha1-canary-NEVER-LEAK-9f3c2a1b"
+
+_HA1_2_XFAIL = pytest.mark.xfail(
+    reason="green after HA1.2: ProviderConfig",
+    strict=False,
+)
+
+# Closed capability vocabulary (HA1 File 1). ``context_limit`` is a sibling
+# ``int | None`` field, not a set member.
+_CLOSED_CAPABILITIES = frozenset(
+    {
+        "tool_calling",
+        "streaming",
+        "reasoning_controls",
+        "structured_output",
+        "custom_base_url",
+        "openai_compatible",
+        "native_opencode",
+    }
+)
+
+# Snapshots of ``build_custom_provider`` at origin/pre-0.0.1 @ HEAD. HA1 is a
+# refactor: emitted JSON must stay byte-identical for these inputs (D16).
+_BYTE_IDENTITY_CASES: tuple[tuple[str, str, dict[str, str], object], ...] = (
+    (
+        "indexed_pairs",
+        "provider_1/some-model",
+        {
+            INDEXED_BASE_URL_FMT.format(n=1): "https://provider-1.example.test/v1",
+            INDEXED_API_KEY_FMT.format(n=1): "key-1",
+            INDEXED_BASE_URL_FMT.format(n=2): "https://provider-2.example.test/v1",
+            INDEXED_API_KEY_FMT.format(n=2): "key-2",
+        },
+        {
+            "provider_1": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "provider_1",
+                "options": {
+                    "baseURL": "https://provider-1.example.test/v1",
+                    "apiKey": "key-1",
+                },
+                "models": {"some-model": {"name": "some-model"}},
+            },
+            "provider_2": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "provider_2",
+                "options": {
+                    "baseURL": "https://provider-2.example.test/v1",
+                    "apiKey": "key-2",
+                },
+                "models": {},
+            },
+        },
+    ),
+    (
+        "named_nous",
+        NOUS_MODEL,
+        {"NOUS_API_KEY": "nous-key"},
+        {
+            "nous": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "nous",
+                "options": {"baseURL": NOUS_BASE_URL, "apiKey": "nous-key"},
+                "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
+            }
+        },
+    ),
+    (
+        "named_tokenhub",
+        TOKENHUB_MODEL,
+        {"TOKENHUB_API_KEY": "th-key"},
+        {
+            "tokenhub": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "tokenhub",
+                "options": {"baseURL": TOKENHUB_BASE_URL, "apiKey": "th-key"},
+                "models": {"hy3": {"name": "hy3"}},
+            }
+        },
+    ),
+    (
+        "custom_singleton",
+        "default/some-model",
+        {
+            SINGLETON_BASE_URL_ENV: "https://custom.example.test/v1",
+            SINGLETON_API_KEY_ENV: "custom-key",
+        },
+        {
+            "default": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "default",
+                "options": {
+                    "baseURL": "https://custom.example.test/v1",
+                    "apiKey": "custom-key",
+                },
+                "models": {"some-model": {"name": "some-model"}},
+            }
+        },
+    ),
+    (
+        "custom_base_url_overrides_nous",
+        NOUS_MODEL,
+        {
+            "NOUS_API_KEY": "nous-key",
+            SINGLETON_BASE_URL_ENV: "https://override.example.test/v1",
+            SINGLETON_API_KEY_ENV: "override-key",
+        },
+        {
+            "nous": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "nous",
+                "options": {
+                    "baseURL": "https://override.example.test/v1",
+                    "apiKey": "override-key",
+                },
+                "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
+            }
+        },
+    ),
+    (
+        "partial_pair",
+        "provider_1/some-model",
+        {INDEXED_API_KEY_FMT.format(n=1): "key-1"},
+        None,
+    ),
+    (
+        "index_gaps",
+        "provider_1/some-model",
+        {
+            INDEXED_BASE_URL_FMT.format(n=1): "https://provider-1.example.test/v1",
+            INDEXED_API_KEY_FMT.format(n=1): "key-1",
+            INDEXED_BASE_URL_FMT.format(n=3): "https://provider-3.example.test/v1",
+            INDEXED_API_KEY_FMT.format(n=3): "key-3",
+        },
+        {
+            "provider_1": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "provider_1",
+                "options": {
+                    "baseURL": "https://provider-1.example.test/v1",
+                    "apiKey": "key-1",
+                },
+                "models": {"some-model": {"name": "some-model"}},
+            },
+            "provider_3": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "provider_3",
+                "options": {
+                    "baseURL": "https://provider-3.example.test/v1",
+                    "apiKey": "key-3",
+                },
+                "models": {},
+            },
+        },
+    ),
+    (
+        "indexed_overrides_singleton",
+        "provider_1/some-model",
+        {
+            SINGLETON_BASE_URL_ENV: "https://default.example.test/v1",
+            SINGLETON_API_KEY_ENV: "default-key",
+            INDEXED_BASE_URL_FMT.format(n=1): "https://provider-1.example.test/v1",
+            INDEXED_API_KEY_FMT.format(n=1): "key-1",
+        },
+        {
+            "provider_1": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "provider_1",
+                "options": {
+                    "baseURL": "https://provider-1.example.test/v1",
+                    "apiKey": "key-1",
+                },
+                "models": {"some-model": {"name": "some-model"}},
+            }
+        },
+    ),
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SINGLETON_BASE_URL_ENV, raising=False)
+    monkeypatch.delenv(SINGLETON_API_KEY_ENV, raising=False)
+    for n in range(1, 8):
+        monkeypatch.delenv(INDEXED_API_KEY_FMT.format(n=n), raising=False)
+        monkeypatch.delenv(INDEXED_BASE_URL_FMT.format(n=n), raising=False)
+    monkeypatch.delenv("NOUS_API_KEY", raising=False)
+    monkeypatch.delenv("NOUS_BASE_URL", raising=False)
+    monkeypatch.delenv("TOKENHUB_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENHUB_BASE_URL", raising=False)
+
+
+def _canonical_json(value: object) -> str:
+    """Stable byte form of ``build_custom_provider`` output (D16 pin)."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _provider_config_type() -> type:
+    """Import HA1's ``ProviderConfig`` — must not be the catalog namesake.
+
+    Import lives in the callee so collection has zero errors until HA1.2.
+    """
+    from mergecraft.agents.openai_compatible_gateways import ProviderConfig
+    from mergecraft.models import ProviderConfig as CatalogProviderConfig
+
+    assert ProviderConfig is not CatalogProviderConfig, (
+        "HA1 ProviderConfig must live on openai_compatible_gateways, "
+        "not mergecraft.models.ProviderConfig"
+    )
+    return ProviderConfig
+
+
+def _make_typed_config(**overrides: object) -> Any:
+    """Construct a frozen ``ProviderConfig`` with HA1 File 1's locked fields."""
+    provider_config_cls = _provider_config_type()
+    kwargs: dict[str, object] = {
+        "provider_id": PROVIDER_1_ID,
+        "model_id": "some-model",
+        "base_url": "https://provider-1.example.test/v1",
+        "api_key_env": INDEXED_API_KEY_FMT.format(n=1),
+        "adapter": "openai-compatible",
+        "capabilities": frozenset(
+            {"openai_compatible", "custom_base_url", "tool_calling", "streaming"}
+        ),
+        "extra_options": {},
+        "context_limit": None,
+    }
+    kwargs.update(overrides)
+    return provider_config_cls(**kwargs)
+
+
+def _assert_key_absent_from_model(config: Any, secret: str) -> None:
+    """Fail if the key is stored on the model or leaks through serialisation.
+
+    Deleting the HA1 File 1 guard (adding an ``api_key`` field / computed
+    field, or baking the resolved value into repr/dump) must fail this check.
+    """
+    fields = getattr(type(config), "model_fields", {})
+    assert "api_key" not in fields, (
+        "ProviderConfig must not store api_key; read it through api_key_env at use time"
+    )
+    computed = getattr(type(config), "model_computed_fields", {})
+    assert "api_key" not in computed, "ProviderConfig must not expose api_key as a computed field"
+    dumped = config.model_dump(mode="json")
+    assert "api_key" not in dumped
+    blob = json.dumps(dumped, default=str) + repr(config) + str(config)
+    assert secret not in blob, (
+        f"resolved API key leaked from ProviderConfig serialisation: {blob!r}"
+    )
+
+
+# -- regression pins (must pass against current env-pair behaviour) ----------
+
+
+def test_partial_pair_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only ``_1`` API key set (no base URL) → ``provider_1`` is absent.
+
+    README: both halves of each numeric pair must be set; partial pairs are
+    silently dropped. Pins today's ``resolve_gateway_endpoints`` /
+    ``build_custom_provider`` / ``_custom_provider_ids`` behaviour.
+    """
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), "key-1")
+
+    records = resolve_gateway_endpoints()
+    assert PROVIDER_1_ID not in records
+
+    emitted = build_custom_provider("provider_1/some-model")
+    if isinstance(emitted, dict):
+        assert PROVIDER_1_ID not in emitted
+    else:
+        assert emitted is None
+
+    assert _custom_provider_ids("provider_1/some-model") == []
+
+
+def test_gaps_in_indices_are_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_1`` + ``_3`` set, ``_2`` absent → providers 1 and 3 present, 2 absent.
+
+    Discovery preserves gaps (no renumbering). ``_custom_provider_ids``
+    mirrors ``build_custom_provider``'s resolution order.
+    """
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=1), "https://provider-1.example.test/v1")
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), "key-1")
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=3), "https://provider-3.example.test/v1")
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=3), "key-3")
+
+    records = resolve_gateway_endpoints()
+    assert PROVIDER_1_ID in records
+    assert PROVIDER_3_ID in records
+    assert PROVIDER_2_ID not in records
+
+    emitted = build_custom_provider("provider_1/some-model")
+    assert isinstance(emitted, dict)
+    assert PROVIDER_1_ID in emitted
+    assert PROVIDER_3_ID in emitted
+    assert PROVIDER_2_ID not in emitted
+
+    assert _custom_provider_ids("provider_1/some-model") == [PROVIDER_1_ID, PROVIDER_3_ID]
+
+
+def test_named_presets_still_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``nous/*`` and ``tokenhub/*`` still resolve from their named env vars."""
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    nous = build_custom_provider(NOUS_MODEL)
+    assert nous == {
+        "nous": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "nous",
+            "options": {"baseURL": NOUS_BASE_URL, "apiKey": "nous-key"},
+            "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
+        }
+    }
+    assert _custom_provider_ids(NOUS_MODEL) == ["nous"]
+
+    monkeypatch.delenv("NOUS_API_KEY")
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    tokenhub = build_custom_provider(TOKENHUB_MODEL)
+    assert tokenhub == {
+        "tokenhub": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "tokenhub",
+            "options": {"baseURL": TOKENHUB_BASE_URL, "apiKey": "th-key"},
+            "models": {"hy3": {"name": "hy3"}},
+        }
+    }
+    assert _custom_provider_ids(TOKENHUB_MODEL) == ["tokenhub"]
+
+
+def test_emitted_opencode_config_is_byte_identical_for_existing_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compatibility pin: ``build_custom_provider`` output matches pre-0.0.1.
+
+    Eight env combinations cover indexed gateway pairs, named presets,
+    custom base URL (singleton + nous override), a dropped partial pair,
+    preserved index gaps, and indexed-wins-over-singleton. Canonical JSON
+    equality is the D16 wire-contract gate that keeps HA1 a refactor.
+    """
+    mismatches: list[str] = []
+    for label, model, env, expected in _BYTE_IDENTITY_CASES:
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        actual = build_custom_provider(model)
+        if _canonical_json(actual) != _canonical_json(expected):
+            mismatches.append(
+                f"{label}: expected {_canonical_json(expected)}, got {_canonical_json(actual)}"
+            )
+        for key in env:
+            monkeypatch.delenv(key, raising=False)
+    assert not mismatches, "emitted OpenCode provider JSON drifted from pre-0.0.1:\n" + "\n".join(
+        mismatches
+    )
+
+
+# -- HA1.2 typed ProviderConfig (RED until the model exists) -----------------
+
+
+@_HA1_2_XFAIL
+def test_gateway_env_pairs_produce_typed_configs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ``_N`` env-pair form yields ``ProviderConfig`` records with today's ids."""
+    provider_config_cls = _provider_config_type()
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=1), "https://provider-1.example.test/v1")
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), "key-1")
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=2), "https://provider-2.example.test/v1")
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=2), "key-2")
+
+    records = resolve_gateway_endpoints()
+    assert set(records) == {PROVIDER_1_ID, PROVIDER_2_ID}
+    for provider_id, record in records.items():
+        assert isinstance(record, provider_config_cls)
+        assert record.provider_id == provider_id
+        index = provider_id.rsplit("_", 1)[-1]
+        assert record.api_key_env == INDEXED_API_KEY_FMT.format(n=index)
+        assert "api_key" not in type(record).model_fields
+
+
+@_HA1_2_XFAIL
+def test_api_key_never_appears_in_repr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Convention 5: the resolved key never appears in ``repr`` / ``str``."""
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
+    config = _make_typed_config()
+    _assert_key_absent_from_model(config, CANARY_API_KEY)
+    assert CANARY_API_KEY not in repr(config)
+    assert CANARY_API_KEY not in str(config)
+
+
+@_HA1_2_XFAIL
+def test_api_key_never_appears_in_json_dump(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Convention 5: ``model_dump`` / ``model_dump_json`` never carry the key."""
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
+    config = _make_typed_config()
+    _assert_key_absent_from_model(config, CANARY_API_KEY)
+    dumped = config.model_dump(mode="json")
+    dumped_json = config.model_dump_json()
+    assert "api_key" not in dumped
+    assert CANARY_API_KEY not in dumped_json
+    assert CANARY_API_KEY not in json.dumps(dumped)
+
+
+@_HA1_2_XFAIL
+def test_api_key_never_reaches_trace_attrs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Construct, emit a span, assert the key is absent from the event.
+
+    The attrs payload is the model's own dump — the path production tracing
+    will take once HA1.2 serialises ``ProviderConfig`` onto a span. If the
+    guard is deleted (key stored on the model), the canary appears in the
+    dump *before* sink deny-key redaction can hide a field named ``api_key``.
+    """
+    from mergecraft.tracing import MemorySink, Tracer
+
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
+    config = _make_typed_config()
+    payload = config.model_dump(mode="json")
+    _assert_key_absent_from_model(config, CANARY_API_KEY)
+
+    sink = MemorySink()
+    tracer = Tracer(sink=sink, session_id="ha1-session", run_id="ha1-run")
+    with tracer.start_span("provider.config", attrs_source=lambda: {"provider": payload}):
+        pass
+
+    assert sink.events, "expected one emitted span"
+    event = sink.events[0]
+    blob = json.dumps(event.model_dump(), default=str)
+    assert CANARY_API_KEY not in blob
+    assert CANARY_API_KEY not in json.dumps(payload)
+
+
+@_HA1_2_XFAIL
+def test_api_key_never_reaches_run_packet(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The resolved key must not land in the run packet's serialised form."""
+    from mergecraft.evidence.run_packet import build_run_packet
+    from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+    from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
+    from mergecraft.modes import compute_modes
+    from mergecraft.utils.github import GitHubClient
+
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
+    config = _make_typed_config()
+    _assert_key_absent_from_model(config, CANARY_API_KEY)
+
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    diff_path = tmp_path / "pr-42.diff"
+    diff_path.write_text(
+        "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-old\n+new\n",
+        encoding="utf-8",
+    )
+    primary_repo_state(tool_state).diff_path = str(diff_path)
+    ctx = ToolContext(
+        agent_id="opencode",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request", issue_number=42)),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("opencode"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        resolved_model="provider_1/some-model",
+    )
+    packet = build_run_packet(ctx, change_id="acme/demo#42", run_succeeded=True)
+    blob = packet.model_dump_json() + json.dumps(config.model_dump(mode="json"))
+    assert CANARY_API_KEY not in blob
+    assert "api_key" not in config.model_dump(mode="json")
+
+
+@_HA1_2_XFAIL
+def test_unsupported_capability_is_a_configuration_error() -> None:
+    """D12: requesting an unsupported capability is a configuration error
+    *before* agent execution, not a runtime degradation.
+    """
+    from mergecraft.agents.openai_compatible_gateways import require_capabilities
+    from mergecraft.main import _ConfigurationError
+
+    config = _make_typed_config(
+        capabilities=frozenset({"openai_compatible", "custom_base_url"}),
+    )
+    with pytest.raises(_ConfigurationError, match="structured_output"):
+        require_capabilities(config, frozenset({"structured_output"}))
+
+
+@_HA1_2_XFAIL
+def test_capability_declaration_round_trips() -> None:
+    """Declared capabilities survive dump/validate and into the harness records."""
+    declared = frozenset({"tool_calling", "streaming", "openai_compatible", "custom_base_url"})
+    config = _make_typed_config(
+        capabilities=declared, extra_options={"wire": "chat"}, context_limit=128_000
+    )
+    assert config.capabilities == declared
+    assert declared <= _CLOSED_CAPABILITIES
+    provider_config_cls = _provider_config_type()
+    restored = provider_config_cls.model_validate(config.model_dump(mode="json"))
+    assert restored.capabilities == declared
+    assert restored.extra_options == {"wire": "chat"}
+    assert restored.context_limit == 128_000
+    assert restored.adapter == "openai-compatible"
+    assert restored.api_key_env == INDEXED_API_KEY_FMT.format(n=1)
+
+
+@_HA1_2_XFAIL
+def test_custom_base_url_validates() -> None:
+    """A malformed base URL is rejected at construction, before execution."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _make_typed_config(base_url="not a url")

--- a/tests/agents/test_provider_config.py
+++ b/tests/agents/test_provider_config.py
@@ -13,8 +13,7 @@ at use time and is never stored on the model (convention 5 / HA1 File 1).
 records internally; emitted OpenCode JSON is byte-identical to
 ``origin/pre-0.0.1``.
 
-Cross-wave markers use ``strict=False`` so an early-passing xfail is XPASS,
-not a hard failure (``xfail_strict = true`` in ``pyproject.toml``).
+HA1.2 landed the typed model; this suite is real passes (xfails cleared).
 """
 
 from __future__ import annotations
@@ -25,7 +24,10 @@ from typing import Any
 
 import pytest
 
-from mergecraft.agents.openai_compatible_gateways import resolve_gateway_endpoints
+from mergecraft.agents.openai_compatible_gateways import (
+    CAPABILITY_VALUES,
+    resolve_gateway_endpoints,
+)
 from mergecraft.agents.opencode import _custom_provider_ids, build_custom_provider
 
 # -- env-var surface (D16 / README "Custom OpenAI-compatible provider") ------
@@ -49,13 +51,9 @@ TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
 # adding ``api_key`` to the model makes this value show up in repr / dump.
 CANARY_API_KEY = "ha1-canary-NEVER-LEAK-9f3c2a1b"
 
-_HA1_2_XFAIL = pytest.mark.xfail(
-    reason="green after HA1.2: ProviderConfig",
-    strict=False,
-)
-
 # Closed capability vocabulary (HA1 File 1). ``context_limit`` is a sibling
-# ``int | None`` field, not a set member.
+# ``int | None`` field, not a set member. Deleting or widening
+# ``CAPABILITY_VALUES`` must fail the round-trip pin.
 _CLOSED_CAPABILITIES = frozenset(
     {
         "tool_calling",
@@ -401,10 +399,9 @@ def test_emitted_opencode_config_is_byte_identical_for_existing_inputs(
     )
 
 
-# -- HA1.2 typed ProviderConfig (RED until the model exists) -----------------
+# -- HA1.2 typed ProviderConfig ----------------------------------------------
 
 
-@_HA1_2_XFAIL
 def test_gateway_env_pairs_produce_typed_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     """The ``_N`` env-pair form yields ``ProviderConfig`` records with today's ids."""
     provider_config_cls = _provider_config_type()
@@ -423,7 +420,6 @@ def test_gateway_env_pairs_produce_typed_configs(monkeypatch: pytest.MonkeyPatch
         assert "api_key" not in type(record).model_fields
 
 
-@_HA1_2_XFAIL
 def test_api_key_never_appears_in_repr(monkeypatch: pytest.MonkeyPatch) -> None:
     """Convention 5: the resolved key never appears in ``repr`` / ``str``."""
     monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
@@ -433,7 +429,6 @@ def test_api_key_never_appears_in_repr(monkeypatch: pytest.MonkeyPatch) -> None:
     assert CANARY_API_KEY not in str(config)
 
 
-@_HA1_2_XFAIL
 def test_api_key_never_appears_in_json_dump(monkeypatch: pytest.MonkeyPatch) -> None:
     """Convention 5: ``model_dump`` / ``model_dump_json`` never carry the key."""
     monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), CANARY_API_KEY)
@@ -446,7 +441,6 @@ def test_api_key_never_appears_in_json_dump(monkeypatch: pytest.MonkeyPatch) -> 
     assert CANARY_API_KEY not in json.dumps(dumped)
 
 
-@_HA1_2_XFAIL
 def test_api_key_never_reaches_trace_attrs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Construct, emit a span, assert the key is absent from the event.
 
@@ -474,7 +468,6 @@ def test_api_key_never_reaches_trace_attrs(monkeypatch: pytest.MonkeyPatch) -> N
     assert CANARY_API_KEY not in json.dumps(payload)
 
 
-@_HA1_2_XFAIL
 def test_api_key_never_reaches_run_packet(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The resolved key must not land in the run packet's serialised form."""
     from mergecraft.evidence.run_packet import build_run_packet
@@ -514,7 +507,6 @@ def test_api_key_never_reaches_run_packet(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert "api_key" not in config.model_dump(mode="json")
 
 
-@_HA1_2_XFAIL
 def test_unsupported_capability_is_a_configuration_error() -> None:
     """D12: requesting an unsupported capability is a configuration error
     *before* agent execution, not a runtime degradation.
@@ -529,7 +521,6 @@ def test_unsupported_capability_is_a_configuration_error() -> None:
         require_capabilities(config, frozenset({"structured_output"}))
 
 
-@_HA1_2_XFAIL
 def test_capability_declaration_round_trips() -> None:
     """Declared capabilities survive dump/validate and into the harness records."""
     declared = frozenset({"tool_calling", "streaming", "openai_compatible", "custom_base_url"})
@@ -538,6 +529,7 @@ def test_capability_declaration_round_trips() -> None:
     )
     assert config.capabilities == declared
     assert declared <= _CLOSED_CAPABILITIES
+    assert CAPABILITY_VALUES == _CLOSED_CAPABILITIES
     provider_config_cls = _provider_config_type()
     restored = provider_config_cls.model_validate(config.model_dump(mode="json"))
     assert restored.capabilities == declared
@@ -547,7 +539,6 @@ def test_capability_declaration_round_trips() -> None:
     assert restored.api_key_env == INDEXED_API_KEY_FMT.format(n=1)
 
 
-@_HA1_2_XFAIL
 def test_custom_base_url_validates() -> None:
     """A malformed base URL is rejected at construction, before execution."""
     from pydantic import ValidationError


### PR DESCRIPTION
## Summary
- Frozen `ProviderConfig` for OpenAI-compatible gateways; API keys stay in env, never on the model
- Emitted OpenCode JSON is unchanged (compatibility pin)

## Test plan
- [x] `make lint` / `make typecheck`
- [x] `make ci-resume`
- [ ] CI on this PR
