### PR TITLE
feat(evidence): shadow the terminal-verdict protocol before enforcing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added: terminal-verdict protocol shadow mode (`gates.terminal_verdict`, default `shadow`) with a closed `VerdictDiagnostic` vocabulary; enforce still applies the fail-closed missing-verdict branch
 - Added: server-side semantic validation of the terminal verdict — `request_changes` with no findings, `approve` over a verifier-confirmed blocker, and `approve` with a failing required deterministic check are all rejected and fail closed
 - Added: `submit_review_verdict` — a typed MCP operation that records a review's terminal verdict
   (`approve` / `request_changes`), summary and structured findings. Unknown fields and invalid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed: terminal-verdict shadow mode now records a predicted outcome beside the legacy result on the live finalize path
 - Fixed: a body-only COMMENT is no longer recorded as `request_changes`, and body-only `request_changes` is rejected unless it has real findings
 - Fixed: publication must match the recorded terminal verdict and is re-validated before sending `APPROVE`
 - Fixed: IncrementalReview `report_progress` no longer advances the model chain

--- a/docs/test-plans/review-integrity-vp3.md
+++ b/docs/test-plans/review-integrity-vp3.md
@@ -1,0 +1,87 @@
+# Review integrity VP3 — terminal-verdict shadow protocol — test plan
+
+Wave plan: `.ignorelocal/01-review-integrity-wave-plan.md`
+Worktree: `mergecraft-vp3-shadow` @ `wave/vp3-shadow` (stacked on VP2 `087df16`)
+
+## xfail schedule
+
+| Wave | Test files | Marker |
+|------|------------|--------|
+| **VP3.2** | `tests/evidence/test_verdict_shadow.py` (all 5) | `@pytest.mark.xfail(reason="green after VP3.2: verdict-protocol shadow predicate", strict=False)` |
+| **VP3.2** | `tests/tracing/test_verdict_diagnostics.py` (both) | `@pytest.mark.xfail(reason="green after VP3.2: verdict diagnostic span + redaction", strict=False)` |
+| **VP3.2** | `tests/review/test_attempt_attribution.py` (both) | `@pytest.mark.xfail(reason="green after VP3.2: attempt_id stamp + stale structural result", strict=False)` |
+
+Never `strict=True` — `xfail_strict = true` in `pyproject.toml` would turn a later XPASS into a hard failure the impl wave cannot touch.
+
+Existing gate-action shadow tests in `tests/evidence/test_gate_actions.py` are not part of this suite and must keep collecting.
+
+### xfail reconciliation log
+
+| Date | Impl wave | Markers removed | Notes |
+|------|-----------|-----------------|-------|
+| *(pending VP3.2)* | | | |
+
+## Named symbols this suite pins
+
+| Symbol | Module | Direct test |
+|--------|--------|-------------|
+| `predict_verdict_protocol` | `evidence/shadow.py` | all five tests in `test_verdict_shadow.py` |
+| `record_shadow_prediction` | `evidence/shadow.py` | `test_shadow_records_prediction_without_changing_outcome`, agreement, diagnostic-on-row |
+| `disagree_with_outcome` | `evidence/shadow.py` | `test_disagreement_is_queryable` (also agreement fallback) |
+| `VerdictDiagnostic` | `mcp/verdict.py` | `test_shadow_row_carries_diagnostic_code`, `test_each_diagnostic_reaches_the_span` |
+| `span_attrs_for_verdict_diagnostic` | `mcp/verdict.py` | both tests in `test_verdict_diagnostics.py` |
+| `redact_attrs` / `redact_event` | `tracing/redaction.py` | `test_each_diagnostic_reaches_the_span`, `test_diagnostics_are_redacted` (guard-deletion) |
+| `GatesSettings.terminal_verdict` | `config/settings.py` | shadow default in `test_shadow_records_prediction_without_changing_outcome`; enforce in `test_enforce_mode_changes_the_outcome` |
+| `_classify_outcome(..., verdict_protocol=)` | `main_outcome.py` | shadow vs enforce outcome tests |
+| `stamp_attempt_id` | `utils/agent_resolve.py` | both tests in `test_attempt_attribution.py` |
+| `ToolState.attempt_id` | `mcp/tool_state.py` | `test_verdict_is_bound_to_its_attempt` (stamped beside `fallback_index`) |
+| `TerminalSubmission.attempt_id` | `mcp/tool_state.py` | `test_verdict_is_bound_to_its_attempt` |
+| `verdict_satisfies_attempt` | `mcp/verdict.py` | `test_stale_structural_result_is_not_reused` |
+| `finalize_agent_result` | `agents/post_run.py` | stale-attempt guard-deletion pin |
+
+`predict_verdict_protocol`, `VerdictDiagnostic`, `span_attrs_for_verdict_diagnostic`, `stamp_attempt_id`, and `verdict_satisfies_attempt` are imported **inside test bodies** so collection stays green before VP3.2 lands them.
+
+### Closed `VerdictDiagnostic` vocabulary
+
+Snake_case `StrEnum` members (name == value), eight values, no more:
+
+| Member | Plan wording | Typical producer |
+|--------|--------------|------------------|
+| `provider_failure` | provider failure | `result.success is False` |
+| `provider_success_without_submission` | provider success w/o submission | VP2 missing-verdict branch |
+| `schema_invalid` | schema-invalid | validator schema rejection |
+| `semantic_invalid` | semantic-invalid | D9 / malformed submission |
+| `policy_rejection` | policy rejection | approve + failed required gate / conflict |
+| `agent_approved_but_blocked` | agent-approved-but-blocked | approve + confirmed blocker |
+| `approved` | approved | valid `approve` + clear gates |
+| `fallback_triggered` | fallback-triggered | HA2 semantic fallback |
+
+## Contract matrix
+
+| Decision | Layer | Scenario | Primary test |
+|----------|-------|----------|--------------|
+| **D6** shadow does not flip the gate | Functional | Happy/edge: missing verdict + `verdict_protocol="shadow"` still reports legacy `passed`; a JSONL row is written with predicted `inconclusive` / `provider_success_without_submission` | `test_shadow_records_prediction_without_changing_outcome` |
+| Agreement when a verdict is present | Functional | Happy: both sides `passed` / `approved`; row `disagreement` is false | `test_shadow_records_agreement_when_verdict_present` |
+| Diagnostic on the shadow row | Unit | Happy: closed `VerdictDiagnostic` value is on the row (`diagnostic` / `verdict_diagnostic`) | `test_shadow_row_carries_diagnostic_code` |
+| Enforce fires the VP2 branch | Unit | Error: `verdict_protocol="enforce"` + missing verdict → `RunOutcome.inconclusive` and the VP2 reason string | `test_enforce_mode_changes_the_outcome` |
+| **D6** disagreement is queryable | Unit | Edge: predicted `inconclusive` vs actual `passed` is a disagreement; matching `passed` is not. Guard-deletion: collapsing both onto a generic "review" direction hides the mismatch | `test_disagreement_is_queryable` |
+| Eight diagnostics reach the span | Integration | Happy: each closed value appears on span attrs produced by `span_attrs_for_verdict_diagnostic`, and survives `redact_attrs` | `test_each_diagnostic_reaches_the_span` |
+| Redaction before surfacing | Integration | Guard-deletion: a `sk-…` submission summary must not appear on the helper's returned attrs. The test does **not** re-apply `redact_attrs` to that output | `test_diagnostics_are_redacted` |
+| **V7** verdict bound to attempt | Functional | Happy: `stamp_attempt_id(..., attempt_id=2)` then `submit_review_verdict` records `TerminalSubmission.attempt_id == 2`; finalize copies it into `diagnostics` | `test_verdict_is_bound_to_its_attempt` |
+| **V7** stale result is not reused | Integration | Error: leftover `attempt_id=0` submission does not satisfy current attempt 1; `finalize_agent_result` leaves `terminal_submission_received=False`. Pairs with HA2 `stale_attempt` | `test_stale_structural_result_is_not_reused` |
+
+No source-grep assertions. Shadow tests drive the real `record_shadow_prediction` / `disagree_with_outcome` once the predicate exists. `_classify_outcome` is called with a real `AgentResult`. Stale-attempt goes through real `finalize_agent_result`.
+
+## Impl notes for VP3.2
+
+- Reuse `evidence/shadow.py`. Extend `record_shadow_prediction` with a `prediction=` (and `actual_outcome=`) kwarg so a verdict-protocol row lands in the **same** JSONL as gate-action rows. Do not add a second log file.
+- `predict_verdict_protocol(result, *, mode)` is the predicate alongside `predict_action`. Return shape must expose `.outcome` / `.predicted_outcome` and `.diagnostic`.
+- `_classify_outcome` grows `verdict_protocol: Literal["shadow", "enforce"]`. Shadow skips the VP2 missing-verdict branch (legacy `passed`); enforce fires it. `GatesSettings.terminal_verdict` defaults to `"shadow"` (D6 / D12 pattern).
+- `disagree_with_outcome` must treat protocol outcomes (`passed` vs `inconclusive`) as distinct directions — today's merge/block/review mapping folds both onto `"review"` and would hide the mismatch.
+- `stamp_attempt_id(tool_state, *, attempt_id, fallback_index)` sets `tool_state.attempt_id` beside `fallback_index` when the model chain starts an attempt. `submit_review_verdict` copies that stamp onto `TerminalSubmission`.
+- `verdict_satisfies_attempt(submission, *, current_attempt_id)` is the freshness predicate; `_terminal_submission_fields` / `finalize_agent_result` must consult it.
+- `span_attrs_for_verdict_diagnostic(diagnostic, *, summary)` returns span attrs (key `verdict.diagnostic` or equivalent) after `redact_attrs`. Putting the diagnostic on the span without going through `tracing/redaction.py` fails the redaction test.
+
+## RED acceptance (VP3.1)
+
+9 collected; 0 pass; 9 xfail pending VP3.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave. VP3.2 / VP3 Final checkboxes are not flipped here.

