### PR TITLE
feat(agents): typed specialist returns, model diversity and ensemble dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added agent registry binding model, prompt, toolset and budget per role with `mergecraft agents list|show|set` and `make agents-check`
 - Added registry-driven harness render for Claude, OpenCode, Codex, Gemini, and Cursor with per-agent models and declared Codex degradation in run metadata
+- Added typed specialist handoff, model-diversity policy for verification, and ensemble or shadow dispatch modes on agent bindings
 
 ### Fixed
 

--- a/docs/test-plans/agent-pipeline-ap3.md
+++ b/docs/test-plans/agent-pipeline-ap3.md
@@ -15,13 +15,13 @@ predict/record/disagree machinery.
 
 ## xfail schedule
 
-| Test file | Tests | Marker | Status at AP3.1 |
-|-----------|-------|--------|-------------------|
-| `tests/agents/test_structured_handoff.py` | 3 | `green after AP3.2: structured handoff` | **RED (xfail)** |
-| `tests/agents/test_model_diversity.py` | 2 | `green after AP3.2: model diversity` | **RED (xfail)** |
-| `tests/agents/test_ensemble.py` | 6 | `green after AP3.2: ensemble dispatch` | **RED (xfail)** |
+| Test file | Tests | Marker | Status |
+|-----------|-------|--------|--------|
+| `tests/agents/test_structured_handoff.py` | 3 | — | **GREEN** |
+| `tests/agents/test_model_diversity.py` | 2 | — | **GREEN** |
+| `tests/agents/test_ensemble.py` | 6 | — | **GREEN** |
 
-**Acceptance (AP3.1):** 11 collected; 0 pass; 11 xfail. `make lint` + `make typecheck` clean.
+**Acceptance (post-AP3.2):** 11 collected; 11 passed; 0 xfail. `make lint` + `make typecheck` clean.
 
 ## Target API AP3.2 must satisfy
 
@@ -93,4 +93,4 @@ collection succeeds before AP3.2.
 
 ## Status
 
-AP3.1 RED suite authored; awaiting AP3.2 implementation and xfail reconciliation.
+AP3.1 suite authored; AP3.2 implementation landed; xfail markers removed (11 passed).

