### PR TITLE
fix(review): fail closed when no terminal verdict was submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added: server-side semantic validation of the terminal verdict — `request_changes` with no findings, `approve` over a verifier-confirmed blocker, and `approve` with a failing required deterministic check are all rejected and fail closed
 - Added: `submit_review_verdict` — a typed MCP operation that records a review's terminal verdict
   (`approve` / `request_changes`), summary and structured findings. Unknown fields and invalid
   verdict values are rejected; an identical re-submission is idempotent, a conflicting one is an
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: a review run that completes without submitting a terminal verdict now reports `inconclusive` (a `neutral` check conclusion) instead of `passed`. Previously a provider that returned successfully without reviewing anything produced a successful run. Prose such as "LGTM" has never been able to approve and still cannot
 - `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real
   registered command is `mergecraft traces show <run-id>` — the stale
   invocation is now generated from the live CLI app instead of hand-maintained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: a verifier `confirm` now persists the finding fingerprint so `approve` over a confirmed blocker is rejected on the live tool path, not only in unit tests that seed `verified_ids`
+- Fixed: a stored `approve` is re-validated at finalize against current evidence, so a later failed required gate or verifier confirm cannot leave the run `passed`
+- Fixed: a provider success without a usable terminal verdict now advances the model chain when fallback is allowed, instead of accepting the first process-successful result
 - Fixed: a later `run_static_checks` call that matches no gates no longer wipes a prior failed row, so `approve` still fails closed
 - Fixed: `approve` is now rejected on the live path when `run_static_checks` recorded a failed required gate; previously the validator only saw those rows in unit tests
 - Fixed: a review run that completes without submitting a terminal verdict now reports `inconclusive` (a `neutral` check conclusion) instead of `passed`. Previously a provider that returned successfully without reviewing anything produced a successful run. Prose such as "LGTM" has never been able to approve and still cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: a later `run_static_checks` call that matches no gates no longer wipes a prior failed row, so `approve` still fails closed
 - Fixed: `approve` is now rejected on the live path when `run_static_checks` recorded a failed required gate; previously the validator only saw those rows in unit tests
 - Fixed: a review run that completes without submitting a terminal verdict now reports `inconclusive` (a `neutral` check conclusion) instead of `passed`. Previously a provider that returned successfully without reviewing anything produced a successful run. Prose such as "LGTM" has never been able to approve and still cannot
 - `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: a body-only COMMENT is no longer recorded as `request_changes`, and body-only `request_changes` is rejected unless it has real findings
+- Fixed: publication must match the recorded terminal verdict and is re-validated before sending `APPROVE`
+- Fixed: IncrementalReview `report_progress` no longer advances the model chain
 - Fixed: Review completion via `create_pull_request_review` now records a terminal verdict, and IncrementalReview may complete via `report_progress` without mapping to `inconclusive`
 - Fixed: verifier confirms persist outside replaceable analyzer run state, including agent-authored findings
 - Fixed: a verifier `confirm` now persists the finding fingerprint so `approve` over a confirmed blocker is rejected on the live tool path, not only in unit tests that seed `verified_ids`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: Review completion via `create_pull_request_review` now records a terminal verdict, and IncrementalReview may complete via `report_progress` without mapping to `inconclusive`
+- Fixed: verifier confirms persist outside replaceable analyzer run state, including agent-authored findings
 - Fixed: a verifier `confirm` now persists the finding fingerprint so `approve` over a confirmed blocker is rejected on the live tool path, not only in unit tests that seed `verified_ids`
 - Fixed: a stored `approve` is re-validated at finalize against current evidence, so a later failed required gate or verifier confirm cannot leave the run `passed`
 - Fixed: a provider success without a usable terminal verdict now advances the model chain when fallback is allowed, instead of accepting the first process-successful result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: `approve` is now rejected on the live path when `run_static_checks` recorded a failed required gate; previously the validator only saw those rows in unit tests
 - Fixed: a review run that completes without submitting a terminal verdict now reports `inconclusive` (a `neutral` check conclusion) instead of `passed`. Previously a provider that returned successfully without reviewing anything produced a successful run. Prose such as "LGTM" has never been able to approve and still cannot
 - `README.md`'s CLI table documented `mergecraft traces <run-id>`, but the real
   registered command is `mergecraft traces show <run-id>` — the stale

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -70,6 +70,42 @@ to `decide_approval(packet, …)`, the explicit `Decision` row on the
 packet wins over every other signal — including the recorded
 `self_assessment`.
 
+## Terminal verdict vs structural verdict (VP2)
+
+A review run is not complete until the agent records a **terminal
+submission** through `submit_review_verdict`. Provider success, review
+prose, and `create_pull_request_review` publication are separate acts:
+
+- **Agent verdict** — the model's `approve` / `request_changes` choice,
+  summary, and structured findings submitted through the typed MCP tool.
+  This is the only signal that answers "did a review happen on this
+  attempt?"
+- **Structural verdict** — what `decide_approval` computes from typed
+  findings, `run_succeeded`, and trust tier. Narrative output and
+  `ApprovalRecord.would_approve` are advisory only and never override a
+  confirmed blocker.
+
+**Schema vs semantic validation.** The tool rejects unknown fields and
+invalid verdict enums at parse time. After schema validation,
+`validate_submission` applies semantic rules server-side: `request_changes`
+with zero findings, `approve` over a verifier-confirmed Critical/Major
+blocker, and `approve` while a required deterministic gate failed are all
+rejected with a typed `rejection_reason`. A rejected submission does not
+set `terminal_submission_received` — the attempt is fallback-eligible and
+maps to `RunOutcome.inconclusive`, same as no submission at all.
+
+**Why prose is not authoritative.** Text such as "LGTM" in `result.output`
+has never been an input to `decide_approval` and cannot approve a pull
+request. A run whose provider returned successfully but never called
+`submit_review_verdict` now reports `inconclusive` (`neutral` check
+conclusion) instead of `passed`.
+
+**Fallback interaction.** Semantic fallback advances when
+`terminal_submission_received` is false — whether because no submission
+was recorded or because the validator rejected one. A valid
+`request_changes` verdict with confirmed findings is a usable result and
+does not trigger fallback.
+
 ## 1. Code correctness and risk
 
 The reviewer reads the whole diff itself, then picks the **lenses** the PR actually warrants and investigates each as a falsifiable question — optionally dispatching a `mergecraft-reviewer` subagent per lens so they run in parallel. Nothing here is a fixed pass; a docs-only diff gets none of it.

--- a/docs/REVIEW-DOCTRINE.md
+++ b/docs/REVIEW-DOCTRINE.md
@@ -291,6 +291,41 @@ The cross-reference is **one-way**: the doctrine refers to the bank, the bank re
 back to the doctrine. The bank does not embed doctrine; the doctrine does not embed
 case payloads. The protocol is the join key (`case_id`).
 
+## Terminal submission requirement (VP2)
+
+mergeCraft separates three layers that older review flows conflated:
+
+1. **Terminal submission** — `submit_review_verdict` records the agent's
+   `approve` / `request_changes` choice, summary, and structured findings on
+   `ToolState`. One authoritative payload per attempt; identical re-submission
+   is idempotent, a conflicting payload is rejected.
+2. **Structural verdict** — `decide_approval(findings, *, run_succeeded, tier)`
+   is a pure function of typed findings and run state. It never reads agent
+   prose, `result.output`, or `ApprovalRecord.would_approve`.
+3. **Publication** — `create_pull_request_review` posts to GitHub and writes an
+   advisory `ApprovalRecord`. It cannot bypass the structural gate.
+
+**Schema vs semantic validation.** Pydantic enforces the wire shape (closed
+verdict enum, `extra="forbid"`). `validate_submission` then applies semantic
+rules in trusted mergeCraft code: `request_changes` with zero findings,
+`approve` over a verifier-confirmed Critical/Major blocker, and `approve` with
+a failing required deterministic check are all rejected with a typed
+`rejection_reason`. A rejected submission leaves
+`terminal_submission_received=false` — fallback-eligible, same as no
+submission (D8).
+
+**Outcome resolution.** In `Review` and `IncrementalReview` modes, a provider
+that returns process success without a usable terminal submission maps to
+`RunOutcome.inconclusive` (`neutral` check conclusion), not `passed`. Build and
+other non-review modes are unchanged.
+
+**Fallback.** The semantic-fallback chain advances on
+`not terminal_submission_received`, not on verdict content. A valid
+`request_changes` with confirmed findings is a usable review result; a missing
+or semantically rejected submission is not.
+
+See also [`REVIEW-CHECKS.md`](../REVIEW-CHECKS.md#terminal-verdict-vs-structural-verdict-vp2).
+
 ## Provenance
 
 (Harvested from pullfrog-py commits; see the heading above for sources.)

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -10,7 +10,7 @@ Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 
 | **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.3** | `tests/review/test_terminal_verdict_policy.py::test_approve_after_failed_run_static_checks_tool_is_rejected` | *(marker removed 2026-08-16 after VP2.3 persist)* |
-| **VP2.4** | `tests/review/test_terminal_verdict_policy.py::test_failed_static_check_survives_empty_plan_rerun` | `@pytest.mark.xfail(reason="green after VP2.4: sticky failed static_checks", strict=False)` |
+| **VP2.4** | `tests/review/test_terminal_verdict_policy.py::test_failed_static_check_survives_empty_plan_rerun` | *(marker removed 2026-08-16 after VP2.4 sticky persist)* |
 
 Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
 
@@ -31,6 +31,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | 2026-08-16 | VP2.3 (RED) | `test_approve_after_failed_run_static_checks_tool_is_rejected` added, xfail pending persist | Security-review medium: `run_static_checks_tool` does not persist rows on `ToolState`; `validation_state_from_tool_context` hardcodes `static_checks=[]`. Injected-row unit test kept. No `unavailable`/empty sibling — that pin would pass today without the persist field. |
 | 2026-08-16 | VP2.3 | `test_approve_after_failed_run_static_checks_tool_is_rejected` xfail removed | Live-path is now a real pass (not XPASS). Direct pin added: `_persist_static_checks`. Injected-row unit test kept. VP2 Final / security-review not flipped. |
 | 2026-08-16 | VP2.4 (RED) | `test_failed_static_check_survives_empty_plan_rerun` added, xfail pending sticky persist | Security-review medium: empty `plan_checks` (suffix-filtered no-op) assigns `ToolState.static_checks = []` and wipes a prior `failed` row. VP2.3 live-path stays a real pass. |
+| 2026-08-16 | VP2.4 | `test_failed_static_check_survives_empty_plan_rerun` xfail removed | Empty-plan rerun is now a real pass (not XPASS). VP2.3 live-path stays a real pass. VP2 Final / security-review not flipped. |
 
 ## Named symbols this suite pins
 
@@ -123,3 +124,7 @@ Expect: existing 22 VP2 policy tests pass; the new test xfails (`strict=False`) 
 `test_failed_static_check_survives_empty_plan_rerun` drives two live `run_static_checks_tool` calls: a failing `.py` gate, then a suffix-filtered `README.md` rerun that plans no checks. `approve` must still reject with `approve_with_failed_required_gate`, leave `terminal_submission` unset (D8), and keep a `status: failed` row on `validation_state_from_tool_context`. `StaticCheckConfig.suffixes` is pinned as a tuple. The VP2.3 live-path test stays a real pass.
 
 Expect: existing policy tests pass; VP2.3 live-path passes; the new test xfails (`strict=False`) until empty `plan_checks` stops clearing `ToolState.static_checks` and any `failed` this session stays sticky. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).
