### PR TITLE
feat(agents): agent registry binding model, prompt, toolset and budget

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -440,7 +440,14 @@ jobs:
         # second PR just to consume the first. 3bf6d7b survives merge intact — this repo
         # merges PRs with a merge commit, never squash — so once #204 lands this pin is
         # already correct; no follow-up bump needed.
-        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
+        # 2026-08-17 (sixth bump): re-bumped to 0592d72 — prep treated a skipped
+        # Python install (`shell: disabled`) as a hard failure, so this repo's own
+        # self-review job (which sets `shell: disabled`) never reached a verdict.
+        # Fixed in #231 (src/mergecraft/prep/). Same self-review limitation as #204:
+        # pull_request_target is resolved from `main`, so #231 cannot consume this
+        # pin until it lands there; pin the product-fix commit now so a follow-up
+        # bump PR is not required after merge. 0592d72 survives merge intact.
+        uses: alexhawat/mergeCraft@0592d72828797005fdc5af1da9e413b0a98bd8a0 # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: 25m
@@ -535,8 +542,10 @@ jobs:
         # f5b070b (#194: $CODEX_HOME/.gemini/.claude also created root-owned before the
         # drop, same bug shape), then to 3bf6d7b (#204: checkout_pr fetch failure on a
         # shared workspace when Nous falls back to Codex, fixed by detaching HEAD before
-        # the fetch) — see the matching comment on the Nous step above for why.
-        uses: alexhawat/mergeCraft@3bf6d7bba38cfeb7966b78316bdc5a150c43ce0d # pre-0.0.1
+        # the fetch), then to 0592d72 (#231: skipped Python install under `shell:
+        # disabled` must not fail prep) — see the matching comment on the Nous step
+        # above for why.
+        uses: alexhawat/mergeCraft@0592d72828797005fdc5af1da9e413b0a98bd8a0 # pre-0.0.1
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added agent registry binding model, prompt, toolset and budget per role with `mergecraft agents list|show|set` and `make agents-check`
+
 ### Fixed
 
 - Fixed: model-chain fallback now advances when the provider succeeds without a terminal verdict; a valid `request_changes` is a usable result and does not trigger fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reviews of Python repositories with `shell: disabled` no longer fail closed after a completed review just because dependency installation was skipped as a security policy
 - Fixed: model-chain fallback now advances when the provider succeeds without a terminal verdict; a valid `request_changes` is a usable result and does not trigger fallback
 - Fixed: explicit `harness:` now selects the runtime agent, not only span labels
 - Fixed: a previously recorded `approve` is re-validated before GitHub publish, so a later confirmed blocker cannot ship an `APPROVE` review

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ pyright: ## Supplemental Pyright pass
 catalog-check: ## Manifest fixture/doc/severity gate (C5/C6)
 	$(UV) run python -m mergecraft.analyzers.catalog_docs
 
+agents-check: ## Agent registry model/prompt/tool validation gate (AP1)
+	$(UV) run python -m mergecraft.agents.catalog_docs
+
 PYTEST_SPLIT := $(if $(MERGECRAFT_TEST_SPLITS),--splits $(MERGECRAFT_TEST_SPLITS) --group $(MERGECRAFT_TEST_GROUP) --splitting-algorithm least_duration,)
 
 test: ## Unit tests
@@ -141,11 +144,11 @@ reference-docs: ## Regenerate the README action + CLI reference tables
 reference-docs-check: ## Fail when README reference tables drift from action.yml / the CLI
 	$(UV) run python scripts/gen_reference_docs.py --check
 
-ci-static: lockcheck lint typecheck pyright catalog-check build example-workflows-check reference-docs-check ## Static/build tier
+ci-static: lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check ## Static/build tier
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check build example-workflows-check reference-docs-check security coverage-gate
+CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check security coverage-gate
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/README.md
+++ b/README.md
@@ -566,6 +566,9 @@ of them for its full flag set):
 <!-- BEGIN:cli-commands -->
 | Command | Description |
 |---------|-------------|
+| `mergecraft agents list` | List agent bindings with model chain, prompt id, and tool count. |
+| `mergecraft agents set <role>` | Write a single agent binding override into `.mergecraft/config.yaml`. |
+| `mergecraft agents show <role>` | Show resolved prompt text and MCP tool names for one role. |
 | `mergecraft analyzers detect` | Show analyzers that would run for changed paths in this repo. |
 | `mergecraft analyzers docs` | Regenerate `docs/ANALYZERS.md` from manifests. |
 | `mergecraft analyzers explain <analyzer-id>` | Print manifest fields and notes for one analyzer. |

--- a/docs/test-plans/agent-pipeline-ap1.md
+++ b/docs/test-plans/agent-pipeline-ap1.md
@@ -26,6 +26,9 @@ post-AP1.2 reconciliation. Previously:
 **Acceptance (post-AP1.2 reconciliation):** 16 collected; 16 pass; 0 xfail/xpass.
 `make lint` + `make typecheck` clean.
 
+**PR #231 review finding:** non-role key without `role:`/`lens:` must not overwrite
+the default reviewer. Coverage rows 17–19; collected count is 19.
+
 ## Target API AP1.2 must satisfy
 
 `src/mergecraft/agents/registry.py` (new):
@@ -49,7 +52,7 @@ post-AP1.2 reconciliation. Previously:
 
 ## Contract → coverage matrix
 
-### `tests/agents/test_agent_registry.py` — 13 tests
+### `tests/agents/test_agent_registry.py` — 15 tests
 
 | # | Test | Layer | Scenario | Contract |
 |---|------|-------|----------|----------|
@@ -66,14 +69,17 @@ post-AP1.2 reconciliation. Previously:
 | 11 | `test_registry_validation_rejects_a_missing_model` | unit | error | Unknown model slug → `RegistryValidationError` |
 | 12 | `test_registry_validation_rejects_an_unknown_prompt_id` | unit | error | Unknown `promptId` → `RegistryValidationError` |
 | 13 | `test_registry_validation_rejects_an_unreachable_lens` | unit | error | Lens entry without registry support → `RegistryValidationError` |
