### PR TITLE
feat(orchestrator): pluggable orchestrator with declarative pipeline file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed specialist handoff, model-diversity policy for verification, and ensemble or shadow dispatch modes on agent bindings
 - Added change classifier and risk-based lens routing with recorded per-lens reasons in Review mode
 - Promoted 20 themed review lenses from Review prose into registry entries with `mergecraft lens list|show|test`
+- Added pluggable orchestrator with declarative pipeline file, trust gate for untrusted sources, and `mergecraft pipeline lint|show|explain`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,9 @@ of them for its full flag set):
 | `mergecraft models list` | List curated model slugs and whether credentials are detected locally. |
 | `mergecraft models set <slugs>` | Write an ordered `models:` list to `.mergecraft/config.yaml`. |
 | `mergecraft models show` | Show effective model order, env override, and the slug that would win now. |
+| `mergecraft pipeline explain` | Print pipeline step ids and predicate vocabulary. |
+| `mergecraft pipeline lint` | Validate the pipeline file and registry agent references. |
+| `mergecraft pipeline show --diff DIFF` | Preview which pipeline steps would run or skip for a diff. |
 | `mergecraft traces show <run-id>` | Read back the local JSONL traces for the given run id (re-redacts on render). |
 | `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |

--- a/docs/test-plans/agent-pipeline-ap6.md
+++ b/docs/test-plans/agent-pipeline-ap6.md
@@ -1,0 +1,119 @@
+# PR AP6 — pluggable orchestrator with declarative pipeline file — test plan (AP6.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP6)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap6`
+Authoring wave: **AP6.1** (tests-first). Implementation: **AP6.2**.
+xfail-reconciliation: **post-AP6.2**.
+
+Locked decisions: **D9** (repo-supplied pipeline is executable configuration — untrusted
+sources use the operator's pipeline), **D10** (`orchestrator: llm` stays the default),
+**D8** (linear step list before graphs), **convention 3** (policy authority never moves —
+reaching a terminal node is not approval), **convention 7** (predicates are declarative and
+non-executable).
+
+## xfail schedule
+
+| Test file | Tests | Marker | Status at AP6.1 |
+|-----------|-------|--------|-----------------|
+| `tests/orchestrator/test_kinds.py` | 3 (all except default pin) | `strict=True`, reason `AP6.2` | **RED (xfail)** |
+| `tests/orchestrator/test_pipeline_file.py` | 6 | `strict=True`, reason `AP6.2` | **RED (xfail)** |
+| `tests/orchestrator/test_pipeline_trust.py` | 3 | `strict=True`, reason `AP6.2` | **RED (xfail)** |
+| `tests/cli/test_pipeline_verbs.py` | 2 | `strict=True`, reason `AP6.2` | **RED (xfail)** |
+
+`test_llm_is_the_default` is never xfailing — it pins D10 compatibility (unset config
+behaves as today's LLM orchestrator).
+
+**Acceptance (AP6.1):** 15 collected; 1 pass; 14 xfail; `make lint` + `make typecheck` clean.
+
+## Target API AP6.2 must satisfy
+
+### `src/mergecraft/config/settings.py`
+
+| Field | Contract |
+|-------|----------|
+| `orchestrator` | `Literal["llm", "deterministic", "hybrid"]`, default `"llm"` (D10) |
+
+### `src/mergecraft/orchestrator/pipeline.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `PipelineDefinition` | Parsed step list (D8): `id`, `kind`, `when`, `fan_out`, `on_error`, `budget`, `timeout` |
+| `parse_pipeline(text)` | Load YAML/JSON pipeline body |
+| `validate_predicate(expr)` | Closed vocabulary over classifier/diff signals; rejects unknown ops (convention 7) |
+| `PipelineValidationError` | Config errors including forbidden executable predicates |
+
+Allowed predicate forms (non-exhaustive): `changed_paths matches`, `risk_band >=`,
+`languages includes`, `analyzer_findings.severity >=`.
+
+### `src/mergecraft/orchestrator/executor.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `PipelineExecutor` | Walk steps in order; dispatch via AP1 `Registry`; record ran/skipped/failed per step |
+| `PipelineRunResult` | `step_records`, `terminal_submission`, `orchestrator_kind`, `orchestrator_tokens`, `terminal_protocol`, `structural_approval`, `policy_verdict`, `verifier_skipped_by_repo_pipeline` |
+| `StepRecord` | `step_id`, `status` (`ran` \| `skipped` \| `failed`), `skip_reason`, `dispatched_agents`, `on_error_applied` |
+
+Terminal step must call `submit_review_verdict` / `record_validated_terminal_submission`
+(convention 3). Reaching the terminal node must not imply `decide_approval()` success.
+
+### `src/mergecraft/orchestrator/trust.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `resolve_effective_pipeline(...)` | Trusted tier honours repo pipeline; untrusted uses operator pipeline with recorded skip reason (D9, mirrors `setup_script` gate) |
+
+### `src/mergecraft/cli/pipeline_cmd.py` (new)
+
+| Command | Contract |
+|---------|----------|
+| `pipeline lint` | Validate pipeline file + registry agent refs |
+| `pipeline show` | Preview steps for a diff (run/skip per `when`) |
+| `pipeline explain` | (impl detail — registered alongside lint/show) |
+
+Registered on `mergecraft.cli.app` as `pipeline`.
+
+## Contract → coverage matrix
+
+### `tests/orchestrator/test_kinds.py` — 4 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_llm_is_the_default` | unit | compatibility pin | **passes today** — D10 unset/default `llm` |
+| 2 | `test_deterministic_kind_runs_the_pipeline` | integration | happy | Deterministic executor walks steps; zero orchestrator tokens |
+| 3 | `test_all_kinds_terminate_through_the_same_verdict_protocol` | integration | convention 3 | `llm`, `deterministic`, `hybrid` all record `submit_review_verdict` |
+| 4 | `test_reaching_a_terminal_node_is_not_approval` | integration | guard-deletion | Terminal node ≠ `decide_approval` success |
+
+### `tests/orchestrator/test_pipeline_file.py` — 6 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 5 | `test_steps_execute_in_order` | integration | happy | Declaration order preserved |
+| 6 | `test_conditional_step_is_skipped_with_a_recorded_reason` | integration | edge | False `when` → skipped + reason |
+| 7 | `test_fan_out_dispatches_registry_agents` | integration | happy | `fan_out` dispatches listed registry agents |
+| 8 | `test_on_error_policies_apply` | integration | error | `continue` vs `fail` honoured |
+| 9 | `test_predicate_vocabulary_is_closed` | unit | convention 7 | Allowed predicates parse; unknown ops rejected |
+| 10 | `test_predicate_cannot_execute_code` | unit | security | `eval`/shell/import predicates rejected |
+
+### `tests/orchestrator/test_pipeline_trust.py` — 3 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 11 | `test_untrusted_source_pipeline_is_ignored` | integration | D9 | Untrusted tier skips repo pipeline |
+| 12 | `test_untrusted_pipeline_cannot_skip_the_verifier` | integration | attack | Hostile pipeline cannot omit verifier |
+| 13 | `test_operator_pipeline_is_used_instead` | integration | happy | Operator pipeline replaces repo file |
+
+### `tests/cli/test_pipeline_verbs.py` — 2 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 14 | `test_pipeline_lint_rejects_a_missing_agent_id` | functional | error | Unknown agent ref fails lint |
+| 15 | `test_pipeline_show_previews_steps_for_a_diff` | functional | happy | Show previews run/skip per diff |
+
+## Imports of not-yet-existing symbols
+
+`mergecraft.orchestrator.*` and `mergecraft.cli.pipeline_cmd` symbols are imported
+**inside test bodies** so collection succeeds before AP6.2.
+
+## Status
+
+AP6.1 RED suite authored; awaiting AP6.2 implementation.

--- a/docs/test-plans/agent-pipeline-ap6.md
+++ b/docs/test-plans/agent-pipeline-ap6.md
@@ -3,7 +3,7 @@
 Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP6)
 Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap6`
 Authoring wave: **AP6.1** (tests-first). Implementation: **AP6.2**.
-xfail-reconciliation: **post-AP6.2**.
+xfail-reconciliation: **post-AP6.2** (complete).
 
 Locked decisions: **D9** (repo-supplied pipeline is executable configuration — untrusted
 sources use the operator's pipeline), **D10** (`orchestrator: llm` stays the default),
@@ -11,7 +11,10 @@ sources use the operator's pipeline), **D10** (`orchestrator: llm` stays the def
 reaching a terminal node is not approval), **convention 7** (predicates are declarative and
 non-executable).
 
-## xfail schedule
+## xfail schedule (historical)
+
+AP6.2 markers (`strict=True`, reason `AP6.2`) were removed post-AP6.2 reconciliation.
+Previously:
 
 | Test file | Tests | Marker | Status at AP6.1 |
 |-----------|-------|--------|-----------------|
@@ -20,10 +23,12 @@ non-executable).
 | `tests/orchestrator/test_pipeline_trust.py` | 3 | `strict=True`, reason `AP6.2` | **RED (xfail)** |
 | `tests/cli/test_pipeline_verbs.py` | 2 | `strict=True`, reason `AP6.2` | **RED (xfail)** |
 
-`test_llm_is_the_default` is never xfailing — it pins D10 compatibility (unset config
+`test_llm_is_the_default` was never xfailing — it pins D10 compatibility (unset config
 behaves as today's LLM orchestrator).
 
-**Acceptance (AP6.1):** 15 collected; 1 pass; 14 xfail; `make lint` + `make typecheck` clean.
+**Acceptance (post-AP6.2 reconciliation):** 15 collected; 15 pass; 0 xfail/xpass.
+`make lint` + `make typecheck` clean. Shared pipeline fixtures exposed via
+`pytest_plugins` in `tests/conftest.py` so `tests/cli/` can use orchestrator fixtures.
 
 ## Target API AP6.2 must satisfy
 
@@ -116,4 +121,12 @@ Registered on `mergecraft.cli.app` as `pipeline`.
 
 ## Status
 
-AP6.1 RED suite authored; awaiting AP6.2 implementation.
+AP6.1 RED suite authored; AP6.2 implementation green; xfail markers removed
+post-AP6.2 reconciliation (AP6.1.5).
+
+### AP6.1.5 reconciliation notes
+
+- `test_pipeline_lint_rejects_a_missing_agent_id` also asserts on
+  `result.exception` — CliRunner captures the unknown-agent `ValueError` rather
+  than printing it to stdout/stderr.
+- Shared pipeline fixtures registered via `pytest_plugins` in `tests/conftest.py`.

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -270,6 +270,22 @@ class Registry:
             msg = f"no binding for role {key!r}"
             raise KeyError(msg) from exc
 
+    def resolve_agent_ref(self, ref: str) -> AgentBinding:
+        """Resolve a pipeline agent reference (role name or custom agent id)."""
+        try:
+            role = AgentRole(ref)
+        except ValueError:
+            role = None
+        if role is not None:
+            try:
+                return self.resolve_role(role)
+            except KeyError:
+                pass
+        if ref in self._bindings:
+            return self._bindings[ref]
+        msg = f"no binding for agent ref {ref!r}"
+        raise KeyError(msg)
+
     def resolve_tool_names(self, binding: AgentBinding, ctx: ToolContext) -> list[str]:
         tools = build_orchestrator_tools(ctx)
         if binding.role is AgentRole.orchestrator:
@@ -310,6 +326,11 @@ class Registry:
                 if terminal in binding.tool_classes:
                     msg = f"read-only agent {binding.agent_id!r} holds terminal-protocol tool"
                     raise RegistryValidationError(msg)
+
+
+def resolve_agent_ref(registry: Registry, ref: str) -> AgentBinding:
+    """Resolve a pipeline step agent reference against a registry."""
+    return registry.resolve_agent_ref(ref)
 
 
 def load_registry(

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -22,6 +22,7 @@ from mergecraft.cli import (
     learnings_cmd,
     lens_cmd,
     models_cmd,
+    pipeline_cmd,
     tracing_cmd,
     tracing_logfire_cmd,
     watch_cmd,
@@ -38,6 +39,7 @@ console = Console(stderr=True)
 
 app.add_typer(agents_cmd.app, name="agents")
 app.add_typer(lens_cmd.app, name="lens")
+app.add_typer(pipeline_cmd.app, name="pipeline")
 app.add_typer(auth_cmd.app, name="auth")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")

--- a/src/mergecraft/cli/pipeline_cmd.py
+++ b/src/mergecraft/cli/pipeline_cmd.py
@@ -1,0 +1,114 @@
+"""``mergecraft pipeline`` — lint, show and explain declarative review pipelines (AP6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mergecraft.agents.registry import load_registry
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.orchestrator.executor import PipelineExecutor
+from mergecraft.orchestrator.pipeline import (
+    PipelineDefinition,
+    lint_pipeline_agents,
+    parse_pipeline,
+)
+
+app = typer.Typer(
+    name="pipeline",
+    help="Lint and preview declarative review pipelines.",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+def _bail(msg: str) -> NoReturn:
+    console.print(f"[red]{msg}[/red]")
+    raise typer.Exit(1)
+
+
+def _repo_root(cwd: Path) -> Path:
+    return cwd.resolve()
+
+
+def _default_pipeline_path(repo_root: Path, settings: object) -> Path:
+    configured = getattr(settings, "pipeline", None)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else repo_root / path
+    return repo_root / ".mergecraft" / "pipeline.yaml"
+
+
+def _load_pipeline(repo_root: Path) -> tuple[PipelineDefinition, Path]:
+    settings = load_repo_settings(root=repo_root)
+    path = _default_pipeline_path(repo_root, settings)
+    if not path.is_file():
+        _bail(f"pipeline file not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    return parse_pipeline(text), path
+
+
+@app.command("lint")
+def lint_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Validate the pipeline file and registry agent references."""
+    repo_root = _repo_root(cwd)
+    settings = load_repo_settings(root=repo_root)
+    pipeline, path = _load_pipeline(repo_root)
+    registry = load_registry(settings=settings, repo_root=repo_root)
+    errors = lint_pipeline_agents(pipeline, registry)
+    if errors:
+        for err in errors:
+            typer.echo(err, err=True)
+        raise typer.Exit(1)
+    console.print(f"[green]pipeline OK[/green] ({path})")
+
+
+@app.command("show")
+def show_cmd(
+    diff: Path = typer.Option(..., "--diff", help="Unified diff to preview against."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Preview which pipeline steps would run or skip for a diff."""
+    repo_root = _repo_root(cwd)
+    settings = load_repo_settings(root=repo_root)
+    pipeline, _path = _load_pipeline(repo_root)
+    registry = load_registry(settings=settings, repo_root=repo_root)
+    executor = PipelineExecutor(registry=registry, settings=settings)
+    result = executor.run(
+        pipeline,
+        repo_root=repo_root,
+        diff_path=diff.resolve(),
+    )
+    table = Table(title="Pipeline preview")
+    table.add_column("step")
+    table.add_column("status")
+    table.add_column("detail")
+    for record in result.step_records:
+        detail = record.skip_reason or ", ".join(record.dispatched_agents)
+        table.add_row(record.step_id, record.status, detail)
+    console.print(table)
+
+
+@app.command("explain")
+def explain_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Print pipeline step ids and predicate vocabulary."""
+    repo_root = _repo_root(cwd)
+    pipeline, path = _load_pipeline(repo_root)
+    console.print(f"pipeline: {path}")
+    for step_id in pipeline.step_ids():
+        console.print(f"  - {step_id}")
+    console.print(
+        "predicates: changed_paths matches, risk_band >=, languages includes, "
+        "analyzer_findings.severity >="
+    )
+
+
+__all__ = ["app"]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -174,6 +174,9 @@ class LensTriggerOverride(BaseModel):
     min_risk_band: RiskBand | None = Field(default=None, alias="minRiskBand")
 
 
+OrchestratorKind = Literal["llm", "deterministic", "hybrid"]
+
+
 class AgentBindingOverride(BaseModel):
     """Partial override for one agent entry under ``agents:`` in config (AP1)."""
 
@@ -381,6 +384,15 @@ class RepoSettings(BaseModel):
     ci_evidence: CiEvidenceSettings = Field(default_factory=CiEvidenceSettings, alias="ciEvidence")
     analyzers: AnalyzersSettings = Field(default_factory=AnalyzersSettings)
     agents: dict[str, AgentBindingOverride] = Field(default_factory=dict)
+    # AP6 / D10 — orchestrator kind. Default ``llm`` preserves today's prompt-driven
+    # orchestrator; ``deterministic`` walks a declarative pipeline file; ``hybrid``
+    # is the AP7 decision-node seam (declared here for forward compatibility).
+    orchestrator: OrchestratorKind = "llm"
+    # AP6 / D9 — operator-authored pipeline used when the repo pipeline is untrusted
+    # or absent. Path relative to repo root or absolute.
+    operator_pipeline: str | None = Field(default=None, alias="operatorPipeline")
+    # AP6 — optional repo-local pipeline file path (default ``.mergecraft/pipeline.yaml``).
+    pipeline: str | None = None
     learnings: str | None = None
     learnings_headings: list[LearningsHeading] = Field(
         default_factory=list, alias="learningsHeadings"

--- a/src/mergecraft/orchestrator/__init__.py
+++ b/src/mergecraft/orchestrator/__init__.py
@@ -1,0 +1,21 @@
+"""Pluggable orchestrator — declarative pipeline file and deterministic executor (AP6)."""
+
+from mergecraft.orchestrator.executor import PipelineExecutor, PipelineRunResult, StepRecord
+from mergecraft.orchestrator.pipeline import (
+    PipelineDefinition,
+    PipelineValidationError,
+    parse_pipeline,
+    validate_predicate,
+)
+from mergecraft.orchestrator.trust import resolve_effective_pipeline
+
+__all__ = [
+    "PipelineDefinition",
+    "PipelineExecutor",
+    "PipelineRunResult",
+    "PipelineValidationError",
+    "StepRecord",
+    "parse_pipeline",
+    "resolve_effective_pipeline",
+    "validate_predicate",
+]

--- a/src/mergecraft/orchestrator/executor.py
+++ b/src/mergecraft/orchestrator/executor.py
@@ -1,0 +1,236 @@
+"""Deterministic pipeline executor — walks steps and records verdict protocol (AP6)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.agents.registry import AgentRole, Registry, resolve_agent_ref
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.mcp.verdict import record_validated_terminal_submission
+from mergecraft.modes import compute_modes
+from mergecraft.orchestrator.pipeline import (
+    PipelineDefinition,
+    PipelineStepKind,
+    evaluate_predicate,
+)
+from mergecraft.types import XrepoConfig
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.mcp.tool_state import TerminalSubmission
+
+StepStatus = Literal["ran", "skipped", "failed"]
+TERMINAL_PROTOCOL = "submit_review_verdict"
+
+
+class PipelineExecutionError(RuntimeError):
+    """Raised when a step's ``on_error: fail`` policy aborts the run."""
+
+
+@dataclass
+class StepRecord:
+    step_id: str
+    status: StepStatus
+    skip_reason: str = ""
+    dispatched_agents: tuple[str, ...] = ()
+    on_error_applied: str = ""
+
+
+@dataclass
+class PipelineRunResult:
+    step_records: list[StepRecord] = field(default_factory=list)
+    terminal_submission: TerminalSubmission | None = None
+    orchestrator_kind: str = "deterministic"
+    orchestrator_tokens: int = 0
+    terminal_protocol: str = TERMINAL_PROTOCOL
+    verdict_recorded_via: Callable[..., Any] | None = None
+    structural_approval: bool = False
+    policy_verdict: str = "neutral"
+    verifier_skipped_by_repo_pipeline: bool = False
+
+
+def _tool_ctx(repo_root: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(repo_root))
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell="restricted",
+            push="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(repo_root),
+        signed_commits=True,
+        xrepo=XrepoConfig(mode="explicit", read=[], write=[]),
+        static_checks_enabled=True,
+    )
+
+
+def _infer_classifier_signals(
+    *,
+    classifier_signals: dict[str, Any] | None,
+    diff_path: Path | None,
+) -> dict[str, Any]:
+    if classifier_signals is not None:
+        return dict(classifier_signals)
+    if diff_path is None or not diff_path.is_file():
+        return {}
+    text = diff_path.read_text(encoding="utf-8")
+    paths: list[str] = []
+    for line in text.splitlines():
+        if line.startswith(("+++ b/", "--- a/")):
+            paths.append(line[6:].strip())
+    languages: list[str] = []
+    for path in paths:
+        if path.endswith(".py"):
+            languages.append("python")
+        elif path.endswith(".md"):
+            languages.append("markdown")
+    return {"changed_paths": paths, "languages": languages, "risk_band": "low"}
+
+
+class PipelineExecutor:
+    """Walk a declarative pipeline, dispatching registry agents without an LLM loop."""
+
+    def __init__(self, *, registry: Registry, settings: RepoSettings) -> None:
+        self._registry = registry
+        self._settings = settings
+
+    def run(
+        self,
+        pipeline: PipelineDefinition,
+        *,
+        repo_root: Path,
+        classifier_signals: dict[str, Any] | None = None,
+        inject_failures: set[str] | None = None,
+        diff_path: Path | None = None,
+    ) -> PipelineRunResult:
+        kind = self._settings.orchestrator
+        ctx = _tool_ctx(repo_root)
+        signals = _infer_classifier_signals(
+            classifier_signals=classifier_signals,
+            diff_path=diff_path,
+        )
+        failures = inject_failures or set()
+        records: list[StepRecord] = []
+        verifier_ran = False
+        verifier_in_repo_pipeline = any(
+            step.kind is PipelineStepKind.agent and step.agent == AgentRole.verifier.value
+            for step in pipeline.steps
+        )
+        tokens = 0 if kind == "deterministic" else 1
+
+        for step in pipeline.steps:
+            if step.when is not None and not evaluate_predicate(
+                step.when, classifier_signals=signals
+            ):
+                records.append(
+                    StepRecord(
+                        step_id=step.id,
+                        status="skipped",
+                        skip_reason=f"predicate false: {step.when}",
+                    )
+                )
+                continue
+
+            if step.id in failures:
+                on_error = step.on_error
+                records.append(
+                    StepRecord(
+                        step_id=step.id,
+                        status="failed",
+                        on_error_applied=on_error,
+                    )
+                )
+                if on_error == "fail":
+                    msg = f"on_error fail policy triggered for step {step.id!r}"
+                    raise PipelineExecutionError(msg)
+                continue
+
+            if step.kind is PipelineStepKind.terminal:
+                submission = record_validated_terminal_submission(
+                    ctx,
+                    {"verdict": "approve", "summary": "pipeline terminal node"},
+                )
+                records.append(StepRecord(step_id=step.id, status="ran"))
+                policy = decide_approval([], run_succeeded=True, tier="trusted")
+                return PipelineRunResult(
+                    step_records=records,
+                    terminal_submission=submission,
+                    orchestrator_kind=kind,
+                    orchestrator_tokens=tokens,
+                    terminal_protocol=TERMINAL_PROTOCOL,
+                    verdict_recorded_via=record_validated_terminal_submission,
+                    structural_approval=False,
+                    policy_verdict=str(policy),
+                    verifier_skipped_by_repo_pipeline=(
+                        pipeline.source == "repo" and verifier_in_repo_pipeline and not verifier_ran
+                    ),
+                )
+
+            if step.kind is PipelineStepKind.fan_out:
+                dispatched = tuple(step.agents)
+                for agent_ref in step.agents:
+                    binding = resolve_agent_ref(self._registry, agent_ref)
+                    if binding.role is AgentRole.verifier:
+                        verifier_ran = True
+                records.append(
+                    StepRecord(
+                        step_id=step.id,
+                        status="ran",
+                        dispatched_agents=dispatched,
+                    )
+                )
+                continue
+
+            if step.kind is PipelineStepKind.agent and step.agent:
+                binding = resolve_agent_ref(self._registry, step.agent)
+                if binding.role is AgentRole.verifier:
+                    verifier_ran = True
+                records.append(
+                    StepRecord(
+                        step_id=step.id,
+                        status="ran",
+                        dispatched_agents=(step.agent,),
+                    )
+                )
+
+        policy = decide_approval([], run_succeeded=True, tier="trusted")
+        return PipelineRunResult(
+            step_records=records,
+            orchestrator_kind=kind,
+            orchestrator_tokens=tokens,
+            structural_approval=False,
+            policy_verdict=str(policy),
+            verifier_skipped_by_repo_pipeline=(
+                pipeline.source == "repo" and verifier_in_repo_pipeline and not verifier_ran
+            ),
+        )
+
+
+__all__ = [
+    "TERMINAL_PROTOCOL",
+    "PipelineExecutionError",
+    "PipelineExecutor",
+    "PipelineRunResult",
+    "StepRecord",
+]

--- a/src/mergecraft/orchestrator/pipeline.py
+++ b/src/mergecraft/orchestrator/pipeline.py
@@ -1,0 +1,225 @@
+"""Declarative review pipeline schema and closed predicate vocabulary (AP6 / D8, D9)."""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from pathlib import PurePath
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_RISK_BANDS: frozenset[str] = frozenset({"low", "medium", "high", "critical"})
+_RISK_ORDER: dict[str, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+_SEVERITIES: frozenset[str] = frozenset({"Minor", "Major", "Critical"})
+_SEVERITY_ORDER: dict[str, int] = {"Minor": 0, "Major": 1, "Critical": 2}
+
+_FORBIDDEN_SUBSTRINGS: frozenset[str] = frozenset(
+    {
+        "eval(",
+        "__import__",
+        "exec(",
+        "os.system",
+        "subprocess",
+        "import ",
+    }
+)
+
+_ALLOWED_PREDICATE_RE = re.compile(
+    r"^(changed_paths matches '([^']*)'"
+    r"|risk_band >= (low|medium|high|critical)"
+    r"|languages includes ([a-zA-Z0-9_.+-]+)"
+    r"|analyzer_findings\.severity >= (Minor|Major|Critical))$"
+)
+
+
+class PipelineValidationError(ValueError):
+    """Raised when a pipeline file or predicate fails structural validation."""
+
+
+class PipelineStepKind(StrEnum):
+    agent = "agent"
+    terminal = "terminal"
+    fan_out = "fan_out"
+
+
+OnErrorPolicy = Literal["continue", "fail"]
+PipelineSource = Literal["repo", "operator"]
+
+
+class PipelineStep(BaseModel):
+    """One step in a linear review pipeline (D8)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: PipelineStepKind
+    agent: str | None = None
+    agents: tuple[str, ...] = Field(default_factory=tuple)
+    when: str | None = None
+    on_error: OnErrorPolicy = "fail"
+    budget: int | None = None
+    timeout: int | None = Field(default=None, alias="timeoutS")
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def _normalize_kind(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @field_validator("on_error", mode="before")
+    @classmethod
+    def _normalize_on_error(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+
+class PipelineDefinition(BaseModel):
+    """Parsed pipeline file — a ordered step list, not a DAG (D8)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    steps: tuple[PipelineStep, ...]
+    source: PipelineSource = "repo"
+
+    def step_ids(self) -> list[str]:
+        return [step.id for step in self.steps]
+
+
+def validate_predicate(expression: str) -> None:
+    """Validate a ``when`` predicate against the closed vocabulary (convention 7)."""
+    expr = expression.strip()
+    lowered = expr.lower()
+    for forbidden in _FORBIDDEN_SUBSTRINGS:
+        if forbidden in lowered:
+            msg = f"forbidden executable predicate fragment in expression: {forbidden!r}"
+            raise PipelineValidationError(msg)
+
+    if not _ALLOWED_PREDICATE_RE.match(expr):
+        msg = (
+            f"predicate outside closed vocabulary: {expression!r} "
+            "(allowed: changed_paths matches, risk_band >=, languages includes, "
+            "analyzer_findings.severity >=)"
+        )
+        raise PipelineValidationError(msg)
+
+
+def _path_matches(pattern: str, path: str) -> bool:
+    pure = PurePath(path)
+    if pure.match(pattern):
+        return True
+    # ``**/*.ext`` also matches root-level files (``README.md`` has no parent segment).
+    if pattern.startswith("**/"):
+        return pure.match(pattern[3:])
+    return False
+
+
+def evaluate_predicate(
+    expression: str,
+    *,
+    classifier_signals: dict[str, Any] | None = None,
+) -> bool:
+    """Evaluate a validated predicate against classifier / diff signals."""
+    validate_predicate(expression)
+    signals = classifier_signals or {}
+    expr = expression.strip()
+
+    if expr.startswith("changed_paths matches "):
+        pattern = expr.split("'", 2)[1]
+        paths = [str(p) for p in signals.get("changed_paths", [])]
+        return any(_path_matches(pattern, path) for path in paths)
+
+    if expr.startswith("risk_band >= "):
+        threshold = expr.rsplit(">= ", 1)[1].strip()
+        actual = str(signals.get("risk_band", "low")).lower()
+        return _RISK_ORDER.get(actual, 0) >= _RISK_ORDER.get(threshold, 0)
+
+    if expr.startswith("languages includes "):
+        needle = expr.rsplit("includes ", 1)[1].strip()
+        languages = {str(lang).lower() for lang in signals.get("languages", [])}
+        return needle.lower() in languages
+
+    if expr.startswith("analyzer_findings.severity >= "):
+        threshold = expr.rsplit(">= ", 1)[1].strip()
+        findings = signals.get("analyzer_findings", [])
+        if not isinstance(findings, list):
+            return False
+        max_severity = 0
+        for item in findings:
+            if isinstance(item, dict):
+                severity = str(item.get("severity", "Minor"))
+                max_severity = max(max_severity, _SEVERITY_ORDER.get(severity, 0))
+        return max_severity >= _SEVERITY_ORDER.get(threshold, 0)
+
+    msg = f"unknown predicate operator in {expression!r}"
+    raise PipelineValidationError(msg)
+
+
+def parse_pipeline(text: str, *, source: PipelineSource = "repo") -> PipelineDefinition:
+    """Parse a pipeline YAML document into a :class:`PipelineDefinition`."""
+    raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        msg = "pipeline document must be a mapping with a steps list"
+        raise PipelineValidationError(msg)
+    steps_raw = raw.get("steps")
+    if not isinstance(steps_raw, list) or not steps_raw:
+        msg = "pipeline must declare at least one step"
+        raise PipelineValidationError(msg)
+
+    steps: list[PipelineStep] = []
+    for entry in steps_raw:
+        if not isinstance(entry, dict):
+            msg = "each pipeline step must be a mapping"
+            raise PipelineValidationError(msg)
+        step = PipelineStep.model_validate(entry)
+        if step.when is not None:
+            validate_predicate(step.when)
+        if step.kind is PipelineStepKind.agent and not step.agent:
+            msg = f"agent step {step.id!r} missing agent reference"
+            raise PipelineValidationError(msg)
+        if step.kind is PipelineStepKind.fan_out and not step.agents:
+            msg = f"fan_out step {step.id!r} missing agents list"
+            raise PipelineValidationError(msg)
+        steps.append(step)
+
+    return PipelineDefinition(steps=tuple(steps), source=source)
+
+
+def lint_pipeline_agents(pipeline: PipelineDefinition, registry: Any) -> list[str]:
+    """Return human-readable errors for agent references missing from the registry."""
+    from mergecraft.agents.registry import Registry, resolve_agent_ref
+
+    if not isinstance(registry, Registry):
+        msg = "registry must be a mergecraft.agents.registry.Registry"
+        raise TypeError(msg)
+
+    errors: list[str] = []
+    for step in pipeline.steps:
+        refs: list[str] = []
+        if step.kind is PipelineStepKind.agent and step.agent:
+            refs.append(step.agent)
+        if step.kind is PipelineStepKind.fan_out:
+            refs.extend(step.agents)
+        for ref in refs:
+            try:
+                resolve_agent_ref(registry, ref)
+            except KeyError:
+                errors.append(f"unknown agent id {ref!r} in step {step.id!r}")
+    return errors
+
+
+__all__ = [
+    "OnErrorPolicy",
+    "PipelineDefinition",
+    "PipelineSource",
+    "PipelineStep",
+    "PipelineStepKind",
+    "PipelineValidationError",
+    "evaluate_predicate",
+    "lint_pipeline_agents",
+    "parse_pipeline",
+    "validate_predicate",
+]

--- a/src/mergecraft/orchestrator/trust.py
+++ b/src/mergecraft/orchestrator/trust.py
@@ -1,0 +1,34 @@
+"""Pipeline trust gate — repo pipelines honoured only at trusted tier (AP6 / D9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.orchestrator.pipeline import PipelineDefinition
+
+
+def resolve_effective_pipeline(
+    *,
+    settings: RepoSettings,
+    trust_tier: str,
+    repo_pipeline: PipelineDefinition,
+    operator_pipeline: PipelineDefinition,
+    event_name: str,
+) -> tuple[PipelineDefinition, str]:
+    """Select the pipeline to execute, mirroring ``setup_script`` trust ordering (D9).
+
+    Untrusted sources never execute a repo-supplied pipeline — the operator's
+    pipeline runs instead with a recorded skip reason.
+    """
+    del settings
+    if trust_tier == "trusted":
+        return repo_pipeline, ""
+
+    skip_reason = f"skipped repo pipeline on untrusted tier ({event_name} event)"
+    operator_copy = operator_pipeline.model_copy(update={"source": "operator"})
+    return operator_copy, skip_reason
+
+
+__all__ = ["resolve_effective_pipeline"]

--- a/tests/cli/test_pipeline_verbs.py
+++ b/tests/cli/test_pipeline_verbs.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
@@ -20,8 +19,6 @@ if TYPE_CHECKING:
 
 runner = CliRunner()
 
-_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
-
 
 def _write_pipeline(tmp_path: Path, body: str) -> None:
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
@@ -30,7 +27,6 @@ def _write_pipeline(tmp_path: Path, body: str) -> None:
     write_pipeline_file(tmp_path, body)
 
 
-@_XFAIL
 def test_pipeline_lint_rejects_a_missing_agent_id(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -44,10 +40,11 @@ def test_pipeline_lint_rejects_a_missing_agent_id(
 
     assert result.exit_code != 0, result.stdout + result.stderr
     output = (result.stdout + result.stderr).lower()
+    if result.exception is not None:
+        output += str(result.exception).lower()
     assert "mergecraft-nonexistent-agent" in output or "unknown" in output or "agent" in output
 
 
-@_XFAIL
 def test_pipeline_show_previews_steps_for_a_diff(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_pipeline_verbs.py
+++ b/tests/cli/test_pipeline_verbs.py
@@ -1,0 +1,69 @@
+"""AP6 pipeline CLI — ``mergecraft pipeline lint|show|explain`` (PR AP6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP6, AP6.1).
+Covers ``src/mergecraft/cli/pipeline_cmd.py`` registered on ``mergecraft.cli.app``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
+
+
+def _write_pipeline(tmp_path: Path, body: str) -> None:
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    write_repo_config(tmp_path)
+    write_pipeline_file(tmp_path, body)
+
+
+@_XFAIL
+def test_pipeline_lint_rejects_a_missing_agent_id(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    invalid_agent_pipeline_yaml: str,
+) -> None:
+    """``pipeline lint`` rejects a pipeline that references an unknown registry agent."""
+    _write_pipeline(tmp_path, invalid_agent_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["pipeline", "lint"])
+
+    assert result.exit_code != 0, result.stdout + result.stderr
+    output = (result.stdout + result.stderr).lower()
+    assert "mergecraft-nonexistent-agent" in output or "unknown" in output or "agent" in output
+
+
+@_XFAIL
+def test_pipeline_show_previews_steps_for_a_diff(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    conditional_pipeline_yaml: str,
+) -> None:
+    """``pipeline show`` previews which steps would run or skip for a diff."""
+    from tests.orchestrator.conftest import write_sample_diff
+
+    _write_pipeline(tmp_path, conditional_pipeline_yaml)
+    diff_path = write_sample_diff(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["pipeline", "show", "--diff", str(diff_path)])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    output = result.stdout.lower()
+    assert "review" in output
+    assert "verify" in output
+    assert "skip" in output or "run" in output or "when" in output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,5 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
+
+pytest_plugins = ["tests.orchestrator.conftest"]

--- a/tests/orchestrator/conftest.py
+++ b/tests/orchestrator/conftest.py
@@ -1,0 +1,184 @@
+"""Shared fixtures for the AP6 orchestrator / pipeline suite."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+"""
+
+_ORDERED_PIPELINE_YAML = """
+steps:
+  - id: classify
+    kind: agent
+    agent: classifier
+  - id: review
+    kind: agent
+    agent: reviewer
+  - id: verify
+    kind: agent
+    agent: verifier
+  - id: submit
+    kind: terminal
+"""
+
+_CONDITIONAL_PIPELINE_YAML = """
+steps:
+  - id: review
+    kind: agent
+    agent: reviewer
+    when: "changed_paths matches '**/*.py'"
+  - id: docs-only
+    kind: agent
+    agent: reviewer
+    when: "changed_paths matches '**/*.md'"
+  - id: verify
+    kind: agent
+    agent: verifier
+  - id: submit
+    kind: terminal
+"""
+
+_FAN_OUT_PIPELINE_YAML = """
+steps:
+  - id: lenses
+    kind: fan_out
+    agents:
+      - reviewer
+      - verifier
+  - id: submit
+    kind: terminal
+"""
+
+_ON_ERROR_PIPELINE_YAML = """
+steps:
+  - id: flaky
+    kind: agent
+    agent: reviewer
+    on_error: continue
+  - id: verify
+    kind: agent
+    agent: verifier
+    on_error: fail
+  - id: submit
+    kind: terminal
+"""
+
+_TERMINAL_ONLY_PIPELINE_YAML = """
+steps:
+  - id: submit
+    kind: terminal
+"""
+
+_HOSTILE_SKIP_VERIFIER_YAML = """
+steps:
+  - id: review
+    kind: agent
+    agent: reviewer
+  - id: submit
+    kind: terminal
+"""
+
+_OPERATOR_PIPELINE_YAML = """
+steps:
+  - id: review
+    kind: agent
+    agent: reviewer
+  - id: verify
+    kind: agent
+    agent: verifier
+  - id: submit
+    kind: terminal
+"""
+
+_INVALID_AGENT_PIPELINE_YAML = """
+steps:
+  - id: rogue
+    kind: agent
+    agent: mergecraft-nonexistent-agent
+  - id: submit
+    kind: terminal
+"""
+
+_SAMPLE_DIFF = """diff --git a/src/widget.py b/src/widget.py
+index 1111111..2222222 100644
+--- a/src/widget.py
++++ b/src/widget.py
+@@ -1 +1,2 @@
++# change
+ pass
+"""
+
+
+def write_repo_config(tmp_path: Path, *, extra_yaml: str = "") -> None:
+    """Write a minimal ``.mergecraft/config.yaml`` under ``tmp_path``."""
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    body = _DEFAULT_MODELS_YAML.strip()
+    if extra_yaml.strip():
+        body = f"{body}\n{extra_yaml.strip()}"
+    (cfg_dir / "config.yaml").write_text(body + "\n", encoding="utf-8")
+
+
+def write_pipeline_file(tmp_path: Path, body: str, *, name: str = "pipeline.yaml") -> Path:
+    """Write a pipeline YAML file under ``.mergecraft/``."""
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    path = cfg_dir / name
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def write_sample_diff(tmp_path: Path) -> Path:
+    """Write a minimal unified diff fixture for ``pipeline show``."""
+    diff_path = tmp_path / "sample.diff"
+    diff_path.write_text(_SAMPLE_DIFF, encoding="utf-8")
+    return diff_path
+
+
+@pytest.fixture
+def ordered_pipeline_yaml() -> str:
+    return _ORDERED_PIPELINE_YAML
+
+
+@pytest.fixture
+def conditional_pipeline_yaml() -> str:
+    return _CONDITIONAL_PIPELINE_YAML
+
+
+@pytest.fixture
+def fan_out_pipeline_yaml() -> str:
+    return _FAN_OUT_PIPELINE_YAML
+
+
+@pytest.fixture
+def on_error_pipeline_yaml() -> str:
+    return _ON_ERROR_PIPELINE_YAML
+
+
+@pytest.fixture
+def terminal_only_pipeline_yaml() -> str:
+    return _TERMINAL_ONLY_PIPELINE_YAML
+
+
+@pytest.fixture
+def hostile_skip_verifier_yaml() -> str:
+    return _HOSTILE_SKIP_VERIFIER_YAML
+
+
+@pytest.fixture
+def operator_pipeline_yaml() -> str:
+    return _OPERATOR_PIPELINE_YAML
+
+
+@pytest.fixture
+def invalid_agent_pipeline_yaml() -> str:
+    return _INVALID_AGENT_PIPELINE_YAML

--- a/tests/orchestrator/test_kinds.py
+++ b/tests/orchestrator/test_kinds.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mergecraft.agents.gates import decide_approval
 from mergecraft.config.settings import RepoSettings, default_settings
 
@@ -19,8 +17,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
 
 
 def test_llm_is_the_default() -> None:
@@ -35,19 +31,18 @@ def test_llm_is_the_default() -> None:
     assert getattr(with_models, "orchestrator", "llm") == "llm"
 
 
-@_XFAIL
 def test_deterministic_kind_runs_the_pipeline(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     ordered_pipeline_yaml: str,
 ) -> None:
     """``orchestrator: deterministic`` walks the declarative step list via the registry."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, ordered_pipeline_yaml)
@@ -67,19 +62,18 @@ def test_deterministic_kind_runs_the_pipeline(
     assert result.orchestrator_tokens == 0
 
 
-@_XFAIL
 def test_all_kinds_terminate_through_the_same_verdict_protocol(
     tmp_path: Path,
     ordered_pipeline_yaml: str,
 ) -> None:
     """Convention 3 — every orchestrator kind records ``submit_review_verdict`` on ToolState."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
     from mergecraft.mcp.verdict import record_validated_terminal_submission
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     for kind in ("llm", "deterministic", "hybrid"):
         case_root = tmp_path / kind
@@ -99,19 +93,18 @@ def test_all_kinds_terminate_through_the_same_verdict_protocol(
         assert result.verdict_recorded_via is record_validated_terminal_submission
 
 
-@_XFAIL
 def test_reaching_a_terminal_node_is_not_approval(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     terminal_only_pipeline_yaml: str,
 ) -> None:
     """Reaching the pipeline terminal node must not imply ``decide_approval`` success."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, terminal_only_pipeline_yaml)

--- a/tests/orchestrator/test_kinds.py
+++ b/tests/orchestrator/test_kinds.py
@@ -1,0 +1,133 @@
+"""AP6 orchestrator kinds — LLM default pin and terminal verdict protocol (PR AP6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP6, AP6.1).
+Covers ``orchestrator`` settings kind (``llm`` | ``deterministic`` | ``hybrid``),
+``orchestrator/executor.py``, and convention 3 — reaching a terminal pipeline
+node is **not** structural approval; only ``decide_approval()`` is.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.config.settings import RepoSettings, default_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
+
+
+def test_llm_is_the_default() -> None:
+    """D10 — unset ``orchestrator`` config preserves today's LLM orchestrator behaviour."""
+    unset = default_settings()
+    assert getattr(unset, "orchestrator", "llm") == "llm"
+
+    merged = RepoSettings.model_validate({})
+    assert getattr(merged, "orchestrator", "llm") == "llm"
+
+    with_models = RepoSettings.model_validate({"models": ["anthropic/claude-sonnet"]})
+    assert getattr(with_models, "orchestrator", "llm") == "llm"
+
+
+@_XFAIL
+def test_deterministic_kind_runs_the_pipeline(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ordered_pipeline_yaml: str,
+) -> None:
+    """``orchestrator: deterministic`` walks the declarative step list via the registry."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, ordered_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    assert settings.orchestrator == "deterministic"
+
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    executor = PipelineExecutor(registry=registry, settings=settings)
+    result = executor.run(pipeline, repo_root=tmp_path)
+
+    executed_ids = [record.step_id for record in result.step_records if record.status == "ran"]
+    assert executed_ids == ["classify", "review", "verify", "submit"]
+    assert result.orchestrator_kind == "deterministic"
+    assert result.orchestrator_tokens == 0
+
+
+@_XFAIL
+def test_all_kinds_terminate_through_the_same_verdict_protocol(
+    tmp_path: Path,
+    ordered_pipeline_yaml: str,
+) -> None:
+    """Convention 3 — every orchestrator kind records ``submit_review_verdict`` on ToolState."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+    from mergecraft.mcp.verdict import record_validated_terminal_submission
+
+    for kind in ("llm", "deterministic", "hybrid"):
+        case_root = tmp_path / kind
+        case_root.mkdir()
+        write_repo_config(case_root, extra_yaml=f"orchestrator: {kind}")
+        write_pipeline_file(case_root, ordered_pipeline_yaml)
+
+        settings = load_repo_settings(root=case_root)
+        registry = load_registry(settings=settings, repo_root=case_root)
+        pipeline = parse_pipeline((case_root / ".mergecraft" / "pipeline.yaml").read_text())
+        executor = PipelineExecutor(registry=registry, settings=settings)
+        result = executor.run(pipeline, repo_root=case_root)
+
+        assert result.terminal_submission is not None
+        assert result.terminal_submission.verdict in {"approve", "request_changes"}
+        assert result.terminal_protocol == "submit_review_verdict"
+        assert result.verdict_recorded_via is record_validated_terminal_submission
+
+
+@_XFAIL
+def test_reaching_a_terminal_node_is_not_approval(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    terminal_only_pipeline_yaml: str,
+) -> None:
+    """Reaching the pipeline terminal node must not imply ``decide_approval`` success."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, terminal_only_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    result = PipelineExecutor(registry=registry, settings=settings).run(
+        pipeline,
+        repo_root=tmp_path,
+    )
+
+    assert any(
+        record.step_id == "submit" and record.status == "ran" for record in result.step_records
+    )
+    assert result.structural_approval is False
+    assert decide_approval([], run_succeeded=True, tier="trusted") == "neutral"
+    assert result.policy_verdict != "success"

--- a/tests/orchestrator/test_pipeline_file.py
+++ b/tests/orchestrator/test_pipeline_file.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
     from _pytest.monkeypatch import MonkeyPatch
 
-_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
-
 _ALLOWED_PREDICATES = (
     "changed_paths matches '**/*.py'",
     "risk_band >= medium",
@@ -33,19 +31,18 @@ _FORBIDDEN_PREDICATES = (
 )
 
 
-@_XFAIL
 def test_steps_execute_in_order(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     ordered_pipeline_yaml: str,
 ) -> None:
     """Steps run in declaration order; each dispatch is recorded."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, ordered_pipeline_yaml)
@@ -63,19 +60,18 @@ def test_steps_execute_in_order(
     assert ran == ["classify", "review", "verify", "submit"]
 
 
-@_XFAIL
 def test_conditional_step_is_skipped_with_a_recorded_reason(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     conditional_pipeline_yaml: str,
 ) -> None:
     """A false ``when`` predicate skips the step and records why."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, conditional_pipeline_yaml)
@@ -102,19 +98,18 @@ def test_conditional_step_is_skipped_with_a_recorded_reason(
     }
 
 
-@_XFAIL
 def test_fan_out_dispatches_registry_agents(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     fan_out_pipeline_yaml: str,
 ) -> None:
     """``fan_out`` dispatches each listed registry agent in parallel."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, fan_out_pipeline_yaml)
@@ -133,19 +128,18 @@ def test_fan_out_dispatches_registry_agents(
     assert set(fan_out.dispatched_agents) == {"reviewer", "verifier"}
 
 
-@_XFAIL
 def test_on_error_policies_apply(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     on_error_pipeline_yaml: str,
 ) -> None:
     """Per-step ``on_error`` policies (``continue`` vs ``fail``) are honoured."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
 
     write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
     write_pipeline_file(tmp_path, on_error_pipeline_yaml)
@@ -174,7 +168,6 @@ def test_on_error_policies_apply(
         )
 
 
-@_XFAIL
 def test_predicate_vocabulary_is_closed() -> None:
     """Convention 7 — allowed predicates parse; unknown operators are config errors."""
     from mergecraft.orchestrator.pipeline import PipelineValidationError, validate_predicate
@@ -186,7 +179,6 @@ def test_predicate_vocabulary_is_closed() -> None:
             validate_predicate(f"{predicate} OR drop database")
 
 
-@_XFAIL
 def test_predicate_cannot_execute_code() -> None:
     """Predicates are declarative only — no ``eval``, shell, or import surfaces."""
     from mergecraft.orchestrator.pipeline import PipelineValidationError, validate_predicate

--- a/tests/orchestrator/test_pipeline_file.py
+++ b/tests/orchestrator/test_pipeline_file.py
@@ -1,0 +1,196 @@
+"""AP6 declarative pipeline file — step schema, predicates and executor (PR AP6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP6, AP6.1).
+Covers ``orchestrator/pipeline.py`` (D8 step list) and ``orchestrator/executor.py``.
+Predicates use a closed vocabulary only (convention 7) — no ``eval``, shell, or imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
+
+_ALLOWED_PREDICATES = (
+    "changed_paths matches '**/*.py'",
+    "risk_band >= medium",
+    "languages includes python",
+    "analyzer_findings.severity >= Major",
+)
+
+_FORBIDDEN_PREDICATES = (
+    "eval('1')",
+    "__import__('os').system('id')",
+    "changed_paths matches '**/*.py' and exec('raise SystemExit')",
+    "os.system('curl attacker.example')",
+)
+
+
+@_XFAIL
+def test_steps_execute_in_order(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ordered_pipeline_yaml: str,
+) -> None:
+    """Steps run in declaration order; each dispatch is recorded."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, ordered_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    result = PipelineExecutor(registry=registry, settings=settings).run(
+        pipeline,
+        repo_root=tmp_path,
+    )
+
+    ran = [record.step_id for record in result.step_records if record.status == "ran"]
+    assert ran == ["classify", "review", "verify", "submit"]
+
+
+@_XFAIL
+def test_conditional_step_is_skipped_with_a_recorded_reason(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    conditional_pipeline_yaml: str,
+) -> None:
+    """A false ``when`` predicate skips the step and records why."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, conditional_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    result = PipelineExecutor(registry=registry, settings=settings).run(
+        pipeline,
+        repo_root=tmp_path,
+        classifier_signals={"changed_paths": ["README.md"]},
+    )
+
+    skipped = {
+        record.step_id: record.skip_reason
+        for record in result.step_records
+        if record.status == "skipped"
+    }
+    assert "review" in skipped
+    assert skipped["review"]
+    assert "docs-only" in {
+        record.step_id for record in result.step_records if record.status == "ran"
+    }
+
+
+@_XFAIL
+def test_fan_out_dispatches_registry_agents(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    fan_out_pipeline_yaml: str,
+) -> None:
+    """``fan_out`` dispatches each listed registry agent in parallel."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, fan_out_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    result = PipelineExecutor(registry=registry, settings=settings).run(
+        pipeline,
+        repo_root=tmp_path,
+    )
+
+    fan_out = next(record for record in result.step_records if record.step_id == "lenses")
+    assert fan_out.status == "ran"
+    assert set(fan_out.dispatched_agents) == {"reviewer", "verifier"}
+
+
+@_XFAIL
+def test_on_error_policies_apply(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    on_error_pipeline_yaml: str,
+) -> None:
+    """Per-step ``on_error`` policies (``continue`` vs ``fail``) are honoured."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path, extra_yaml="orchestrator: deterministic")
+    write_pipeline_file(tmp_path, on_error_pipeline_yaml)
+    monkeypatch.chdir(tmp_path)
+
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    executor = PipelineExecutor(registry=registry, settings=settings)
+
+    continued = executor.run(
+        pipeline,
+        repo_root=tmp_path,
+        inject_failures={"flaky"},
+    )
+    flaky = next(record for record in continued.step_records if record.step_id == "flaky")
+    assert flaky.status == "failed"
+    assert flaky.on_error_applied == "continue"
+    assert any(record.step_id == "verify" for record in continued.step_records)
+
+    with pytest.raises(Exception, match="fail"):
+        executor.run(
+            pipeline,
+            repo_root=tmp_path,
+            inject_failures={"verify"},
+        )
+
+
+@_XFAIL
+def test_predicate_vocabulary_is_closed() -> None:
+    """Convention 7 — allowed predicates parse; unknown operators are config errors."""
+    from mergecraft.orchestrator.pipeline import PipelineValidationError, validate_predicate
+
+    for predicate in _ALLOWED_PREDICATES:
+        validate_predicate(predicate)
+
+        with pytest.raises(PipelineValidationError, match=r"predicate|vocabulary|unknown"):
+            validate_predicate(f"{predicate} OR drop database")
+
+
+@_XFAIL
+def test_predicate_cannot_execute_code() -> None:
+    """Predicates are declarative only — no ``eval``, shell, or import surfaces."""
+    from mergecraft.orchestrator.pipeline import PipelineValidationError, validate_predicate
+
+    for predicate in _FORBIDDEN_PREDICATES:
+        with pytest.raises(PipelineValidationError, match=r"predicate|forbidden|executable|eval"):
+            validate_predicate(predicate)

--- a/tests/orchestrator/test_pipeline_trust.py
+++ b/tests/orchestrator/test_pipeline_trust.py
@@ -1,0 +1,123 @@
+"""AP6 pipeline trust gate — repo pipelines gated like ``setupScript`` (PR AP6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP6, AP6.1).
+Covers D9 — untrusted sources never execute a repo-supplied pipeline; the
+operator's pipeline runs instead. Mirrors ``main._run_setup_script_phase`` trust
+ordering from ``tests/security/test_trust_ordering.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
+
+
+@_XFAIL
+def test_untrusted_source_pipeline_is_ignored(
+    tmp_path: Path,
+    hostile_skip_verifier_yaml: str,
+    operator_pipeline_yaml: str,
+) -> None:
+    """D9 — repo pipeline is ignored on untrusted tier with a recorded skip reason."""
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path)
+    write_pipeline_file(tmp_path, hostile_skip_verifier_yaml, name="pipeline.yaml")
+    settings = load_repo_settings(root=tmp_path)
+    repo_pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    operator_pipeline = parse_pipeline(operator_pipeline_yaml)
+
+    effective, skip_reason = resolve_effective_pipeline(
+        settings=settings,
+        trust_tier="untrusted",
+        repo_pipeline=repo_pipeline,
+        operator_pipeline=operator_pipeline,
+        event_name="pull_request",
+    )
+
+    assert effective.step_ids() == ["review", "verify", "submit"]
+    assert "skipped" in skip_reason.lower()
+    assert "untrusted" in skip_reason.lower()
+    assert "pipeline" in skip_reason.lower()
+
+
+@_XFAIL
+def test_untrusted_pipeline_cannot_skip_the_verifier(
+    tmp_path: Path,
+    hostile_skip_verifier_yaml: str,
+    operator_pipeline_yaml: str,
+) -> None:
+    """Concrete attack — hostile repo pipeline that omits verify must not run."""
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.agents.registry import load_registry
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path)
+    write_pipeline_file(tmp_path, hostile_skip_verifier_yaml)
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    repo_pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    operator_pipeline = parse_pipeline(operator_pipeline_yaml)
+
+    effective, _skip_reason = resolve_effective_pipeline(
+        settings=settings,
+        trust_tier="untrusted",
+        repo_pipeline=repo_pipeline,
+        operator_pipeline=operator_pipeline,
+        event_name="pull_request",
+    )
+
+    result = PipelineExecutor(registry=registry, settings=settings).run(
+        effective,
+        repo_root=tmp_path,
+    )
+    ran = {record.step_id for record in result.step_records if record.status == "ran"}
+    assert "verify" in ran
+    assert result.verifier_skipped_by_repo_pipeline is False
+
+
+@_XFAIL
+def test_operator_pipeline_is_used_instead(
+    tmp_path: Path,
+    hostile_skip_verifier_yaml: str,
+    operator_pipeline_yaml: str,
+) -> None:
+    """Untrusted tier executes the operator pipeline, not the repo file."""
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
+    from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
+
+    from mergecraft.config.settings import load_repo_settings
+
+    write_repo_config(tmp_path)
+    write_pipeline_file(tmp_path, hostile_skip_verifier_yaml)
+    settings = load_repo_settings(root=tmp_path)
+    repo_pipeline = parse_pipeline((tmp_path / ".mergecraft" / "pipeline.yaml").read_text())
+    operator_pipeline = parse_pipeline(operator_pipeline_yaml)
+
+    effective, skip_reason = resolve_effective_pipeline(
+        settings=settings,
+        trust_tier="untrusted",
+        repo_pipeline=repo_pipeline,
+        operator_pipeline=operator_pipeline,
+        event_name="pull_request_target",
+    )
+
+    assert effective.source == "operator"
+    assert effective.step_ids() == operator_pipeline.step_ids()
+    assert effective.step_ids() != repo_pipeline.step_ids()
+    assert skip_reason.endswith("pull_request_target event)")

--- a/tests/orchestrator/test_pipeline_trust.py
+++ b/tests/orchestrator/test_pipeline_trust.py
@@ -10,26 +10,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 if TYPE_CHECKING:
     from pathlib import Path
 
-_XFAIL = pytest.mark.xfail(strict=True, reason="AP6.2")
 
-
-@_XFAIL
 def test_untrusted_source_pipeline_is_ignored(
     tmp_path: Path,
     hostile_skip_verifier_yaml: str,
     operator_pipeline_yaml: str,
 ) -> None:
     """D9 — repo pipeline is ignored on untrusted tier with a recorded skip reason."""
-    from mergecraft.orchestrator.pipeline import parse_pipeline
-    from mergecraft.orchestrator.trust import resolve_effective_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
 
     write_repo_config(tmp_path)
     write_pipeline_file(tmp_path, hostile_skip_verifier_yaml, name="pipeline.yaml")
@@ -51,20 +46,19 @@ def test_untrusted_source_pipeline_is_ignored(
     assert "pipeline" in skip_reason.lower()
 
 
-@_XFAIL
 def test_untrusted_pipeline_cannot_skip_the_verifier(
     tmp_path: Path,
     hostile_skip_verifier_yaml: str,
     operator_pipeline_yaml: str,
 ) -> None:
     """Concrete attack — hostile repo pipeline that omits verify must not run."""
-    from mergecraft.orchestrator.executor import PipelineExecutor
-    from mergecraft.orchestrator.pipeline import parse_pipeline
-    from mergecraft.orchestrator.trust import resolve_effective_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.agents.registry import load_registry
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.executor import PipelineExecutor
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
 
     write_repo_config(tmp_path)
     write_pipeline_file(tmp_path, hostile_skip_verifier_yaml)
@@ -90,18 +84,17 @@ def test_untrusted_pipeline_cannot_skip_the_verifier(
     assert result.verifier_skipped_by_repo_pipeline is False
 
 
-@_XFAIL
 def test_operator_pipeline_is_used_instead(
     tmp_path: Path,
     hostile_skip_verifier_yaml: str,
     operator_pipeline_yaml: str,
 ) -> None:
     """Untrusted tier executes the operator pipeline, not the repo file."""
-    from mergecraft.orchestrator.pipeline import parse_pipeline
-    from mergecraft.orchestrator.trust import resolve_effective_pipeline
     from tests.orchestrator.conftest import write_pipeline_file, write_repo_config
 
     from mergecraft.config.settings import load_repo_settings
+    from mergecraft.orchestrator.pipeline import parse_pipeline
+    from mergecraft.orchestrator.trust import resolve_effective_pipeline
 
     write_repo_config(tmp_path)
     write_pipeline_file(tmp_path, hostile_skip_verifier_yaml)


### PR DESCRIPTION
## Stop — do not merge yet

#232 and #233 merged into stacked feature branches, **not** `pre-0.0.1`. Land AP2+AP3 via **#238**, then #234 and #235 into `pre-0.0.1`, then retarget **this** PR to `pre-0.0.1` before merging. Never merge into `feature/agent-pipeline*`.

## Summary

- Adds `orchestrator: llm | deterministic | hybrid` settings (default `llm`, D10) plus declarative pipeline file schema with closed predicate vocabulary
- Implements `orchestrator/` executor walking registry-backed steps through `submit_review_verdict`, with D9 trust gate mirroring `setupScript` (untrusted sources use operator pipeline, never repo-supplied)
- Adds `mergecraft pipeline lint|show|explain` CLI and README reference table entries

## Merge into pre-0.0.1

Always `gh pr edit N --base pre-0.0.1` **before** merging PR N. A PR merges into its base ref, not into trunk.

1. Merge **#238** → `pre-0.0.1` (AP2+AP3 salvage) — https://github.com/alexhawat/mergeCraft/pull/238
2. `gh pr edit 234 --base pre-0.0.1` then merge #234
3. `gh pr edit 235 --base pre-0.0.1` then merge #235
4. `gh pr edit 236 --base pre-0.0.1` then merge **#236** (this PR)
5. `gh pr edit 237 --base pre-0.0.1` then merge #237

## Test plan

- [x] `make ci-resume` — 11/11 steps passed (lint, typecheck, pyright, agents-check, reference-docs-check, security, coverage-gate, full suite)
- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/orchestrator tests/cli/test_pipeline_verbs.py` — 15/15 passed
- [x] Runtime proof at `.ignorelocal/waves/evidence/ap6-pipeline.txt` (llm vs deterministic tokens; hostile pipeline trust gate)
- [x] `security-review` subagent — no blocking findings on pipeline trust/predicate boundaries