+
+## VP2.4 xfail reconciliation
+
+24 VP2 policy tests across `tests/review/test_terminal_verdict_policy.py` (22) + `tests/review/test_post_run_terminal_gate.py` (2); 22/22 pass on the policy file; 0 xfail / 0 XPASS. Live-path `test_approve_after_failed_run_static_checks_tool_is_rejected` and `test_failed_static_check_survives_empty_plan_rerun` are real passes. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -1,0 +1,93 @@
+# Review integrity VP2 — fail-closed terminal verdict — test plan
+
+Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md`
+Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 `08cb957`)
+
+## xfail schedule
+
+| Wave | Test files | Marker |
+|------|------------|--------|
+| **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | `@pytest.mark.xfail(reason="green after VP2.2: fail-closed terminal verdict", strict=False)` |
+| **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | same marker |
+
+Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
+
+### Pins that must pass against current code (do not xfail)
+
+| Test | Why it is green today |
+|------|------------------------|
+| `test_verifier_dropped_finding_does_not_block_approval` | Real `decide_approval` — a Trivial-only list is not `"failure"`; including the dropped Critical still is (guard-deletion pin). Signature unchanged (convention 4). |
+| `test_verifier_confirmed_finding_blocks_approval` | Real `decide_approval` — a Critical finding is `"failure"`. Narrative is not a parameter. |
+| `test_publication_cannot_bypass_structural_policy` | `create_pull_request_review(approved=True)` still writes `ApprovalRecord`; `decide_approval` still returns `"failure"` for a blocker. |
+| `test_existing_review_and_comment_behaviour_unchanged` | Fingerprinted inline comments, same-SHA replay skip, `create_issue_comment`, `report_progress`. |
+
+### xfail reconciliation log
+
+| Date | Impl wave | Markers removed | Notes |
+|------|-----------|-----------------|-------|
+| — | VP2.2 | *(pending)* | Remove the 18 markers after the outcome resolver, post-run gate, and `validate_submission` land. |
+
+## Named symbols this suite pins
+
+| Symbol | Module | Direct test |
+|--------|--------|-------------|
+| `validate_submission` | `mcp/verdict.py` | schema tests, D9, D4, approve+blocker, approve+failed gate, valid approve |
+| `SubmissionValidation` | `mcp/verdict.py` | every validator test (`accepted` + closed `rejection_reason`; result is not a bool — D5) |
+| `_classify_outcome` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (real `AgentResult`, not a mock), V3, D8, harness parity |
+| `get_unsubmitted_review` | `agents/post_run.py` | `test_unsubmitted_review_without_progress_comment_still_gates` |
+| `run_post_run_retry_loop` | `agents/post_run.py` | `test_retry_exhaustion_yields_inconclusive_not_passed` |
+| `decide_approval` | `agents/gates.py` | dropped / confirmed / publication pins; signature `findings, *, run_succeeded, tier` |
+| `RunOutcome.inconclusive` | `run_outcome.py` | D2 core case; taxonomy stays six values |
+| `AgentResult.terminal_submission_received` | `agents/shared.py` | D2, D8, D13, D4 finalize paths |
+| `submit_review_verdict_tool` | `mcp/verdict.py` | D4 conflict / idempotent (policy layer on top of VP1) |
+| `create_pull_request_review_tool` | `mcp/review.py` | publication pin + existing-behaviour pin |
+| `create_issue_comment_tool` / `report_progress_tool` | `mcp/comment.py` | `test_existing_review_and_comment_behaviour_unchanged` |
+
+`validate_submission` / `SubmissionValidation` are imported **inside test bodies** so collection succeeds before VP2.2.
+
+### Closed `rejection_reason` vocabulary (D5)
+
+| Reason | Class | Test |
+|--------|-------|------|
+| `invalid_verdict` | schema | `test_invalid_verdict_enum_rejected` |
+| `unknown_fields` | schema | `test_unknown_fields_rejected` |
+| `missing_required_fields` | schema | `test_missing_required_fields_rejected` |
+| `request_changes_without_findings` | semantic | `test_request_changes_with_no_findings_is_semantically_rejected` (D9) |
+| `approve_with_confirmed_blocker` | policy | `test_agent_approve_with_verified_blocker_fails_structurally` |
+| `approve_with_failed_required_gate` | policy | `test_approve_with_failing_required_deterministic_check_fails` |
+| `conflicting_submission` | policy | `test_duplicate_conflicting_submissions_fail_closed` (D4) |
+
+`state` duck-types `ToolState` plus `confirmed_findings`, `static_checks` (`run_static_checks` row shape: `name` + `status`), and `withdrawn_fingerprints`.
+
+`_classify_outcome` grows a `mode` parameter. Before the final `return RunOutcome.passed`, review modes with `not result.terminal_submission_received` return `RunOutcome.inconclusive` with reason `"no terminal review verdict was submitted for this attempt"`. Do not add a seventh `RunOutcome` member.
+
+## Contract matrix
+
+| Decision | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| Valid approve + clear gates | Functional | Happy: validator accepts; classify with `received=True` is `passed`; trivial finding may approve | `test_valid_approve_and_clear_gates_succeeds` |
+| Approve + confirmed blocker | Integration | Error: typed policy rejection **and** `decide_approval` is `"failure"` | `test_agent_approve_with_verified_blocker_fails_structurally` |
+| Request-changes + blocker | Integration | Happy+gate: validator accepts; `decide_approval` still `"failure"` | `test_request_changes_with_verified_blocker_blocks` |
+| **D2** missing verdict | Unit | Core: real `AgentResult(success=True, terminal_submission_received=False)` → `inconclusive`, not `failed`; Build still `passed` | `test_no_terminal_submission_is_inconclusive` |
+| Prose is not a verdict | Unit | Edge: output `"LGTM"` is not a `decide_approval` input and cannot yield `passed` | `test_prose_lgtm_without_terminal_call_cannot_approve` |
+| Schema enum / extra / required | Unit | Error: typed `SubmissionValidation`, not a bool | three schema tests |
+| **D9** | Unit | Semantic: `request_changes` + `[]` rejected; reason is not `missing_required_fields` | `test_request_changes_with_no_findings_is_semantically_rejected` |
+| **D4** conflict | Functional | Error: tool conflict + validator reject + finalize `received=False` → `inconclusive` | `test_duplicate_conflicting_submissions_fail_closed` |
+| **D4** identical | Functional | Happy: same id, `received=True`, classify `passed` | `test_identical_resubmission_is_idempotent` |
+| **V3** | Unit | Error: provider success without a verdict is not `passed` | `test_provider_success_without_verdict_is_not_a_successful_review` |
+| **D8** fallback-eligible | Unit | Edge: missing **and** semantically rejected submissions keep `received=False` and map to `inconclusive` | `test_missing_verdict_leaves_run_fallback_eligible` |
+| Fresh verdict | Unit | Happy: `received=True` → `passed`, not fallback-eligible (D13) | `test_fresh_valid_verdict_does_not_trigger_fallback` |
+| Failed required gate | Unit | Error: `static_checks` row `status=failed` rejects `approve` | `test_approve_with_failing_required_deterministic_check_fails` |
+| Dropped finding | Unit | Regression: remainder does not fail; including the dropped Critical would | `test_verifier_dropped_finding_does_not_block_approval` |
+| Confirmed finding | Unit | Regression: real `decide_approval`, not a reimplemented severity check | `test_verifier_confirmed_finding_blocks_approval` |
+| Publication vs policy | Integration | Regression: GitHub `APPROVE` / `would_approve=True` cannot outvote a blocker | `test_publication_cannot_bypass_structural_policy` |
+| Existing MCP review+comment | Functional | Regression: fingerprint, same-SHA skip, issue comment, progress | `test_existing_review_and_comment_behaviour_unchanged` |
+| Harness parity | Unit | Happy: OpenCode-shaped and Codex-shaped `AgentResult` → same `inconclusive` | `test_both_harness_paths_obey_the_same_contract` |
+| **V4** progress-comment precondition | Unit | Edge: `had_progress_comment=False` still gates; `tool_state.review` does not satisfy; `terminal_submission` does | `test_unsubmitted_review_without_progress_comment_still_gates` |
+| **V4** retry exhaustion | Integration | Error: `MAX_POST_RUN_RETRIES` resumes, then `inconclusive` not `passed`/`failed` | `test_retry_exhaustion_yields_inconclusive_not_passed` |
+
+No source-grep assertions. `_classify_outcome` is called with a real `AgentResult`. Confirmed/dropped approval tests call real `decide_approval`.
+
+## RED acceptance (VP2.1)
+
+22 collected; 4 pass (the `decide_approval` / existing review+comment pins); 18 xfail pending VP2.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave.

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -10,6 +10,7 @@ Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 
 | **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.3** | `tests/review/test_terminal_verdict_policy.py::test_approve_after_failed_run_static_checks_tool_is_rejected` | *(marker removed 2026-08-16 after VP2.3 persist)* |
+| **VP2.4** | `tests/review/test_terminal_verdict_policy.py::test_failed_static_check_survives_empty_plan_rerun` | `@pytest.mark.xfail(reason="green after VP2.4: sticky failed static_checks", strict=False)` |
 
 Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
 
@@ -29,6 +30,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | 2026-08-16 | VP2.2 | `_VP22` on 16 tests in `test_terminal_verdict_policy.py` + both tests in `test_post_run_terminal_gate.py` | Suite is now 22/22 real passes. Direct pins added: `validation_state_from_tool_context`, `_is_review_mode`, `has_failed_required_static_check`. VP2 Final not flipped. |
 | 2026-08-16 | VP2.3 (RED) | `test_approve_after_failed_run_static_checks_tool_is_rejected` added, xfail pending persist | Security-review medium: `run_static_checks_tool` does not persist rows on `ToolState`; `validation_state_from_tool_context` hardcodes `static_checks=[]`. Injected-row unit test kept. No `unavailable`/empty sibling — that pin would pass today without the persist field. |
 | 2026-08-16 | VP2.3 | `test_approve_after_failed_run_static_checks_tool_is_rejected` xfail removed | Live-path is now a real pass (not XPASS). Direct pin added: `_persist_static_checks`. Injected-row unit test kept. VP2 Final / security-review not flipped. |
+| 2026-08-16 | VP2.4 (RED) | `test_failed_static_check_survives_empty_plan_rerun` added, xfail pending sticky persist | Security-review medium: empty `plan_checks` (suffix-filtered no-op) assigns `ToolState.static_checks = []` and wipes a prior `failed` row. VP2.3 live-path stays a real pass. |
 
 ## Named symbols this suite pins
 
@@ -36,8 +38,8 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 |--------|--------|-------------|
 | `validate_submission` | `mcp/verdict.py` | schema tests, D9, D4, approve+blocker, approve+failed gate, valid approve |
 | `SubmissionValidation` | `mcp/verdict.py` | every validator test (`accepted` + closed `rejection_reason`; result is not a bool — D5) |
-| `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`); `test_approve_after_failed_run_static_checks_tool_is_rejected` (must copy a `status: failed` row from `ToolState` — guard-deletion pin) |
-| `run_static_checks_tool` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (live failing command; payload `status == "failed"`) |
+| `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`); `test_approve_after_failed_run_static_checks_tool_is_rejected` (must copy a `status: failed` row from `ToolState` — guard-deletion pin); `test_failed_static_check_survives_empty_plan_rerun` (failed row still present after empty-plan rerun) |
+| `run_static_checks_tool` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (live failing command; payload `status == "failed"`); `test_failed_static_check_survives_empty_plan_rerun` (suffix-filtered empty plan must not wipe a prior `failed`) |
 | `_persist_static_checks` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (callable + `ToolState.static_checks` carries a `status: failed` row after the live tool run — deleting the helper fails the suite) |
 | `_classify_outcome` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (real `AgentResult`, not a mock), V3, D8, harness parity |
 | `_is_review_mode` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (Review / IncrementalReview true; Build / `None` false; `Mode` object true) |
@@ -47,7 +49,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `decide_approval` | `agents/gates.py` | dropped / confirmed / publication pins; signature `findings, *, run_succeeded, tier` |
 | `RunOutcome.inconclusive` | `run_outcome.py` | D2 core case; taxonomy stays six values |
 | `AgentResult.terminal_submission_received` | `agents/shared.py` | D2, D8, D13, D4 finalize paths |
-| `submit_review_verdict_tool` | `mcp/verdict.py` | D4 conflict / idempotent (policy layer on top of VP1); `test_approve_after_failed_run_static_checks_tool_is_rejected` |
+| `submit_review_verdict_tool` | `mcp/verdict.py` | D4 conflict / idempotent (policy layer on top of VP1); `test_approve_after_failed_run_static_checks_tool_is_rejected`; `test_failed_static_check_survives_empty_plan_rerun` |
 | `create_pull_request_review_tool` | `mcp/review.py` | publication pin + existing-behaviour pin |
 | `create_issue_comment_tool` / `report_progress_tool` | `mcp/comment.py` | `test_existing_review_and_comment_behaviour_unchanged` |
 
@@ -62,7 +64,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `missing_required_fields` | schema | `test_missing_required_fields_rejected` |
 | `request_changes_without_findings` | semantic | `test_request_changes_with_no_findings_is_semantically_rejected` (D9) |
 | `approve_with_confirmed_blocker` | policy | `test_agent_approve_with_verified_blocker_fails_structurally` |
-| `approve_with_failed_required_gate` | policy | `test_approve_with_failing_required_deterministic_check_fails` (injected rows); `test_approve_after_failed_run_static_checks_tool_is_rejected` (live tool path) |
+| `approve_with_failed_required_gate` | policy | `test_approve_with_failing_required_deterministic_check_fails` (injected rows); `test_approve_after_failed_run_static_checks_tool_is_rejected` (live tool path); `test_failed_static_check_survives_empty_plan_rerun` (failed row sticky across empty-plan rerun) |
 | `conflicting_submission` | policy | `test_duplicate_conflicting_submissions_fail_closed` (D4) |
 
 `state` duck-types `ToolState` plus `confirmed_findings`, `static_checks` (`run_static_checks` row shape: `name` + `status`), and `withdrawn_fingerprints`.
@@ -87,6 +89,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | Fresh verdict | Unit | Happy: `received=True` → `passed`, not fallback-eligible (D13) | `test_fresh_valid_verdict_does_not_trigger_fallback` |
 | Failed required gate | Unit | Error: `static_checks` row `status=failed` rejects `approve` | `test_approve_with_failing_required_deterministic_check_fails` |
 | Failed required gate (live MCP) | Functional | Error: `run_static_checks_tool` failing command → `submit_review_verdict(approve)` rejected; `terminal_submission` unset (D8); `validation_state_from_tool_context` carries the `failed` row | `test_approve_after_failed_run_static_checks_tool_is_rejected` |
+| Failed required gate (empty-plan rerun) | Functional | Error: suffix-filtered no-op `run_static_checks` must not wipe a prior `failed` row; `approve` still rejected; `terminal_submission` unset (D8) | `test_failed_static_check_survives_empty_plan_rerun` |
 | Dropped finding | Unit | Regression: remainder does not fail; including the dropped Critical would | `test_verifier_dropped_finding_does_not_block_approval` |
 | Confirmed finding | Unit | Regression: real `decide_approval`, not a reimplemented severity check | `test_verifier_confirmed_finding_blocks_approval` |
 | Publication vs policy | Integration | Regression: GitHub `APPROVE` / `would_approve=True` cannot outvote a blocker | `test_publication_cannot_bypass_structural_policy` |
@@ -114,3 +117,9 @@ Expect: existing 22 VP2 policy tests pass; the new test xfails (`strict=False`) 
 ## VP2.3 xfail reconciliation
 
 23 VP2 policy tests across `tests/review/test_terminal_verdict_policy.py` (21) + `tests/review/test_post_run_terminal_gate.py` (2); 21/21 pass on the policy file; 0 xfail / 0 XPASS. Live-path `test_approve_after_failed_run_static_checks_tool_is_rejected` is a real pass. `_persist_static_checks` now has a direct `tests/` reference. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).
+
+## VP2.4 RED (security-review follow-up — empty-plan wipe)
+
+`test_failed_static_check_survives_empty_plan_rerun` drives two live `run_static_checks_tool` calls: a failing `.py` gate, then a suffix-filtered `README.md` rerun that plans no checks. `approve` must still reject with `approve_with_failed_required_gate`, leave `terminal_submission` unset (D8), and keep a `status: failed` row on `validation_state_from_tool_context`. `StaticCheckConfig.suffixes` is pinned as a tuple. The VP2.3 live-path test stays a real pass.
+
+Expect: existing policy tests pass; VP2.3 live-path passes; the new test xfails (`strict=False`) until empty `plan_checks` stops clearing `ToolState.static_checks` and any `failed` this session stays sticky. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -9,7 +9,7 @@ Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 
 |------|------------|--------|
 | **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | *(markers removed 2026-08-16 after VP2.2)* |
-| **VP2.3** | `tests/review/test_terminal_verdict_policy.py::test_approve_after_failed_run_static_checks_tool_is_rejected` | `@pytest.mark.xfail(reason="green after VP2.3: persist static_checks on ToolState", strict=False)` |
+| **VP2.3** | `tests/review/test_terminal_verdict_policy.py::test_approve_after_failed_run_static_checks_tool_is_rejected` | *(marker removed 2026-08-16 after VP2.3 persist)* |
 
 Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
 
@@ -28,6 +28,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 |------|-----------|-----------------|-------|
 | 2026-08-16 | VP2.2 | `_VP22` on 16 tests in `test_terminal_verdict_policy.py` + both tests in `test_post_run_terminal_gate.py` | Suite is now 22/22 real passes. Direct pins added: `validation_state_from_tool_context`, `_is_review_mode`, `has_failed_required_static_check`. VP2 Final not flipped. |
 | 2026-08-16 | VP2.3 (RED) | `test_approve_after_failed_run_static_checks_tool_is_rejected` added, xfail pending persist | Security-review medium: `run_static_checks_tool` does not persist rows on `ToolState`; `validation_state_from_tool_context` hardcodes `static_checks=[]`. Injected-row unit test kept. No `unavailable`/empty sibling — that pin would pass today without the persist field. |
+| 2026-08-16 | VP2.3 | `test_approve_after_failed_run_static_checks_tool_is_rejected` xfail removed | Live-path is now a real pass (not XPASS). Direct pin added: `_persist_static_checks`. Injected-row unit test kept. VP2 Final / security-review not flipped. |
 
 ## Named symbols this suite pins
 
@@ -37,6 +38,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `SubmissionValidation` | `mcp/verdict.py` | every validator test (`accepted` + closed `rejection_reason`; result is not a bool — D5) |
 | `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`); `test_approve_after_failed_run_static_checks_tool_is_rejected` (must copy a `status: failed` row from `ToolState` — guard-deletion pin) |
 | `run_static_checks_tool` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (live failing command; payload `status == "failed"`) |
+| `_persist_static_checks` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (callable + `ToolState.static_checks` carries a `status: failed` row after the live tool run — deleting the helper fails the suite) |
 | `_classify_outcome` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (real `AgentResult`, not a mock), V3, D8, harness parity |
 | `_is_review_mode` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (Review / IncrementalReview true; Build / `None` false; `Mode` object true) |
 | `has_failed_required_static_check` | `agents/gates.py` | `test_approve_with_failing_required_deterministic_check_fails` (`failed` true; `passed` / empty false) |
@@ -108,3 +110,7 @@ No source-grep assertions. `_classify_outcome` is called with a real `AgentResul
 `test_approve_after_failed_run_static_checks_tool_is_rejected` drives the live MCP path: a configured failing `StaticCheckConfig` through `run_static_checks_tool`, then `submit_review_verdict_tool(approve)`. It must reject with `approve_with_failed_required_gate`, leave `terminal_submission` unset (D8), and show a `status: failed` row on `validation_state_from_tool_context(ctx).static_checks`. The injected-row unit test stays. No `unavailable`/empty-checks sibling — `has_failed_required_static_check` already treats only `failed` as negative, and that pin would pass today without persisting rows.
 
 Expect: existing 22 VP2 policy tests pass; the new test xfails (`strict=False`) until ToolState persist + copy in `validation_state_from_tool_context`. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).
+
+## VP2.3 xfail reconciliation
+
+23 VP2 policy tests across `tests/review/test_terminal_verdict_policy.py` (21) + `tests/review/test_post_run_terminal_gate.py` (2); 21/21 pass on the policy file; 0 xfail / 0 XPASS. Live-path `test_approve_after_failed_run_static_checks_tool_is_rejected` is a real pass. `_persist_static_checks` now has a direct `tests/` reference. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -7,8 +7,8 @@ Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 
 
 | Wave | Test files | Marker |
 |------|------------|--------|
-| **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | `@pytest.mark.xfail(reason="green after VP2.2: fail-closed terminal verdict", strict=False)` |
-| **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | same marker |
+| **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | *(markers removed 2026-08-16 after VP2.2)* |
+| **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | *(markers removed 2026-08-16 after VP2.2)* |
 
 Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
 
@@ -25,7 +25,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 
 | Date | Impl wave | Markers removed | Notes |
 |------|-----------|-----------------|-------|
-| — | VP2.2 | *(pending)* | Remove the 18 markers after the outcome resolver, post-run gate, and `validate_submission` land. |
+| 2026-08-16 | VP2.2 | `_VP22` on 16 tests in `test_terminal_verdict_policy.py` + both tests in `test_post_run_terminal_gate.py` | Suite is now 22/22 real passes. Direct pins added: `validation_state_from_tool_context`, `_is_review_mode`, `has_failed_required_static_check`. VP2 Final not flipped. |
 
 ## Named symbols this suite pins
 
@@ -33,7 +33,10 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 |--------|--------|-------------|
 | `validate_submission` | `mcp/verdict.py` | schema tests, D9, D4, approve+blocker, approve+failed gate, valid approve |
 | `SubmissionValidation` | `mcp/verdict.py` | every validator test (`accepted` + closed `rejection_reason`; result is not a bool — D5) |
+| `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`) |
 | `_classify_outcome` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (real `AgentResult`, not a mock), V3, D8, harness parity |
+| `_is_review_mode` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (Review / IncrementalReview true; Build / `None` false; `Mode` object true) |
+| `has_failed_required_static_check` | `agents/gates.py` | `test_approve_with_failing_required_deterministic_check_fails` (`failed` true; `passed` / empty false) |
 | `get_unsubmitted_review` | `agents/post_run.py` | `test_unsubmitted_review_without_progress_comment_still_gates` |
 | `run_post_run_retry_loop` | `agents/post_run.py` | `test_retry_exhaustion_yields_inconclusive_not_passed` |
 | `decide_approval` | `agents/gates.py` | dropped / confirmed / publication pins; signature `findings, *, run_succeeded, tier` |
@@ -43,7 +46,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `create_pull_request_review_tool` | `mcp/review.py` | publication pin + existing-behaviour pin |
 | `create_issue_comment_tool` / `report_progress_tool` | `mcp/comment.py` | `test_existing_review_and_comment_behaviour_unchanged` |
 
-`validate_submission` / `SubmissionValidation` are imported **inside test bodies** so collection succeeds before VP2.2.
+`validate_submission` / `SubmissionValidation` stay imported **inside test bodies** (collection-safe leftover from the RED wave).
 
 ### Closed `rejection_reason` vocabulary (D5)
 
@@ -91,3 +94,7 @@ No source-grep assertions. `_classify_outcome` is called with a real `AgentResul
 ## RED acceptance (VP2.1)
 
 22 collected; 4 pass (the `decide_approval` / existing review+comment pins); 18 xfail pending VP2.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave.
+
+## VP2.2 xfail reconciliation
+
+22 collected; 22 pass; 0 xfail / 0 XPASS on `tests/review/test_terminal_verdict_policy.py` + `tests/review/test_post_run_terminal_gate.py`. Markers cleared; three previously zero-test-ref symbols pinned by extra assertions in existing tests. Product code is not edited in this wave. VP2 Final remains open.

--- a/docs/test-plans/review-integrity-vp2.md
+++ b/docs/test-plans/review-integrity-vp2.md
@@ -9,6 +9,7 @@ Worktree: `mergecraft-vp2-fail-closed` @ `wave/vp2-fail-closed` (stacked on VP1 
 |------|------------|--------|
 | **VP2.2** | `tests/review/test_terminal_verdict_policy.py` (16 of 20) | *(markers removed 2026-08-16 after VP2.2)* |
 | **VP2.2** | `tests/review/test_post_run_terminal_gate.py` (both) | *(markers removed 2026-08-16 after VP2.2)* |
+| **VP2.3** | `tests/review/test_terminal_verdict_policy.py::test_approve_after_failed_run_static_checks_tool_is_rejected` | `@pytest.mark.xfail(reason="green after VP2.3: persist static_checks on ToolState", strict=False)` |
 
 Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failure the impl wave cannot touch.
 
@@ -26,6 +27,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | Date | Impl wave | Markers removed | Notes |
 |------|-----------|-----------------|-------|
 | 2026-08-16 | VP2.2 | `_VP22` on 16 tests in `test_terminal_verdict_policy.py` + both tests in `test_post_run_terminal_gate.py` | Suite is now 22/22 real passes. Direct pins added: `validation_state_from_tool_context`, `_is_review_mode`, `has_failed_required_static_check`. VP2 Final not flipped. |
+| 2026-08-16 | VP2.3 (RED) | `test_approve_after_failed_run_static_checks_tool_is_rejected` added, xfail pending persist | Security-review medium: `run_static_checks_tool` does not persist rows on `ToolState`; `validation_state_from_tool_context` hardcodes `static_checks=[]`. Injected-row unit test kept. No `unavailable`/empty sibling — that pin would pass today without the persist field. |
 
 ## Named symbols this suite pins
 
@@ -33,7 +35,8 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 |--------|--------|-------------|
 | `validate_submission` | `mcp/verdict.py` | schema tests, D9, D4, approve+blocker, approve+failed gate, valid approve |
 | `SubmissionValidation` | `mcp/verdict.py` | every validator test (`accepted` + closed `rejection_reason`; result is not a bool — D5) |
-| `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`) |
+| `validation_state_from_tool_context` | `mcp/verdict.py` | `test_valid_approve_and_clear_gates_succeeds` (wires `tool_state` / `analyzer_run` / `terminal_submission` from `ToolContext`); `test_approve_after_failed_run_static_checks_tool_is_rejected` (must copy a `status: failed` row from `ToolState` — guard-deletion pin) |
+| `run_static_checks_tool` | `mcp/static_checks.py` | `test_approve_after_failed_run_static_checks_tool_is_rejected` (live failing command; payload `status == "failed"`) |
 | `_classify_outcome` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (real `AgentResult`, not a mock), V3, D8, harness parity |
 | `_is_review_mode` | `main_outcome.py` | `test_no_terminal_submission_is_inconclusive` (Review / IncrementalReview true; Build / `None` false; `Mode` object true) |
 | `has_failed_required_static_check` | `agents/gates.py` | `test_approve_with_failing_required_deterministic_check_fails` (`failed` true; `passed` / empty false) |
@@ -42,7 +45,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `decide_approval` | `agents/gates.py` | dropped / confirmed / publication pins; signature `findings, *, run_succeeded, tier` |
 | `RunOutcome.inconclusive` | `run_outcome.py` | D2 core case; taxonomy stays six values |
 | `AgentResult.terminal_submission_received` | `agents/shared.py` | D2, D8, D13, D4 finalize paths |
-| `submit_review_verdict_tool` | `mcp/verdict.py` | D4 conflict / idempotent (policy layer on top of VP1) |
+| `submit_review_verdict_tool` | `mcp/verdict.py` | D4 conflict / idempotent (policy layer on top of VP1); `test_approve_after_failed_run_static_checks_tool_is_rejected` |
 | `create_pull_request_review_tool` | `mcp/review.py` | publication pin + existing-behaviour pin |
 | `create_issue_comment_tool` / `report_progress_tool` | `mcp/comment.py` | `test_existing_review_and_comment_behaviour_unchanged` |
 
@@ -57,7 +60,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | `missing_required_fields` | schema | `test_missing_required_fields_rejected` |
 | `request_changes_without_findings` | semantic | `test_request_changes_with_no_findings_is_semantically_rejected` (D9) |
 | `approve_with_confirmed_blocker` | policy | `test_agent_approve_with_verified_blocker_fails_structurally` |
-| `approve_with_failed_required_gate` | policy | `test_approve_with_failing_required_deterministic_check_fails` |
+| `approve_with_failed_required_gate` | policy | `test_approve_with_failing_required_deterministic_check_fails` (injected rows); `test_approve_after_failed_run_static_checks_tool_is_rejected` (live tool path) |
 | `conflicting_submission` | policy | `test_duplicate_conflicting_submissions_fail_closed` (D4) |
 
 `state` duck-types `ToolState` plus `confirmed_findings`, `static_checks` (`run_static_checks` row shape: `name` + `status`), and `withdrawn_fingerprints`.
@@ -81,6 +84,7 @@ Never `strict=True` — a strict xfail that XPASSes after VP2.2 is a hard failur
 | **D8** fallback-eligible | Unit | Edge: missing **and** semantically rejected submissions keep `received=False` and map to `inconclusive` | `test_missing_verdict_leaves_run_fallback_eligible` |
 | Fresh verdict | Unit | Happy: `received=True` → `passed`, not fallback-eligible (D13) | `test_fresh_valid_verdict_does_not_trigger_fallback` |
 | Failed required gate | Unit | Error: `static_checks` row `status=failed` rejects `approve` | `test_approve_with_failing_required_deterministic_check_fails` |
+| Failed required gate (live MCP) | Functional | Error: `run_static_checks_tool` failing command → `submit_review_verdict(approve)` rejected; `terminal_submission` unset (D8); `validation_state_from_tool_context` carries the `failed` row | `test_approve_after_failed_run_static_checks_tool_is_rejected` |
 | Dropped finding | Unit | Regression: remainder does not fail; including the dropped Critical would | `test_verifier_dropped_finding_does_not_block_approval` |
 | Confirmed finding | Unit | Regression: real `decide_approval`, not a reimplemented severity check | `test_verifier_confirmed_finding_blocks_approval` |
 | Publication vs policy | Integration | Regression: GitHub `APPROVE` / `would_approve=True` cannot outvote a blocker | `test_publication_cannot_bypass_structural_policy` |
@@ -98,3 +102,9 @@ No source-grep assertions. `_classify_outcome` is called with a real `AgentResul
 ## VP2.2 xfail reconciliation
 
 22 collected; 22 pass; 0 xfail / 0 XPASS on `tests/review/test_terminal_verdict_policy.py` + `tests/review/test_post_run_terminal_gate.py`. Markers cleared; three previously zero-test-ref symbols pinned by extra assertions in existing tests. Product code is not edited in this wave. VP2 Final remains open.
