### PR TITLE
feat(agents): land AP2 harness render and AP3 structured handoff on pre-0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added agent registry binding model, prompt, toolset and budget per role with `mergecraft agents list|show|set` and `make agents-check`
+- Added registry-driven harness render for Claude, OpenCode, Codex, Gemini, and Cursor with per-agent models and declared Codex degradation in run metadata
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Two ensemble models that both report no findings no longer escalate to a judge (#238)
 - Reviews of Python repositories with `shell: disabled` no longer fail closed after a completed review just because dependency installation was skipped as a security policy
 - Fixed: model-chain fallback now advances when the provider succeeds without a terminal verdict; a valid `request_changes` is a usable result and does not trigger fallback
 - Fixed: explicit `harness:` now selects the runtime agent, not only span labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added agent registry binding model, prompt, toolset and budget per role with `mergecraft agents list|show|set` and `make agents-check`
 - Added registry-driven harness render for Claude, OpenCode, Codex, Gemini, and Cursor with per-agent models and declared Codex degradation in run metadata
+- Added typed specialist handoff, model-diversity policy for verification, and ensemble or shadow dispatch modes on agent bindings
 
 ### Fixed
 

--- a/docs/test-plans/agent-pipeline-ap2.md
+++ b/docs/test-plans/agent-pipeline-ap2.md
@@ -49,7 +49,7 @@ evidence packets can distinguish prose-only collapse from toolset parity.
 
 | # | Test | Layer | Scenario | Contract |
 |---|------|-------|----------|----------|
-| 1 | `test_claude_agents_json_renders_from_registry` | integration | compatibility pin | Registry-derived Claude JSON matches `build_agents_json()` bytes for default config + class-derived deny lists |
+| 1 | `test_claude_agents_json_renders_from_registry` | integration | compatibility pin (#238) | Production ``render_agents(..., harness="claude")`` (``_render_claude``) payload matches legacy ``build_agents_json()`` bytes for default config + class-derived deny lists — not a hand-rolled registry JSON helper |
 | 2 | `test_opencode_subagents_carry_per_agent_models` | integration | P4 | Two-model override → OpenCode subagent `model` fields match `resolve_agent_model` per binding |
 | 3 | `test_codex_renders_real_subagents_or_declares_degradation` | integration | D5 | Codex payload has real subagents **or** `harness_degradations` lists `CODEX_SUBAGENT_DEGRADATION.kind` |
 | 4 | `test_gemini_and_cursor_render_or_declare` | integration | D5 parity | Gemini and Cursor each render subagent surface **or** declare per-harness degradation |
@@ -68,4 +68,5 @@ the implementation.
 AP2.1 RED suite authored (`d96c9dd`); AP2.2 implementation landed locally;
 AP2.1.5 reconciled — seven tests pass with no xfail markers. OpenCode model
 test stubs `has_credentials_for_slug` so per-binding chain resolution is
-deterministic without live provider credentials.
+deterministic without live provider credentials. #238 review pin: Claude
+byte-compat goes through production ``render_agents(..., harness="claude")``.

--- a/docs/test-plans/agent-pipeline-ap2.md
+++ b/docs/test-plans/agent-pipeline-ap2.md
@@ -3,7 +3,7 @@
 Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP2)
 Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap2`
 Authoring wave: **AP2.1** (tests-first). Implementation: **AP2.2**.
-xfail-reconciliation: **post-AP2.2** (pending).
+xfail-reconciliation: **AP2.1.5** (post-AP2.2).
 
 Locked decisions: **D2** (registry is config — only routed agents render per run),
 **D4** (where a harness cannot express a binding, fail loudly),
@@ -11,15 +11,13 @@ Locked decisions: **D2** (registry is config — only routed agents render per r
 
 ## xfail schedule
 
-All cross-wave markers are **non-strict** (`strict=False`). Reason prefix:
-`green after AP2.2: harness render`.
+All cross-wave markers removed at **AP2.1.5** (post-AP2.2).
 
-| Test file | Tests | Marker | Status at AP2.1 |
-|-----------|-------|--------|-----------------|
-| `tests/agents/test_harness_render.py` | 6 harness-render tests | `green after AP2.2: harness render` | **RED (xfail)** |
-| `tests/agents/test_harness_render.py::test_claude_agents_json_renders_from_registry` | 1 | none | **green today** — byte-identical pin |
+| Test file | Tests | Marker | Status |
+|-----------|-------|--------|--------|
+| `tests/agents/test_harness_render.py` | 7 harness-render tests | none | **green** — 7 pass; 0 xfail |
 
-**Acceptance (AP2.1):** 7 collected; 1 pass; 6 xfail. `make lint` + `make typecheck` clean.
+**Acceptance (AP2.1.5):** 7 collected; 7 pass; 0 xfail. `make lint` + `make typecheck` clean.
 
 ## Target API AP2.2 must satisfy
 
@@ -61,11 +59,13 @@ evidence packets can distinguish prose-only collapse from toolset parity.
 
 ## Imports of not-yet-existing symbols
 
-`mergecraft.agents.harness_render` symbols are imported **inside test bodies**
-(or under the xfail-marked tests) so collection succeeds before AP2.2.
+`mergecraft.agents.harness_render` symbols are imported inside test bodies so
+collection succeeds before AP2.2 lands on branches that have not yet merged
+the implementation.
 
 ## Status
 
-AP2.1 RED suite authored; AP2.2 implementation pending. Six tests xfail;
-`test_claude_agents_json_renders_from_registry` passes as the byte-identical
-compatibility pin.
+AP2.1 RED suite authored (`d96c9dd`); AP2.2 implementation landed locally;
+AP2.1.5 reconciled — seven tests pass with no xfail markers. OpenCode model
+test stubs `has_credentials_for_slug` so per-binding chain resolution is
+deterministic without live provider credentials.

--- a/docs/test-plans/agent-pipeline-ap2.md
+++ b/docs/test-plans/agent-pipeline-ap2.md
@@ -1,0 +1,71 @@
+# PR AP2 — harness render — test plan (AP2.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP2)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap2`
+Authoring wave: **AP2.1** (tests-first). Implementation: **AP2.2**.
+xfail-reconciliation: **post-AP2.2** (pending).
+
+Locked decisions: **D2** (registry is config — only routed agents render per run),
+**D4** (where a harness cannot express a binding, fail loudly),
+**D5** (Codex degradation is declared in run metadata, not hidden).
+
+## xfail schedule
+
+All cross-wave markers are **non-strict** (`strict=False`). Reason prefix:
+`green after AP2.2: harness render`.
+
+| Test file | Tests | Marker | Status at AP2.1 |
+|-----------|-------|--------|-----------------|
+| `tests/agents/test_harness_render.py` | 6 harness-render tests | `green after AP2.2: harness render` | **RED (xfail)** |
+| `tests/agents/test_harness_render.py::test_claude_agents_json_renders_from_registry` | 1 | none | **green today** — byte-identical pin |
+
+**Acceptance (AP2.1):** 7 collected; 1 pass; 6 xfail. `make lint` + `make typecheck` clean.
+
+## Target API AP2.2 must satisfy
+
+`src/mergecraft/agents/harness_render.py` (new):
+
+| Symbol | Contract |
+|--------|----------|
+| `HarnessRenderResult` | Frozen/dataclass: `harness`, `payload` (`str` or harness-shaped `dict`), `selected_agent_ids`, `metadata` |
+| `UnrenderableBindingError` | Raised when a selected binding cannot be expressed on the target harness (D4) |
+| `render_agents(registry, *, selected, harness, ctx)` | Projects only `selected` bindings (roles or agent ids) into the harness config (D2) |
+| `run_manifest_metadata(result)` | Returns the metadata dict merged into `AgentResult.metadata` / evidence run manifest |
+
+Harness-specific contracts:
+
+| Harness | Render contract |
+|---------|-----------------|
+| `claude` | `payload` is byte-identical to legacy `build_agents_json()` for default reviewer+verifier |
+| `opencode` | Subagent blocks include per-binding `model` (P4) |
+| `codex` | Real subagent dispatch **or** `metadata["harness_degradations"]` with `kind` / `toolset_parity` (D5) |
+| `gemini`, `cursor` | Subagent surface in payload **or** per-harness degradation row |
+
+`metadata["harness_degradations"]` entries must include at least
+`harness`, `kind`, `toolset_parity`, `selected_agents` so benchmarks and
+evidence packets can distinguish prose-only collapse from toolset parity.
+
+## Contract → coverage matrix
+
+### `tests/agents/test_harness_render.py` — 7 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_claude_agents_json_renders_from_registry` | integration | compatibility pin | Registry-derived Claude JSON matches `build_agents_json()` bytes for default config + class-derived deny lists |
+| 2 | `test_opencode_subagents_carry_per_agent_models` | integration | P4 | Two-model override → OpenCode subagent `model` fields match `resolve_agent_model` per binding |
+| 3 | `test_codex_renders_real_subagents_or_declares_degradation` | integration | D5 | Codex payload has real subagents **or** `harness_degradations` lists `CODEX_SUBAGENT_DEGRADATION.kind` |
+| 4 | `test_gemini_and_cursor_render_or_declare` | integration | D5 parity | Gemini and Cursor each render subagent surface **or** declare per-harness degradation |
+| 5 | `test_unrenderable_binding_fails_loudly` | unit | D4 guard-deletion | Selecting `orchestrator` for Claude harness raises `UnrenderableBindingError` |
+| 6 | `test_only_routed_agents_are_rendered` | integration | D2 | Selecting reviewer+verifier+classifier renders exactly three agents, not the full roster |
+| 7 | `test_declared_degradation_reaches_the_run_manifest` | integration | D5 manifest | `run_manifest_metadata` exposes `harness_degradations`; merge into `AgentResult.metadata` preserves Codex degradation row |
+
+## Imports of not-yet-existing symbols
+
+`mergecraft.agents.harness_render` symbols are imported **inside test bodies**
+(or under the xfail-marked tests) so collection succeeds before AP2.2.
+
+## Status
+
+AP2.1 RED suite authored; AP2.2 implementation pending. Six tests xfail;
+`test_claude_agents_json_renders_from_registry` passes as the byte-identical
+compatibility pin.

--- a/docs/test-plans/agent-pipeline-ap3.md
+++ b/docs/test-plans/agent-pipeline-ap3.md
@@ -19,9 +19,9 @@ predict/record/disagree machinery.
 |-----------|-------|--------|--------|
 | `tests/agents/test_structured_handoff.py` | 3 | — | **GREEN** |
 | `tests/agents/test_model_diversity.py` | 2 | — | **GREEN** |
-| `tests/agents/test_ensemble.py` | 6 | — | **GREEN** |
+| `tests/agents/test_ensemble.py` | 7 | — | **GREEN** |
 
-**Acceptance (post-AP3.2):** 11 collected; 11 passed; 0 xfail. `make lint` + `make typecheck` clean.
+**Acceptance (post-AP3.2 + #238 review pin):** 12 collected; 12 passed; 0 xfail. `make lint` + `make typecheck` clean.
 
 ## Target API AP3.2 must satisfy
 
@@ -74,16 +74,17 @@ Default reviewer binding sets ``output_schema == "mergecraft.agent_finding"``.
 | 4 | `test_verification_never_runs_on_the_authoring_family` | integration | #45 generalized | Same-family override rejected; diverse resolver succeeds |
 | 5 | `test_policy_holds_across_harnesses` | integration | happy | ``enforce_policy_for_harness`` for `claude`, `opencode`, `codex` |
 
-### `tests/agents/test_ensemble.py` — 6 tests
+### `tests/agents/test_ensemble.py` — 7 tests
 
 | # | Test | Layer | Scenario | Contract |
 |---|------|-------|----------|----------|
 | 6 | `test_ensemble_runs_the_same_agent_on_two_models` | integration | happy | ``dispatch: ensemble`` runs two chain slugs |
 | 7 | `test_agreement_raises_confidence` | unit | happy | ``reconcile_ensemble`` → ``agreement=True``, ``confidence_boost > 0`` |
 | 8 | `test_disagreement_is_routed_to_the_judge` | unit | edge | Disagreement → ``judge_dispatch`` with both briefs |
-| 9 | `test_shadow_model_output_is_recorded_but_never_acted_on` | integration | shadow | Shadow row on disk; ``acted_findings`` == primary only |
-| 10 | `test_orchestrator_cannot_be_ensembled` | unit | D7 guard-deletion | Orchestrator → ``EnsembleCardinalityError`` |
-| 11 | `test_ensemble_respects_the_agent_budget` | integration | CC3 | Total findings ≤ binding ``budget`` |
+| 9 | `test_empty_vs_empty_is_agreement_without_confidence_boost` | unit | edge (#238) | Empty-vs-empty → ``agreement=True``, ``confidence_boost == 0``, ``judge_dispatch is None``, empty ``merged_findings`` |
+| 10 | `test_shadow_model_output_is_recorded_but_never_acted_on` | integration | shadow | Shadow row on disk; ``acted_findings`` == primary only |
+| 11 | `test_orchestrator_cannot_be_ensembled` | unit | D7 guard-deletion | Orchestrator → ``EnsembleCardinalityError`` |
+| 12 | `test_ensemble_respects_the_agent_budget` | integration | CC3 | Total findings ≤ binding ``budget`` |
 
 ## Imports of not-yet-existing symbols
 
@@ -93,4 +94,6 @@ collection succeeds before AP3.2.
 
 ## Status
 
-AP3.1 suite authored; AP3.2 implementation landed; xfail markers removed (11 passed).
+AP3.1 suite authored; AP3.2 implementation landed; xfail markers removed.
+#238 review pin: empty-vs-empty ensemble is agreement without a confidence boost
+(12 collected: 3+2+7).

--- a/docs/test-plans/agent-pipeline-ap3.md
+++ b/docs/test-plans/agent-pipeline-ap3.md
@@ -15,13 +15,13 @@ predict/record/disagree machinery.
 
 ## xfail schedule
 
-| Test file | Tests | Marker | Status at AP3.1 |
-|-----------|-------|--------|-------------------|
-| `tests/agents/test_structured_handoff.py` | 3 | `green after AP3.2: structured handoff` | **RED (xfail)** |
-| `tests/agents/test_model_diversity.py` | 2 | `green after AP3.2: model diversity` | **RED (xfail)** |
-| `tests/agents/test_ensemble.py` | 6 | `green after AP3.2: ensemble dispatch` | **RED (xfail)** |
+| Test file | Tests | Marker | Status |
+|-----------|-------|--------|--------|
+| `tests/agents/test_structured_handoff.py` | 3 | — | **GREEN** |
+| `tests/agents/test_model_diversity.py` | 2 | — | **GREEN** |
+| `tests/agents/test_ensemble.py` | 6 | — | **GREEN** |
 
-**Acceptance (AP3.1):** 11 collected; 0 pass; 11 xfail. `make lint` + `make typecheck` clean.
+**Acceptance (post-AP3.2):** 11 collected; 11 passed; 0 xfail. `make lint` + `make typecheck` clean.
 
 ## Target API AP3.2 must satisfy
 
@@ -93,4 +93,4 @@ collection succeeds before AP3.2.
 
 ## Status
 
-AP3.1 RED suite authored; awaiting AP3.2 implementation and xfail reconciliation.
+AP3.1 suite authored; AP3.2 implementation landed; xfail markers removed (11 passed).

--- a/docs/test-plans/agent-pipeline-ap3.md
+++ b/docs/test-plans/agent-pipeline-ap3.md
@@ -1,0 +1,96 @@
+# PR AP3 — structured handoff, model diversity, ensemble dispatch — test plan (AP3.1)
+
+Wave plan: `.ignorelocal/03-agent-pipeline-wave-plan.md` (PR AP3)
+Worktree: `../mergecraft-agent-pipeline` @ `feature/agent-pipeline-ap3`
+Authoring wave: **AP3.1** (tests-first). Implementation: **AP3.2**.
+xfail-reconciliation: **post-AP3.2**.
+
+Locked decisions: **D6** (structure the hand-off, not the reasoning — free-form
+discovery, typed ``AgentFinding`` emission at the boundary), **D7** (ensembles
+never include the orchestrator; ``ensemble`` / ``shadow`` for discovery and
+verification only), dispatch modes ``single`` (default), ``ensemble``, ``shadow``
+on ``AgentBinding``, model diversity (verification must not share the authoring
+model family — generalizes #45), shadow reuses ``evidence/shadow.py``
+predict/record/disagree machinery.
+
+## xfail schedule
+
+| Test file | Tests | Marker | Status at AP3.1 |
+|-----------|-------|--------|-------------------|
+| `tests/agents/test_structured_handoff.py` | 3 | `green after AP3.2: structured handoff` | **RED (xfail)** |
+| `tests/agents/test_model_diversity.py` | 2 | `green after AP3.2: model diversity` | **RED (xfail)** |
+| `tests/agents/test_ensemble.py` | 6 | `green after AP3.2: ensemble dispatch` | **RED (xfail)** |
+
+**Acceptance (AP3.1):** 11 collected; 0 pass; 11 xfail. `make lint` + `make typecheck` clean.
+
+## Target API AP3.2 must satisfy
+
+### `src/mergecraft/agents/structured_handoff.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `SpecialistHandoff` | Dataclass/model: ``reasoning`` (prose) + ``findings: list[AgentFinding]`` |
+| `parse_specialist_handoff(raw)` | Split prose from ``---typed-findings---`` tail; validate ``AgentFinding`` rows |
+| `build_specialist_dispatch_prompt(binding)` | Discovery brief — **no** finding schema, ``set_output``, or JSON schema (D6) |
+| `verification_plan_from_handoff(handoff, *, budget)` | Bridge to ``plan_agent_verifications`` |
+
+Default reviewer binding sets ``output_schema == "mergecraft.agent_finding"``.
+
+### `src/mergecraft/agents/model_diversity.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `ModelDiversityViolation` | Raised when verification shares the authoring provider family |
+| `assert_verification_diverse(authoring_slug, verification_slug)` | Guard — same family is rejected (#45 generalized) |
+| `resolve_diverse_verification_model(authoring_slug, *, registry, settings)` | Pick a verifier slug in a different family |
+| `enforce_policy_for_harness(registry, *, settings, harness)` | Harness-agnostic policy check (`claude`, `opencode`, `codex`, …) |
+
+### `src/mergecraft/agents/ensemble.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `EnsembleRun` / `ModelRun` | Per-model findings from one binding |
+| `plan_ensemble_models(binding, *, settings)` | Two distinct slugs from the binding chain |
+| `run_ensemble_dispatch(binding, *, registry, settings, execute)` | Fan-out dispatch respecting binding budget (CC3) |
+| `reconcile_ensemble(run)` | Agreement → ``confidence_boost``; disagreement → ``judge_dispatch`` |
+| `run_shadow_dispatch(binding, *, registry, settings, execute, record_path)` | Primary acted; shadow recorded via ``record_shadow_prediction`` |
+| `validate_ensemble_eligible(binding)` | **D7** — raises ``EnsembleCardinalityError`` for orchestrator |
+| `EnsembleCardinalityError` | Cardinality guard when orchestrator is ensembled |
+
+## Contract → coverage matrix
+
+### `tests/agents/test_structured_handoff.py` — 3 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_specialist_returns_typed_findings` | unit + integration | D6 happy | Prose preserved; typed tail → ``AgentFinding`` via ``output_schema`` |
+| 2 | `test_free_form_discovery_is_not_constrained` | unit | D6 guard-deletion | Discovery prompt lacks schema / ``set_output`` / ``"findings"`` |
+| 3 | `test_typed_findings_feed_the_verifier_directly` | integration | happy | ``verification_plan_from_handoff`` queues verifier dispatches with rubric brief |
+
+### `tests/agents/test_model_diversity.py` — 2 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 4 | `test_verification_never_runs_on_the_authoring_family` | integration | #45 generalized | Same-family override rejected; diverse resolver succeeds |
+| 5 | `test_policy_holds_across_harnesses` | integration | happy | ``enforce_policy_for_harness`` for `claude`, `opencode`, `codex` |
+
+### `tests/agents/test_ensemble.py` — 6 tests
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 6 | `test_ensemble_runs_the_same_agent_on_two_models` | integration | happy | ``dispatch: ensemble`` runs two chain slugs |
+| 7 | `test_agreement_raises_confidence` | unit | happy | ``reconcile_ensemble`` → ``agreement=True``, ``confidence_boost > 0`` |
+| 8 | `test_disagreement_is_routed_to_the_judge` | unit | edge | Disagreement → ``judge_dispatch`` with both briefs |
+| 9 | `test_shadow_model_output_is_recorded_but_never_acted_on` | integration | shadow | Shadow row on disk; ``acted_findings`` == primary only |
+| 10 | `test_orchestrator_cannot_be_ensembled` | unit | D7 guard-deletion | Orchestrator → ``EnsembleCardinalityError`` |
+| 11 | `test_ensemble_respects_the_agent_budget` | integration | CC3 | Total findings ≤ binding ``budget`` |
+
+## Imports of not-yet-existing symbols
+
+``mergecraft.agents.structured_handoff``, ``mergecraft.agents.model_diversity``, and
+``mergecraft.agents.ensemble`` symbols are imported inside test bodies so
+collection succeeds before AP3.2.
+
+## Status
+
+AP3.1 RED suite authored; awaiting AP3.2 implementation and xfail reconciliation.

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -100,7 +100,15 @@ def build_agents_json(
     *,
     verifier_denied_tools: Sequence[str] = (),
     subagent_denied_tools: Sequence[str] = (),
+    agents_json: str | None = None,
 ) -> str:
+    """Return Claude ``--agents`` JSON for reviewer and verifier subagents.
+
+    When ``agents_json`` is supplied (registry render from AP2), return it
+    verbatim for backward-compatible call sites.
+    """
+    if agents_json is not None:
+        return agents_json
     verifier: dict[str, Any] = {
         "description": (
             "Read-only verification subagent for Critical/Major analyzer, CI and "
@@ -630,9 +638,17 @@ def _run_claude_once(
     mcp_config: str,
     continue_session: bool = False,
 ) -> AgentResult:
+    from mergecraft.agents.harness_render import render_for_run
+
+    harness_render = render_for_run(ctx, "claude")
     model = None
     if ctx.resolved_model:
         model = _strip_provider_prefix(ctx.resolved_model)
+    agents_payload = (
+        harness_render.payload
+        if isinstance(harness_render.payload, str)
+        else json.dumps(harness_render.payload)
+    )
     cmd = [
         cli,
         "--print",
@@ -646,6 +662,7 @@ def _run_claude_once(
         build_agents_json(
             verifier_denied_tools=ctx.verifier_denied_tools,
             subagent_denied_tools=ctx.subagent_denied_tools,
+            agents_json=agents_payload,
         ),
         "--effort",
         "high",

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -253,7 +253,9 @@ def _codex_mcp_tool_preamble() -> str:
     )
 
 
-def _build_subagent_instructions() -> str:
+def _build_subagent_instructions(subagent_block: str | None = None) -> str:
+    if subagent_block is not None:
+        return subagent_block
     return "\n\n".join(
         [
             "Registered read-only subagents (spawn via Codex subagent tooling when needed):",
@@ -452,7 +454,11 @@ def _append_read_only_mcp_network_lines(lines: list[str]) -> None:
     )
 
 
-def write_mcp_config(ctx: AgentRunContext) -> str:
+def write_mcp_config(
+    ctx: AgentRunContext,
+    *,
+    subagent_block: str | None = None,
+) -> str:
     """Write Codex ``config.toml`` under ``$CODEX_HOME`` and return its path."""
     codex_home = _codex_home(ctx)
     codex_home.mkdir(parents=True, exist_ok=True)
@@ -461,7 +467,7 @@ def write_mcp_config(ctx: AgentRunContext) -> str:
         instructions_parts.append(_codex_mcp_tool_preamble())
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
-    instructions_parts.append(_build_subagent_instructions())
+    instructions_parts.append(_build_subagent_instructions(subagent_block))
     instructions_path = codex_home / "mergecraft-instructions.md"
     instructions_path.write_text("\n\n".join(instructions_parts), encoding="utf-8")
 
@@ -970,12 +976,16 @@ def _codex_stream_event_handler(
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    mcp_config = write_mcp_config(ctx)
+    render_result = render_for_run(ctx, "codex")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    mcp_config = write_mcp_config(ctx, subagent_block=subagent_block)
     # Blocking Popen/wait/stream consume runs in a worker thread so
     # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
     initial = await asyncio.to_thread(
@@ -997,7 +1007,8 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         )
 
     result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
-    return await finalize_agent_result(ctx, result)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 codex = agent(name="codex", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/cursor.py
+++ b/src/mergecraft/agents/cursor.py
@@ -83,11 +83,13 @@ def _starting_ref_from_ctx(ctx: AgentRunContext) -> str:
     return "main"
 
 
-def _build_review_prompt(ctx: AgentRunContext) -> str:
+def _build_review_prompt(ctx: AgentRunContext, *, subagent_block: str | None = None) -> str:
     parts: list[str] = []
     system = getattr(ctx.instructions, "system", "")
     if isinstance(system, str) and system.strip():
         parts.append(system.strip())
+    if subagent_block:
+        parts.append(subagent_block)
     user = getattr(ctx.instructions, "user", "")
     if isinstance(user, str) and user.strip():
         parts.append(user.strip())
@@ -171,7 +173,11 @@ async def _poll_run_to_terminal(
     raise TimeoutError(msg)
 
 
-async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
+async def _run_cursor_once(
+    *,
+    ctx: AgentRunContext,
+    subagent_block: str | None = None,
+) -> AgentResult:
     api_key = resolve_cursor_api_key()
     if not api_key:
         return AgentResult(
@@ -183,7 +189,7 @@ async def _run_cursor_once(*, ctx: AgentRunContext) -> AgentResult:
         )
 
     client = CursorCloudClient(api_key=api_key)
-    prompt = _build_review_prompt(ctx)
+    prompt = _build_review_prompt(ctx, subagent_block=subagent_block)
     repo_url = _repo_url_from_ctx(ctx)
     starting_ref = _starting_ref_from_ctx(ctx)
     model_id = _resolve_cloud_model_id(ctx)
@@ -275,13 +281,18 @@ async def _install(_token: str | None = None) -> str:
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    result = await _run_cursor_once(ctx=ctx)
-    return await finalize_agent_result(ctx, result)
+    render_result = render_for_run(ctx, "cursor")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    result = await _run_cursor_once(ctx=ctx, subagent_block=subagent_block)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 cursor = agent(name="cursor", install=_install, run=_run)

--- a/src/mergecraft/agents/ensemble.py
+++ b/src/mergecraft/agents/ensemble.py
@@ -1,0 +1,288 @@
+"""Ensemble and shadow dispatch for registry agents (AP3, D7).
+
+``dispatch: ensemble`` runs one binding on two models from its chain; agreement
+raises confidence, disagreement routes to the judge. ``dispatch: shadow`` records
+alternate-model output via ``evidence.shadow`` without acting on it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from mergecraft.agents.registry import AgentRole, resolve_agent_model
+from mergecraft.evidence.shadow import ShadowRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.agents.registry import AgentBinding, Registry
+    from mergecraft.config.settings import RepoSettings
+
+ExecuteFn = Callable[..., list[dict[str, object]]]
+
+
+class EnsembleCardinalityError(ValueError):
+    """Raised when ensemble/shadow dispatch targets the orchestrator (D7)."""
+
+
+class ModelRun(BaseModel):
+    """Findings returned by one model in an ensemble fan-out."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    findings: tuple[dict[str, object], ...] = ()
+
+
+class EnsembleRun(BaseModel):
+    """Per-model results from one ensemble dispatch."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_id: str
+    model_runs: tuple[ModelRun, ...] = ()
+
+
+class JudgeDispatch(BaseModel):
+    """Brief routed to the judge when ensemble models disagree."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["judge"] = "judge"
+    brief: str
+
+
+class EnsembleReconciliation(BaseModel):
+    """Merged ensemble outcome — agreement signal or judge escalation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agreement: bool
+    confidence_boost: float = 0.0
+    merged_findings: tuple[dict[str, object], ...] = ()
+    judge_dispatch: JudgeDispatch | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDispatchResult:
+    """Primary findings acted on; shadow findings recorded only."""
+
+    primary_findings: list[dict[str, object]]
+    acted_findings: list[dict[str, object]]
+    shadow_model: str
+    shadow_findings: list[dict[str, object]]
+
+
+_ENSEMBLE_ELIGIBLE_ROLES: frozenset[AgentRole] = frozenset(
+    {
+        AgentRole.reviewer,
+        AgentRole.verifier,
+        AgentRole.judge,
+        AgentRole.classifier,
+    }
+)
+
+
+def validate_ensemble_eligible(binding: AgentBinding) -> None:
+    """Reject ensemble/shadow on orchestrator bindings (D7)."""
+    if binding.role is AgentRole.orchestrator:
+        msg = (
+            f"orchestrator agent {binding.agent_id!r} cannot use ensemble or shadow "
+            "dispatch — two orchestrators violate the terminal cardinality rule (D7)"
+        )
+        raise EnsembleCardinalityError(msg)
+    if binding.role not in _ENSEMBLE_ELIGIBLE_ROLES:
+        msg = f"agent {binding.agent_id!r} is not eligible for ensemble dispatch"
+        raise ValueError(msg)
+
+
+def plan_ensemble_models(
+    binding: AgentBinding,
+    *,
+    settings: RepoSettings,
+) -> tuple[str, str]:
+    """Return two distinct runnable slugs from the binding chain."""
+    from mergecraft.utils.agent_resolve import pick_runnable_slug_from_chain
+
+    validate_ensemble_eligible(binding)
+    chain = list(binding.model_chain)
+    if len(chain) < 2:
+        msg = f"ensemble dispatch requires at least two models on {binding.agent_id!r}"
+        raise ValueError(msg)
+
+    primary = resolve_agent_model(binding, settings=settings).dispatched_model
+    secondary: str | None = None
+    for slug in chain:
+        if slug == binding.model_chain[0]:
+            continue
+        runnable = pick_runnable_slug_from_chain(
+            [slug],
+            allow_fallback=settings.allow_fallback,
+        )
+        if runnable is not None and runnable != primary:
+            secondary = runnable
+            break
+
+    if secondary is None:
+        msg = f"ensemble dispatch could not resolve a second model for {binding.agent_id!r}"
+        raise ValueError(msg)
+
+    return primary, secondary
+
+
+def _cap_findings(
+    rows: list[dict[str, object]],
+    *,
+    budget: int,
+    remaining: int,
+) -> tuple[list[dict[str, object]], int]:
+    if remaining <= 0:
+        return [], 0
+    capped = rows[:remaining]
+    return capped, remaining - len(capped)
+
+
+def run_ensemble_dispatch(
+    binding: AgentBinding,
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    execute: ExecuteFn,
+) -> EnsembleRun:
+    """Fan out one binding to two models, honouring the binding budget (CC3)."""
+    del registry
+    validate_ensemble_eligible(binding)
+    primary, secondary = plan_ensemble_models(binding, settings=settings)
+    remaining = max(binding.budget, 0)
+    model_runs: list[ModelRun] = []
+
+    for model in (primary, secondary):
+        raw = list(execute(model=model))
+        capped, remaining = _cap_findings(raw, budget=binding.budget, remaining=remaining)
+        model_runs.append(ModelRun(model=model, findings=tuple(capped)))
+
+    return EnsembleRun(agent_id=binding.agent_id, model_runs=tuple(model_runs))
+
+
+def _finding_key(row: dict[str, object]) -> tuple[str, str]:
+    path = str(row.get("path", ""))
+    body = str(row.get("body", ""))
+    return path, body
+
+
+def reconcile_ensemble(run: EnsembleRun) -> EnsembleReconciliation:
+    """Merge ensemble runs — agreement boosts confidence; disagreement → judge."""
+    if len(run.model_runs) < 2:
+        merged = tuple(run.model_runs[0].findings) if run.model_runs else ()
+        return EnsembleReconciliation(agreement=True, merged_findings=merged)
+
+    left, right = run.model_runs[0], run.model_runs[1]
+    left_keys = {_finding_key(row) for row in left.findings}
+    right_keys = {_finding_key(row) for row in right.findings}
+    agreement = left_keys == right_keys and bool(left_keys)
+
+    if agreement:
+        merged = left.findings
+        return EnsembleReconciliation(
+            agreement=True,
+            confidence_boost=0.25,
+            merged_findings=merged,
+        )
+
+    brief_parts = [
+        "Two ensemble models disagreed on findings for the same agent dispatch.",
+        "",
+        f"### Model {left.model}",
+        "",
+    ]
+    for row in left.findings:
+        brief_parts.append(f"- `{row.get('path')}`: {row.get('body')}")
+    brief_parts.extend(["", f"### Model {right.model}", ""])
+    for row in right.findings:
+        brief_parts.append(f"- `{row.get('path')}`: {row.get('body')}")
+    brief_parts.append("")
+    brief_parts.append("Return confirm / downgrade / drop for each disputed finding.")
+
+    return EnsembleReconciliation(
+        agreement=False,
+        merged_findings=tuple(left.findings),
+        judge_dispatch=JudgeDispatch(brief="\n".join(brief_parts)),
+    )
+
+
+def _record_ensemble_shadow(
+    *,
+    record_path: Path,
+    run_id: str,
+    change_id: str,
+    policy_id: str,
+    shadow_model: str,
+    shadow_findings: list[dict[str, object]],
+) -> ShadowRecord:
+    record = ShadowRecord(
+        run_id=run_id,
+        change_id=change_id,
+        policy_id=policy_id,
+        rule_id="ensemble_shadow",
+        action="shadow",
+        lane="ensemble",
+        repo_area=policy_id,
+        metadata={"shadow_model": shadow_model, "shadow_model_findings": shadow_findings},
+    )
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    with record_path.open("a", encoding="utf-8") as handle:
+        handle.write(record.model_dump_json())
+        handle.write("\n")
+    return record
+
+
+def run_shadow_dispatch(
+    binding: AgentBinding,
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    execute: ExecuteFn,
+    record_path: Path,
+    run_id: str = "ensemble-shadow",
+    change_id: str = "shadow-dispatch",
+    policy_id: str = "ensemble.shadow",
+) -> ShadowDispatchResult:
+    """Run primary model for action; record shadow model output only."""
+    del registry
+    validate_ensemble_eligible(binding)
+    primary, secondary = plan_ensemble_models(binding, settings=settings)
+    primary_findings = list(execute(model=primary, primary=True))
+    shadow_findings = list(execute(model=secondary, primary=False))
+    _record_ensemble_shadow(
+        record_path=record_path,
+        run_id=run_id,
+        change_id=change_id,
+        policy_id=policy_id,
+        shadow_model=secondary,
+        shadow_findings=shadow_findings,
+    )
+    return ShadowDispatchResult(
+        primary_findings=primary_findings,
+        acted_findings=list(primary_findings),
+        shadow_model=secondary,
+        shadow_findings=shadow_findings,
+    )
+
+
+__all__ = [
+    "EnsembleCardinalityError",
+    "EnsembleReconciliation",
+    "EnsembleRun",
+    "JudgeDispatch",
+    "ModelRun",
+    "ShadowDispatchResult",
+    "plan_ensemble_models",
+    "reconcile_ensemble",
+    "run_ensemble_dispatch",
+    "run_shadow_dispatch",
+    "validate_ensemble_eligible",
+]

--- a/src/mergecraft/agents/ensemble.py
+++ b/src/mergecraft/agents/ensemble.py
@@ -183,14 +183,14 @@ def reconcile_ensemble(run: EnsembleRun) -> EnsembleReconciliation:
     left, right = run.model_runs[0], run.model_runs[1]
     left_keys = {_finding_key(row) for row in left.findings}
     right_keys = {_finding_key(row) for row in right.findings}
-    agreement = left_keys == right_keys and bool(left_keys)
-
-    if agreement:
-        merged = left.findings
+    if left_keys == right_keys:
+        # Empty-vs-empty is agreement (both found nothing) but not a
+        # confidence boost — there is no corroborated finding set.
+        boost = 0.25 if left_keys else 0.0
         return EnsembleReconciliation(
             agreement=True,
-            confidence_boost=0.25,
-            merged_findings=merged,
+            confidence_boost=boost,
+            merged_findings=left.findings,
         )
 
     brief_parts = [

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -59,7 +59,9 @@ def _gemini_home(ctx: AgentRunContext) -> Path:
     return Path(ctx.tmpdir) / ".gemini"
 
 
-def _build_subagent_instructions() -> str:
+def _build_subagent_instructions(subagent_block: str | None = None) -> str:
+    if subagent_block is not None:
+        return subagent_block
     return "\n\n".join(
         [
             "Registered read-only subagents (spawn when needed):",
@@ -71,11 +73,11 @@ def _build_subagent_instructions() -> str:
     )
 
 
-def _build_instruction_text(ctx: AgentRunContext) -> str:
+def _build_instruction_text(ctx: AgentRunContext, *, subagent_block: str | None = None) -> str:
     instructions_parts: list[str] = []
     if ctx.instructions.system:
         instructions_parts.append(ctx.instructions.system)
-    instructions_parts.append(_build_subagent_instructions())
+    instructions_parts.append(_build_subagent_instructions(subagent_block))
     return "\n\n".join(instructions_parts)
 
 
@@ -87,12 +89,19 @@ def _build_gemini_prompt(ctx: AgentRunContext, prompt: str) -> str:
     return "\n\n".join(sections)
 
 
-def write_mcp_config(ctx: AgentRunContext) -> str:
+def write_mcp_config(
+    ctx: AgentRunContext,
+    *,
+    subagent_block: str | None = None,
+) -> str:
     """Write Gemini ``settings.json`` under the run temp dir and return its path."""
     gemini_home = _gemini_home(ctx)
     gemini_home.mkdir(parents=True, exist_ok=True)
     instructions_path = gemini_home / "GEMINI.md"
-    instructions_path.write_text(_build_instruction_text(ctx), encoding="utf-8")
+    instructions_path.write_text(
+        _build_instruction_text(ctx, subagent_block=subagent_block),
+        encoding="utf-8",
+    )
 
     server_config: dict[str, object] = {
         "httpUrl": ctx.mcp_server_url,
@@ -549,12 +558,16 @@ def _gemini_stream_event_handler(
 
 
 async def _run(ctx: AgentRunContext) -> AgentResult:
+    from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
+
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    write_mcp_config(ctx)
+    render_result = render_for_run(ctx, "gemini")
+    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+    write_mcp_config(ctx, subagent_block=subagent_block)
     # Blocking Popen/wait/stream consume runs in a worker thread so
     # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
     initial = await asyncio.to_thread(
@@ -576,7 +589,8 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         )
 
     result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
-    return await finalize_agent_result(ctx, result)
+    finalized = await finalize_agent_result(ctx, result)
+    return merge_manifest_metadata(finalized, render_result)
 
 
 gemini = agent(name="gemini", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/harness_render.py
+++ b/src/mergecraft/agents/harness_render.py
@@ -1,0 +1,393 @@
+"""Render registry bindings into per-harness subagent configuration (AP2).
+
+Projects only the routed roster (D2) into each driver's native shape. Where a
+harness cannot express a binding, raises :class:`UnrenderableBindingError` (D4).
+Codex/Gemini/Cursor prose-only subagent paths record declared degradation in
+``metadata`` for the run manifest (D5).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from mergecraft.agents.registry import (
+    AgentBinding,
+    AgentRole,
+    Registry,
+    resolve_agent_model,
+    resolve_prompt_text,
+)
+from mergecraft.agents.shared import AgentResult, AgentRunContext
+from mergecraft.agents.verifier import (
+    VERIFIER_RUBRIC_VERSION,
+    pinned_judge_model,
+)
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.types import format_mcp_tool_ref
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from mergecraft.mcp.context import ToolContext
+
+HarnessName = Literal["claude", "opencode", "codex", "gemini", "cursor"]
+
+_REVIEWER_DESCRIPTION = (
+    "Read-only review subagent for lens-based code review. "
+    "Reads only — no writes, no state-changing shell or MCP calls."
+)
+
+_VERIFIER_DESCRIPTION = (
+    "Read-only verification subagent for Critical/Major analyzer, CI and "
+    "agent-authored findings. Confirms, downgrades, or drops before "
+    f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
+)
+
+_CLASSIFIER_DESCRIPTION = (
+    "Read-only change classifier subagent. Emits a typed risk and change map for lens routing."
+)
+
+_PROSE_ONLY_HARNESSES: frozenset[HarnessName] = frozenset({"codex", "gemini", "cursor"})
+
+_CLAUDE_UNRENDERABLE_ROLES: frozenset[AgentRole] = frozenset({AgentRole.orchestrator})
+
+
+class UnrenderableBindingError(ValueError):
+    """A selected binding cannot be expressed on the target harness (D4)."""
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRenderResult:
+    """One harness projection of a routed agent roster."""
+
+    harness: HarnessName
+    payload: str | dict[str, Any]
+    selected_agent_ids: tuple[str, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def run_manifest_metadata(result: HarnessRenderResult) -> dict[str, Any]:
+    """Return metadata merged into ``AgentResult.metadata`` / evidence manifest."""
+    if not result.metadata:
+        return {}
+    return dict(result.metadata)
+
+
+def _repo_root_from_ctx(ctx: AgentRunContext | ToolContext) -> Path | None:
+    tool_state = getattr(ctx, "tool_state", None)
+    if tool_state is not None:
+        repo = primary_repo_state(tool_state)
+        if repo.dir:
+            return Path(repo.dir)
+    tmpdir = getattr(ctx, "tmpdir", None)
+    if tmpdir:
+        return Path(tmpdir)
+    return None
+
+
+def _settings_for_ctx(ctx: AgentRunContext | ToolContext) -> Any:
+    root = _repo_root_from_ctx(ctx)
+    if root is not None:
+        return load_repo_settings(root=root)
+    from mergecraft.config.settings import default_settings
+
+    return default_settings()
+
+
+def _resolve_selected_bindings(
+    registry: Registry,
+    selected: Sequence[str],
+) -> list[AgentBinding]:
+    bindings: list[AgentBinding] = []
+    role_values = {role.value for role in AgentRole}
+    by_id = {binding.agent_id: binding for binding in registry.all_bindings()}
+    for key in selected:
+        if key in role_values:
+            bindings.append(registry.resolve_role(key))
+            continue
+        if key in by_id:
+            bindings.append(by_id[key])
+            continue
+        for binding in registry.all_bindings():
+            if binding.agent_id == key:
+                bindings.append(binding)
+                break
+        else:
+            msg = f"no registry binding for selected agent {key!r}"
+            raise KeyError(msg)
+    return bindings
+
+
+def _denied_tool_names(
+    ctx: AgentRunContext | ToolContext,
+    binding: AgentBinding,
+) -> list[str]:
+    from mergecraft.agents.gates import subagent_denied_tool_names
+    from mergecraft.agents.verifier import verifier_denied_tool_names
+
+    if isinstance(ctx, AgentRunContext):
+        if binding.role in (AgentRole.verifier, AgentRole.judge):
+            return list(ctx.verifier_denied_tools)
+        return list(ctx.subagent_denied_tools)
+    if binding.role in (AgentRole.verifier, AgentRole.judge):
+        return verifier_denied_tool_names(ctx)
+    return subagent_denied_tool_names(ctx)
+
+
+def _strip_provider_prefix(specifier: str) -> str:
+    slash = specifier.find("/")
+    return specifier[slash + 1 :] if slash > 0 else specifier
+
+
+def _harness_dispatched_model(binding: AgentBinding, settings: Any) -> str:
+    """Return the model slug written into harness config (declared intent, not runtime pick)."""
+    chain = list(binding.model_chain)
+    if not chain:
+        msg = f"empty model_chain on agent {binding.agent_id!r}"
+        raise RuntimeError(msg)
+    try:
+        return resolve_agent_model(binding, settings=settings).dispatched_model
+    except RuntimeError:
+        return chain[0]
+
+
+def _claude_harness_model(binding: AgentBinding, settings: Any) -> str:
+    if binding.role is AgentRole.verifier:
+        return pinned_judge_model("claude") or "claude-sonnet-5"
+    if binding.role is AgentRole.reviewer:
+        return "claude-sonnet-5"
+    return _strip_provider_prefix(_harness_dispatched_model(binding, settings))
+
+
+def _role_description(binding: AgentBinding) -> str:
+    match binding.role:
+        case AgentRole.reviewer:
+            return _REVIEWER_DESCRIPTION
+        case AgentRole.verifier | AgentRole.judge:
+            return _VERIFIER_DESCRIPTION
+        case AgentRole.classifier:
+            return _CLASSIFIER_DESCRIPTION
+        case AgentRole.orchestrator:
+            return "Orchestrator agent."
+    return f"mergeCraft {binding.role.value} agent."
+
+
+def _claude_agent_entry(
+    binding: AgentBinding,
+    *,
+    settings: Any,
+    denied_tools: Sequence[str],
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "description": _role_description(binding),
+        "prompt": resolve_prompt_text(
+            binding.prompt_id,
+            version=binding.prompt_version,
+        ),
+        "model": _claude_harness_model(binding, settings),
+    }
+    denied = [format_mcp_tool_ref("claude", name) for name in denied_tools]
+    if denied:
+        entry["disallowedTools"] = denied
+    return entry
+
+
+def _render_claude(
+    bindings: Sequence[AgentBinding],
+    *,
+    ctx: AgentRunContext | ToolContext,
+    settings: Any,
+) -> HarnessRenderResult:
+    agents: dict[str, Any] = {}
+    selected_ids: list[str] = []
+    for binding in bindings:
+        if binding.role in _CLAUDE_UNRENDERABLE_ROLES:
+            msg = (
+                f"claude harness cannot render orchestrator binding "
+                f"{binding.agent_id!r} as a subagent (D4)"
+            )
+            raise UnrenderableBindingError(msg)
+        denied = _denied_tool_names(ctx, binding)
+        agents[binding.agent_id] = _claude_agent_entry(
+            binding,
+            settings=settings,
+            denied_tools=denied,
+        )
+        selected_ids.append(binding.agent_id)
+    return HarnessRenderResult(
+        harness="claude",
+        payload=json.dumps(agents),
+        selected_agent_ids=tuple(selected_ids),
+    )
+
+
+def _opencode_agent_entry(
+    binding: AgentBinding,
+    *,
+    settings: Any,
+    denied_tools: Sequence[str],
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "description": _role_description(binding),
+        "prompt": resolve_prompt_text(
+            binding.prompt_id,
+            version=binding.prompt_version,
+        ),
+        "mode": "subagent",
+        "model": _harness_dispatched_model(binding, settings),
+    }
+    denied = {format_mcp_tool_ref("opencode", name): "deny" for name in denied_tools}
+    if denied:
+        entry["permission"] = denied
+    return entry
+
+
+def _render_opencode(
+    bindings: Sequence[AgentBinding],
+    *,
+    ctx: AgentRunContext | ToolContext,
+    settings: Any,
+) -> HarnessRenderResult:
+    agents: dict[str, Any] = {}
+    selected_ids: list[str] = []
+    for binding in bindings:
+        denied = _denied_tool_names(ctx, binding)
+        agents[binding.agent_id] = _opencode_agent_entry(
+            binding,
+            settings=settings,
+            denied_tools=denied,
+        )
+        selected_ids.append(binding.agent_id)
+    return HarnessRenderResult(
+        harness="opencode",
+        payload={"agent": agents},
+        selected_agent_ids=tuple(selected_ids),
+    )
+
+
+def _prose_subagent_instructions(bindings: Sequence[AgentBinding]) -> str:
+    parts = [
+        "Registered read-only subagents (spawn via subagent tooling when needed):",
+    ]
+    for binding in bindings:
+        parts.append(f"## {binding.agent_id}")
+        parts.append(
+            resolve_prompt_text(
+                binding.prompt_id,
+                version=binding.prompt_version,
+            )
+        )
+    return "\n\n".join(parts)
+
+
+def _degradation_row(
+    harness: HarnessName,
+    *,
+    kind: str,
+    toolset_parity: bool,
+    selected_agents: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "harness": harness,
+        "kind": kind,
+        "toolset_parity": toolset_parity,
+        "selected_agents": list(selected_agents),
+    }
+
+
+def _render_prose_only(
+    harness: HarnessName,
+    bindings: Sequence[AgentBinding],
+) -> HarnessRenderResult:
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+
+    selected_ids = tuple(binding.agent_id for binding in bindings)
+    instructions = _prose_subagent_instructions(bindings)
+    degradation = _degradation_row(
+        harness,
+        kind=CODEX_SUBAGENT_DEGRADATION.kind,
+        toolset_parity=CODEX_SUBAGENT_DEGRADATION.toolset_parity,
+        selected_agents=selected_ids,
+    )
+    return HarnessRenderResult(
+        harness=harness,
+        payload=instructions,
+        selected_agent_ids=selected_ids,
+        metadata={"harness_degradations": [degradation]},
+    )
+
+
+def render_agents(
+    registry: Registry,
+    *,
+    selected: Sequence[str],
+    harness: HarnessName | str,
+    ctx: AgentRunContext | ToolContext,
+) -> HarnessRenderResult:
+    """Project ``selected`` registry bindings into ``harness`` config (D2)."""
+    harness_name: HarnessName = harness  # type: ignore[assignment]
+    bindings = _resolve_selected_bindings(registry, selected)
+    settings = _settings_for_ctx(ctx)
+
+    if harness_name == "claude":
+        return _render_claude(bindings, ctx=ctx, settings=settings)
+    if harness_name == "opencode":
+        return _render_opencode(bindings, ctx=ctx, settings=settings)
+    if harness_name in _PROSE_ONLY_HARNESSES:
+        return _render_prose_only(harness_name, bindings)
+
+    msg = f"unknown harness {harness!r}"
+    raise ValueError(msg)
+
+
+def default_subagent_selection(registry: Registry) -> tuple[str, str]:
+    """Default routed roster before AP4 lens routing — reviewer + verifier."""
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    verifier = registry.resolve_role(AgentRole.verifier)
+    return (reviewer.agent_id, verifier.agent_id)
+
+
+def render_for_run(
+    ctx: AgentRunContext,
+    harness: HarnessName,
+    *,
+    selected: Sequence[str] | None = None,
+) -> HarnessRenderResult:
+    """Load the repo registry and render the routed roster for one agent run."""
+    from mergecraft.agents.registry import load_registry
+
+    root = _repo_root_from_ctx(ctx) or Path(ctx.tmpdir)
+    settings = load_repo_settings(root=root)
+    registry = load_registry(settings=settings, repo_root=root)
+    roster = tuple(selected) if selected is not None else default_subagent_selection(registry)
+    return render_agents(registry, selected=roster, harness=harness, ctx=ctx)
+
+
+def merge_manifest_metadata(
+    result: AgentResult,
+    render_result: HarnessRenderResult,
+) -> AgentResult:
+    """Merge harness degradation metadata into an ``AgentResult``."""
+    from dataclasses import replace
+
+    manifest_meta = run_manifest_metadata(render_result)
+    if not manifest_meta:
+        return result
+    meta = dict(result.metadata or {})
+    meta.update(manifest_meta)
+    return replace(result, metadata=meta)
+
+
+__all__ = [
+    "HarnessRenderResult",
+    "UnrenderableBindingError",
+    "default_subagent_selection",
+    "merge_manifest_metadata",
+    "render_agents",
+    "render_for_run",
+    "run_manifest_metadata",
+]

--- a/src/mergecraft/agents/model_diversity.py
+++ b/src/mergecraft/agents/model_diversity.py
@@ -1,0 +1,122 @@
+"""Model diversity policy — verification must not share the authoring family (AP3, #45).
+
+Generalizes ``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
+declared rule: the verifier's executed model must come from a different provider
+family than the authoring (reviewer / specialist) model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mergecraft.agents.registry import AgentRole, ResolvedAgentModel, resolve_agent_model
+from mergecraft.agents.verifier import pinned_judge_model
+from mergecraft.models import MODEL_ALIASES, get_model_provider, resolve_display_alias
+from mergecraft.utils.agent_resolve import effective_model_chain, pick_runnable_slug_from_chain
+
+if TYPE_CHECKING:
+    from mergecraft.agents.registry import Registry
+    from mergecraft.config.settings import RepoSettings
+
+
+class ModelDiversityViolation(ValueError):
+    """Raised when verification would run on the authoring provider family."""
+
+
+def model_family(slug: str) -> str:
+    """Coarse provider family for diversity checks (e.g. ``anthropic``, ``openai``)."""
+    pinned_claude = pinned_judge_model("claude")
+    if pinned_claude is not None and slug == pinned_claude:
+        return "anthropic"
+    alias = resolve_display_alias(slug)
+    if alias is not None:
+        return alias.provider
+    for entry in MODEL_ALIASES:
+        if entry.slug == slug or entry.resolve == slug:
+            return entry.provider
+    if "/" in slug:
+        return get_model_provider(slug)
+    msg = f"cannot resolve model family for slug {slug!r}"
+    raise ValueError(msg)
+
+
+def assert_verification_diverse(
+    *,
+    authoring_slug: str,
+    verification_slug: str,
+) -> None:
+    """Reject verification on the same provider family as the authoring model."""
+    if model_family(authoring_slug) == model_family(verification_slug):
+        msg = (
+            f"verification model {verification_slug!r} shares the authoring family "
+            f"{model_family(authoring_slug)!r} with {authoring_slug!r}"
+        )
+        raise ModelDiversityViolation(msg)
+
+
+def resolve_diverse_verification_model(
+    *,
+    authoring_slug: str,
+    registry: Registry,
+    settings: RepoSettings,
+) -> ResolvedAgentModel:
+    """Pick a runnable verifier slug from a different provider family."""
+    verifier = registry.resolve_role(AgentRole.verifier)
+    candidates = list(verifier.model_chain) + effective_model_chain(settings)
+    seen: set[str] = set()
+    authoring_family = model_family(authoring_slug)
+
+    for slug in candidates:
+        if slug in seen:
+            continue
+        seen.add(slug)
+        if model_family(slug) == authoring_family:
+            continue
+        runnable = pick_runnable_slug_from_chain(
+            [slug],
+            allow_fallback=settings.allow_fallback,
+        )
+        if runnable is None:
+            continue
+        assert_verification_diverse(
+            authoring_slug=authoring_slug,
+            verification_slug=runnable,
+        )
+        return ResolvedAgentModel(
+            requested_model=slug,
+            executed_model=runnable,
+            recorded_model=runnable,
+            dispatched_model=runnable,
+        )
+
+    msg = (
+        f"no verification model in a different family from authoring "
+        f"{authoring_slug!r} ({authoring_family!r})"
+    )
+    raise ModelDiversityViolation(msg)
+
+
+def enforce_policy_for_harness(
+    *,
+    registry: Registry,
+    settings: RepoSettings,
+    harness: str,
+) -> None:
+    """Ensure model-diversity policy can be satisfied for this harness roster."""
+    del harness
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    authoring = resolve_agent_model(reviewer, settings=settings).dispatched_model
+    resolve_diverse_verification_model(
+        authoring_slug=authoring,
+        registry=registry,
+        settings=settings,
+    )
+
+
+__all__ = [
+    "ModelDiversityViolation",
+    "assert_verification_diverse",
+    "enforce_policy_for_harness",
+    "model_family",
+    "resolve_diverse_verification_model",
+]

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -23,7 +23,6 @@ from mergecraft.agents.openai_compatible_gateways import (
     resolve_gateway_endpoints,
 )
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
-from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
     AgentResult,
     AgentRunContext,
@@ -32,10 +31,9 @@ from mergecraft.agents.shared import (
     log_token_table,
     spawn_agent_cli,
 )
-from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.http import instrument_httpx
-from mergecraft.types import MERGECRAFT_MCP_NAME, format_mcp_tool_ref
+from mergecraft.types import MERGECRAFT_MCP_NAME
 from mergecraft.utils.privilege import agent_subprocess_env, wrap_agent_command
 from mergecraft.utils.process_group import (
     kill_process_group,
@@ -152,30 +150,6 @@ def _custom_provider_ids(model: str | None) -> list[str]:
     if endpoint is None:
         return []
     return [endpoint[0]]
-
-
-def _reviewer_agent_config(ctx: AgentRunContext) -> dict[str, object]:
-    config: dict[str, object] = {
-        "description": ("Read-only review subagent for lens-based code review."),
-        "prompt": REVIEWER_SYSTEM_PROMPT,
-        "mode": "subagent",
-    }
-    denied = {format_mcp_tool_ref("opencode", name): "deny" for name in ctx.subagent_denied_tools}
-    if denied:
-        config["permission"] = denied
-    return config
-
-
-def _verifier_agent_config(ctx: AgentRunContext) -> dict[str, object]:
-    config: dict[str, object] = {
-        "description": ("Read-only verification subagent for Critical/Major analyzer findings."),
-        "prompt": VERIFIER_SYSTEM_PROMPT,
-        "mode": "subagent",
-    }
-    denied = {format_mcp_tool_ref("opencode", name): "deny" for name in ctx.verifier_denied_tools}
-    if denied:
-        config["permission"] = denied
-    return config
 
 
 def build_security_config(ctx: AgentRunContext, model: str | None) -> str:

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -23,7 +23,7 @@ from mergecraft.agents.openai_compatible_gateways import (
     resolve_gateway_endpoints,
 )
 from mergecraft.agents.post_run import finalize_agent_result, run_post_run_retry_loop
-from mergecraft.agents.reviewer import REVIEWER_AGENT_NAME, REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
 from mergecraft.agents.shared import (
     AgentResult,
     AgentRunContext,
@@ -32,7 +32,7 @@ from mergecraft.agents.shared import (
     log_token_table,
     spawn_agent_cli,
 )
-from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
+from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.http import instrument_httpx
 from mergecraft.types import MERGECRAFT_MCP_NAME, format_mcp_tool_ref
@@ -179,7 +179,11 @@ def _verifier_agent_config(ctx: AgentRunContext) -> dict[str, object]:
 
 
 def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
+    from mergecraft.agents.harness_render import render_for_run
+
     fs_perm = build_opencode_native_fs_permission()
+    render_result = render_for_run(ctx, "opencode")
+    agent_block = render_result.payload["agent"] if isinstance(render_result.payload, dict) else {}
     config: dict[str, object] = {
         "permission": {
             "bash": "deny",
@@ -196,10 +200,7 @@ def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
                 "timeout": 300_000,
             }
         },
-        "agent": {
-            REVIEWER_AGENT_NAME: _reviewer_agent_config(ctx),
-            VERIFIER_AGENT_NAME: _verifier_agent_config(ctx),
-        },
+        "agent": agent_block,
     }
     if model:
         config["model"] = model

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Final
 from pydantic import BaseModel, ConfigDict
 
 from mergecraft.agents.reviewer import REVIEWER_SYSTEM_PROMPT
+from mergecraft.agents.structured_handoff import agent_finding_output_schema_id
 from mergecraft.agents.verifier import VERIFIER_SYSTEM_PROMPT, pinned_judge_model
 from mergecraft.config.settings import AgentBindingOverride, DispatchMode  # noqa: TC001
 from mergecraft.mcp.server import build_orchestrator_tools
@@ -179,6 +180,12 @@ def _default_prompt_id(role: AgentRole) -> str:
     return f"mergecraft.{role.value}"
 
 
+def _default_output_schema(role: AgentRole) -> str | None:
+    if role is AgentRole.reviewer:
+        return agent_finding_output_schema_id()
+    return None
+
+
 def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBinding:
     return AgentBinding(
         agent_id=_default_agent_id(role),
@@ -190,6 +197,7 @@ def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBind
         tool_classes=_default_tool_classes(role),
         budget=_DEFAULT_BUDGET,
         timeout_s=_DEFAULT_TIMEOUT_S,
+        output_schema=_default_output_schema(role),
     )
 
 

--- a/src/mergecraft/agents/structured_handoff.py
+++ b/src/mergecraft/agents/structured_handoff.py
@@ -1,0 +1,108 @@
+"""Typed specialist handoff — prose discovery, typed ``AgentFinding`` emission (AP3, D6).
+
+Specialists reason in free-form prose during discovery; the orchestrator dispatch
+prompt deliberately carries no finding schema. At the boundary the specialist
+emits typed findings (``---typed-findings---`` tail or structured output schema).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Final
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from mergecraft.agents.verifier import AgentFinding, plan_agent_verifications
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.agents.registry import AgentBinding
+
+_TYPED_FINDINGS_MARKER: Final[str] = "---typed-findings---"
+_AGENT_FINDING_SCHEMA_ID: Final[str] = "mergecraft.agent_finding"
+
+
+class SpecialistHandoff(BaseModel):
+    """Prose reasoning plus typed findings at the specialist boundary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reasoning: str
+    findings: tuple[AgentFinding, ...]
+
+
+def agent_finding_output_schema_id() -> str:
+    """Registry ``output_schema`` id for specialist typed emission."""
+    return _AGENT_FINDING_SCHEMA_ID
+
+
+def parse_specialist_handoff(raw: str) -> SpecialistHandoff:
+    """Split prose reasoning from a typed findings tail (D6)."""
+    text = raw.strip()
+    marker = _TYPED_FINDINGS_MARKER
+    if marker.casefold() in text.casefold():
+        head, _, tail = text.partition(marker)
+        reasoning = head.strip()
+        payload = tail.strip()
+    else:
+        reasoning = text
+        payload = "[]"
+
+    try:
+        rows = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        msg = f"specialist handoff: typed-findings tail is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+
+    if not isinstance(rows, list):
+        msg = "specialist handoff: typed-findings tail must be a JSON array"
+        raise ValueError(msg)
+
+    findings: list[AgentFinding] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            msg = "specialist handoff: each finding must be a JSON object"
+            raise ValueError(msg)
+        try:
+            findings.append(AgentFinding.model_validate(row))
+        except ValidationError as exc:
+            msg = f"specialist handoff: invalid finding row: {exc}"
+            raise ValueError(msg) from exc
+
+    return SpecialistHandoff(reasoning=reasoning, findings=tuple(findings))
+
+
+def build_specialist_dispatch_prompt(binding: AgentBinding) -> str:
+    """Discovery dispatch brief — no finding schema pre-shapes output (D6)."""
+    del binding
+    return (
+        "Review the dispatched scope using read-only tools. Reason in free-form "
+        "prose while you investigate — do not pre-format findings as JSON during "
+        "discovery and do not call structured-output tools until handoff."
+    )
+
+
+def verification_plan_from_handoff(
+    handoff: SpecialistHandoff,
+    *,
+    budget: int,
+    learnings_text: str = "",
+    repo_root: Path | None = None,
+) -> object:
+    """Queue verifier dispatches from typed handoff findings."""
+    return plan_agent_verifications(
+        list(handoff.findings),
+        budget=budget,
+        learnings_text=learnings_text,
+        repo_root=repo_root,
+    )
+
+
+__all__ = [
+    "SpecialistHandoff",
+    "agent_finding_output_schema_id",
+    "build_specialist_dispatch_prompt",
+    "parse_specialist_handoff",
+    "verification_plan_from_handoff",
+]

--- a/src/mergecraft/evidence/shadow.py
+++ b/src/mergecraft/evidence/shadow.py
@@ -112,6 +112,7 @@ class ShadowRecord(BaseModel):
     predicted_outcome: str | None = None
     diagnostic: str | None = None
     verdict_diagnostic: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/agents/test_ensemble.py
+++ b/tests/agents/test_ensemble.py
@@ -1,0 +1,268 @@
+"""AP3 ensemble dispatch suite — parallel models, shadow, and cardinality guards.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.ensemble`` — ``dispatch`` modes ``single`` (default),
+``ensemble``, and ``shadow`` (reusing ``evidence/shadow.py`` record machinery).
+Locked decision **D7**: orchestrator cannot be ensembled.
+
+AP3.1: six tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_ENSEMBLE_OVERRIDE = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+agents:
+  reviewer:
+    dispatch: ensemble
+    modelChain:
+      - anthropic/claude-sonnet
+      - openai/gpt-5.3-codex
+    budget: 2
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+
+@_AP3_XFAIL
+def test_ensemble_runs_the_same_agent_on_two_models(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``dispatch: ensemble`` runs one binding on two models from its chain."""
+    from mergecraft.agents.ensemble import plan_ensemble_models, run_ensemble_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _ENSEMBLE_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.dispatch == "ensemble"
+
+    primary, secondary = plan_ensemble_models(reviewer, settings=settings)
+    assert primary != secondary
+
+    calls: list[str] = []
+
+    def _execute(*, model: str, **_kwargs: object) -> list[dict[str, object]]:
+        calls.append(model)
+        return [{"path": "pkg/a.go", "body": f"finding from {model}", "severity": "Major"}]
+
+    run = run_ensemble_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+    )
+    assert set(calls) == {primary, secondary}
+    assert len(run.model_runs) == 2
+    assert run.model_runs[0].model in {primary, secondary}
+    assert run.model_runs[1].model in {primary, secondary}
+
+
+@_AP3_XFAIL
+def test_agreement_raises_confidence(tmp_path: Path) -> None:
+    """When both ensemble models agree, the merged signal gains confidence."""
+    from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
+
+    shared_finding = {
+        "path": "pkg/auth.go",
+        "body": "nil deref when session expires",
+        "severity": "Critical",
+        "line": 88,
+    }
+    run = EnsembleRun(
+        agent_id="mergecraft-reviewer",
+        model_runs=(
+            ModelRun(model="anthropic/claude-sonnet", findings=(shared_finding,)),
+            ModelRun(model="openai/gpt-5.3-codex", findings=(shared_finding,)),
+        ),
+    )
+    reconciliation = reconcile_ensemble(run)
+    assert reconciliation.agreement is True
+    assert reconciliation.confidence_boost > 0
+    assert len(reconciliation.merged_findings) == 1
+
+
+@_AP3_XFAIL
+def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
+    """Disagreeing ensemble outputs escalate to the judge role."""
+    from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
+
+    run = EnsembleRun(
+        agent_id="mergecraft-reviewer",
+        model_runs=(
+            ModelRun(
+                model="anthropic/claude-sonnet",
+                findings=(
+                    {
+                        "path": "pkg/auth.go",
+                        "body": "race on session refresh",
+                        "severity": "Major",
+                    },
+                ),
+            ),
+            ModelRun(
+                model="openai/gpt-5.3-codex",
+                findings=(
+                    {
+                        "path": "pkg/auth.go",
+                        "body": "benign logging noise",
+                        "severity": "Minor",
+                    },
+                ),
+            ),
+        ),
+    )
+    reconciliation = reconcile_ensemble(run)
+    assert reconciliation.agreement is False
+    assert reconciliation.judge_dispatch is not None
+    assert reconciliation.judge_dispatch.role == "judge"
+    assert "race on session refresh" in reconciliation.judge_dispatch.brief
+    assert "benign logging noise" in reconciliation.judge_dispatch.brief
+
+
+@_AP3_XFAIL
+def test_shadow_model_output_is_recorded_but_never_acted_on(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``dispatch: shadow`` records alternate output without changing the primary result."""
+    from mergecraft.agents.ensemble import run_shadow_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+    from mergecraft.evidence.shadow import load_shadow_records
+
+    _stub_slug_runnability(monkeypatch)
+    body = (
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    dispatch: shadow
+    modelChain:
+      - anthropic/claude-sonnet
+      - openai/gpt-5.3-codex
+"""
+    )
+    _write_config(tmp_path, body)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    shadow_path = tmp_path / "merge-evidence-shadow.jsonl"
+
+    primary_findings = [{"path": "pkg/a.go", "body": "primary only", "severity": "Major"}]
+    shadow_findings = [{"path": "pkg/b.go", "body": "shadow only", "severity": "Critical"}]
+
+    def _execute(*, model: str, primary: bool, **_kwargs: object) -> list[dict[str, object]]:
+        return primary_findings if primary else shadow_findings
+
+    result = run_shadow_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+        record_path=shadow_path,
+    )
+    assert result.primary_findings == primary_findings
+    assert result.acted_findings == primary_findings
+    records = load_shadow_records(shadow_path)
+    assert len(records) == 1
+    assert records[0].metadata["shadow_model_findings"] == shadow_findings
+
+
+@_AP3_XFAIL
+def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
+    """D7 — ensemble/shadow apply to discovery and verification agents only."""
+    from mergecraft.agents.ensemble import EnsembleCardinalityError, validate_ensemble_eligible
+
+    from mergecraft.agents.registry import AgentRole
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    orchestrator = registry.resolve_role(AgentRole.orchestrator)
+    with pytest.raises(EnsembleCardinalityError, match="orchestrator"):
+        validate_ensemble_eligible(orchestrator)
+
+
+@_AP3_XFAIL
+def test_ensemble_respects_the_agent_budget(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Ensemble fan-out honours the binding budget (file 2 CC3 integration)."""
+    from mergecraft.agents.ensemble import run_ensemble_dispatch
+
+    from mergecraft.agents.registry import AgentRole
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _ENSEMBLE_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.budget == 2
+
+    def _execute(*, model: str, **_kwargs: object) -> list[dict[str, object]]:
+        return [
+            {
+                "path": f"pkg/{model.replace('/', '-')}.go",
+                "body": f"finding from {model}",
+                "severity": "Major",
+            }
+            for _ in range(5)
+        ]
+
+    run = run_ensemble_dispatch(
+        reviewer,
+        registry=registry,
+        settings=settings,
+        execute=_execute,
+    )
+    total_findings = sum(len(model_run.findings) for model_run in run.model_runs)
+    assert total_findings <= reviewer.budget

--- a/tests/agents/test_ensemble.py
+++ b/tests/agents/test_ensemble.py
@@ -5,7 +5,7 @@ Covers ``mergecraft.agents.ensemble`` — ``dispatch`` modes ``single`` (default
 ``ensemble``, and ``shadow`` (reusing ``evidence/shadow.py`` record machinery).
 Locked decision **D7**: orchestrator cannot be ensembled.
 
-AP3.1: six tests; green after AP3.2.
+AP3.1: seven tests; green after AP3.2. #238 pins empty-vs-empty as agreement.
 """
 
 from __future__ import annotations
@@ -160,6 +160,24 @@ def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
     assert reconciliation.judge_dispatch.role == "judge"
     assert "race on session refresh" in reconciliation.judge_dispatch.brief
     assert "benign logging noise" in reconciliation.judge_dispatch.brief
+
+
+def test_empty_vs_empty_is_agreement_without_confidence_boost(tmp_path: Path) -> None:
+    """Two empty finding sets agree without a confidence boost or judge dispatch."""
+    from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
+
+    run = EnsembleRun(
+        agent_id="mergecraft-reviewer",
+        model_runs=(
+            ModelRun(model="anthropic/claude-sonnet", findings=()),
+            ModelRun(model="openai/gpt-5.3-codex", findings=()),
+        ),
+    )
+    reconciliation = reconcile_ensemble(run)
+    assert reconciliation.agreement is True
+    assert reconciliation.confidence_boost == 0
+    assert reconciliation.judge_dispatch is None
+    assert reconciliation.merged_findings == ()
 
 
 def test_shadow_model_output_is_recorded_but_never_acted_on(

--- a/tests/agents/test_ensemble.py
+++ b/tests/agents/test_ensemble.py
@@ -5,7 +5,7 @@ Covers ``mergecraft.agents.ensemble`` — ``dispatch`` modes ``single`` (default
 ``ensemble``, and ``shadow`` (reusing ``evidence/shadow.py`` record machinery).
 Locked decision **D7**: orchestrator cannot be ensembled.
 
-AP3.1: six tests; all ``xfail`` until AP3.2.
+AP3.1: six tests; green after AP3.2.
 """
 
 from __future__ import annotations
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -68,14 +66,12 @@ def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-@_AP3_XFAIL
 def test_ensemble_runs_the_same_agent_on_two_models(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """``dispatch: ensemble`` runs one binding on two models from its chain."""
     from mergecraft.agents.ensemble import plan_ensemble_models, run_ensemble_dispatch
-
     from mergecraft.agents.registry import AgentRole
 
     _stub_slug_runnability(monkeypatch)
@@ -106,7 +102,6 @@ def test_ensemble_runs_the_same_agent_on_two_models(
     assert run.model_runs[1].model in {primary, secondary}
 
 
-@_AP3_XFAIL
 def test_agreement_raises_confidence(tmp_path: Path) -> None:
     """When both ensemble models agree, the merged signal gains confidence."""
     from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
@@ -130,7 +125,6 @@ def test_agreement_raises_confidence(tmp_path: Path) -> None:
     assert len(reconciliation.merged_findings) == 1
 
 
-@_AP3_XFAIL
 def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
     """Disagreeing ensemble outputs escalate to the judge role."""
     from mergecraft.agents.ensemble import EnsembleRun, ModelRun, reconcile_ensemble
@@ -168,14 +162,12 @@ def test_disagreement_is_routed_to_the_judge(tmp_path: Path) -> None:
     assert "benign logging noise" in reconciliation.judge_dispatch.brief
 
 
-@_AP3_XFAIL
 def test_shadow_model_output_is_recorded_but_never_acted_on(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """``dispatch: shadow`` records alternate output without changing the primary result."""
     from mergecraft.agents.ensemble import run_shadow_dispatch
-
     from mergecraft.agents.registry import AgentRole
     from mergecraft.evidence.shadow import load_shadow_records
 
@@ -217,11 +209,9 @@ agents:
     assert records[0].metadata["shadow_model_findings"] == shadow_findings
 
 
-@_AP3_XFAIL
 def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
     """D7 — ensemble/shadow apply to discovery and verification agents only."""
     from mergecraft.agents.ensemble import EnsembleCardinalityError, validate_ensemble_eligible
-
     from mergecraft.agents.registry import AgentRole
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -231,14 +221,12 @@ def test_orchestrator_cannot_be_ensembled(tmp_path: Path) -> None:
         validate_ensemble_eligible(orchestrator)
 
 
-@_AP3_XFAIL
 def test_ensemble_respects_the_agent_budget(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Ensemble fan-out honours the binding budget (file 2 CC3 integration)."""
     from mergecraft.agents.ensemble import run_ensemble_dispatch
-
     from mergecraft.agents.registry import AgentRole
 
     _stub_slug_runnability(monkeypatch)

--- a/tests/agents/test_harness_render.py
+++ b/tests/agents/test_harness_render.py
@@ -15,17 +15,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
 from mergecraft.agents.claude import build_agents_json
 from mergecraft.agents.gates import subagent_denied_tool_names
-from mergecraft.agents.verifier import (
-    VERIFIER_RUBRIC_VERSION,
-    pinned_judge_model,
-    verifier_denied_tool_names,
-)
+from mergecraft.agents.verifier import verifier_denied_tool_names
 from mergecraft.config.settings import load_repo_settings
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -35,11 +31,10 @@ from mergecraft.mcp.context import (
 )
 from mergecraft.mcp.tool_state import init_tool_state
 from mergecraft.modes import compute_modes
-from mergecraft.types import REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME, format_mcp_tool_ref
+from mergecraft.types import REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME
 from mergecraft.utils.github import GitHubClient
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
@@ -52,17 +47,6 @@ models:
   - openai/gpt-5.3-codex
   - google/gemini-3.1-pro-preview
 """
-
-_REVIEWER_DESCRIPTION = (
-    "Read-only review subagent for lens-based code review. "
-    "Reads only — no writes, no state-changing shell or MCP calls."
-)
-
-_VERIFIER_DESCRIPTION = (
-    "Read-only verification subagent for Critical/Major analyzer, CI and "
-    "agent-authored findings. Confirms, downgrades, or drops before "
-    f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
-)
 
 
 def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
@@ -114,69 +98,26 @@ def _load_registry(tmp_path: Path) -> Registry:
     return load_registry(settings=settings, repo_root=tmp_path)
 
 
-def _registry_claude_agents_json(
-    registry: Registry,
-    *,
-    verifier_denied_tools: Sequence[str],
-    subagent_denied_tools: Sequence[str],
-) -> str:
-    """Reconstruct Claude ``agents.json`` from registry bindings (AP2 contract)."""
-    from mergecraft.agents.registry import resolve_prompt_text
-
-    reviewer_binding = registry.resolve_role("reviewer")
-    verifier_binding = registry.resolve_role("verifier")
-    # Claude harness dispatch format — AP2 maps registry chains to these fields.
-    reviewer_model = "claude-sonnet-5"
-    verifier_model = pinned_judge_model("claude") or "claude-sonnet-5"
-
-    verifier: dict[str, Any] = {
-        "description": _VERIFIER_DESCRIPTION,
-        "prompt": resolve_prompt_text(
-            verifier_binding.prompt_id,
-            version=verifier_binding.prompt_version,
-        ),
-        "model": verifier_model,
-    }
-    denied_verifier = [format_mcp_tool_ref("claude", name) for name in verifier_denied_tools]
-    if denied_verifier:
-        verifier["disallowedTools"] = denied_verifier
-
-    reviewer: dict[str, Any] = {
-        "description": _REVIEWER_DESCRIPTION,
-        "prompt": resolve_prompt_text(
-            reviewer_binding.prompt_id,
-            version=reviewer_binding.prompt_version,
-        ),
-        "model": reviewer_model,
-    }
-    denied_reviewer = [format_mcp_tool_ref("claude", name) for name in subagent_denied_tools]
-    if denied_reviewer:
-        reviewer["disallowedTools"] = denied_reviewer
-
-    agents = {
-        REVIEWER_AGENT_NAME: reviewer,
-        VERIFIER_AGENT_NAME: verifier,
-    }
-    return json.dumps(agents)
-
-
 def test_claude_agents_json_renders_from_registry(tmp_path: Path) -> None:
-    """Default registry bindings must reproduce today's ``build_agents_json`` bytes."""
+    """Production ``render_agents(..., harness="claude")`` must match legacy bytes."""
+    from mergecraft.agents.harness_render import default_subagent_selection, render_agents
+
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     ctx = _tool_ctx(tmp_path)
     denied_verifier = verifier_denied_tool_names(ctx)
     denied_reviewer = subagent_denied_tool_names(ctx)
+    registry = _load_registry(tmp_path)
+    result = render_agents(
+        registry,
+        selected=default_subagent_selection(registry),
+        harness="claude",
+        ctx=ctx,
+    )
     legacy = build_agents_json(
         verifier_denied_tools=denied_verifier,
         subagent_denied_tools=denied_reviewer,
     )
-    registry = _load_registry(tmp_path)
-    from_registry = _registry_claude_agents_json(
-        registry,
-        verifier_denied_tools=denied_verifier,
-        subagent_denied_tools=denied_reviewer,
-    )
-    assert from_registry == legacy
+    assert result.payload == legacy
 
 
 def test_opencode_subagents_carry_per_agent_models(

--- a/tests/agents/test_harness_render.py
+++ b/tests/agents/test_harness_render.py
@@ -8,9 +8,7 @@ degradation). Locked decisions: **D2** (only routed agents render),
 **D4** (unrenderable bindings fail loudly), **D5** (Codex degradation is
 declared in run metadata, not hidden).
 
-AP2.1: seven tests; ``test_claude_agents_json_renders_from_registry`` passes
-today as the byte-identical compatibility pin. Six implementation-dependent
-tests are ``xfail`` until AP2.2.
+AP2.1: seven tests; reconciled post-AP2.2 — all pass with no xfail markers.
 """
 
 from __future__ import annotations
@@ -44,9 +42,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from mergecraft.agents.registry import Registry
+    from _pytest.monkeypatch import MonkeyPatch
 
-_AP2_XFAIL = pytest.mark.xfail(reason="green after AP2.2: harness render", strict=False)
+    from mergecraft.agents.registry import Registry
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -65,6 +63,18 @@ _VERIFIER_DESCRIPTION = (
     "agent-authored findings. Confirms, downgrades, or drops before "
     f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
 )
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    """Deterministic model-chain resolution without live credentials or binaries."""
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
 
 
 def _write_config(tmp_path: Path, body: str) -> None:
@@ -169,12 +179,15 @@ def test_claude_agents_json_renders_from_registry(tmp_path: Path) -> None:
     assert from_registry == legacy
 
 
-@_AP2_XFAIL
-def test_opencode_subagents_carry_per_agent_models(tmp_path: Path) -> None:
+def test_opencode_subagents_carry_per_agent_models(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     """P4 — OpenCode subagent blocks carry each binding's dispatched model."""
-    from mergecraft.agents.harness_render import render_agents
-
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
     from mergecraft.agents.registry import resolve_agent_model
+
+    _stub_slug_runnability(monkeypatch)
 
     body = (
         _DEFAULT_MODELS_YAML
@@ -202,18 +215,17 @@ agents:
         harness="opencode",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     config = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
     agents = config["agent"]
     assert agents[REVIEWER_AGENT_NAME]["model"] == reviewer_model
     assert agents[VERIFIER_AGENT_NAME]["model"] == verifier_model
 
 
-@_AP2_XFAIL
 def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) -> None:
     """D5 — Codex either renders real subagents or records declared degradation."""
-    from mergecraft.agents.harness_render import render_agents
-
     from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -224,6 +236,7 @@ def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) ->
         harness="codex",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     payload_text = result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
     has_real_subagents = (
         REVIEWER_AGENT_NAME in payload_text
@@ -239,10 +252,9 @@ def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) ->
         assert CODEX_SUBAGENT_DEGRADATION.kind in kinds
 
 
-@_AP2_XFAIL
 def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
     """Gemini and Cursor harnesses render subagents or declare degradation like Codex."""
-    from mergecraft.agents.harness_render import render_agents
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -256,6 +268,7 @@ def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
             harness=harness,
             ctx=ctx,
         )
+        assert isinstance(result, HarnessRenderResult)
         payload_text = (
             result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
         )
@@ -269,7 +282,6 @@ def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
         assert has_subagent_surface or has_declared
 
 
-@_AP2_XFAIL
 def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
     """D4 — bindings a harness cannot express raise instead of silently collapsing."""
     from mergecraft.agents.harness_render import UnrenderableBindingError, render_agents
@@ -286,10 +298,11 @@ def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
         )
 
 
-@_AP2_XFAIL
-def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
+def test_only_routed_agents_are_rendered(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """D2 — only the selected roster is rendered, not the full registry."""
-    from mergecraft.agents.harness_render import render_agents
+    from mergecraft.agents.harness_render import HarnessRenderResult, render_agents
+
+    _stub_slug_runnability(monkeypatch)
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -301,6 +314,7 @@ def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
         harness="claude",
         ctx=ctx,
     )
+    assert isinstance(result, HarnessRenderResult)
     agents = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
     assert len(agents) == 3
     rendered_ids = set(agents)
@@ -313,12 +327,14 @@ def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
     assert len(registry.all_bindings()) > len(agents)
 
 
-@_AP2_XFAIL
 def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
     """Declared harness degradation must flow into run-manifest metadata."""
-    from mergecraft.agents.harness_render import render_agents, run_manifest_metadata
-
     from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.harness_render import (
+        HarnessRenderResult,
+        render_agents,
+        run_manifest_metadata,
+    )
     from mergecraft.agents.shared import AgentResult
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -330,6 +346,7 @@ def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
         harness="codex",
         ctx=ctx,
     )
+    assert isinstance(render_result, HarnessRenderResult)
     manifest_meta = run_manifest_metadata(render_result)
     assert "harness_degradations" in manifest_meta
     degradations = manifest_meta["harness_degradations"]

--- a/tests/agents/test_harness_render.py
+++ b/tests/agents/test_harness_render.py
@@ -1,0 +1,350 @@
+"""AP2 harness render suite — registry-driven subagent config per driver.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP2).
+Covers ``mergecraft.agents.harness_render`` — ``render_agents`` projects
+selected registry bindings into each harness shape (Claude ``agents.json``,
+OpenCode subagent blocks, Codex/Gemini/Cursor subagent dispatch or declared
+degradation). Locked decisions: **D2** (only routed agents render),
+**D4** (unrenderable bindings fail loudly), **D5** (Codex degradation is
+declared in run metadata, not hidden).
+
+AP2.1: seven tests; ``test_claude_agents_json_renders_from_registry`` passes
+today as the byte-identical compatibility pin. Six implementation-dependent
+tests are ``xfail`` until AP2.2.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.claude import build_agents_json
+from mergecraft.agents.gates import subagent_denied_tool_names
+from mergecraft.agents.verifier import (
+    VERIFIER_RUBRIC_VERSION,
+    pinned_judge_model,
+    verifier_denied_tool_names,
+)
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.types import REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME, format_mcp_tool_ref
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from mergecraft.agents.registry import Registry
+
+_AP2_XFAIL = pytest.mark.xfail(reason="green after AP2.2: harness render", strict=False)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_REVIEWER_DESCRIPTION = (
+    "Read-only review subagent for lens-based code review. "
+    "Reads only — no writes, no state-changing shell or MCP calls."
+)
+
+_VERIFIER_DESCRIPTION = (
+    "Read-only verification subagent for Critical/Major analyzer, CI and "
+    "agent-authored findings. Confirms, downgrades, or drops before "
+    f"publication against rubric v{VERIFIER_RUBRIC_VERSION}."
+)
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _tool_ctx(tmp_path: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request"),
+            shell="restricted",
+            push="restricted",
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        signed_commits=True,
+        xrepo=None,
+        static_checks_enabled=True,
+    )
+
+
+def _load_registry(tmp_path: Path) -> Registry:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _registry_claude_agents_json(
+    registry: Registry,
+    *,
+    verifier_denied_tools: Sequence[str],
+    subagent_denied_tools: Sequence[str],
+) -> str:
+    """Reconstruct Claude ``agents.json`` from registry bindings (AP2 contract)."""
+    from mergecraft.agents.registry import resolve_prompt_text
+
+    reviewer_binding = registry.resolve_role("reviewer")
+    verifier_binding = registry.resolve_role("verifier")
+    # Claude harness dispatch format — AP2 maps registry chains to these fields.
+    reviewer_model = "claude-sonnet-5"
+    verifier_model = pinned_judge_model("claude") or "claude-sonnet-5"
+
+    verifier: dict[str, Any] = {
+        "description": _VERIFIER_DESCRIPTION,
+        "prompt": resolve_prompt_text(
+            verifier_binding.prompt_id,
+            version=verifier_binding.prompt_version,
+        ),
+        "model": verifier_model,
+    }
+    denied_verifier = [format_mcp_tool_ref("claude", name) for name in verifier_denied_tools]
+    if denied_verifier:
+        verifier["disallowedTools"] = denied_verifier
+
+    reviewer: dict[str, Any] = {
+        "description": _REVIEWER_DESCRIPTION,
+        "prompt": resolve_prompt_text(
+            reviewer_binding.prompt_id,
+            version=reviewer_binding.prompt_version,
+        ),
+        "model": reviewer_model,
+    }
+    denied_reviewer = [format_mcp_tool_ref("claude", name) for name in subagent_denied_tools]
+    if denied_reviewer:
+        reviewer["disallowedTools"] = denied_reviewer
+
+    agents = {
+        REVIEWER_AGENT_NAME: reviewer,
+        VERIFIER_AGENT_NAME: verifier,
+    }
+    return json.dumps(agents)
+
+
+def test_claude_agents_json_renders_from_registry(tmp_path: Path) -> None:
+    """Default registry bindings must reproduce today's ``build_agents_json`` bytes."""
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    ctx = _tool_ctx(tmp_path)
+    denied_verifier = verifier_denied_tool_names(ctx)
+    denied_reviewer = subagent_denied_tool_names(ctx)
+    legacy = build_agents_json(
+        verifier_denied_tools=denied_verifier,
+        subagent_denied_tools=denied_reviewer,
+    )
+    registry = _load_registry(tmp_path)
+    from_registry = _registry_claude_agents_json(
+        registry,
+        verifier_denied_tools=denied_verifier,
+        subagent_denied_tools=denied_reviewer,
+    )
+    assert from_registry == legacy
+
+
+@_AP2_XFAIL
+def test_opencode_subagents_carry_per_agent_models(tmp_path: Path) -> None:
+    """P4 — OpenCode subagent blocks carry each binding's dispatched model."""
+    from mergecraft.agents.harness_render import render_agents
+
+    from mergecraft.agents.registry import resolve_agent_model
+
+    body = (
+        _DEFAULT_MODELS_YAML
+        + """
+agents:
+  reviewer:
+    model: anthropic/claude-sonnet
+  verifier:
+    model: openai/gpt-5.3-codex
+"""
+    )
+    _write_config(tmp_path, body)
+    registry = _load_registry(tmp_path)
+    settings = load_repo_settings(root=tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    reviewer_binding = registry.resolve_role("reviewer")
+    verifier_binding = registry.resolve_role("verifier")
+    reviewer_model = resolve_agent_model(reviewer_binding, settings=settings).dispatched_model
+    verifier_model = resolve_agent_model(verifier_binding, settings=settings).dispatched_model
+    assert reviewer_model != verifier_model
+
+    result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="opencode",
+        ctx=ctx,
+    )
+    config = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
+    agents = config["agent"]
+    assert agents[REVIEWER_AGENT_NAME]["model"] == reviewer_model
+    assert agents[VERIFIER_AGENT_NAME]["model"] == verifier_model
+
+
+@_AP2_XFAIL
+def test_codex_renders_real_subagents_or_declares_degradation(tmp_path: Path) -> None:
+    """D5 — Codex either renders real subagents or records declared degradation."""
+    from mergecraft.agents.harness_render import render_agents
+
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="codex",
+        ctx=ctx,
+    )
+    payload_text = result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
+    has_real_subagents = (
+        REVIEWER_AGENT_NAME in payload_text
+        and VERIFIER_AGENT_NAME in payload_text
+        and "subagent" in payload_text.lower()
+        and result.metadata.get("harness_degradations") is None
+    )
+    degradations = result.metadata.get("harness_degradations")
+    has_declared_degradation = isinstance(degradations, list) and len(degradations) >= 1
+    assert has_real_subagents or has_declared_degradation
+    if has_declared_degradation:
+        kinds = {entry.get("kind") for entry in degradations}
+        assert CODEX_SUBAGENT_DEGRADATION.kind in kinds
+
+
+@_AP2_XFAIL
+def test_gemini_and_cursor_render_or_declare(tmp_path: Path) -> None:
+    """Gemini and Cursor harnesses render subagents or declare degradation like Codex."""
+    from mergecraft.agents.harness_render import render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    selected = (REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME)
+
+    for harness in ("gemini", "cursor"):
+        result = render_agents(
+            registry,
+            selected=selected,
+            harness=harness,
+            ctx=ctx,
+        )
+        payload_text = (
+            result.payload if isinstance(result.payload, str) else json.dumps(result.payload)
+        )
+        has_subagent_surface = (
+            REVIEWER_AGENT_NAME in payload_text and VERIFIER_AGENT_NAME in payload_text
+        )
+        degradations = result.metadata.get("harness_degradations")
+        has_declared = isinstance(degradations, list) and any(
+            entry.get("harness") == harness for entry in degradations
+        )
+        assert has_subagent_surface or has_declared
+
+
+@_AP2_XFAIL
+def test_unrenderable_binding_fails_loudly(tmp_path: Path) -> None:
+    """D4 — bindings a harness cannot express raise instead of silently collapsing."""
+    from mergecraft.agents.harness_render import UnrenderableBindingError, render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    with pytest.raises(UnrenderableBindingError, match="orchestrator"):
+        render_agents(
+            registry,
+            selected=("orchestrator",),
+            harness="claude",
+            ctx=ctx,
+        )
+
+
+@_AP2_XFAIL
+def test_only_routed_agents_are_rendered(tmp_path: Path) -> None:
+    """D2 — only the selected roster is rendered, not the full registry."""
+    from mergecraft.agents.harness_render import render_agents
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    selected = ("reviewer", "verifier", "classifier")
+    result = render_agents(
+        registry,
+        selected=selected,
+        harness="claude",
+        ctx=ctx,
+    )
+    agents = json.loads(result.payload) if isinstance(result.payload, str) else result.payload
+    assert len(agents) == 3
+    rendered_ids = set(agents)
+    assert REVIEWER_AGENT_NAME in rendered_ids
+    assert VERIFIER_AGENT_NAME in rendered_ids
+    classifier_binding = registry.resolve_role("classifier")
+    assert classifier_binding.agent_id in rendered_ids
+    assert registry.resolve_role("orchestrator").agent_id not in rendered_ids
+    assert registry.resolve_role("judge").agent_id not in rendered_ids
+    assert len(registry.all_bindings()) > len(agents)
+
+
+@_AP2_XFAIL
+def test_declared_degradation_reaches_the_run_manifest(tmp_path: Path) -> None:
+    """Declared harness degradation must flow into run-manifest metadata."""
+    from mergecraft.agents.harness_render import render_agents, run_manifest_metadata
+
+    from mergecraft.agents.codex import CODEX_SUBAGENT_DEGRADATION
+    from mergecraft.agents.shared import AgentResult
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    ctx = _tool_ctx(tmp_path)
+    render_result = render_agents(
+        registry,
+        selected=(REVIEWER_AGENT_NAME, VERIFIER_AGENT_NAME),
+        harness="codex",
+        ctx=ctx,
+    )
+    manifest_meta = run_manifest_metadata(render_result)
+    assert "harness_degradations" in manifest_meta
+    degradations = manifest_meta["harness_degradations"]
+    assert isinstance(degradations, list)
+    assert degradations
+    codex_entries = [entry for entry in degradations if entry.get("harness") == "codex"]
+    assert codex_entries
+    entry = codex_entries[0]
+    assert entry["kind"] == CODEX_SUBAGENT_DEGRADATION.kind
+    assert entry["toolset_parity"] is CODEX_SUBAGENT_DEGRADATION.toolset_parity
+    assert set(entry) >= {"harness", "kind", "toolset_parity", "selected_agents"}
+
+    agent_result = AgentResult(success=True)
+    merged = {**(agent_result.metadata or {}), **manifest_meta}
+    assert merged["harness_degradations"] == degradations
+    assert asdict(CODEX_SUBAGENT_DEGRADATION)["kind"] in {
+        row.get("kind") for row in merged["harness_degradations"]
+    }

--- a/tests/agents/test_model_diversity.py
+++ b/tests/agents/test_model_diversity.py
@@ -5,7 +5,7 @@ Covers ``mergecraft.agents.model_diversity`` — generalizes #45 /
 ``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
 declared policy that holds for every harness.
 
-AP3.1: two tests; all ``xfail`` until AP3.2.
+AP3.1: two tests; green after AP3.2.
 """
 
 from __future__ import annotations
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -66,7 +64,6 @@ def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-@_AP3_XFAIL
 def test_verification_never_runs_on_the_authoring_family(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -77,7 +74,6 @@ def test_verification_never_runs_on_the_authoring_family(
         assert_verification_diverse,
         resolve_diverse_verification_model,
     )
-
     from mergecraft.agents.registry import AgentRole, resolve_agent_model
 
     _stub_slug_runnability(monkeypatch)
@@ -107,7 +103,6 @@ def test_verification_never_runs_on_the_authoring_family(
     )
 
 
-@_AP3_XFAIL
 def test_policy_holds_across_harnesses(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_model_diversity.py
+++ b/tests/agents/test_model_diversity.py
@@ -1,0 +1,124 @@
+"""AP3 model diversity suite — verification never shares the authoring family.
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.model_diversity`` — generalizes #45 /
+``PINNED_JUDGE_MODELS`` from a single hard-coded Claude entry into a
+declared policy that holds for every harness.
+
+AP3.1: two tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_SAME_FAMILY_OVERRIDE = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+agents:
+  reviewer:
+    model: anthropic/claude-sonnet
+  verifier:
+    model: anthropic/claude-haiku
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+def _stub_slug_runnability(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve.has_credentials_for_slug",
+        lambda _slug: True,
+    )
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available",
+        lambda _slug: True,
+    )
+
+
+@_AP3_XFAIL
+def test_verification_never_runs_on_the_authoring_family(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """#45 generalized — verifier must not share the reviewer's provider family."""
+    from mergecraft.agents.model_diversity import (
+        ModelDiversityViolation,
+        assert_verification_diverse,
+        resolve_diverse_verification_model,
+    )
+
+    from mergecraft.agents.registry import AgentRole, resolve_agent_model
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _SAME_FAMILY_OVERRIDE)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    verifier = registry.resolve_role(AgentRole.verifier)
+    reviewer_model = resolve_agent_model(reviewer, settings=settings).dispatched_model
+    verifier_model = resolve_agent_model(verifier, settings=settings).dispatched_model
+
+    with pytest.raises(ModelDiversityViolation, match="authoring family"):
+        assert_verification_diverse(
+            authoring_slug=reviewer_model,
+            verification_slug=verifier_model,
+        )
+
+    diverse = resolve_diverse_verification_model(
+        authoring_slug=reviewer_model,
+        registry=registry,
+        settings=settings,
+    )
+    assert diverse.dispatched_model != reviewer_model
+    assert_verification_diverse(
+        authoring_slug=reviewer_model,
+        verification_slug=diverse.dispatched_model,
+    )
+
+
+@_AP3_XFAIL
+def test_policy_holds_across_harnesses(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Model-diversity policy applies for Claude, OpenCode and Codex harness contexts."""
+    from mergecraft.agents.model_diversity import enforce_policy_for_harness
+
+    _stub_slug_runnability(monkeypatch)
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    settings = load_repo_settings(root=tmp_path)
+    registry = _load_registry(tmp_path)
+
+    for harness in ("claude", "opencode", "codex"):
+        enforce_policy_for_harness(registry=registry, settings=settings, harness=harness)

--- a/tests/agents/test_structured_handoff.py
+++ b/tests/agents/test_structured_handoff.py
@@ -6,21 +6,17 @@ free-form prose and emit typed ``AgentFinding`` values at the boundary;
 discovery dispatch prompts carry no finding schema; typed findings feed
 ``plan_agent_verifications`` without orchestrator prose re-judgement.
 
-AP3.1: three tests; all ``xfail`` until AP3.2.
+AP3.1: three tests; green after AP3.2.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mergecraft.config.settings import load_repo_settings
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
 
 _DEFAULT_MODELS_YAML = """
 models:
@@ -58,12 +54,10 @@ def _load_registry(tmp_path: Path) -> object:
     return load_registry(settings=settings, repo_root=tmp_path)
 
 
-@_AP3_XFAIL
 def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
     """D6 — prose reasoning is preserved; findings at the boundary are typed."""
-    from mergecraft.agents.structured_handoff import parse_specialist_handoff
-
     from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.structured_handoff import parse_specialist_handoff
     from mergecraft.agents.verifier import AgentFinding
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
@@ -82,12 +76,10 @@ def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
     assert "double-spend" in finding.body
 
 
-@_AP3_XFAIL
 def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
     """Discovery dispatch must not pre-shape output with a finding schema (D6)."""
-    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
-
     from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
 
     _write_config(tmp_path, _DEFAULT_MODELS_YAML)
     registry = _load_registry(tmp_path)
@@ -101,14 +93,12 @@ def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
     assert "typed-findings" not in lowered
 
 
-@_AP3_XFAIL
 def test_typed_findings_feed_the_verifier_directly(tmp_path: Path) -> None:
     """Typed handoff findings queue verifier dispatches without prose aggregation."""
     from mergecraft.agents.structured_handoff import (
         parse_specialist_handoff,
         verification_plan_from_handoff,
     )
-
     from mergecraft.agents.verifier import VERIFIER_SEVERITIES
 
     handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)

--- a/tests/agents/test_structured_handoff.py
+++ b/tests/agents/test_structured_handoff.py
@@ -1,0 +1,122 @@
+"""AP3 structured handoff suite — typed specialist returns (D6).
+
+Wave plan: ``.ignorelocal/03-agent-pipeline-wave-plan.md`` (PR AP3).
+Covers ``mergecraft.agents.structured_handoff`` — specialists reason in
+free-form prose and emit typed ``AgentFinding`` values at the boundary;
+discovery dispatch prompts carry no finding schema; typed findings feed
+``plan_agent_verifications`` without orchestrator prose re-judgement.
+
+AP3.1: three tests; all ``xfail`` until AP3.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_AP3_XFAIL = pytest.mark.xfail(reason="AP3.2", strict=True)
+
+_DEFAULT_MODELS_YAML = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+  - google/gemini-3.1-pro-preview
+"""
+
+_SAMPLE_HANDOFF = """\
+I read the diff end-to-end and traced the checkout path. The race is real
+because two goroutines can observe the same version before either write lands.
+
+---typed-findings---
+[
+  {
+    "path": "internal/store/checkout.go",
+    "body": "Concurrent checkouts can double-spend inventory when two requests read the same stock level.",
+    "severity": "Major",
+    "line": 142
+  }
+]
+"""
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(body.strip() + "\n", encoding="utf-8")
+
+
+def _load_registry(tmp_path: Path) -> object:
+    from mergecraft.agents.registry import load_registry
+
+    settings = load_repo_settings(root=tmp_path)
+    return load_registry(settings=settings, repo_root=tmp_path)
+
+
+@_AP3_XFAIL
+def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
+    """D6 — prose reasoning is preserved; findings at the boundary are typed."""
+    from mergecraft.agents.structured_handoff import parse_specialist_handoff
+
+    from mergecraft.agents.registry import AgentRole
+    from mergecraft.agents.verifier import AgentFinding
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    assert reviewer.output_schema == "mergecraft.agent_finding"
+
+    handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)
+    assert "race is real" in handoff.reasoning
+    assert len(handoff.findings) == 1
+    finding = handoff.findings[0]
+    assert isinstance(finding, AgentFinding)
+    assert finding.path == "internal/store/checkout.go"
+    assert finding.severity == "Major"
+    assert finding.line == 142
+    assert "double-spend" in finding.body
+
+
+@_AP3_XFAIL
+def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
+    """Discovery dispatch must not pre-shape output with a finding schema (D6)."""
+    from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
+
+    from mergecraft.agents.registry import AgentRole
+
+    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
+    registry = _load_registry(tmp_path)
+    reviewer = registry.resolve_role(AgentRole.reviewer)
+    prompt = build_specialist_dispatch_prompt(reviewer)
+    lowered = prompt.casefold()
+    assert "json schema" not in lowered
+    assert "output_schema" not in lowered
+    assert "set_output" not in lowered
+    assert '"findings"' not in prompt
+    assert "typed-findings" not in lowered
+
+
+@_AP3_XFAIL
+def test_typed_findings_feed_the_verifier_directly(tmp_path: Path) -> None:
+    """Typed handoff findings queue verifier dispatches without prose aggregation."""
+    from mergecraft.agents.structured_handoff import (
+        parse_specialist_handoff,
+        verification_plan_from_handoff,
+    )
+
+    from mergecraft.agents.verifier import VERIFIER_SEVERITIES
+
+    handoff = parse_specialist_handoff(_SAMPLE_HANDOFF)
+    plan = verification_plan_from_handoff(handoff, budget=4)
+    assert plan.budget == 4
+    assert len(plan.dispatch) == 1
+    dispatch = plan.dispatch[0]
+    assert dispatch.finding.path == "internal/store/checkout.go"
+    assert dispatch.finding.severity in VERIFIER_SEVERITIES
+    assert "Verify one finding" in dispatch.brief
+    assert plan.skipped_below_severity == []


### PR DESCRIPTION
## Summary
- Lands already-reviewed AP2 (harness render of registry bindings) and AP3 (typed specialist handoff, model diversity, ensemble dispatch) onto `pre-0.0.1`
- Salvages the commits from #232 and #233, which merged into stacked feature branches instead of trunk
- Does **not** include AP4–AP7; #234–#237 stay separate

## Why
A GitHub PR merges into its **base ref**. #232 still had base `feature/agent-pipeline` and #233 still had base `feature/agent-pipeline-ap2`, so those merges never reached `pre-0.0.1`. This PR’s base is already `pre-0.0.1`; its head is `feature/agent-pipeline-ap3` (AP2+AP3 only).

## Merge into pre-0.0.1

Always retarget the next PR to `pre-0.0.1` **before** merging it. Never merge into `feature/agent-pipeline*`.

1. Merge **this PR** → `pre-0.0.1` (base already `pre-0.0.1`)
2. `gh pr edit 234 --base pre-0.0.1` then merge #234
3. `gh pr edit 235 --base pre-0.0.1` then merge #235
4. `gh pr edit 236 --base pre-0.0.1` then merge #236
5. `gh pr edit 237 --base pre-0.0.1` then merge #237

## Test plan
- [x] Commits are the already-reviewed #232 / #233 series (7 unique commits vs `pre-0.0.1`)
- [x] Local merge-tree against `origin/pre-0.0.1`: no conflicts (diverged by the #231 merge commit only)
- [x] Diff is AP2+AP3 only (18 files); AP4–AP7 commits are not on this head