--- a/docs/test-plans/review-integrity-vp3.md
+++ b/docs/test-plans/review-integrity-vp3.md
@@ -7,25 +7,26 @@ Worktree: `mergecraft-vp3-shadow` @ `wave/vp3-shadow` (stacked on VP2 `087df16`)
 
 | Wave | Test files | Marker |
 |------|------------|--------|
-| **VP3.2** | `tests/evidence/test_verdict_shadow.py` (all 5) | `@pytest.mark.xfail(reason="green after VP3.2: verdict-protocol shadow predicate", strict=False)` |
-| **VP3.2** | `tests/tracing/test_verdict_diagnostics.py` (both) | `@pytest.mark.xfail(reason="green after VP3.2: verdict diagnostic span + redaction", strict=False)` |
-| **VP3.2** | `tests/review/test_attempt_attribution.py` (both) | `@pytest.mark.xfail(reason="green after VP3.2: attempt_id stamp + stale structural result", strict=False)` |
+| **VP3.2** | `tests/evidence/test_verdict_shadow.py` (all 5) | *(markers removed 2026-08-16 after VP3.2)* |
+| **VP3.2** | `tests/tracing/test_verdict_diagnostics.py` (both) | *(markers removed 2026-08-16 after VP3.2)* |
+| **VP3.2** | `tests/review/test_attempt_attribution.py` (both) | *(markers removed 2026-08-16 after VP3.2)* |
 
 Never `strict=True` — `xfail_strict = true` in `pyproject.toml` would turn a later XPASS into a hard failure the impl wave cannot touch.
 
-Existing gate-action shadow tests in `tests/evidence/test_gate_actions.py` are not part of this suite and must keep collecting.
+Existing gate-action shadow tests in `tests/evidence/test_gate_actions.py` are not part of this suite and must keep collecting. Their leftover W9/W10 xfails are unchanged.
 
 ### xfail reconciliation log
 
 | Date | Impl wave | Markers removed | Notes |
 |------|-----------|-----------------|-------|
-| *(pending VP3.2)* | | | |
+| 2026-08-16 | VP3.2 | `_VP32` on all 5 tests in `test_verdict_shadow.py`, both tests in `test_verdict_diagnostics.py`, and both tests in `test_attempt_attribution.py` | Suite is now 9/9 real passes (0 xfail / 0 XPASS). Direct pin added: `VerdictProtocolPrediction`. Gate-action W9/W10 xfails in `test_gate_actions.py` left in place. VP3 Final not flipped. |
 
 ## Named symbols this suite pins
 
 | Symbol | Module | Direct test |
 |--------|--------|-------------|
 | `predict_verdict_protocol` | `evidence/shadow.py` | all five tests in `test_verdict_shadow.py` |
+| `VerdictProtocolPrediction` | `evidence/shadow.py` | `test_shadow_records_prediction_without_changing_outcome` (`isinstance` pin) |
 | `record_shadow_prediction` | `evidence/shadow.py` | `test_shadow_records_prediction_without_changing_outcome`, agreement, diagnostic-on-row |
 | `disagree_with_outcome` | `evidence/shadow.py` | `test_disagreement_is_queryable` (also agreement fallback) |
 | `VerdictDiagnostic` | `mcp/verdict.py` | `test_shadow_row_carries_diagnostic_code`, `test_each_diagnostic_reaches_the_span` |
@@ -39,7 +40,7 @@ Existing gate-action shadow tests in `tests/evidence/test_gate_actions.py` are n
 | `verdict_satisfies_attempt` | `mcp/verdict.py` | `test_stale_structural_result_is_not_reused` |
 | `finalize_agent_result` | `agents/post_run.py` | stale-attempt guard-deletion pin |
 
-`predict_verdict_protocol`, `VerdictDiagnostic`, `span_attrs_for_verdict_diagnostic`, `stamp_attempt_id`, and `verdict_satisfies_attempt` are imported **inside test bodies** so collection stays green before VP3.2 lands them.
+`predict_verdict_protocol`, `VerdictProtocolPrediction`, `VerdictDiagnostic`, `span_attrs_for_verdict_diagnostic`, `stamp_attempt_id`, and `verdict_satisfies_attempt` are imported **inside test bodies**.
 
 ### Closed `VerdictDiagnostic` vocabulary
 