+| 17 | `test_non_role_override_without_role_or_lens_raises` | unit | error / guard-deletion | Custom `agents:` key without `role:`/`lens:` → `RegistryValidationError` (`(?i)role\|lens\|unknown`); must not silently become reviewer (PR #231) |
+| 18 | `test_custom_keyed_override_with_explicit_role_does_not_clobber_reviewer` | integration | happy | Custom key with explicit `role: verifier` binds verifier as `senior-reviewer`; reviewer stays `mergecraft-reviewer` |
 
-### `tests/cli/test_agents_verbs.py` — 3 tests
+### `tests/cli/test_agents_verbs.py` — 4 tests
 
 | # | Test | Layer | Scenario | Contract |
 |---|------|-------|----------|----------|
 | 14 | `test_agents_list_shows_model_prompt_and_tools` | functional | happy | `agents list` shows role, model, prompt, tools |
 | 15 | `test_agents_show_prints_the_resolved_prompt_and_exact_tool_names` | functional | happy | `agents show reviewer` prints prompt body + exact tool names |
 | 16 | `test_agents_set_overrides_one_binding` | functional | happy | `agents set reviewer --model …` persists override; reload shows new chain head |
+| 19 | `test_agents_set_rejects_unknown_role` | functional | error / guard-deletion | `agents set senior-reviewer` exits non-zero, mentions unknown/role, and does not persist the typo key (PR #231) |
 
 ## Imports of not-yet-existing symbols
 
@@ -84,4 +90,6 @@ AP1.2.
 ## Status
 
 AP1.1 RED suite authored; AP1.2 implementation green; xfail markers removed
-post-AP1.2 reconciliation. All 16 tests pass.
+post-AP1.2 reconciliation. Original 16 tests pass. Rows 17–19 pin the PR #231
+review finding (non-role key without `role:`/`lens:` must not overwrite the
+default reviewer). Collected count is 19.

--- a/docs/test-plans/agent-pipeline-ap1.md
+++ b/docs/test-plans/agent-pipeline-ap1.md
@@ -1,0 +1,86 @@
+# PR AP1 — agent registry — test plan (AP1.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP1)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline`
+Authoring wave: **AP1.1** (tests-first). Implementation: **AP1.2**.
+xfail-reconciliation: **post-AP1.2**.
+
+Locked decisions: **D3** (per-agent model chain defaults to run chain, reuses
+`pick_runnable_slug_from_chain`), **D4** (record executed model, fail loudly when
+a harness cannot express a binding), **D2** (full roster is config — only routed
+agents render per run; AP1 loads defaults + overrides).
+
+## xfail schedule
+
+All AP1.2 markers use `strict=False` (`pyproject.toml` sets `xfail_strict = true`).
+Reason prefix: `green after AP1.2`.
+
+| Test file | Tests | Marker | Status at AP1.1 |
+|-----------|-------|--------|-----------------|
+| `tests/agents/test_registry.py` | 12 registry tests (all except `test_agent_chain_defaults_to_the_run_chain`) | `green after AP1.2: agent registry` | **RED (xfail)** |
+| `tests/cli/test_agents_verbs.py` | 3 CLI tests | `green after AP1.2: agents CLI` | **RED (xfail)** |
+
+`test_agent_chain_defaults_to_the_run_chain` is never xfailing — it pins today's
+run-level `effective_model_chain` behaviour that AP1 defaults must preserve.
+
+**Acceptance (AP1.1):** 16 collected; 1 pass; 15 xfail. Zero collection errors.
+`make lint` + `make typecheck` clean. No `src/` edits.
+
+## Target API AP1.2 must satisfy
+
+`src/mergecraft/agents/registry.py` (new):
+
+| Symbol | Contract |
+|--------|----------|
+| `AgentRole` | Closed enum: `orchestrator`, `reviewer`, `verifier`, `judge`, `classifier` |
+| `AgentBinding` | Frozen Pydantic: `agent_id`, `role`, `lens`, `model_chain`, `prompt_id`, `prompt_version`, `tool_classes`, `budget`, `timeout_s`, `dispatch`, `output_schema` |
+| `ResolvedAgentModel` | `requested_model`, `executed_model`, `recorded_model`, `dispatched_model` — executed/recorded/dispatched align (D4) |
+| `AgentLimits` | `budget`, `timeout_s` from binding + config |
+| `RegistryValidationError` | Raised by `Registry.validate()` |
+| `load_registry(settings, repo_root)` | Defaults reproduce today; merges `.mergecraft/config.yaml` `agents:` overrides |
+| `Registry.resolve_role(role)` | Returns binding for each core role |
+| `Registry.resolve_tool_names(binding, ctx)` | HA4 class-filtered MCP tool **names** for the binding |
+| `resolve_agent_model(binding, settings, slug_runnable=...)` | Per-agent chain via `pick_runnable_slug_from_chain`; records executed slug |
+| `resolve_prompt_text(prompt_id, version=...)` | Catalog lookup — unknown id fails validation |
+| `effective_agent_limits(binding, settings)` | Applies per-agent budget/timeout |
+
+`src/mergecraft/cli/agents_cmd.py` (new): `agents list|show|set`, registered on
+`mergecraft.cli.app`.
+
+## Contract → coverage matrix
+
+### `tests/agents/test_registry.py` — 13 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_every_role_resolves_to_a_binding` | integration | happy | All five roles resolve with model, prompt, and tool metadata |
+| 2 | `test_reviewer_and_verifier_have_different_toolsets` | integration | P2 guard-deletion | Real registry builds both toolsets; name sets differ (`checkout_pr` vs `verify_agent_findings`) |
+| 3 | `test_per_agent_model_chain_falls_back` | unit | P3/D3 edge | Agent-owned chain skips unavailable primary |
+| 4 | `test_executed_model_is_recorded_not_requested` | unit | D4 error path | `recorded_model` is the executed fallback, not the requested head |
+| 5 | `test_verifier_pin_invariant_survives_fallback` | integration | #45 | Verifier chain head is `pinned_judge_model("claude")`; after fallback, `recorded_model == dispatched_model == executed_model` |
+| 6 | `test_agent_chain_defaults_to_the_run_chain` | unit | compatibility pin | **passes today** — `effective_model_chain` for a three-model config |
+| 7 | `test_prompt_id_and_version_are_bound` | integration | happy | Reviewer/verifier ids resolve to `REVIEWER_SYSTEM_PROMPT` / `VERIFIER_SYSTEM_PROMPT` |
+| 8 | `test_toolset_derives_from_tool_classes` | integration | HA4 | Declared `tool_classes` match `build_reviewer_tools` name/class sets |
+| 9 | `test_no_read_only_agent_gets_a_terminal_protocol_tool` | integration | guard-deletion | Reviewer, verifier, classifier lack `submit_review_verdict` |
+| 10 | `test_per_agent_budget_and_timeout_apply` | integration | happy + override | Config `budget` / `timeoutS` flow to binding and `effective_agent_limits` |
+| 11 | `test_registry_validation_rejects_a_missing_model` | unit | error | Unknown model slug → `RegistryValidationError` |
+| 12 | `test_registry_validation_rejects_an_unknown_prompt_id` | unit | error | Unknown `promptId` → `RegistryValidationError` |
+| 13 | `test_registry_validation_rejects_an_unreachable_lens` | unit | error | Lens entry without registry support → `RegistryValidationError` |
+
+### `tests/cli/test_agents_verbs.py` — 3 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 14 | `test_agents_list_shows_model_prompt_and_tools` | functional | happy | `agents list` shows role, model, prompt, tools |
+| 15 | `test_agents_show_prints_the_resolved_prompt_and_exact_tool_names` | functional | happy | `agents show reviewer` prints prompt body + exact tool names |
+| 16 | `test_agents_set_overrides_one_binding` | functional | happy | `agents set reviewer --model …` persists override; reload shows new chain head |
+
+## Imports of not-yet-existing symbols
+
+`mergecraft.agents.registry` and `mergecraft.cli.agents_cmd` symbols are imported
+**inside test bodies** (or helpers those bodies call) so collection succeeds before
+AP1.2.
+
+## Status
+
+AP1.1 RED suite authored. Pending AP1.2 implementation and xfail reconciliation.

--- a/docs/test-plans/agent-pipeline-ap1.md
+++ b/docs/test-plans/agent-pipeline-ap1.md
@@ -3,28 +3,28 @@
 Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP1)
 Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline`
 Authoring wave: **AP1.1** (tests-first). Implementation: **AP1.2**.
-xfail-reconciliation: **post-AP1.2**.
+xfail-reconciliation: **post-AP1.2** (complete).
 
 Locked decisions: **D3** (per-agent model chain defaults to run chain, reuses
 `pick_runnable_slug_from_chain`), **D4** (record executed model, fail loudly when
 a harness cannot express a binding), **D2** (full roster is config — only routed
 agents render per run; AP1 loads defaults + overrides).
 
-## xfail schedule
+## xfail schedule (historical)
 
-All AP1.2 markers use `strict=False` (`pyproject.toml` sets `xfail_strict = true`).
-Reason prefix: `green after AP1.2`.
+AP1.2 markers (`strict=False`, reason prefix `green after AP1.2`) were removed
+post-AP1.2 reconciliation. Previously:
 
 | Test file | Tests | Marker | Status at AP1.1 |
 |-----------|-------|--------|-----------------|
 | `tests/agents/test_registry.py` | 12 registry tests (all except `test_agent_chain_defaults_to_the_run_chain`) | `green after AP1.2: agent registry` | **RED (xfail)** |
 | `tests/cli/test_agents_verbs.py` | 3 CLI tests | `green after AP1.2: agents CLI` | **RED (xfail)** |
 
-`test_agent_chain_defaults_to_the_run_chain` is never xfailing — it pins today's
-run-level `effective_model_chain` behaviour that AP1 defaults must preserve.
+`test_agent_chain_defaults_to_the_run_chain` was never xfailing — it pins run-level
+`effective_model_chain` behaviour that AP1 defaults must preserve.
 
-**Acceptance (AP1.1):** 16 collected; 1 pass; 15 xfail. Zero collection errors.
-`make lint` + `make typecheck` clean. No `src/` edits.
+**Acceptance (post-AP1.2 reconciliation):** 16 collected; 16 pass; 0 xfail/xpass.
+`make lint` + `make typecheck` clean.
 
 ## Target API AP1.2 must satisfy
 
@@ -83,4 +83,5 @@ AP1.2.
 
 ## Status
 
-AP1.1 RED suite authored. Pending AP1.2 implementation and xfail reconciliation.
+AP1.1 RED suite authored; AP1.2 implementation green; xfail markers removed
+post-AP1.2 reconciliation. All 16 tests pass.

--- a/docs/test-plans/agent-pipeline-ap1.md
+++ b/docs/test-plans/agent-pipeline-ap1.md
@@ -17,7 +17,7 @@ post-AP1.2 reconciliation. Previously:
 
 | Test file | Tests | Marker | Status at AP1.1 |
 |-----------|-------|--------|-----------------|
-| `tests/agents/test_registry.py` | 12 registry tests (all except `test_agent_chain_defaults_to_the_run_chain`) | `green after AP1.2: agent registry` | **RED (xfail)** |
+| `tests/agents/test_agent_registry.py` | 12 registry tests (all except `test_agent_chain_defaults_to_the_run_chain`) | `green after AP1.2: agent registry` | **RED (xfail)** |
 | `tests/cli/test_agents_verbs.py` | 3 CLI tests | `green after AP1.2: agents CLI` | **RED (xfail)** |
 
 `test_agent_chain_defaults_to_the_run_chain` was never xfailing — it pins run-level
@@ -49,7 +49,7 @@ post-AP1.2 reconciliation. Previously:
 
 ## Contract → coverage matrix
 
-### `tests/agents/test_registry.py` — 13 tests
+### `tests/agents/test_agent_registry.py` — 13 tests
 
 | # | Test | Layer | Scenario | Contract |
 |---|------|-------|----------|----------|

--- a/docs/test-plans/prep-shell-disabled-python-skip.md
+++ b/docs/test-plans/prep-shell-disabled-python-skip.md
@@ -1,0 +1,74 @@
+# Prep — `shell: disabled` Python skip is not an install failure
+
+Regression for the live Action failure where a completed Nous review of a
+Python repo never posted `mergecraft-approval` because
+`InstallPythonDependencies` skipped under `shell: disabled` (this repo's
+`.github/workflows/mergecraft.yml` always does) and that skip was treated as
+`status="failed"`, then mapped to `RunOutcome.inconclusive`.
+
+Live: https://github.com/alexhawat/mergeCraft/actions/runs/31946428769/job/95163172432
+
+Log: `prep failure mapped run to inconclusive: skipped: python dependency
+installation can execute arbitrary code ... which is blocked when shell is
+disabled`
+
+W6.1 fail-closed for a **real** install failure is unchanged — see
+`tests/prep/test_prep_fail_closed.py` (`test_prep_failure_makes_run_inconclusive`
+and `test_prep_failure_reason_is_recorded`). These tests add the skip-not-failure
+counterpart; they do not weaken that suite.
+
+Worktree: `../mergecraft-agent-pipeline-ap1` @ `feature/agent-pipeline`
+
+## Contract
+
+| Surface | Skip (`ignore_scripts` / `shell: disabled`) | Real install failure |
+|---------|----------------------------------------------|----------------------|
+| `PrepResult` | `skipped=True`, `dependencies_installed=False`; issues may describe the skip | `skipped=False`, issues non-empty, not installed |
+| `is_prep_install_failure` | `False` | `True` |
+| `start_installation` done-callback | `status="completed"` | `status="failed"` |
+| `_format_prep_results` | `"installation skipped"` | `"installation failed"` |
+| `_prep_failure_reason` / run outcome | no reason; run is **not** `inconclusive` | reason recorded; run is `inconclusive` |
+
+## Contract → coverage matrix
+
+### `tests/prep/test_types.py`
+
+| Test | Layer | Scenario | Contract |
+|------|-------|----------|----------|
+| `test_is_prep_install_failure[skipped_with_issues]` | unit | happy / guard-deletion | Skip with issues → False (fails if the `skipped` short-circuit is deleted) |
+| `test_is_prep_install_failure[failed_install]` | unit | error (W6.1) | Not skipped, not installed, issues → True |
+| `test_is_prep_install_failure[successful_install]` | unit | happy | Installed → False |
+| `test_is_prep_install_failure[skipped_empty_issues]` | unit | edge | Skip with empty issues → False |
+| `test_is_prep_install_failure[installed_with_issues]` | unit | edge | Installed even with leftover issues → False |
+| `test_is_prep_install_failure[not_installed_empty_issues]` | unit | edge | Not installed, empty issues, not skipped → False |
+| `test_prep_result_skipped_defaults_false` | unit | edge | `PrepResult.skipped` defaults to `False` |
+
+### `tests/prep/test_python.py`
+
+| Test | Layer | Scenario | Contract |
+|------|-------|----------|----------|
+| `test_install_python_dependencies_skip_when_ignore_scripts` | unit | happy | `uv.lock` + `PrepOptions(ignore_scripts=True)` → `skipped=True`, `dependencies_installed=False` |
+
+### `tests/mcp/test_dependencies.py`
+
+| Test | Layer | Scenario | Contract |
+|------|-------|----------|----------|
+| `test_format_prep_results_skip_is_not_installation_failed` | unit | happy / guard-deletion | Formatter wording is "installation skipped", never "installation failed" |
+| `test_format_prep_results_real_failure_still_says_failed` | unit | error (W6.1) | Genuine pip failure still says "installation failed" |
+| `test_start_installation_skip_only_completes_not_failed` | unit | happy / guard-deletion | Skip-only → `status="completed"`; `ignore_scripts=True` when `shell: disabled` |
+| `test_start_installation_real_failure_still_sets_failed` | unit | error (W6.1) | Real install failure still → `status="failed"` |
+
+### `tests/prep/test_prep_fail_closed.py` (skip counterpart; existing fail-closed tests unchanged)
+
+| Test | Layer | Scenario | Contract |
+|------|-------|----------|----------|
+| `test_python_skip_prep_does_not_make_run_inconclusive` | integration | happy | `prep_skip=True` through `main()` is not `inconclusive` |
+| `test_prep_failure_reason_none_for_python_skip_only` | integration | happy | `_prep_failure_reason` is `None` for skip-only `status="completed"` |
+| `test_prep_failure_reason_excludes_skipped_python_install` | integration | guard-deletion + W6.1 | Mixed skip + node failure: reason is the npm error, never the skip text |
+| `test_prep_failure_makes_run_inconclusive` (existing) | integration | error | Do not weaken — genuine prep failure still maps the run to `inconclusive` |
+
+## Status
+
+Bugfix characterisation — tests are written to **pass against current `src/`**.
+A genuine pip/npm failure must still fail closed (rows above marked W6.1, and
+the existing tests in `tests/prep/test_prep_fail_closed.py`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ branch = true
 omit = ["*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 75
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/src/mergecraft/agents/catalog_docs.py
+++ b/src/mergecraft/agents/catalog_docs.py
@@ -1,0 +1,39 @@
+"""Agent registry validation gate — mirror of ``analyzers/catalog_docs`` (AP1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mergecraft.agents.registry import RegistryValidationError, load_registry
+from mergecraft.config.settings import default_settings, load_repo_settings
+
+
+def validate_agent_registry(*, repo_root: Path | None = None) -> None:
+    """Validate bundled defaults and every known prompt/model reference."""
+    root = repo_root or Path(__file__).resolve().parents[3]
+    settings = (
+        load_repo_settings(root=root)
+        if (root / ".mergecraft" / "config.yaml").is_file()
+        else default_settings()
+    )
+    registry = load_registry(settings=settings, repo_root=root)
+    try:
+        registry.validate()
+    except RegistryValidationError as exc:
+        msg = f"agent registry validation failed: {exc}"
+        raise SystemExit(msg) from exc
+
+    # Defaults-only pass — every core role must resolve.
+    for role in ("orchestrator", "reviewer", "verifier", "judge", "classifier"):
+        binding = registry.resolve_role(role)
+        if not binding.model_chain:
+            msg = f"default binding for {role!r} has empty model_chain"
+            raise SystemExit(msg)
+
+
+def main() -> None:
+    validate_agent_registry()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mergecraft/agents/catalog_docs.py
+++ b/src/mergecraft/agents/catalog_docs.py
@@ -16,8 +16,8 @@ def validate_agent_registry(*, repo_root: Path | None = None) -> None:
         if (root / ".mergecraft" / "config.yaml").is_file()
         else default_settings()
     )
-    registry = load_registry(settings=settings, repo_root=root)
     try:
+        registry = load_registry(settings=settings, repo_root=root)
         registry.validate()
     except RegistryValidationError as exc:
         msg = f"agent registry validation failed: {exc}"

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -123,6 +123,13 @@ def _model_reference_valid(ref: str) -> bool:
     return any(alias.resolve == ref for alias in MODEL_ALIASES)
 
 
+def _parse_role(value: str) -> AgentRole | None:
+    try:
+        return AgentRole(value)
+    except ValueError:
+        return None
+
+
 def _default_model_chain(settings: RepoSettings, *, role: AgentRole) -> list[str]:
     run_chain = effective_model_chain(settings)
     if not run_chain:
@@ -278,13 +285,16 @@ def load_registry(
         bindings[role.value] = _build_default_binding(settings, role)
 
     for agent_key, override in settings.agents.items():
-        base_key = override.role or agent_key
-        try:
-            base_role = AgentRole(base_key)
-            base = bindings.get(base_role.value) or _build_default_binding(settings, base_role)
-        except ValueError:
-            base_role = AgentRole.reviewer
-            base = _build_default_binding(settings, base_role)
+        key_role = _parse_role(agent_key)
+        declared_role = _parse_role(override.role) if override.role is not None else None
+        if key_role is None and declared_role is None and override.lens is None:
+            msg = (
+                f"unknown agent key {agent_key!r}: set role: or lens: "
+                "so it does not silently replace a default role binding"
+            )
+            raise RegistryValidationError(msg)
+        base_role = declared_role or key_role or AgentRole.reviewer
+        base = bindings.get(base_role.value) or _build_default_binding(settings, base_role)
         bindings[agent_key] = _apply_override(
             base, override, agent_key=agent_key, settings=settings
         )

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -1,0 +1,331 @@
+"""Agent registry — model, prompt, toolset and budget per role and lens (AP1).
+
+Loads bundled defaults plus ``.mergecraft/config.yaml`` overrides. Per-agent
+model chains reuse :func:`mergecraft.utils.agent_resolve.effective_model_chain`
+and :func:`pick_runnable_slug_from_chain` (D3).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from pydantic import BaseModel, ConfigDict
+
+from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT, pinned_judge_model
+from mergecraft.config.settings import AgentBindingOverride, DispatchMode  # noqa: TC001
+from mergecraft.mcp.server import build_orchestrator_tools
+from mergecraft.mcp.shared import (
+    REVIEWER_ALLOWED_TOOL_CLASSES,
+    VERIFIER_ALLOWED_TOOL_CLASSES,
+    ToolClass,
+    admits_readonly_role,
+)
+from mergecraft.models import AUTO_EFFICIENT, MODEL_ALIASES, resolve_display_alias
+from mergecraft.types import REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME
+from mergecraft.utils.agent_resolve import effective_model_chain, pick_runnable_slug_from_chain
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.mcp.context import ToolContext
+
+_DEFAULT_BUDGET: Final[int] = 8
+_DEFAULT_TIMEOUT_S: Final[int] = 600
+_DEFAULT_PROMPT_VERSION: Final[str] = "1.0.0"
+
+_PROMPT_CATALOG: Final[dict[str, tuple[str, str]]] = {
+    "mergecraft.reviewer": (REVIEWER_SYSTEM_PROMPT, _DEFAULT_PROMPT_VERSION),
+    "mergecraft.verifier": (VERIFIER_SYSTEM_PROMPT, _DEFAULT_PROMPT_VERSION),
+    "mergecraft.orchestrator": ("", _DEFAULT_PROMPT_VERSION),
+    "mergecraft.judge": (VERIFIER_SYSTEM_PROMPT, _DEFAULT_PROMPT_VERSION),
+    "mergecraft.classifier": ("", _DEFAULT_PROMPT_VERSION),
+}
+
+# Lenses ship in AP5 — until then the set is empty and any lens binding fails validation.
+_KNOWN_LENS_IDS: Final[frozenset[str]] = frozenset()
+
+_ORCHESTRATOR_TOOL_CLASSES: Final[frozenset[ToolClass]] = frozenset(ToolClass)
+
+
+class AgentRole(StrEnum):
+    orchestrator = "orchestrator"
+    reviewer = "reviewer"
+    verifier = "verifier"
+    judge = "judge"
+    classifier = "classifier"
+
+
+class RegistryValidationError(ValueError):
+    """Raised when a registry binding fails structural validation."""
+
+
+class AgentBinding(BaseModel):
+    """Frozen resolved identity for one agent role or lens."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    agent_id: str
+    role: AgentRole
+    lens: str | None = None
+    model_chain: tuple[str, ...]
+    prompt_id: str
+    prompt_version: str
+    tool_classes: frozenset[ToolClass]
+    budget: int
+    timeout_s: int
+    dispatch: DispatchMode = "single"
+    output_schema: str | None = None
+
+
+class ResolvedAgentModel(BaseModel):
+    """Per-agent model resolution with executed-model recording (D4)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    requested_model: str
+    executed_model: str
+    recorded_model: str
+    dispatched_model: str
+
+
+class AgentLimits(BaseModel):
+    """Effective budget and timeout for one binding."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    budget: int
+    timeout_s: int
+
+
+def resolve_prompt_text(prompt_id: str, *, version: str | None = None) -> str:
+    """Return the prompt body for ``prompt_id`` at ``version`` (or latest)."""
+    entry = _PROMPT_CATALOG.get(prompt_id)
+    if entry is None:
+        msg = f"unknown prompt id: {prompt_id!r}"
+        raise KeyError(msg)
+    text, catalog_version = entry
+    if version is not None and version != catalog_version:
+        msg = f"unknown prompt version {version!r} for {prompt_id!r}"
+        raise KeyError(msg)
+    return text
+
+
+def _model_reference_valid(ref: str) -> bool:
+    if resolve_display_alias(ref) is not None:
+        return True
+    pinned = pinned_judge_model("claude")
+    if pinned is not None and ref == pinned:
+        return True
+    return any(alias.resolve == ref for alias in MODEL_ALIASES)
+
+
+def _default_model_chain(settings: RepoSettings, *, role: AgentRole) -> list[str]:
+    run_chain = effective_model_chain(settings)
+    if not run_chain:
+        run_chain = [AUTO_EFFICIENT]
+    if role is AgentRole.verifier:
+        pinned = pinned_judge_model("claude")
+        if pinned is None:
+            return run_chain
+        tail = [entry for entry in run_chain if entry != pinned]
+        return [pinned, *tail]
+    return run_chain
+
+
+def _default_tool_classes(role: AgentRole) -> frozenset[ToolClass]:
+    match role:
+        case AgentRole.orchestrator:
+            return _ORCHESTRATOR_TOOL_CLASSES
+        case AgentRole.reviewer:
+            return REVIEWER_ALLOWED_TOOL_CLASSES
+        case AgentRole.verifier | AgentRole.judge:
+            return VERIFIER_ALLOWED_TOOL_CLASSES
+        case AgentRole.classifier:
+            return frozenset(
+                {
+                    ToolClass.SCOPE,
+                    ToolClass.REPOSITORY_READ,
+                    ToolClass.ANALYSIS,
+                }
+            )
+
+
+def _default_agent_id(role: AgentRole) -> str:
+    match role:
+        case AgentRole.reviewer:
+            return REVIEWER_AGENT_NAME
+        case AgentRole.verifier:
+            return VERIFIER_AGENT_NAME
+        case AgentRole.orchestrator:
+            return "mergecraft-orchestrator"
+        case AgentRole.judge:
+            return "mergecraft-judge"
+        case AgentRole.classifier:
+            return "mergecraft-classifier"
+
+
+def _default_prompt_id(role: AgentRole) -> str:
+    return f"mergecraft.{role.value}"
+
+
+def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBinding:
+    return AgentBinding(
+        agent_id=_default_agent_id(role),
+        role=role,
+        lens=None,
+        model_chain=tuple(_default_model_chain(settings, role=role)),
+        prompt_id=_default_prompt_id(role),
+        prompt_version=_DEFAULT_PROMPT_VERSION,
+        tool_classes=_default_tool_classes(role),
+        budget=_DEFAULT_BUDGET,
+        timeout_s=_DEFAULT_TIMEOUT_S,
+    )
+
+
+def _apply_override(
+    base: AgentBinding,
+    override: AgentBindingOverride,
+    *,
+    agent_key: str,
+    settings: RepoSettings,
+) -> AgentBinding:
+    role = AgentRole(override.role) if override.role is not None else base.role
+    model_chain = (
+        tuple(override.model_chain) if override.model_chain is not None else base.model_chain
+    )
+    if override.model is not None and override.model_chain is None:
+        model_chain = (override.model, *tuple(base.model_chain))
+    return AgentBinding(
+        agent_id=agent_key if agent_key not in {r.value for r in AgentRole} else base.agent_id,
+        role=role,
+        lens=override.lens if override.lens is not None else base.lens,
+        model_chain=model_chain,
+        prompt_id=override.prompt_id or base.prompt_id,
+        prompt_version=override.prompt_version or base.prompt_version,
+        tool_classes=base.tool_classes,
+        budget=override.budget if override.budget is not None else base.budget,
+        timeout_s=override.timeout_s if override.timeout_s is not None else base.timeout_s,
+        dispatch=override.dispatch or base.dispatch,
+        output_schema=base.output_schema,
+    )
+
+
+class Registry:
+    """Resolved agent roster for one repo configuration."""
+
+    def __init__(self, bindings: dict[str, AgentBinding]) -> None:
+        self._bindings = bindings
+        self._by_role: dict[AgentRole, AgentBinding] = {}
+        for binding in bindings.values():
+            if binding.lens is None:
+                self._by_role[binding.role] = binding
+
+    def resolve_role(self, role: AgentRole | str) -> AgentBinding:
+        key = AgentRole(role) if isinstance(role, str) else role
+        try:
+            return self._by_role[key]
+        except KeyError as exc:
+            msg = f"no binding for role {key!r}"
+            raise KeyError(msg) from exc
+
+    def resolve_tool_names(self, binding: AgentBinding, ctx: ToolContext) -> list[str]:
+        tools = build_orchestrator_tools(ctx)
+        if binding.role is AgentRole.orchestrator:
+            return [spec.name for spec in tools]
+        return [spec.name for spec in tools if admits_readonly_role(spec, binding.tool_classes)]
+
+    def all_bindings(self) -> tuple[AgentBinding, ...]:
+        return tuple(self._bindings.values())
+
+    def validate(self) -> None:
+        for binding in self._bindings.values():
+            if not binding.model_chain:
+                msg = f"agent {binding.agent_id!r} has empty model_chain"
+                raise RegistryValidationError(msg)
+            for slug in binding.model_chain:
+                if not _model_reference_valid(slug):
+                    msg = f"unresolvable model slug {slug!r} on agent {binding.agent_id!r}"
+                    raise RegistryValidationError(msg)
+            if binding.prompt_id not in _PROMPT_CATALOG:
+                msg = f"unknown prompt id {binding.prompt_id!r} on agent {binding.agent_id!r}"
+                raise RegistryValidationError(msg)
+            if binding.lens is not None and binding.lens not in _KNOWN_LENS_IDS:
+                msg = (
+                    f"unreachable lens {binding.lens!r} on agent {binding.agent_id!r} "
+                    "(lens not in registry)"
+                )
+                raise RegistryValidationError(msg)
+            if binding.role is not AgentRole.orchestrator:
+                terminal = "submit_review_verdict"
+                if terminal in binding.tool_classes:
+                    msg = f"read-only agent {binding.agent_id!r} holds terminal-protocol tool"
+                    raise RegistryValidationError(msg)
+
+
+def load_registry(
+    *,
+    settings: RepoSettings,
+    repo_root: Path | None = None,
+) -> Registry:
+    """Load defaults merged with ``settings.agents`` overrides."""
+    del repo_root  # reserved for future repo-local agent manifests (AP5)
+    bindings: dict[str, AgentBinding] = {}
+    for role in AgentRole:
+        bindings[role.value] = _build_default_binding(settings, role)
+
+    for agent_key, override in settings.agents.items():
+        base_key = override.role or agent_key
+        try:
+            base_role = AgentRole(base_key)
+            base = bindings.get(base_role.value) or _build_default_binding(settings, base_role)
+        except ValueError:
+            base_role = AgentRole.reviewer
+            base = _build_default_binding(settings, base_role)
+        bindings[agent_key] = _apply_override(
+            base, override, agent_key=agent_key, settings=settings
+        )
+
+    return Registry(bindings)
+
+
+def resolve_agent_model(
+    binding: AgentBinding,
+    *,
+    settings: RepoSettings,
+    slug_runnable: Callable[[str], bool] | None = None,
+) -> ResolvedAgentModel:
+    """Resolve the runnable model for ``binding``, recording the executed slug (D4)."""
+    chain = list(binding.model_chain) or effective_model_chain(settings)
+    requested = chain[0]
+    executed: str | None = None
+
+    if slug_runnable is not None:
+        for slug in chain:
+            if slug_runnable(slug):
+                executed = slug
+                break
+    else:
+        executed = pick_runnable_slug_from_chain(
+            chain,
+            allow_fallback=settings.allow_fallback,
+        )
+
+    if executed is None:
+        msg = f"no runnable model in chain for agent {binding.agent_id!r}"
+        raise RuntimeError(msg)
+
+    return ResolvedAgentModel(
+        requested_model=requested,
+        executed_model=executed,
+        recorded_model=executed,
+        dispatched_model=executed,
+    )
+
+
+def effective_agent_limits(binding: AgentBinding, *, settings: RepoSettings) -> AgentLimits:
+    del settings
+    return AgentLimits(budget=binding.budget, timeout_s=binding.timeout_s)

--- a/src/mergecraft/cli/agents_cmd.py
+++ b/src/mergecraft/cli/agents_cmd.py
@@ -1,0 +1,159 @@
+"""``mergecraft agents`` — registry inspection and per-agent overrides (AP1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from mergecraft.agents.registry import load_registry, resolve_prompt_text
+from mergecraft.config.settings import AgentBindingOverride, load_repo_settings
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.types import XrepoConfig
+from mergecraft.utils.github import GitHubClient
+
+app = typer.Typer(
+    name="agents",
+    help="Inspect and override the mergeCraft agent registry.",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+def _bail(msg: str) -> NoReturn:
+    console.print(f"[red]{msg}[/red]")
+    raise typer.Exit(1)
+
+
+def _repo_root(cwd: Path) -> Path:
+    return cwd.resolve()
+
+
+def _tool_ctx(repo_root: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(repo_root))
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell="restricted",
+            push="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(repo_root),
+        signed_commits=True,
+        xrepo=XrepoConfig(mode="explicit", read=[], write=[]),
+        static_checks_enabled=True,
+    )
+
+
+@app.command("list")
+def list_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """List agent bindings with model chain, prompt id, and tool count."""
+    repo_root = _repo_root(cwd)
+    settings = load_repo_settings(root=repo_root)
+    registry = load_registry(settings=settings, repo_root=repo_root)
+    ctx = _tool_ctx(repo_root)
+
+    table = Table(title="Agent registry")
+    table.add_column("role")
+    table.add_column("model chain")
+    table.add_column("prompt")
+    table.add_column("tools")
+    for binding in sorted(registry.all_bindings(), key=lambda b: b.role.value):
+        if binding.lens is not None:
+            continue
+        chain = ", ".join(binding.model_chain[:2])
+        if len(binding.model_chain) > 2:
+            chain += ", …"
+        tool_count = len(registry.resolve_tool_names(binding, ctx))
+        table.add_row(
+            binding.role.value,
+            chain,
+            binding.prompt_id,
+            str(tool_count),
+        )
+    console.print(table)
+
+
+@app.command("show")
+def show_cmd(
+    role: str = typer.Argument(..., help="Agent role (e.g. reviewer)."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Show resolved prompt text and MCP tool names for one role."""
+    repo_root = _repo_root(cwd)
+    settings = load_repo_settings(root=repo_root)
+    registry = load_registry(settings=settings, repo_root=repo_root)
+    try:
+        binding = registry.resolve_role(role)
+    except KeyError:
+        _bail(f"unknown role: {role!r}")
+
+    prompt = resolve_prompt_text(binding.prompt_id, version=binding.prompt_version)
+    tools = registry.resolve_tool_names(binding, _tool_ctx(repo_root))
+
+    console.print(f"[bold]{binding.role.value}[/bold] ({binding.agent_id})")
+    console.print(f"model chain: {', '.join(binding.model_chain)}")
+    console.print(f"prompt: {binding.prompt_id} v{binding.prompt_version}")
+    if prompt:
+        typer.echo("\n--- prompt ---\n")
+        typer.echo(prompt)
+    typer.echo("\n--- tools ---\n")
+    for name in sorted(tools):
+        typer.echo(name)
+
+
+@app.command("set")
+def set_cmd(
+    role: str = typer.Argument(..., help="Agent role to override."),
+    model: str | None = typer.Option(None, "--model", help="Primary model slug override."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Write a single agent binding override into ``.mergecraft/config.yaml``."""
+    if model is None:
+        _bail("pass at least one override flag (e.g. --model)")
+
+    repo_root = _repo_root(cwd)
+    config_path = repo_root / ".mergecraft" / "config.yaml"
+    if not config_path.is_file():
+        _bail(f"no config at {config_path} — run mergecraft init first")
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        _bail(f"config must be a mapping: {config_path}")
+
+    agents = raw.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        _bail("agents block must be a mapping")
+
+    entry = agents.setdefault(role, {})
+    if not isinstance(entry, dict):
+        _bail(f"agents.{role} must be a mapping")
+
+    if model is not None:
+        entry["modelChain"] = [model]
+
+    # Validate the override round-trips through Pydantic before writing.
+    AgentBindingOverride.model_validate(entry)
+    config_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    console.print(f"[green]updated agents.{role} in {config_path}[/green]")

--- a/src/mergecraft/cli/agents_cmd.py
+++ b/src/mergecraft/cli/agents_cmd.py
@@ -10,7 +10,12 @@ import yaml
 from rich.console import Console
 from rich.table import Table
 
-from mergecraft.agents.registry import load_registry, resolve_prompt_text
+from mergecraft.agents.registry import (
+    AgentRole,
+    RegistryValidationError,
+    load_registry,
+    resolve_prompt_text,
+)
 from mergecraft.config.settings import AgentBindingOverride, load_repo_settings
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -71,7 +76,10 @@ def list_cmd(
     """List agent bindings with model chain, prompt id, and tool count."""
     repo_root = _repo_root(cwd)
     settings = load_repo_settings(root=repo_root)
-    registry = load_registry(settings=settings, repo_root=repo_root)
+    try:
+        registry = load_registry(settings=settings, repo_root=repo_root)
+    except RegistryValidationError as exc:
+        _bail(str(exc))
     ctx = _tool_ctx(repo_root)
 
     table = Table(title="Agent registry")
@@ -102,10 +110,17 @@ def show_cmd(
 ) -> None:
     """Show resolved prompt text and MCP tool names for one role."""
     repo_root = _repo_root(cwd)
-    settings = load_repo_settings(root=repo_root)
-    registry = load_registry(settings=settings, repo_root=repo_root)
     try:
+        AgentRole(role)
+    except ValueError:
+        _bail(f"unknown role: {role!r}")
+
+    settings = load_repo_settings(root=repo_root)
+    try:
+        registry = load_registry(settings=settings, repo_root=repo_root)
         binding = registry.resolve_role(role)
+    except RegistryValidationError as exc:
+        _bail(str(exc))
     except KeyError:
         _bail(f"unknown role: {role!r}")
 
@@ -133,6 +148,13 @@ def set_cmd(
     if model is None:
         _bail("pass at least one override flag (e.g. --model)")
 
+    role_key = role.lower()
+    try:
+        AgentRole(role_key)
+    except ValueError:
+        known = ", ".join(item.value for item in AgentRole)
+        _bail(f"unknown role: {role!r} (expected one of: {known})")
+
     repo_root = _repo_root(cwd)
     config_path = repo_root / ".mergecraft" / "config.yaml"
     if not config_path.is_file():
@@ -146,9 +168,9 @@ def set_cmd(
     if not isinstance(agents, dict):
         _bail("agents block must be a mapping")
 
-    entry = agents.setdefault(role, {})
+    entry = agents.setdefault(role_key, {})
     if not isinstance(entry, dict):
-        _bail(f"agents.{role} must be a mapping")
+        _bail(f"agents.{role_key} must be a mapping")
 
     if model is not None:
         entry["modelChain"] = [model]
@@ -156,4 +178,4 @@ def set_cmd(
     # Validate the override round-trips through Pydantic before writing.
     AgentBindingOverride.model_validate(entry)
     config_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
-    console.print(f"[green]updated agents.{role} in {config_path}[/green]")
+    console.print(f"[green]updated agents.{role_key} in {config_path}[/green]")

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from mergecraft import __version__
 from mergecraft.cli import (
+    agents_cmd,
     analyzers_cmd,
     auth_cmd,
     diff_review_cmd,
@@ -34,6 +35,7 @@ app = typer.Typer(
 )
 console = Console(stderr=True)
 
+app.add_typer(agents_cmd.app, name="agents")
 app.add_typer(auth_cmd.app, name="auth")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -161,6 +161,32 @@ class AnalyzerPatternSettings(_OptionalFeatureModel):
     backend: str | None = None
 
 
+DispatchMode = Literal["single", "ensemble", "shadow"]
+
+
+class AgentBindingOverride(BaseModel):
+    """Partial override for one agent entry under ``agents:`` in config (AP1)."""
+
+    model_config = ConfigDict(extra=_SECURITY_RUNTIME_EXTRA, populate_by_name=True)
+
+    role: str | None = None
+    lens: str | None = None
+    model: str | None = None
+    model_chain: list[str] | None = Field(default=None, alias="modelChain")
+    prompt_id: str | None = Field(default=None, alias="promptId")
+    prompt_version: str | None = Field(default=None, alias="promptVersion")
+    budget: int | None = None
+    timeout_s: int | None = Field(default=None, alias="timeoutS")
+    dispatch: DispatchMode | None = None
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def _normalize_role(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+
 class AnalyzersSettings(BaseModel):
     """Catalog analyzer configuration block.
 
@@ -343,6 +369,7 @@ class RepoSettings(BaseModel):
     # no declaration, no substitution, no extra API call.
     ci_evidence: CiEvidenceSettings = Field(default_factory=CiEvidenceSettings, alias="ciEvidence")
     analyzers: AnalyzersSettings = Field(default_factory=AnalyzersSettings)
+    agents: dict[str, AgentBindingOverride] = Field(default_factory=dict)
     learnings: str | None = None
     learnings_headings: list[LearningsHeading] = Field(
         default_factory=list, alias="learningsHeadings"

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -34,6 +34,7 @@ from mergecraft.mcp.dependencies import start_installation
 from mergecraft.mcp.server import start_mcp_http_server
 from mergecraft.mcp.tool_state import ProgressComment, ToolState, init_tool_state
 from mergecraft.modes import _custom_modes, compute_modes
+from mergecraft.prep.types import is_prep_install_failure
 from mergecraft.review_checks import StaticCheckConfig
 from mergecraft.run_outcome import RUN_OUTCOME_CONCLUSION, RunOutcome, run_succeeded_for_outcome
 from mergecraft.utils.agent_resolve import (
@@ -381,7 +382,7 @@ async def _prep_failure_reason(tool_context: ToolContext) -> str | None:
         return None
     reasons: list[str] = []
     for result in state.results or []:
-        if not result.dependencies_installed and result.issues:
+        if is_prep_install_failure(result):
             reasons.extend(str(item) for item in result.issues)
     if reasons:
         return "; ".join(reasons)

--- a/src/mergecraft/mcp/dependencies.py
+++ b/src/mergecraft/mcp/dependencies.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from mergecraft.mcp.shared import EMPTY_SCHEMA, ToolClass, execute, tool
 from mergecraft.mcp.tool_state import DependencyInstallationState
-from mergecraft.prep import PrepOptions, PrepResult, run_prep_phase
+from mergecraft.prep import PrepOptions, PrepResult, is_prep_install_failure, run_prep_phase
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -30,6 +30,9 @@ def _format_prep_results(results: list[PrepResult]) -> str:
             lines.append(
                 f"{lang} dependencies installed successfully via {result.package_manager}."
             )
+        elif result.skipped:
+            reason = result.issues[0] if result.issues else "skipped by policy"
+            lines.append(f"{lang} dependency installation skipped: {reason}")
         else:
             err = "\n".join(result.issues) if result.issues else "unknown error"
             lines.append(f"{lang} dependency installation failed.\n\nError:\n{err}")
@@ -57,7 +60,7 @@ def start_installation(ctx: ToolContext) -> None:
             # ``status="failed"`` to ``RunOutcome.inconclusive`` (not silent
             # continue). The MCP tools still return the formatted summary so
             # the agent can see the reason.
-            has_failure = any((not r.dependencies_installed and r.issues) for r in results)
+            has_failure = any(is_prep_install_failure(r) for r in results)
             state.status = "failed" if has_failure else "completed"
             state.results = results
         except Exception:

--- a/src/mergecraft/prep/__init__.py
+++ b/src/mergecraft/prep/__init__.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from mergecraft.prep.node import install_node_dependencies
 from mergecraft.prep.python import install_python_dependencies
-from mergecraft.prep.types import PrepOptions, PrepResult
+from mergecraft.prep.types import PrepOptions, PrepResult, is_prep_install_failure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -77,8 +77,10 @@ async def run_prep_phase(options: PrepOptions | None = None) -> list[PrepResult]
     Individual step failures are recorded on :class:`PrepResult` (issues +
     ``dependencies_installed=False``) rather than raising — the live Action
     path maps a failed install to ``RunOutcome.inconclusive`` (W6.1 / D4).
-    Callers that need fail-closed behaviour must inspect the returned results
-    (see ``main._prep_failure_reason`` / ``mcp.dependencies``).
+    A policy skip (``skipped=True``, e.g. Python install with ``shell:
+    disabled``) is not a failure. Callers that need fail-closed behaviour
+    must inspect results via ``is_prep_install_failure`` (see
+    ``main._prep_failure_reason`` / ``mcp.dependencies``).
     """
     opts = options or PrepOptions()
     logger.debug("» starting prep phase...")
@@ -109,6 +111,12 @@ async def run_prep_phase(options: PrepOptions | None = None) -> list[PrepResult]
                 results.append(result)
                 if result.dependencies_installed:
                     logger.debug("» {}: dependencies installed", step.name)
+                elif result.skipped:
+                    logger.info(
+                        "» {}: {}",
+                        step.name,
+                        result.issues[0] if result.issues else "skipped",
+                    )
                 elif result.issues:
                     logger.warning("» {}: {}", step.name, result.issues[0])
         finally:
@@ -122,4 +130,4 @@ async def run_prep_phase(options: PrepOptions | None = None) -> list[PrepResult]
     return results
 
 
-__all__ = ["PrepOptions", "PrepResult", "run_prep_phase"]
+__all__ = ["PrepOptions", "PrepResult", "is_prep_install_failure", "run_prep_phase"]

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -110,6 +110,7 @@ class InstallPythonDependencies:
                 package_manager=config.tool,
                 config_file=config.file,
                 dependencies_installed=False,
+                skipped=True,
                 issues=[
                     "skipped: python dependency installation can execute arbitrary code "
                     "(setup.py, build backends, local path references), which is blocked "

--- a/src/mergecraft/prep/types.py
+++ b/src/mergecraft/prep/types.py
@@ -27,7 +27,21 @@ class PrepResult:
     dependencies_installed: bool
     package_manager: str | None = None
     config_file: str | None = None
+    skipped: bool = False
     issues: list[str] = field(default_factory=list)
+
+
+def is_prep_install_failure(result: PrepResult) -> bool:
+    """True when a language prep step attempted an install and failed.
+
+    A policy skip (``shell: disabled`` / ``ignore_scripts``) is not an
+    install failure. W6.1 fail-closed must not map that skip to
+    ``RunOutcome.inconclusive`` — otherwise a completed review of a Python
+    repo never posts ``mergecraft-approval``.
+    """
+    if result.skipped or result.dependencies_installed:
+        return False
+    return bool(result.issues)
 
 
 class PrepDefinition(Protocol):
@@ -45,4 +59,5 @@ __all__ = [
     "PrepOptions",
     "PrepResult",
     "PythonPackageManager",
+    "is_prep_install_failure",
 ]

--- a/tests/agents/test_agent_registry.py
+++ b/tests/agents/test_agent_registry.py
@@ -412,3 +412,52 @@ agents:
     registry = _load_registry(tmp_path)
     with pytest.raises(RegistryValidationError, match=r"(?i)lens|unreachable|unknown"):
         registry.validate()
+
+
+def test_non_role_override_without_role_or_lens_raises(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A custom ``agents:`` key without ``role:`` or ``lens:`` must not become reviewer.
+
+    Guard-deletion pin (PR #231): a silent ``AgentRole.reviewer`` fallback would
+    overwrite ``_by_role[reviewer]`` and this assertion would fail.
+    """
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  senior-reviewer:
+    modelChain:
+      - anthropic/claude-sonnet
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import RegistryValidationError
+
+    with pytest.raises(RegistryValidationError, match=r"(?i)role|lens|unknown"):
+        _load_registry(tmp_path)
+
+
+def test_custom_keyed_override_with_explicit_role_does_not_clobber_reviewer(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Explicit ``role:`` on a custom key binds that role and leaves reviewer intact."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  senior-reviewer:
+    role: verifier
+    modelChain:
+      - anthropic/claude-sonnet
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    registry = _load_registry(tmp_path)
+
+    reviewer = _resolve_role(registry, "reviewer")
+    verifier = _resolve_role(registry, "verifier")
+    assert reviewer.agent_id == "mergecraft-reviewer"
+    assert verifier.agent_id == "senior-reviewer"

--- a/tests/agents/test_agent_registry.py
+++ b/tests/agents/test_agent_registry.py
@@ -1,5 +1,8 @@
 """AP1 agent registry suite — binding model, prompt, toolset and budget.
 
+Module: ``tests/agents/test_agent_registry.py`` (renamed from ``test_registry.py``
+to avoid pytest import collision with ``tests/mcp/test_registry.py``).
+
 Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP1).
 Covers ``mergecraft.agents.registry`` — frozen ``AgentBinding``, ``Registry``
 loading defaults + ``.mergecraft/config.yaml`` overrides, per-agent chain

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -1,13 +1,10 @@
-"""AP1.1 RED suite — agent registry binding model, prompt, toolset and budget.
+"""AP1 agent registry suite — binding model, prompt, toolset and budget.
 
-Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP1 / AP1.1).
-Fifteen tests are ``@pytest.mark.xfail(strict=False)`` pending AP1.2; one
-compatibility pin passes today (run-level model chain).
-
-Target API (AP1.2): ``mergecraft.agents.registry`` — frozen ``AgentBinding``,
-``Registry`` loading defaults + ``.mergecraft/config.yaml`` overrides, per-agent
-chain resolution reusing ``pick_runnable_slug_from_chain``, and
-``resolve_agent_model`` recording the executed slug (D4).
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP1).
+Covers ``mergecraft.agents.registry`` — frozen ``AgentBinding``, ``Registry``
+loading defaults + ``.mergecraft/config.yaml`` overrides, per-agent chain
+resolution reusing ``pick_runnable_slug_from_chain``, and ``resolve_agent_model``
+recording the executed slug (D4). Reconciled green after AP1.2.
 """
 
 from __future__ import annotations
@@ -36,8 +33,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_AP12_XFAIL = pytest.mark.xfail(reason="green after AP1.2: agent registry", strict=False)
 
 _ROLES: tuple[str, ...] = (
     "orchestrator",
@@ -133,7 +128,6 @@ def test_agent_chain_defaults_to_the_run_chain(tmp_path: Path, monkeypatch: Monk
     assert effective_model_chain(settings) == expected
 
 
-@_AP12_XFAIL
 def test_every_role_resolves_to_a_binding(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Each core role — orchestrator, reviewer, verifier, judge, classifier — has a binding."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -150,7 +144,6 @@ def test_every_role_resolves_to_a_binding(tmp_path: Path, monkeypatch: MonkeyPat
         assert binding.tool_classes
 
 
-@_AP12_XFAIL
 def test_reviewer_and_verifier_have_different_toolsets(tmp_path: Path) -> None:
     """P2 regression pin — reviewer and verifier tool-name sets must differ via the registry."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -173,7 +166,6 @@ def test_reviewer_and_verifier_have_different_toolsets(tmp_path: Path) -> None:
     assert "verify_agent_findings" not in reviewer_names
 
 
-@_AP12_XFAIL
 def test_per_agent_model_chain_falls_back(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """P3/D3 — an agent's own fallback runs when its primary slug is unavailable."""
     _write_config(
@@ -209,7 +201,6 @@ agents:
     assert resolved.executed_model == fallback
 
 
-@_AP12_XFAIL
 def test_executed_model_is_recorded_not_requested(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """D4 — the executed slug is recorded, never the unavailable requested head."""
     _write_config(
@@ -244,7 +235,6 @@ agents:
     assert resolved.recorded_model == executed
 
 
-@_AP12_XFAIL
 def test_verifier_pin_invariant_survives_fallback(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """#45 — the recorded judge model always matches the dispatched verifier slug."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -274,7 +264,6 @@ def test_verifier_pin_invariant_survives_fallback(tmp_path: Path, monkeypatch: M
     assert resolved.dispatched_model == resolved.executed_model
 
 
-@_AP12_XFAIL
 def test_prompt_id_and_version_are_bound(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Each binding carries a prompt id/version that resolves to the live prompt text."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -294,7 +283,6 @@ def test_prompt_id_and_version_are_bound(tmp_path: Path, monkeypatch: MonkeyPatc
     assert reviewer.prompt_id != verifier.prompt_id
 
 
-@_AP12_XFAIL
 def test_toolset_derives_from_tool_classes(tmp_path: Path) -> None:
     """HA4 integration — registry tool names are the class-filtered MCP surface."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -317,7 +305,6 @@ def test_toolset_derives_from_tool_classes(tmp_path: Path) -> None:
     assert ToolClass.VERIFICATION not in reviewer.tool_classes
 
 
-@_AP12_XFAIL
 def test_no_read_only_agent_gets_a_terminal_protocol_tool(tmp_path: Path) -> None:
     """Read-only roles must never receive ``terminal-protocol`` tools."""
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -330,7 +317,6 @@ def test_no_read_only_agent_gets_a_terminal_protocol_tool(tmp_path: Path) -> Non
         assert _TERMINAL_PROTOCOL_TOOL not in names, f"{role} received terminal protocol tool"
 
 
-@_AP12_XFAIL
 def test_per_agent_budget_and_timeout_apply(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Per-agent ``budget`` and ``timeout_s`` overrides apply from config."""
     _write_config(
@@ -358,7 +344,6 @@ agents:
     assert limits.timeout_s == 120
 
 
-@_AP12_XFAIL
 def test_registry_validation_rejects_a_missing_model(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -381,7 +366,6 @@ agents:
         registry.validate()
 
 
-@_AP12_XFAIL
 def test_registry_validation_rejects_an_unknown_prompt_id(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -404,7 +388,6 @@ agents:
         registry.validate()
 
 
-@_AP12_XFAIL
 def test_registry_validation_rejects_an_unreachable_lens(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -1,0 +1,428 @@
+"""AP1.1 RED suite — agent registry binding model, prompt, toolset and budget.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP1 / AP1.1).
+Fifteen tests are ``@pytest.mark.xfail(strict=False)`` pending AP1.2; one
+compatibility pin passes today (run-level model chain).
+
+Target API (AP1.2): ``mergecraft.agents.registry`` — frozen ``AgentBinding``,
+``Registry`` loading defaults + ``.mergecraft/config.yaml`` overrides, per-agent
+chain resolution reusing ``pick_runnable_slug_from_chain``, and
+``resolve_agent_model`` recording the executed slug (D4).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import pytest
+
+from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT, pinned_judge_model
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.shared import ToolClass, ToolSpec
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.types import XrepoConfig
+from mergecraft.utils.agent_resolve import effective_model_chain
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_AP12_XFAIL = pytest.mark.xfail(reason="green after AP1.2: agent registry", strict=False)
+
+_ROLES: tuple[str, ...] = (
+    "orchestrator",
+    "reviewer",
+    "verifier",
+    "judge",
+    "classifier",
+)
+
+_TERMINAL_PROTOCOL_TOOL = "submit_review_verdict"
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _tool_ctx(
+    tmp_path: Path,
+    *,
+    shell: Literal["disabled", "restricted", "enabled"] = "restricted",
+    push: Literal["disabled", "restricted", "enabled"] = "restricted",
+) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell=shell,
+            push=push,
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        signed_commits=True,
+        xrepo=XrepoConfig(mode="explicit", read=["other"], write=["other"]),
+        static_checks_enabled=True,
+    )
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _resolve_role(registry: object, role: str) -> object:
+    from mergecraft.agents.registry import AgentRole
+
+    resolve = registry.resolve_role
+    return resolve(AgentRole(role))
+
+
+def _tool_names(registry: object, binding: object, ctx: ToolContext) -> frozenset[str]:
+    resolve_tool_names = registry.resolve_tool_names
+    names = resolve_tool_names(binding, ctx)
+    return frozenset(names)
+
+
+def _class_names(specs: list[ToolSpec]) -> frozenset[str]:
+    return frozenset(str(spec.tool_class) for spec in specs)
+
+
+def test_agent_chain_defaults_to_the_run_chain(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Compatibility pin: the run-level chain is ``effective_model_chain`` (today's behaviour).
+
+    AP1.2 must default every agent binding's ``model_chain`` to this chain when
+    the operator supplies no per-agent override.
+    """
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    monkeypatch.chdir(tmp_path)
+    settings = load_repo_settings(root=tmp_path)
+    expected = [
+        "anthropic/claude-sonnet",
+        "openai/gpt-5.3-codex",
+        "google/gemini-3.1-pro-preview",
+    ]
+    assert effective_model_chain(settings) == expected
+
+
+@_AP12_XFAIL
+def test_every_role_resolves_to_a_binding(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Each core role — orchestrator, reviewer, verifier, judge, classifier — has a binding."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    monkeypatch.chdir(tmp_path)
+    registry = _load_registry(tmp_path)
+
+    for role in _ROLES:
+        binding = _resolve_role(registry, role)
+        assert binding.role.value == role
+        assert binding.agent_id
+        assert binding.model_chain
+        assert binding.prompt_id
+        assert binding.prompt_version
+        assert binding.tool_classes
+
+
+@_AP12_XFAIL
+def test_reviewer_and_verifier_have_different_toolsets(tmp_path: Path) -> None:
+    """P2 regression pin — reviewer and verifier tool-name sets must differ via the registry."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+
+    reviewer = _resolve_role(registry, "reviewer")
+    verifier = _resolve_role(registry, "verifier")
+    reviewer_names = _tool_names(registry, reviewer, ctx)
+    verifier_names = _tool_names(registry, verifier, ctx)
+
+    assert reviewer_names, "reviewer toolset must not be empty"
+    assert verifier_names, "verifier toolset must not be empty"
+    assert reviewer_names != verifier_names, (
+        "reviewer and verifier must not share an identical tool-name set (P2)"
+    )
+    assert "checkout_pr" in reviewer_names
+    assert "checkout_pr" not in verifier_names
+    assert "verify_agent_findings" in verifier_names
+    assert "verify_agent_findings" not in reviewer_names
+
+
+@_AP12_XFAIL
+def test_per_agent_model_chain_falls_back(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """P3/D3 — an agent's own fallback runs when its primary slug is unavailable."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    modelChain:
+      - anthropic/claude-opus
+      - anthropic/claude-sonnet
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import resolve_agent_model
+
+    registry = _load_registry(tmp_path)
+    binding = _resolve_role(registry, "reviewer")
+    settings = load_repo_settings(root=tmp_path)
+
+    unavailable_primary = "anthropic/claude-opus"
+    fallback = "anthropic/claude-sonnet"
+
+    def _runnable(slug: str) -> bool:
+        return slug == fallback
+
+    resolved = resolve_agent_model(
+        binding,
+        settings=settings,
+        slug_runnable=_runnable,
+    )
+    assert resolved.requested_model == unavailable_primary
+    assert resolved.executed_model == fallback
+
+
+@_AP12_XFAIL
+def test_executed_model_is_recorded_not_requested(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """D4 — the executed slug is recorded, never the unavailable requested head."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    modelChain:
+      - anthropic/claude-opus
+      - openai/gpt-5.3-codex
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import resolve_agent_model
+
+    registry = _load_registry(tmp_path)
+    binding = _resolve_role(registry, "reviewer")
+    settings = load_repo_settings(root=tmp_path)
+
+    requested = "anthropic/claude-opus"
+    executed = "openai/gpt-5.3-codex"
+
+    resolved = resolve_agent_model(
+        binding,
+        settings=settings,
+        slug_runnable=lambda slug: slug == executed,
+    )
+    assert resolved.requested_model == requested
+    assert resolved.executed_model == executed
+    assert resolved.executed_model != resolved.requested_model
+    assert resolved.recorded_model == executed
+
+
+@_AP12_XFAIL
+def test_verifier_pin_invariant_survives_fallback(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """#45 — the recorded judge model always matches the dispatched verifier slug."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import resolve_agent_model
+
+    registry = _load_registry(tmp_path)
+    verifier = _resolve_role(registry, "verifier")
+    settings = load_repo_settings(root=tmp_path)
+    pinned = pinned_judge_model("claude")
+    assert pinned is not None
+    assert verifier.model_chain[0] == pinned
+
+    backup = "openai/gpt-5.3-codex"
+    chain = list(verifier.model_chain)
+    assert len(chain) >= 2, "verifier must carry its own fallback chain (#45 / D3)"
+    assert backup in chain[1:], f"expected {backup!r} in verifier fallback tail, got {chain!r}"
+
+    resolved = resolve_agent_model(
+        verifier,
+        settings=settings,
+        slug_runnable=lambda slug: slug == backup,
+    )
+    assert resolved.requested_model == pinned
+    assert resolved.executed_model != pinned
+    assert resolved.recorded_model == resolved.executed_model
+    assert resolved.dispatched_model == resolved.executed_model
+
+
+@_AP12_XFAIL
+def test_prompt_id_and_version_are_bound(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Each binding carries a prompt id/version that resolves to the live prompt text."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import resolve_prompt_text
+
+    registry = _load_registry(tmp_path)
+    reviewer = _resolve_role(registry, "reviewer")
+    verifier = _resolve_role(registry, "verifier")
+
+    assert resolve_prompt_text(reviewer.prompt_id, version=reviewer.prompt_version) == (
+        REVIEWER_SYSTEM_PROMPT
+    )
+    assert resolve_prompt_text(verifier.prompt_id, version=verifier.prompt_version) == (
+        VERIFIER_SYSTEM_PROMPT
+    )
+    assert reviewer.prompt_id != verifier.prompt_id
+
+
+@_AP12_XFAIL
+def test_toolset_derives_from_tool_classes(tmp_path: Path) -> None:
+    """HA4 integration — registry tool names are the class-filtered MCP surface."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    reviewer = _resolve_role(registry, "reviewer")
+
+    from mergecraft.mcp.server import build_reviewer_tools
+
+    expected_specs = build_reviewer_tools(ctx)
+    expected_names = {spec.name for spec in expected_specs}
+    expected_classes = _class_names(expected_specs)
+
+    derived_names = _tool_names(registry, reviewer, ctx)
+    assert derived_names == expected_names
+
+    declared_classes = frozenset(str(cls) for cls in reviewer.tool_classes)
+    assert declared_classes == expected_classes
+    assert ToolClass.SCOPE in reviewer.tool_classes
+    assert ToolClass.VERIFICATION not in reviewer.tool_classes
+
+
+@_AP12_XFAIL
+def test_no_read_only_agent_gets_a_terminal_protocol_tool(tmp_path: Path) -> None:
+    """Read-only roles must never receive ``terminal-protocol`` tools."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+
+    for role in ("reviewer", "verifier", "classifier"):
+        binding = _resolve_role(registry, role)
+        names = _tool_names(registry, binding, ctx)
+        assert _TERMINAL_PROTOCOL_TOOL not in names, f"{role} received terminal protocol tool"
+
+
+@_AP12_XFAIL
+def test_per_agent_budget_and_timeout_apply(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Per-agent ``budget`` and ``timeout_s`` overrides apply from config."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    budget: 5
+    timeoutS: 120
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import effective_agent_limits
+
+    registry = _load_registry(tmp_path)
+    reviewer = _resolve_role(registry, "reviewer")
+    settings = load_repo_settings(root=tmp_path)
+
+    assert reviewer.budget == 5
+    assert reviewer.timeout_s == 120
+
+    limits = effective_agent_limits(reviewer, settings=settings)
+    assert limits.budget == 5
+    assert limits.timeout_s == 120
+
+
+@_AP12_XFAIL
+def test_registry_validation_rejects_a_missing_model(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Validation fails when a binding references an unknown model slug."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    modelChain:
+      - not-a-real-mergecraft-model
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import RegistryValidationError
+
+    registry = _load_registry(tmp_path)
+    with pytest.raises(RegistryValidationError, match=r"(?i)model|slug|unknown|unresolvable"):
+        registry.validate()
+
+
+@_AP12_XFAIL
+def test_registry_validation_rejects_an_unknown_prompt_id(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Validation fails when ``prompt_id`` is not in the prompt catalog."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    promptId: not.a.real.prompt.id
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import RegistryValidationError
+
+    registry = _load_registry(tmp_path)
+    with pytest.raises(RegistryValidationError, match=r"(?i)prompt"):
+        registry.validate()
+
+
+@_AP12_XFAIL
+def test_registry_validation_rejects_an_unreachable_lens(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Validation fails when a lens binding references an id absent from the registry."""
+    _write_config(
+        tmp_path,
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  lens-security:
+    lens: security
+    role: reviewer
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+    from mergecraft.agents.registry import RegistryValidationError
+
+    registry = _load_registry(tmp_path)
+    with pytest.raises(RegistryValidationError, match=r"(?i)lens|unreachable|unknown"):
+        registry.validate()

--- a/tests/cli/test_agents_verbs.py
+++ b/tests/cli/test_agents_verbs.py
@@ -1,14 +1,13 @@
-"""AP1.1 RED suite — ``mergecraft agents list|show|set`` (PR AP1).
+"""AP1 agents CLI suite — ``mergecraft agents list|show|set`` (PR AP1).
 
-Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (AP1.1).
-All three tests are ``@pytest.mark.xfail(strict=False)`` pending AP1.2.
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP1).
+Reconciled green after AP1.2.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from typer.testing import CliRunner
 
 from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
@@ -20,8 +19,6 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
 runner = CliRunner()
-
-_AP12_XFAIL = pytest.mark.xfail(reason="green after AP1.2: agents CLI", strict=False)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -36,7 +33,6 @@ def _write_config(tmp_path: Path, body: str = _DEFAULT_MODELS_YAML) -> None:
     (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
 
 
-@_AP12_XFAIL
 def test_agents_list_shows_model_prompt_and_tools(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """``agents list`` surfaces model chain, prompt id, and tool count per binding."""
     _write_config(tmp_path)
@@ -53,7 +49,6 @@ def test_agents_list_shows_model_prompt_and_tools(tmp_path: Path, monkeypatch: M
     assert "tool" in output
 
 
-@_AP12_XFAIL
 def test_agents_show_prints_the_resolved_prompt_and_exact_tool_names(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -71,7 +66,6 @@ def test_agents_show_prints_the_resolved_prompt_and_exact_tool_names(
     assert "verify_agent_findings" not in output
 
 
-@_AP12_XFAIL
 def test_agents_set_overrides_one_binding(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """``agents set`` writes a single binding override into ``.mergecraft/config.yaml``."""
     _write_config(tmp_path)
@@ -85,7 +79,6 @@ def test_agents_set_overrides_one_binding(tmp_path: Path, monkeypatch: MonkeyPat
     assert result.exit_code == 0, result.stdout + result.stderr
 
     from mergecraft.agents.registry import load_registry
-
     from mergecraft.config.settings import load_repo_settings
 
     settings = load_repo_settings(root=tmp_path)

--- a/tests/cli/test_agents_verbs.py
+++ b/tests/cli/test_agents_verbs.py
@@ -1,0 +1,95 @@
+"""AP1.1 RED suite — ``mergecraft agents list|show|set`` (PR AP1).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (AP1.1).
+All three tests are ``@pytest.mark.xfail(strict=False)`` pending AP1.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_AP12_XFAIL = pytest.mark.xfail(reason="green after AP1.2: agents CLI", strict=False)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+"""
+
+
+def _write_config(tmp_path: Path, body: str = _DEFAULT_MODELS_YAML) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+@_AP12_XFAIL
+def test_agents_list_shows_model_prompt_and_tools(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``agents list`` surfaces model chain, prompt id, and tool count per binding."""
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["agents", "list"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    output = result.stdout.lower()
+    assert "reviewer" in output
+    assert "verifier" in output
+    assert "prompt" in output
+    assert "anthropic/claude-sonnet" in output or "claude-sonnet" in output
+    assert "tool" in output
+
+
+@_AP12_XFAIL
+def test_agents_show_prints_the_resolved_prompt_and_exact_tool_names(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``agents show <role>`` prints the resolved prompt body and exact MCP tool names."""
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["agents", "show", "reviewer"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    output = result.stdout
+    assert REVIEWER_SYSTEM_PROMPT[:80] in output
+    assert "checkout_pr" in output
+    assert "verify_agent_findings" not in output
+
+
+@_AP12_XFAIL
+def test_agents_set_overrides_one_binding(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``agents set`` writes a single binding override into ``.mergecraft/config.yaml``."""
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    override_model = "google/gemini-3.1-pro-preview"
+
+    result = runner.invoke(
+        app,
+        ["agents", "set", "reviewer", "--model", override_model],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    from mergecraft.agents.registry import load_registry
+
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    binding = registry.resolve_role("reviewer")
+    assert override_model in binding.model_chain
+    assert binding.model_chain[0] == override_model

--- a/tests/cli/test_agents_verbs.py
+++ b/tests/cli/test_agents_verbs.py
@@ -86,3 +86,25 @@ def test_agents_set_overrides_one_binding(tmp_path: Path, monkeypatch: MonkeyPat
     binding = registry.resolve_role("reviewer")
     assert override_model in binding.model_chain
     assert binding.model_chain[0] == override_model
+
+
+def test_agents_set_rejects_unknown_role(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """``agents set`` bails on an unknown role before writing ``.mergecraft/config.yaml``.
+
+    Guard-deletion pin (PR #231): without the ``AgentRole`` check the typo key
+    would be persisted and this assertion would fail.
+    """
+    _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+
+    result = runner.invoke(
+        app,
+        ["agents", "set", "senior-reviewer", "--model", "google/gemini-3.1-pro-preview"],
+    )
+
+    assert result.exit_code != 0
+    output = (result.stdout + result.stderr).lower()
+    assert "unknown" in output or "role" in output
+    yaml_text = config_path.read_text(encoding="utf-8")
+    assert "senior-reviewer" not in yaml_text

--- a/tests/mcp/test_dependencies_python_skip.py
+++ b/tests/mcp/test_dependencies_python_skip.py
@@ -1,0 +1,136 @@
+"""MCP dependency tools treat a Python policy skip as completed, not failed."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.dependencies import _format_prep_results, start_installation
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.prep.types import PrepOptions, PrepResult
+from mergecraft.utils.github import GitHubClient
+
+_SKIP_ISSUE = (
+    "skipped: python dependency installation can execute arbitrary code "
+    "(setup.py, build backends, local path references), which is blocked "
+    "when shell is disabled"
+)
+_PIP_FAIL = "pip install -r requirements.txt failed (exit 1)"
+
+
+def _skip_result() -> PrepResult:
+    return PrepResult(
+        language="python",
+        dependencies_installed=False,
+        skipped=True,
+        package_manager="uv",
+        config_file="uv.lock",
+        issues=[_SKIP_ISSUE],
+    )
+
+
+def _fail_result() -> PrepResult:
+    return PrepResult(
+        language="python",
+        dependencies_installed=False,
+        skipped=False,
+        package_manager="pip",
+        config_file="requirements.txt",
+        issues=[_PIP_FAIL],
+    )
+
+
+def _tool_ctx(
+    tmp_path: Path,
+    *,
+    shell: Literal["disabled", "restricted", "enabled"] = "disabled",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell=shell,
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def test_format_prep_results_says_skipped_not_failed_for_python_skip() -> None:
+    text = _format_prep_results([_skip_result()])
+    assert "installation skipped" in text
+    assert _SKIP_ISSUE in text
+    assert "installation failed" not in text
+
+
+def test_format_prep_results_still_reports_genuine_install_failure() -> None:
+    text = _format_prep_results([_fail_result()])
+    assert "installation failed" in text
+    assert _PIP_FAIL in text
+    assert "installation skipped" not in text
+
+
+@pytest.mark.asyncio
+async def test_start_installation_completes_on_python_policy_skip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skip-only prep must land ``status="completed"``, not ``"failed"``."""
+    skip = _skip_result()
+
+    async def _fake_prep(options: PrepOptions) -> list[PrepResult]:
+        assert options.ignore_scripts is True
+        return [skip]
+
+    monkeypatch.setattr("mergecraft.mcp.dependencies.run_prep_phase", _fake_prep)
+
+    ctx = _tool_ctx(tmp_path, shell="disabled")
+    start_installation(ctx)
+    state = ctx.tool_state.dependency_installation
+    assert state is not None
+    assert state.promise is not None
+    await state.promise
+    await asyncio.sleep(0)
+
+    assert state.status == "completed"
+    assert state.results == [skip]
+
+
+@pytest.mark.asyncio
+async def test_start_installation_fails_on_genuine_install_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """W6.1 fail-closed: a real install failure still sets ``status="failed"``."""
+    failed = _fail_result()
+
+    async def _fake_prep(_options: PrepOptions) -> list[PrepResult]:
+        return [failed]
+
+    monkeypatch.setattr("mergecraft.mcp.dependencies.run_prep_phase", _fake_prep)
+
+    ctx = _tool_ctx(tmp_path, shell="restricted")
+    start_installation(ctx)
+    state = ctx.tool_state.dependency_installation
+    assert state is not None
+    assert state.promise is not None
+    await state.promise
+    await asyncio.sleep(0)
+
+    assert state.status == "failed"
+    assert state.results == [failed]

--- a/tests/prep/test_prep_fail_closed.py
+++ b/tests/prep/test_prep_fail_closed.py
@@ -4,6 +4,9 @@ Contracts:
 
 - A review-relevant setup failure (dependency install failed) maps the run to
   ``inconclusive`` with the reason recorded — never a silent continue (D4).
+- A Python *policy skip* (``shell: disabled`` / ``ignore_scripts``,
+  ``PrepResult.skipped=True``) is **not** an install failure and must not
+  map the run to ``inconclusive``.
 - ``setup_script`` failure on the *trusted* tier maps the run to
   ``RunOutcome.inconclusive`` under the default ``setupFailurePolicy``
   (S1 / D5 / D10). Operators can opt into the legacy warn-only behaviour
@@ -14,14 +17,62 @@ Contracts:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from tests.support.run_main_harness import FakeAgent, run_main_for_test
 
 from mergecraft.agents.shared import AgentResult
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import DependencyInstallationState, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.prep import PrepResult
+from mergecraft.run_outcome import RunOutcome
+from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
+
+_SKIP_ISSUE = (
+    "skipped: python dependency installation can execute arbitrary code "
+    "(setup.py, build backends, local path references), which is blocked "
+    "when shell is disabled"
+)
+
+_PrepStatus = Literal["not_started", "in_progress", "completed", "failed"]
+
+
+def _ctx_with_prep(
+    tmp_path: Path,
+    *,
+    status: _PrepStatus,
+    results: list[PrepResult],
+) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    state.dependency_installation = DependencyInstallationState(
+        status=status,
+        promise=None,
+        results=results,
+    )
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="unknown"), shell="disabled"),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
 
 
 async def test_prep_failure_makes_run_inconclusive(
@@ -158,3 +209,74 @@ def test_prep_failure_reason_docstring_describes_three_value_policy() -> None:
         f"_prep_failure_reason docstring should reference the canonical "
         f"SetupFailurePolicy name so future drift is detectable; got:\n{doc}"
     )
+
+
+async def test_python_skip_prep_does_not_make_run_inconclusive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Skip counterpart to ``test_prep_failure_makes_run_inconclusive``.
+
+    ``shell: disabled`` skipping Python install must not map a completed
+    review to ``RunOutcome.inconclusive`` (live:
+    actions/runs/31946428769/job/95163172432).
+    """
+    rec = await run_main_for_test(monkeypatch=monkeypatch, tmp_path=tmp_path, prep_skip=True)
+    assert rec.result is not None
+    outcome = getattr(rec.result, "outcome", None)
+    assert outcome is not RunOutcome.inconclusive, (
+        f"python policy skip produced {outcome!r} (result: {rec.result})"
+    )
+    assert rec.result.success, f"python policy skip failed the run: {rec.result}"
+
+
+async def test_prep_failure_reason_none_for_python_skip_only(tmp_path: Path) -> None:
+    """``_prep_failure_reason`` returns None when the only prep result is a skip."""
+    from mergecraft.main import _prep_failure_reason
+
+    ctx = _ctx_with_prep(
+        tmp_path,
+        status="completed",
+        results=[
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[_SKIP_ISSUE],
+            )
+        ],
+    )
+    assert await _prep_failure_reason(ctx) is None
+
+
+async def test_prep_failure_reason_excludes_skipped_python_install(tmp_path: Path) -> None:
+    """Guard-deletion: skip text must not leak into the fail-closed reason.
+
+    A sibling real install failure still yields a reason (W6.1). Deleting
+    the ``is_prep_install_failure`` filter in ``_prep_failure_reason`` must
+    fail this test by including the skip message.
+    """
+    from mergecraft.main import _prep_failure_reason
+
+    ctx = _ctx_with_prep(
+        tmp_path,
+        status="failed",
+        results=[
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[_SKIP_ISSUE],
+            ),
+            PrepResult(
+                language="node",
+                dependencies_installed=False,
+                skipped=False,
+                issues=["npm ci failed: ERESOLVE"],
+            ),
+        ],
+    )
+    reason = await _prep_failure_reason(ctx)
+    assert reason is not None
+    assert "npm ci failed: ERESOLVE" in reason
+    assert _SKIP_ISSUE not in reason
+    assert "skipped:" not in reason

--- a/tests/prep/test_python_shell_disabled_skip.py
+++ b/tests/prep/test_python_shell_disabled_skip.py
@@ -1,0 +1,113 @@
+"""Python prep skip under ``shell: disabled`` / ``ignore_scripts`` is not a failure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mergecraft.prep.python import InstallPythonDependencies
+from mergecraft.prep.types import PrepOptions, PrepResult, is_prep_install_failure
+
+_SKIP_ISSUE = (
+    "skipped: python dependency installation can execute arbitrary code "
+    "(setup.py, build backends, local path references), which is blocked "
+    "when shell is disabled"
+)
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[_SKIP_ISSUE],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=True,
+                skipped=False,
+                package_manager="uv",
+                issues=[],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=True,
+                skipped=False,
+                issues=["stale warning"],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=False,
+                issues=[],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=False,
+                issues=["pip install -r requirements.txt failed (exit 1)"],
+            ),
+            True,
+        ),
+    ],
+    ids=(
+        "skipped_with_skip_message",
+        "skipped_empty_issues",
+        "installed_clean",
+        "installed_with_issues",
+        "not_installed_empty_issues",
+        "genuine_install_failure",
+    ),
+)
+def test_is_prep_install_failure(result: PrepResult, expected: bool) -> None:
+    """Policy skip is never an install failure; only a real failed install is.
+
+    Deleting the ``result.skipped`` short-circuit in ``is_prep_install_failure``
+    must fail ``skipped_with_skip_message`` — that was the live bug: skip text
+    in ``issues`` was treated as ``status="failed"``.
+    """
+    assert is_prep_install_failure(result) is expected
+
+
+@pytest.mark.asyncio
+async def test_install_python_dependencies_skips_when_ignore_scripts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``uv.lock`` + ``ignore_scripts=True`` is a policy skip, not a failed install."""
+    (tmp_path / "uv.lock").write_text("# test lockfile\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = await InstallPythonDependencies().run(PrepOptions(ignore_scripts=True))
+
+    assert result.skipped is True
+    assert result.dependencies_installed is False
+    assert result.language == "python"
+    assert result.package_manager == "uv"
+    assert result.config_file == "uv.lock"
+    assert result.issues == [_SKIP_ISSUE]
+    assert is_prep_install_failure(result) is False

--- a/tests/prep/test_types.py
+++ b/tests/prep/test_types.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from mergecraft.prep import PrepOptions, PrepResult, run_prep_phase
+from mergecraft.prep import PrepOptions, PrepResult, is_prep_install_failure, run_prep_phase
 from mergecraft.prep.types import NodePackageManager, PythonPackageManager
 
 
@@ -26,6 +26,94 @@ def test_prep_result_shape() -> None:
     assert result.language == "node"
     assert result.dependencies_installed is True
     assert result.package_manager == "npm"
+    assert result.skipped is False
+
+
+def test_prep_result_skipped_defaults_false() -> None:
+    result = PrepResult(language="python", dependencies_installed=False)
+    assert result.skipped is False
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[
+                    "skipped: python dependency installation can execute arbitrary code "
+                    "(setup.py, build backends, local path references), which is blocked "
+                    "when shell is disabled"
+                ],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=False,
+                issues=["pip install -r requirements.txt failed (exit 1)"],
+            ),
+            True,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=True,
+                package_manager="uv",
+                issues=[],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=True,
+                issues=[],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=True,
+                skipped=False,
+                issues=["stale warning"],
+            ),
+            False,
+        ),
+        (
+            PrepResult(
+                language="python",
+                dependencies_installed=False,
+                skipped=False,
+                issues=[],
+            ),
+            False,
+        ),
+    ],
+    ids=(
+        "skipped_with_issues",
+        "failed_install",
+        "successful_install",
+        "skipped_empty_issues",
+        "installed_with_issues",
+        "not_installed_empty_issues",
+    ),
+)
+def test_is_prep_install_failure(result: PrepResult, expected: bool) -> None:
+    """A policy skip is not an install failure even when ``issues`` describe it.
+
+    Deleting the ``skipped`` short-circuit in ``is_prep_install_failure``
+    must fail ``skipped_with_issues`` (the live Action bug: skip text in
+    ``issues`` was treated as ``status="failed"``).
+    """
+    assert is_prep_install_failure(result) is expected
 
 
 def test_package_manager_literals() -> None:

--- a/tests/support/run_main_harness.py
+++ b/tests/support/run_main_harness.py
@@ -181,6 +181,7 @@ async def run_main_for_test(
     agent: FakeAgent | None = None,
     agents_by_slug: dict[str, FakeAgent] | None = None,
     prep_failure: str | None = None,
+    prep_skip: bool = False,
     setup_script_rc: int = 0,
     setup_script_stdout: bytes = b"",
     setup_script_stderr: bytes = b"",
@@ -194,7 +195,9 @@ async def run_main_for_test(
     Parameters select the scenario; every collaborator records into the
     returned :class:`MainRunRecord`. ``prep_failure`` (a reason string) makes
     the dependency-installation state land in ``failed`` before the agent runs,
-    emulating a broken prep phase. ``cleanup_tmpdir=False`` leaves the run's
+    emulating a broken prep phase. ``prep_skip=True`` injects a Python policy
+    skip (``skipped=True``, ``status="completed"``) — ``shell: disabled`` must
+    not map that skip to ``RunOutcome.inconclusive``. ``cleanup_tmpdir=False`` leaves the run's
     temp dir alone so cleanup-contract tests can observe what ``main()`` did.
     """
     repo_root = tmp_path / "workspace"
@@ -348,6 +351,26 @@ async def run_main_for_test(
                         language="python",
                         dependencies_installed=False,
                         issues=[prep_failure],
+                    )
+                ],
+            )
+        elif prep_skip:
+            # Mirrors ``start_installation``'s done-callback after a Python
+            # ``ignore_scripts`` skip: issues may describe the skip, but
+            # ``skipped=True`` keeps status ``completed`` (not ``failed``).
+            tool_context.tool_state.dependency_installation = DependencyInstallationState(
+                status="completed",
+                promise=None,
+                results=[
+                    PrepResult(
+                        language="python",
+                        dependencies_installed=False,
+                        skipped=True,
+                        issues=[
+                            "skipped: python dependency installation can execute arbitrary code "
+                            "(setup.py, build backends, local path references), which is blocked "
+                            "when shell is disabled"
+                        ],
                     )
                 ],
             )


### PR DESCRIPTION
## Summary
- Add agent registry (`AgentBinding`, per-role defaults, config overrides) with per-agent model chain resolution and executed-model recording
- Add `mergecraft agents list|show|set` CLI and `make agents-check` validation gate
- AP1.1 RED test suite green; AP1 Final close-out complete (ci-resume 11/11, runtime proof captured)

## Merge into pre-0.0.1

Linear stack AP1→AP7. After each merge, retarget the **next** PR's base to `pre-0.0.1` before merging it.

1. Merge **#231** → `pre-0.0.1` (this PR; base already `pre-0.0.1`)
2. Retarget #232 to `pre-0.0.1`, merge #232
3. Retarget #233 to `pre-0.0.1`, merge #233
4. Retarget #234 to `pre-0.0.1`, merge #234
5. Retarget #235 to `pre-0.0.1`, merge #235
6. Retarget #236 to `pre-0.0.1`, merge #236
7. Retarget #237 to `pre-0.0.1`, merge #237

## Test plan
- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/agents/test_agent_registry.py tests/cli/test_agents_verbs.py -q` — 16 passed
- [x] `make lint && make typecheck && make agents-check`
- [x] `make ci-resume` — all 11 steps passed (2469 passed, coverage 74.74%)
