### PR TITLE
feat(agents): render the registry into every harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added agent registry binding model, prompt, toolset and budget per role with `mergecraft agents list|show|set` and `make agents-check`
+- Added registry-driven harness render for Claude, OpenCode, Codex, Gemini, and Cursor with per-agent models and declared Codex degradation in run metadata
 
 ### Fixed
 

--- a/docs/test-plans/agent-pipeline-ap2.md
+++ b/docs/test-plans/agent-pipeline-ap2.md
@@ -3,7 +3,7 @@
 Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP2)
 Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap2`
 Authoring wave: **AP2.1** (tests-first). Implementation: **AP2.2**.
-xfail-reconciliation: **post-AP2.2** (pending).
+xfail-reconciliation: **AP2.1.5** (post-AP2.2).
 
 Locked decisions: **D2** (registry is config — only routed agents render per run),
 **D4** (where a harness cannot express a binding, fail loudly),
@@ -11,15 +11,13 @@ Locked decisions: **D2** (registry is config — only routed agents render per r
 
 ## xfail schedule
 
-All cross-wave markers are **non-strict** (`strict=False`). Reason prefix:
-`green after AP2.2: harness render`.
+All cross-wave markers removed at **AP2.1.5** (post-AP2.2).
 
-| Test file | Tests | Marker | Status at AP2.1 |
-|-----------|-------|--------|-----------------|
-| `tests/agents/test_harness_render.py` | 6 harness-render tests | `green after AP2.2: harness render` | **RED (xfail)** |
-| `tests/agents/test_harness_render.py::test_claude_agents_json_renders_from_registry` | 1 | none | **green today** — byte-identical pin |
+| Test file | Tests | Marker | Status |
+|-----------|-------|--------|--------|
+| `tests/agents/test_harness_render.py` | 7 harness-render tests | none | **green** — 7 pass; 0 xfail |
 
-**Acceptance (AP2.1):** 7 collected; 1 pass; 6 xfail. `make lint` + `make typecheck` clean.
+**Acceptance (AP2.1.5):** 7 collected; 7 pass; 0 xfail. `make lint` + `make typecheck` clean.
 
 ## Target API AP2.2 must satisfy
 
@@ -61,11 +59,13 @@ evidence packets can distinguish prose-only collapse from toolset parity.
 
 ## Imports of not-yet-existing symbols
 
-`mergecraft.agents.harness_render` symbols are imported **inside test bodies**
-(or under the xfail-marked tests) so collection succeeds before AP2.2.
+`mergecraft.agents.harness_render` symbols are imported inside test bodies so
+collection succeeds before AP2.2 lands on branches that have not yet merged
+the implementation.
 
 ## Status
 
-AP2.1 RED suite authored; AP2.2 implementation pending. Six tests xfail;
-`test_claude_agents_json_renders_from_registry` passes as the byte-identical
-compatibility pin.
+AP2.1 RED suite authored (`d96c9dd`); AP2.2 implementation landed locally;
+AP2.1.5 reconciled — seven tests pass with no xfail markers. OpenCode model
+test stubs `has_credentials_for_slug` so per-binding chain resolution is
+deterministic without live provider credentials.

--- a/docs/test-plans/agent-pipeline-ap2.md
+++ b/docs/test-plans/agent-pipeline-ap2.md
@@ -1,0 +1,71 @@
+# PR AP2 — harness render — test plan (AP2.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP2)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap2`
+Authoring wave: **AP2.1** (tests-first). Implementation: **AP2.2**.
+xfail-reconciliation: **post-AP2.2** (pending).
+
+Locked decisions: **D2** (registry is config — only routed agents render per run),
+**D4** (where a harness cannot express a binding, fail loudly),
+**D5** (Codex degradation is declared in run metadata, not hidden).
+
+## xfail schedule
+
+All cross-wave markers are **non-strict** (`strict=False`). Reason prefix:
+`green after AP2.2: harness render`.
+
+| Test file | Tests | Marker | Status at AP2.1 |
+|-----------|-------|--------|-----------------|
+| `tests/agents/test_harness_render.py` | 6 harness-render tests | `green after AP2.2: harness render` | **RED (xfail)** |
+| `tests/agents/test_harness_render.py::test_claude_agents_json_renders_from_registry` | 1 | none | **green today** — byte-identical pin |
+
+**Acceptance (AP2.1):** 7 collected; 1 pass; 6 xfail. `make lint` + `make typecheck` clean.
+
+## Target API AP2.2 must satisfy
+
+`src/mergecraft/agents/harness_render.py` (new):
+
+| Symbol | Contract |
+|--------|----------|
+| `HarnessRenderResult` | Frozen/dataclass: `harness`, `payload` (`str` or harness-shaped `dict`), `selected_agent_ids`, `metadata` |
+| `UnrenderableBindingError` | Raised when a selected binding cannot be expressed on the target harness (D4) |
+| `render_agents(registry, *, selected, harness, ctx)` | Projects only `selected` bindings (roles or agent ids) into the harness config (D2) |
+| `run_manifest_metadata(result)` | Returns the metadata dict merged into `AgentResult.metadata` / evidence run manifest |
+
+Harness-specific contracts:
+
+| Harness | Render contract |
+|---------|-----------------|
+| `claude` | `payload` is byte-identical to legacy `build_agents_json()` for default reviewer+verifier |
+| `opencode` | Subagent blocks include per-binding `model` (P4) |
+| `codex` | Real subagent dispatch **or** `metadata["harness_degradations"]` with `kind` / `toolset_parity` (D5) |
+| `gemini`, `cursor` | Subagent surface in payload **or** per-harness degradation row |
+
+`metadata["harness_degradations"]` entries must include at least
+`harness`, `kind`, `toolset_parity`, `selected_agents` so benchmarks and
+evidence packets can distinguish prose-only collapse from toolset parity.
+
+## Contract → coverage matrix
+
+### `tests/agents/test_harness_render.py` — 7 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_claude_agents_json_renders_from_registry` | integration | compatibility pin | Registry-derived Claude JSON matches `build_agents_json()` bytes for default config + class-derived deny lists |
+| 2 | `test_opencode_subagents_carry_per_agent_models` | integration | P4 | Two-model override → OpenCode subagent `model` fields match `resolve_agent_model` per binding |
+| 3 | `test_codex_renders_real_subagents_or_declares_degradation` | integration | D5 | Codex payload has real subagents **or** `harness_degradations` lists `CODEX_SUBAGENT_DEGRADATION.kind` |
+| 4 | `test_gemini_and_cursor_render_or_declare` | integration | D5 parity | Gemini and Cursor each render subagent surface **or** declare per-harness degradation |
+| 5 | `test_unrenderable_binding_fails_loudly` | unit | D4 guard-deletion | Selecting `orchestrator` for Claude harness raises `UnrenderableBindingError` |
+| 6 | `test_only_routed_agents_are_rendered` | integration | D2 | Selecting reviewer+verifier+classifier renders exactly three agents, not the full roster |
+| 7 | `test_declared_degradation_reaches_the_run_manifest` | integration | D5 manifest | `run_manifest_metadata` exposes `harness_degradations`; merge into `AgentResult.metadata` preserves Codex degradation row |
+
+## Imports of not-yet-existing symbols
+
+`mergecraft.agents.harness_render` symbols are imported **inside test bodies**
+(or under the xfail-marked tests) so collection succeeds before AP2.2.
+
+## Status
+
+AP2.1 RED suite authored; AP2.2 implementation pending. Six tests xfail;
+`test_claude_agents_json_renders_from_registry` passes as the byte-identical
+compatibility pin.

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -100,7 +100,15 @@ def build_agents_json(
     *,
     verifier_denied_tools: Sequence[str] = (),
     subagent_denied_tools: Sequence[str] = (),
+    agents_json: str | None = None,
 ) -> str:
+    """Return Claude ``--agents`` JSON for reviewer and verifier subagents.
+
+    When ``agents_json`` is supplied (registry render from AP2), return it
+    verbatim for backward-compatible call sites.
+    """
+    if agents_json is not None:
+        return agents_json
     verifier: dict[str, Any] = {
         "description": (
             "Read-only verification subagent for Critical/Major analyzer, CI and "
@@ -630,9 +638,17 @@ def _run_claude_once(
     mcp_config: str,
     continue_session: bool = False,
 ) -> AgentResult:
+    from mergecraft.agents.harness_render import render_for_run
+
+    harness_render = render_for_run(ctx, "claude")
     model = None
     if ctx.resolved_model:
         model = _strip_provider_prefix(ctx.resolved_model)
+    agents_payload = (
+        harness_render.payload
+        if isinstance(harness_render.payload, str)
+        else json.dumps(harness_render.payload)
+    )
     cmd = [
         cli,
         "--print",
@@ -646,6 +662,7 @@ def _run_claude_once(
         build_agents_json(
             verifier_denied_tools=ctx.verifier_denied_tools,
             subagent_denied_tools=ctx.subagent_denied_tools,
+            agents_json=agents_payload,
         ),
         "--effort",
         "high",

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -253,7 +253,9 @@ def _codex_mcp_tool_preamble() -> str:
     )
 
 
-def _build_subagent_instructions() -> str:
+def _build_subagent_instructions(subagent_block: str | None = None) -> str:
+    if subagent_block is not None:
+        return subagent_block
     return "\n\n".join(
         [
             "Registered read-only subagents (spawn via Codex subagent tooling when needed):",
@@ -452,7 +454,11 @@ def _append_read_only_mcp_network_lines(lines: list[str]) -> None:
     )
 
 
-def write_mcp_config(ctx: AgentRunContext) -> str:
+def write_mcp_config(
+    ctx: AgentRunContext,
+    *,
+    subagent_block: str | None = None,
+) -> str:
     """Write Codex ``config.toml`` under ``$CODEX_HOME`` and return its path."""
     codex_home = _codex_home(ctx)
     codex_home.mkdir(parents=True, exist_ok=True)
@@ -461,7 +467,7 @@ def write_mcp_config(ctx: AgentRunContext) -> str:
         instructions_parts.append(_codex_mcp_tool_preamble())
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
-    instructions_parts.append(_build_subagent_instructions())
+    instructions_parts.append(_build_subagent_instructions(subagent_block))
     instructions_path = codex_home / "mergecraft-instructions.md"
     instructions_path.write_text("\n\n".join(instructions_parts), encoding="utf-8")
 
@@ -970,12 +976,16 @@ def _codex_stream_event_handler(
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    mcp_config = write_mcp_config(ctx)
+    render_result = render_for_run(ctx, "codex")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    mcp_config = write_mcp_config(ctx, subagent_block=subagent_block)
     # Blocking Popen/wait/stream consume runs in a worker thread so
     # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
     initial = await asyncio.to_thread(
@@ -997,7 +1007,8 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         )
 
     result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
-    return await finalize_agent_result(ctx, result)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 codex = agent(name="codex", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/cursor.py
+++ b/src/mergecraft/agents/cursor.py
@@ -83,11 +83,13 @@ def _starting_ref_from_ctx(ctx: AgentRunContext) -> str:
     return "main"
 
 
-def _build_review_prompt(ctx: AgentRunContext) -> str:
+def _build_review_prompt(ctx: AgentRunContext, *, subagent_block: str | None = None) -> str:
     parts: list[str] = []
     system = getattr(ctx.instructions, "system", "")
     if isinstance(system, str) and system.strip():
         parts.append(system.strip())
+    if subagent_block:
+        parts.append(subagent_block)
     user = getattr(ctx.instructions, "user", "")
     if isinstance(user, str) and user.strip():
         parts.append(user.strip())
@@ -171,7 +173,11 @@ async def _poll_run_to_terminal(
     raise TimeoutError(msg)
 
 
-async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
+async def _run_cursor_once(
+    *,
+    ctx: AgentRunContext,
+    subagent_block: str | None = None,
+) -> AgentResult:
     api_key = resolve_cursor_api_key()
     if not api_key:
         return AgentResult(
@@ -183,7 +189,7 @@ async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
         )
 
     client = CursorCloudClient(api_key=api_key)
-    prompt = _build_review_prompt(ctx)
+    prompt = _build_review_prompt(ctx, subagent_block=subagent_block)
     repo_url = _repo_url_from_ctx(ctx)
     starting_ref = _starting_ref_from_ctx(ctx)
     model_id = _resolve_cloud_model_id(ctx)
@@ -275,13 +281,18 @@ async def _install(_token: str | None = None) -> str:
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    result = await _run_cursor_once(ctx=ctx)
-    return await finalize_agent_result(ctx, result)
+    render_result = render_for_run(ctx, "cursor")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    result = await _run_cursor_once(ctx=ctx, subagent_block=subagent_block)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 cursor = agent(name="cursor", install=_install, run=_run)

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -59,7 +59,9 @@ def _gemini_home(ctx: AgentRunContext) -> Path:
     return Path(ctx.tmpdir) / ".gemini"
 
 
-def _build_subagent_instructions() -> str:
+def _build_subagent_instructions(subagent_block: str | None = None) -> str:
+    if subagent_block is not None:
+        return subagent_block
     return "\n\n".join(
         [
             "Registered read-only subagents (spawn when needed):",
@@ -71,11 +73,11 @@ def _build_subagent_instructions() -> str:
     )
 
 
-def _build_instruction_text(ctx: AgentRunContext) -> str:
+def _build_instruction_text(ctx: AgentRunContext, *, subagent_block: str | None = None) -> str:
     instructions_parts: list[str] = []
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
-    instructions_parts.append(_build_subagent_instructions())
+    instructions_parts.append(_build_subagent_instructions(subagent_block))
     return "\n\n".join(instructions_parts)
 
 
@@ -87,12 +89,19 @@ def _build_gemini_prompt(ctx: AgentRunContext, prompt: str) -> str:
     return "\n\n".join(sections)
 
 
-def write_mcp_config(ctx: AgentRunContext) -> str:
+def write_mcp_config(
+    ctx: AgentRunContext,
+    *,
+    subagent_block: str | None = None,
+) -> str:
     """Write Gemini ``settings.json`` under the run temp dir and return its path."""
     gemini_home = _gemini_home(ctx)
     gemini_home.mkdir(parents=True, exist_ok=True)
     instructions_path = gemini_home / "GEMINI.md"
-    instructions_path.write_text(_build_instruction_text(ctx), encoding="utf-8")
+    instructions_path.write_text(
+        _build_instruction_text(ctx, subagent_block=subagent_block),
+        encoding="utf-8",
+    )
 
     server_config: dict[str, object] = {
         "httpUrl": ctx.mcp_server_url,
@@ -549,12 +558,16 @@ def _gemini_stream_event_handler(
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    write_mcp_config(ctx)
+    render_result = render_for_run(ctx, "gemini")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    write_mcp_config(ctx, subagent_block=subagent_block)
     # Blocking Popen/wait/stream consume runs in a worker thread so
     # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
     initial = await asyncio.to_thread(
@@ -576,7 +589,8 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         )
 
     result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
-    return await finalize_agent_result(ctx, result)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 gemini = agent(name="gemini", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/harness_render.py
+++ b/src/mergecraft/agents/harness_render.py
@@ -1,0 +1,393 @@
+"""Render registry bindings into per-harness subagent configuration (AP2).
+
+Projects only the routed roster (D2) into each driver's native shape. Where a
+harness cannot express a binding, raises :class:`UnrenderableBindingError` (D4).
+Codex/Gemini/Cursor prose-only subagent paths record declared degradation in
+``metadata`` for the run manifest (D5).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from mergecraft.agents.registry import (
+    AgentBinding,
+    AgentRole,
+    Registry,
+    resolve_agent_model,
+    resolve_prompt_text,
+)
+from mergecraft.agents.shared import AgentResult, AgentRunContext
+from mergecraft.agents.verifier import (
+    VERIFIER_RUBRIC_VERSION,
+    pinned_judge_model,
+)
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.types import format_mcp_tool_ref
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from mergecraft.mcp.context import ToolContext
+
+HarnessName = Literal["claude", "opencode", "codex", "gemini", "cursor"]
+
+_REVIEWER_DESCRIPTION = (
+    "Read-only review subagent for lens-based code review. "
+    "Reads only — no writes, no state-changing shell or MCP calls."
+)
+
+_VERIFIER_DESCRIPTION = (
+    "Read-only verification subagent for Critical/Major analyzer, CI and "
+    "agent-authored findings. Confirms, downgrades, or drops before "
+    f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
+)
+
+_CLASSIFIER_DESCRIPTION = (
+    "Read-only change classifier subagent. Emits a typed risk and change map for lens routing."
+)
+
+_PROSE_ONLY_HARNESSES: frozenset[HarnessName] = frozenset({"codex", "gemini", "cursor"})
+
+_CLAUDE_UNRENDERABLE_ROLES: frozenset[AgentRole] = frozenset({AgentRole.orchestrator})
+
+
+class UnrenderableBindingError(ValueError):
+    """A selected binding cannot be expressed on the target harness (D4)."""
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRenderResult:
+    """One harness projection of a routed agent roster."""
+
+    harness: HarnessName
+    payload: str | dict[str, Any]
+    selected_agent_ids: tuple[str, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def run_manifest_metadata(result: HarnessRenderResult) -> dict[str, Any]:
+    """Return metadata merged into ``AgentResult.metadata`` / evidence manifest."""
+    if not result.metadata:
+        return {}
+    return dict(result.metadata)
+
+
+def _repo_root_from_ctx(ctx: AgentRunContext | ToolContext) -> Path | None:
+    tool_state = getattr(ctx, "tool_state", None)
+    if tool_state is not None:
+        repo = primary_repo_state(tool_state)
+        if repo.dir:
+            return Path(repo.dir)
+    tmpdir = getattr(ctx, "tmpdir", None)
+    if tmpdir:
+        return Path(tmpdir)
+    return None
+
+
+def _settings_for_ctx(ctx: AgentRunContext | ToolContext) -> Any:
+    root = _repo_root_from_ctx(ctx)
+    if root is not None:
+        return load_repo_settings(root=root)
+    from mergecraft.config.settings import default_settings
+
+    return default_settings()
+
+
+def _resolve_selected_bindings(
+    registry: Registry,
+    selected: Sequence[str],
+) -> list[AgentBinding]:
+    bindings: list[AgentBinding] = []
+    role_values = {role.value for role in AgentRole}
+    by_id = {binding.agent_id: binding for binding in registry.all_bindings()}
+    for key in selected:
+        if key in role_values:
+            bindings.append(registry.resolve_role(key))
+            continue
+        if key in by_id:
+            bindings.append(by_id[key])
+            continue
+        for binding in registry.all_bindings():
+            if binding.agent_id == key:
+                bindings.append(binding)
+                break
+        else:
+            msg = f"no registry binding for selected agent {key!r}"
+            raise KeyError(msg)
+    return bindings
+
+
+def _denied_tool_names(
+    ctx: AgentRunContext | ToolContext,
+    binding: AgentBinding,
+) -> list[str]:
+    from mergecraft.agents.gates import subagent_denied_tool_names
+    from mergecraft.agents.verifier import verifier_denied_tool_names
+
+    if isinstance(ctx, AgentRunContext):
+        if binding.role in (AgentRole.verifier, AgentRole.judge):
+            return list(ctx.verifier_denied_tools)
+        return list(ctx.subagent_denied_tools)
+    if binding.role in (AgentRole.verifier, AgentRole.judge):
+        return verifier_denied_tool_names(ctx)
+    return subagent_denied_tool_names(ctx)
+
+
+def _strip_provider_prefix(specifier: str) -> str:
+    slash = specifier.find("/")
+    return specifier[slash + 1 :] if slash > 0 else specifier
+
+
+def _harness_dispatched_model(binding: AgentBinding, settings: Any) -> str:
+    """Return the model slug written into harness config (declared intent, not runtime pick)."""
+    chain = list(binding.model_chain)
+    if not chain:
+        msg = f"empty model_chain on agent {binding.agent_id!r}"
+        raise RuntimeError(msg)
+    try:
+        return resolve_agent_model(binding, settings=settings).dispatched_model
+    except RuntimeError:
+        return chain[0]
+
+
+def _claude_harness_model(binding: AgentBinding, settings: Any) -> str:
+    if binding.role is AgentRole.verifier:
+        return pinned_judge_model("claude") or "claude-sonnet-5"
+    if binding.role is AgentRole.reviewer:
+        return "claude-sonnet-5"
+    return _strip_provider_prefix(_harness_dispatched_model(binding, settings))
+
+
+def _role_description(binding: AgentBinding) -> str:
+    match binding.role:
+        case AgentRole.reviewer:
+            return _REVIEWER_DESCRIPTION
+        case AgentRole.verifier | AgentRole.judge:
+            return _VERIFIER_DESCRIPTION
+        case AgentRole.classifier:
+            return _CLASSIFIER_DESCRIPTION
+        case AgentRole.orchestrator:
+            return "Orchestrator agent."
+    return f"mergeCraft {binding.role.value} agent."
+
+
+def _claude_agent_entry(
+    binding: AgentBinding,
+    *,
+    settings: Any,
+    denied_tools: Sequence[str],
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "description": _role_description(binding),
+        "prompt": resolve_prompt_text(
+            binding.prompt_id,
+            version=binding.prompt_version,
+        ),
+        "model": _claude_harness_model(binding, settings),
+    }
+    denied = [format_mcp_tool_ref("claude", name) for name in denied_tools]
+    if denied:
+        entry["disallowedTools"] = denied
+    return entry
+
+
+def _render_claude(
+    bindings: Sequence[AgentBinding],
+    *,
+    ctx: AgentRunContext | ToolContext,
+    settings: Any,
+) -> HarnessRenderResult:
+    agents: dict[str, Any] = {}
+    selected_ids: list[str] = []
+    for binding in bindings:
+        if binding.role in _CLAUDE_UNRENDERABLE_ROLES:
+            msg = (
+                f"claude harness cannot render orchestrator binding "
+                f"{binding.agent_id!r} as a subagent (D4)"
+            )
+            raise UnrenderableBindingError(msg)
+        denied = _denied_tool_names(ctx, binding)
+        agents[binding.agent_id] = _claude_agent_entry(
+            binding,
+            settings=settings,
+            denied_tools=denied,
+        )
+        selected_ids.append(binding.agent_id)
+    return HarnessRenderResult(
+        harness="claude",
+        payload=json.dumps(agents),
+        selected_agent_ids=tuple(selected_ids),
+    )
+
+
+def _opencode_agent_entry(
+    binding: AgentBinding,
+    *,
+    settings: Any,
+    denied_tools: Sequence[str],
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "description": _role_description(binding),
+        "prompt": resolve_prompt_text(
+            binding.prompt_id,
+            version=binding.prompt_version,
+        ),
+        "mode": "subagent",
+        "model": _harness_dispatched_model(binding, settings),
+    }
+    denied = {format_mcp_tool_ref("opencode", name): "deny" for name in denied_tools}
+    if denied:
+        entry["permission"] = denied
+    return entry
+
+
+def _render_opencode(
+    bindings: Sequence[AgentBinding],
+    *,
+    ctx: AgentRunContext | ToolContext,
+    settings: Any,
+) -> HarnessRenderResult:
+    agents: dict[str, Any] = {}
+    selected_ids: list[str] = []
+    for binding in bindings:
+        denied = _denied_tool_names(ctx, binding)
+        agents[binding.agent_id] = _opencode_agent_entry(
+            binding,
+            settings=settings,
+            denied_tools=denied,
+        )
+        selected_ids.append(binding.agent_id)
+    return HarnessRenderResult(
+        harness="opencode",
+        payload={"agent": agents},
+        selected_agent_ids=tuple(selected_ids),
+    )
+
+
+def _prose_subagent_instructions(bindings: Sequence[AgentBinding]) -> str:
+    parts = [
+        "Registered read-only subagents (spawn via subagent tooling when needed):",
+    ]
+    for binding in bindings:
+        parts.append(f"## {binding.agent_id}")
+        parts.append(
+            resolve_prompt_text(
+                binding.prompt_id,
+                version=binding.prompt_version,
+            )
+        )
+    return "\n\n".join(parts)
+
+
+def _degradation_row(
+    harness: HarnessName,
+    *,
+    kind: str,
+    toolset_parity: bool,
+    selected_agents: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "harness": harness,
+        "kind": kind,
+        "toolset_parity": toolset_parity,
+        "selected_agents": list(selected_agents),
+    }
+
+
+def _render_prose_only(
+    harness: HarnessName,
+    bindings: Sequence[AgentBinding],
+) -> HarnessRenderResult:
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+
+    selected_ids = tuple(binding.agent_id for binding in bindings)
+    instructions = _prose_subagent_instructions(bindings)
+    degradation = _degradation_row(
+        harness,
+        kind=CODEX_SUBAGENT_DEGRADATION.kind,
+        toolset_parity=CODEX_SUBAGENT_DEGRADATION.toolset_parity,
+        selected_agents=selected_ids,
+    )
+    return HarnessRenderResult(
+        harness=harness,
+        payload=instructions,
+        selected_agent_ids=selected_ids,
+        metadata={"harness_degradations": [degradation]},
+    )
+
+
+def render_agents(
+    registry: Registry,
+    *,
+    selected: Sequence[str],
+    harness: HarnessName | str,
+    ctx: AgentRunContext | ToolContext,
+) -> HarnessRenderResult:
+    """Project ``selected`` registry bindings into ``harness`` config (D2)."""
+    harness_name: HarnessName = harness  # type: ignore[assignment]
+    bindings = _resolve_selected_bindings(registry, selected)
+    settings = _settings_for_ctx(ctx)
+
+    if harness_name == "claude":
+        return _render_claude(bindings, ctx=ctx, settings=settings)
+    if harness_name == "opencode":
+        return _render_opencode(bindings, ctx=ctx, settings=settings)
+    if harness_name in _PROSE_ONLY_HARNESSES:
+        return _render_prose_only(harness_name, bindings)
+
+    msg = f"unknown harness {harness!r}"
+    raise ValueError(msg)
+
+
+def default_subagent_selection(registry: Registry) -> tuple[str, str]:
+    """Default routed roster before AP4 lens routing — reviewer + verifier."""
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    verifier = registry.resolve_role(AgentRole.verifier)
+    return (reviewer.agent_id, verifier.agent_id)
+
+
+def render_for_run(
+    ctx: AgentRunContext,
+    harness: HarnessName,
+    *,
+    selected: Sequence[str] | None = None,
+) -> HarnessRenderResult:
+    """Load the repo registry and render the routed roster for one agent run."""
+    from mergecraft.agents.registry import load_registry
+
+    root = _repo_root_from_ctx(ctx) or Path(ctx.tmpdir)
+    settings = load_repo_settings(root=root)
+    registry = load_registry(settings=settings, repo_root=root)
+    roster = tuple(selected) if selected is not None else default_subagent_selection(registry)
+    return render_agents(registry, selected=roster, harness=harness, ctx=ctx)
+
+
+def merge_manifest_metadata(
+    result: AgentResult,
+    render_result: HarnessRenderResult,
+) -> AgentResult:
+    """Merge harness degradation metadata into an ``AgentResult``."""
+    from dataclasses import replace
+
+    manifest_meta = run_manifest_metadata(render_result)
+    if not manifest_meta:
+        return result
+    meta = dict(result.metadata or {})
+    meta.update(manifest_meta)
+    return replace(result, metadata=meta)
+
+
+__all__ = [
+    "HarnessRenderResult",
+    "UnrenderableBindingError",
+    "default_subagent_selection",
+    "merge_manifest_metadata",
+    "render_agents",
+    "render_for_run",
+    "run_manifest_metadata",
+]

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -23,7 +23,7 @@ from mergecraft.agents.openai_compatible_gateways import (
     resolve_gateway_endpoints,
 )
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
-from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
     AgentResult,
     AgentRunContext,
@@ -32,7 +32,7 @@ from mergecraft.agents.shared import (
     log_token_table,
     spawn_agent_cli,
 )
-from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.http import instrument_httpx
 from mergecraft.types import MERGECRAFT_MCP_NAME, format_mcp_tool_ref
@@ -179,7 +179,11 @@ def _verifier_agent_config(ctx: AgentRunContext) -> dict[str, object]:
 
 
 def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
+    from mergecraft.agents.harness_render import render_for_run
+
     fs_perm = build_opencode_native_fs_permission()
+    render_result = render_for_run(ctx, "opencode")
+    agent_block = render_result.payload["agent"] if isinstance(render_result.payload, dict) else {}
     config: dict[str, object] = {
         "permission": {
             "bash": "deny",
@@ -196,10 +200,7 @@ def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
                 "timeout": 300_000,
             }
         },
-        "agent": {
-            REVIEWER_AGENT_NAME: _reviewer_agent_config(ctx),
-            VERIFIER_AGENT_NAME: _verifier_agent_config(ctx),
-        },
+        "agent": agent_block,
     }
     if model:
         config["model"] = model

--- a/tests/agents/test_harness_render.py
+++ b/tests/agents/test_harness_render.py
@@ -8,9 +8,7 @@ degradation). Locked decisions: **D2** (only routed agents render),
 **D4** (unrenderable bindings fail loudly), **D5** (Codex degradation is
 declared in run metadata, not hidden).
 
-AP2.1: seven tests; ``test_claude_agents_json_renders_from_registry`` passes
-today as the byte-identical compatibility pin. Six implementation-dependent
-tests are ``xfail`` until AP2.2.
+AP2.1: seven tests; reconciled post-AP2.2 — all pass with no xfail markers.
 """
 
 from __future__ import annotations
@@ -44,9 +42,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from mergecraft.agents.registry import Registry
+    from _pytest.monkeypatch import MonkeyPatch
 
-_AP2_XFAIL = pytest.mark.xfail(reason="green after AP2.2: harness render", strict=False)
+    from mergecraft.agents.registry import Registry
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -65,6 +63,18 @@ _VERIFIER_DESCRIPTION = (
     "agent-authored findings. Confirms, downgrades, or drops before "
     f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
 )
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    """Deterministic model-chain resolution without live credentials or binaries."""
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
 
 
 def _write_config(tmp_path: Path, body: str) -> None:
@@ -169,12 +179,15 @@ def test_claude_agents_json_renders_from_registry(tmp_path: Path) -> None:
     assert from_registry == legacy
 
 
-@_AP2_XFAIL
-def test_opencode_subagents_carry_per_agent_models(tmp_path: Path) -> None:
+def test_opencode_subagents_carry_per_agent_models(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     """P4 — OpenCode subagent blocks carry each binding's dispatched model."""
-    from mergecraft.agents.harness_render import render_agents
-
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
     from mergecraft.agents.registry import resolve_agent_model
+
+    _stub_slug_runnability(monkeypatch)
 
     body = (
         _DEFAULT_MODELS_YAML
@@ -202,18 +215,17 @@ agents:
         harness="opencode",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     config = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
     agents = config["agent"]
     assert agents[REVIEWER_AGENT_NAME]["model"] == reviewer_model
     assert agents[VERIFIER_AGENT_NAME]["model"] == verifier_model
 
 
-@_AP2_XFAIL
 def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) -> None:
     """D5 — Codex either renders real subagents or records declared degradation."""
-    from mergecraft.agents.harness_render import render_agents
-
     from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -224,6 +236,7 @@ def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) ->
         harness="codex",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     payload_text = result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
     has_real_subagents = (
         REVIEWER_AGENT_NAME in payload_text
@@ -239,10 +252,9 @@ def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) ->
         assert CODEX_SUBAGENT_DEGRADATION.kind in kinds
 
 
-@_AP2_XFAIL
 def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
     """Gemini and Cursor harnesses render subagents or declare degradation like Codex."""
-    from mergecraft.agents.harness_render import render_agents
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -256,6 +268,7 @@ def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
             harness=harness,
             ctx=ctx,
         )
+        assert isinstance(result, HarnessRenderResult)
         payload_text = (
             result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
         )
@@ -269,7 +282,6 @@ def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
         assert has_subagent_surface or has_declared
 
 
-@_AP2_XFAIL
 def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
     """D4 — bindings a harness cannot express raise instead of silently collapsing."""
     from mergecraft.agents.harness_render import UnrenderableBindingError, render_agents
@@ -286,10 +298,11 @@ def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
         )
 
 
-@_AP2_XFAIL
-def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
+def test_only_routed_agents_are_rendered(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """D2 — only the selected roster is rendered, not the full registry."""
-    from mergecraft.agents.harness_render import render_agents
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
+
+    _stub_slug_runnability(monkeypatch)
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -301,6 +314,7 @@ def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
         harness="claude",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     agents = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
     assert len(agents) == 3
     rendered_ids = set(agents)
@@ -313,12 +327,14 @@ def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
     assert len(registry.all_bindings()) > len(agents)
 
 
-@_AP2_XFAIL
 def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
     """Declared harness degradation must flow into run-manifest metadata."""
-    from mergecraft.agents.harness_render import render_agents, run_manifest_metadata
-
     from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.harness_render import (
+        HarnessRenderResult,
+        render_agents,
+        run_manifest_metadata,
+    )
     from mergecraft.agents.shared import AgentResult
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -330,6 +346,7 @@ def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
         harness="codex",
         ctx=ctx,
     )
+    assert isinstance(render_result, HarnessRenderResult)
     manifest_meta = run_manifest_metadata(render_result)
     assert "harness_degradations" in manifest_meta
     degradations = manifest_meta["harness_degradations"]

--- a/tests/agents/test_harness_render.py
+++ b/tests/agents/test_harness_render.py
@@ -1,0 +1,350 @@
+"""AP2 harness render suite — registry-driven subagent config per driver.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP2).
+Covers ``mergecraft.agents.harness_render`` — ``render_agents`` projects
+selected registry bindings into each harness shape (Claude ``agents.json``,
+OpenCode subagent blocks, Codex/Gemini/Cursor subagent dispatch or declared
+degradation). Locked decisions: **D2** (only routed agents render),
+**D4** (unrenderable bindings fail loudly), **D5** (Codex degradation is
+declared in run metadata, not hidden).
+
+AP2.1: seven tests; ``test_claude_agents_json_renders_from_registry`` passes
+today as the byte-identical compatibility pin. Six implementation-dependent
+tests are ``xfail`` until AP2.2.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.claude import build_agents_json
+from mergecraft.agents.gates import subagent_denied_tool_names
+from mergecraft.agents.verifier import (
+    VERIFIER_RUBRIC_VERSION,
+    pinned_judge_model,
+    verifier_denied_tool_names,
+)
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.types import REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME, format_mcp_tool_ref
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from mergecraft.agents.registry import Registry
+
+_AP2_XFAIL = pytest.mark.xfail(reason="green after AP2.2: harness render", strict=False)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_REVIEWER_DESCRIPTION = (
+    "Read-only review subagent for lens-based code review. "
+    "Reads only — no writes, no state-changing shell or MCP calls."
+)
+
+_VERIFIER_DESCRIPTION = (
+    "Read-only verification subagent for Critical/Major analyzer, CI and "
+    "agent-authored findings. Confirms, downgrades, or drops before "
+    f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
+)
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _tool_ctx(tmp_path: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request"),
+            shell="restricted",
+            push="restricted",
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        signed_commits=True,
+        xrepo=None,
+        static_checks_enabled=True,
+    )
+
+
+def _load_registry(tmp_path: Path) -> Registry:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _registry_claude_agents_json(
+    registry: Registry,
+    *,
+    verifier_denied_tools: Sequence[str],
+    subagent_denied_tools: Sequence[str],
+) -> str:
+    """Reconstruct Claude ``agents.json`` from registry bindings (AP2 contract)."""
+    from mergecraft.agents.registry import resolve_prompt_text
+
+    reviewer_binding = registry.resolve_role("reviewer")
+    verifier_binding = registry.resolve_role("verifier")
+    # Claude harness dispatch format — AP2 maps registry chains to these fields.
+    reviewer_model = "claude-sonnet-5"
+    verifier_model = pinned_judge_model("claude") or "claude-sonnet-5"
+
+    verifier: dict[str, Any] = {
+        "description": _VERIFIER_DESCRIPTION,
+        "prompt": resolve_prompt_text(
+            verifier_binding.prompt_id,
+            version=verifier_binding.prompt_version,
+        ),
+        "model": verifier_model,
+    }
+    denied_verifier = [format_mcp_tool_ref("claude", name) for name in verifier_denied_tools]
+    if denied_verifier:
+        verifier["disallowedTools"] = denied_verifier
+
+    reviewer: dict[str, Any] = {
+        "description": _REVIEWER_DESCRIPTION,
+        "prompt": resolve_prompt_text(
+            reviewer_binding.prompt_id,
+            version=reviewer_binding.prompt_version,
+        ),
+        "model": reviewer_model,
+    }
+    denied_reviewer = [format_mcp_tool_ref("claude", name) for name in subagent_denied_tools]
+    if denied_reviewer:
+        reviewer["disallowedTools"] = denied_reviewer
+
+    agents = {
+        REVIEWER_AGENT_NAME: reviewer,
+        VERIFIER_AGENT_NAME: verifier,
+    }
+    return json.dumps(agents)
+
+
+def test_claude_agents_json_renders_from_registry(tmp_path: Path) -> None:
+    """Default registry bindings must reproduce today's ``build_agents_json`` bytes."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    ctx = _tool_ctx(tmp_path)
+    denied_verifier = verifier_denied_tool_names(ctx)
+    denied_reviewer = subagent_denied_tool_names(ctx)
+    legacy = build_agents_json(
+        verifier_denied_tools=denied_verifier,
+        subagent_denied_tools=denied_reviewer,
+    )
+    registry = _load_registry(tmp_path)
+    from_registry = _registry_claude_agents_json(
+        registry,
+        verifier_denied_tools=denied_verifier,
+        subagent_denied_tools=denied_reviewer,
+    )
+    assert from_registry == legacy
+
+
+@_AP2_XFAIL
+def test_opencode_subagents_carry_per_agent_models(tmp_path: Path) -> None:
+    """P4 — OpenCode subagent blocks carry each binding's dispatched model."""
+    from mergecraft.agents.harness_render import render_agents
+
+    from mergecraft.agents.registry import resolve_agent_model
+
+    body = (
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    model: anthropic/claude-sonnet
+  verifier:
+    model: openai/gpt-5.3-codex
+"""
+    )
+    _write_config(tmp_path, body)
+    registry = _load_registry(tmp_path)
+    settings = load_repo_settings(root=tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    reviewer_binding = registry.resolve_role("reviewer")
+    verifier_binding = registry.resolve_role("verifier")
+    reviewer_model = resolve_agent_model(reviewer_binding, settings=settings).dispatched_model
+    verifier_model = resolve_agent_model(verifier_binding, settings=settings).dispatched_model
+    assert reviewer_model != verifier_model
+
+    result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="opencode",
+        ctx=ctx,
+    )
+    config = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
+    agents = config["agent"]
+    assert agents[REVIEWER_AGENT_NAME]["model"] == reviewer_model
+    assert agents[VERIFIER_AGENT_NAME]["model"] == verifier_model
+
+
+@_AP2_XFAIL
+def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) -> None:
+    """D5 — Codex either renders real subagents or records declared degradation."""
+    from mergecraft.agents.harness_render import render_agents
+
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="codex",
+        ctx=ctx,
+    )
+    payload_text = result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
+    has_real_subagents = (
+        REVIEWER_AGENT_NAME in payload_text
+        and VERIFIER_AGENT_NAME in payload_text
+        and "subagent" in payload_text.lower()
+        and result.metadata.get("harness_degradations") is None
+    )
+    degradations = result.metadata.get("harness_degradations")
+    has_declared_degradation = isinstance(degradations, list) and len(degradations) >= 1
+    assert has_real_subagents or has_declared_degradation
+    if has_declared_degradation:
+        kinds = {entry.get("kind") for entry in degradations}
+        assert CODEX_SUBAGENT_DEGRADATION.kind in kinds
+
+
+@_AP2_XFAIL
+def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
+    """Gemini and Cursor harnesses render subagents or declare degradation like Codex."""
+    from mergecraft.agents.harness_render import render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    selected = (REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME)
+
+    for harness in ("gemini", "cursor"):
+        result = render_agents(
+            registry,
+            selected=selected,
+            harness=harness,
+            ctx=ctx,
+        )
+        payload_text = (
+            result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
+        )
+        has_subagent_surface = (
+            REVIEWER_AGENT_NAME in payload_text and VERIFIER_AGENT_NAME in payload_text
+        )
+        degradations = result.metadata.get("harness_degradations")
+        has_declared = isinstance(degradations, list) and any(
+            entry.get("harness") == harness for entry in degradations
+        )
+        assert has_subagent_surface or has_declared
+
+
+@_AP2_XFAIL
+def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
+    """D4 — bindings a harness cannot express raise instead of silently collapsing."""
+    from mergecraft.agents.harness_render import UnrenderableBindingError, render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    with pytest.raises(UnrenderableBindingError, match="orchestrator"):
+        render_agents(
+            registry,
+            selected=("orchestrator",),
+            harness="claude",
+            ctx=ctx,
+        )
+
+
+@_AP2_XFAIL
+def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
+    """D2 — only the selected roster is rendered, not the full registry."""
+    from mergecraft.agents.harness_render import render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    selected = ("reviewer", "verifier", "classifier")
+    result = render_agents(
+        registry,
+        selected=selected,
+        harness="claude",
+        ctx=ctx,
+    )
+    agents = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
+    assert len(agents) == 3
+    rendered_ids = set(agents)
+    assert REVIEWER_AGENT_NAME in rendered_ids
+    assert VERIFIER_AGENT_NAME in rendered_ids
+    classifier_binding = registry.resolve_role("classifier")
+    assert classifier_binding.agent_id in rendered_ids
+    assert registry.resolve_role("orchestrator").agent_id not in rendered_ids
+    assert registry.resolve_role("judge").agent_id not in rendered_ids
+    assert len(registry.all_bindings()) > len(agents)
+
+
+@_AP2_XFAIL
+def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
+    """Declared harness degradation must flow into run-manifest metadata."""
+    from mergecraft.agents.harness_render import render_agents, run_manifest_metadata
+
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.shared import AgentResult
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    render_result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="codex",
+        ctx=ctx,
+    )
+    manifest_meta = run_manifest_metadata(render_result)
+    assert "harness_degradations" in manifest_meta
+    degradations = manifest_meta["harness_degradations"]
+    assert isinstance(degradations, list)
+    assert degradations
+    codex_entries = [entry for entry in degradations if entry.get("harness") == "codex"]
+    assert codex_entries
+    entry = codex_entries[0]
+    assert entry["kind"] == CODEX_SUBAGENT_DEGRADATION.kind
+    assert entry["toolset_parity"] is CODEX_SUBAGENT_DEGRADATION.toolset_parity
+    assert set(entry) >= {"harness", "kind", "toolset_parity", "selected_agents"}
+
+    agent_result = AgentResult(success=True)
+    merged = {**(agent_result.metadata or {}), **manifest_meta}
+    assert merged["harness_degradations"] == degradations
+    assert asdict(CODEX_SUBAGENT_DEGRADATION)["kind"] in {
+        row.get("kind") for row in merged["harness_degradations"]
+    }


### PR DESCRIPTION
## Summary

- Add `mergecraft.agents.harness_render` to project selected registry bindings into each agent harness (Claude `agents.json`, OpenCode subagent blocks, Codex/Gemini/Cursor prose instructions)
- OpenCode subagents now carry per-binding `model` fields from the registry (P4); Codex/Gemini/Cursor record declared prose-only degradation in `harness_degradations` run metadata (D5)
- Unrenderable bindings (e.g. orchestrator on Claude) raise `UnrenderableBindingError` instead of silently collapsing (D4); only routed agents are rendered per run (D2)

## Merge into pre-0.0.1

**Stacks on #231** (`feature/agent-pipeline`). After #231 merges into `pre-0.0.1`, retarget **this** PR to `pre-0.0.1`, then merge.

1. Merge #231 → `pre-0.0.1`
2. Retarget **#232** to `pre-0.0.1`, merge #232
3. Retarget #233 to `pre-0.0.1`, merge #233
4. Retarget #234 to `pre-0.0.1`, merge #234
5. Retarget #235 to `pre-0.0.1`, merge #235
6. Retarget #236 to `pre-0.0.1`, merge #236
7. Retarget #237 to `pre-0.0.1`, merge #237

## Test plan

- [x] `make lint` + `make typecheck`
- [x] `uv run pytest tests/agents/test_harness_render.py` — 7/7 pass
- [x] `make ci-resume` — all 11 steps passed
- [x] Runtime proof captured at `.ignorelocal/waves/evidence/ap2-harness-render.txt` (local gitignored)