@@ -85,3 +86,7 @@ No source-grep assertions. Shadow tests drive the real `record_shadow_prediction
 ## RED acceptance (VP3.1)
 
 9 collected; 0 pass; 9 xfail pending VP3.2. Zero collection errors. `make lint` and `make typecheck` clean. Product code is not edited in this wave. VP3.2 / VP3 Final checkboxes are not flipped here.
+
+## VP3.2 xfail reconciliation
+
+9 collected; 9 pass; 0 xfail / 0 XPASS on `tests/evidence/test_verdict_shadow.py` + `tests/tracing/test_verdict_diagnostics.py` + `tests/review/test_attempt_attribution.py`. Markers cleared; `VerdictProtocolPrediction` directly pinned. Gate-action leftover xfails in `tests/evidence/test_gate_actions.py` unchanged. Product code is not edited in this wave. VP3 Final remains open.

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -203,7 +203,14 @@ def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None,
         submission,
         current_attempt_id=ctx.tool_state.attempt_id,
     ):
-        return False, None, {}
+        return (
+            False,
+            None,
+            {
+                "rejection_reason": "stale_attempt",
+                "attempt_id": submission.attempt_id,
+            },
+        )
 
     validation = validate_submission(
         recorded_submission_payload(submission),

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -175,13 +175,20 @@ def build_reflection_prompt(issues: PostRunIssues) -> str:
 
 
 def _terminal_submission_fields(ctx: AgentRunContext) -> tuple[bool, str | None, dict[str, Any]]:
+    from mergecraft.mcp.verdict import verdict_satisfies_attempt
+
     submission = ctx.tool_state.terminal_submission
     if submission is None or ctx.tool_state.terminal_submission_conflict:
         diagnostics: dict[str, Any] = {}
         if ctx.tool_state.terminal_submission_conflict:
             diagnostics["rejection_reason"] = "conflicting_submission"
         return False, None, diagnostics
-    return True, submission.id, {}
+    if not verdict_satisfies_attempt(
+        submission,
+        current_attempt_id=ctx.tool_state.attempt_id,
+    ):
+        return False, None, {}
+    return True, submission.id, {"attempt_id": submission.attempt_id}
 
 
 async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> AgentResult:

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -151,6 +151,7 @@ class GatesSettings(BaseModel):
 
     gate_action: GateMode = "shadow"
     thermostat: GateMode = "shadow"
+    terminal_verdict: GateMode = "shadow"
     override: dict[str, str] = Field(default_factory=dict)
 
 

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -448,6 +448,8 @@ def emit_run_packet(
     change_id: str | None = None,
     extra_findings: list[Finding] | None = None,
     output_path: Path | None = None,
+    verdict_prediction: Any | None = None,
+    actual_outcome: str | None = None,
 ) -> Path | None:
     """Build and write this run's evidence packet; return its path.
 
@@ -497,6 +499,22 @@ def emit_run_packet(
                 )
             except Exception as shadow_err:  # a shadow record never fails the run
                 logger.warning("shadow record: emission failed — {}", shadow_err)
+        if verdict_prediction is not None:
+            from mergecraft.evidence.shadow import record_shadow_prediction
+
+            shadow_path = path.with_name("merge-evidence-shadow.jsonl")
+            try:
+                record_shadow_prediction(
+                    packet,
+                    change_id=resolved_change_id,
+                    run_id=_shadow_run_id(ctx),
+                    policy_id="verdict-protocol",
+                    output_path=shadow_path,
+                    prediction=verdict_prediction,
+                    actual_outcome=actual_outcome,
+                )
+            except Exception as shadow_err:  # a shadow record never fails the run
+                logger.warning("verdict-protocol shadow record: emission failed — {}", shadow_err)
     except Exception as err:  # an audit artifact never fails the run
         logger.warning("evidence packet: emission failed — {}", err)
         return None

--- a/src/mergecraft/evidence/shadow.py
+++ b/src/mergecraft/evidence/shadow.py
@@ -42,24 +42,41 @@ Exports:
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
 from mergecraft.agents.gates import decide_action, select_rule_id
 from mergecraft.evidence.gate_policy import GATE_ACTIONS, GateAction, GateActionPolicy
+from mergecraft.run_outcome import RunOutcome
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mergecraft.agents.shared import AgentResult
     from mergecraft.evidence.packet import MergeEvidencePacket
 
 
 # Closed action vocabulary: the predicted action must be one of the
 # seven names. Anything outside is rejected here, not by the consumer.
 _VALID_ACTIONS: Final[frozenset[str]] = frozenset(GATE_ACTIONS)
+
+# Run-outcome strings compared by the verdict-protocol shadow path. Each maps
+# to its own direction so ``passed`` vs ``inconclusive`` disagreements stay
+# visible — folding both onto a generic "review" direction would hide them.
+_PROTOCOL_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {
+        str(RunOutcome.passed),
+        str(RunOutcome.inconclusive),
+        str(RunOutcome.failed),
+        str(RunOutcome.configuration_error),
+    }
+)
+
+_REVIEW_MODE_NAMES: Final[frozenset[str]] = frozenset({"Review", "IncrementalReview"})
 
 
 # Map a packet's blast radius lane to a coarse repo area for the
@@ -97,6 +114,22 @@ class ShadowRecord(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     actual_outcome: str | None = None
     disagreement: bool | None = None
+    outcome: str | None = None
+    predicted_outcome: str | None = None
+    diagnostic: str | None = None
+    verdict_diagnostic: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VerdictProtocolPrediction:
+    """Pure verdict-protocol shadow prediction (VP3)."""
+
+    outcome: RunOutcome
+    diagnostic: str
+
+    @property
+    def predicted_outcome(self) -> RunOutcome:
+        return self.outcome
 
 
 def _validate_action(action: str) -> None:
@@ -118,6 +151,52 @@ def _lane_to_repo_area(packet: MergeEvidencePacket) -> str | None:
         return None
     lane = packet.blast_radius.lane
     return _LANE_TO_AREA.get(lane, lane)
+
+
+def _prediction_outcome_value(prediction: Any) -> str:
+    if hasattr(prediction, "outcome"):
+        return str(prediction.outcome)
+    if hasattr(prediction, "predicted_outcome"):
+        return str(prediction.predicted_outcome)
+    if isinstance(prediction, dict):
+        raw = prediction.get("outcome") or prediction.get("predicted_outcome")
+        return str(raw)
+    msg = f"unsupported verdict-protocol prediction shape: {type(prediction).__name__}"
+    raise TypeError(msg)
+
+
+def _prediction_diagnostic_value(prediction: Any) -> str:
+    if hasattr(prediction, "diagnostic"):
+        return str(prediction.diagnostic)
+    if isinstance(prediction, dict):
+        raw = prediction.get("diagnostic")
+        return str(raw)
+    msg = f"unsupported verdict-protocol prediction shape: {type(prediction).__name__}"
+    raise TypeError(msg)
+
+
+def predict_verdict_protocol(
+    result: AgentResult,
+    *,
+    mode: str,
+) -> VerdictProtocolPrediction:
+    """Read the terminal-verdict protocol prediction without recording it (VP3)."""
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    if not result.success:
+        return VerdictProtocolPrediction(
+            outcome=RunOutcome.failed,
+            diagnostic=VerdictDiagnostic.provider_failure.value,
+        )
+    if mode in _REVIEW_MODE_NAMES and not result.terminal_submission_received:
+        return VerdictProtocolPrediction(
+            outcome=RunOutcome.inconclusive,
+            diagnostic=VerdictDiagnostic.provider_success_without_submission.value,
+        )
+    return VerdictProtocolPrediction(
+        outcome=RunOutcome.passed,
+        diagnostic=VerdictDiagnostic.approved.value,
+    )
 
 
 def predict_action(
@@ -159,18 +238,55 @@ def record_shadow_prediction(
     policy_id: str,
     output_path: Path,
     policy: GateActionPolicy | None = None,
+    prediction: Any | None = None,
+    actual_outcome: str | None = None,
 ) -> ShadowRecord:
-    """Build a :class:`ShadowRecord` and append it to ``output_path`` (W10.2).
+    """Build a :class:`ShadowRecord` and append it to ``output_path`` (W10.2 / VP3).
 
-    The function never re-derives evidence. It reads the packet's
-    blast radius, decides the rule key, computes the action via the
-    gate, and writes one JSON-Lines row. The output file is the
-    audit trail of what the gate *would* have done — the disagreement
-    report reads it later.
-
-    The record is returned so the caller can attach it to the packet
-    directly. The file write is the durable side.
+    When ``prediction`` is supplied the row records a verdict-protocol shadow
+    prediction in the same JSONL file as gate-action rows (D6). Otherwise the
+    gate-action path is unchanged.
     """
+    if prediction is not None:
+        predicted_outcome = _prediction_outcome_value(prediction)
+        diagnostic = _prediction_diagnostic_value(prediction)
+        disagreement: bool | None = None
+        if actual_outcome is not None:
+            report = disagree_with_outcome(
+                predicted_action=predicted_outcome,
+                actual_outcome=actual_outcome,
+                predicted_lane="review",
+                predicted_rule_id=diagnostic,
+                repo_area=policy_id,
+            )
+            raw_disagreement = report["disagreement"]
+            disagreement = raw_disagreement if isinstance(raw_disagreement, bool) else None
+        record = ShadowRecord(
+            run_id=run_id,
+            change_id=change_id,
+            policy_id=policy_id,
+            rule_id=diagnostic,
+            action=predicted_outcome,
+            repo_area=policy_id,
+            outcome=predicted_outcome,
+            predicted_outcome=predicted_outcome,
+            diagnostic=diagnostic,
+            verdict_diagnostic=diagnostic,
+            actual_outcome=actual_outcome,
+            disagreement=disagreement,
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("a", encoding="utf-8") as handle:
+            handle.write(record.model_dump_json())
+            handle.write("\n")
+        logger.info(
+            "» shadow record: change={} verdict_protocol outcome={} diagnostic={}",
+            change_id,
+            predicted_outcome,
+            diagnostic,
+        )
+        return record
+
     rule_id = select_rule_id(packet)
     action = predict_action(packet, policy=policy)
     _validate_action(action.value)
@@ -226,16 +342,20 @@ def disagree_with_outcome(
     # human final state. A "merge-shaped" outcome is a merge.
     block_shape = {"closed", "changes_requested", "block"}
     merge_shape = {"merged", "auto_merge"}
-    if predicted_action in merge_shape:
+    # Normalize gate-action vocabulary and verdict-protocol run outcomes onto
+    # comparable directions. Protocol outcomes each get their own direction so
+    # ``passed`` vs ``inconclusive`` mismatches are not folded away.
+    if predicted_action in _PROTOCOL_OUTCOMES:
+        predicted_direction = predicted_action
+    elif predicted_action in merge_shape:
         predicted_direction = "merge"
     elif predicted_action in block_shape:
         predicted_direction = "block"
     else:
-        # ``request_changes`` / ``require_human_review`` /
-        # ``require_more_tests`` / ``quarantine`` / ``escalate`` are
-        # all "the gate wants a human look before merging".
         predicted_direction = "review"
-    if actual_outcome in merge_shape:
+    if actual_outcome in _PROTOCOL_OUTCOMES:
+        actual_direction = actual_outcome
+    elif actual_outcome in merge_shape:
         actual_direction = "merge"
     elif actual_outcome in block_shape:
         actual_direction = "block"
@@ -320,10 +440,12 @@ def disagreement_report(
 
 __all__ = [
     "ShadowRecord",
+    "VerdictProtocolPrediction",
     "disagree_with_outcome",
     "disagreement_report",
     "enforce_action",
     "load_shadow_records",
     "predict_action",
+    "predict_verdict_protocol",
     "record_shadow_prediction",
 ]

--- a/src/mergecraft/evidence/shadow.py
+++ b/src/mergecraft/evidence/shadow.py
@@ -67,16 +67,10 @@ _VALID_ACTIONS: Final[frozenset[str]] = frozenset(GATE_ACTIONS)
 # Run-outcome strings compared by the verdict-protocol shadow path. Each maps
 # to its own direction so ``passed`` vs ``inconclusive`` disagreements stay
 # visible — folding both onto a generic "review" direction would hide them.
-_PROTOCOL_OUTCOMES: Final[frozenset[str]] = frozenset(
-    {
-        str(RunOutcome.passed),
-        str(RunOutcome.inconclusive),
-        str(RunOutcome.failed),
-        str(RunOutcome.configuration_error),
-    }
-)
+_PROTOCOL_OUTCOMES: Final[frozenset[str]] = frozenset(str(value) for value in RunOutcome)
 
 _REVIEW_MODE_NAMES: Final[frozenset[str]] = frozenset({"Review", "IncrementalReview"})
+_INCREMENTAL_REVIEW_NAMES: Final[frozenset[str]] = frozenset({"IncrementalReview"})
 
 
 # Map a packet's blast radius lane to a coarse repo area for the
@@ -179,8 +173,18 @@ def predict_verdict_protocol(
     result: AgentResult,
     *,
     mode: str,
+    setup_reason: str = "",
+    setup_policy: str = "warn",
+    prep_reason: str | None = None,
+    final_summary_written: bool = False,
 ) -> VerdictProtocolPrediction:
-    """Read the terminal-verdict protocol prediction without recording it (VP3)."""
+    """Read the terminal-verdict protocol prediction without recording it (VP3).
+
+    Mirrors the enforce path of ``_classify_outcome`` so a later flip is
+    comparable: IncrementalReview + ``final_summary_written`` is complete,
+    and setup/prep failures map to the same outcomes the resolver would
+    produce with ``verdict_protocol="enforce"``.
+    """
     from mergecraft.mcp.verdict import VerdictDiagnostic
 
     if not result.success:
@@ -188,7 +192,27 @@ def predict_verdict_protocol(
             outcome=RunOutcome.failed,
             diagnostic=VerdictDiagnostic.provider_failure.value,
         )
+    if setup_reason and setup_policy == "fail":
+        return VerdictProtocolPrediction(
+            outcome=RunOutcome.configuration_error,
+            diagnostic=VerdictDiagnostic.policy_rejection.value,
+        )
+    if setup_reason and setup_policy == "inconclusive":
+        return VerdictProtocolPrediction(
+            outcome=RunOutcome.inconclusive,
+            diagnostic=VerdictDiagnostic.policy_rejection.value,
+        )
+    if prep_reason:
+        return VerdictProtocolPrediction(
+            outcome=RunOutcome.inconclusive,
+            diagnostic=VerdictDiagnostic.policy_rejection.value,
+        )
     if mode in _REVIEW_MODE_NAMES and not result.terminal_submission_received:
+        if mode in _INCREMENTAL_REVIEW_NAMES and final_summary_written:
+            return VerdictProtocolPrediction(
+                outcome=RunOutcome.passed,
+                diagnostic=VerdictDiagnostic.approved.value,
+            )
         return VerdictProtocolPrediction(
             outcome=RunOutcome.inconclusive,
             diagnostic=VerdictDiagnostic.provider_success_without_submission.value,
@@ -267,6 +291,7 @@ def record_shadow_prediction(
             policy_id=policy_id,
             rule_id=diagnostic,
             action=predicted_outcome,
+            lane="review",
             repo_area=policy_id,
             outcome=predicted_outcome,
             predicted_outcome=predicted_outcome,

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -1216,6 +1216,7 @@ async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
         setup_policy=settings.setup_failure_policy,
         prep_reason=prep_reason,
         mode=tool_state.selected_mode,
+        verdict_protocol=settings.gates.terminal_verdict,
     )
 
     selected_mode_obj = next(

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -23,7 +23,11 @@ from mergecraft.analyzers.trust import (
     resolve_analyzers_mode,
 )
 from mergecraft.evidence.run_packet import emit_run_packet
-from mergecraft.main_outcome import _classify_outcome, _publish_span_attrs
+from mergecraft.main_outcome import (
+    _classify_outcome,
+    _publish_span_attrs,
+    _verdict_protocol_publish,
+)
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.dependencies import start_installation
 from mergecraft.mcp.server import start_mcp_http_server
@@ -303,6 +307,8 @@ async def _publish(
     outcome: RunOutcome,
     failure_reason: str | None,
     attrs_source: Callable[[], dict[str, Any]],
+    verdict_prediction: Any | None = None,
+    actual_outcome: str | None = None,
 ) -> str | None:
     """Tracer span + status check + evidence packet — the run's publish block.
 
@@ -335,7 +341,11 @@ async def _publish(
         # final state. A blocked or failed run is exactly when the
         # evidence matters most, so this runs on both branches below.
         written = await asyncio.to_thread(
-            emit_run_packet, tool_context, run_succeeded=outcome is RunOutcome.passed
+            emit_run_packet,
+            tool_context,
+            run_succeeded=outcome is RunOutcome.passed,
+            verdict_prediction=verdict_prediction,
+            actual_outcome=actual_outcome,
         )
         return str(written) if written else None
 
@@ -1220,6 +1230,15 @@ async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
         verdict_protocol=settings.gates.terminal_verdict,
         final_summary_written=tool_state.final_summary_written,
     )
+    diagnostic_attrs, verdict_prediction = _verdict_protocol_publish(
+        result=result,
+        mode=tool_state.selected_mode,
+        setup_reason=setup_reason,
+        setup_policy=settings.setup_failure_policy,
+        prep_reason=prep_reason,
+        final_summary_written=tool_state.final_summary_written,
+        terminal_verdict=settings.gates.terminal_verdict,
+    )
 
     selected_mode_obj = next(
         (m for m in tool_context.modes if m.name == tool_context.tool_state.selected_mode),
@@ -1229,7 +1248,9 @@ async def _finalize(ctx: RunContext, result: AgentResult) -> MainResult:
         ctx,
         outcome=outcome,
         failure_reason=failure_reason,
-        attrs_source=lambda: _publish_span_attrs(outcome, selected_mode_obj),
+        attrs_source=lambda: _publish_span_attrs(outcome, selected_mode_obj) | diagnostic_attrs,
+        verdict_prediction=verdict_prediction,
+        actual_outcome=str(outcome) if verdict_prediction is not None else None,
     )
 
     if outcome is not RunOutcome.passed:

--- a/src/mergecraft/main_outcome.py
+++ b/src/mergecraft/main_outcome.py
@@ -107,4 +107,44 @@ def _classify_outcome(
     return RunOutcome.passed, None
 
 
-__all__ = ["_classify_outcome", "_is_review_mode", "_publish_span_attrs"]
+def _verdict_protocol_publish(
+    *,
+    result: AgentResult,
+    mode: str | Mode | None,
+    setup_reason: str,
+    setup_policy: SetupFailurePolicy,
+    prep_reason: str | None,
+    final_summary_written: bool,
+    terminal_verdict: str,
+) -> tuple[dict[str, Any], Any | None]:
+    """Predict the enforce-path verdict protocol and build publish span attrs.
+
+    The prediction is always computed so the ``mergecraft.publish`` span
+    carries a closed ``VerdictDiagnostic``. The shadow recorder only
+    receives the prediction when ``terminal_verdict == "shadow"``.
+    """
+    from mergecraft.evidence.shadow import predict_verdict_protocol
+    from mergecraft.mcp.verdict import VerdictDiagnostic, span_attrs_for_verdict_diagnostic
+
+    mode_name = mode if isinstance(mode, str) else (mode.name if mode is not None else "")
+    prediction = predict_verdict_protocol(
+        result,
+        mode=mode_name,
+        setup_reason=setup_reason,
+        setup_policy=str(setup_policy),
+        prep_reason=prep_reason,
+        final_summary_written=final_summary_written,
+    )
+    diagnostic = VerdictDiagnostic(prediction.diagnostic)
+    attrs = span_attrs_for_verdict_diagnostic(diagnostic, summary=result.output or "")
+    if terminal_verdict != "shadow":
+        return attrs, None
+    return attrs, prediction
+
+
+__all__ = [
+    "_classify_outcome",
+    "_is_review_mode",
+    "_publish_span_attrs",
+    "_verdict_protocol_publish",
+]

--- a/src/mergecraft/main_outcome.py
+++ b/src/mergecraft/main_outcome.py
@@ -8,7 +8,7 @@ Both helpers carry over verbatim — the audit confirmed ``NO_ISSUES`` on the
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
 
@@ -51,6 +51,7 @@ def _classify_outcome(
     setup_policy: SetupFailurePolicy,
     prep_reason: str | None,
     mode: str | Mode | None = None,
+    verdict_protocol: Literal["shadow", "enforce"] | None = None,
 ) -> tuple[RunOutcome, str | None]:
     """Map the run's result + side-channels to a ``RunOutcome`` (D3/W5.2 + S1/D5/D10).
 
@@ -81,7 +82,11 @@ def _classify_outcome(
     if prep_reason:
         logger.warning("» prep failure mapped run to inconclusive: {}", prep_reason)
         return RunOutcome.inconclusive, prep_reason
-    if _is_review_mode(mode) and not result.terminal_submission_received:
+    if (
+        _is_review_mode(mode)
+        and not result.terminal_submission_received
+        and verdict_protocol != "shadow"
+    ):
         logger.warning("» {}", _MISSING_TERMINAL_VERDICT_REASON)
         return RunOutcome.inconclusive, _MISSING_TERMINAL_VERDICT_REASON
     # ``setup_policy`` is the closed ``SetupFailurePolicy`` vocabulary; any

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -276,6 +276,7 @@ class ToolState:
     # the live path so the packet can prove which model actually ran).
     requested_model: str | None = None
     fallback_index: int = 0
+    attempt_id: int = 0
     fallback_occurred: bool = False
     unselected_proxy_default: bool | None = None
     model_clamped: dict[str, str] | None = None

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -13,12 +13,14 @@ import json
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mergecraft.mcp.shared import execute, tool
 from mergecraft.mcp.tool_state import TerminalSubmission
+from mergecraft.tracing.redaction import redact_attrs
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -34,6 +36,42 @@ REJECTION_REQUEST_CHANGES_NO_FINDINGS = "request_changes_without_findings"
 REJECTION_APPROVE_CONFIRMED_BLOCKER = "approve_with_confirmed_blocker"
 REJECTION_APPROVE_FAILED_GATE = "approve_with_failed_required_gate"
 REJECTION_CONFLICTING_SUBMISSION = "conflicting_submission"
+
+
+class VerdictDiagnostic(StrEnum):
+    """Closed vocabulary for terminal-verdict shadow diagnostics (VP3)."""
+
+    provider_failure = "provider_failure"
+    provider_success_without_submission = "provider_success_without_submission"
+    schema_invalid = "schema_invalid"
+    semantic_invalid = "semantic_invalid"
+    policy_rejection = "policy_rejection"
+    agent_approved_but_blocked = "agent_approved_but_blocked"
+    approved = "approved"
+    fallback_triggered = "fallback_triggered"
+
+
+def span_attrs_for_verdict_diagnostic(
+    diagnostic: VerdictDiagnostic,
+    *,
+    summary: str,
+) -> dict[str, Any]:
+    """Build redacted span attrs carrying a closed ``VerdictDiagnostic`` code."""
+    return redact_attrs(
+        {
+            "verdict.diagnostic": diagnostic.value,
+            "summary": summary,
+        }
+    )
+
+
+def verdict_satisfies_attempt(
+    submission: TerminalSubmission,
+    *,
+    current_attempt_id: int,
+) -> bool:
+    """Return whether ``submission`` belongs to the active model-chain attempt (V7)."""
+    return submission.attempt_id == current_attempt_id
 
 
 def _canonical_payload_hash(payload: dict[str, Any]) -> str:
@@ -233,7 +271,7 @@ def submit_review_verdict_tool(ctx: ToolContext):
             findings=list(validated.findings),
             payload_hash=payload_hash,
             submitted_at=datetime.now(UTC).isoformat(),
-            attempt_id=ctx.tool_state.fallback_index,
+            attempt_id=ctx.tool_state.attempt_id,
         )
         ctx.tool_state.terminal_submission = submission
         ctx.tool_state.terminal_submission_conflict = False
@@ -302,7 +340,10 @@ __all__ = [
     "REJECTION_UNKNOWN_FIELDS",
     "SubmissionValidation",
     "SubmitReviewVerdictParams",
+    "VerdictDiagnostic",
+    "span_attrs_for_verdict_diagnostic",
     "submit_review_verdict_tool",
     "validate_submission",
     "validation_state_from_tool_context",
+    "verdict_satisfies_attempt",
 ]

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -411,6 +411,22 @@ def _attach_model_evidence(
     return result
 
 
+def stamp_attempt_id(
+    tool_state: ToolState,
+    *,
+    attempt_id: int,
+    fallback_index: int,
+) -> None:
+    """Stamp the active model-chain attempt on ``tool_state`` (V7 / VP3).
+
+    Called when a model-chain attempt starts so ``submit_review_verdict`` can
+    copy the same id onto ``TerminalSubmission`` instead of inferring one at
+    submit time.
+    """
+    tool_state.attempt_id = attempt_id
+    tool_state.fallback_index = fallback_index
+
+
 def promote_model_evidence(
     tool_state: ToolState,
     *,
@@ -967,4 +983,5 @@ __all__ = [
     "resolve_runtime_agent",
     "run_with_model_chain",
     "select_runnable_model_slug",
+    "stamp_attempt_id",
 ]

--- a/tests/evidence/test_verdict_shadow.py
+++ b/tests/evidence/test_verdict_shadow.py
@@ -81,6 +81,7 @@ def _classify(
     *,
     verdict_protocol: str,
     mode: str = "Review",
+    final_summary_written: bool = False,
 ) -> tuple[RunOutcome, str | None]:
     """Drive the real ``_classify_outcome`` with the VP3 protocol-mode kwarg."""
     from mergecraft.main_outcome import _classify_outcome
@@ -92,6 +93,7 @@ def _classify(
         prep_reason=None,
         mode=mode,
         verdict_protocol=verdict_protocol,
+        final_summary_written=final_summary_written,
     )
     return outcome, reason
 
@@ -191,6 +193,7 @@ def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> N
     )
     assert _as_outcome(row_outcome) is RunOutcome.inconclusive
     assert _row_diagnostic(row) is not None
+    assert getattr(row, "lane", None) == "review"
 
 
 def test_shadow_records_agreement_when_verdict_present(tmp_path: Path) -> None:
@@ -328,3 +331,84 @@ def test_disagreement_is_queryable() -> None:
         str(VerdictDiagnostic.provider_success_without_submission),
     }
     assert predicted == str(RunOutcome.inconclusive)
+
+
+def test_predictor_matches_enforce_for_incremental_progress() -> None:
+    """IncrementalReview + ``final_summary_written`` is complete under enforce and shadow."""
+    from mergecraft.evidence.shadow import predict_verdict_protocol
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    result = _missing_verdict_result()
+    outcome, reason = _classify(
+        result,
+        verdict_protocol="enforce",
+        mode="IncrementalReview",
+        final_summary_written=True,
+    )
+    assert outcome is RunOutcome.passed
+    assert reason is None
+
+    prediction = predict_verdict_protocol(
+        result,
+        mode="IncrementalReview",
+        final_summary_written=True,
+    )
+    assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.passed
+    diagnostic = _prediction_diagnostic(prediction)
+    assert diagnostic == VerdictDiagnostic.approved or (
+        str(diagnostic) == VerdictDiagnostic.approved.value
+    )
+
+
+def test_predictor_mirrors_setup_and_prep_branches() -> None:
+    """Setup/prep failures must not be predicted as a missing-verdict inconclusive."""
+    from mergecraft.evidence.shadow import predict_verdict_protocol
+
+    result = _present_verdict_result()
+    failed = predict_verdict_protocol(
+        result,
+        mode="Review",
+        setup_reason="setup script failed",
+        setup_policy="fail",
+    )
+    assert _as_outcome(_prediction_outcome(failed)) is RunOutcome.configuration_error
+
+    prep = predict_verdict_protocol(
+        result,
+        mode="Review",
+        prep_reason="dependency installation failed",
+    )
+    assert _as_outcome(_prediction_outcome(prep)) is RunOutcome.inconclusive
+
+
+def test_verdict_protocol_publish_records_only_in_shadow_mode() -> None:
+    """The live finalize helper predicts always and records only under shadow."""
+    from mergecraft.main_outcome import _verdict_protocol_publish
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    result = _missing_verdict_result()
+    attrs, prediction = _verdict_protocol_publish(
+        result=result,
+        mode="Review",
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        final_summary_written=False,
+        terminal_verdict="shadow",
+    )
+    assert prediction is not None
+    assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.inconclusive
+    assert attrs.get("verdict.diagnostic") == (
+        VerdictDiagnostic.provider_success_without_submission.value
+    )
+
+    _enforce_attrs, enforce_prediction = _verdict_protocol_publish(
+        result=result,
+        mode="Review",
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        final_summary_written=False,
+        terminal_verdict="enforce",
+    )
+    assert enforce_prediction is None

--- a/tests/evidence/test_verdict_shadow.py
+++ b/tests/evidence/test_verdict_shadow.py
@@ -1,6 +1,7 @@
-"""VP3.1 RED suite — shadow the terminal-verdict protocol (D6).
+"""VP3 shadow suite — terminal-verdict protocol (D6).
 
-Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1).
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1 RED,
+VP3.2 impl; xfail markers cleared after VP3.2).
 
 Pinned contracts (W0):
     **D6** — reuse ``evidence/shadow.py`` (``record_shadow_prediction``,
@@ -12,19 +13,12 @@ Pinned contracts (W0):
     actually fires.
 
 House style matches ``tests/evidence/test_gate_actions.py``: helpers at
-the top, one behaviour per test, imports of not-yet-landed symbols live
-inside test bodies so collection stays green.
-
-Every test is ``@pytest.mark.xfail(..., strict=False)`` pending VP3.2.
-Never ``strict=True`` — ``xfail_strict = true`` in pyproject.toml would
-turn a later XPASS into a hard failure the impl wave cannot touch.
+the top, one behaviour per test.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-
-import pytest
 
 from mergecraft.agents.shared import AgentResult
 from mergecraft.run_outcome import RunOutcome
@@ -33,11 +27,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mergecraft.evidence.packet import MergeEvidencePacket
-
-_VP32 = pytest.mark.xfail(
-    reason="green after VP3.2: verdict-protocol shadow predicate",
-    strict=False,
-)
 
 _POLICY_ID = "verdict-protocol"
 _MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
@@ -151,7 +140,6 @@ def _as_outcome(value: Any) -> RunOutcome:
 # ── D6 — shadow records without changing the legacy outcome ───────────────────
 
 
-@_VP32
 def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> None:
     """Shadow on, missing terminal verdict: legacy outcome unchanged, a row is written.
 
@@ -161,7 +149,11 @@ def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> N
     through the existing ``record_shadow_prediction`` writer (D6).
     """
     from mergecraft.config.settings import default_settings
-    from mergecraft.evidence.shadow import predict_verdict_protocol, record_shadow_prediction
+    from mergecraft.evidence.shadow import (
+        VerdictProtocolPrediction,
+        predict_verdict_protocol,
+        record_shadow_prediction,
+    )
     from mergecraft.mcp.verdict import VerdictDiagnostic
 
     assert default_settings().gates.terminal_verdict == "shadow"
@@ -173,6 +165,7 @@ def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> N
     )
 
     prediction = predict_verdict_protocol(result, mode="Review")
+    assert isinstance(prediction, VerdictProtocolPrediction)
     assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.inconclusive
     diagnostic = _prediction_diagnostic(prediction)
     assert diagnostic == VerdictDiagnostic.provider_success_without_submission or (
@@ -200,7 +193,6 @@ def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> N
     assert _row_diagnostic(row) is not None
 
 
-@_VP32
 def test_shadow_records_agreement_when_verdict_present(tmp_path: Path) -> None:
     """Both decisions agree when a terminal verdict is present; the row says so."""
     from mergecraft.evidence.shadow import (
@@ -249,7 +241,6 @@ def test_shadow_records_agreement_when_verdict_present(tmp_path: Path) -> None:
     assert disagreement is False
 
 
-@_VP32
 def test_shadow_row_carries_diagnostic_code(tmp_path: Path) -> None:
     """The closed ``VerdictDiagnostic`` value is on the shadow row."""
     from mergecraft.evidence.shadow import predict_verdict_protocol, record_shadow_prediction
@@ -274,7 +265,6 @@ def test_shadow_row_carries_diagnostic_code(tmp_path: Path) -> None:
     )
 
 
-@_VP32
 def test_enforce_mode_changes_the_outcome() -> None:
     """With enforce on, the VP2 ``_classify_outcome`` branch fires.
 
@@ -295,7 +285,6 @@ def test_enforce_mode_changes_the_outcome() -> None:
     assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.inconclusive
 
 
-@_VP32
 def test_disagreement_is_queryable() -> None:
     """``disagree_with_outcome`` surfaces shadow-vs-actual mismatches (D6).
 

--- a/tests/evidence/test_verdict_shadow.py
+++ b/tests/evidence/test_verdict_shadow.py
@@ -1,0 +1,341 @@
+"""VP3.1 RED suite — shadow the terminal-verdict protocol (D6).
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1).
+
+Pinned contracts (W0):
+    **D6** — reuse ``evidence/shadow.py`` (``record_shadow_prediction``,
+    ``disagree_with_outcome``). Do not invent a second shadow log.
+    **Convention 5** — same module as the gate-action recorder; the
+    verdict-protocol predicate sits *alongside* ``predict_action``.
+    Shadow mode records the new protocol's decision beside the legacy
+    outcome; enforce mode is when the VP2 ``_classify_outcome`` branch
+    actually fires.
+
+House style matches ``tests/evidence/test_gate_actions.py``: helpers at
+the top, one behaviour per test, imports of not-yet-landed symbols live
+inside test bodies so collection stays green.
+
+Every test is ``@pytest.mark.xfail(..., strict=False)`` pending VP3.2.
+Never ``strict=True`` — ``xfail_strict = true`` in pyproject.toml would
+turn a later XPASS into a hard failure the impl wave cannot touch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.shared import AgentResult
+from mergecraft.run_outcome import RunOutcome
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+_VP32 = pytest.mark.xfail(
+    reason="green after VP3.2: verdict-protocol shadow predicate",
+    strict=False,
+)
+
+_POLICY_ID = "verdict-protocol"
+_MISSING_VERDICT_REASON = "no terminal review verdict was submitted for this attempt"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _packet(**overrides: Any) -> MergeEvidencePacket:
+    """Minimal packet so ``record_shadow_prediction`` keeps its existing signature."""
+    from mergecraft.evidence.packet import (
+        PACKET_SCHEMA_VERSION,
+        AgentMetadata,
+        MergeEvidencePacket,
+    )
+
+    base: dict[str, Any] = {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "change_id": "acme/demo#42",
+        "agent": AgentMetadata(id="claude", version="0.0.0", model="claude-sonnet-4-5"),
+        "files_changed": [],
+        "findings": [],
+        "deterministic_checks": [],
+        "self_assessment": None,
+        "decision": None,
+        "blast_radius": None,
+        "trajectory": None,
+        "evals": None,
+    }
+    base.update(overrides)
+    return MergeEvidencePacket(**base)
+
+
+def _missing_verdict_result() -> AgentResult:
+    """Provider success, no terminal submission — the VP2 / VP3 core case."""
+    return AgentResult(success=True, output="LGTM", terminal_submission_received=False)
+
+
+def _present_verdict_result() -> AgentResult:
+    """A usable terminal verdict is on the result."""
+    return AgentResult(
+        success=True,
+        output="reviewed",
+        terminal_submission_received=True,
+        terminal_submission_id="sub-1",
+        diagnostics={"attempt_id": 0},
+    )
+
+
+def _classify(
+    result: AgentResult,
+    *,
+    verdict_protocol: str,
+    mode: str = "Review",
+) -> tuple[RunOutcome, str | None]:
+    """Drive the real ``_classify_outcome`` with the VP3 protocol-mode kwarg."""
+    from mergecraft.main_outcome import _classify_outcome
+
+    outcome, reason = _classify_outcome(
+        result=result,
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        mode=mode,
+        verdict_protocol=verdict_protocol,
+    )
+    return outcome, reason
+
+
+def _prediction_outcome(prediction: Any) -> Any:
+    if hasattr(prediction, "outcome"):
+        return prediction.outcome
+    if hasattr(prediction, "predicted_outcome"):
+        return prediction.predicted_outcome
+    if isinstance(prediction, dict):
+        return prediction.get("outcome") or prediction.get("predicted_outcome")
+    msg = f"unsupported verdict-protocol prediction shape: {type(prediction).__name__}"
+    raise TypeError(msg)
+
+
+def _prediction_diagnostic(prediction: Any) -> Any:
+    if hasattr(prediction, "diagnostic"):
+        return prediction.diagnostic
+    if isinstance(prediction, dict):
+        return prediction.get("diagnostic")
+    msg = f"unsupported verdict-protocol prediction shape: {type(prediction).__name__}"
+    raise TypeError(msg)
+
+
+def _row_diagnostic(row: Any) -> Any:
+    """Read the closed diagnostic off a shadow row, regardless of field name."""
+    for attr in ("diagnostic", "verdict_diagnostic"):
+        if hasattr(row, attr):
+            value = getattr(row, attr)
+            if value is not None:
+                return value
+    if isinstance(row, dict):
+        return row.get("diagnostic") or row.get("verdict_diagnostic")
+    dumped = row.model_dump() if hasattr(row, "model_dump") else None
+    if isinstance(dumped, dict):
+        return dumped.get("diagnostic") or dumped.get("verdict_diagnostic")
+    return None
+
+
+def _as_outcome(value: Any) -> RunOutcome:
+    if isinstance(value, RunOutcome):
+        return value
+    return RunOutcome(str(value))
+
+
+# ── D6 — shadow records without changing the legacy outcome ───────────────────
+
+
+@_VP32
+def test_shadow_records_prediction_without_changing_outcome(tmp_path: Path) -> None:
+    """Shadow on, missing terminal verdict: legacy outcome unchanged, a row is written.
+
+    Pre-VP2, provider success reported ``passed``. VP3 shadow mode must keep
+    that legacy outcome while ``predict_verdict_protocol`` records the new
+    protocol's prediction (``inconclusive`` / missing-verdict diagnostic)
+    through the existing ``record_shadow_prediction`` writer (D6).
+    """
+    from mergecraft.config.settings import default_settings
+    from mergecraft.evidence.shadow import predict_verdict_protocol, record_shadow_prediction
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    assert default_settings().gates.terminal_verdict == "shadow"
+
+    result = _missing_verdict_result()
+    outcome, _reason = _classify(result, verdict_protocol="shadow")
+    assert outcome is RunOutcome.passed, (
+        f"shadow mode must leave the legacy outcome unchanged, got {outcome!r}"
+    )
+
+    prediction = predict_verdict_protocol(result, mode="Review")
+    assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.inconclusive
+    diagnostic = _prediction_diagnostic(prediction)
+    assert diagnostic == VerdictDiagnostic.provider_success_without_submission or (
+        str(diagnostic) == VerdictDiagnostic.provider_success_without_submission.value
+    )
+
+    target = tmp_path / "shadow.jsonl"
+    row = record_shadow_prediction(
+        _packet(),
+        change_id="acme/demo#42",
+        run_id="run-1",
+        policy_id=_POLICY_ID,
+        output_path=target,
+        prediction=prediction,
+        actual_outcome=str(outcome),
+    )
+    assert target.is_file(), "shadow recorder did not write to disk"
+    assert target.read_text(encoding="utf-8").strip(), "shadow record is empty"
+    row_outcome = (
+        _prediction_outcome(row)
+        if hasattr(row, "outcome") or hasattr(row, "predicted_outcome")
+        else _prediction_outcome(prediction)
+    )
+    assert _as_outcome(row_outcome) is RunOutcome.inconclusive
+    assert _row_diagnostic(row) is not None
+
+
+@_VP32
+def test_shadow_records_agreement_when_verdict_present(tmp_path: Path) -> None:
+    """Both decisions agree when a terminal verdict is present; the row says so."""
+    from mergecraft.evidence.shadow import (
+        disagree_with_outcome,
+        predict_verdict_protocol,
+        record_shadow_prediction,
+    )
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    result = _present_verdict_result()
+    outcome, reason = _classify(result, verdict_protocol="shadow")
+    assert outcome is RunOutcome.passed
+    assert reason is None
+
+    prediction = predict_verdict_protocol(result, mode="Review")
+    predicted = _as_outcome(_prediction_outcome(prediction))
+    assert predicted is RunOutcome.passed
+    diagnostic = _prediction_diagnostic(prediction)
+    assert diagnostic == VerdictDiagnostic.approved or str(diagnostic) == (
+        VerdictDiagnostic.approved.value
+    )
+
+    target = tmp_path / "shadow.jsonl"
+    row = record_shadow_prediction(
+        _packet(),
+        change_id="acme/demo#42",
+        run_id="run-2",
+        policy_id=_POLICY_ID,
+        output_path=target,
+        prediction=prediction,
+        actual_outcome=str(outcome),
+    )
+    disagreement = getattr(row, "disagreement", None)
+    if disagreement is None:
+        dumped = row.model_dump() if hasattr(row, "model_dump") else {}
+        disagreement = dumped.get("disagreement") if isinstance(dumped, dict) else None
+    if disagreement is None:
+        report = disagree_with_outcome(
+            predicted_action=str(predicted),
+            actual_outcome=str(outcome),
+            predicted_lane="review",
+            predicted_rule_id=str(_prediction_diagnostic(prediction)),
+            repo_area=_POLICY_ID,
+        )
+        disagreement = report["disagreement"]
+    assert disagreement is False
+
+
+@_VP32
+def test_shadow_row_carries_diagnostic_code(tmp_path: Path) -> None:
+    """The closed ``VerdictDiagnostic`` value is on the shadow row."""
+    from mergecraft.evidence.shadow import predict_verdict_protocol, record_shadow_prediction
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    result = _missing_verdict_result()
+    prediction = predict_verdict_protocol(result, mode="Review")
+    target = tmp_path / "shadow.jsonl"
+    row = record_shadow_prediction(
+        _packet(),
+        change_id="acme/demo#42",
+        run_id="run-3",
+        policy_id=_POLICY_ID,
+        output_path=target,
+        prediction=prediction,
+        actual_outcome=str(RunOutcome.passed),
+    )
+    code = _row_diagnostic(row)
+    assert code is not None, "shadow row is missing the VerdictDiagnostic"
+    assert code == VerdictDiagnostic.provider_success_without_submission or (
+        str(code) == VerdictDiagnostic.provider_success_without_submission.value
+    )
+
+
+@_VP32
+def test_enforce_mode_changes_the_outcome() -> None:
+    """With enforce on, the VP2 ``_classify_outcome`` branch fires.
+
+    Missing verdict → ``RunOutcome.inconclusive`` with the VP2 reason.
+    """
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.evidence.shadow import predict_verdict_protocol
+
+    settings = RepoSettings.model_validate({"gates": {"terminal_verdict": "enforce"}})
+    assert settings.gates.terminal_verdict == "enforce"
+
+    result = _missing_verdict_result()
+    outcome, reason = _classify(result, verdict_protocol="enforce")
+    assert outcome is RunOutcome.inconclusive
+    assert reason == _MISSING_VERDICT_REASON
+
+    prediction = predict_verdict_protocol(result, mode="Review")
+    assert _as_outcome(_prediction_outcome(prediction)) is RunOutcome.inconclusive
+
+
+@_VP32
+def test_disagreement_is_queryable() -> None:
+    """``disagree_with_outcome`` surfaces shadow-vs-actual mismatches (D6).
+
+    Predicted ``inconclusive`` (new protocol) against an actual legacy
+    ``passed`` is a disagreement. Deleting the verdict-protocol mapping
+    and folding both onto a generic "review" direction would hide it.
+    """
+    from mergecraft.evidence.shadow import disagree_with_outcome
+
+    # Drive the real comparer first: protocol outcomes must not collapse onto
+    # a generic "review" direction (today's merge/block/review mapping would).
+    rows = disagree_with_outcome(
+        predicted_action=str(RunOutcome.inconclusive),
+        actual_outcome=str(RunOutcome.passed),
+        predicted_lane="review",
+        predicted_rule_id="provider_success_without_submission",
+        repo_area=_POLICY_ID,
+    )
+    assert rows["predicted_action"] == str(RunOutcome.inconclusive)
+    assert rows["actual_outcome"] == str(RunOutcome.passed)
+    assert rows["disagreement"] is True
+
+    agree = disagree_with_outcome(
+        predicted_action=str(RunOutcome.passed),
+        actual_outcome=str(RunOutcome.passed),
+        predicted_lane="review",
+        predicted_rule_id="approved",
+        repo_area=_POLICY_ID,
+    )
+    assert agree["disagreement"] is False
+
+    from mergecraft.evidence.shadow import predict_verdict_protocol
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+
+    result = _missing_verdict_result()
+    prediction = predict_verdict_protocol(result, mode="Review")
+    predicted = str(_as_outcome(_prediction_outcome(prediction)))
+    diagnostic = str(_prediction_diagnostic(prediction))
+    assert diagnostic in {
+        VerdictDiagnostic.provider_success_without_submission.value,
+        str(VerdictDiagnostic.provider_success_without_submission),
+    }
+    assert predicted == str(RunOutcome.inconclusive)

--- a/tests/review/test_attempt_attribution.py
+++ b/tests/review/test_attempt_attribution.py
@@ -134,3 +134,5 @@ async def test_stale_structural_result_is_not_reused(tmp_path: Path) -> None:
         "stale TerminalSubmission must not satisfy the current attempt"
     )
     assert finalized.terminal_submission_id is None
+    assert finalized.diagnostics.get("rejection_reason") == "stale_attempt"
+    assert finalized.diagnostics.get("attempt_id") == 0

--- a/tests/review/test_attempt_attribution.py
+++ b/tests/review/test_attempt_attribution.py
@@ -1,6 +1,7 @@
-"""VP3.1 RED suite — V7 attempt attribution / verdict freshness.
+"""VP3 attempt attribution — V7 verdict freshness.
 
-Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3 File 3).
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3 File 3,
+VP3.2 impl; xfail markers cleared after VP3.2).
 
 **V7**: bind the terminal verdict to the attempt that produced it. Stamp
 ``attempt_id`` when the model chain starts an attempt (beside
@@ -32,11 +33,6 @@ from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_VP32 = pytest.mark.xfail(
-    reason="green after VP3.2: attempt_id stamp + stale structural result",
-    strict=False,
-)
 
 
 def _ctx(tmp_path: Path) -> ToolContext:
@@ -77,7 +73,6 @@ def _approve_payload() -> dict[str, str | list[object]]:
     }
 
 
-@_VP32
 @pytest.mark.asyncio
 async def test_verdict_is_bound_to_its_attempt(tmp_path: Path) -> None:
     """V7: ``TerminalSubmission.attempt_id`` is the id stamped when the attempt starts.
@@ -106,7 +101,6 @@ async def test_verdict_is_bound_to_its_attempt(tmp_path: Path) -> None:
     assert finalized.diagnostics.get("attempt_id") == 2
 
 
-@_VP32
 @pytest.mark.asyncio
 async def test_stale_structural_result_is_not_reused(tmp_path: Path) -> None:
     """A result whose ``attempt_id`` does not match the current attempt does not satisfy it.

--- a/tests/review/test_attempt_attribution.py
+++ b/tests/review/test_attempt_attribution.py
@@ -1,0 +1,142 @@
+"""VP3.1 RED suite — V7 attempt attribution / verdict freshness.
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3 File 3).
+
+**V7**: bind the terminal verdict to the attempt that produced it. Stamp
+``attempt_id`` when the model chain starts an attempt (beside
+``fallback_index`` in ``utils/agent_resolve.py``), record it on
+``TerminalSubmission``, and refuse to treat a structural result whose
+``attempt_id`` does not match the current attempt as satisfying it.
+
+Pairs with HA2 ``stale_attempt``: a result from a previous attempt must
+not be reused by a later one.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents.post_run import finalize_agent_result
+from mergecraft.agents.shared import AgentResult, AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import TerminalSubmission, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_VP32 = pytest.mark.xfail(
+    reason="green after VP3.2: attempt_id stamp + stale structural result",
+    strict=False,
+)
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=7, is_pr=True),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def _run_ctx(tool_ctx: ToolContext) -> AgentRunContext:
+    return AgentRunContext(
+        payload=tool_ctx.payload,
+        mcp_server_url=tool_ctx.mcp_server_url,
+        tmpdir=tool_ctx.tmpdir,
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(),
+        tool_state=tool_ctx.tool_state,
+    )
+
+
+def _approve_payload() -> dict[str, str | list[object]]:
+    return {
+        "verdict": "approve",
+        "summary": "No blocking issues in the diff.",
+        "findings": [],
+    }
+
+
+@_VP32
+@pytest.mark.asyncio
+async def test_verdict_is_bound_to_its_attempt(tmp_path: Path) -> None:
+    """V7: ``TerminalSubmission.attempt_id`` is the id stamped when the attempt starts.
+
+    ``stamp_attempt_id`` lives beside ``fallback_index`` in
+    ``utils/agent_resolve.py``. The recorder must copy that stamp onto
+    the submission — not invent a second id at submit time.
+    """
+    from mergecraft.mcp.verdict import submit_review_verdict_tool
+    from mergecraft.utils.agent_resolve import stamp_attempt_id
+
+    ctx = _ctx(tmp_path)
+    stamp_attempt_id(ctx.tool_state, attempt_id=2, fallback_index=2)
+    assert ctx.tool_state.attempt_id == 2
+    assert ctx.tool_state.fallback_index == 2
+
+    result = await submit_review_verdict_tool(ctx).execute(_approve_payload())
+    assert result.is_error is False
+    recorded = ctx.tool_state.terminal_submission
+    assert recorded is not None
+    assert isinstance(recorded, TerminalSubmission)
+    assert recorded.attempt_id == 2
+
+    finalized = await finalize_agent_result(_run_ctx(ctx), AgentResult(success=True))
+    assert finalized.terminal_submission_received is True
+    assert finalized.diagnostics.get("attempt_id") == 2
+
+
+@_VP32
+@pytest.mark.asyncio
+async def test_stale_structural_result_is_not_reused(tmp_path: Path) -> None:
+    """A result whose ``attempt_id`` does not match the current attempt does not satisfy it.
+
+    Guard-deletion: if the freshness check is removed, ``finalize_agent_result``
+    would still set ``terminal_submission_received=True`` for a leftover
+    attempt-0 submission while the chain is on attempt 1. Pairs with HA2
+    ``stale_attempt``.
+    """
+    from mergecraft.mcp.verdict import verdict_satisfies_attempt
+    from mergecraft.utils.agent_resolve import stamp_attempt_id
+
+    ctx = _ctx(tmp_path)
+    stale = TerminalSubmission(
+        id="attempt-0-submission",
+        verdict="approve",
+        summary="cached review from attempt 0",
+        findings=[],
+        payload_hash="abc",
+        submitted_at="2026-08-16T00:00:00+00:00",
+        attempt_id=0,
+    )
+    ctx.tool_state.terminal_submission = stale
+    stamp_attempt_id(ctx.tool_state, attempt_id=1, fallback_index=1)
+
+    assert verdict_satisfies_attempt(stale, current_attempt_id=1) is False
+    assert verdict_satisfies_attempt(stale, current_attempt_id=0) is True
+
+    finalized = await finalize_agent_result(_run_ctx(ctx), AgentResult(success=True))
+    assert finalized.terminal_submission_received is False, (
+        "stale TerminalSubmission must not satisfy the current attempt"
+    )
+    assert finalized.terminal_submission_id is None

--- a/tests/test_runtime_call_sites.py
+++ b/tests/test_runtime_call_sites.py
@@ -220,6 +220,22 @@ _CONTRACTS: Final[tuple[_Contract, ...]] = (
             "report has no data and W10.4 cannot render anything (#50)"
         ),
     ),
+    _Contract(
+        symbol="predict_verdict_protocol",
+        defined_in="evidence/shadow.py",
+        why=(
+            "no reachable caller means terminal-verdict shadow mode never records a prediction "
+            "beside the legacy outcome, so a later enforce flip has nothing to compare (VP3)"
+        ),
+    ),
+    _Contract(
+        symbol="span_attrs_for_verdict_diagnostic",
+        defined_in="mcp/verdict.py",
+        why=(
+            "no reachable caller means VerdictDiagnostic never reaches the mergecraft.publish "
+            "span, so shadow/enforce runs have no diagnostic on the trace (VP3)"
+        ),
+    ),
 )
 
 

--- a/tests/tracing/test_verdict_diagnostics.py
+++ b/tests/tracing/test_verdict_diagnostics.py
@@ -1,6 +1,7 @@
-"""VP3.1 RED suite — ``VerdictDiagnostic`` on the span, through redaction.
+"""VP3 diagnostics suite — ``VerdictDiagnostic`` on the span, through redaction.
 
-Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1 File 4).
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1 File 4,
+VP3.2 impl; xfail markers cleared after VP3.2).
 
 The eight closed values (snake_case ``StrEnum`` members) must each appear
 as a span attribute and/or check-run summary **through**
@@ -13,13 +14,6 @@ from __future__ import annotations
 
 import json
 from typing import Any
-
-import pytest
-
-_VP32 = pytest.mark.xfail(
-    reason="green after VP3.2: verdict diagnostic span + redaction",
-    strict=False,
-)
 
 # Plan VP3.1: provider failure · provider success w/o submission ·
 # schema-invalid · semantic-invalid · policy rejection ·
@@ -75,7 +69,6 @@ def _attrs_from_helper(diagnostic: Any, *, summary: str) -> dict[str, Any]:
     return attrs
 
 
-@_VP32
 def test_each_diagnostic_reaches_the_span() -> None:
     """Each of the eight closed ``VerdictDiagnostic`` values reaches the span.
 
@@ -120,7 +113,6 @@ def test_each_diagnostic_reaches_the_span() -> None:
         assert _diagnostic_on_attrs(event.attrs, member.value)
 
 
-@_VP32
 def test_diagnostics_are_redacted() -> None:
     """A submission summary that looks like a token must not appear on the span.
 

--- a/tests/tracing/test_verdict_diagnostics.py
+++ b/tests/tracing/test_verdict_diagnostics.py
@@ -1,0 +1,147 @@
+"""VP3.1 RED suite — ``VerdictDiagnostic`` on the span, through redaction.
+
+Wave plan: ``.ignorelocal/01-review-integrity-wave-plan.md`` (VP3.1 File 4).
+
+The eight closed values (snake_case ``StrEnum`` members) must each appear
+as a span attribute and/or check-run summary **through**
+``tracing/redaction.py``. A submission summary that looks like a token
+must not survive onto the span — deleting the redaction call must fail
+``test_diagnostics_are_redacted``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+_VP32 = pytest.mark.xfail(
+    reason="green after VP3.2: verdict diagnostic span + redaction",
+    strict=False,
+)
+
+# Plan VP3.1: provider failure · provider success w/o submission ·
+# schema-invalid · semantic-invalid · policy rejection ·
+# agent-approved-but-blocked · approved · fallback-triggered.
+_CLOSED_DIAGNOSTICS: tuple[str, ...] = (
+    "provider_failure",
+    "provider_success_without_submission",
+    "schema_invalid",
+    "semantic_invalid",
+    "policy_rejection",
+    "agent_approved_but_blocked",
+    "approved",
+    "fallback_triggered",
+)
+
+_TOKEN = "sk-abcdefghijklmnopqrstuvwxyz"
+_TOKEN_SUMMARY = f"Looks good. token={_TOKEN}"
+_SPAN_ATTR_KEYS: tuple[str, ...] = (
+    "verdict.diagnostic",
+    "mergecraft.verdict.diagnostic",
+    "diagnostic",
+)
+
+
+def _diagnostic_on_attrs(attrs: dict[str, Any], expected: str) -> bool:
+    values = {str(value) for value in attrs.values()}
+    if expected in values:
+        return True
+    for key in _SPAN_ATTR_KEYS:
+        if str(attrs.get(key, "")) == expected:
+            return True
+    return expected in json.dumps(attrs, default=str)
+
+
+def _attrs_from_helper(diagnostic: Any, *, summary: str) -> dict[str, Any]:
+    """Drive the product emission helper VP3.2 must add.
+
+    The helper is required to run the payload through
+    ``tracing/redaction.py`` (``redact_attrs`` / ``redact_event``) before
+    returning. This test inspects the helper's return value directly —
+    the test itself does **not** call ``redact_attrs``, so skipping
+    redaction in the helper leaves the token on the attrs.
+    """
+    from mergecraft.mcp.verdict import span_attrs_for_verdict_diagnostic
+
+    raw = span_attrs_for_verdict_diagnostic(diagnostic, summary=summary)
+    attrs = raw[0] if isinstance(raw, tuple) else raw
+    if not isinstance(attrs, dict):
+        msg = (
+            f"span_attrs_for_verdict_diagnostic must return attrs dict, got {type(attrs).__name__}"
+        )
+        raise TypeError(msg)
+    return attrs
+
+
+@_VP32
+def test_each_diagnostic_reaches_the_span() -> None:
+    """Each of the eight closed ``VerdictDiagnostic`` values reaches the span.
+
+    Iterated in one collected test so VP3.1 acceptance stays 9 collected.
+    """
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+    from mergecraft.tracing.event import TraceEvent
+    from mergecraft.tracing.redaction import redact_attrs
+
+    members = tuple(member.value for member in VerdictDiagnostic)
+    assert members == _CLOSED_DIAGNOSTICS, (
+        f"VerdictDiagnostic must be the eight closed values, got {members!r}"
+    )
+    assert {member.name for member in VerdictDiagnostic} == set(_CLOSED_DIAGNOSTICS)
+
+    for member in VerdictDiagnostic:
+        attrs = _attrs_from_helper(member, summary=f"diagnostic={member.value}")
+        assert _diagnostic_on_attrs(attrs, member.value), (
+            f"{member.value!r} missing from span attrs {attrs!r}"
+        )
+        # The emission path is defined to go through redaction.py; applying
+        # it again must not drop the diagnostic code itself.
+        redacted = redact_attrs(attrs)
+        assert _diagnostic_on_attrs(redacted, member.value), (
+            f"redaction dropped diagnostic {member.value!r}"
+        )
+        event = TraceEvent.model_validate(
+            {
+                "kind": "mergecraft.publish",
+                "span_id": "span-verdict",
+                "parent_span_id": None,
+                "session_id": "run-1",
+                "turn_id": "turn-1",
+                "tier": "trusted",
+                "ts_start_ns": 1_000,
+                "ts_end_ns": 2_000,
+                "status": "ok",
+                "attrs": attrs,
+                "trace_id": "trace-verdict-0001",
+            }
+        )
+        assert _diagnostic_on_attrs(event.attrs, member.value)
+
+
+@_VP32
+def test_diagnostics_are_redacted() -> None:
+    """A submission summary that looks like a token must not appear on the span.
+
+    Guard-deletion: if ``span_attrs_for_verdict_diagnostic`` skips
+    ``tracing/redaction.py``, ``_TOKEN`` survives on the returned attrs
+    and this test fails. The test does not re-apply ``redact_attrs`` to
+    the helper output before the leak assertion.
+    """
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+    from mergecraft.tracing.redaction import redact_attrs
+
+    # Prove the canary is actually secret-shaped for this redaction layer.
+    leaked = {"summary": _TOKEN_SUMMARY}
+    assert _TOKEN in json.dumps(leaked)
+    assert _TOKEN not in json.dumps(redact_attrs(leaked)), (
+        "fixture token is not redacted by tracing/redaction.py — pick another canary"
+    )
+
+    attrs = _attrs_from_helper(VerdictDiagnostic.approved, summary=_TOKEN_SUMMARY)
+    serialized = json.dumps(attrs, default=str)
+    assert _TOKEN not in serialized, (
+        "submission summary token leaked onto the span; redaction was skipped"
+    )
+    assert _diagnostic_on_attrs(attrs, VerdictDiagnostic.approved.value)


### PR DESCRIPTION
## Summary
- Default `gates.terminal_verdict` is `shadow`: the new protocol is predicted and logged beside the legacy outcome without changing it
- Adds verdict diagnostics and attempt attribution so a later enforce flip is comparable
- Depends on VP2 (#226). Merge #223 then #226 into `pre-0.0.1` first; this PR then contains only the VP3 commits

## Test plan
- [x] `make lint` / `make typecheck`
- [x] `make ci-resume`
- [ ] CI on this PR