+
+## VP2.3 RED (security-review follow-up)
+
+`test_approve_after_failed_run_static_checks_tool_is_rejected` drives the live MCP path: a configured failing `StaticCheckConfig` through `run_static_checks_tool`, then `submit_review_verdict_tool(approve)`. It must reject with `approve_with_failed_required_gate`, leave `terminal_submission` unset (D8), and show a `status: failed` row on `validation_state_from_tool_context(ctx).static_checks`. The injected-row unit test stays. No `unavailable`/empty-checks sibling — `has_failed_required_static_check` already treats only `failed` as negative, and that pin would pass today without persisting rows.
+
+Expect: existing 22 VP2 policy tests pass; the new test xfails (`strict=False`) until ToolState persist + copy in `validation_state_from_tool_context`. Product code is not edited in this wave. VP2 Final remains open (security-review still `[ ]`).

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -96,6 +96,16 @@ def _has_blocker(findings: list[Finding]) -> bool:
     return any(f.severity in BLOCKING_SEVERITIES for f in findings)
 
 
+def has_failed_required_static_check(static_checks: list[dict[str, str]]) -> bool:
+    """True when any ``run_static_checks`` row reports ``status: failed``.
+
+    The terminal-verdict validator consults this for ``approve`` submissions.
+    Only ``failed`` is a negative gate signal — ``unavailable`` and friends are
+    honest skips, not blockers.
+    """
+    return any(row.get("status") == "failed" for row in static_checks)
+
+
 @overload
 def decide_approval(
     findings: list[Finding],
@@ -493,6 +503,7 @@ __all__ = [
     "decide_action",
     "decide_approval",
     "decision_summary_lines",
+    "has_failed_required_static_check",
     "log_decision",
     "select_rule_id",
     "subagent_denied_tool_names",

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -176,20 +176,6 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
     return f"{base}\n\nThis is a reflection turn — address the issues above, then stop."
 
 
-def _submission_as_payload(submission: Any) -> dict[str, Any]:
-    findings: list[Any] = []
-    for item in submission.findings:
-        if hasattr(item, "model_dump"):
-            findings.append(item.model_dump(mode="json"))
-        else:
-            findings.append(item)
-    return {
-        "verdict": submission.verdict,
-        "summary": submission.summary,
-        "findings": findings,
-    }
-
-
 def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
     """Copy the recorded terminal submission onto ``AgentResult``.
 
@@ -209,10 +195,14 @@ def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None,
             diagnostics["attempt_id"] = submission.attempt_id
         return False, None, diagnostics
 
-    from mergecraft.mcp.verdict import validate_submission, validation_state_from_tool_state
+    from mergecraft.mcp.verdict import (
+        recorded_submission_payload,
+        validate_submission,
+        validation_state_from_tool_state,
+    )
 
     validation = validate_submission(
-        _submission_as_payload(submission),
+        recorded_submission_payload(submission),
         state=validation_state_from_tool_state(ctx.tool_state),
     )
     if not validation.accepted:

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -30,12 +30,10 @@ if TYPE_CHECKING:
 
 def get_unsubmitted_review(tool_state: ToolState) -> str | None:
     mode = tool_state.selected_mode
-    if not tool_state.had_progress_comment:
-        return None
     if mode == "Review":
-        return None if tool_state.review else "Review"
+        return None if tool_state.terminal_submission else "Review"
     if mode == "IncrementalReview":
-        if tool_state.review or tool_state.final_summary_written:
+        if tool_state.terminal_submission or tool_state.final_summary_written:
             return None
         return "IncrementalReview"
     return None
@@ -178,8 +176,11 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
 
 def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
     submission = ctx.tool_state.terminal_submission
-    if submission is None:
-        return False, None, {}
+    if submission is None or ctx.tool_state.terminal_submission_conflict:
+        diagnostics: dict[str, Any] = {}
+        if ctx.tool_state.terminal_submission_conflict:
+            diagnostics["rejection_reason"] = "conflicting_submission"
+        return False, None, diagnostics
     return True, submission.id, {}
 
 
@@ -189,28 +190,6 @@ async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> Ag
     if not result.success:
         return replace(
             result,
-            terminal_submission_received=received,
-            terminal_submission_id=submission_id,
-            diagnostics=diagnostics,
-        )
-    issues = await collect_post_run_issues(ctx, skip_summary_stale=True)
-    if issues.unsubmitted_review:
-        expected = (
-            "create_pull_request_review"
-            if issues.unsubmitted_review == "Review"
-            else "create_pull_request_review or report_progress"
-        )
-        return replace(
-            AgentResult(
-                success=False,
-                output=result.output,
-                error=(
-                    f"post-run gate failed: selected {issues.unsubmitted_review} mode but "
-                    f"never called {expected}"
-                ),
-                usage=result.usage,
-                metadata=result.metadata,
-            ),
             terminal_submission_received=received,
             terminal_submission_id=submission_id,
             diagnostics=diagnostics,

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -174,12 +174,29 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
     return f"{base}\n\nThis is a reflection turn — address the issues above, then stop."
 
 
+def _submission_as_payload(submission: Any) -> dict[str, Any]:
+    findings: list[Any] = []
+    for item in submission.findings:
+        if hasattr(item, "model_dump"):
+            findings.append(item.model_dump(mode="json"))
+        else:
+            findings.append(item)
+    return {
+        "verdict": submission.verdict,
+        "summary": submission.summary,
+        "findings": findings,
+    }
+
+
 def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
     """Copy the recorded terminal submission onto ``AgentResult``.
 
     Diagnostics stay thin in VP1: ``attempt_id`` is the only field the
     submission carries that finalize does not already promote as a first-class
     attribute. VP3 fills the rest of the attempt envelope.
+
+    A stored ``approve`` is re-validated against current evidence so a later
+    failed gate or verifier confirm cannot leave a stale usable verdict.
     """
     submission = ctx.tool_state.terminal_submission
     if submission is None or ctx.tool_state.terminal_submission_conflict:
@@ -188,6 +205,19 @@ def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None,
             diagnostics["rejection_reason"] = "conflicting_submission"
         if submission is not None:
             diagnostics["attempt_id"] = submission.attempt_id
+        return False, None, diagnostics
+
+    from mergecraft.mcp.verdict import validate_submission, validation_state_from_tool_state
+
+    validation = validate_submission(
+        _submission_as_payload(submission),
+        state=validation_state_from_tool_state(ctx.tool_state),
+    )
+    if not validation.accepted:
+        diagnostics = {
+            "rejection_reason": validation.rejection_reason,
+            "attempt_id": submission.attempt_id,
+        }
         return False, None, diagnostics
     return True, submission.id, {"attempt_id": submission.attempt_id}
 

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -89,21 +89,23 @@ def build_unsubmitted_review_prompt(mode: str) -> str:
         return "\n".join(
             [
                 "MISSING REVIEW OUTPUT — you selected Review mode but stopped without "
-                "calling `create_pull_request_review`.",
+                "recording a terminal verdict via `submit_review_verdict`.",
                 "",
-                "call `create_pull_request_review` now with your aggregated review.",
+                "call `submit_review_verdict` now (approve or request_changes), then "
+                "call `create_pull_request_review` with the same outcome.",
                 "",
-                "do NOT stop again until `create_pull_request_review` has been called "
-                "successfully.",
+                "do NOT stop again until `submit_review_verdict` has been called successfully.",
             ]
         )
     return "\n".join(
         [
             "MISSING REVIEW OUTPUT — you selected IncrementalReview mode but stopped "
-            "without calling `create_pull_request_review` or `report_progress`.",
+            "without calling `submit_review_verdict` / `create_pull_request_review` "
+            "or `report_progress`.",
             "",
             "do exactly one of:",
-            "- if you have findings: call `create_pull_request_review`",
+            "- if you have findings: call `submit_review_verdict` then "
+            "`create_pull_request_review`",
             "- if no review warranted: call `report_progress` with a short summary",
         ]
     )

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -1215,6 +1215,7 @@ async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
         setup_reason=setup_reason,
         setup_policy=settings.setup_failure_policy,
         prep_reason=prep_reason,
+        mode=tool_state.selected_mode,
     )
 
     selected_mode_obj = next(

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -1217,6 +1217,7 @@ async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
         setup_policy=settings.setup_failure_policy,
         prep_reason=prep_reason,
         mode=tool_state.selected_mode,
+        final_summary_written=tool_state.final_summary_written,
     )
 
     selected_mode_obj = next(

--- a/src/mergecraft/main_outcome.py
+++ b/src/mergecraft/main_outcome.py
@@ -20,6 +20,17 @@ if TYPE_CHECKING:
     from mergecraft.agents.shared import AgentResult
     from mergecraft.modes import Mode
 
+_REVIEW_MODE_NAMES = frozenset({"Review", "IncrementalReview"})
+_MISSING_TERMINAL_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
+
+
+def _is_review_mode(mode: str | Mode | None) -> bool:
+    if mode is None:
+        return False
+    if isinstance(mode, str):
+        return mode in _REVIEW_MODE_NAMES
+    return mode.name in _REVIEW_MODE_NAMES
+
 
 def _publish_span_attrs(outcome: RunOutcome, mode: Mode | None) -> dict[str, Any]:
     """Build the attrs dict the ``mergecraft.publish`` span emits.
@@ -39,6 +50,7 @@ def _classify_outcome(
     setup_reason: str,
     setup_policy: SetupFailurePolicy,
     prep_reason: str | None,
+    mode: str | Mode | None = None,
 ) -> tuple[RunOutcome, str | None]:
     """Map the run's result + side-channels to a ``RunOutcome`` (D3/W5.2 + S1/D5/D10).
 
@@ -69,6 +81,9 @@ def _classify_outcome(
     if prep_reason:
         logger.warning("» prep failure mapped run to inconclusive: {}", prep_reason)
         return RunOutcome.inconclusive, prep_reason
+    if _is_review_mode(mode) and not result.terminal_submission_received:
+        logger.warning("» {}", _MISSING_TERMINAL_VERDICT_REASON)
+        return RunOutcome.inconclusive, _MISSING_TERMINAL_VERDICT_REASON
     # ``setup_policy`` is the closed ``SetupFailurePolicy`` vocabulary; any
     # value other than ``fail`` / ``inconclusive`` (i.e. ``warn``, or the
     # Pydantic default the action-input resolver accepted) means "proceed
@@ -76,4 +91,4 @@ def _classify_outcome(
     return RunOutcome.passed, None
 
 
-__all__ = ["_classify_outcome", "_publish_span_attrs"]
+__all__ = ["_classify_outcome", "_is_review_mode", "_publish_span_attrs"]

--- a/src/mergecraft/main_outcome.py
+++ b/src/mergecraft/main_outcome.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from mergecraft.modes import Mode
 
 _REVIEW_MODE_NAMES = frozenset({"Review", "IncrementalReview"})
+_INCREMENTAL_REVIEW_NAMES = frozenset({"IncrementalReview"})
 _MISSING_TERMINAL_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
 
 
@@ -30,6 +31,13 @@ def _is_review_mode(mode: str | Mode | None) -> bool:
     if isinstance(mode, str):
         return mode in _REVIEW_MODE_NAMES
     return mode.name in _REVIEW_MODE_NAMES
+
+
+def _is_incremental_review(mode: str | Mode | None) -> bool:
+    if mode is None:
+        return False
+    name = mode if isinstance(mode, str) else mode.name
+    return name in _INCREMENTAL_REVIEW_NAMES
 
 
 def _publish_span_attrs(outcome: RunOutcome, mode: Mode | None) -> dict[str, Any]:
@@ -51,6 +59,7 @@ def _classify_outcome(
     setup_policy: SetupFailurePolicy,
     prep_reason: str | None,
     mode: str | Mode | None = None,
+    final_summary_written: bool = False,
 ) -> tuple[RunOutcome, str | None]:
     """Map the run's result + side-channels to a ``RunOutcome`` (D3/W5.2 + S1/D5/D10).
 
@@ -82,6 +91,8 @@ def _classify_outcome(
         logger.warning("» prep failure mapped run to inconclusive: {}", prep_reason)
         return RunOutcome.inconclusive, prep_reason
     if _is_review_mode(mode) and not result.terminal_submission_received:
+        if _is_incremental_review(mode) and final_summary_written:
+            return RunOutcome.passed, None
         logger.warning("» {}", _MISSING_TERMINAL_VERDICT_REASON)
         return RunOutcome.inconclusive, _MISSING_TERMINAL_VERDICT_REASON
     # ``setup_policy`` is the closed ``SetupFailurePolicy`` vocabulary; any

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -26,7 +26,13 @@ def _resolve_tier(ctx: ToolContext) -> str:
 
 
 def _store_run_state(ctx: ToolContext, state: AnalyzerRunState) -> None:
+    session_ids = set(ctx.tool_state.verified_ids)
+    prior = ctx.tool_state.analyzer_run
+    if prior is not None:
+        session_ids |= set(prior.verified_ids)
+    state.verified_ids = set(state.verified_ids) | session_ids
     ctx.tool_state.analyzer_run = state
+    ctx.tool_state.verified_ids = session_ids | set(state.verified_ids)
 
 
 def run_analyzers_tool(ctx: ToolContext):

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -155,6 +155,37 @@ async def _resolve_fixed_finding_threads(
     return resolved
 
 
+def _comments_to_findings(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for comment in comments:
+        row: dict[str, Any] = {
+            "path": str(comment["path"]),
+            "body": str(comment.get("body") or ""),
+            "severity": "Major",
+        }
+        if "line" in comment:
+            row["line"] = int(comment["line"])
+        findings.append(row)
+    return findings
+
+
+def _legacy_params_to_submission(params: dict[str, Any]) -> dict[str, Any]:
+    """Map ``create_pull_request_review`` params onto the terminal-verdict shape."""
+    approved = bool(params.get("approved"))
+    body = str(params.get("body") or "")
+    comments = list(params.get("comments") or [])
+    if approved:
+        return {"verdict": "approve", "summary": body or "Approve", "findings": []}
+    findings = _comments_to_findings(comments)
+    if not findings:
+        findings = [{"path": ".", "body": body or "Review comment", "severity": "Minor"}]
+    return {
+        "verdict": "request_changes",
+        "summary": body or "Request changes",
+        "findings": findings,
+    }
+
+
 def create_pull_request_review_tool(ctx: ToolContext):
     async def _run(params: dict[str, Any]):
         pull_number = int(params["pull_number"])
@@ -187,6 +218,11 @@ def create_pull_request_review_tool(ctx: ToolContext):
                     ),
                     "reviewId": ctx.tool_state.review.id,
                 }
+
+        if ctx.tool_state.terminal_submission is None:
+            from mergecraft.mcp.verdict import record_validated_terminal_submission
+
+            record_validated_terminal_submission(ctx, _legacy_params_to_submission(params))
 
         event = "COMMENT"
         if approved and ctx.pr_approve_enabled and ctx.trust_tier == "trusted":

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -169,21 +169,50 @@ def _comments_to_findings(comments: list[dict[str, Any]]) -> list[dict[str, Any]
     return findings
 
 
-def _legacy_params_to_submission(params: dict[str, Any]) -> dict[str, Any]:
-    """Map ``create_pull_request_review`` params onto the terminal-verdict shape."""
+def _legacy_params_to_submission(params: dict[str, Any]) -> dict[str, Any] | None:
+    """Map ``create_pull_request_review`` params onto the terminal-verdict shape.
+
+    A plain COMMENT (no ``approved`` / ``request_changes`` and no inline
+    comments) is not a terminal verdict. ``request_changes`` with no findings
+    is left empty so ``validate_submission`` can apply D9 rather than
+    fabricating a ``path="."`` row.
+    """
     approved = bool(params.get("approved"))
+    request_changes = bool(params.get("request_changes"))
     body = str(params.get("body") or "")
     comments = list(params.get("comments") or [])
     if approved:
         return {"verdict": "approve", "summary": body or "Approve", "findings": []}
     findings = _comments_to_findings(comments)
-    if not findings:
-        findings = [{"path": ".", "body": body or "Review comment", "severity": "Minor"}]
-    return {
-        "verdict": "request_changes",
-        "summary": body or "Request changes",
-        "findings": findings,
-    }
+    if request_changes:
+        return {
+            "verdict": "request_changes",
+            "summary": body or "Request changes",
+            "findings": findings,
+        }
+    if findings:
+        return {
+            "verdict": "request_changes",
+            "summary": body or "Review findings",
+            "findings": findings,
+        }
+    return None
+
+
+def _requested_publication_verdict(params: dict[str, Any]) -> str | None:
+    if bool(params.get("approved")):
+        return "approve"
+    if bool(params.get("request_changes")):
+        return "request_changes"
+    return None
+
+
+def _reject_mismatched_publication(submission: Any, params: dict[str, Any]) -> None:
+    wanted = _requested_publication_verdict(params)
+    if wanted is None or wanted == submission.verdict:
+        return
+    msg = f"publication {wanted} does not match recorded terminal verdict {submission.verdict}"
+    raise ValueError(msg)
 
 
 def create_pull_request_review_tool(ctx: ToolContext):
@@ -222,7 +251,14 @@ def create_pull_request_review_tool(ctx: ToolContext):
         if ctx.tool_state.terminal_submission is None:
             from mergecraft.mcp.verdict import record_validated_terminal_submission
 
-            record_validated_terminal_submission(ctx, _legacy_params_to_submission(params))
+            submission_payload = _legacy_params_to_submission(params)
+            if submission_payload is not None:
+                record_validated_terminal_submission(ctx, submission_payload)
+        else:
+            from mergecraft.mcp.verdict import revalidate_recorded_submission
+
+            _reject_mismatched_publication(ctx.tool_state.terminal_submission, params)
+            revalidate_recorded_submission(ctx)
 
         event = "COMMENT"
         if approved and ctx.pr_approve_enabled and ctx.trust_tier == "trusted":

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -33,7 +33,15 @@ def _serialize(outcome: StaticCheckOutcome) -> dict[str, Any]:
     }
 
 
+def _persist_static_checks(ctx: ToolContext, outcomes: list[StaticCheckOutcome]) -> None:
+    """Replace ``ToolState.static_checks`` with the last run's normalized rows."""
+    ctx.tool_state.static_checks = [
+        {"name": outcome.name, "status": outcome.status} for outcome in outcomes
+    ]
+
+
 def _report(
+    ctx: ToolContext,
     outcomes: list[StaticCheckOutcome],
     substitutions: list[GateSubstitution],
     *,
@@ -45,6 +53,7 @@ def _report(
     declared CI check run proved counts, which is exactly how #36 removes the
     duplicate ``unavailable`` row without inventing a second reporting shape.
     """
+    _persist_static_checks(ctx, outcomes)
     executed = [outcome for outcome in outcomes if outcome.ran]
     payload: dict[str, Any] = {"checks": [_serialize(o) for o in outcomes]}
     if substitutions:
@@ -117,6 +126,7 @@ def run_static_checks_tool(ctx: ToolContext):
             changed_files=changed,
         )
         if not checks:
+            ctx.tool_state.static_checks = []
             return {
                 "ran": False,
                 "reason": (
@@ -135,7 +145,7 @@ def run_static_checks_tool(ctx: ToolContext):
             )
             declared = declared_cannot_run_outcomes(checks, reason=reason)
             outcomes, substitutions = await _apply_ci_evidence(ctx, declared)
-            return _report(outcomes, substitutions, reason=reason)
+            return _report(ctx, outcomes, substitutions, reason=reason)
 
         outcomes = run_checks(checks, root=root)
         outcomes, substitutions = await _apply_ci_evidence(ctx, outcomes)
@@ -147,6 +157,7 @@ def run_static_checks_tool(ctx: ToolContext):
             len(outcomes) - len(executed),
         )
         return _report(
+            ctx,
             outcomes,
             substitutions,
             reason=(

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -34,10 +34,23 @@ def _serialize(outcome: StaticCheckOutcome) -> dict[str, Any]:
 
 
 def _persist_static_checks(ctx: ToolContext, outcomes: list[StaticCheckOutcome]) -> None:
-    """Replace ``ToolState.static_checks`` with the last run's normalized rows."""
-    ctx.tool_state.static_checks = [
-        {"name": outcome.name, "status": outcome.status} for outcome in outcomes
+    """Update ``ToolState.static_checks`` with this run's rows.
+
+    Same-name outcomes replace prior rows. Prior ``failed`` rows whose gate was
+    not in this plan stay — a suffix-filtered or partial rerun must not clear an
+    earlier failure the session already recorded.
+    """
+    incoming = {
+        outcome.name: {"name": outcome.name, "status": outcome.status} for outcome in outcomes
+    }
+    retained_failed = [
+        row
+        for row in ctx.tool_state.static_checks
+        if isinstance(row, dict)
+        and row.get("status") == "failed"
+        and row.get("name") not in incoming
     ]
+    ctx.tool_state.static_checks = [*retained_failed, *incoming.values()]
 
 
 def _report(
@@ -126,7 +139,6 @@ def run_static_checks_tool(ctx: ToolContext):
             changed_files=changed,
         )
         if not checks:
-            ctx.tool_state.static_checks = []
             return {
                 "ran": False,
                 "reason": (

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -293,6 +293,10 @@ class ToolState:
     # verification tools (D14): an LLM judge may not evaluate a finding before
     # the deterministic checks it is meant to supplement have had their turn.
     static_checks_ran: bool = False
+    # Last ``run_static_checks`` report — ``{name, status}`` rows, replaced (not
+    # appended) on each call. Read by ``validation_state_from_tool_context`` so
+    # ``approve`` is rejected when a required gate recorded ``status: failed``.
+    static_checks: list[dict[str, Any]] = field(default_factory=list)
 
 
 def repo_key(owner: str, name: str) -> str:

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -285,6 +285,11 @@ class ToolState:
     agent_diagnostic: Any = None
     browser_daemon: Any = None
     analyzer_run: AnalyzerRunState | None = None
+    # Session-scoped verifier confirms. ``run_analyzers`` replaces
+    # ``analyzer_run`` wholesale, so confirmations must not live only there.
+    verified_ids: set[str] = field(default_factory=set)
+    confirmed_findings: list[dict[str, Any]] = field(default_factory=list)
+    agent_findings: list[dict[str, Any]] = field(default_factory=list)
     # Evidence normalised from the consumer's finished CI (#36). ``None`` until
     # a CI source is actually read, so a run that consulted no CI records
     # nothing rather than an empty section.

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -50,28 +50,73 @@ class SubmissionValidation:
     rejection_reason: str | None
 
 
+def _finding_fingerprint(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("fingerprint") or "")
+    return str(getattr(item, "fingerprint", "") or "")
+
+
+def _coerce_confirmed_finding(item: Any) -> Any | None:
+    from mergecraft.analyzers.finding import Finding, FindingValidationError
+
+    if isinstance(item, Finding):
+        return item
+    if hasattr(item, "severity") and not isinstance(item, dict):
+        return item
+    if isinstance(item, dict):
+        try:
+            return Finding.model_validate(item)
+        except FindingValidationError, ValueError, TypeError:
+            severity = item.get("severity")
+            if not severity:
+                return None
+            from types import SimpleNamespace
+
+            return SimpleNamespace(
+                fingerprint=str(item.get("fingerprint") or ""),
+                severity=str(severity),
+            )
+    return None
+
+
 def _confirmed_findings_from_state(state: Any) -> list[Any]:
+    collected: list[Any] = []
+    seen: set[str] = set()
+
+    def _add(item: Any) -> None:
+        coerced = _coerce_confirmed_finding(item)
+        if coerced is None:
+            return
+        fingerprint = _finding_fingerprint(coerced)
+        if fingerprint:
+            if fingerprint in seen:
+                return
+            seen.add(fingerprint)
+        collected.append(coerced)
+
     explicit = getattr(state, "confirmed_findings", None)
     if explicit:
-        return list(explicit)
-    analyzer_run = getattr(state, "analyzer_run", None)
-    if analyzer_run is None:
-        return []
-    verified_ids = getattr(analyzer_run, "verified_ids", None) or set()
-    findings_raw = getattr(analyzer_run, "findings", None) or []
-    from mergecraft.analyzers.finding import Finding
+        for item in explicit:
+            _add(item)
+        return collected
 
-    confirmed: list[Any] = []
-    for item in findings_raw:
-        if isinstance(item, Finding):
-            finding = item
-        elif isinstance(item, dict):
-            finding = Finding.model_validate(item)
-        else:
-            continue
-        if finding.fingerprint in verified_ids:
-            confirmed.append(finding)
-    return confirmed
+    tool_state = getattr(state, "tool_state", None)
+    if tool_state is not None:
+        for item in getattr(tool_state, "confirmed_findings", None) or []:
+            _add(item)
+
+    analyzer_run = getattr(state, "analyzer_run", None)
+    if analyzer_run is None and tool_state is not None:
+        analyzer_run = getattr(tool_state, "analyzer_run", None)
+    verified_ids: set[str] = set()
+    if tool_state is not None:
+        verified_ids |= set(getattr(tool_state, "verified_ids", None) or set())
+    if analyzer_run is not None:
+        verified_ids |= set(getattr(analyzer_run, "verified_ids", None) or set())
+        for item in getattr(analyzer_run, "findings", None) or []:
+            if _finding_fingerprint(item) in verified_ids:
+                _add(item)
+    return collected
 
 
 def _static_checks_from_state(state: Any) -> list[dict[str, str]]:
@@ -203,13 +248,57 @@ class SubmitReviewVerdictParams(BaseModel):
         return coerced
 
 
+def record_validated_terminal_submission(
+    ctx: ToolContext,
+    submission: dict[str, Any],
+) -> TerminalSubmission:
+    """Validate and record a terminal submission on ``ToolState``."""
+    validated = SubmitReviewVerdictParams.model_validate(submission)
+    payload_hash = _canonical_payload_hash(validated.model_dump(mode="json"))
+    existing = ctx.tool_state.terminal_submission
+    if existing is not None:
+        if existing.payload_hash == payload_hash:
+            return existing
+        ctx.tool_state.terminal_submission_conflict = True
+        msg = (
+            "terminal submission conflict: a different verdict payload was already "
+            "recorded for this run"
+        )
+        raise ValueError(msg)
+
+    payload = {
+        "verdict": validated.verdict,
+        "summary": validated.summary,
+        "findings": [item.model_dump(mode="json") for item in validated.findings],
+    }
+    validation = validate_submission(
+        payload,
+        state=validation_state_from_tool_context(ctx),
+    )
+    if not validation.accepted:
+        msg = f"terminal submission rejected: {validation.rejection_reason}"
+        raise ValueError(msg)
+
+    recorded = TerminalSubmission(
+        id=uuid.uuid4().hex,
+        verdict=validated.verdict,
+        summary=validated.summary,
+        findings=list(validated.findings),
+        payload_hash=payload_hash,
+        submitted_at=datetime.now(UTC).isoformat(),
+        attempt_id=ctx.tool_state.fallback_index,
+    )
+    ctx.tool_state.terminal_submission = recorded
+    ctx.tool_state.terminal_submission_conflict = False
+    return recorded
+
+
 def submit_review_verdict_tool(ctx: ToolContext):
     async def _run(params: dict[str, Any]) -> dict[str, Any]:
-        validated = SubmitReviewVerdictParams.model_validate(params)
-        payload_hash = _canonical_payload_hash(validated.model_dump(mode="json"))
         existing = ctx.tool_state.terminal_submission
-
         if existing is not None:
+            validated = SubmitReviewVerdictParams.model_validate(params)
+            payload_hash = _canonical_payload_hash(validated.model_dump(mode="json"))
             if existing.payload_hash == payload_hash:
                 # Conflict stays sticky for this attempt. VP2 treats the flag as
                 # "this attempt is unusable"; a later identical replay must not
@@ -227,29 +316,11 @@ def submit_review_verdict_tool(ctx: ToolContext):
             )
             raise ValueError(msg)
 
-        validation = validate_submission(
-            dict(params),
-            state=validation_state_from_tool_context(ctx),
-        )
-        if not validation.accepted:
-            msg = f"terminal submission rejected: {validation.rejection_reason}"
-            raise ValueError(msg)
-
-        submission = TerminalSubmission(
-            id=uuid.uuid4().hex,
-            verdict=validated.verdict,
-            summary=validated.summary,
-            findings=list(validated.findings),
-            payload_hash=payload_hash,
-            submitted_at=datetime.now(UTC).isoformat(),
-            attempt_id=ctx.tool_state.fallback_index,
-        )
-        ctx.tool_state.terminal_submission = submission
-        ctx.tool_state.terminal_submission_conflict = False
+        recorded = record_validated_terminal_submission(ctx, dict(params))
         return {
             "recorded": True,
-            "id": submission.id,
-            "verdict": submission.verdict,
+            "id": recorded.id,
+            "verdict": recorded.verdict,
             "replayed": False,
         }
 
@@ -311,7 +382,9 @@ __all__ = [
     "REJECTION_UNKNOWN_FIELDS",
     "SubmissionValidation",
     "SubmitReviewVerdictParams",
+    "record_validated_terminal_submission",
     "submit_review_verdict_tool",
     "validate_submission",
     "validation_state_from_tool_context",
+    "validation_state_from_tool_state",
 ]

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -66,7 +66,7 @@ def _coerce_confirmed_finding(item: Any) -> Any | None:
     if isinstance(item, dict):
         try:
             return Finding.model_validate(item)
-        except FindingValidationError, ValueError, TypeError:
+        except (FindingValidationError, ValueError, TypeError):  # fmt: skip
             severity = item.get("severity")
             if not severity:
                 return None

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -1,8 +1,9 @@
-"""Terminal review verdict MCP tool (VP1).
+"""Terminal review verdict MCP tool (VP1) and semantic validation (VP2).
 
 Records a typed terminal submission on ``ToolState`` without publishing to
-GitHub. Enforcement and outcome wiring land in VP2; this module is inert for
-run outcomes until then.
+GitHub. VP2 adds ``validate_submission`` and wires it into the tool so
+schema-invalid and semantically-invalid payloads fail closed without setting
+``terminal_submission``.
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -21,10 +23,148 @@ from mergecraft.mcp.tool_state import TerminalSubmission
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
 
+_ALLOWED_VERDICTS = frozenset({"approve", "request_changes"})
+_ALLOWED_TOP_LEVEL_KEYS = frozenset({"verdict", "summary", "findings"})
+_REQUIRED_TOP_LEVEL_KEYS = frozenset({"verdict", "summary"})
+
+REJECTION_INVALID_VERDICT = "invalid_verdict"
+REJECTION_UNKNOWN_FIELDS = "unknown_fields"
+REJECTION_MISSING_REQUIRED_FIELDS = "missing_required_fields"
+REJECTION_REQUEST_CHANGES_NO_FINDINGS = "request_changes_without_findings"
+REJECTION_APPROVE_CONFIRMED_BLOCKER = "approve_with_confirmed_blocker"
+REJECTION_APPROVE_FAILED_GATE = "approve_with_failed_required_gate"
+REJECTION_CONFLICTING_SUBMISSION = "conflicting_submission"
+
 
 def _canonical_payload_hash(payload: dict[str, Any]) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionValidation:
+    """Typed validator result (D5) — not a bare bool."""
+
+    accepted: bool
+    rejection_reason: str | None
+
+
+def _confirmed_findings_from_state(state: Any) -> list[Any]:
+    explicit = getattr(state, "confirmed_findings", None)
+    if explicit:
+        return list(explicit)
+    analyzer_run = getattr(state, "analyzer_run", None)
+    if analyzer_run is None:
+        return []
+    verified_ids = getattr(analyzer_run, "verified_ids", None) or set()
+    findings_raw = getattr(analyzer_run, "findings", None) or []
+    from mergecraft.analyzers.finding import Finding
+
+    confirmed: list[Any] = []
+    for item in findings_raw:
+        if isinstance(item, Finding):
+            finding = item
+        elif isinstance(item, dict):
+            finding = Finding.model_validate(item)
+        else:
+            continue
+        if finding.fingerprint in verified_ids:
+            confirmed.append(finding)
+    return confirmed
+
+
+def _static_checks_from_state(state: Any) -> list[dict[str, str]]:
+    explicit = getattr(state, "static_checks", None)
+    if explicit:
+        return [dict(row) for row in explicit if isinstance(row, dict)]
+    return []
+
+
+def validation_state_from_tool_context(ctx: ToolContext) -> Any:
+    """Build the duck-typed consultation object ``validate_submission`` reads."""
+    from types import SimpleNamespace
+
+    tool_state = ctx.tool_state
+    state = SimpleNamespace(
+        terminal_submission=tool_state.terminal_submission,
+        terminal_submission_conflict=tool_state.terminal_submission_conflict,
+        confirmed_findings=[],
+        static_checks=[],
+        withdrawn_fingerprints=set(),
+        tool_state=tool_state,
+        analyzer_run=tool_state.analyzer_run,
+    )
+    state.confirmed_findings = _confirmed_findings_from_state(state)
+    return state
+
+
+def validate_submission(submission: dict[str, Any], *, state: Any) -> SubmissionValidation:
+    """Pure semantic + structural validation for a terminal verdict payload (D5, D9)."""
+    if getattr(state, "terminal_submission_conflict", False):
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_CONFLICTING_SUBMISSION,
+        )
+
+    if not isinstance(submission, dict):
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_MISSING_REQUIRED_FIELDS,
+        )
+
+    unknown = set(submission.keys()) - _ALLOWED_TOP_LEVEL_KEYS
+    if unknown:
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_UNKNOWN_FIELDS,
+        )
+
+    for key in _REQUIRED_TOP_LEVEL_KEYS:
+        if key not in submission:
+            return SubmissionValidation(
+                accepted=False,
+                rejection_reason=REJECTION_MISSING_REQUIRED_FIELDS,
+            )
+
+    verdict = submission["verdict"]
+    if verdict not in _ALLOWED_VERDICTS:
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_INVALID_VERDICT,
+        )
+
+    findings_raw = submission.get("findings", [])
+    if findings_raw is None:
+        findings_raw = []
+    if not isinstance(findings_raw, list):
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_MISSING_REQUIRED_FIELDS,
+        )
+
+    if verdict == "request_changes" and len(findings_raw) == 0:
+        return SubmissionValidation(
+            accepted=False,
+            rejection_reason=REJECTION_REQUEST_CHANGES_NO_FINDINGS,
+        )
+
+    if verdict == "approve":
+        from mergecraft.agents.gates import BLOCKING_SEVERITIES, has_failed_required_static_check
+
+        for finding in _confirmed_findings_from_state(state):
+            severity = finding.severity if hasattr(finding, "severity") else finding.get("severity")
+            if severity in BLOCKING_SEVERITIES:
+                return SubmissionValidation(
+                    accepted=False,
+                    rejection_reason=REJECTION_APPROVE_CONFIRMED_BLOCKER,
+                )
+        if has_failed_required_static_check(_static_checks_from_state(state)):
+            return SubmissionValidation(
+                accepted=False,
+                rejection_reason=REJECTION_APPROVE_FAILED_GATE,
+            )
+
+    return SubmissionValidation(accepted=True, rejection_reason=None)
 
 
 class SubmitReviewVerdictParams(BaseModel):
@@ -76,6 +216,14 @@ def submit_review_verdict_tool(ctx: ToolContext):
                 "terminal submission conflict: a different verdict payload was already "
                 "recorded for this run"
             )
+            raise ValueError(msg)
+
+        validation = validate_submission(
+            dict(params),
+            state=validation_state_from_tool_context(ctx),
+        )
+        if not validation.accepted:
+            msg = f"terminal submission rejected: {validation.rejection_reason}"
             raise ValueError(msg)
 
         submission = TerminalSubmission(
@@ -144,4 +292,17 @@ def submit_review_verdict_tool(ctx: ToolContext):
     )
 
 
-__all__ = ["SubmitReviewVerdictParams", "submit_review_verdict_tool"]
+__all__ = [
+    "REJECTION_APPROVE_CONFIRMED_BLOCKER",
+    "REJECTION_APPROVE_FAILED_GATE",
+    "REJECTION_CONFLICTING_SUBMISSION",
+    "REJECTION_INVALID_VERDICT",
+    "REJECTION_MISSING_REQUIRED_FIELDS",
+    "REJECTION_REQUEST_CHANGES_NO_FINDINGS",
+    "REJECTION_UNKNOWN_FIELDS",
+    "SubmissionValidation",
+    "SubmitReviewVerdictParams",
+    "submit_review_verdict_tool",
+    "validate_submission",
+    "validation_state_from_tool_context",
+]

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -81,11 +81,10 @@ def _static_checks_from_state(state: Any) -> list[dict[str, str]]:
     return []
 
 
-def validation_state_from_tool_context(ctx: ToolContext) -> Any:
+def validation_state_from_tool_state(tool_state: Any) -> Any:
     """Build the duck-typed consultation object ``validate_submission`` reads."""
     from types import SimpleNamespace
 
-    tool_state = ctx.tool_state
     state = SimpleNamespace(
         terminal_submission=tool_state.terminal_submission,
         terminal_submission_conflict=tool_state.terminal_submission_conflict,
@@ -93,10 +92,15 @@ def validation_state_from_tool_context(ctx: ToolContext) -> Any:
         static_checks=[dict(row) for row in tool_state.static_checks if isinstance(row, dict)],
         withdrawn_fingerprints=set(),
         tool_state=tool_state,
-        analyzer_run=tool_state.analyzer_run,
+        analyzer_run=getattr(tool_state, "analyzer_run", None),
     )
     state.confirmed_findings = _confirmed_findings_from_state(state)
     return state
+
+
+def validation_state_from_tool_context(ctx: ToolContext) -> Any:
+    """Build the consultation object from a live ``ToolContext``."""
+    return validation_state_from_tool_state(ctx.tool_state)
 
 
 def validate_submission(submission: dict[str, Any], *, state: Any) -> SubmissionValidation:

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -293,6 +293,34 @@ def record_validated_terminal_submission(
     return recorded
 
 
+def recorded_submission_payload(submission: Any) -> dict[str, Any]:
+    findings: list[Any] = []
+    for item in submission.findings:
+        if hasattr(item, "model_dump"):
+            findings.append(item.model_dump(mode="json"))
+        else:
+            findings.append(item)
+    return {
+        "verdict": submission.verdict,
+        "summary": submission.summary,
+        "findings": findings,
+    }
+
+
+def revalidate_recorded_submission(ctx: ToolContext) -> None:
+    """Reject a stored verdict that current evidence has made unusable."""
+    submission = ctx.tool_state.terminal_submission
+    if submission is None:
+        return
+    validation = validate_submission(
+        recorded_submission_payload(submission),
+        state=validation_state_from_tool_context(ctx),
+    )
+    if not validation.accepted:
+        msg = f"terminal submission rejected: {validation.rejection_reason}"
+        raise ValueError(msg)
+
+
 def submit_review_verdict_tool(ctx: ToolContext):
     async def _run(params: dict[str, Any]) -> dict[str, Any]:
         existing = ctx.tool_state.terminal_submission
@@ -383,6 +411,8 @@ __all__ = [
     "SubmissionValidation",
     "SubmitReviewVerdictParams",
     "record_validated_terminal_submission",
+    "recorded_submission_payload",
+    "revalidate_recorded_submission",
     "submit_review_verdict_tool",
     "validate_submission",
     "validation_state_from_tool_context",

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -89,7 +89,7 @@ def validation_state_from_tool_context(ctx: ToolContext) -> Any:
         terminal_submission=tool_state.terminal_submission,
         terminal_submission_conflict=tool_state.terminal_submission_conflict,
         confirmed_findings=[],
-        static_checks=[],
+        static_checks=[dict(row) for row in tool_state.static_checks if isinstance(row, dict)],
         withdrawn_fingerprints=set(),
         tool_state=tool_state,
         analyzer_run=tool_state.analyzer_run,

--- a/src/mergecraft/mcp/verification.py
+++ b/src/mergecraft/mcp/verification.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.mcp.shared import execute, tool
-from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.mcp.tool_state import AnalyzerRunState, primary_repo_state
 from mergecraft.utils.learnings import learnings_file_path
 
 if TYPE_CHECKING:
@@ -62,6 +62,15 @@ def _learnings_text(ctx: ToolContext) -> str:
     if not candidate.is_file():
         return ""
     return candidate.read_text(encoding="utf-8")
+
+
+def _persist_confirmed_fingerprint(ctx: ToolContext, fingerprint: str) -> None:
+    """Record a live confirm so ``validate_submission`` can see the blocker."""
+    run = ctx.tool_state.analyzer_run
+    if run is None:
+        run = AnalyzerRunState(ran=True)
+        ctx.tool_state.analyzer_run = run
+    run.verified_ids.add(fingerprint)
 
 
 def _run_lane(ctx: ToolContext) -> str | None:
@@ -215,6 +224,16 @@ def record_finding_verdict_tool(ctx: ToolContext):
         outcome = record_verifier_verdict(verdict, learnings_path=Path(path))
         if outcome.recorded_withdrawn:
             ctx.tool_state.was_updated = True
+        if outcome.verdict == "confirm" and outcome.publishable:
+            _persist_confirmed_fingerprint(ctx, outcome.fingerprint)
+        elif outcome.verdict == "downgrade" and outcome.publishable:
+            from mergecraft.agents.gates import BLOCKING_SEVERITIES
+
+            new_severity = verdict.new_severity
+            if new_severity in BLOCKING_SEVERITIES:
+                _persist_confirmed_fingerprint(ctx, outcome.fingerprint)
+            elif ctx.tool_state.analyzer_run is not None:
+                ctx.tool_state.analyzer_run.verified_ids.discard(outcome.fingerprint)
         return {
             "recorded": True,
             "fingerprint": outcome.fingerprint,

--- a/src/mergecraft/mcp/verification.py
+++ b/src/mergecraft/mcp/verification.py
@@ -64,13 +64,47 @@ def _learnings_text(ctx: ToolContext) -> str:
     return candidate.read_text(encoding="utf-8")
 
 
-def _persist_confirmed_fingerprint(ctx: ToolContext, fingerprint: str) -> None:
-    """Record a live confirm so ``validate_submission`` can see the blocker."""
+def _persist_confirmed_fingerprint(
+    ctx: ToolContext,
+    fingerprint: str,
+    *,
+    severity: str | None = None,
+) -> None:
+    """Record a live confirm outside replaceable ``analyzer_run`` state."""
+    ctx.tool_state.verified_ids.add(fingerprint)
     run = ctx.tool_state.analyzer_run
     if run is None:
         run = AnalyzerRunState(ran=True)
         ctx.tool_state.analyzer_run = run
     run.verified_ids.add(fingerprint)
+    row = _finding_row_for_fingerprint(ctx, fingerprint)
+    if row is None:
+        if not severity:
+            return
+        row = {"fingerprint": fingerprint, "severity": severity}
+    else:
+        row.setdefault("fingerprint", fingerprint)
+        if severity:
+            row["severity"] = severity
+    existing = {
+        item.get("fingerprint")
+        for item in ctx.tool_state.confirmed_findings
+        if isinstance(item, dict)
+    }
+    if fingerprint not in existing:
+        ctx.tool_state.confirmed_findings.append(row)
+
+
+def _finding_row_for_fingerprint(ctx: ToolContext, fingerprint: str) -> dict[str, Any] | None:
+    run = ctx.tool_state.analyzer_run
+    if run is not None:
+        for item in run.findings:
+            if isinstance(item, dict) and item.get("fingerprint") == fingerprint:
+                return dict(item)
+    for item in ctx.tool_state.agent_findings:
+        if item.get("fingerprint") == fingerprint:
+            return dict(item)
+    return None
 
 
 def _run_lane(ctx: ToolContext) -> str | None:
@@ -123,6 +157,16 @@ def verify_agent_findings_tool(ctx: ToolContext):
             )
             for row in (params.get("findings") or [])
         ]
+        stored: dict[str, dict[str, Any]] = {}
+        for item in ctx.tool_state.agent_findings:
+            fingerprint = item.get("fingerprint") if isinstance(item, dict) else None
+            if isinstance(fingerprint, str) and fingerprint:
+                stored[fingerprint] = item
+        for finding in findings:
+            row = finding.model_dump(mode="json")
+            row["fingerprint"] = finding.identity()
+            stored[str(row["fingerprint"])] = row
+        ctx.tool_state.agent_findings = list(stored.values())
         plan = plan_agent_verifications(
             findings,
             budget=settings.inline_budget,
@@ -231,9 +275,20 @@ def record_finding_verdict_tool(ctx: ToolContext):
 
             new_severity = verdict.new_severity
             if new_severity in BLOCKING_SEVERITIES:
-                _persist_confirmed_fingerprint(ctx, outcome.fingerprint)
-            elif ctx.tool_state.analyzer_run is not None:
-                ctx.tool_state.analyzer_run.verified_ids.discard(outcome.fingerprint)
+                _persist_confirmed_fingerprint(
+                    ctx,
+                    outcome.fingerprint,
+                    severity=new_severity,
+                )
+            else:
+                ctx.tool_state.verified_ids.discard(outcome.fingerprint)
+                if ctx.tool_state.analyzer_run is not None:
+                    ctx.tool_state.analyzer_run.verified_ids.discard(outcome.fingerprint)
+                ctx.tool_state.confirmed_findings = [
+                    row
+                    for row in ctx.tool_state.confirmed_findings
+                    if row.get("fingerprint") != outcome.fingerprint
+                ]
         return {
             "recorded": True,
             "fingerprint": outcome.fingerprint,

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -396,10 +396,12 @@ def _is_incomplete_review_success(
     """
     if tool_state is None or not result.success or result.terminal_submission_received:
         return False
-    from mergecraft.main_outcome import _is_review_mode
+    from mergecraft.main_outcome import _is_incremental_review, _is_review_mode
 
     mode = tool_state.selected_mode
     if mode is not None and not _is_review_mode(mode):
+        return False
+    if _is_incremental_review(mode) and tool_state.final_summary_written:
         return False
     submission = tool_state.terminal_submission
     if submission is not None and not tool_state.terminal_submission_conflict:

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -385,6 +385,28 @@ def _is_retryable_failure(result: AgentResult) -> bool:
     return retryable is True
 
 
+def _is_incomplete_review_success(
+    result: AgentResult,
+    tool_state: ToolState | None,
+) -> bool:
+    """True when a successful provider result is not a usable review winner.
+
+    Scripted chain tests that omit ``tool_state`` keep success=True winner
+    semantics. The live orchestrator always passes ``tool_state``.
+    """
+    if tool_state is None or not result.success or result.terminal_submission_received:
+        return False
+    from mergecraft.main_outcome import _is_review_mode
+
+    mode = tool_state.selected_mode
+    if mode is not None and not _is_review_mode(mode):
+        return False
+    submission = tool_state.terminal_submission
+    if submission is not None and not tool_state.terminal_submission_conflict:
+        return bool((result.diagnostics or {}).get("rejection_reason"))
+    return True
+
+
 def _attach_model_evidence(
     result: AgentResult,
     *,
@@ -583,10 +605,32 @@ async def run_with_model_chain(
                 ) as _call_span:
                     pass
 
-                if result.success:
+                incomplete = _is_incomplete_review_success(result, tool_state)
+                can_advance_incomplete = (
+                    incomplete and settings.allow_fallback and chain_index < len(chain) - 1
+                )
+                if result.success and not can_advance_incomplete:
                     attempt_span.set_status("ok")
                     terminal_status = "ok"
-                    logger.info("» model chain succeeded slug={}", slug)
+                    if incomplete:
+                        logger.warning(
+                            "» model chain slug={} succeeded without a usable terminal verdict",
+                            slug,
+                        )
+                    else:
+                        logger.info("» model chain succeeded slug={}", slug)
+                elif result.success and can_advance_incomplete:
+                    nxt = chain[chain_index + 1]
+                    attempt_span.set_status("retryable", "no terminal review verdict")
+                    terminal_status = "retryable"
+                    logger.warning(
+                        "model fallback occurred: requested={} skipped "
+                        "(no terminal verdict); advancing to executed={} "
+                        "(fallback_index={})",
+                        requested_model or slug,
+                        nxt,
+                        chain_index + 1,
+                    )
                 elif not _is_retryable_failure(result):
                     attempt_span.set_status("error", result.error or "unknown error")
                     terminal_status = "error"

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -419,3 +419,56 @@ async def test_model_chain_resets_terminal_submission_on_fallback(
     assert recorded.attempt_id == 1
     assert recorded.summary == "Fallback model recorded the verdict."
     assert ctx.tool_state.terminal_submission_conflict is False
+
+
+@pytest.mark.asyncio
+async def test_model_chain_advances_when_first_success_has_no_terminal_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A process-successful first slug with no submit must not win the chain."""
+    from mergecraft.agents.shared import AgentResult
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.utils.agent_resolve import run_with_model_chain
+
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.selected_mode = "Review"
+    calls: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        calls.append(slug)
+        if slug.startswith("openai/"):
+            return AgentResult(success=True, output="LGTM — looks good to me.")
+        recorded = await _submit(ctx, _valid_payload())
+        assert recorded.is_error is False
+        submission = ctx.tool_state.terminal_submission
+        assert submission is not None
+        return AgentResult(
+            success=True,
+            output="review complete",
+            terminal_submission_received=True,
+            terminal_submission_id=submission.id,
+        )
+
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    winning_slug, result = await run_with_model_chain(
+        settings=settings,
+        run_once=run_once,
+        tool_state=ctx.tool_state,
+    )
+
+    assert calls == ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]
+    assert winning_slug == "google/gemini-3.1-pro-preview"
+    assert result.success is True
+    assert result.terminal_submission_received is True
+    recorded = ctx.tool_state.terminal_submission
+    assert recorded is not None
+    assert recorded.attempt_id == 1

--- a/tests/mcp/test_submit_review_verdict.py
+++ b/tests/mcp/test_submit_review_verdict.py
@@ -472,3 +472,46 @@ async def test_model_chain_advances_when_first_success_has_no_terminal_verdict(
     recorded = ctx.tool_state.terminal_submission
     assert recorded is not None
     assert recorded.attempt_id == 1
+
+
+@pytest.mark.asyncio
+async def test_model_chain_does_not_advance_after_incremental_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IncrementalReview ``report_progress`` is a complete result; do not fallback."""
+    from mergecraft.agents.shared import AgentResult
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.utils.agent_resolve import run_with_model_chain
+
+    monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.selected_mode = "IncrementalReview"
+    calls: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        calls.append(slug)
+        if not slug.startswith("openai/"):
+            raise AssertionError(f"fallback model {slug} must not run")
+        ctx.tool_state.final_summary_written = True
+        return AgentResult(success=True, output="no new findings")
+
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    winning_slug, result = await run_with_model_chain(
+        settings=settings,
+        run_once=run_once,
+        tool_state=ctx.tool_state,
+    )
+
+    assert calls == ["openai/gpt-5.3-codex"]
+    assert winning_slug == "openai/gpt-5.3-codex"
+    assert result.success is True
+    assert ctx.tool_state.final_summary_written is True
+    assert ctx.tool_state.terminal_submission is None

--- a/tests/review/__init__.py
+++ b/tests/review/__init__.py
@@ -1,0 +1,1 @@
+"""Review-integrity suites (terminal verdict, fail-closed outcome)."""

--- a/tests/review/test_post_run_terminal_gate.py
+++ b/tests/review/test_post_run_terminal_gate.py
@@ -1,9 +1,9 @@
 """VP2 fail-closed post-run gate — unsubmitted review without a progress comment.
 
 Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
-impl). V4: ``get_unsubmitted_review`` must gate Review / IncrementalReview even
-when ``had_progress_comment`` is false, and retry exhaustion must not fall
-through to ``passed``.
+impl; xfail markers cleared after VP2.2). V4: ``get_unsubmitted_review`` must
+gate Review / IncrementalReview even when ``had_progress_comment`` is false,
+and retry exhaustion must not fall through to ``passed``.
 """
 
 from __future__ import annotations
@@ -27,11 +27,6 @@ from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_VP22 = pytest.mark.xfail(
-    reason="green after VP2.2: fail-closed terminal verdict",
-    strict=False,
-)
 
 _MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
 
@@ -91,7 +86,6 @@ def _recorded_submission() -> TerminalSubmission:
     )
 
 
-@_VP22
 def test_unsubmitted_review_without_progress_comment_still_gates(tmp_path: Path) -> None:
     """V4: Review / IncrementalReview gate on ``terminal_submission``, not ``review``.
 
@@ -117,7 +111,6 @@ def test_unsubmitted_review_without_progress_comment_still_gates(tmp_path: Path)
     assert get_unsubmitted_review(state) is None
 
 
-@_VP22
 @pytest.mark.asyncio
 async def test_retry_exhaustion_yields_inconclusive_not_passed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/review/test_post_run_terminal_gate.py
+++ b/tests/review/test_post_run_terminal_gate.py
@@ -1,0 +1,156 @@
+"""VP2 fail-closed post-run gate — unsubmitted review without a progress comment.
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
+impl). V4: ``get_unsubmitted_review`` must gate Review / IncrementalReview even
+when ``had_progress_comment`` is false, and retry exhaustion must not fall
+through to ``passed``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents.post_run import get_unsubmitted_review, run_post_run_retry_loop
+from mergecraft.agents.shared import (
+    MAX_POST_RUN_RETRIES,
+    AgentResult,
+    AgentRunContext,
+    ResolvedInstructions,
+)
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import ReviewRecord, TerminalSubmission, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.run_outcome import RunOutcome, run_succeeded_for_outcome
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_VP22 = pytest.mark.xfail(
+    reason="green after VP2.2: fail-closed terminal verdict",
+    strict=False,
+)
+
+_MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
+
+
+def _tool_ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def _run_ctx(tool_ctx: ToolContext) -> AgentRunContext:
+    return AgentRunContext(
+        payload=tool_ctx.payload,
+        mcp_server_url=tool_ctx.mcp_server_url,
+        tmpdir=tool_ctx.tmpdir,
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(),
+        tool_state=tool_ctx.tool_state,
+    )
+
+
+def _classify(result: AgentResult, *, mode: str = "Review") -> tuple[RunOutcome, str | None]:
+    from mergecraft.main_outcome import _classify_outcome
+
+    outcome, reason = _classify_outcome(
+        result=result,
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        mode=mode,
+    )
+    return outcome, reason
+
+
+def _recorded_submission() -> TerminalSubmission:
+    return TerminalSubmission(
+        id="sub-recorded",
+        verdict="approve",
+        summary="No blocking issues in the diff.",
+        findings=[],
+        payload_hash="abc",
+        submitted_at="2026-08-16T00:00:00+00:00",
+        attempt_id=0,
+    )
+
+
+@_VP22
+def test_unsubmitted_review_without_progress_comment_still_gates(tmp_path: Path) -> None:
+    """V4: Review / IncrementalReview gate on ``terminal_submission``, not ``review``.
+
+    ``had_progress_comment`` is false. A legacy ``ReviewRecord`` must not satisfy
+    the gate — only a recorded ``TerminalSubmission`` does.
+    """
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    state.had_progress_comment = False
+    state.review = ReviewRecord(id=99, node_id="legacy", reviewed_sha="abc")
+    assert state.terminal_submission is None
+
+    state.selected_mode = "Review"
+    assert get_unsubmitted_review(state) == "Review"
+
+    state.selected_mode = "IncrementalReview"
+    state.final_summary_written = False
+    assert get_unsubmitted_review(state) == "IncrementalReview"
+
+    state.terminal_submission = _recorded_submission()
+    state.selected_mode = "Review"
+    assert get_unsubmitted_review(state) is None
+    state.selected_mode = "IncrementalReview"
+    assert get_unsubmitted_review(state) is None
+
+
+@_VP22
+@pytest.mark.asyncio
+async def test_retry_exhaustion_yields_inconclusive_not_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """V4: exhausting the post-run retry loop must not fall through to ``passed``."""
+    monkeypatch.setattr("mergecraft.agents.post_run.get_git_status", lambda: "")
+
+    tool_ctx = _tool_ctx(tmp_path)
+    tool_ctx.tool_state.selected_mode = "Review"
+    tool_ctx.tool_state.had_progress_comment = False
+    assert tool_ctx.tool_state.terminal_submission is None
+
+    prompts: list[str] = []
+
+    async def resume(prompt: str) -> AgentResult:
+        prompts.append(prompt)
+        return AgentResult(
+            success=True,
+            output="still no terminal verdict",
+            terminal_submission_received=False,
+        )
+
+    final = await run_post_run_retry_loop(
+        _run_ctx(tool_ctx),
+        initial=AgentResult(success=True, output="done", terminal_submission_received=False),
+        resume=resume,
+    )
+    assert len(prompts) == MAX_POST_RUN_RETRIES
+    assert final.terminal_submission_received is False
+
+    outcome, reason = _classify(final, mode="Review")
+    assert outcome is not RunOutcome.passed
+    assert outcome is RunOutcome.inconclusive
+    assert outcome is not RunOutcome.failed
+    assert reason == _MISSING_VERDICT_REASON
+    assert run_succeeded_for_outcome(outcome) is False

--- a/tests/review/test_post_run_terminal_gate.py
+++ b/tests/review/test_post_run_terminal_gate.py
@@ -61,7 +61,9 @@ def _run_ctx(tool_ctx: ToolContext) -> AgentRunContext:
     )
 
 
-def _classify(result: AgentResult, *, mode: str = "Review") -> tuple[RunOutcome, str | None]:
+def _classify(
+    result: AgentResult, *, mode: str = "Review", final_summary_written: bool = False
+) -> tuple[RunOutcome, str | None]:
     from mergecraft.main_outcome import _classify_outcome
 
     outcome, reason = _classify_outcome(
@@ -70,6 +72,7 @@ def _classify(result: AgentResult, *, mode: str = "Review") -> tuple[RunOutcome,
         setup_policy="warn",
         prep_reason=None,
         mode=mode,
+        final_summary_written=final_summary_written,
     )
     return outcome, reason
 
@@ -109,6 +112,31 @@ def test_unsubmitted_review_without_progress_comment_still_gates(tmp_path: Path)
     assert get_unsubmitted_review(state) is None
     state.selected_mode = "IncrementalReview"
     assert get_unsubmitted_review(state) is None
+
+
+def test_incremental_review_progress_without_terminal_is_complete(tmp_path: Path) -> None:
+    """IncrementalReview may complete via ``report_progress`` without a terminal verdict."""
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    state.selected_mode = "IncrementalReview"
+    state.final_summary_written = True
+    assert state.terminal_submission is None
+    assert get_unsubmitted_review(state) is None
+
+    result = AgentResult(success=True, terminal_submission_received=False)
+    outcome, reason = _classify(result, mode="IncrementalReview", final_summary_written=True)
+    assert outcome is RunOutcome.passed
+    assert reason is None
+    assert run_succeeded_for_outcome(outcome) is True
+
+
+def test_review_nudge_instructs_submit_review_verdict() -> None:
+    from mergecraft.agents.post_run import build_unsubmitted_review_prompt
+
+    review_prompt = build_unsubmitted_review_prompt("Review")
+    assert "submit_review_verdict" in review_prompt
+    incremental_prompt = build_unsubmitted_review_prompt("IncrementalReview")
+    assert "submit_review_verdict" in incremental_prompt
+    assert "report_progress" in incremental_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -38,7 +38,7 @@ from mergecraft.mcp.context import (
 )
 from mergecraft.mcp.review import create_pull_request_review_tool
 from mergecraft.mcp.shared import ToolResult
-from mergecraft.mcp.static_checks import run_static_checks_tool
+from mergecraft.mcp.static_checks import _persist_static_checks, run_static_checks_tool
 from mergecraft.mcp.tool_state import AnalyzerRunState, init_tool_state, primary_repo_state
 from mergecraft.modes import compute_modes
 from mergecraft.review_checks import StaticCheckConfig
@@ -573,10 +573,6 @@ def test_approve_with_failing_required_deterministic_check_fails(tmp_path: Path)
     _assert_typed_rejection(validation, _REASON_APPROVE_FAILED_GATE)
 
 
-@pytest.mark.xfail(
-    reason="green after VP2.3: persist static_checks on ToolState",
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_approve_after_failed_run_static_checks_tool_is_rejected(
     tmp_path: Path,
@@ -601,6 +597,11 @@ async def test_approve_after_failed_run_static_checks_tool_is_rejected(
     assert checks_result.is_error is False
     payload = json.loads(checks_result.content[0]["text"])
     assert any(check.get("status") == "failed" for check in payload["checks"])
+    # Direct pin: `_persist_static_checks` must have written the failed row
+    # onto ToolState. Deleting the helper fails this import; skipping the
+    # write leaves `tool_state.static_checks` without a failed row.
+    assert callable(_persist_static_checks)
+    assert any(row.get("status") == "failed" for row in ctx.tool_state.static_checks)
 
     verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
     assert verdict.is_error is True

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -117,6 +117,7 @@ def _classify(
     result: AgentResult,
     *,
     mode: str = "Review",
+    final_summary_written: bool = False,
 ) -> tuple[RunOutcome, str | None]:
     """Drive the real ``_classify_outcome`` with the VP2 ``mode`` parameter."""
     from mergecraft.main_outcome import _classify_outcome
@@ -127,6 +128,7 @@ def _classify(
         setup_policy="warn",
         prep_reason=None,
         mode=mode,
+        final_summary_written=final_summary_written,
     )
     return outcome, reason
 
@@ -356,6 +358,7 @@ async def test_live_confirm_blocks_approve_via_verified_ids(tmp_path: Path) -> N
 
     assert callable(_persist_confirmed_fingerprint)
     assert blocker.fingerprint in ctx.tool_state.analyzer_run.verified_ids
+    assert blocker.fingerprint in ctx.tool_state.verified_ids
 
     derived = validation_state_from_tool_context(ctx)
     _assert_typed_rejection(
@@ -366,6 +369,80 @@ async def test_live_confirm_blocks_approve_via_verified_ids(tmp_path: Path) -> N
     assert verdict.is_error is True
     assert _REASON_APPROVE_CONFIRMED_BLOCKER in verdict.content[0]["text"]
     assert ctx.tool_state.terminal_submission is None
+
+
+@pytest.mark.asyncio
+async def test_live_agent_confirm_blocks_approve_without_analyzer_findings(
+    tmp_path: Path,
+) -> None:
+    """A confirmed agent-authored blocker must reject approve without seeding analyzer findings."""
+    from mergecraft.mcp.verdict import (
+        submit_review_verdict_tool,
+        validation_state_from_tool_context,
+    )
+    from mergecraft.mcp.verification import record_finding_verdict_tool, verify_agent_findings_tool
+
+    finding = _agent_blocker()
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = AnalyzerRunState(ran=True, findings=[], verified_ids=set())
+    planned = await verify_agent_findings_tool(ctx).execute({"findings": [finding.model_dump()]})
+    assert planned.is_error is False
+    recorded = await record_finding_verdict_tool(ctx).execute(
+        {
+            "fingerprint": finding.fingerprint,
+            "verdict": "confirm",
+            "reason": "Reproduced the secret leak.",
+        }
+    )
+    assert recorded.is_error is False
+    assert finding.fingerprint in ctx.tool_state.verified_ids
+    assert ctx.tool_state.analyzer_run.findings == []
+
+    derived = validation_state_from_tool_context(ctx)
+    _assert_typed_rejection(
+        _validate(_approve_payload(), state=derived),
+        _REASON_APPROVE_CONFIRMED_BLOCKER,
+    )
+    verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert verdict.is_error is True
+    assert _REASON_APPROVE_CONFIRMED_BLOCKER in verdict.content[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_survives_analyzer_rerun(tmp_path: Path) -> None:
+    """A later ``run_analyzers`` replace must not drop a confirmed blocker."""
+    from mergecraft.mcp.analyzers import _store_run_state
+    from mergecraft.mcp.verdict import (
+        submit_review_verdict_tool,
+        validation_state_from_tool_context,
+    )
+    from mergecraft.mcp.verification import record_finding_verdict_tool
+
+    blocker = _blocker_finding()
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = AnalyzerRunState(
+        ran=True,
+        findings=[blocker.model_dump()],
+        verified_ids=set(),
+    )
+    recorded = await record_finding_verdict_tool(ctx).execute(
+        {
+            "fingerprint": blocker.fingerprint,
+            "verdict": "confirm",
+            "reason": "Reproduced the secret leak.",
+        }
+    )
+    assert recorded.is_error is False
+    _store_run_state(ctx, AnalyzerRunState(ran=True, findings=[], verified_ids=set()))
+    assert blocker.fingerprint in ctx.tool_state.verified_ids
+    derived = validation_state_from_tool_context(ctx)
+    _assert_typed_rejection(
+        _validate(_approve_payload(), state=derived),
+        _REASON_APPROVE_CONFIRMED_BLOCKER,
+    )
+    verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert verdict.is_error is True
+    assert _REASON_APPROVE_CONFIRMED_BLOCKER in verdict.content[0]["text"]
 
 
 def test_request_changes_with_verified_blocker_blocks(tmp_path: Path) -> None:
@@ -810,6 +887,8 @@ async def test_existing_review_and_comment_behaviour_unchanged(tmp_path: Path) -
     assert first.is_error is False
     assert ctx.tool_state.review is not None
     assert ctx.tool_state.review.id == 1
+    assert ctx.tool_state.terminal_submission is not None
+    assert ctx.tool_state.terminal_submission.verdict == "request_changes"
     inline = github.review_payloads[0].get("comments") or []
     assert inline
     expected_fp = finding_fingerprint(path="src/app.py", body="A finding.")

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -1,8 +1,7 @@
 """VP2 fail-closed terminal verdict — policy, validator, and outcome resolver.
 
 Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
-impl). Unimplemented contracts are marked
-``xfail(reason="green after VP2.2: fail-closed terminal verdict", strict=False)``.
+impl; xfail markers cleared after VP2.2).
 
 Pinned contracts (W0):
     D2 — missing verdict → ``RunOutcome.inconclusive``, not ``failed``.
@@ -46,11 +45,6 @@ from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_VP22 = pytest.mark.xfail(
-    reason="green after VP2.2: fail-closed terminal verdict",
-    strict=False,
-)
 
 _MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
 _DECIDE_APPROVAL_PARAMS = ("findings", "run_succeeded", "tier")
@@ -274,10 +268,15 @@ class _RecordingGitHub(GitHubClient):
         return record
 
 
-@_VP22
 def test_valid_approve_and_clear_gates_succeeds(tmp_path: Path) -> None:
     """A schema-valid ``approve`` with no blockers and passing gates is accepted."""
+    from mergecraft.mcp.verdict import validation_state_from_tool_context
+
     ctx = _ctx(tmp_path)
+    derived = validation_state_from_tool_context(ctx)
+    assert derived.tool_state is ctx.tool_state
+    assert derived.analyzer_run is ctx.tool_state.analyzer_run
+    assert derived.terminal_submission is ctx.tool_state.terminal_submission
     state = _validation_state(ctx.tool_state, static_checks=[{"name": "lint", "status": "passed"}])
     validation = _validate(_approve_payload(), state=state)
     assert isinstance(validation, _validation_type())
@@ -296,7 +295,6 @@ def test_valid_approve_and_clear_gates_succeeds(tmp_path: Path) -> None:
     assert decide_approval([_trivial_finding()], run_succeeded=True, tier="trusted") == "success"
 
 
-@_VP22
 def test_agent_approve_with_verified_blocker_fails_structurally(tmp_path: Path) -> None:
     """``approve`` over a verifier-confirmed Critical/Major finding is rejected."""
     blocker = _blocker_finding()
@@ -314,7 +312,6 @@ def test_agent_approve_with_verified_blocker_fails_structurally(tmp_path: Path) 
     assert conclusion == "failure"
 
 
-@_VP22
 def test_request_changes_with_verified_blocker_blocks(tmp_path: Path) -> None:
     """``request_changes`` with a confirmed blocker is a usable verdict; the gate blocks."""
     blocker = _blocker_finding()
@@ -336,10 +333,17 @@ def test_request_changes_with_verified_blocker_blocks(tmp_path: Path) -> None:
     assert decide_approval([blocker], run_succeeded=True, tier="trusted") == "failure"
 
 
-@_VP22
 def test_no_terminal_submission_is_inconclusive() -> None:
     """D2: a successful provider result with no terminal verdict is ``inconclusive``."""
+    from mergecraft.main_outcome import _is_review_mode
+
     _assert_run_outcome_not_widened()
+    assert _is_review_mode("Review") is True
+    assert _is_review_mode("IncrementalReview") is True
+    assert _is_review_mode("Build") is False
+    assert _is_review_mode(None) is False
+    review_mode = next(m for m in compute_modes("claude") if m.name == "Review")
+    assert _is_review_mode(review_mode) is True
     result = AgentResult(success=True, terminal_submission_received=False)
     assert result.success is True
     assert result.terminal_submission_received is False
@@ -355,7 +359,6 @@ def test_no_terminal_submission_is_inconclusive() -> None:
     assert build_outcome is RunOutcome.passed
 
 
-@_VP22
 def test_prose_lgtm_without_terminal_call_cannot_approve() -> None:
     """Narrative ``LGTM`` is not an input to ``decide_approval`` and cannot pass a review."""
     _assert_decide_approval_signature_unchanged()
@@ -383,7 +386,6 @@ def test_prose_lgtm_without_terminal_call_cannot_approve() -> None:
     assert conclusion != "success"
 
 
-@_VP22
 def test_invalid_verdict_enum_rejected(tmp_path: Path) -> None:
     """Schema: ``\"lgtm\"`` is not a verdict — typed rejection, not a bool."""
     ctx = _ctx(tmp_path)
@@ -394,7 +396,6 @@ def test_invalid_verdict_enum_rejected(tmp_path: Path) -> None:
     _assert_typed_rejection(validation, _REASON_INVALID_VERDICT)
 
 
-@_VP22
 def test_unknown_fields_rejected(tmp_path: Path) -> None:
     """Schema: an unrecognized key is a typed rejection, not a silent drop."""
     ctx = _ctx(tmp_path)
@@ -405,7 +406,6 @@ def test_unknown_fields_rejected(tmp_path: Path) -> None:
     _assert_typed_rejection(validation, _REASON_UNKNOWN_FIELDS)
 
 
-@_VP22
 def test_missing_required_fields_rejected(tmp_path: Path) -> None:
     """Schema: absent ``summary`` / ``verdict`` is a typed rejection."""
     ctx = _ctx(tmp_path)
@@ -417,7 +417,6 @@ def test_missing_required_fields_rejected(tmp_path: Path) -> None:
         _assert_typed_rejection(validation, _REASON_MISSING_REQUIRED)
 
 
-@_VP22
 def test_request_changes_with_no_findings_is_semantically_rejected(tmp_path: Path) -> None:
     """D9: ``request_changes`` with zero findings is a semantic rejection."""
     ctx = _ctx(tmp_path)
@@ -434,7 +433,6 @@ def test_request_changes_with_no_findings_is_semantically_rejected(tmp_path: Pat
     assert validation.rejection_reason != _REASON_MISSING_REQUIRED
 
 
-@_VP22
 @pytest.mark.asyncio
 async def test_duplicate_conflicting_submissions_fail_closed(tmp_path: Path) -> None:
     """D4: a differing payload is rejected and the attempt is unusable."""
@@ -463,7 +461,6 @@ async def test_duplicate_conflicting_submissions_fail_closed(tmp_path: Path) -> 
     assert run_succeeded_for_outcome(outcome) is False
 
 
-@_VP22
 @pytest.mark.asyncio
 async def test_identical_resubmission_is_idempotent(tmp_path: Path) -> None:
     """D4: the same payload hash returns the original id and remains a usable verdict."""
@@ -493,7 +490,6 @@ async def test_identical_resubmission_is_idempotent(tmp_path: Path) -> None:
     assert run_succeeded_for_outcome(outcome) is True
 
 
-@_VP22
 def test_provider_success_without_verdict_is_not_a_successful_review() -> None:
     """V3: ``_classify_outcome`` must not return ``passed`` when no verdict was submitted."""
     result = AgentResult(success=True, output="done", terminal_submission_received=False)
@@ -504,7 +500,6 @@ def test_provider_success_without_verdict_is_not_a_successful_review() -> None:
     assert run_succeeded_for_outcome(outcome) is False
 
 
-@_VP22
 def test_missing_verdict_leaves_run_fallback_eligible(tmp_path: Path) -> None:
     """D8 / D13: absence and semantic rejection both leave ``received=False``."""
     missing = AgentResult(success=True, terminal_submission_received=False)
@@ -536,7 +531,6 @@ def test_missing_verdict_leaves_run_fallback_eligible(tmp_path: Path) -> None:
     assert rejected_outcome is not RunOutcome.failed
 
 
-@_VP22
 def test_fresh_valid_verdict_does_not_trigger_fallback() -> None:
     """A usable terminal submission is not fallback-eligible (D13)."""
     result = AgentResult(
@@ -551,13 +545,18 @@ def test_fresh_valid_verdict_does_not_trigger_fallback() -> None:
     assert run_succeeded_for_outcome(outcome) is True
 
 
-@_VP22
 def test_approve_with_failing_required_deterministic_check_fails(tmp_path: Path) -> None:
     """``approve`` with a failed required ``run_static_checks`` gate is rejected."""
+    from mergecraft.agents.gates import has_failed_required_static_check
+
     ctx = _ctx(tmp_path)
+    failed_rows = [{"name": "lint", "status": "failed"}]
+    assert has_failed_required_static_check(failed_rows) is True
+    assert has_failed_required_static_check([{"name": "lint", "status": "passed"}]) is False
+    assert has_failed_required_static_check([]) is False
     state = _validation_state(
         ctx.tool_state,
-        static_checks=[{"name": "lint", "status": "failed"}],
+        static_checks=failed_rows,
     )
     validation = _validate(_approve_payload(), state=state)
     _assert_typed_rejection(validation, _REASON_APPROVE_FAILED_GATE)
@@ -658,7 +657,6 @@ async def test_existing_review_and_comment_behaviour_unchanged(tmp_path: Path) -
     assert ctx.tool_state.last_progress_body == "still working"
 
 
-@_VP22
 def test_both_harness_paths_obey_the_same_contract() -> None:
     """An OpenCode-shaped and a Codex-shaped ``AgentResult`` reach the same outcome."""
     opencode = AgentResult(

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -1,0 +1,684 @@
+"""VP2 fail-closed terminal verdict — policy, validator, and outcome resolver.
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
+impl). Unimplemented contracts are marked
+``xfail(reason="green after VP2.2: fail-closed terminal verdict", strict=False)``.
+
+Pinned contracts (W0):
+    D2 — missing verdict → ``RunOutcome.inconclusive``, not ``failed``.
+    D4 — identical resubmit is idempotent; a conflicting payload fails closed.
+    D5 — ``validate_submission`` returns a typed ``SubmissionValidation``, not a bool.
+    D8 — semantic rejection is fallback-eligible (``terminal_submission_received``
+         stays false) and maps to ``inconclusive``.
+    D9 — ``request_changes`` with zero findings is semantically rejected.
+    V3 — provider success without a terminal verdict is not a successful review.
+    Convention 3 — do not widen ``RunOutcome``.
+    Convention 4 — do not change ``decide_approval``'s signature.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.agents.post_run import finalize_agent_result
+from mergecraft.agents.shared import AgentResult, AgentRunContext, AgentUsage, ResolvedInstructions
+from mergecraft.agents.verifier import AgentFinding
+from mergecraft.analyzers.finding import Finding, make_finding
+from mergecraft.mcp.comment import create_issue_comment_tool, report_progress_tool
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.review import create_pull_request_review_tool
+from mergecraft.mcp.shared import ToolResult
+from mergecraft.mcp.tool_state import AnalyzerRunState, init_tool_state, primary_repo_state
+from mergecraft.modes import compute_modes
+from mergecraft.review_taxonomy import FINDING_MARKER_PREFIX, finding_fingerprint
+from mergecraft.run_outcome import RunOutcome, run_succeeded_for_outcome
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_VP22 = pytest.mark.xfail(
+    reason="green after VP2.2: fail-closed terminal verdict",
+    strict=False,
+)
+
+_MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
+_DECIDE_APPROVAL_PARAMS = ("findings", "run_succeeded", "tier")
+_CLOSED_OUTCOMES = frozenset(
+    {
+        "passed",
+        "failed",
+        "inconclusive",
+        "infra_error",
+        "timed_out",
+        "configuration_error",
+    }
+)
+
+# Closed ``rejection_reason`` vocabulary (D5). Schema / semantic / policy stay
+# distinct so a check-run can name which class of rejection fired.
+_REASON_INVALID_VERDICT = "invalid_verdict"
+_REASON_UNKNOWN_FIELDS = "unknown_fields"
+_REASON_MISSING_REQUIRED = "missing_required_fields"
+_REASON_REQUEST_CHANGES_NO_FINDINGS = "request_changes_without_findings"
+_REASON_APPROVE_CONFIRMED_BLOCKER = "approve_with_confirmed_blocker"
+_REASON_APPROVE_FAILED_GATE = "approve_with_failed_required_gate"
+_REASON_CONFLICTING_SUBMISSION = "conflicting_submission"
+
+
+def _ctx(tmp_path: Path, *, issue_number: int | None = 7) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=issue_number, is_pr=True),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+    )
+
+
+def _run_ctx(tool_ctx: ToolContext) -> AgentRunContext:
+    return AgentRunContext(
+        payload=tool_ctx.payload,
+        mcp_server_url=tool_ctx.mcp_server_url,
+        tmpdir=tool_ctx.tmpdir,
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(),
+        tool_state=tool_ctx.tool_state,
+    )
+
+
+def _classify(
+    result: AgentResult,
+    *,
+    mode: str = "Review",
+) -> tuple[RunOutcome, str | None]:
+    """Drive the real ``_classify_outcome`` with the VP2 ``mode`` parameter."""
+    from mergecraft.main_outcome import _classify_outcome
+
+    outcome, reason = _classify_outcome(
+        result=result,
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        mode=mode,
+    )
+    return outcome, reason
+
+
+def _validate(submission: dict[str, Any], *, state: Any) -> Any:
+    """Import ``validate_submission`` inside the body so collection stays green."""
+    from mergecraft.mcp.verdict import validate_submission
+
+    return validate_submission(submission, state=state)
+
+
+def _validation_type() -> type[Any]:
+    from mergecraft.mcp.verdict import SubmissionValidation
+
+    return SubmissionValidation
+
+
+def _validation_state(
+    tool_state: Any,
+    *,
+    confirmed_findings: list[Finding] | None = None,
+    static_checks: list[dict[str, str]] | None = None,
+    withdrawn_fingerprints: frozenset[str] | None = None,
+) -> Any:
+    """Consultation inputs the validator reads (D5 / required-gate rows).
+
+    ``state`` duck-types ``ToolState`` fields plus the VP2.2 surfaces the
+    validator consults: verifier-confirmed findings, ``run_static_checks``
+    status rows, and withdrawn fingerprints.
+    """
+    return SimpleNamespace(
+        terminal_submission=tool_state.terminal_submission,
+        terminal_submission_conflict=tool_state.terminal_submission_conflict,
+        confirmed_findings=list(confirmed_findings or []),
+        static_checks=list(static_checks or []),
+        withdrawn_fingerprints=set(withdrawn_fingerprints or []),
+        tool_state=tool_state,
+        analyzer_run=tool_state.analyzer_run,
+    )
+
+
+def _approve_payload() -> dict[str, Any]:
+    return {
+        "verdict": "approve",
+        "summary": "No blocking issues in the diff.",
+        "findings": [],
+    }
+
+
+def _blocker_finding() -> Finding:
+    return make_finding(
+        tool="vp2-fixture",
+        rule_id="VP2-BLOCKER",
+        category="Security & Privacy",
+        severity="Critical",
+        confidence="certain",
+        message="Secret written to logs.",
+        path="src/app.py",
+        start_line=12,
+        end_line=12,
+        source="agent",
+        evidence=["logger.info(api_key)"],
+        fingerprint="vp2-blocker-cr",
+    )
+
+
+def _trivial_finding() -> Finding:
+    return make_finding(
+        tool="vp2-fixture",
+        rule_id="VP2-NIT",
+        category="Maintainability & Code Quality",
+        severity="Trivial",
+        confidence="possible",
+        message="Missing trailing period in a docstring.",
+        path="src/app.py",
+        start_line=1,
+        end_line=1,
+        source="agent",
+        evidence=["line 1"],
+        fingerprint="vp2-trivial-tr",
+    )
+
+
+def _agent_blocker() -> AgentFinding:
+    return AgentFinding(
+        path="src/app.py",
+        body="Secret written to logs.",
+        severity="Critical",
+        line=12,
+        fingerprint="vp2-blocker-cr",
+    )
+
+
+def _assert_typed_rejection(validation: Any, reason: str) -> None:
+    validation_cls = _validation_type()
+    assert isinstance(validation, validation_cls)
+    assert type(validation) is not bool
+    assert validation.accepted is False
+    assert validation.rejection_reason == reason
+
+
+def _assert_decide_approval_signature_unchanged() -> None:
+    params = inspect.signature(decide_approval).parameters
+    assert tuple(params) == _DECIDE_APPROVAL_PARAMS
+    assert params["run_succeeded"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params["tier"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def _assert_run_outcome_not_widened() -> None:
+    assert {member.value for member in RunOutcome} == _CLOSED_OUTCOMES
+    assert len(RunOutcome) == 6
+
+
+async def _submit_verdict(ctx: ToolContext, payload: dict[str, Any]) -> ToolResult:
+    from mergecraft.mcp.verdict import submit_review_verdict_tool
+
+    return await submit_review_verdict_tool(ctx).execute(payload)
+
+
+class _RecordingGitHub(GitHubClient):
+    """Captures review and comment payloads instead of sending them."""
+
+    def __init__(self) -> None:
+        super().__init__(token="test-token")
+        self.review_payloads: list[dict[str, Any]] = []
+        self.comment_payloads: list[dict[str, Any]] = []
+        self._comment_id = 100
+
+    async def create_review(
+        self, owner: str, repo: str, pull_number: int, **payload: Any
+    ) -> dict[str, Any]:
+        self.review_payloads.append(payload)
+        return {
+            "id": 1,
+            "node_id": "n1",
+            "html_url": "https://example.test/1",
+            "state": payload.get("event") or "COMMENTED",
+        }
+
+    async def create_issue_comment(
+        self, owner: str, repo: str, issue_number: int, body: str
+    ) -> dict[str, Any]:
+        self._comment_id += 1
+        record = {
+            "id": self._comment_id,
+            "html_url": f"https://example.test/comments/{self._comment_id}",
+            "body": body,
+            "issue_number": issue_number,
+        }
+        self.comment_payloads.append(record)
+        return record
+
+
+@_VP22
+def test_valid_approve_and_clear_gates_succeeds(tmp_path: Path) -> None:
+    """A schema-valid ``approve`` with no blockers and passing gates is accepted."""
+    ctx = _ctx(tmp_path)
+    state = _validation_state(ctx.tool_state, static_checks=[{"name": "lint", "status": "passed"}])
+    validation = _validate(_approve_payload(), state=state)
+    assert isinstance(validation, _validation_type())
+    assert validation.accepted is True
+    assert validation.rejection_reason is None
+
+    result = AgentResult(
+        success=True,
+        terminal_submission_received=True,
+        terminal_submission_id="sub-1",
+    )
+    outcome, reason = _classify(result, mode="Review")
+    _assert_run_outcome_not_widened()
+    assert outcome is RunOutcome.passed
+    assert reason is None
+    assert decide_approval([_trivial_finding()], run_succeeded=True, tier="trusted") == "success"
+
+
+@_VP22
+def test_agent_approve_with_verified_blocker_fails_structurally(tmp_path: Path) -> None:
+    """``approve`` over a verifier-confirmed Critical/Major finding is rejected."""
+    blocker = _blocker_finding()
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = AnalyzerRunState(
+        ran=True,
+        findings=[blocker.model_dump()],
+        verified_ids={blocker.fingerprint},
+    )
+    state = _validation_state(ctx.tool_state, confirmed_findings=[blocker])
+    validation = _validate(_approve_payload(), state=state)
+    _assert_typed_rejection(validation, _REASON_APPROVE_CONFIRMED_BLOCKER)
+
+    conclusion = decide_approval([blocker], run_succeeded=True, tier="trusted")
+    assert conclusion == "failure"
+
+
+@_VP22
+def test_request_changes_with_verified_blocker_blocks(tmp_path: Path) -> None:
+    """``request_changes`` with a confirmed blocker is a usable verdict; the gate blocks."""
+    blocker = _blocker_finding()
+    finding = _agent_blocker()
+    ctx = _ctx(tmp_path)
+    state = _validation_state(ctx.tool_state, confirmed_findings=[blocker])
+    validation = _validate(
+        {
+            "verdict": "request_changes",
+            "summary": "One critical finding stands.",
+            "findings": [finding.model_dump()],
+        },
+        state=state,
+    )
+    assert isinstance(validation, _validation_type())
+    assert validation.accepted is True
+    assert validation.rejection_reason is None
+
+    assert decide_approval([blocker], run_succeeded=True, tier="trusted") == "failure"
+
+
+@_VP22
+def test_no_terminal_submission_is_inconclusive() -> None:
+    """D2: a successful provider result with no terminal verdict is ``inconclusive``."""
+    _assert_run_outcome_not_widened()
+    result = AgentResult(success=True, terminal_submission_received=False)
+    assert result.success is True
+    assert result.terminal_submission_received is False
+
+    for mode in ("Review", "IncrementalReview"):
+        outcome, reason = _classify(result, mode=mode)
+        assert outcome is RunOutcome.inconclusive
+        assert outcome is not RunOutcome.failed
+        assert reason == _MISSING_VERDICT_REASON
+        assert run_succeeded_for_outcome(outcome) is False
+
+    build_outcome, _ = _classify(result, mode="Build")
+    assert build_outcome is RunOutcome.passed
+
+
+@_VP22
+def test_prose_lgtm_without_terminal_call_cannot_approve() -> None:
+    """Narrative ``LGTM`` is not an input to ``decide_approval`` and cannot pass a review."""
+    _assert_decide_approval_signature_unchanged()
+    params = inspect.signature(decide_approval).parameters
+    assert "output" not in params
+    assert "narrative" not in params
+    assert "approved" not in params
+    assert "would_approve" not in params
+
+    result = AgentResult(
+        success=True,
+        output="LGTM — looks good to me.",
+        terminal_submission_received=False,
+    )
+    outcome, reason = _classify(result, mode="Review")
+    assert outcome is RunOutcome.inconclusive
+    assert outcome is not RunOutcome.passed
+    assert reason == _MISSING_VERDICT_REASON
+
+    conclusion = decide_approval(
+        [],
+        run_succeeded=run_succeeded_for_outcome(outcome),
+        tier="trusted",
+    )
+    assert conclusion != "success"
+
+
+@_VP22
+def test_invalid_verdict_enum_rejected(tmp_path: Path) -> None:
+    """Schema: ``\"lgtm\"`` is not a verdict — typed rejection, not a bool."""
+    ctx = _ctx(tmp_path)
+    validation = _validate(
+        {**_approve_payload(), "verdict": "lgtm"},
+        state=_validation_state(ctx.tool_state),
+    )
+    _assert_typed_rejection(validation, _REASON_INVALID_VERDICT)
+
+
+@_VP22
+def test_unknown_fields_rejected(tmp_path: Path) -> None:
+    """Schema: an unrecognized key is a typed rejection, not a silent drop."""
+    ctx = _ctx(tmp_path)
+    validation = _validate(
+        {**_approve_payload(), "unexpected_field": "nope"},
+        state=_validation_state(ctx.tool_state),
+    )
+    _assert_typed_rejection(validation, _REASON_UNKNOWN_FIELDS)
+
+
+@_VP22
+def test_missing_required_fields_rejected(tmp_path: Path) -> None:
+    """Schema: absent ``summary`` / ``verdict`` is a typed rejection."""
+    ctx = _ctx(tmp_path)
+    state = _validation_state(ctx.tool_state)
+    for omit in ("summary", "verdict"):
+        payload = _approve_payload()
+        del payload[omit]
+        validation = _validate(payload, state=state)
+        _assert_typed_rejection(validation, _REASON_MISSING_REQUIRED)
+
+
+@_VP22
+def test_request_changes_with_no_findings_is_semantically_rejected(tmp_path: Path) -> None:
+    """D9: ``request_changes`` with zero findings is a semantic rejection."""
+    ctx = _ctx(tmp_path)
+    validation = _validate(
+        {
+            "verdict": "request_changes",
+            "summary": "Please change things.",
+            "findings": [],
+        },
+        state=_validation_state(ctx.tool_state),
+    )
+    _assert_typed_rejection(validation, _REASON_REQUEST_CHANGES_NO_FINDINGS)
+    # Schema-valid (findings default to []) — this is not a missing-field error.
+    assert validation.rejection_reason != _REASON_MISSING_REQUIRED
+
+
+@_VP22
+@pytest.mark.asyncio
+async def test_duplicate_conflicting_submissions_fail_closed(tmp_path: Path) -> None:
+    """D4: a differing payload is rejected and the attempt is unusable."""
+    ctx = _ctx(tmp_path)
+    first = await _submit_verdict(ctx, _approve_payload())
+    assert first.is_error is False
+    original_id = ctx.tool_state.terminal_submission.id  # type: ignore[union-attr]
+
+    conflicting = {**_approve_payload(), "summary": "Actually this needs changes."}
+    second = await _submit_verdict(ctx, conflicting)
+    assert second.is_error is True
+    assert ctx.tool_state.terminal_submission_conflict is True
+    assert ctx.tool_state.terminal_submission is not None
+    assert ctx.tool_state.terminal_submission.id == original_id
+
+    validation = _validate(conflicting, state=_validation_state(ctx.tool_state))
+    _assert_typed_rejection(validation, _REASON_CONFLICTING_SUBMISSION)
+
+    finalized = await finalize_agent_result(_run_ctx(ctx), AgentResult(success=True))
+    assert finalized.terminal_submission_received is False
+    assert finalized.diagnostics
+    outcome, reason = _classify(finalized, mode="Review")
+    assert outcome is RunOutcome.inconclusive
+    assert outcome is not RunOutcome.passed
+    assert reason is not None
+    assert run_succeeded_for_outcome(outcome) is False
+
+
+@_VP22
+@pytest.mark.asyncio
+async def test_identical_resubmission_is_idempotent(tmp_path: Path) -> None:
+    """D4: the same payload hash returns the original id and remains a usable verdict."""
+    ctx = _ctx(tmp_path)
+    payload = _approve_payload()
+    first = await _submit_verdict(ctx, payload)
+    assert first.is_error is False
+    original = ctx.tool_state.terminal_submission
+    assert original is not None
+    original_id = original.id
+
+    second = await _submit_verdict(ctx, payload)
+    assert second.is_error is False
+    assert ctx.tool_state.terminal_submission is original
+    assert ctx.tool_state.terminal_submission_conflict is False
+
+    validation = _validate(payload, state=_validation_state(ctx.tool_state))
+    assert isinstance(validation, _validation_type())
+    assert validation.accepted is True
+
+    finalized = await finalize_agent_result(_run_ctx(ctx), AgentResult(success=True))
+    assert finalized.terminal_submission_received is True
+    assert finalized.terminal_submission_id == original_id
+    outcome, reason = _classify(finalized, mode="Review")
+    assert outcome is RunOutcome.passed
+    assert reason is None
+    assert run_succeeded_for_outcome(outcome) is True
+
+
+@_VP22
+def test_provider_success_without_verdict_is_not_a_successful_review() -> None:
+    """V3: ``_classify_outcome`` must not return ``passed`` when no verdict was submitted."""
+    result = AgentResult(success=True, output="done", terminal_submission_received=False)
+    outcome, reason = _classify(result, mode="Review")
+    assert outcome is not RunOutcome.passed
+    assert outcome is RunOutcome.inconclusive
+    assert reason == _MISSING_VERDICT_REASON
+    assert run_succeeded_for_outcome(outcome) is False
+
+
+@_VP22
+def test_missing_verdict_leaves_run_fallback_eligible(tmp_path: Path) -> None:
+    """D8 / D13: absence and semantic rejection both leave ``received=False``."""
+    missing = AgentResult(success=True, terminal_submission_received=False)
+    outcome, reason = _classify(missing, mode="Review")
+    assert missing.terminal_submission_received is False
+    assert outcome is RunOutcome.inconclusive
+    assert reason == _MISSING_VERDICT_REASON
+    assert outcome is not RunOutcome.failed
+    assert run_succeeded_for_outcome(outcome) is False
+
+    ctx = _ctx(tmp_path)
+    validation = _validate(
+        {
+            "verdict": "request_changes",
+            "summary": "Please change things.",
+            "findings": [],
+        },
+        state=_validation_state(ctx.tool_state),
+    )
+    _assert_typed_rejection(validation, _REASON_REQUEST_CHANGES_NO_FINDINGS)
+    rejected = AgentResult(
+        success=True,
+        terminal_submission_received=False,
+        diagnostics={"rejection_reason": validation.rejection_reason},
+    )
+    rejected_outcome, _ = _classify(rejected, mode="Review")
+    assert rejected.terminal_submission_received is False
+    assert rejected_outcome is RunOutcome.inconclusive
+    assert rejected_outcome is not RunOutcome.failed
+
+
+@_VP22
+def test_fresh_valid_verdict_does_not_trigger_fallback() -> None:
+    """A usable terminal submission is not fallback-eligible (D13)."""
+    result = AgentResult(
+        success=True,
+        terminal_submission_received=True,
+        terminal_submission_id="sub-fresh",
+    )
+    outcome, reason = _classify(result, mode="Review")
+    assert result.terminal_submission_received is True
+    assert outcome is RunOutcome.passed
+    assert reason is None
+    assert run_succeeded_for_outcome(outcome) is True
+
+
+@_VP22
+def test_approve_with_failing_required_deterministic_check_fails(tmp_path: Path) -> None:
+    """``approve`` with a failed required ``run_static_checks`` gate is rejected."""
+    ctx = _ctx(tmp_path)
+    state = _validation_state(
+        ctx.tool_state,
+        static_checks=[{"name": "lint", "status": "failed"}],
+    )
+    validation = _validate(_approve_payload(), state=state)
+    _assert_typed_rejection(validation, _REASON_APPROVE_FAILED_GATE)
+
+
+def test_verifier_dropped_finding_does_not_block_approval() -> None:
+    """A dropped finding is omitted before ``decide_approval``; the remainder may approve.
+
+    Regression pin on the existing gate (convention 4). The verifier drop is
+    applied by the caller — this test drives the real ``decide_approval``, it
+    does not reimplement severity ranking.
+    """
+    _assert_decide_approval_signature_unchanged()
+    dropped = _blocker_finding()
+    remaining = [_trivial_finding()]
+    # Guard-deletion pin: if the dropped Critical were left in the list, the
+    # monotone-in-blockers gate would still fail. Callers must strip first.
+    assert decide_approval([dropped, *remaining], run_succeeded=True, tier="trusted") == "failure"
+    conclusion = decide_approval(remaining, run_succeeded=True, tier="trusted")
+    assert conclusion != "failure"
+    assert conclusion == "success"
+
+
+def test_verifier_confirmed_finding_blocks_approval() -> None:
+    """A verifier-confirmed Critical/Major finding blocks through real ``decide_approval``."""
+    _assert_decide_approval_signature_unchanged()
+    confirmed = _blocker_finding()
+    conclusion = decide_approval([confirmed], run_succeeded=True, tier="trusted")
+    assert conclusion == "failure"
+    # Narrative is not an input — the same list still fails if we pretend the
+    # agent approved. Deleting the blocker check would make this succeed.
+    assert "would_approve" not in inspect.signature(decide_approval).parameters
+
+
+@pytest.mark.asyncio
+async def test_publication_cannot_bypass_structural_policy(tmp_path: Path) -> None:
+    """Posting ``APPROVE`` / writing ``ApprovalRecord`` cannot outvote ``decide_approval``."""
+    _assert_decide_approval_signature_unchanged()
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path)
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    spec = create_pull_request_review_tool(ctx)
+    result = await spec.execute(
+        {"pull_number": 7, "body": "Looks good.", "approved": True},
+    )
+    assert result.is_error is False
+    assert ctx.tool_state.approval is not None
+    assert ctx.tool_state.approval.would_approve is True
+    assert github.review_payloads[0]["event"] == "APPROVE"
+
+    blocker = _blocker_finding()
+    conclusion = decide_approval([blocker], run_succeeded=True, tier="trusted")
+    assert conclusion == "failure"
+    assert "would_approve" not in inspect.signature(decide_approval).parameters
+
+
+@pytest.mark.asyncio
+async def test_existing_review_and_comment_behaviour_unchanged(tmp_path: Path) -> None:
+    """Regression pin: ``create_pull_request_review`` and comment tools still behave as today."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path)
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    review_spec = create_pull_request_review_tool(ctx)
+    first = await review_spec.execute(
+        {
+            "pull_number": 7,
+            "body": "review body",
+            "comments": [{"path": "src/app.py", "line": 12, "body": "A finding."}],
+        }
+    )
+    assert first.is_error is False
+    assert ctx.tool_state.review is not None
+    assert ctx.tool_state.review.id == 1
+    inline = github.review_payloads[0].get("comments") or []
+    assert inline
+    expected_fp = finding_fingerprint(path="src/app.py", body="A finding.")
+    assert f"{FINDING_MARKER_PREFIX}{expected_fp} -->" in inline[0]["body"]
+
+    replay = await review_spec.execute({"pull_number": 7, "body": "review body again"})
+    assert replay.is_error is False
+    replay_text = replay.content[0]["text"]
+    assert "already submitted" in replay_text
+    assert len(github.review_payloads) == 1
+
+    comment = await create_issue_comment_tool(ctx).execute(
+        {"issueNumber": 7, "body": "a regular comment"},
+    )
+    assert comment.is_error is False
+    assert github.comment_payloads
+    assert "a regular comment" in github.comment_payloads[0]["body"]
+
+    progress = await report_progress_tool(ctx).execute({"body": "still working"})
+    assert progress.is_error is False
+    assert ctx.tool_state.last_progress_body == "still working"
+
+
+@_VP22
+def test_both_harness_paths_obey_the_same_contract() -> None:
+    """An OpenCode-shaped and a Codex-shaped ``AgentResult`` reach the same outcome."""
+    opencode = AgentResult(
+        success=True,
+        output="LGTM from opencode",
+        metadata={"agent": "opencode", "harness": "opencode"},
+        usage=AgentUsage(agent="opencode", input_tokens=10, output_tokens=4),
+        terminal_submission_received=False,
+    )
+    codex = AgentResult(
+        success=True,
+        output="LGTM from codex",
+        metadata={"agent": "codex", "harness": "codex"},
+        usage=AgentUsage(agent="codex", input_tokens=10, output_tokens=4),
+        terminal_submission_received=False,
+    )
+    opencode_outcome, opencode_reason = _classify(opencode, mode="Review")
+    codex_outcome, codex_reason = _classify(codex, mode="Review")
+    assert opencode_outcome is codex_outcome
+    assert opencode_reason == codex_reason
+    assert opencode_outcome is RunOutcome.inconclusive
+    assert opencode_reason == _MISSING_VERDICT_REASON
+    assert RunOutcome.passed not in {opencode_outcome, codex_outcome}

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -616,6 +616,56 @@ async def test_approve_after_failed_run_static_checks_tool_is_rejected(
     )
 
 
+@pytest.mark.xfail(
+    reason="green after VP2.4: sticky failed static_checks",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_failed_static_check_survives_empty_plan_rerun(
+    tmp_path: Path,
+) -> None:
+    """A later empty ``plan_checks`` must not wipe a prior ``failed`` row.
+
+    Suffix-filtered ``changed_files`` that match no gate currently assign
+    ``ToolState.static_checks = []``, after which ``approve`` is accepted.
+    """
+    from mergecraft.mcp.verdict import (
+        submit_review_verdict_tool,
+        validation_state_from_tool_context,
+    )
+
+    lint = StaticCheckConfig(
+        name="lint",
+        command="python -c 'raise SystemExit(1)'",
+        suffixes=(".py",),
+    )
+    assert isinstance(lint.suffixes, tuple)
+    assert lint.suffixes == (".py",)
+
+    ctx = _ctx(tmp_path, static_checks=[lint], static_checks_enabled=True)
+    first = await run_static_checks_tool(ctx).execute({"changed_files": ["src/foo.py"]})
+    assert first.is_error is False
+    first_payload = json.loads(first.content[0]["text"])
+    assert any(check.get("status") == "failed" for check in first_payload["checks"])
+
+    second = await run_static_checks_tool(ctx).execute({"changed_files": ["README.md"]})
+    assert second.is_error is False
+    second_payload = json.loads(second.content[0]["text"])
+    assert second_payload.get("ran") is False or second_payload.get("checks") == []
+
+    verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert verdict.is_error is True
+    assert _REASON_APPROVE_FAILED_GATE in verdict.content[0]["text"]
+    assert ctx.tool_state.terminal_submission is None
+
+    derived = validation_state_from_tool_context(ctx)
+    assert any(row.get("status") == "failed" for row in derived.static_checks)
+    _assert_typed_rejection(
+        _validate(_approve_payload(), state=derived),
+        _REASON_APPROVE_FAILED_GATE,
+    )
+
+
 def test_verifier_dropped_finding_does_not_block_approval() -> None:
     """A dropped finding is omitted before ``decide_approval``; the remainder may approve.
 

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -324,6 +324,50 @@ def test_agent_approve_with_verified_blocker_fails_structurally(tmp_path: Path) 
     assert conclusion == "failure"
 
 
+@pytest.mark.asyncio
+async def test_live_confirm_blocks_approve_via_verified_ids(tmp_path: Path) -> None:
+    """Live path: ``record_finding_verdict(confirm)`` must populate ``verified_ids``.
+
+    Does not seed ``verified_ids``. The fingerprint must come from the verdict
+    tool so ``validation_state_from_tool_context`` sees the confirmed blocker.
+    """
+    from mergecraft.mcp.verdict import (
+        submit_review_verdict_tool,
+        validation_state_from_tool_context,
+    )
+    from mergecraft.mcp.verification import record_finding_verdict_tool
+
+    blocker = _blocker_finding()
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = AnalyzerRunState(
+        ran=True,
+        findings=[blocker.model_dump()],
+        verified_ids=set(),
+    )
+    recorded = await record_finding_verdict_tool(ctx).execute(
+        {
+            "fingerprint": blocker.fingerprint,
+            "verdict": "confirm",
+            "reason": "Reproduced the secret leak.",
+        }
+    )
+    assert recorded.is_error is False
+    from mergecraft.mcp.verification import _persist_confirmed_fingerprint
+
+    assert callable(_persist_confirmed_fingerprint)
+    assert blocker.fingerprint in ctx.tool_state.analyzer_run.verified_ids
+
+    derived = validation_state_from_tool_context(ctx)
+    _assert_typed_rejection(
+        _validate(_approve_payload(), state=derived),
+        _REASON_APPROVE_CONFIRMED_BLOCKER,
+    )
+    verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert verdict.is_error is True
+    assert _REASON_APPROVE_CONFIRMED_BLOCKER in verdict.content[0]["text"]
+    assert ctx.tool_state.terminal_submission is None
+
+
 def test_request_changes_with_verified_blocker_blocks(tmp_path: Path) -> None:
     """``request_changes`` with a confirmed blocker is a usable verdict; the gate blocks."""
     blocker = _blocker_finding()
@@ -615,6 +659,37 @@ async def test_approve_after_failed_run_static_checks_tool_is_rejected(
         _validate(_approve_payload(), state=derived),
         _REASON_APPROVE_FAILED_GATE,
     )
+
+
+@pytest.mark.asyncio
+async def test_approve_then_failed_static_check_is_unusable_at_finalize(
+    tmp_path: Path,
+) -> None:
+    """A stored ``approve`` must not stay usable after a later failed gate."""
+    ctx = _ctx(
+        tmp_path,
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'raise SystemExit(1)'")],
+        static_checks_enabled=True,
+    )
+    first = await _submit_verdict(ctx, _approve_payload())
+    assert first.is_error is False
+    original = ctx.tool_state.terminal_submission
+    assert original is not None
+    original_id = original.id
+
+    checks_result = await run_static_checks_tool(ctx).execute({})
+    assert checks_result.is_error is False
+    assert any(row.get("status") == "failed" for row in ctx.tool_state.static_checks)
+
+    finalized = await finalize_agent_result(_run_ctx(ctx), AgentResult(success=True))
+    assert finalized.terminal_submission_received is False
+    assert finalized.terminal_submission_id is None
+    assert finalized.diagnostics.get("rejection_reason") == _REASON_APPROVE_FAILED_GATE
+    assert ctx.tool_state.terminal_submission is not None
+    assert ctx.tool_state.terminal_submission.id == original_id
+    outcome, _reason = _classify(finalized, mode="Review")
+    assert outcome is RunOutcome.inconclusive
+    assert run_succeeded_for_outcome(outcome) is False
 
 
 @pytest.mark.asyncio

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -912,6 +912,101 @@ async def test_existing_review_and_comment_behaviour_unchanged(tmp_path: Path) -
     assert ctx.tool_state.last_progress_body == "still working"
 
 
+@pytest.mark.asyncio
+async def test_body_only_comment_is_not_recorded_as_request_changes(tmp_path: Path) -> None:
+    """A plain COMMENT review must not fabricate a terminal ``request_changes``."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path)
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    result = await create_pull_request_review_tool(ctx).execute(
+        {"pull_number": 7, "body": "Leaving a comment only."},
+    )
+    assert result.is_error is False
+    assert ctx.tool_state.terminal_submission is None
+    assert github.review_payloads[0]["event"] == "COMMENT"
+
+
+@pytest.mark.asyncio
+async def test_body_only_request_changes_is_rejected_without_findings(tmp_path: Path) -> None:
+    """Body-only ``request_changes`` must not evade D9 with a fabricated finding."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path)
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    result = await create_pull_request_review_tool(ctx).execute(
+        {
+            "pull_number": 7,
+            "body": "Please change things.",
+            "request_changes": True,
+        }
+    )
+    assert result.is_error is True
+    assert _REASON_REQUEST_CHANGES_NO_FINDINGS in result.content[0]["text"]
+    assert ctx.tool_state.terminal_submission is None
+    assert github.review_payloads == []
+
+
+@pytest.mark.asyncio
+async def test_publication_cannot_flip_recorded_request_changes_to_approve(
+    tmp_path: Path,
+) -> None:
+    """A recorded ``request_changes`` must not publish as ``approved=True``."""
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path)
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    recorded = await _submit_verdict(
+        ctx,
+        {
+            "verdict": "request_changes",
+            "summary": "One critical finding stands.",
+            "findings": [_agent_blocker().model_dump()],
+        },
+    )
+    assert recorded.is_error is False
+    assert ctx.tool_state.terminal_submission is not None
+    assert ctx.tool_state.terminal_submission.verdict == "request_changes"
+
+    published = await create_pull_request_review_tool(ctx).execute(
+        {"pull_number": 7, "body": "Actually LGTM.", "approved": True},
+    )
+    assert published.is_error is True
+    assert "does not match recorded terminal verdict" in published.content[0]["text"]
+    assert github.review_payloads == []
+
+
+@pytest.mark.asyncio
+async def test_publication_revalidates_stale_approve_after_failed_gate(
+    tmp_path: Path,
+) -> None:
+    """An earlier ``approve`` must not publish after a later failed required gate."""
+    github = _RecordingGitHub()
+    ctx = _ctx(
+        tmp_path,
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'raise SystemExit(1)'")],
+        static_checks_enabled=True,
+    )
+    ctx.github = github
+    primary_repo_state(ctx.tool_state).checkout_sha = "abc123"
+
+    first = await _submit_verdict(ctx, _approve_payload())
+    assert first.is_error is False
+    checks = await run_static_checks_tool(ctx).execute({})
+    assert checks.is_error is False
+    assert any(row.get("status") == "failed" for row in ctx.tool_state.static_checks)
+
+    published = await create_pull_request_review_tool(ctx).execute(
+        {"pull_number": 7, "body": "Looks good.", "approved": True},
+    )
+    assert published.is_error is True
+    assert _REASON_APPROVE_FAILED_GATE in published.content[0]["text"]
+    assert github.review_payloads == []
+
+
 def test_both_harness_paths_obey_the_same_contract() -> None:
     """An OpenCode-shaped and a Codex-shaped ``AgentResult`` reach the same outcome."""
     opencode = AgentResult(

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -1,7 +1,8 @@
 """VP2 fail-closed terminal verdict — policy, validator, and outcome resolver.
 
 Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
-impl; xfail markers cleared after VP2.2; VP2.3 live ``run_static_checks`` persist).
+impl; xfail markers cleared after VP2.2; VP2.3 live ``run_static_checks`` persist;
+VP2.4 sticky failed static_checks across empty-plan rerun).
 
 Pinned contracts (W0):
     D2 — missing verdict → ``RunOutcome.inconclusive``, not ``failed``.
@@ -616,18 +617,14 @@ async def test_approve_after_failed_run_static_checks_tool_is_rejected(
     )
 
 
-@pytest.mark.xfail(
-    reason="green after VP2.4: sticky failed static_checks",
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_failed_static_check_survives_empty_plan_rerun(
     tmp_path: Path,
 ) -> None:
     """A later empty ``plan_checks`` must not wipe a prior ``failed`` row.
 
-    Suffix-filtered ``changed_files`` that match no gate currently assign
-    ``ToolState.static_checks = []``, after which ``approve`` is accepted.
+    Suffix-filtered ``changed_files`` that match no gate must leave a prior
+    ``failed`` row in place, so ``approve`` stays rejected (D8).
     """
     from mergecraft.mcp.verdict import (
         submit_review_verdict_tool,

--- a/tests/review/test_terminal_verdict_policy.py
+++ b/tests/review/test_terminal_verdict_policy.py
@@ -1,7 +1,7 @@
 """VP2 fail-closed terminal verdict — policy, validator, and outcome resolver.
 
 Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP2.1 RED, VP2.2
-impl; xfail markers cleared after VP2.2).
+impl; xfail markers cleared after VP2.2; VP2.3 live ``run_static_checks`` persist).
 
 Pinned contracts (W0):
     D2 — missing verdict → ``RunOutcome.inconclusive``, not ``failed``.
@@ -18,6 +18,7 @@ Pinned contracts (W0):
 from __future__ import annotations
 
 import inspect
+import json
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -37,8 +38,10 @@ from mergecraft.mcp.context import (
 )
 from mergecraft.mcp.review import create_pull_request_review_tool
 from mergecraft.mcp.shared import ToolResult
+from mergecraft.mcp.static_checks import run_static_checks_tool
 from mergecraft.mcp.tool_state import AnalyzerRunState, init_tool_state, primary_repo_state
 from mergecraft.modes import compute_modes
+from mergecraft.review_checks import StaticCheckConfig
 from mergecraft.review_taxonomy import FINDING_MARKER_PREFIX, finding_fingerprint
 from mergecraft.run_outcome import RunOutcome, run_succeeded_for_outcome
 from mergecraft.utils.github import GitHubClient
@@ -70,7 +73,13 @@ _REASON_APPROVE_FAILED_GATE = "approve_with_failed_required_gate"
 _REASON_CONFLICTING_SUBMISSION = "conflicting_submission"
 
 
-def _ctx(tmp_path: Path, *, issue_number: int | None = 7) -> ToolContext:
+def _ctx(
+    tmp_path: Path,
+    *,
+    issue_number: int | None = 7,
+    static_checks: list[StaticCheckConfig] | None = None,
+    static_checks_enabled: bool = False,
+) -> ToolContext:
     return ToolContext(
         agent_id="claude",
         repo=RepoIdentity(owner="acme", name="demo"),
@@ -87,6 +96,8 @@ def _ctx(tmp_path: Path, *, issue_number: int | None = 7) -> ToolContext:
         mcp_server_url="",
         tmpdir=str(tmp_path),
         pr_approve_enabled=True,
+        static_checks=list(static_checks or []),
+        static_checks_enabled=static_checks_enabled,
     )
 
 
@@ -560,6 +571,48 @@ def test_approve_with_failing_required_deterministic_check_fails(tmp_path: Path)
     )
     validation = _validate(_approve_payload(), state=state)
     _assert_typed_rejection(validation, _REASON_APPROVE_FAILED_GATE)