--- a/docs/test-plans/agent-pipeline-ap3.md
+++ b/docs/test-plans/agent-pipeline-ap3.md
@@ -1,0 +1,96 @@
+# PR AP3 — structured handoff, model diversity, ensemble dispatch — test plan (AP3.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP3)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap3`
+Authoring wave: **AP3.1** (tests-first). Implementation: **AP3.2**.
+xfail-reconciliation: **post-AP3.2**.
+
+Locked decisions: **D6** (structure the hand-off, not the reasoning — free-form
+discovery, typed ``AgentFinding`` emission at the boundary), **D7** (ensembles
+never include the orchestrator; ``ensemble`` / ``shadow`` for discovery and
+verification only), dispatch modes ``single`` (default), ``ensemble``, ``shadow``
+on ``AgentBinding``, model diversity (verification must not share the authoring
+model family — generalizes #45), shadow reuses ``evidence/shadow.py``
+predict/record/disagree machinery.
+
+## xfail schedule
+
+| Test file | Tests | Marker | Status at AP3.1 |
+|-----------|-------|--------|-------------------|
+| `tests/agents/test_structured_handoff.py` | 3 | `green after AP3.2: structured handoff` | **RED (xfail)** |
+| `tests/agents/test_model_diversity.py` | 2 | `green after AP3.2: model diversity` | **RED (xfail)** |
+| `tests/agents/test_ensemble.py` | 6 | `green after AP3.2: ensemble dispatch` | **RED (xfail)** |
+
+**Acceptance (AP3.1):** 11 collected; 0 pass; 11 xfail. `make lint` + `make typecheck` clean.
+
+## Target API AP3.2 must satisfy
+
+### `src/mergecraft/agents/structured_handoff.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `SpecialistHandoff` | Dataclass/model: ``reasoning`` (prose) + ``findings: list[AgentFinding]`` |
+| `parse_specialist_handoff(raw)` | Split prose from ``---typed-findings---`` tail; validate ``AgentFinding`` rows |
+| `build_specialist_dispatch_prompt(binding)` | Discovery brief — **no** finding schema, ``set_output``, or JSON schema (D6) |
+| `verification_plan_from_handoff(handoff, *, budget)` | Bridge to ``plan_agent_verifications`` |
+
+Default reviewer binding sets ``output_schema == "mergecraft.agent_finding"``.
+
+### `src/mergecraft/agents/model_diversity.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `ModelDiversityViolation` | Raised when verification shares the authoring provider family |
+| `assert_verification_diverse(authoring_slug, verification_slug)` | Guard — same family is rejected (#45 generalized) |
+| `resolve_diverse_verification_model(authoring_slug, *, registry, settings)` | Pick a verifier slug in a different family |
+| `enforce_policy_for_harness(registry, *, settings, harness)` | Harness-agnostic policy check (`claude`, `opencode`, `codex`, …) |
+
+### `src/mergecraft/agents/ensemble.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `EnsembleRun` / `ModelRun` | Per-model findings from one binding |
+| `plan_ensemble_models(binding, *, settings)` | Two distinct slugs from the binding chain |
+| `run_ensemble_dispatch(binding, *, registry, settings, execute)` | Fan-out dispatch respecting binding budget (CC3) |
+| `reconcile_ensemble(run)` | Agreement → ``confidence_boost``; disagreement → ``judge_dispatch`` |
+| `run_shadow_dispatch(binding, *, registry, settings, execute, record_path)` | Primary acted; shadow recorded via ``record_shadow_prediction`` |
+| `validate_ensemble_eligible(binding)` | **D7** — raises ``EnsembleCardinalityError`` for orchestrator |
+| `EnsembleCardinalityError` | Cardinality guard when orchestrator is ensembled |
+
+## Contract → coverage matrix
+
+### `tests/agents/test_structured_handoff.py` — 3 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_specialist_returns_typed_findings` | unit + integration | D6 happy | Prose preserved; typed tail → ``AgentFinding`` via ``output_schema`` |
+| 2 | `test_free_form_discovery_is_not_constrained` | unit | D6 guard-deletion | Discovery prompt lacks schema / ``set_output`` / ``"findings"`` |
+| 3 | `test_typed_findings_feed_the_verifier_directly` | integration | happy | ``verification_plan_from_handoff`` queues verifier dispatches with rubric brief |
+
+### `tests/agents/test_model_diversity.py` — 2 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 4 | `test_verification_never_runs_on_the_authoring_family` | integration | #45 generalized | Same-family override rejected; diverse resolver succeeds |
+| 5 | `test_policy_holds_across_harnesses` | integration | happy | ``enforce_policy_for_harness`` for `claude`, `opencode`, `codex` |
+
+### `tests/agents/test_ensemble.py` — 6 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 6 | `test_ensemble_runs_the_same_agent_on_two_models` | integration | happy | ``dispatch: ensemble`` runs two chain slugs |
+| 7 | `test_agreement_raises_confidence` | unit | happy | ``reconcile_ensemble`` → ``agreement=True``, ``confidence_boost > 0`` |
+| 8 | `test_disagreement_is_routed_to_the_judge` | unit | edge | Disagreement → ``judge_dispatch`` with both briefs |
+| 9 | `test_shadow_model_output_is_recorded_but_never_acted_on` | integration | shadow | Shadow row on disk; ``acted_findings`` == primary only |
+| 10 | `test_orchestrator_cannot_be_ensembled` | unit | D7 guard-deletion | Orchestrator → ``EnsembleCardinalityError`` |
+| 11 | `test_ensemble_respects_the_agent_budget` | integration | CC3 | Total findings ≤ binding ``budget`` |
+
+## Imports of not-yet-existing symbols
+
+``mergecraft.agents.structured_handoff``, ``mergecraft.agents.model_diversity``, and
+``mergecraft.agents.ensemble`` symbols are imported inside test bodies so
+collection succeeds before AP3.2.
+
+## Status
+
+AP3.1 RED suite authored; awaiting AP3.2 implementation and xfail reconciliation.

--- a/src/mergecraft/agents/ensemble.py
+++ b/src/mergecraft/agents/ensemble.py
@@ -1,0 +1,288 @@
+"""Ensemble and shadow dispatch for registry agents (AP3, D7).
+
+``dispatch: ensemble`` runs one binding on two models from its chain; agreement
+raises confidence, disagreement routes to the judge. ``dispatch: shadow`` records
+alternate-model output via ``evidence.shadow`` without acting on it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from mergecraft.agents.registry import AgentRole, resolve_agent_model
+from mergecraft.evidence.shadow import ShadowRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.agents.registry import AgentBinding, Registry
+    from mergecraft.config.settings import RepoSettings
+
+ExecuteFn = Callable[..., list[dict[str, object]]]
+
+
+class EnsembleCardinalityError(ValueError):
+    """Raised when ensemble/shadow dispatch targets the orchestrator (D7)."""
+
+
+class ModelRun(BaseModel):
+    """Findings returned by one model in an ensemble fan-out."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    findings: tuple[dict[str, object], ...] = ()
+
+
+class EnsembleRun(BaseModel):
+    """Per-model results from one ensemble dispatch."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_id: str
+    model_runs: tuple[ModelRun, ...] = ()
+
+
+class JudgeDispatch(BaseModel):
+    """Brief routed to the judge when ensemble models disagree."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["judge"] = "judge"
+    brief: str
+
+
+class EnsembleReconciliation(BaseModel):
+    """Merged ensemble outcome — agreement signal or judge escalation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agreement: bool
+    confidence_boost: float = 0.0
+    merged_findings: tuple[dict[str, object], ...] = ()
+    judge_dispatch: JudgeDispatch | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDispatchResult:
+    """Primary findings acted on; shadow findings recorded only."""
+
+    primary_findings: list[dict[str, object]]
+    acted_findings: list[dict[str, object]]
+    shadow_model: str
+    shadow_findings: list[dict[str, object]]
+
+
+_ENSEMBLE_ELIGIBLE_ROLES: frozenset[AgentRole] = frozenset(
+    {
+        AgentRole.reviewer,
+        AgentRole.verifier,
+        AgentRole.judge,
+        AgentRole.classifier,
+    }
+)
+
+
+def validate_ensemble_eligible(binding: AgentBinding) -> None:
+    """Reject ensemble/shadow on orchestrator bindings (D7)."""
+    if binding.role is AgentRole.orchestrator:
+        msg = (
+            f"orchestrator agent {binding.agent_id!r} cannot use ensemble or shadow "
+            "dispatch — two orchestrators violate the terminal cardinality rule (D7)"
+        )
+        raise EnsembleCardinalityError(msg)
+    if binding.role not in _ENSEMBLE_ELIGIBLE_ROLES:
+        msg = f"agent {binding.agent_id!r} is not eligible for ensemble dispatch"
+        raise ValueError(msg)
+
+
+def plan_ensemble_models(
+    binding: AgentBinding,
+    *,
+    settings: RepoSettings,
+) -> tuple[str, str]:
+    """Return two distinct runnable slugs from the binding chain."""
+    from mergecraft.utils.agent_resolve import pick_runnable_slug_from_chain
+
+    validate_ensemble_eligible(binding)
+    chain = list(binding.model_chain)
+    if len(chain) < 2:
+        msg = f"ensemble dispatch requires at least two models on {binding.agent_id!r}"
+        raise ValueError(msg)
+
+    primary = resolve_agent_model(binding, settings=settings).dispatched_model
+    secondary: str | None = None
+    for slug in chain:
+        if slug == binding.model_chain[0]:
+            continue
+        runnable = pick_runnable_slug_from_chain(
+            [slug],
+            allow_fallback=settings.allow_fallback,
+        )
+        if runnable is not None and runnable != primary:
+            secondary = runnable
+            break
+
+    if secondary is None:
+        msg = f"ensemble dispatch could not resolve a second model for {binding.agent_id!r}"
+        raise ValueError(msg)
+
+    return primary, secondary
+
+
+def _cap_findings(
+    rows: list[dict[str, object]],
+    *,
+    budget: int,
+    remaining: int,
+) -> tuple[list[dict[str, object]], int]:
+    if remaining <= 0:
+        return [], 0
+    capped = rows[:remaining]
+    return capped, remaining - len(capped)
+
+
+def run_ensemble_dispatch(
+    binding: AgentBinding,
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    execute: ExecuteFn,
+) -> EnsembleRun:
+    """Fan out one binding to two models, honouring the binding budget (CC3)."""
+    del registry
+    validate_ensemble_eligible(binding)
+    primary, secondary = plan_ensemble_models(binding, settings=settings)
+    remaining = max(binding.budget, 0)
+    model_runs: list[ModelRun] = []
+
+    for model in (primary, secondary):
+        raw = list(execute(model=model))
+        capped, remaining = _cap_findings(raw, budget=binding.budget, remaining=remaining)
+        model_runs.append(ModelRun(model=model, findings=tuple(capped)))
+
+    return EnsembleRun(agent_id=binding.agent_id, model_runs=tuple(model_runs))
+
+
+def _finding_key(row: dict[str, object]) -> tuple[str, str]:
+    path = str(row.get("path", ""))
+    body = str(row.get("body", ""))
+    return path, body
+
+
+def reconcile_ensemble(run: EnsembleRun) -> EnsembleReconciliation:
+    """Merge ensemble runs — agreement boosts confidence; disagreement → judge."""
+    if len(run.model_runs) < 2:
+        merged = tuple(run.model_runs[0].findings) if run.model_runs else ()
+        return EnsembleReconciliation(agreement=True, merged_findings=merged)
+
+    left, right = run.model_runs[0], run.model_runs[1]
+    left_keys = {_finding_key(row) for row in left.findings}
+    right_keys = {_finding_key(row) for row in right.findings}
+    agreement = left_keys == right_keys and bool(left_keys)
+
+    if agreement:
+        merged = left.findings
+        return EnsembleReconciliation(
+            agreement=True,
+            confidence_boost=0.25,
+            merged_findings=merged,
+        )
+
+    brief_parts = [
+        "Two ensemble models disagreed on findings for the same agent dispatch.",
+        "",
+        f"### Model {left.model}",
+        "",
+    ]
+    for row in left.findings:
+        brief_parts.append(f"- `{row.get('path')}`: {row.get('body')}")
+    brief_parts.extend(["", f"### Model {right.model}", ""])
+    for row in right.findings:
+        brief_parts.append(f"- `{row.get('path')}`: {row.get('body')}")
+    brief_parts.append("")
+    brief_parts.append("Return confirm / downgrade / drop for each disputed finding.")
+
+    return EnsembleReconciliation(
+        agreement=False,
+        merged_findings=tuple(left.findings),
+        judge_dispatch=JudgeDispatch(brief="\n".join(brief_parts)),
+    )
+
+
+def _record_ensemble_shadow(
+    *,
+    record_path: Path,
+    run_id: str,
+    change_id: str,
+    policy_id: str,
+    shadow_model: str,
+    shadow_findings: list[dict[str, object]],
+) -> ShadowRecord:
+    record = ShadowRecord(
+        run_id=run_id,
+        change_id=change_id,
+        policy_id=policy_id,
+        rule_id="ensemble_shadow",
+        action="shadow",
+        lane="ensemble",
+        repo_area=policy_id,
+        metadata={"shadow_model": shadow_model, "shadow_model_findings": shadow_findings},
+    )
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    with record_path.open("a", encoding="utf-8") as handle:
+        handle.write(record.model_dump_json())
+        handle.write("\n")
+    return record
+
+
+def run_shadow_dispatch(
+    binding: AgentBinding,
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    execute: ExecuteFn,
+    record_path: Path,
+    run_id: str = "ensemble-shadow",
+    change_id: str = "shadow-dispatch",
+    policy_id: str = "ensemble.shadow",
+) -> ShadowDispatchResult:
+    """Run primary model for action; record shadow model output only."""
+    del registry
+    validate_ensemble_eligible(binding)
+    primary, secondary = plan_ensemble_models(binding, settings=settings)
+    primary_findings = list(execute(model=primary, primary=True))
+    shadow_findings = list(execute(model=secondary, primary=False))
+    _record_ensemble_shadow(
+        record_path=record_path,
+        run_id=run_id,
+        change_id=change_id,
+        policy_id=policy_id,
+        shadow_model=secondary,
+        shadow_findings=shadow_findings,
+    )
+    return ShadowDispatchResult(
+        primary_findings=primary_findings,
+        acted_findings=list(primary_findings),
+        shadow_model=secondary,
+        shadow_findings=shadow_findings,
+    )
+
+
+__all__ = [
+    "EnsembleCardinalityError",
+    "EnsembleReconciliation",
+    "EnsembleRun",
+    "JudgeDispatch",
+    "ModelRun",
+    "ShadowDispatchResult",
+    "plan_ensemble_models",
+    "reconcile_ensemble",
+    "run_ensemble_dispatch",
+    "run_shadow_dispatch",
+    "validate_ensemble_eligible",
+]

--- a/src/mergecraft/agents/model_diversity.py
+++ b/src/mergecraft/agents/model_diversity.py
@@ -1,0 +1,122 @@
+"""Model diversity policy — verification must not share the authoring family (AP3, #45).
+
+Generalizes ``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
+declared rule: the verifier's executed model must come from a different provider
+family than the authoring (reviewer / specialist) model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mergecraft.agents.registry import AgentRole, ResolvedAgentModel, resolve_agent_model
+from mergecraft.agents.verifier import pinned_judge_model
+from mergecraft.models import MODEL_ALIASES, get_model_provider, resolve_display_alias
+from mergecraft.utils.agent_resolve import effective_model_chain, pick_runnable_slug_from_chain
+
+if TYPE_CHECKING:
+    from mergecraft.agents.registry import Registry
+    from mergecraft.config.settings import RepoSettings
+
+
+class ModelDiversityViolation(ValueError):
+    """Raised when verification would run on the authoring provider family."""
+
+
+def model_family(slug: str) -> str:
+    """Coarse provider family for diversity checks (e.g. ``anthropic``, ``openai``)."""
+    pinned_claude = pinned_judge_model("claude")
+    if pinned_claude is not None and slug == pinned_claude:
+        return "anthropic"
+    alias = resolve_display_alias(slug)
+    if alias is not None:
+        return alias.provider
+    for entry in MODEL_ALIASES:
+        if entry.slug == slug or entry.resolve == slug:
+            return entry.provider
+    if "/" in slug:
+        return get_model_provider(slug)
+    msg = f"cannot resolve model family for slug {slug!r}"
+    raise ValueError(msg)
+
+
+def assert_verification_diverse(
+    *,
+    authoring_slug: str,
+    verification_slug: str,
+) -> None:
+    """Reject verification on the same provider family as the authoring model."""
+    if model_family(authoring_slug) == model_family(verification_slug):
+        msg = (
+            f"verification model {verification_slug!r} shares the authoring family "
+            f"{model_family(authoring_slug)!r} with {authoring_slug!r}"
+        )
+        raise ModelDiversityViolation(msg)
+
+
+def resolve_diverse_verification_model(
+    *,
+    authoring_slug: str,
+    registry: Registry,
+    settings: RepoSettings,
+) -> ResolvedAgentModel:
+    """Pick a runnable verifier slug from a different provider family."""
+    verifier = registry.resolve_role(AgentRole.verifier)
+    candidates = list(verifier.model_chain) + effective_model_chain(settings)
+    seen: set[str] = set()
+    authoring_family = model_family(authoring_slug)
+
+    for slug in candidates:
+        if slug in seen:
+            continue
+        seen.add(slug)
+        if model_family(slug) == authoring_family:
+            continue
+        runnable = pick_runnable_slug_from_chain(
+            [slug],
+            allow_fallback=settings.allow_fallback,
+        )
+        if runnable is None:
+            continue
+        assert_verification_diverse(
+            authoring_slug=authoring_slug,
+            verification_slug=runnable,
+        )
+        return ResolvedAgentModel(
+            requested_model=slug,
+            executed_model=runnable,
+            recorded_model=runnable,
+            dispatched_model=runnable,
+        )
+
+    msg = (
+        f"no verification model in a different family from authoring "
+        f"{authoring_slug!r} ({authoring_family!r})"
+    )
+    raise ModelDiversityViolation(msg)
+
+
+def enforce_policy_for_harness(
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    harness: str,
+) -> None:
+    """Ensure model-diversity policy can be satisfied for this harness roster."""
+    del harness
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    authoring = resolve_agent_model(reviewer, settings=settings).dispatched_model
+    resolve_diverse_verification_model(
+        authoring_slug=authoring,
+        registry=registry,
+        settings=settings,
+    )
+
+
+__all__ = [
+    "ModelDiversityViolation",
+    "assert_verification_diverse",
+    "enforce_policy_for_harness",
+    "model_family",
+    "resolve_diverse_verification_model",
+]

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Final
 from pydantic import BaseModel, ConfigDict
 
 from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.structured_handoff import agent_finding_output_schema_id
 from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT, pinned_judge_model
 from mergecraft.config.settings import AgentBindingOverride, DispatchMode  # noqa: TC001
 from mergecraft.mcp.server import build_orchestrator_tools
@@ -179,6 +180,12 @@ def _default_prompt_id(role: AgentRole) -> str:
     return f"mergecraft.{role.value}"
 
 
+def _default_output_schema(role: AgentRole) -> str | None:
+    if role is AgentRole.reviewer:
+        return agent_finding_output_schema_id()
+    return None
+
+
 def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBinding:
     return AgentBinding(
         agent_id=_default_agent_id(role),
@@ -190,6 +197,7 @@ def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBind
         tool_classes=_default_tool_classes(role),
         budget=_DEFAULT_BUDGET,
         timeout_s=_DEFAULT_TIMEOUT_S,
+        output_schema=_default_output_schema(role),
     )
 
 

--- a/src/mergecraft/agents/structured_handoff.py
+++ b/src/mergecraft/agents/structured_handoff.py
@@ -1,0 +1,108 @@
+"""Typed specialist handoff — prose discovery, typed ``AgentFinding`` emission (AP3, D6).
+
+Specialists reason in free-form prose during discovery; the orchestrator dispatch
+prompt deliberately carries no finding schema. At the boundary the specialist
+emits typed findings (``---typed-findings---`` tail or structured output schema).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Final
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from mergecraft.agents.verifier import AgentFinding, plan_agent_verifications
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.agents.registry import AgentBinding
+
+_TYPED_FINDINGS_MARKER: Final[str] = "---typed-findings---"
+_AGENT_FINDING_SCHEMA_ID: Final[str] = "mergecraft.agent_finding"
+
+
+class SpecialistHandoff(BaseModel):
+    """Prose reasoning plus typed findings at the specialist boundary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reasoning: str
+    findings: tuple[AgentFinding, ...]
+
+
+def agent_finding_output_schema_id() -> str:
+    """Registry ``output_schema`` id for specialist typed emission."""
+    return _AGENT_FINDING_SCHEMA_ID
+
+
+def parse_specialist_handoff(raw: str) -> SpecialistHandoff:
+    """Split prose reasoning from a typed findings tail (D6)."""
+    text = raw.strip()
+    marker = _TYPED_FINDINGS_MARKER
+    if marker.casefold() in text.casefold():
+        head, _, tail = text.partition(marker)
+        reasoning = head.strip()
+        payload = tail.strip()
+    else:
+        reasoning = text
+        payload = "[]"
+
+    try:
+        rows = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        msg = f"specialist handoff: typed-findings tail is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+
+    if not isinstance(rows, list):
+        msg = "specialist handoff: typed-findings tail must be a JSON array"
+        raise ValueError(msg)
+
+    findings: list[AgentFinding] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            msg = "specialist handoff: each finding must be a JSON object"
+            raise ValueError(msg)
+        try:
+            findings.append(AgentFinding.model_validate(row))
+        except ValidationError as exc:
+            msg = f"specialist handoff: invalid finding row: {exc}"
+            raise ValueError(msg) from exc
+
+    return SpecialistHandoff(reasoning=reasoning, findings=tuple(findings))
+
+
+def build_specialist_dispatch_prompt(binding: AgentBinding) -> str:
+    """Discovery dispatch brief — no finding schema pre-shapes output (D6)."""
+    del binding
+    return (
+        "Review the dispatched scope using read-only tools. Reason in free-form "
+        "prose while you investigate — do not pre-format findings as JSON during "
+        "discovery and do not call structured-output tools until handoff."
+    )
+
+
+def verification_plan_from_handoff(
+    handoff: SpecialistHandoff,
+    *,
+    budget: int,
+    learnings_text: str = "",
+    repo_root: Path | None = None,
+) -> object:
+    """Queue verifier dispatches from typed handoff findings."""
+    return plan_agent_verifications(
+        list(handoff.findings),
+        budget=budget,
+        learnings_text=learnings_text,
+        repo_root=repo_root,
+    )
+
+
+__all__ = [
+    "SpecialistHandoff",
+    "agent_finding_output_schema_id",
+    "build_specialist_dispatch_prompt",
+    "parse_specialist_handoff",
+    "verification_plan_from_handoff",
+]

--- a/src/mergecraft/evidence/shadow.py
+++ b/src/mergecraft/evidence/shadow.py
@@ -112,6 +112,7 @@ class ShadowRecord(BaseModel):
     predicted_outcome: str | None = None
     diagnostic: str | None = None
     verdict_diagnostic: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/agents/test_ensemble.py
+++ b/tests/agents/test_ensemble.py
@@ -1,0 +1,268 @@
+"""AP3 ensemble dispatch suite — parallel models, shadow, and cardinality guards.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.ensemble`` — ``dispatch`` modes ``single`` (default),
+``ensemble``, and ``shadow`` (reusing ``evidence/shadow.py`` record machinery).
+Locked decision **D7**: orchestrator cannot be ensembled.
+
+AP3.1: six tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_ENSEMBLE_OVERRIDE = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+agents:
+  reviewer:
+    dispatch: ensemble
+    modelChain:
+      - anthropic/claude-sonnet
+      - openai/gpt-5.3-codex
+    budget: 2
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+
+@_AP3_XFAIL
+def test_ensemble_runs_the_same_agent_on_two_models(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``dispatch: ensemble`` runs one binding on two models from its chain."""
+    from mergecraft.agents.ensemble import plan_ensemble_models, run_ensemble_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _ENSEMBLE_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.dispatch == "ensemble"
+
+    primary, secondary = plan_ensemble_models(reviewer, settings=settings)
+    assert primary != secondary
+
+    calls: list[str] = []
+
+    def _execute(*, model: str, **_kwargs: object) -> list[dict[str, object]]:
+        calls.append(model)
+        return [{"path": "pkg/a.go", "body": f"finding from {model}", "severity": "Major"}]
+
+    run = run_ensemble_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+    )
+    assert set(calls) == {primary, secondary}
+    assert len(run.model_runs) == 2
+    assert run.model_runs[0].model in {primary, secondary}
+    assert run.model_runs[1].model in {primary, secondary}
+
+
+@_AP3_XFAIL
+def test_agreement_raises_confidence(tmp_path: Path) -> None:
+    """When both ensemble models agree, the merged signal gains confidence."""
+    from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
+
+    shared_finding = {
+        "path": "pkg/auth.go",
+        "body": "nil deref when session expires",
+        "severity": "Critical",
+        "line": 88,
+    }
+    run = EnsembleRun(
+        agent_id="mergecraft-reviewer",
+        model_runs=(
+            ModelRun(model="anthropic/claude-sonnet", findings=(shared_finding,)),
+            ModelRun(model="openai/gpt-5.3-codex", findings=(shared_finding,)),
+        ),
+    )
+    reconciliation = reconcile_ensemble(run)
+    assert reconciliation.agreement is True
+    assert reconciliation.confidence_boost > 0
+    assert len(reconciliation.merged_findings) == 1
+
+
+@_AP3_XFAIL
+def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
+    """Disagreeing ensemble outputs escalate to the judge role."""
+    from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
+
+    run = EnsembleRun(
+        agent_id="mergecraft-reviewer",
+        model_runs=(
+            ModelRun(
+                model="anthropic/claude-sonnet",
+                findings=(
+                    {
+                        "path": "pkg/auth.go",
+                        "body": "race on session refresh",
+                        "severity": "Major",
+                    },
+                ),
+            ),
+            ModelRun(
+                model="openai/gpt-5.3-codex",
+                findings=(
+                    {
+                        "path": "pkg/auth.go",
+                        "body": "benign logging noise",
+                        "severity": "Minor",
+                    },
+                ),
+            ),
+        ),
+    )
+    reconciliation = reconcile_ensemble(run)
+    assert reconciliation.agreement is False
+    assert reconciliation.judge_dispatch is not None
+    assert reconciliation.judge_dispatch.role == "judge"
+    assert "race on session refresh" in reconciliation.judge_dispatch.brief
+    assert "benign logging noise" in reconciliation.judge_dispatch.brief
+
+
+@_AP3_XFAIL
+def test_shadow_model_output_is_recorded_but_never_acted_on(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``dispatch: shadow`` records alternate output without changing the primary result."""
+    from mergecraft.agents.ensemble import run_shadow_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+    from mergecraft.evidence.shadow import load_shadow_records
+
+    _stub_slug_runnability(monkeypatch)
+    body = (
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    dispatch: shadow
+    modelChain:
+      - anthropic/claude-sonnet
+      - openai/gpt-5.3-codex
+"""
+    )
+    _write_config(tmp_path, body)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    shadow_path = tmp_path / "merge-evidence-shadow.jsonl"
+
+    primary_findings = [{"path": "pkg/a.go", "body": "primary only", "severity": "Major"}]
+    shadow_findings = [{"path": "pkg/b.go", "body": "shadow only", "severity": "Critical"}]
+
+    def _execute(*, model: str, primary: bool, **_kwargs: object) -> list[dict[str, object]]:
+        return primary_findings if primary else shadow_findings
+
+    result = run_shadow_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+        record_path=shadow_path,
+    )
+    assert result.primary_findings == primary_findings
+    assert result.acted_findings == primary_findings
+    records = load_shadow_records(shadow_path)
+    assert len(records) == 1
+    assert records[0].metadata["shadow_model_findings"] == shadow_findings
+
+
+@_AP3_XFAIL
+def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
+    """D7 — ensemble/shadow apply to discovery and verification agents only."""
+    from mergecraft.agents.ensemble import EnsembleCardinalityError, validate_ensemble_eligible
+
+    from mergecraft.agents.registry import AgentRole
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    orchestrator = registry.resolve_role(AgentRole.orchestrator)
+    with pytest.raises(EnsembleCardinalityError, match="orchestrator"):
+        validate_ensemble_eligible(orchestrator)
+
+
+@_AP3_XFAIL
+def test_ensemble_respects_the_agent_budget(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Ensemble fan-out honours the binding budget (file 2 CC3 integration)."""
+    from mergecraft.agents.ensemble import run_ensemble_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _ENSEMBLE_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.budget == 2
+
+    def _execute(*, model: str, **_kwargs: object) -> list[dict[str, object]]:
+        return [
+            {
+                "path": f"pkg/{model.replace('/', '-')}.go",
+                "body": f"finding from {model}",
+                "severity": "Major",
+            }
+            for _ in range(5)
+        ]
+
+    run = run_ensemble_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+    )
+    total_findings = sum(len(model_run.findings) for model_run in run.model_runs)
+    assert total_findings <= reviewer.budget

--- a/tests/agents/test_ensemble.py
+++ b/tests/agents/test_ensemble.py
@@ -5,7 +5,7 @@ Covers ``mergecraft.agents.ensemble`` — ``dispatch`` modes ``single`` (default
 ``ensemble``, and ``shadow`` (reusing ``evidence/shadow.py`` record machinery).
 Locked decision **D7**: orchestrator cannot be ensembled.
 
-AP3.1: six tests; all ``xfail`` until AP3.2.
+AP3.1: six tests; green after AP3.2.
 """
 
 from __future__ import annotations
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -68,14 +66,12 @@ def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-@_AP3_XFAIL
 def test_ensemble_runs_the_same_agent_on_two_models(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """``dispatch: ensemble`` runs one binding on two models from its chain."""
     from mergecraft.agents.ensemble import plan_ensemble_models, run_ensemble_dispatch
-
     from mergecraft.agents.registry import AgentRole
 
     _stub_slug_runnability(monkeypatch)
@@ -106,7 +102,6 @@ def test_ensemble_runs_the_same_agent_on_two_models(
     assert run.model_runs[1].model in {primary, secondary}
 
 
-@_AP3_XFAIL
 def test_agreement_raises_confidence(tmp_path: Path) -> None:
     """When both ensemble models agree, the merged signal gains confidence."""
     from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
@@ -130,7 +125,6 @@ def test_agreement_raises_confidence(tmp_path: Path) -> None:
     assert len(reconciliation.merged_findings) == 1
 
 
-@_AP3_XFAIL
 def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
     """Disagreeing ensemble outputs escalate to the judge role."""
     from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
@@ -168,14 +162,12 @@ def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
     assert "benign logging noise" in reconciliation.judge_dispatch.brief
 
 
-@_AP3_XFAIL
 def test_shadow_model_output_is_recorded_but_never_acted_on(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """``dispatch: shadow`` records alternate output without changing the primary result."""
     from mergecraft.agents.ensemble import run_shadow_dispatch
-
     from mergecraft.agents.registry import AgentRole
     from mergecraft.evidence.shadow import load_shadow_records
 
@@ -217,11 +209,9 @@ agents:
     assert records[0].metadata["shadow_model_findings"] == shadow_findings
 
 
-@_AP3_XFAIL
 def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
     """D7 — ensemble/shadow apply to discovery and verification agents only."""
     from mergecraft.agents.ensemble import EnsembleCardinalityError, validate_ensemble_eligible
-
     from mergecraft.agents.registry import AgentRole
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -231,14 +221,12 @@ def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
         validate_ensemble_eligible(orchestrator)
 
 
-@_AP3_XFAIL
 def test_ensemble_respects_the_agent_budget(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Ensemble fan-out honours the binding budget (file 2 CC3 integration)."""
     from mergecraft.agents.ensemble import run_ensemble_dispatch
-
     from mergecraft.agents.registry import AgentRole
 
     _stub_slug_runnability(monkeypatch)

--- a/tests/agents/test_model_diversity.py
+++ b/tests/agents/test_model_diversity.py
@@ -5,7 +5,7 @@ Covers ``mergecraft.agents.model_diversity`` — generalizes #45 /
 ``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
 declared policy that holds for every harness.
 
-AP3.1: two tests; all ``xfail`` until AP3.2.
+AP3.1: two tests; green after AP3.2.
 """
 
 from __future__ import annotations
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -66,7 +64,6 @@ def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-@_AP3_XFAIL
 def test_verification_never_runs_on_the_authoring_family(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -77,7 +74,6 @@ def test_verification_never_runs_on_the_authoring_family(
         assert_verification_diverse,
         resolve_diverse_verification_model,
     )
-
     from mergecraft.agents.registry import AgentRole, resolve_agent_model
 
     _stub_slug_runnability(monkeypatch)
@@ -107,7 +103,6 @@ def test_verification_never_runs_on_the_authoring_family(
     )
 
 
-@_AP3_XFAIL
 def test_policy_holds_across_harnesses(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_model_diversity.py
+++ b/tests/agents/test_model_diversity.py
@@ -1,0 +1,124 @@
+"""AP3 model diversity suite — verification never shares the authoring family.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.model_diversity`` — generalizes #45 /
+``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
+declared policy that holds for every harness.
+
+AP3.1: two tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_SAME_FAMILY_OVERRIDE = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+agents:
+  reviewer:
+    model: anthropic/claude-sonnet
+  verifier:
+    model: anthropic/claude-haiku
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+
+@_AP3_XFAIL
+def test_verification_never_runs_on_the_authoring_family(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """#45 generalized — verifier must not share the reviewer's provider family."""
+    from mergecraft.agents.model_diversity import (
+        ModelDiversityViolation,
+        assert_verification_diverse,
+        resolve_diverse_verification_model,
+    )
+
+    from mergecraft.agents.registry import AgentRole, resolve_agent_model
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _SAME_FAMILY_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    verifier = registry.resolve_role(AgentRole.verifier)
+    reviewer_model = resolve_agent_model(reviewer, settings=settings).dispatched_model
+    verifier_model = resolve_agent_model(verifier, settings=settings).dispatched_model
+
+    with pytest.raises(ModelDiversityViolation, match="authoring family"):
+        assert_verification_diverse(
+            authoring_slug=reviewer_model,
+            verification_slug=verifier_model,
+        )
+
+    diverse = resolve_diverse_verification_model(
+        authoring_slug=reviewer_model,
+        registry=registry,
+        settings=settings,
+    )
+    assert diverse.dispatched_model != reviewer_model
+    assert_verification_diverse(
+        authoring_slug=reviewer_model,
+        verification_slug=diverse.dispatched_model,
+    )
+
+
+@_AP3_XFAIL
+def test_policy_holds_across_harnesses(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Model-diversity policy applies for Claude, OpenCode and Codex harness contexts."""
+    from mergecraft.agents.model_diversity import enforce_policy_for_harness
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+
+    for harness in ("claude", "opencode", "codex"):
+        enforce_policy_for_harness(registry=registry, settings=settings, harness=harness)

--- a/tests/agents/test_structured_handoff.py
+++ b/tests/agents/test_structured_handoff.py
@@ -6,21 +6,17 @@ free-form prose and emit typed ``AgentFinding`` values at the boundary;
 discovery dispatch prompts carry no finding schema; typed findings feed
 ``plan_agent_verifications`` without orchestrator prose re-judgement.
 
-AP3.1: three tests; all ``xfail`` until AP3.2.
+AP3.1: three tests; green after AP3.2.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mergecraft.config.settings import load_repo_settings
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -58,12 +54,10 @@ def _load_registry(tmp_path: Path) -> object:
     return load_registry(settings=settings, repo_root=tmp_path)
 
 
-@_AP3_XFAIL
 def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
     """D6 — prose reasoning is preserved; findings at the boundary are typed."""
-    from mergecraft.agents.structured_handoff import parse_specialist_handoff
-
     from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.structured_handoff import parse_specialist_handoff
     from mergecraft.agents.verifier import AgentFinding
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -82,12 +76,10 @@ def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
     assert "double-spend" in finding.body
 
 
-@_AP3_XFAIL
 def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
     """Discovery dispatch must not pre-shape output with a finding schema (D6)."""
-    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
-
     from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -101,14 +93,12 @@ def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
     assert "typed-findings" not in lowered
 
 
-@_AP3_XFAIL
 def test_typed_findings_feed_the_verifier_directly(tmp_path: Path) -> None:
     """Typed handoff findings queue verifier dispatches without prose aggregation."""
     from mergecraft.agents.structured_handoff import (
         parse_specialist_handoff,
         verification_plan_from_handoff,
     )
-
     from mergecraft.agents.verifier import VERIFIER_SEVERITIES
 
     handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)

--- a/tests/agents/test_structured_handoff.py
+++ b/tests/agents/test_structured_handoff.py
@@ -1,0 +1,122 @@
+"""AP3 structured handoff suite — typed specialist returns (D6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.structured_handoff`` — specialists reason in
+free-form prose and emit typed ``AgentFinding`` values at the boundary;
+discovery dispatch prompts carry no finding schema; typed findings feed
+``plan_agent_verifications`` without orchestrator prose re-judgement.
+
+AP3.1: three tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_SAMPLE_HANDOFF = """\
+I read the diff end-to-end and traced the checkout path. The race is real
+because two goroutines can observe the same version before either write lands.
+
+---typed-findings---
+[
+  {
+    "path": "internal/store/checkout.go",
+    "body": "Concurrent checkouts can double-spend inventory when two requests read the same stock level.",
+    "severity": "Major",
+    "line": 142
+  }
+]
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+@_AP3_XFAIL
+def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
+    """D6 — prose reasoning is preserved; findings at the boundary are typed."""
+    from mergecraft.agents.structured_handoff import parse_specialist_handoff
+
+    from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.verifier import AgentFinding
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.output_schema == "mergecraft.agent_finding"
+
+    handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)
+    assert "race is real" in handoff.reasoning
+    assert len(handoff.findings) == 1
+    finding = handoff.findings[0]
+    assert isinstance(finding, AgentFinding)
+    assert finding.path == "internal/store/checkout.go"
+    assert finding.severity == "Major"
+    assert finding.line == 142
+    assert "double-spend" in finding.body
+
+
+@_AP3_XFAIL
+def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
+    """Discovery dispatch must not pre-shape output with a finding schema (D6)."""
+    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
+
+    from mergecraft.agents.registry import AgentRole
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    prompt = build_specialist_dispatch_prompt(reviewer)
+    lowered = prompt.casefold()
+    assert "json schema" not in lowered
+    assert "output_schema" not in lowered
+    assert "set_output" not in lowered
+    assert '"findings"' not in prompt
+    assert "typed-findings" not in lowered
+
+
+@_AP3_XFAIL
+def test_typed_findings_feed_the_verifier_directly(tmp_path: Path) -> None:
+    """Typed handoff findings queue verifier dispatches without prose aggregation."""
+    from mergecraft.agents.structured_handoff import (
+        parse_specialist_handoff,
+        verification_plan_from_handoff,
+    )
+
+    from mergecraft.agents.verifier import VERIFIER_SEVERITIES
+
+    handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)
+    plan = verification_plan_from_handoff(handoff, budget=4)
+    assert plan.budget == 4
+    assert len(plan.dispatch) == 1
+    dispatch = plan.dispatch[0]
+    assert dispatch.finding.path == "internal/store/checkout.go"
+    assert dispatch.finding.severity in VERIFIER_SEVERITIES
+    assert "Verify one finding" in dispatch.brief
+    assert plan.skipped_below_severity == []


### PR DESCRIPTION
## Summary

- Adds typed specialist handoff (`structured_handoff.py`): free-form discovery prompts, `---typed-findings---` parsing into `AgentFinding`, and direct verifier queue bridging
- Generalizes #45 model-diversity policy (`model_diversity.py`): verification must not share the authoring provider family, with harness-agnostic enforcement
- Adds ensemble and shadow dispatch (`ensemble.py`): parallel two-model fan-out with agreement/confidence or judge escalation; shadow records alternate-model output via `evidence.shadow` without acting on it
- Default reviewer binding sets `output_schema=mergecraft.agent_finding`; `ShadowRecord` gains optional `metadata` for ensemble shadow rows

## Merge into pre-0.0.1

**Stacks on #232** (`feature/agent-pipeline-ap2`). After #232 merges into `pre-0.0.1`, retarget **this** PR to `pre-0.0.1`, then merge.

1. Merge #231 → `pre-0.0.1`
2. Retarget #232 to `pre-0.0.1`, merge #232
3. Retarget **#233** to `pre-0.0.1`, merge #233
4. Retarget #234 to `pre-0.0.1`, merge #234
5. Retarget #235 to `pre-0.0.1`, merge #235
6. Retarget #236 to `pre-0.0.1`, merge #236
7. Retarget #237 to `pre-0.0.1`, merge #237

## Test plan

- [x] `uv run pytest tests/agents/test_structured_handoff.py tests/agents/test_model_diversity.py tests/agents/test_ensemble.py` — 11/11 pass
- [x] `make lint` + `make typecheck`
- [x] `make ci-resume` — 11/11 steps passed
- [x] Runtime proof captured at `.ignorelocal/waves/evidence/ap3-structured-handoff.txt` (ensemble agreement + shadow record)