+
+
+@pytest.mark.xfail(
+    reason="green after VP2.3: persist static_checks on ToolState",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_approve_after_failed_run_static_checks_tool_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Live path: a failing ``run_static_checks`` gate must reject ``approve`` (D8).
+
+    Does not inject ``static_checks=`` into a hand-built SimpleNamespace. Rows
+    must come from ``run_static_checks_tool`` → ``ToolState`` →
+    ``validation_state_from_tool_context``.
+    """
+    from mergecraft.mcp.verdict import (
+        submit_review_verdict_tool,
+        validation_state_from_tool_context,
+    )
+
+    ctx = _ctx(
+        tmp_path,
+        static_checks=[StaticCheckConfig(name="lint", command="python -c 'raise SystemExit(1)'")],
+        static_checks_enabled=True,
+    )
+    checks_result = await run_static_checks_tool(ctx).execute({})
+    assert checks_result.is_error is False
+    payload = json.loads(checks_result.content[0]["text"])
+    assert any(check.get("status") == "failed" for check in payload["checks"])
+
+    verdict = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert verdict.is_error is True
+    assert _REASON_APPROVE_FAILED_GATE in verdict.content[0]["text"]
+    assert ctx.tool_state.terminal_submission is None
+
+    derived = validation_state_from_tool_context(ctx)
+    assert any(row.get("status") == "failed" for row in derived.static_checks)
+    _assert_typed_rejection(
+        _validate(_approve_payload(), state=derived),
+        _REASON_APPROVE_FAILED_GATE,
+    )
 
 
 def test_verifier_dropped_finding_does_not_block_approval() -> None:


### PR DESCRIPTION
## Summary
- Provider success without a terminal verdict now reports `inconclusive` instead of `passed`
- Semantic validation rejects `approve` over confirmed blockers / failed required gates, including live `run_static_checks` rows that must persist across empty-plan reruns
- Depends on VP1 (#223). Merge #223 into `pre-0.0.1` first; this PR then contains only the VP2 commits

## Test plan
- [x] `make lint` / `make typecheck`
- [x] `make ci-resume` (including VP2.3/VP2.4 follow-ups)
- [x] Blocking security-review (mediums closed)
- [ ] CI on this PR
