### PR TITLE
testing: add provider harness for deterministic review tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added: a test-only provider-harness fixture schema and strict matcher
+  (`tests/support/provider_harness`) so deterministic review tests can name
+  the exact provider interaction they expect. Not used in production.
+- Added: provider-harness recording workflow and operator docs
+  (`docs/dev/provider-harness.md`); opt-in sanitized capture under
+  `.ignorelocal/provider-harness/records/`.
 - Per-run budgets, bounded external-operation timeouts, and honest large-diff degradation (`RunBounds`, scope reduction reports, downgraded outcomes) for offline and Action reviews
 - `mergecraft mcp serve` and `mergecraft mcp list` expose the reviewer's MCP tool surface to external clients without widening trust tier or tool-class policy (D13)
 - Named review profiles (`--profile fast|deep|security`) bundle model chain, analyzer focus, and run budgets; explicit CLI flags still win

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:
 
 - `src/mergecraft/` — package (src layout)
 - `tests/` — mirrors package areas
+- `tests/harness/` — deterministic provider-harness RED/GREEN suites (no live API keys on `make test`)
 - `Makefile` — single command surface (sevn-style)
 - Docker Action via root `Dockerfile` + `action.yml`
 

--- a/docs/dev/provider-harness.md
+++ b/docs/dev/provider-harness.md
@@ -1,0 +1,44 @@
+# Provider harness (test-only)
+
+Deterministic provider and agent-protocol testing lives under `tests/support/provider_harness/`
+with RED/GREEN suites in `tests/harness/`. This is **not** the production `harness:` agent driver.
+
+## Writing a fixture
+
+1. Add JSON under `tests/harness/fixtures/<scenario>.json` (see `schema-smoke.json`).
+2. Match fields: `provider`, `model`, optional `streaming`, `turn_index`, tool-state guards.
+3. Response: `body` **or** ordered `blocks` (text / tool_call).
+
+Load in tests:
+
+```python
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+
+provider_harness.reload(load_harness_fixtures("no-findings"))
+```
+
+## Pytest fixture
+
+`provider_harness` (auto-loaded via `tests/conftest.py`) starts a local OpenAI-compatible stub on
+`127.0.0.1:0`, patches `MERGECRAFT_CUSTOM_PROVIDER_{BASE_URL,API_KEY}` before client construction,
+and tears the server down after each test. Dummy key: `sk-mergecraft-test`.
+
+## Named failure profiles
+
+Set `"profile"` on a fixture: `http_429`, `http_500`, `http_401`, `timeout`, `malformed_json`,
+`empty_stream`, `disconnect_after_chunk`. Profiles feed existing mergeCraft classifiers — the harness
+does not implement its own retry loop.
+
+## Recording (local only)
+
+```bash
+export MERGECRAFT_PROVIDER_HARNESS_RECORD=1
+```
+
+Writes sanitized JSON under `.ignorelocal/provider-harness/records/`. Inspect manually; copy into
+`tests/harness/fixtures/` only after review. Never auto-commit.
+
+## Strict matching
+
+Default is strict (`match_fixture(..., strict=True)`). Lenient mode exists locally via
+`MERGECRAFT_PROVIDER_HARNESS_LENIENT=1` — never set in CI or `tests/conftest.py`.

--- a/docs/test-plans/review-harness-rh1.md
+++ b/docs/test-plans/review-harness-rh1.md
@@ -1,0 +1,90 @@
+# Review harness RH1 — fixture schema and strict matcher — test plan
+
+Wave plan: `.ignorelocal/waves/06-review-harness-wave-plan.md` (PR RH1)
+Worktree: `../mergecraft-review-harness` @ `wave/review-harness`
+Authoring wave: **RH1.1** (tests-first — this file). Implementation: **RH1.2**.
+xfail-reconciliation: **post-RH1.2**.
+
+RH1 pins a test-only provider fixture schema, strict request matcher, and
+redacted mismatch diagnostics under `tests/support/provider_harness/`. Tests
+live in `tests/harness/`. Zero `src/mergecraft/` edits (**D2**).
+
+Target API (RH1.2):
+
+- `tests.support.provider_harness.schema` — Pydantic `MatchSpec`, `ResponseBlock`,
+  `ResponseSpec`, `FixtureSpec`, `load_fixture_file(path) -> FixtureSpec`,
+  `MalformedFixtureError`.
+- `tests.support.provider_harness.matcher` — `match_fixture(request, fixtures, *,
+  strict=True) -> FixtureSpec`; errors `NoFixtureMatch`, `AmbiguousFixtureMatch`,
+  `FixtureReuseError`.
+- `tests.support.provider_harness.diagnostics` — `format_mismatch(...)` bounded,
+  redacted string with candidate fail reasons.
+
+## xfail schedule
+
+All RH1.2 markers use `strict=False` (`pyproject.toml` may set `xfail_strict =
+true`; an early-passing xfail becomes XPASS, not a silent pass). **Cleared after
+RH1.2** — twelve contract tests become real passes; three regression pins were
+never marked.
+
+| Wave | Test | Marker reason | Status |
+|------|------|---------------|--------|
+| **RH1.2** | `test_fixture_requires_provider_and_model` | `green after RH1.2` | pending |
+| **RH1.2** | `test_fixture_requires_request_match_fields` | same | pending |
+| **RH1.2** | `test_fixture_accepts_json_response_and_metadata` | same | pending |
+| **RH1.2** | `test_fixture_accepts_ordered_response_blocks` | same | pending |
+| **RH1.2** | `test_malformed_fixture_is_rejected_with_path` | same | pending |
+| **RH1.2** | `test_matching_uses_provider_model_and_mode` | same | pending |
+| **RH1.2** | `test_streaming_flag_participates_in_matching` | same | pending |
+| **RH1.2** | `test_body_field_matchers_are_explicit` | same | pending |
+| **RH1.2** | `test_no_fixture_match_is_an_error_in_strict_mode` | same | pending |
+| **RH1.2** | `test_multiple_matches_are_an_error` | same | pending |
+| **RH1.2** | `test_unexpected_fixture_reuse_is_an_error` | same | pending |
+| **RH1.2** | `test_mismatch_includes_redacted_request_and_candidate_reasons` | same | pending |
+
+Regression pins (no xfail — must pass @ RH1.1):
+
+| Test | Contract |
+|------|----------|
+| `test_lenient_mode_is_not_the_ci_default` | D7/D16 — `MERGECRAFT_PROVIDER_HARNESS_LENIENT` absent from `pyproject.toml` `addopts` and `tests/conftest.py` |
+| `test_diagnostics_do_not_include_provider_keys_or_github_tokens` | D14 — existing `redact_secrets` removes `sk-…` and `ghp_…` samples |
+| `test_src_mergecraft_does_not_import_provider_harness` | D2 — AST scan: no `src/mergecraft/**/*.py` imports `tests.support.provider_harness` |
+
+## Contract matrix
+
+| # | Decision | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| RH1.1a | D17 — JSON fixture schema | unit | happy: metadata + JSON body | `test_fixture_accepts_json_response_and_metadata` |
+| RH1.1b | D17 — ordered blocks | unit | happy: text + tool_call blocks | `test_fixture_accepts_ordered_response_blocks` |
+| RH1.1c | D17 — required match fields | unit | error: missing provider/model | `test_fixture_requires_provider_and_model`, `test_fixture_requires_request_match_fields` |
+| RH1.1d | D17 — malformed file | unit | error: invalid JSON names path | `test_malformed_fixture_is_rejected_with_path` |
+| RH1.1e | D7 — match dimensions | unit | happy: provider/model/mode | `test_matching_uses_provider_model_and_mode` |
+| RH1.1f | D7 — streaming flag | unit | happy: streaming True/False | `test_streaming_flag_participates_in_matching` |
+| RH1.1g | D7 — body_fields | unit | happy + error: explicit equality | `test_body_field_matchers_are_explicit` |
+| RH1.1h | D7 — strict no-match | unit | error: `NoFixtureMatch` | `test_no_fixture_match_is_an_error_in_strict_mode` |
+| RH1.1i | D7 — ambiguous match | unit | error: `AmbiguousFixtureMatch` | `test_multiple_matches_are_an_error` |
+| RH1.1j | D7 — reuse policy | unit | error: default `max_uses=1` | `test_unexpected_fixture_reuse_is_an_error` |
+| RH1.1k | D14 — redacted diagnostics | integration | mismatch string redacts key, lists candidates | `test_mismatch_includes_redacted_request_and_candidate_reasons` |
+| RH1.1l | D16 — lenient not CI default | pin | env var absent from pytest defaults | `test_lenient_mode_is_not_the_ci_default` |
+| RH1.1m | D14 — redaction pin | pin | `redact_secrets` contract | `test_diagnostics_do_not_include_provider_keys_or_github_tokens` |
+| RH1.1n | D2 — production fence | pin | no prod import of harness | `test_src_mergecraft_does_not_import_provider_harness` |
+
+## RED acceptance (RH1.1)
+
+- `uv run pytest --collect-only -q tests/harness/` → **15** collected, zero collection errors.
+- File run: **3 pass** (lenient pin, redaction pin, import fence) + **12 xfail** (schema,
+  matcher, diagnostics). Do not edit `tests/support/provider_harness/` or `src/` to green
+  the suite in RH1.1.
+
+## Files
+
+| Path | Role |
+|------|------|
+| `tests/harness/test_fixture_schema.py` | Pydantic schema + `load_fixture_file` |
+| `tests/harness/test_fixture_matcher.py` | `match_fixture` strict matching |
+| `tests/harness/test_diagnostics.py` | `format_mismatch` + redaction pin |
+| `tests/harness/test_production_import_fence.py` | D2 import fence |
+| `tests/harness/_helpers.py` | Shared request snapshot builder |
+
+Implementation lands in RH1.2 under `tests/support/provider_harness/{schema,matcher,diagnostics}.py`
+and `tests/harness/fixtures/schema-smoke.json`.

--- a/tests/ci/test_harness_workflow.py
+++ b/tests/ci/test_harness_workflow.py
@@ -1,0 +1,18 @@
+"""RH5 — CI pin: unit tests require no provider secret."""
+
+from __future__ import annotations
+
+from tests.ci.workflow_support import job, load_workflow
+
+
+def test_unit_ci_job_has_no_provider_secret() -> None:
+    doc = load_workflow("ci.yml")
+    test_job = job(doc, "test")
+    env = test_job.get("env") or {}
+    forbidden = {
+        "NOUS_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+    }
+    assert forbidden.isdisjoint(set(env.keys()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,4 +9,4 @@ _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-pytest_plugins = ["tests.orchestrator.conftest"]
+pytest_plugins = ["tests.orchestrator.conftest", "tests.support.provider_harness.pytest_plugin"]

--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic provider-harness contract tests (RH1+)."""

--- a/tests/harness/_helpers.py
+++ b/tests/harness/_helpers.py
@@ -1,0 +1,21 @@
+"""Shared helpers for RH1 RED tests — imports stay lazy in callers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def snapshot(**overrides: Any) -> dict[str, Any]:
+    """Minimal request snapshot passed to ``match_fixture`` (RH1.2 contract)."""
+    base: dict[str, Any] = {
+        "provider": "default",
+        "model": "dummy",
+        "mode": "review",
+        "streaming": False,
+        "turn_index": 0,
+        "has_tool_results": None,
+        "test_context_id": None,
+        "body": {"messages": [{"role": "user", "content": "review this diff"}]},
+    }
+    base.update(overrides)
+    return base

--- a/tests/harness/fixtures/blocking-correctness.json
+++ b/tests/harness/fixtures/blocking-correctness.json
@@ -3,13 +3,19 @@
   "match": {
     "provider": "default",
     "model": "dummy",
-    "mode": "review",
     "streaming": false
   },
   "response": {
     "body": {
       "id": "blocking",
-      "choices": [{"message": {"role": "assistant", "content": "Critical issue."}}]
+      "choices": [
+        {
+          "message": {
+            "role": "assistant",
+            "content": "Critical issue."
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/harness/fixtures/blocking-correctness.json
+++ b/tests/harness/fixtures/blocking-correctness.json
@@ -1,0 +1,15 @@
+{
+  "name": "blocking-correctness",
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "mode": "review",
+    "streaming": false
+  },
+  "response": {
+    "body": {
+      "id": "blocking",
+      "choices": [{"message": {"role": "assistant", "content": "Critical issue."}}]
+    }
+  }
+}

--- a/tests/harness/fixtures/missing-terminal.json
+++ b/tests/harness/fixtures/missing-terminal.json
@@ -1,0 +1,7 @@
+{
+  "name": "missing-terminal",
+  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "response": {
+    "blocks": [{"kind": "text", "text": "Review done but no verdict tool."}]
+  }
+}

--- a/tests/harness/fixtures/missing-terminal.json
+++ b/tests/harness/fixtures/missing-terminal.json
@@ -1,7 +1,16 @@
 {
   "name": "missing-terminal",
-  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "streaming": false
+  },
   "response": {
-    "blocks": [{"kind": "text", "text": "Review done but no verdict tool."}]
+    "blocks": [
+      {
+        "kind": "text",
+        "text": "Review done but no verdict tool."
+      }
+    ]
   }
 }

--- a/tests/harness/fixtures/multi-turn-tool-result.json
+++ b/tests/harness/fixtures/multi-turn-tool-result.json
@@ -1,0 +1,16 @@
+{
+  "name": "multi-turn-tool-result",
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "turn_index": 1,
+    "has_tool_results": true,
+    "tool_result_content": "analyzer output"
+  },
+  "response": {
+    "body": {
+      "id": "turn-1",
+      "choices": [{"message": {"role": "assistant", "content": "second turn"}}]
+    }
+  }
+}

--- a/tests/harness/fixtures/multi-turn-tool-result.json
+++ b/tests/harness/fixtures/multi-turn-tool-result.json
@@ -10,7 +10,14 @@
   "response": {
     "body": {
       "id": "turn-1",
-      "choices": [{"message": {"role": "assistant", "content": "second turn"}}]
+      "choices": [
+        {
+          "message": {
+            "role": "assistant",
+            "content": "second turn"
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/harness/fixtures/narrative-lgtm.json
+++ b/tests/harness/fixtures/narrative-lgtm.json
@@ -1,0 +1,7 @@
+{
+  "name": "narrative-lgtm",
+  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "response": {
+    "blocks": [{"kind": "text", "text": "LGTM ship it"}]
+  }
+}

--- a/tests/harness/fixtures/narrative-lgtm.json
+++ b/tests/harness/fixtures/narrative-lgtm.json
@@ -1,7 +1,16 @@
 {
   "name": "narrative-lgtm",
-  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "streaming": false
+  },
   "response": {
-    "blocks": [{"kind": "text", "text": "LGTM ship it"}]
+    "blocks": [
+      {
+        "kind": "text",
+        "text": "LGTM ship it"
+      }
+    ]
   }
 }

--- a/tests/harness/fixtures/no-findings.json
+++ b/tests/harness/fixtures/no-findings.json
@@ -3,13 +3,19 @@
   "match": {
     "provider": "default",
     "model": "dummy",
-    "mode": "review",
     "streaming": false
   },
   "response": {
     "body": {
       "id": "no-findings",
-      "choices": [{"message": {"role": "assistant", "content": "No findings."}}]
+      "choices": [
+        {
+          "message": {
+            "role": "assistant",
+            "content": "No findings."
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/harness/fixtures/no-findings.json
+++ b/tests/harness/fixtures/no-findings.json
@@ -1,0 +1,15 @@
+{
+  "name": "no-findings",
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "mode": "review",
+    "streaming": false
+  },
+  "response": {
+    "body": {
+      "id": "no-findings",
+      "choices": [{"message": {"role": "assistant", "content": "No findings."}}]
+    }
+  }
+}

--- a/tests/harness/fixtures/schema-smoke.json
+++ b/tests/harness/fixtures/schema-smoke.json
@@ -3,13 +3,19 @@
   "match": {
     "provider": "default",
     "model": "dummy",
-    "mode": "review",
     "streaming": false
   },
   "response": {
     "body": {
       "id": "stub",
-      "choices": [{"message": {"role": "assistant", "content": "{}"}}]
+      "choices": [
+        {
+          "message": {
+            "role": "assistant",
+            "content": "{}"
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/harness/fixtures/schema-smoke.json
+++ b/tests/harness/fixtures/schema-smoke.json
@@ -1,0 +1,15 @@
+{
+  "name": "schema-smoke",
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "mode": "review",
+    "streaming": false
+  },
+  "response": {
+    "body": {
+      "id": "stub",
+      "choices": [{"message": {"role": "assistant", "content": "{}"}}]
+    }
+  }
+}

--- a/tests/harness/fixtures/valid-request-changes.json
+++ b/tests/harness/fixtures/valid-request-changes.json
@@ -1,6 +1,10 @@
 {
   "name": "valid-request-changes",
-  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "match": {
+    "provider": "default",
+    "model": "dummy",
+    "streaming": false
+  },
   "response": {
     "blocks": [
       {
@@ -12,16 +16,17 @@
           "summary": "Blocking issue",
           "findings": [
             {
-              "severity": "Critical",
-              "category": "correctness",
-              "title": "Bug",
-              "description": "Fails tests",
-              "location": "src/foo.py:1"
+              "path": "src/foo.py",
+              "body": "Critical correctness issue",
+              "severity": "Critical"
             }
           ]
         }
       },
-      {"kind": "text", "text": "ignored trailing narrative"}
+      {
+        "kind": "text",
+        "text": "ignored trailing narrative"
+      }
     ]
   }
 }

--- a/tests/harness/fixtures/valid-request-changes.json
+++ b/tests/harness/fixtures/valid-request-changes.json
@@ -1,0 +1,27 @@
+{
+  "name": "valid-request-changes",
+  "match": {"provider": "default", "model": "dummy", "streaming": false},
+  "response": {
+    "blocks": [
+      {
+        "kind": "tool_call",
+        "tool_name": "submit_review_verdict",
+        "tool_call_id": "call-verdict-1",
+        "arguments": {
+          "verdict": "request_changes",
+          "summary": "Blocking issue",
+          "findings": [
+            {
+              "severity": "Critical",
+              "category": "correctness",
+              "title": "Bug",
+              "description": "Fails tests",
+              "location": "src/foo.py:1"
+            }
+          ]
+        }
+      },
+      {"kind": "text", "text": "ignored trailing narrative"}
+    ]
+  }
+}

--- a/tests/harness/test_diagnostics.py
+++ b/tests/harness/test_diagnostics.py
@@ -1,0 +1,63 @@
+"""RH1.1 RED — mismatch diagnostics contract (``tests.support.provider_harness.diagnostics``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.analyzers.redact import redact_secrets
+from tests.harness._helpers import snapshot
+
+_MIN_CHAT_BODY = {
+    "id": "stub",
+    "choices": [{"message": {"role": "assistant", "content": "{}"}}],
+}
+
+
+def _fixture(name: str, *, model: str = "dummy") -> object:
+    from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+    return FixtureSpec(
+        name=name,
+        match=MatchSpec(provider="default", model=model, mode="review"),
+        response=ResponseSpec(body=_MIN_CHAT_BODY),
+    )
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
+    from tests.support.provider_harness.diagnostics import format_mismatch
+    from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
+
+    api_key = "sk-mergecraft-test"
+    req = snapshot(
+        body={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "review"}],
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    fixtures = [_fixture("candidate-a", model="other-a"), _fixture("candidate-b", model="other-b")]
+
+    try:
+        match_fixture(req, fixtures, strict=True)
+    except NoFixtureMatch as err:
+        diagnostic = format_mismatch(err)
+    else:
+        pytest.fail("expected NoFixtureMatch")
+
+    assert "candidate-a" in diagnostic
+    assert "candidate-b" in diagnostic
+    assert api_key not in diagnostic
+    assert "[REDACTED]" in diagnostic
+    assert "provider" in diagnostic.lower() or "default" in diagnostic
+    assert "model" in diagnostic.lower() or "dummy" in diagnostic
+
+
+def test_diagnostics_do_not_include_provider_keys_or_github_tokens() -> None:
+    """Pin — ``redact_secrets`` contract harness diagnostics must reuse (D14)."""
+    raw = "sk-abc12345ghi and ghp_" + "x" * 36
+    redacted = redact_secrets(raw)
+
+    assert "sk-abc12345ghi" not in redacted
+    assert "ghp_" + "x" * 36 not in redacted
+    assert "[REDACTED]" in redacted

--- a/tests/harness/test_diagnostics.py
+++ b/tests/harness/test_diagnostics.py
@@ -23,7 +23,6 @@ def _fixture(name: str, *, model: str = "dummy") -> object:
     )
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
     from tests.support.provider_harness.diagnostics import format_mismatch
     from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
@@ -61,3 +60,32 @@ def test_diagnostics_do_not_include_provider_keys_or_github_tokens() -> None:
     assert "sk-abc12345ghi" not in redacted
     assert "ghp_" + "x" * 36 not in redacted
     assert "[REDACTED]" in redacted
+
+
+def test_failure_diagnostic_contains_fixture_usage_and_latency() -> None:
+    from tests.support.provider_harness.diagnostics import format_mismatch
+    from tests.support.provider_harness.matcher import NoFixtureMatch
+    from tests.support.provider_harness.metrics import HarnessMetrics
+
+    metrics = HarnessMetrics()
+    metrics.fixture_usage["candidate"] = 2
+    err = NoFixtureMatch(
+        request=snapshot(), fixtures=[], candidate_reasons={"candidate": "model mismatch"}
+    )
+    text = format_mismatch(err, metrics=metrics, latency_ms=12.5)
+    assert "fixture_usage" in text
+    assert "latency_ms" in text
+
+
+def test_diagnostics_never_dump_unbounded_payloads() -> None:
+    from tests.support.provider_harness.diagnostics import format_mismatch
+    from tests.support.provider_harness.matcher import NoFixtureMatch
+
+    huge = "x" * 5000
+    err = NoFixtureMatch(
+        request=snapshot(body={"blob": huge}),
+        fixtures=[],
+        candidate_reasons={"x": "y"},
+    )
+    text = format_mismatch(err)
+    assert len(text) < 5000

--- a/tests/harness/test_diagnostics.py
+++ b/tests/harness/test_diagnostics.py
@@ -47,7 +47,7 @@ def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
     assert "candidate-a" in diagnostic
     assert "candidate-b" in diagnostic
     assert api_key not in diagnostic
-    assert "[REDACTED]" in diagnostic
+    assert "[REDACTED]" in diagnostic or "<redacted>" in diagnostic
     assert "provider" in diagnostic.lower() or "default" in diagnostic
     assert "model" in diagnostic.lower() or "dummy" in diagnostic
 

--- a/tests/harness/test_diagnostics.py
+++ b/tests/harness/test_diagnostics.py
@@ -13,12 +13,16 @@ _MIN_CHAT_BODY = {
 }
 
 
-def _fixture(name: str, *, model: str = "dummy") -> object:
+def _fixture(
+    name: str, *, model: str = "dummy", body_fields: dict[str, object] | None = None
+) -> object:
     from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
 
     return FixtureSpec(
         name=name,
-        match=MatchSpec(provider="default", model=model, mode="review"),
+        match=MatchSpec(
+            provider="default", model=model, mode="review", body_fields=body_fields or {}
+        ),
         response=ResponseSpec(body=_MIN_CHAT_BODY),
     )
 
@@ -33,9 +37,13 @@ def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
             "model": "dummy",
             "messages": [{"role": "user", "content": "review"}],
             "Authorization": f"Bearer {api_key}",
+            "api_key": api_key,
         },
     )
-    fixtures = [_fixture("candidate-a", model="other-a"), _fixture("candidate-b", model="other-b")]
+    fixtures = [
+        _fixture("candidate-a", model="other-a", body_fields={"api_key": "expected-a"}),
+        _fixture("candidate-b", model="other-b", body_fields={"api_key": "expected-b"}),
+    ]
 
     try:
         match_fixture(req, fixtures, strict=True)
@@ -85,7 +93,7 @@ def test_diagnostics_never_dump_unbounded_payloads() -> None:
     err = NoFixtureMatch(
         request=snapshot(body={"blob": huge}),
         fixtures=[],
-        candidate_reasons={"x": "y"},
+        candidate_reasons={"x": f"body_fields['blob']: expected 'y', got {huge!r}"},
     )
     text = format_mismatch(err)
     assert len(text) < 5000

--- a/tests/harness/test_failure_profiles.py
+++ b/tests/harness/test_failure_profiles.py
@@ -1,0 +1,98 @@
+"""RH3 — named failure profiles on the HTTP stub."""
+
+from __future__ import annotations
+
+import contextlib
+
+import httpx
+
+from mergecraft.utils.retry_policy import is_transient_http_error
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+
+def _profile_fixture(profile: str, *, streaming: bool = False) -> FixtureSpec:
+    return FixtureSpec(
+        name=f"profile-{profile}",
+        match=MatchSpec(provider="default", model="dummy", streaming=streaming),
+        response=ResponseSpec(body={"id": "stub", "choices": []}),
+        profile=profile,
+    )
+
+
+def test_http_429_profile_emits_retry_after(provider_harness) -> None:
+    provider_harness.reload([_profile_fixture("http_429")])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 429
+    assert response.headers.get("Retry-After") == "1"
+
+
+def test_http_500_profile_is_deterministic(provider_harness) -> None:
+    provider_harness.reload([_profile_fixture("http_500")])
+    assert (
+        httpx.post(
+            provider_harness.base_url + "/chat/completions",
+            headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+            json={"model": "default/dummy", "messages": []},
+            timeout=5.0,
+        ).status_code
+        == 500
+    )
+
+
+def test_timeout_profile_is_deterministic(provider_harness) -> None:
+
+    provider_harness.reload([_profile_fixture("timeout")])
+    with httpx.Client(timeout=0.05) as client, contextlib.suppress(httpx.ReadTimeout):
+        client.post(
+            provider_harness.base_url + "/chat/completions",
+            headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+            json={"model": "default/dummy", "messages": []},
+        )
+
+
+def test_malformed_json_profile_returns_invalid_payload(provider_harness) -> None:
+    provider_harness.reload([_profile_fixture("malformed_json")])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+    assert "not-json" in response.text or response.text.startswith("{")
+
+
+def test_empty_stream_profile_completes_without_content(provider_harness) -> None:
+    provider_harness.reload([_profile_fixture("empty_stream", streaming=True)])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "stream": True, "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+
+
+def test_http_401_profile_is_not_transient(provider_harness) -> None:
+    provider_harness.reload([_profile_fixture("http_401")])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 401
+    assert (
+        is_transient_http_error(
+            httpx.HTTPStatusError(
+                "401", request=httpx.Request("POST", "http://x"), response=httpx.Response(401)
+            )
+        )
+        is False
+    )

--- a/tests/harness/test_fixture_matcher.py
+++ b/tests/harness/test_fixture_matcher.py
@@ -119,12 +119,13 @@ def test_unexpected_fixture_reuse_is_an_error() -> None:
 
     fixtures = [_fixture(name="single-use", max_uses=1)]
     req = snapshot()
+    usage: dict[str, int] = {}
 
-    first = match_fixture(req, fixtures, strict=True)
+    first = match_fixture(req, fixtures, strict=True, usage_counts=usage)
     assert first.name == "single-use"
 
     with pytest.raises(FixtureReuseError):
-        match_fixture(req, fixtures, strict=True)
+        match_fixture(req, fixtures, strict=True, usage_counts=usage)
 
 
 def test_lenient_mode_is_not_the_ci_default() -> None:

--- a/tests/harness/test_fixture_matcher.py
+++ b/tests/harness/test_fixture_matcher.py
@@ -1,0 +1,143 @@
+"""RH1.1 RED — strict fixture matcher contract (``tests.support.provider_harness.matcher``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.harness._helpers import snapshot
+
+_MIN_CHAT_BODY = {
+    "id": "stub",
+    "choices": [{"message": {"role": "assistant", "content": "{}"}}],
+}
+
+
+def _fixture(
+    *,
+    name: str,
+    provider: str = "default",
+    model: str = "dummy",
+    mode: str | None = "review",
+    streaming: bool = False,
+    turn_index: int = 0,
+    body_fields: dict[str, object] | None = None,
+    max_uses: int = 1,
+) -> object:
+    from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+    return FixtureSpec(
+        name=name,
+        match=MatchSpec(
+            provider=provider,
+            model=model,
+            mode=mode,
+            streaming=streaming,
+            turn_index=turn_index,
+            body_fields=body_fields or {},
+        ),
+        response=ResponseSpec(body=_MIN_CHAT_BODY),
+        max_uses=max_uses,
+    )
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_matching_uses_provider_model_and_mode() -> None:
+    from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
+
+    fixtures = [
+        _fixture(name="default-review", provider="default", model="dummy", mode="review"),
+        _fixture(name="other-model", provider="default", model="other", mode="review"),
+    ]
+
+    matched = match_fixture(snapshot(), fixtures, strict=True)
+    assert matched.name == "default-review"
+
+    with pytest.raises(NoFixtureMatch):
+        match_fixture(snapshot(model="unknown"), fixtures, strict=True)
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_streaming_flag_participates_in_matching() -> None:
+    from tests.support.provider_harness.matcher import match_fixture
+
+    fixtures = [
+        _fixture(name="non-stream", streaming=False),
+        _fixture(name="stream", streaming=True),
+    ]
+
+    matched = match_fixture(snapshot(streaming=False), fixtures, strict=True)
+    assert matched.name == "non-stream"
+
+    matched_stream = match_fixture(snapshot(streaming=True), fixtures, strict=True)
+    assert matched_stream.name == "stream"
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_body_field_matchers_are_explicit() -> None:
+    from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
+
+    fixtures = [
+        _fixture(
+            name="temperature-zero",
+            body_fields={"temperature": 0},
+        ),
+        _fixture(
+            name="temperature-one",
+            body_fields={"temperature": 1},
+        ),
+    ]
+
+    matched = match_fixture(snapshot(body={"temperature": 0}), fixtures, strict=True)
+    assert matched.name == "temperature-zero"
+
+    with pytest.raises(NoFixtureMatch):
+        match_fixture(snapshot(body={"temperature": 0.5}), fixtures, strict=True)
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_no_fixture_match_is_an_error_in_strict_mode() -> None:
+    from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
+
+    fixtures = [_fixture(name="only-one", model="other-model")]
+
+    with pytest.raises(NoFixtureMatch):
+        match_fixture(snapshot(model="dummy"), fixtures, strict=True)
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_multiple_matches_are_an_error() -> None:
+    from tests.support.provider_harness.matcher import AmbiguousFixtureMatch, match_fixture
+
+    fixtures = [
+        _fixture(name="dup-a"),
+        _fixture(name="dup-b"),
+    ]
+
+    with pytest.raises(AmbiguousFixtureMatch):
+        match_fixture(snapshot(), fixtures, strict=True)
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_unexpected_fixture_reuse_is_an_error() -> None:
+    from tests.support.provider_harness.matcher import FixtureReuseError, match_fixture
+
+    fixtures = [_fixture(name="single-use", max_uses=1)]
+    req = snapshot()
+
+    first = match_fixture(req, fixtures, strict=True)
+    assert first.name == "single-use"
+
+    with pytest.raises(FixtureReuseError):
+        match_fixture(req, fixtures, strict=True)
+
+
+def test_lenient_mode_is_not_the_ci_default() -> None:
+    """CI pin — lenient env must not be set in pytest defaults (D7/D16)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    conftest = (repo_root / "tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert "MERGECRAFT_PROVIDER_HARNESS_LENIENT" not in pyproject
+    assert "MERGECRAFT_PROVIDER_HARNESS_LENIENT" not in conftest

--- a/tests/harness/test_fixture_matcher.py
+++ b/tests/harness/test_fixture_matcher.py
@@ -42,7 +42,6 @@ def _fixture(
     )
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_matching_uses_provider_model_and_mode() -> None:
     from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
 
@@ -58,7 +57,6 @@ def test_matching_uses_provider_model_and_mode() -> None:
         match_fixture(snapshot(model="unknown"), fixtures, strict=True)
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_streaming_flag_participates_in_matching() -> None:
     from tests.support.provider_harness.matcher import match_fixture
 
@@ -74,7 +72,6 @@ def test_streaming_flag_participates_in_matching() -> None:
     assert matched_stream.name == "stream"
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_body_field_matchers_are_explicit() -> None:
     from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
 
@@ -96,7 +93,6 @@ def test_body_field_matchers_are_explicit() -> None:
         match_fixture(snapshot(body={"temperature": 0.5}), fixtures, strict=True)
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_no_fixture_match_is_an_error_in_strict_mode() -> None:
     from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
 
@@ -106,7 +102,6 @@ def test_no_fixture_match_is_an_error_in_strict_mode() -> None:
         match_fixture(snapshot(model="dummy"), fixtures, strict=True)
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_multiple_matches_are_an_error() -> None:
     from tests.support.provider_harness.matcher import AmbiguousFixtureMatch, match_fixture
 
@@ -119,7 +114,6 @@ def test_multiple_matches_are_an_error() -> None:
         match_fixture(snapshot(), fixtures, strict=True)
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_unexpected_fixture_reuse_is_an_error() -> None:
     from tests.support.provider_harness.matcher import FixtureReuseError, match_fixture
 

--- a/tests/harness/test_fixture_schema.py
+++ b/tests/harness/test_fixture_schema.py
@@ -13,7 +13,6 @@ _MIN_CHAT_BODY = {
 }
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_fixture_requires_provider_and_model() -> None:
     from pydantic import ValidationError
 
@@ -34,7 +33,6 @@ def test_fixture_requires_provider_and_model() -> None:
         )
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_fixture_requires_request_match_fields() -> None:
     from pydantic import ValidationError
 
@@ -47,7 +45,6 @@ def test_fixture_requires_request_match_fields() -> None:
         MatchSpec(provider="")  # type: ignore[call-arg]
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_fixture_accepts_json_response_and_metadata() -> None:
     from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
 
@@ -72,7 +69,6 @@ def test_fixture_accepts_json_response_and_metadata() -> None:
     }
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_fixture_accepts_ordered_response_blocks() -> None:
     from tests.support.provider_harness.schema import (
         FixtureSpec,
@@ -102,7 +98,6 @@ def test_fixture_accepts_ordered_response_blocks() -> None:
     assert fixture.response.blocks[1].tool_name == "submit_review_verdict"
 
 
-@pytest.mark.xfail(reason="green after RH1.2", strict=False)
 def test_malformed_fixture_is_rejected_with_path(tmp_path: Path) -> None:
     from tests.support.provider_harness.schema import MalformedFixtureError, load_fixture_file
 

--- a/tests/harness/test_fixture_schema.py
+++ b/tests/harness/test_fixture_schema.py
@@ -1,0 +1,124 @@
+"""RH1.1 RED — provider fixture schema contract (``tests.support.provider_harness.schema``)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_MIN_CHAT_BODY = {
+    "id": "stub",
+    "choices": [{"message": {"role": "assistant", "content": "{}"}}],
+}
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_fixture_requires_provider_and_model() -> None:
+    from pydantic import ValidationError
+
+    from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+    with pytest.raises(ValidationError):
+        FixtureSpec(
+            name="missing-provider",
+            match=MatchSpec(model="dummy"),  # type: ignore[call-arg]
+            response=ResponseSpec(body=_MIN_CHAT_BODY),
+        )
+
+    with pytest.raises(ValidationError):
+        FixtureSpec(
+            name="missing-model",
+            match=MatchSpec(provider="default"),  # type: ignore[call-arg]
+            response=ResponseSpec(body=_MIN_CHAT_BODY),
+        )
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_fixture_requires_request_match_fields() -> None:
+    from pydantic import ValidationError
+
+    from tests.support.provider_harness.schema import MatchSpec
+
+    with pytest.raises(ValidationError):
+        MatchSpec()  # type: ignore[call-arg]
+
+    with pytest.raises(ValidationError):
+        MatchSpec(provider="")  # type: ignore[call-arg]
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_fixture_accepts_json_response_and_metadata() -> None:
+    from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+    fixture = FixtureSpec(
+        name="json-with-metadata",
+        match=MatchSpec(provider="default", model="dummy", mode="review"),
+        response=ResponseSpec(
+            status_code=200,
+            body=_MIN_CHAT_BODY,
+            usage={"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            request_id="req-test-001",
+            finish_reason="stop",
+        ),
+    )
+
+    assert fixture.response.request_id == "req-test-001"
+    assert fixture.response.finish_reason == "stop"
+    assert fixture.response.usage == {
+        "prompt_tokens": 1,
+        "completion_tokens": 2,
+        "total_tokens": 3,
+    }
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_fixture_accepts_ordered_response_blocks() -> None:
+    from tests.support.provider_harness.schema import (
+        FixtureSpec,
+        MatchSpec,
+        ResponseBlock,
+        ResponseSpec,
+    )
+
+    fixture = FixtureSpec(
+        name="ordered-blocks",
+        match=MatchSpec(provider="default", model="dummy"),
+        response=ResponseSpec(
+            blocks=[
+                ResponseBlock(kind="text", text="Review complete."),
+                ResponseBlock(
+                    kind="tool_call",
+                    tool_name="submit_review_verdict",
+                    tool_call_id="call-1",
+                    arguments={"verdict": "approve"},
+                ),
+            ],
+        ),
+    )
+
+    assert len(fixture.response.blocks) == 2
+    assert fixture.response.blocks[0].kind == "text"
+    assert fixture.response.blocks[1].tool_name == "submit_review_verdict"
+
+
+@pytest.mark.xfail(reason="green after RH1.2", strict=False)
+def test_malformed_fixture_is_rejected_with_path(tmp_path: Path) -> None:
+    from tests.support.provider_harness.schema import MalformedFixtureError, load_fixture_file
+
+    bad_path = tmp_path / "broken-scenario.json"
+    bad_path.write_text("{ not valid json", encoding="utf-8")
+
+    with pytest.raises(MalformedFixtureError) as exc_info:
+        load_fixture_file(bad_path)
+
+    assert str(bad_path) in str(exc_info.value)
+
+    missing_required = tmp_path / "incomplete-scenario.json"
+    missing_required.write_text(
+        json.dumps({"name": "incomplete", "match": {"provider": "default"}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(MalformedFixtureError) as exc_info2:
+        load_fixture_file(missing_required)
+    assert str(missing_required) in str(exc_info2.value)

--- a/tests/harness/test_lifecycle.py
+++ b/tests/harness/test_lifecycle.py
@@ -1,0 +1,78 @@
+"""RH2 — pytest lifecycle and provider env patching."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from mergecraft.agents.openai_compatible_gateways import ProviderConfig
+from mergecraft.agents.opencode import build_custom_provider
+from mergecraft.cli.auth_cmd import _validate_openai_compatible_key
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+from tests.support.provider_harness.server import ProviderHarnessServer
+
+
+def test_provider_can_use_local_openai_compatible_base_url(provider_harness, monkeypatch) -> None:
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", provider_harness.base_url)
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", DUMMY_API_KEY)
+    emitted = build_custom_provider("default/dummy")
+    assert emitted is not None
+    assert emitted["default"]["options"]["baseURL"] == provider_harness.base_url
+
+
+def test_auth_models_probe_succeeds_against_stub(provider_harness) -> None:
+    assert _validate_openai_compatible_key(
+        api_key=DUMMY_API_KEY,
+        base_url=provider_harness.base_url,
+        label="harness",
+    )
+
+
+def test_fixture_state_is_isolated_between_tests(provider_harness) -> None:
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    assert (
+        httpx.post(
+            provider_harness.base_url + "/chat/completions",
+            headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+            json={"model": "default/dummy", "messages": []},
+            timeout=5.0,
+        ).status_code
+        == 200
+    )
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    assert (
+        httpx.post(
+            provider_harness.base_url + "/chat/completions",
+            headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+            json={"model": "default/dummy", "messages": []},
+            timeout=5.0,
+        ).status_code
+        == 200
+    )
+
+
+def test_server_stops_during_fixture_teardown() -> None:
+    server = ProviderHarnessServer()
+    server.start()
+    url = server.url_for("/health")
+    assert httpx.get(url, timeout=5.0).status_code == 200
+    server.close()
+    with pytest.raises((httpx.ConnectError, httpx.ReadError, OSError)):
+        httpx.get(url, timeout=1.0)
+
+
+def test_client_is_constructed_after_environment_patch(provider_harness) -> None:
+    assert os.environ["MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"] == provider_harness.base_url
+    assert os.environ["MERGECRAFT_CUSTOM_PROVIDER_API_KEY"] == DUMMY_API_KEY
+
+
+def test_localhost_base_url_is_already_legal() -> None:
+    cfg = ProviderConfig(
+        provider_id="default",
+        base_url="http://127.0.0.1:9/v1",
+        api_key_env="MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+    )
+    assert cfg.base_url.endswith("/v1")

--- a/tests/harness/test_mcp_double.py
+++ b/tests/harness/test_mcp_double.py
@@ -1,0 +1,23 @@
+"""RH4 — MCP scripted double."""
+
+from __future__ import annotations
+
+from tests.support.provider_harness.mcp_double import scripted_mcp_app
+
+
+def test_tool_listing_and_call_are_deterministic() -> None:
+    client = scripted_mcp_app({"calls": {"echo": {"result": {"ok": True}}}})
+    payload = client.call_tool("echo", {"x": 1})
+    assert payload["result"]["ok"] is True
+
+
+def test_resource_read_and_prompt_retrieval_are_deterministic() -> None:
+    client = scripted_mcp_app({"calls": {"read_resource": {"result": {"contents": []}}}})
+    payload = client.call_tool("read_resource", {"uri": "file://x"})
+    assert "result" in payload
+
+
+def test_protocol_error_is_explicit() -> None:
+    client = scripted_mcp_app({"calls": {"broken": {"error": "protocol failure"}}})
+    payload = client.call_tool("broken", {})
+    assert payload["error"] == "protocol failure"

--- a/tests/harness/test_metadata.py
+++ b/tests/harness/test_metadata.py
@@ -1,0 +1,51 @@
+"""RH3 — response metadata overrides."""
+
+from __future__ import annotations
+
+import httpx
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+
+def test_fixture_controls_response_usage_and_request_id(provider_harness) -> None:
+    fixture = FixtureSpec(
+        name="metadata",
+        match=MatchSpec(provider="default", model="dummy"),
+        response=ResponseSpec(
+            body={
+                "id": "meta-id",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            },
+            usage={"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+            request_id="req-123",
+            finish_reason="stop",
+        ),
+    )
+    provider_harness.reload([fixture])
+    body = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    ).json()
+    assert body["id"] == "req-123"
+    assert body.get("usage", {}).get("total_tokens") == 7
+
+
+def test_rate_limit_headers_are_preserved_on_429(provider_harness) -> None:
+    fixture = FixtureSpec(
+        name="rate-limit",
+        match=MatchSpec(provider="default", model="dummy"),
+        response=ResponseSpec(body={"error": "rate_limit"}),
+        profile="http_429",
+    )
+    provider_harness.reload([fixture])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers

--- a/tests/harness/test_metrics.py
+++ b/tests/harness/test_metrics.py
@@ -1,0 +1,40 @@
+"""RH5 — harness metrics."""
+
+from __future__ import annotations
+
+import httpx
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+
+
+def test_metrics_count_matches_mismatches_statuses_and_retries(provider_harness) -> None:
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/unknown", "messages": []},
+        timeout=5.0,
+    )
+    snap = provider_harness.metrics.snapshot()
+    assert snap["matches"] >= 1
+    assert snap["mismatches"] >= 1
+
+
+def test_metrics_are_bounded_and_reset_per_server(provider_harness) -> None:
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    snap = provider_harness.metrics.snapshot()
+    assert snap["request_count"] >= 0

--- a/tests/harness/test_metrics.py
+++ b/tests/harness/test_metrics.py
@@ -6,6 +6,16 @@ import httpx
 
 from tests.support.provider_harness import DUMMY_API_KEY
 from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+
+def _profile_fixture(profile: str) -> FixtureSpec:
+    return FixtureSpec(
+        name=f"profile-{profile}",
+        match=MatchSpec(provider="default", model="dummy"),
+        response=ResponseSpec(body={"id": "stub", "choices": []}),
+        profile=profile,
+    )
 
 
 def test_metrics_count_matches_mismatches_statuses_and_retries(provider_harness) -> None:
@@ -26,6 +36,16 @@ def test_metrics_count_matches_mismatches_statuses_and_retries(provider_harness)
     assert snap["matches"] >= 1
     assert snap["mismatches"] >= 1
 
+    provider_harness.reload([_profile_fixture("http_429")])
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    snap = provider_harness.metrics.snapshot()
+    assert snap["retries"] >= 1
+
 
 def test_metrics_are_bounded_and_reset_per_server(provider_harness) -> None:
     provider_harness.reload(load_harness_fixtures("no-findings"))
@@ -37,4 +57,4 @@ def test_metrics_are_bounded_and_reset_per_server(provider_harness) -> None:
     )
     provider_harness.reload(load_harness_fixtures("no-findings"))
     snap = provider_harness.metrics.snapshot()
-    assert snap["request_count"] >= 0
+    assert snap["request_count"] == 0

--- a/tests/harness/test_multi_turn.py
+++ b/tests/harness/test_multi_turn.py
@@ -1,0 +1,54 @@
+"""RH4 — multi-turn fixture matching."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.harness._helpers import snapshot
+from tests.support.provider_harness.matcher import NoFixtureMatch, match_fixture
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+from tests.support.provider_harness.schema import FixtureSpec, MatchSpec, ResponseSpec
+
+
+def test_turn_index_and_tool_result_select_next_fixture() -> None:
+    fixtures = load_harness_fixtures("no-findings", "multi-turn-tool-result")
+    matched = match_fixture(
+        snapshot(turn_index=1, has_tool_results=True, tool_result_content="analyzer output"),
+        fixtures,
+        strict=True,
+    )
+    assert matched.name == "multi-turn-tool-result"
+
+
+def test_tool_call_id_disambiguates_repeated_turns() -> None:
+    fixtures = [
+        FixtureSpec(
+            name="turn-a",
+            match=MatchSpec(provider="default", model="dummy", turn_index=1, tool_call_id="call-a"),
+            response=ResponseSpec(body={"id": "a", "choices": []}),
+        ),
+        FixtureSpec(
+            name="turn-b",
+            match=MatchSpec(provider="default", model="dummy", turn_index=1, tool_call_id="call-b"),
+            response=ResponseSpec(body={"id": "b", "choices": []}),
+        ),
+    ]
+    assert match_fixture(snapshot(turn_index=1, tool_call_id="call-b"), fixtures).name == "turn-b"
+
+
+def test_tool_result_content_can_be_a_match_guard() -> None:
+    fixtures = load_harness_fixtures("multi-turn-tool-result")
+    matched = match_fixture(
+        snapshot(turn_index=1, has_tool_results=True, tool_result_content="analyzer output"),
+        fixtures,
+        strict=True,
+    )
+    assert matched.name == "multi-turn-tool-result"
+
+
+def test_turn_mismatch_reports_expected_and_observed_state() -> None:
+    fixtures = load_harness_fixtures("multi-turn-tool-result")
+    with pytest.raises(NoFixtureMatch) as exc:
+        match_fixture(snapshot(turn_index=0, has_tool_results=False), fixtures, strict=True)
+    reason = str(exc.value.candidate_reasons.get("multi-turn-tool-result", ""))
+    assert "turn_index" in reason or "has_tool_results" in reason or "tool_result_content" in reason

--- a/tests/harness/test_ndjson_stream.py
+++ b/tests/harness/test_ndjson_stream.py
@@ -1,0 +1,19 @@
+"""RH3 — NDJSON replay through ``consume_stream``."""
+
+from __future__ import annotations
+
+from mergecraft.agents._stream_consumer import StreamSpanAccumulator, consume_stream
+from tests.support.provider_harness.ndjson import lines_from_blocks
+from tests.support.provider_harness.schema import ResponseBlock
+
+
+def test_consume_stream_replays_ordered_lines() -> None:
+    lines = lines_from_blocks(
+        [
+            ResponseBlock(kind="text", text="alpha"),
+            ResponseBlock(kind="text", text="beta"),
+        ]
+    )
+    acc = StreamSpanAccumulator(agent_name="test")
+    consume_stream(raw_stream=lines, accumulator=acc, handler=lambda _event: None)
+    assert len(lines) == 2

--- a/tests/harness/test_ndjson_stream.py
+++ b/tests/harness/test_ndjson_stream.py
@@ -15,5 +15,5 @@ def test_consume_stream_replays_ordered_lines() -> None:
         ]
     )
     acc = StreamSpanAccumulator(agent_name="test")
-    consume_stream(raw_stream=lines, accumulator=acc, handler=lambda _event: None)
-    assert len(lines) == 2
+    consume_stream(raw_stream=lines, accumulator=acc, handler=lambda _acc, _event: None)
+    assert acc.parsed_event_count == 2

--- a/tests/harness/test_ordered_blocks.py
+++ b/tests/harness/test_ordered_blocks.py
@@ -1,0 +1,92 @@
+"""RH4 — ordered block replay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.support.provider_harness.blocks import replay_blocks
+from tests.support.provider_harness.schema import ResponseBlock
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def ctx(tmp_path, monkeypatch):
+    from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+    from mergecraft.mcp.tool_state import init_tool_state
+    from mergecraft.modes import compute_modes
+    from mergecraft.utils.github import GitHubClient
+
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=7, is_pr=True),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+    )
+
+
+def test_text_before_terminal_tool_call_is_replayed(ctx) -> None:
+    blocks = [
+        ResponseBlock(kind="text", text="thinking"),
+        ResponseBlock(
+            kind="tool_call",
+            tool_name="submit_review_verdict",
+            arguments={"verdict": "approve", "summary": "ok", "findings": []},
+        ),
+    ]
+    result = replay_blocks(blocks, ctx=ctx)
+    assert result.output == "thinking"
+    assert result.terminal_submission_received is True
+
+
+def test_terminal_tool_call_before_text_is_replayed(ctx) -> None:
+    blocks = [
+        ResponseBlock(
+            kind="tool_call",
+            tool_name="submit_review_verdict",
+            arguments={"verdict": "approve", "summary": "ok", "findings": []},
+        ),
+        ResponseBlock(kind="text", text="after"),
+    ]
+    result = replay_blocks(blocks, ctx=ctx)
+    assert result.terminal_submission_received is True
+    assert "after" in (result.output or "")
+
+
+def test_multiple_tool_calls_preserve_order(ctx) -> None:
+    blocks = [
+        ResponseBlock(kind="tool_call", tool_name="other_tool", tool_call_id="a", arguments={}),
+        ResponseBlock(
+            kind="tool_call",
+            tool_name="submit_review_verdict",
+            arguments={"verdict": "approve", "summary": "ok", "findings": []},
+        ),
+    ]
+    result = replay_blocks(blocks, ctx=ctx)
+    assert result.terminal_submission_received is True
+
+
+def test_malformed_tool_arguments_are_visible_to_validation(ctx) -> None:
+    blocks = [
+        ResponseBlock(
+            kind="tool_call",
+            tool_name="submit_review_verdict",
+            arguments={"verdict": "approve"},
+        ),
+    ]
+    result = replay_blocks(blocks, ctx=ctx)
+    assert result.success is False
+    assert result.error

--- a/tests/harness/test_production_import_fence.py
+++ b/tests/harness/test_production_import_fence.py
@@ -1,0 +1,42 @@
+"""RH1.1 pin — production code must not import the test-only provider harness (D2)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "mergecraft"
+_FORBIDDEN = frozenset(
+    {
+        "tests.support.provider_harness",
+        "provider_harness",
+    }
+)
+
+
+def _imports_provider_harness(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in _FORBIDDEN):
+                    hits.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in _FORBIDDEN):
+                hits.append(f"from {node.module} import …")
+            for alias in node.names:
+                if alias.name == "provider_harness":
+                    hits.append(f"from {node.module} import {alias.name}")
+    return hits
+
+
+def test_src_mergecraft_does_not_import_provider_harness() -> None:
+    """No ``src/mergecraft/**/*.py`` may reference ``tests.support.provider_harness``."""
+    violations: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        hits = _imports_provider_harness(path)
+        if hits:
+            rel = path.relative_to(_SRC_ROOT)
+            violations.append(f"{rel}: {', '.join(hits)}")
+    assert violations == []

--- a/tests/harness/test_recording.py
+++ b/tests/harness/test_recording.py
@@ -1,0 +1,57 @@
+"""RH5 — sanitized recording workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+from tests.support.provider_harness.recorder import write_record
+
+
+def test_sanitized_record_can_be_replayed(provider_harness, monkeypatch, tmp_path, chdir_tmp):
+    monkeypatch.setenv("MERGECRAFT_PROVIDER_HARNESS_RECORD", "1")
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    records = list(Path(".ignorelocal/provider-harness/records").glob("*.json"))
+    assert records
+    payload = json.loads(records[0].read_text(encoding="utf-8"))
+    assert DUMMY_API_KEY not in json.dumps(payload)
+
+
+def test_recording_preserves_match_fields_and_response_metadata(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGECRAFT_PROVIDER_HARNESS_RECORD", "1")
+    fixture = load_harness_fixtures("no-findings")[0]
+    path = write_record(
+        request={"provider": "default", "model": "dummy", "body": {}}, fixture=fixture
+    )
+    assert path is not None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["match"]["provider"] == "default"
+    assert data["response"]
+
+
+def test_recorder_writes_under_ignorelocal_not_committed_fixtures(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGECRAFT_PROVIDER_HARNESS_RECORD", "1")
+    fixture = load_harness_fixtures("no-findings")[0]
+    path = write_record(
+        request={"provider": "default", "model": "dummy", "body": {}}, fixture=fixture
+    )
+    assert path is not None
+    assert str(path).startswith(str(tmp_path / ".ignorelocal"))
+
+
+@pytest.fixture
+def chdir_tmp(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)

--- a/tests/harness/test_redactor.py
+++ b/tests/harness/test_redactor.py
@@ -1,0 +1,39 @@
+"""RH5 — redaction pins for recorder."""
+
+from __future__ import annotations
+
+import inspect
+
+from mergecraft.analyzers.redact import redact_secrets
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness import recorder as recorder_module
+
+
+def test_redacts_provider_api_keys() -> None:
+    assert DUMMY_API_KEY not in redact_secrets(DUMMY_API_KEY)
+    assert "[REDACTED]" in redact_secrets(DUMMY_API_KEY)
+
+
+def test_redacts_github_tokens_and_secret_like_values() -> None:
+    raw = "ghp_" + "x" * 36
+    redacted = redact_secrets(raw)
+    assert raw not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redacts_sensitive_request_fields_before_fixture_write() -> None:
+    source = inspect.getsource(recorder_module._sanitize)
+    assert "redact_secrets" in source or "redact_attrs" in inspect.getsource(
+        recorder_module.write_record
+    )
+
+
+def test_recording_requires_explicit_local_opt_in(monkeypatch) -> None:
+    monkeypatch.delenv("MERGECRAFT_PROVIDER_HARNESS_RECORD", raising=False)
+    assert recorder_module.recording_enabled() is False
+
+
+def test_recording_never_commits_or_pushes() -> None:
+    source = inspect.getsource(recorder_module)
+    assert "git" not in source
+    assert "subprocess" not in source

--- a/tests/harness/test_redactor.py
+++ b/tests/harness/test_redactor.py
@@ -22,10 +22,11 @@ def test_redacts_github_tokens_and_secret_like_values() -> None:
 
 
 def test_redacts_sensitive_request_fields_before_fixture_write() -> None:
-    source = inspect.getsource(recorder_module._sanitize)
-    assert "redact_secrets" in source or "redact_attrs" in inspect.getsource(
-        recorder_module.write_record
-    )
+    from tests.support.provider_harness import redaction as redaction_module
+
+    source = inspect.getsource(redaction_module.sanitize_value)
+    assert "redact_secrets" in source
+    assert "redact_attrs" in source
 
 
 def test_recording_requires_explicit_local_opt_in(monkeypatch) -> None:

--- a/tests/harness/test_server.py
+++ b/tests/harness/test_server.py
@@ -12,6 +12,7 @@ from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
 from tests.support.provider_harness.schema import load_fixture_file
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_health_and_readiness_report_server_state(provider_harness) -> None:
@@ -60,7 +61,7 @@ def test_dummy_api_key_is_accepted_only_by_test_server(provider_harness) -> None
         timeout=5.0,
     )
     assert response.status_code == 401
-    assert "sk-mergecraft-test" not in Path("src/mergecraft/agents/opencode.py").read_text(
+    assert "sk-mergecraft-test" not in (_REPO_ROOT / "src/mergecraft/agents/opencode.py").read_text(
         encoding="utf-8"
     )
 

--- a/tests/harness/test_server.py
+++ b/tests/harness/test_server.py
@@ -1,0 +1,84 @@
+"""RH2 — local OpenAI-compatible stub HTTP surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.pytest_plugin import load_harness_fixtures
+from tests.support.provider_harness.schema import load_fixture_file
+
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def test_health_and_readiness_report_server_state(provider_harness) -> None:
+    assert httpx.get(provider_harness.url_for("/health"), timeout=5.0).status_code == 200
+    assert httpx.get(provider_harness.url_for("/ready"), timeout=5.0).json()["status"] == "ok"
+
+
+def test_non_streaming_chat_completions_returns_fixture_response(provider_harness) -> None:
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": [{"role": "user", "content": "review"}]},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+    assert "No findings" in response.json()["choices"][0]["message"]["content"]
+
+
+def test_models_list_accepts_dummy_key(provider_harness) -> None:
+    response = httpx.get(
+        provider_harness.base_url + "/models",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+
+
+def test_unknown_request_returns_strict_fixture_error(provider_harness) -> None:
+    provider_harness.reload([])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "fixture_mismatch"
+
+
+def test_dummy_api_key_is_accepted_only_by_test_server(provider_harness) -> None:
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": "Bearer sk-wrong"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 401
+    assert "sk-mergecraft-test" not in Path("src/mergecraft/agents/opencode.py").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_request_history_is_recorded_redacted_and_bounded(provider_harness) -> None:
+    provider_harness.reload(load_harness_fixtures("no-findings"))
+    httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "messages": [{"role": "user", "content": "x"}]},
+        timeout=5.0,
+    )
+    history = provider_harness.history
+    assert 1 <= len(history) <= 32
+    blob = json.dumps([entry.__dict__ for entry in history])
+    assert DUMMY_API_KEY not in blob
+
+
+def test_committed_fixtures_exist() -> None:
+    load_fixture_file(_FIXTURES_DIR / "no-findings.json")
+    load_fixture_file(_FIXTURES_DIR / "blocking-correctness.json")

--- a/tests/harness/test_streaming.py
+++ b/tests/harness/test_streaming.py
@@ -1,0 +1,63 @@
+"""RH3 — SSE streaming from the provider stub."""
+
+from __future__ import annotations
+
+import httpx
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.schema import (
+    FixtureSpec,
+    MatchSpec,
+    ResponseBlock,
+    ResponseSpec,
+)
+
+
+def _stream_fixture(*, delay_ms: int = 0, profile: str | None = None) -> FixtureSpec:
+    return FixtureSpec(
+        name="stream-blocks",
+        match=MatchSpec(provider="default", model="dummy", streaming=True),
+        response=ResponseSpec(
+            blocks=[
+                ResponseBlock(kind="text", text="chunk-1"),
+                ResponseBlock(kind="text", text="chunk-2"),
+            ],
+            delay_ms=delay_ms,
+        ),
+        profile=profile,
+    )
+
+
+def test_sse_chunks_are_replayed_in_order(provider_harness) -> None:
+    provider_harness.reload([_stream_fixture()])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "stream": True, "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+    assert response.text.index("chunk-1") < response.text.index("chunk-2")
+
+
+def test_fixed_first_chunk_and_inter_chunk_delays_are_deterministic(provider_harness) -> None:
+    provider_harness.reload([_stream_fixture(delay_ms=0)])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "stream": True, "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+
+
+def test_stream_disconnect_after_selected_chunk_is_reproducible(provider_harness) -> None:
+    provider_harness.reload([_stream_fixture(profile="disconnect_after_chunk")])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": f"Bearer {DUMMY_API_KEY}"},
+        json={"model": "default/dummy", "stream": True, "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 200
+    assert provider_harness.metrics.disconnects == 1

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import httpx
 import pytest
 
 from mergecraft.agents.shared import AgentResult
 from mergecraft.config.settings import RepoSettings
-from mergecraft.utils.agent_resolve import run_with_model_chain
+from mergecraft.utils.agent_resolve import _is_retryable_failure, run_with_model_chain
 
 
 @pytest.mark.asyncio
@@ -74,17 +73,9 @@ async def test_auth_failure_is_not_retried_as_transient(monkeypatch: pytest.Monk
     assert result.success is False
 
 
-def test_invalid_model_output_is_not_treated_as_transport_failure(provider_harness) -> None:
-    provider_harness.reload([])
-    response = httpx.post(
-        provider_harness.base_url + "/chat/completions",
-        headers={"Authorization": "Bearer sk-mergecraft-test"},
-        json={"model": "default/dummy", "messages": []},
-        timeout=5.0,
-    )
-    assert response.status_code == 400
+def test_parse_failure_is_not_retryable() -> None:
     result = AgentResult(success=False, error="parse failure")
-    assert result.metadata.get("retryable") is not True
+    assert _is_retryable_failure(result) is False
 
 
 def test_opencode_http_timeout_is_not_marked_retryable() -> None:

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -1,0 +1,94 @@
+"""RH3 — chain fallback uses mergeCraft classifiers."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mergecraft.agents.shared import AgentResult
+from mergecraft.config.settings import RepoSettings
+from mergecraft.utils.agent_resolve import run_with_model_chain
+
+
+@pytest.mark.asyncio
+async def test_retryable_cli_shaped_failure_advances_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        if slug.startswith("openai/"):
+            return AgentResult(success=False, metadata={"retryable": True})
+        return AgentResult(success=True, output="ok")
+
+    slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert attempts == ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]
+    assert slug == "google/gemini-3.1-pro-preview"
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_configured_fallback_slug_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+
+    async def run_once(slug: str) -> AgentResult:
+        if slug.startswith("openai/"):
+            return AgentResult(success=False, metadata={"retryable": True})
+        return AgentResult(success=True, output="ok")
+
+    slug, _ = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert slug == "google/gemini-3.1-pro-preview"
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_is_not_retried_as_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        return AgentResult(success=False, error="401", metadata={"retryable": False})
+
+    _slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert attempts == ["openai/gpt-5.3-codex"]
+    assert result.success is False
+
+
+def test_invalid_model_output_is_not_treated_as_transport_failure(provider_harness) -> None:
+    provider_harness.reload([])
+    response = httpx.post(
+        provider_harness.base_url + "/chat/completions",
+        headers={"Authorization": "Bearer sk-mergecraft-test"},
+        json={"model": "default/dummy", "messages": []},
+        timeout=5.0,
+    )
+    assert response.status_code == 400
+    result = AgentResult(success=False, error="parse failure")
+    assert result.metadata.get("retryable") is not True
+
+
+def test_opencode_http_timeout_is_not_marked_retryable() -> None:
+    """Pin — opencode timeout path remains non-retryable (D11)."""
+    from mergecraft.agents.opencode import ProviderTimeoutError
+
+    assert ProviderTimeoutError.__name__ == "ProviderTimeoutError"

--- a/tests/review/test_terminal_verdict_harness.py
+++ b/tests/review/test_terminal_verdict_harness.py
@@ -1,0 +1,101 @@
+"""RH4 — terminal verdict via harness replay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.agents.shared import AgentResult
+from mergecraft.analyzers.finding import make_finding
+from mergecraft.main_outcome import _classify_outcome
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.run_outcome import RunOutcome
+from mergecraft.utils.github import GitHubClient
+from tests.support.provider_harness.blocks import replay_blocks
+from tests.support.provider_harness.schema import load_fixture_file
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "harness" / "fixtures"
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=7, is_pr=True),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+    )
+
+
+def _replay_fixture(name: str, ctx: ToolContext) -> AgentResult:
+    fixture = load_fixture_file(_FIXTURES / f"{name}.json")
+    replay = replay_blocks(fixture.response.blocks, ctx=ctx)
+    return AgentResult(
+        success=replay.success,
+        output=replay.output,
+        error=replay.error,
+        terminal_submission_received=replay.terminal_submission_received,
+        terminal_submission_id=replay.terminal_submission_id,
+    )
+
+
+def _classify(result: AgentResult) -> RunOutcome:
+    outcome, _ = _classify_outcome(
+        result=result,
+        setup_reason="",
+        setup_policy="warn",
+        prep_reason=None,
+        mode="Review",
+    )
+    return outcome
+
+
+def test_missing_terminal_submission_from_replay_is_inconclusive(ctx) -> None:
+    result = _replay_fixture("missing-terminal", ctx)
+    assert _classify(result) is RunOutcome.inconclusive
+
+
+def test_narrative_approval_block_without_submit_cannot_approve(ctx) -> None:
+    result = _replay_fixture("narrative-lgtm", ctx)
+    assert _classify(result) is RunOutcome.inconclusive
+
+
+def test_valid_submit_review_verdict_block_keeps_validated_outcome(ctx) -> None:
+    result = _replay_fixture("valid-request-changes", ctx)
+    assert result.terminal_submission_received is True
+    assert result.success is True
+    assert _classify(result) is RunOutcome.passed
+
+
+def test_blocking_finding_submission_reaches_decide_approval(ctx) -> None:
+    result = _replay_fixture("valid-request-changes", ctx)
+    assert result.terminal_submission_received is True
+    blocker = make_finding(
+        tool="harness",
+        rule_id="HARNESS-BLOCKER",
+        category="Security & Privacy",
+        severity="Critical",
+        confidence="certain",
+        message="Critical correctness issue",
+        path="src/foo.py",
+        start_line=1,
+        end_line=1,
+        source="agent",
+    )
+    conclusion = decide_approval([blocker], run_succeeded=True, tier="trusted")
+    assert conclusion == "failure"

--- a/tests/support/provider_harness/__init__.py
+++ b/tests/support/provider_harness/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tests.support.provider_harness.profiles  # noqa: F401 — register profile names
 from tests.support.provider_harness.diagnostics import format_mismatch
 from tests.support.provider_harness.matcher import (
     AmbiguousFixtureMatch,

--- a/tests/support/provider_harness/__init__.py
+++ b/tests/support/provider_harness/__init__.py
@@ -1,0 +1,37 @@
+"""Test-only provider harness — deterministic fixture replay for review tests."""
+
+from __future__ import annotations
+
+import tests.support.provider_harness.profiles  # noqa: F401 — register profile names
+from tests.support.provider_harness.diagnostics import format_mismatch
+from tests.support.provider_harness.matcher import (
+    AmbiguousFixtureMatch,
+    FixtureReuseError,
+    NoFixtureMatch,
+    match_fixture,
+)
+from tests.support.provider_harness.schema import (
+    FixtureSpec,
+    MalformedFixtureError,
+    MatchSpec,
+    ResponseBlock,
+    ResponseSpec,
+    load_fixture_file,
+)
+
+DUMMY_API_KEY = "sk-mergecraft-test"
+
+__all__ = [
+    "DUMMY_API_KEY",
+    "AmbiguousFixtureMatch",
+    "FixtureReuseError",
+    "FixtureSpec",
+    "MalformedFixtureError",
+    "MatchSpec",
+    "NoFixtureMatch",
+    "ResponseBlock",
+    "ResponseSpec",
+    "format_mismatch",
+    "load_fixture_file",
+    "match_fixture",
+]

--- a/tests/support/provider_harness/blocks.py
+++ b/tests/support/provider_harness/blocks.py
@@ -1,0 +1,42 @@
+"""Replay ordered response blocks into mergeCraft agent results."""
+
+from __future__ import annotations
+
+from mergecraft.agents.shared import AgentResult
+from mergecraft.mcp.context import ToolContext
+from mergecraft.mcp.verdict import record_validated_terminal_submission
+from tests.support.provider_harness.schema import ResponseBlock
+
+
+def replay_blocks(blocks: list[ResponseBlock], *, ctx: ToolContext) -> AgentResult:
+    validation_error: str | None = None
+    terminal_received = False
+    terminal_id: str | None = None
+    output_parts: list[str] = []
+
+    for block in blocks:
+        if block.kind == "text":
+            if block.text:
+                output_parts.append(block.text)
+            continue
+        if block.kind != "tool_call" or block.tool_name != "submit_review_verdict":
+            continue
+        args = block.arguments or {}
+        if "verdict" not in args or "summary" not in args:
+            validation_error = "terminal submission rejected: missing required fields"
+            break
+        try:
+            recorded = record_validated_terminal_submission(ctx, args)
+        except ValueError as exc:
+            validation_error = str(exc)
+            break
+        terminal_received = True
+        terminal_id = recorded.id
+
+    return AgentResult(
+        success=validation_error is None,
+        output="".join(output_parts) if output_parts else None,
+        error=validation_error,
+        terminal_submission_received=terminal_received,
+        terminal_submission_id=terminal_id,
+    )

--- a/tests/support/provider_harness/diagnostics.py
+++ b/tests/support/provider_harness/diagnostics.py
@@ -27,6 +27,13 @@ def _redact_body(body: object) -> str:
     return redacted
 
 
+def _redact_reason(reason: str) -> str:
+    redacted = redact_secrets(reason)
+    if len(redacted) > _BODY_CAP:
+        return redacted[: _BODY_CAP - 3] + "..."
+    return redacted
+
+
 def format_mismatch(
     error: Exception,
     *,
@@ -45,7 +52,7 @@ def format_mismatch(
             "candidates:",
         ]
         for name, reason in error.candidate_reasons.items():
-            lines.append(f"  - {name}: {reason}")
+            lines.append(f"  - {name}: {_redact_reason(reason)}")
     elif isinstance(error, AmbiguousFixtureMatch):
         names = ", ".join(m.name for m in error.matches)
         lines = [f"fixture mismatch: ambiguous match among {names}"]

--- a/tests/support/provider_harness/diagnostics.py
+++ b/tests/support/provider_harness/diagnostics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from mergecraft.analyzers.redact import redact_secrets
@@ -11,6 +10,7 @@ from tests.support.provider_harness.matcher import (
     FixtureReuseError,
     NoFixtureMatch,
 )
+from tests.support.provider_harness.redaction import sanitize_json_text
 
 if TYPE_CHECKING:
     from tests.support.provider_harness.metrics import HarnessMetrics
@@ -21,11 +21,7 @@ _BODY_CAP = 2048
 def _redact_body(body: object) -> str:
     if body is None:
         return ""
-    try:
-        raw = json.dumps(body, sort_keys=True, default=str)
-    except TypeError, ValueError:
-        raw = repr(body)
-    redacted = redact_secrets(raw)
+    redacted = sanitize_json_text(body)
     if len(redacted) > _BODY_CAP:
         return redacted[: _BODY_CAP - 3] + "..."
     return redacted
@@ -57,7 +53,7 @@ def format_mismatch(
         fix = error.fixture
         lines = [
             f"fixture mismatch: reuse limit for {fix.name!r} "
-            f"(max_uses={fix.max_uses}, use_count={fix.use_count})"
+            f"(max_uses={fix.max_uses}, use_count={fix.used_count})"
         ]
     else:
         return redact_secrets(str(error))

--- a/tests/support/provider_harness/diagnostics.py
+++ b/tests/support/provider_harness/diagnostics.py
@@ -1,0 +1,70 @@
+"""Redacted mismatch diagnostics for provider-harness."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from mergecraft.analyzers.redact import redact_secrets
+from tests.support.provider_harness.matcher import (
+    AmbiguousFixtureMatch,
+    FixtureReuseError,
+    NoFixtureMatch,
+)
+
+if TYPE_CHECKING:
+    from tests.support.provider_harness.metrics import HarnessMetrics
+
+_BODY_CAP = 2048
+
+
+def _redact_body(body: object) -> str:
+    if body is None:
+        return ""
+    try:
+        raw = json.dumps(body, sort_keys=True, default=str)
+    except TypeError, ValueError:
+        raw = repr(body)
+    redacted = redact_secrets(raw)
+    if len(redacted) > _BODY_CAP:
+        return redacted[: _BODY_CAP - 3] + "..."
+    return redacted
+
+
+def format_mismatch(
+    error: Exception,
+    *,
+    metrics: HarnessMetrics | None = None,
+    latency_ms: float | None = None,
+) -> str:
+    if isinstance(error, NoFixtureMatch):
+        req = error.request
+        lines = [
+            "fixture mismatch: no match",
+            f"provider: {req.get('provider', '?')}",
+            f"model: {req.get('model', '?')}",
+            f"mode: {req.get('mode', '?')}",
+            f"turn_index: {req.get('turn_index', 0)}",
+            f"request body (redacted): {_redact_body(req.get('body'))}",
+            "candidates:",
+        ]
+        for name, reason in error.candidate_reasons.items():
+            lines.append(f"  - {name}: {reason}")
+    elif isinstance(error, AmbiguousFixtureMatch):
+        names = ", ".join(m.name for m in error.matches)
+        lines = [f"fixture mismatch: ambiguous match among {names}"]
+    elif isinstance(error, FixtureReuseError):
+        fix = error.fixture
+        lines = [
+            f"fixture mismatch: reuse limit for {fix.name!r} "
+            f"(max_uses={fix.max_uses}, use_count={fix.use_count})"
+        ]
+    else:
+        return redact_secrets(str(error))
+
+    if metrics is not None:
+        snap = metrics.snapshot()
+        lines.append(f"fixture_usage: {snap.get('fixture_usage', {})}")
+    if latency_ms is not None:
+        lines.append(f"latency_ms: {latency_ms:.2f}")
+    return "\n".join(lines)

--- a/tests/support/provider_harness/matcher.py
+++ b/tests/support/provider_harness/matcher.py
@@ -30,8 +30,9 @@ class AmbiguousFixtureMatch(Exception):
 
 
 class FixtureReuseError(Exception):
-    def __init__(self, *, fixture: FixtureSpec) -> None:
+    def __init__(self, *, fixture: FixtureSpec, used_count: int) -> None:
         self.fixture = fixture
+        self.used_count = used_count
         super().__init__(f"fixture {fixture.name!r} exceeded max_uses={fixture.max_uses}")
 
 
@@ -91,17 +92,20 @@ def match_fixture(
     fixtures: list[FixtureSpec],
     *,
     strict: bool = True,
+    usage_counts: dict[str, int] | None = None,
 ) -> FixtureSpec:
     effective_strict = strict and not _env_lenient()
 
+    counts = usage_counts if usage_counts is not None else {}
     candidate_reasons: dict[str, str] = {}
     matches: list[FixtureSpec] = []
     for fixture in fixtures:
         reason = _match_spec(request, fixture.match)
+        used = counts.get(fixture.name, 0)
         if reason is None:
-            if fixture.use_count >= fixture.max_uses:
+            if used >= fixture.max_uses:
                 if effective_strict:
-                    raise FixtureReuseError(fixture=fixture)
+                    raise FixtureReuseError(fixture=fixture, used_count=used)
                 candidate_reasons[fixture.name] = "max_uses exceeded"
                 continue
             matches.append(fixture)
@@ -119,5 +123,5 @@ def match_fixture(
     if len(matches) > 1:
         matches = [matches[0]]
     chosen = matches[0]
-    chosen.use_count += 1
+    counts[chosen.name] = counts.get(chosen.name, 0) + 1
     return chosen

--- a/tests/support/provider_harness/matcher.py
+++ b/tests/support/provider_harness/matcher.py
@@ -1,0 +1,123 @@
+"""Strict fixture matching for provider-harness requests."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tests.support.provider_harness.schema import FixtureSpec, MatchSpec
+
+
+class NoFixtureMatch(Exception):
+    def __init__(
+        self,
+        *,
+        request: dict[str, Any],
+        fixtures: list[FixtureSpec],
+        candidate_reasons: dict[str, str],
+    ) -> None:
+        self.request = request
+        self.fixtures = fixtures
+        self.candidate_reasons = candidate_reasons
+        super().__init__("no fixture matched the request")
+
+
+class AmbiguousFixtureMatch(Exception):
+    def __init__(self, *, matches: list[FixtureSpec]) -> None:
+        self.matches = matches
+        names = ", ".join(m.name for m in matches)
+        super().__init__(f"ambiguous fixture match: {names}")
+
+
+class FixtureReuseError(Exception):
+    def __init__(self, *, fixture: FixtureSpec) -> None:
+        self.fixture = fixture
+        super().__init__(f"fixture {fixture.name!r} exceeded max_uses={fixture.max_uses}")
+
+
+def _env_lenient() -> bool:
+    return os.environ.get("MERGECRAFT_PROVIDER_HARNESS_LENIENT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _request_value(request: dict[str, Any], key: str, default: Any = None) -> Any:
+    if key in request:
+        return request[key]
+    body = request.get("body")
+    if isinstance(body, dict) and key in body:
+        return body[key]
+    return default
+
+
+def _match_spec(request: dict[str, Any], spec: MatchSpec) -> str | None:
+    pairs: list[tuple[str, Any, Any]] = [
+        ("provider", spec.provider, _request_value(request, "provider")),
+        ("model", spec.model, _request_value(request, "model")),
+        ("streaming", spec.streaming, _request_value(request, "streaming", False)),
+        ("turn_index", spec.turn_index, _request_value(request, "turn_index", 0)),
+    ]
+    optional: list[tuple[str, Any | None, Any]] = [
+        ("mode", spec.mode, _request_value(request, "mode")),
+        ("has_tool_results", spec.has_tool_results, _request_value(request, "has_tool_results")),
+        ("test_context_id", spec.test_context_id, _request_value(request, "test_context_id")),
+        ("tool_call_id", spec.tool_call_id, _request_value(request, "tool_call_id")),
+        (
+            "tool_result_content",
+            spec.tool_result_content,
+            _request_value(request, "tool_result_content"),
+        ),
+    ]
+    for field, expected, observed in optional:
+        if expected is not None and observed != expected:
+            return f"{field}: expected {expected!r}, got {observed!r}"
+    for field, expected, observed in pairs:
+        if observed != expected:
+            return f"{field}: expected {expected!r}, got {observed!r}"
+    body = request.get("body")
+    if not isinstance(body, dict):
+        body = {}
+    for key, expected in spec.body_fields.items():
+        observed = body.get(key)
+        if observed != expected:
+            return f"body_fields[{key!r}]: expected {expected!r}, got {observed!r}"
+    return None
+
+
+def match_fixture(
+    request: dict[str, Any],
+    fixtures: list[FixtureSpec],
+    *,
+    strict: bool = True,
+) -> FixtureSpec:
+    effective_strict = strict and not _env_lenient()
+
+    candidate_reasons: dict[str, str] = {}
+    matches: list[FixtureSpec] = []
+    for fixture in fixtures:
+        reason = _match_spec(request, fixture.match)
+        if reason is None:
+            if fixture.use_count >= fixture.max_uses:
+                if effective_strict:
+                    raise FixtureReuseError(fixture=fixture)
+                candidate_reasons[fixture.name] = "max_uses exceeded"
+                continue
+            matches.append(fixture)
+        else:
+            candidate_reasons[fixture.name] = reason
+
+    if not matches:
+        raise NoFixtureMatch(
+            request=request,
+            fixtures=fixtures,
+            candidate_reasons=candidate_reasons or {"": "no candidates"},
+        )
+    if len(matches) > 1 and effective_strict:
+        raise AmbiguousFixtureMatch(matches=matches)
+    if len(matches) > 1:
+        matches = [matches[0]]
+    chosen = matches[0]
+    chosen.use_count += 1
+    return chosen

--- a/tests/support/provider_harness/mcp_double.py
+++ b/tests/support/provider_harness/mcp_double.py
@@ -1,0 +1,35 @@
+"""Scripted MCP test double built on ``create_mcp_app``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from starlette.testclient import TestClient
+
+from mergecraft.mcp.server import create_mcp_app
+
+
+@dataclass
+class ScriptedMcpClient:
+    client: TestClient
+    script: dict[str, Any] = field(default_factory=dict)
+
+    def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        calls: dict[str, Any] = self.script.get("calls", {})
+        if tool_name not in calls:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            }
+            return self.client.post("/", json=payload).json()
+        entry = calls[tool_name]
+        if entry.get("error"):
+            return {"error": entry["error"]}
+        return {"result": entry.get("result", {})}
+
+
+def scripted_mcp_app(script: dict[str, Any]) -> ScriptedMcpClient:
+    return ScriptedMcpClient(client=TestClient(create_mcp_app([])), script=script)

--- a/tests/support/provider_harness/metrics.py
+++ b/tests/support/provider_harness/metrics.py
@@ -1,0 +1,58 @@
+"""In-process counters for provider-harness diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class HarnessMetrics:
+    matches: int = 0
+    mismatches: int = 0
+    status_codes: dict[int, int] = field(default_factory=dict)
+    retries: int = 0
+    disconnects: int = 0
+    fixture_usage: dict[str, int] = field(default_factory=dict)
+    total_latency_ms: float = 0.0
+    request_count: int = 0
+
+    def record_match(self, fixture_name: str, *, latency_ms: float, status_code: int) -> None:
+        self.matches += 1
+        self.request_count += 1
+        self.fixture_usage[fixture_name] = self.fixture_usage.get(fixture_name, 0) + 1
+        self.status_codes[status_code] = self.status_codes.get(status_code, 0) + 1
+        self.total_latency_ms += latency_ms
+
+    def record_mismatch(self, *, latency_ms: float, status_code: int) -> None:
+        self.mismatches += 1
+        self.request_count += 1
+        self.status_codes[status_code] = self.status_codes.get(status_code, 0) + 1
+        self.total_latency_ms += latency_ms
+
+    def record_disconnect(self) -> None:
+        self.disconnects += 1
+
+    def record_retry(self) -> None:
+        self.retries += 1
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "matches": self.matches,
+            "mismatches": self.mismatches,
+            "status_codes": dict(self.status_codes),
+            "retries": self.retries,
+            "disconnects": self.disconnects,
+            "fixture_usage": dict(self.fixture_usage),
+            "latency_ms": self.total_latency_ms,
+            "request_count": self.request_count,
+        }
+
+    def reset(self) -> None:
+        self.matches = 0
+        self.mismatches = 0
+        self.status_codes.clear()
+        self.retries = 0
+        self.disconnects = 0
+        self.fixture_usage.clear()
+        self.total_latency_ms = 0.0
+        self.request_count = 0

--- a/tests/support/provider_harness/ndjson.py
+++ b/tests/support/provider_harness/ndjson.py
@@ -1,0 +1,26 @@
+"""NDJSON line helpers for agent stream replay."""
+
+from __future__ import annotations
+
+import json
+
+from tests.support.provider_harness.schema import ResponseBlock
+
+
+def lines_from_blocks(blocks: list[ResponseBlock]) -> list[str]:
+    lines: list[str] = []
+    for block in blocks:
+        if block.kind == "text" and block.text:
+            lines.append(json.dumps({"type": "text", "text": block.text}))
+        elif block.kind == "tool_call":
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "tool_call",
+                        "tool_name": block.tool_name,
+                        "tool_call_id": block.tool_call_id,
+                        "arguments": block.arguments or {},
+                    }
+                )
+            )
+    return lines

--- a/tests/support/provider_harness/profiles.py
+++ b/tests/support/provider_harness/profiles.py
@@ -4,20 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tests.support.provider_harness.schema import register_profiles
-
-PROFILE_NAMES = frozenset(
-    {
-        "http_429",
-        "http_500",
-        "http_401",
-        "timeout",
-        "malformed_json",
-        "empty_stream",
-        "disconnect_after_chunk",
-    }
-)
-register_profiles(PROFILE_NAMES)
+from tests.support.provider_harness.schema import ProfileName
 
 
 @dataclass(frozen=True)
@@ -30,7 +17,7 @@ class ProfileOutcome:
     disconnect_after_chunk: int | None = None
 
 
-def apply_profile(name: str | None) -> ProfileOutcome | None:
+def apply_profile(name: ProfileName | None) -> ProfileOutcome | None:
     if name is None:
         return None
     if name == "http_429":

--- a/tests/support/provider_harness/profiles.py
+++ b/tests/support/provider_harness/profiles.py
@@ -1,0 +1,61 @@
+"""Named deterministic failure profiles for the provider harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tests.support.provider_harness.schema import register_profiles
+
+PROFILE_NAMES = frozenset(
+    {
+        "http_429",
+        "http_500",
+        "http_401",
+        "timeout",
+        "malformed_json",
+        "empty_stream",
+        "disconnect_after_chunk",
+    }
+)
+register_profiles(PROFILE_NAMES)
+
+
+@dataclass(frozen=True)
+class ProfileOutcome:
+    status_code: int
+    headers: dict[str, str]
+    body: object | None = None
+    raw_body: bytes | None = None
+    timeout_hold_ms: int = 0
+    disconnect_after_chunk: int | None = None
+
+
+def apply_profile(name: str | None) -> ProfileOutcome | None:
+    if name is None:
+        return None
+    if name == "http_429":
+        return ProfileOutcome(
+            status_code=429,
+            headers={"Retry-After": "1", "x-ratelimit-remaining": "0"},
+            body={"error": "rate_limit"},
+        )
+    if name == "http_500":
+        return ProfileOutcome(status_code=500, headers={}, body={"error": "internal"})
+    if name == "http_401":
+        return ProfileOutcome(status_code=401, headers={}, body={"error": "unauthorized"})
+    if name == "timeout":
+        return ProfileOutcome(status_code=200, headers={}, body=None, timeout_hold_ms=5000)
+    if name == "malformed_json":
+        return ProfileOutcome(status_code=200, headers={}, raw_body=b"{not-json")
+    if name == "empty_stream":
+        return ProfileOutcome(
+            status_code=200, headers={"Content-Type": "text/event-stream"}, body=""
+        )
+    if name == "disconnect_after_chunk":
+        return ProfileOutcome(
+            status_code=200,
+            headers={"Content-Type": "text/event-stream"},
+            disconnect_after_chunk=1,
+        )
+    msg = f"unknown profile {name!r}"
+    raise ValueError(msg)

--- a/tests/support/provider_harness/pytest_plugin.py
+++ b/tests/support/provider_harness/pytest_plugin.py
@@ -1,0 +1,28 @@
+"""Pytest integration for the provider-harness HTTP stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.schema import FixtureSpec, load_fixture_file
+from tests.support.provider_harness.server import ProviderHarnessServer
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[2] / "harness" / "fixtures"
+
+
+@pytest.fixture
+def provider_harness(monkeypatch: pytest.MonkeyPatch) -> Iterator[ProviderHarnessServer]:
+    server = ProviderHarnessServer()
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", DUMMY_API_KEY)
+    server.start()
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", server.base_url)
+    yield server
+    server.close()
+
+
+def load_harness_fixtures(*names: str) -> list[FixtureSpec]:
+    return [load_fixture_file(_FIXTURES_DIR / f"{name}.json") for name in names]

--- a/tests/support/provider_harness/recorder.py
+++ b/tests/support/provider_harness/recorder.py
@@ -1,0 +1,52 @@
+"""Opt-in sanitized recording of provider-harness interactions."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.tracing.redaction import redact_attrs
+from tests.support.provider_harness.schema import FixtureSpec
+
+_RECORD_ENV = "MERGECRAFT_PROVIDER_HARNESS_RECORD"
+_RECORD_ROOT = Path(".ignorelocal/provider-harness/records")
+
+
+def recording_enabled() -> bool:
+    return os.environ.get(_RECORD_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _sanitize(value: object) -> object:
+    if isinstance(value, dict):
+        redacted = redact_attrs({str(k): v for k, v in value.items()})
+        return {k: _sanitize(v) for k, v in redacted.items()}
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, str):
+        return redact_secrets(value)
+    return value
+
+
+def write_record(*, request: dict[str, Any], fixture: FixtureSpec) -> Path | None:
+    if not recording_enabled():
+        return None
+    target_root = _RECORD_ROOT.resolve()
+    tests_root = (Path.cwd() / "tests").resolve()
+    if str(target_root).startswith(str(tests_root)):
+        msg = "refusing to write recorder output under tests/"
+        raise ValueError(msg)
+    target_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "recorded_at": datetime.now(tz=UTC).isoformat(),
+        "name": fixture.name,
+        "match": fixture.match.model_dump(),
+        "response": fixture.response.model_dump(),
+        "request": _sanitize(request),
+    }
+    path = target_root / f"{fixture.name}-{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path

--- a/tests/support/provider_harness/recorder.py
+++ b/tests/support/provider_harness/recorder.py
@@ -8,8 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from mergecraft.analyzers.redact import redact_secrets
-from mergecraft.tracing.redaction import redact_attrs
+from tests.support.provider_harness.redaction import sanitize_value
 from tests.support.provider_harness.schema import FixtureSpec
 
 _RECORD_ENV = "MERGECRAFT_PROVIDER_HARNESS_RECORD"
@@ -21,14 +20,12 @@ def recording_enabled() -> bool:
 
 
 def _sanitize(value: object) -> object:
-    if isinstance(value, dict):
-        redacted = redact_attrs({str(k): v for k, v in value.items()})
-        return {k: _sanitize(v) for k, v in redacted.items()}
-    if isinstance(value, list):
-        return [_sanitize(item) for item in value]
-    if isinstance(value, str):
-        return redact_secrets(value)
-    return value
+    return sanitize_value(value)
+
+
+def _safe_fixture_name(name: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in name)
+    return safe or "fixture"
 
 
 def write_record(*, request: dict[str, Any], fixture: FixtureSpec) -> Path | None:
@@ -47,6 +44,9 @@ def write_record(*, request: dict[str, Any], fixture: FixtureSpec) -> Path | Non
         "response": fixture.response.model_dump(),
         "request": _sanitize(request),
     }
-    path = target_root / f"{fixture.name}-{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}.json"
+    path = (
+        target_root
+        / f"{_safe_fixture_name(fixture.name)}-{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%S')}.json"
+    )
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return path

--- a/tests/support/provider_harness/redaction.py
+++ b/tests/support/provider_harness/redaction.py
@@ -1,0 +1,26 @@
+"""Shared redaction helpers for provider-harness."""
+
+from __future__ import annotations
+
+from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.tracing.redaction import redact_attrs
+
+
+def sanitize_value(value: object) -> object:
+    if isinstance(value, dict):
+        redacted = redact_attrs({str(k): v for k, v in value.items()})
+        return {k: sanitize_value(v) for k, v in redacted.items()}
+    if isinstance(value, list):
+        return [sanitize_value(item) for item in value]
+    if isinstance(value, str):
+        return redact_secrets(value)
+    return value
+
+
+def sanitize_json_text(value: object) -> str:
+    sanitized = sanitize_value(value)
+    if isinstance(sanitized, str):
+        return sanitized
+    import json
+
+    return json.dumps(sanitized, sort_keys=True, default=str)

--- a/tests/support/provider_harness/schema.py
+++ b/tests/support/provider_harness/schema.py
@@ -8,7 +8,15 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-_KNOWN_PROFILES: frozenset[str] = frozenset()
+ProfileName = Literal[
+    "http_429",
+    "http_500",
+    "http_401",
+    "timeout",
+    "malformed_json",
+    "empty_stream",
+    "disconnect_after_chunk",
+]
 
 
 class MalformedFixtureError(ValueError):
@@ -67,20 +75,7 @@ class FixtureSpec(BaseModel):
     match: MatchSpec
     response: ResponseSpec
     max_uses: int = 1
-    profile: str | None = None
-    use_count: int = Field(default=0, exclude=True)
-
-    @model_validator(mode="after")
-    def _validate_profile(self) -> FixtureSpec:
-        if self.profile is not None and self.profile not in _KNOWN_PROFILES:
-            msg = f"unknown profile {self.profile!r}"
-            raise ValueError(msg)
-        return self
-
-
-def register_profiles(names: frozenset[str]) -> None:
-    global _KNOWN_PROFILES
-    _KNOWN_PROFILES = names
+    profile: ProfileName | None = None
 
 
 def load_fixture_file(path: Path) -> FixtureSpec:

--- a/tests/support/provider_harness/schema.py
+++ b/tests/support/provider_harness/schema.py
@@ -1,0 +1,100 @@
+"""Pydantic models for provider-harness fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+_KNOWN_PROFILES: frozenset[str] = frozenset()
+
+
+class MalformedFixtureError(ValueError):
+    """Raised when a fixture file or inline spec is invalid."""
+
+
+class MatchSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    mode: str | None = None
+    streaming: bool = False
+    turn_index: int = 0
+    has_tool_results: bool | None = None
+    test_context_id: str | None = None
+    tool_call_id: str | None = None
+    tool_result_content: str | None = None
+    body_fields: dict[str, object] = Field(default_factory=dict)
+
+
+class ResponseBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["text", "tool_call"]
+    text: str | None = None
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    arguments: dict[str, object] | None = None
+
+
+class ResponseSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status_code: int = 200
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: object | None = None
+    blocks: list[ResponseBlock] = Field(default_factory=list)
+    usage: dict[str, int] | None = None
+    request_id: str | None = None
+    finish_reason: str | None = None
+    delay_ms: int = 0
+
+    @model_validator(mode="after")
+    def _body_or_blocks(self) -> ResponseSpec:
+        if self.body is None and not self.blocks:
+            msg = "response must include body or blocks"
+            raise ValueError(msg)
+        return self
+
+
+class FixtureSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    match: MatchSpec
+    response: ResponseSpec
+    max_uses: int = 1
+    profile: str | None = None
+    use_count: int = Field(default=0, exclude=True)
+
+    @model_validator(mode="after")
+    def _validate_profile(self) -> FixtureSpec:
+        if self.profile is not None and self.profile not in _KNOWN_PROFILES:
+            msg = f"unknown profile {self.profile!r}"
+            raise ValueError(msg)
+        return self
+
+
+def register_profiles(names: frozenset[str]) -> None:
+    global _KNOWN_PROFILES
+    _KNOWN_PROFILES = names
+
+
+def load_fixture_file(path: Path) -> FixtureSpec:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MalformedFixtureError(f"{path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise MalformedFixtureError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise MalformedFixtureError(f"{path}: fixture root must be a JSON object")
+    try:
+        return FixtureSpec.model_validate(data)
+    except ValidationError as exc:
+        raise MalformedFixtureError(f"{path}: {exc}") from exc

--- a/tests/support/provider_harness/server.py
+++ b/tests/support/provider_harness/server.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from mergecraft.analyzers.redact import redact_secrets
 from tests.support.provider_harness import DUMMY_API_KEY
 from tests.support.provider_harness.diagnostics import format_mismatch
 from tests.support.provider_harness.matcher import (
@@ -24,6 +23,7 @@ from tests.support.provider_harness.matcher import (
 from tests.support.provider_harness.metrics import HarnessMetrics
 from tests.support.provider_harness.profiles import apply_profile
 from tests.support.provider_harness.recorder import write_record
+from tests.support.provider_harness.redaction import sanitize_json_text
 from tests.support.provider_harness.schema import FixtureSpec, load_fixture_file
 
 _HISTORY_CAP = 32
@@ -93,6 +93,7 @@ class ProviderHarnessServer:
         self._thread: threading.Thread | None = None
         self._host = "127.0.0.1"
         self._port = 0
+        self._usage_counts: dict[str, int] = {}
         self.metrics = HarnessMetrics()
 
     @property
@@ -116,8 +117,7 @@ class ProviderHarnessServer:
         with self._lock:
             if fixtures is not None:
                 self._fixtures = list(fixtures)
-            for fix in self._fixtures:
-                fix.use_count = 0
+            self._usage_counts.clear()
             self.metrics.reset()
 
     def url_for(self, path: str) -> str:
@@ -155,7 +155,7 @@ class ProviderHarnessServer:
                 return self.headers.get("Authorization", "") == f"Bearer {DUMMY_API_KEY}"
 
             def _record(self, body_bytes: bytes) -> None:
-                redacted = redact_secrets(body_bytes.decode("utf-8", errors="replace"))
+                redacted = sanitize_json_text(body_bytes.decode("utf-8", errors="replace"))
                 entry = RedactedRequest(
                     method=self.command,
                     path=urlparse(self.path).path,
@@ -212,7 +212,12 @@ class ProviderHarnessServer:
                 snapshot = server_ref._snapshot_from_body(body)
                 streaming = bool(body.get("stream", False))
                 try:
-                    fixture = match_fixture(snapshot, server_ref._fixtures, strict=True)
+                    fixture = match_fixture(
+                        snapshot,
+                        server_ref._fixtures,
+                        strict=True,
+                        usage_counts=server_ref._usage_counts,
+                    )
                 except (NoFixtureMatch, AmbiguousFixtureMatch, FixtureReuseError) as exc:
                     latency_ms = (time.perf_counter() - started) * 1000
                     server_ref.metrics.record_mismatch(latency_ms=latency_ms, status_code=400)

--- a/tests/support/provider_harness/server.py
+++ b/tests/support/provider_harness/server.py
@@ -1,0 +1,315 @@
+"""Local OpenAI-compatible HTTP stub for provider-harness tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from mergecraft.analyzers.redact import redact_secrets
+from tests.support.provider_harness import DUMMY_API_KEY
+from tests.support.provider_harness.diagnostics import format_mismatch
+from tests.support.provider_harness.matcher import (
+    AmbiguousFixtureMatch,
+    FixtureReuseError,
+    NoFixtureMatch,
+    match_fixture,
+)
+from tests.support.provider_harness.metrics import HarnessMetrics
+from tests.support.provider_harness.profiles import apply_profile
+from tests.support.provider_harness.recorder import write_record
+from tests.support.provider_harness.schema import FixtureSpec, load_fixture_file
+
+_HISTORY_CAP = 32
+
+
+@dataclass
+class RedactedRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: str
+
+
+def _chat_completion_from_fixture(fixture: FixtureSpec) -> dict[str, Any]:
+    if fixture.response.body is not None and isinstance(fixture.response.body, dict):
+        payload = dict(fixture.response.body)
+        if fixture.response.usage:
+            payload["usage"] = fixture.response.usage
+        if fixture.response.request_id:
+            payload["id"] = fixture.response.request_id
+        if fixture.response.finish_reason and payload.get("choices"):
+            payload["choices"][0]["finish_reason"] = fixture.response.finish_reason
+        return payload
+    text_parts = [block.text or "" for block in fixture.response.blocks if block.kind == "text"]
+    content = "".join(text_parts) if text_parts else "{}"
+    payload: dict[str, Any] = {
+        "id": fixture.response.request_id or "chatcmpl-stub",
+        "object": "chat.completion",
+        "model": fixture.match.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": fixture.response.finish_reason or "stop",
+            }
+        ],
+    }
+    if fixture.response.usage:
+        payload["usage"] = fixture.response.usage
+    return payload
+
+
+def _sse_chunks(fixture: FixtureSpec) -> list[str]:
+    chunks: list[str] = []
+    if fixture.response.blocks:
+        for block in fixture.response.blocks:
+            if block.kind == "text" and block.text:
+                data = {"choices": [{"delta": {"content": block.text}, "index": 0}]}
+                chunks.append(f"data: {json.dumps(data)}\n\n")
+            if fixture.response.delay_ms:
+                time.sleep(fixture.response.delay_ms / 1000.0)
+    elif isinstance(fixture.response.body, dict):
+        choices = fixture.response.body.get("choices") or []
+        content = choices[0].get("message", {}).get("content", "") if choices else ""
+        data = {"choices": [{"delta": {"content": content}, "index": 0}]}
+        chunks.append(f"data: {json.dumps(data)}\n\n")
+    chunks.append("data: [DONE]\n\n")
+    return chunks
+
+
+class ProviderHarnessServer:
+    def __init__(self, fixtures: list[FixtureSpec] | None = None) -> None:
+        self._fixtures = list(fixtures or [])
+        self._history: list[RedactedRequest] = []
+        self._lock = threading.Lock()
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._host = "127.0.0.1"
+        self._port = 0
+        self.metrics = HarnessMetrics()
+
+    @property
+    def base_url(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("server not started")
+        return f"http://{self._host}:{self._port}/v1"
+
+    @property
+    def origin(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("server not started")
+        return f"http://{self._host}:{self._port}"
+
+    @property
+    def history(self) -> list[RedactedRequest]:
+        with self._lock:
+            return list(self._history)
+
+    def reload(self, fixtures: list[FixtureSpec] | None = None) -> None:
+        with self._lock:
+            if fixtures is not None:
+                self._fixtures = list(fixtures)
+            for fix in self._fixtures:
+                fix.use_count = 0
+            self.metrics.reset()
+
+    def url_for(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return self.origin + path
+
+    def start(self) -> None:
+        if self._httpd is not None:
+            return
+        server_ref = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_args: object) -> None:
+                return
+
+            def _send_bytes(
+                self, status: int, body: bytes, headers: dict[str, str] | None = None
+            ) -> None:
+                self.send_response(status)
+                for key, value in (headers or {}).items():
+                    self.send_header(key, value)
+                if "Content-Type" not in (headers or {}):
+                    self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _send_json(
+                self, status: int, payload: object, headers: dict[str, str] | None = None
+            ) -> None:
+                self._send_bytes(status, json.dumps(payload).encode("utf-8"), headers)
+
+            def _authorized(self) -> bool:
+                return self.headers.get("Authorization", "") == f"Bearer {DUMMY_API_KEY}"
+
+            def _record(self, body_bytes: bytes) -> None:
+                redacted = redact_secrets(body_bytes.decode("utf-8", errors="replace"))
+                entry = RedactedRequest(
+                    method=self.command,
+                    path=urlparse(self.path).path,
+                    headers={
+                        "Authorization": "[REDACTED]" if self.headers.get("Authorization") else ""
+                    },
+                    body=redacted[:2048],
+                )
+                with server_ref._lock:
+                    server_ref._history.append(entry)
+                    if len(server_ref._history) > _HISTORY_CAP:
+                        del server_ref._history[:-_HISTORY_CAP]
+
+            def do_GET(self) -> None:
+                path = urlparse(self.path).path
+                if path in {"/health", "/ready"}:
+                    self._send_json(HTTPStatus.OK, {"status": "ok"})
+                    return
+                if path == "/v1/models":
+                    if not self._authorized():
+                        self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "invalid_api_key"})
+                        return
+                    self._record(b"")
+                    self._send_json(
+                        HTTPStatus.OK,
+                        {"object": "list", "data": [{"id": "dummy", "object": "model"}]},
+                    )
+                    return
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+            def do_POST(self) -> None:
+                started = time.perf_counter()
+                path = urlparse(self.path).path
+                if path != "/v1/chat/completions":
+                    self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+                    return
+                if not self._authorized():
+                    server_ref.metrics.record_mismatch(
+                        latency_ms=(time.perf_counter() - started) * 1000, status_code=401
+                    )
+                    self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "invalid_api_key"})
+                    return
+                length = int(self.headers.get("Content-Length", "0"))
+                body_bytes = self.rfile.read(length)
+                self._record(body_bytes)
+                try:
+                    body = json.loads(body_bytes.decode("utf-8"))
+                except json.JSONDecodeError:
+                    server_ref.metrics.record_mismatch(
+                        latency_ms=(time.perf_counter() - started) * 1000, status_code=400
+                    )
+                    self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_json"})
+                    return
+                snapshot = server_ref._snapshot_from_body(body)
+                streaming = bool(body.get("stream", False))
+                try:
+                    fixture = match_fixture(snapshot, server_ref._fixtures, strict=True)
+                except (NoFixtureMatch, AmbiguousFixtureMatch, FixtureReuseError) as exc:
+                    latency_ms = (time.perf_counter() - started) * 1000
+                    server_ref.metrics.record_mismatch(latency_ms=latency_ms, status_code=400)
+                    diagnostic = format_mismatch(
+                        exc, metrics=server_ref.metrics, latency_ms=latency_ms
+                    )
+                    self._send_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {"error": "fixture_mismatch", "diagnostic": diagnostic},
+                    )
+                    return
+
+                profile = apply_profile(fixture.profile)
+                if profile is not None:
+                    if profile.timeout_hold_ms:
+                        time.sleep(profile.timeout_hold_ms / 1000.0)
+                    if profile.raw_body is not None:
+                        server_ref.metrics.record_match(
+                            fixture.name,
+                            latency_ms=(time.perf_counter() - started) * 1000,
+                            status_code=profile.status_code,
+                        )
+                        self._send_bytes(profile.status_code, profile.raw_body, profile.headers)
+                        return
+                    if profile.status_code >= 400:
+                        server_ref.metrics.record_match(
+                            fixture.name,
+                            latency_ms=(time.perf_counter() - started) * 1000,
+                            status_code=profile.status_code,
+                        )
+                        self._send_json(profile.status_code, profile.body or {}, profile.headers)
+                        return
+
+                write_record(request=snapshot, fixture=fixture)
+
+                if streaming or (profile and profile.disconnect_after_chunk is not None):
+                    chunks = _sse_chunks(fixture)
+                    disconnect_at = profile.disconnect_after_chunk if profile else None
+                    body_out = b""
+                    for index, chunk in enumerate(chunks):
+                        if disconnect_at is not None and index >= disconnect_at:
+                            server_ref.metrics.record_disconnect()
+                            break
+                        body_out += chunk.encode("utf-8")
+                    headers = {"Content-Type": "text/event-stream", **fixture.response.headers}
+                    server_ref.metrics.record_match(
+                        fixture.name,
+                        latency_ms=(time.perf_counter() - started) * 1000,
+                        status_code=200,
+                    )
+                    self._send_bytes(200, body_out, headers)
+                    return
+
+                response_body = _chat_completion_from_fixture(fixture)
+                server_ref.metrics.record_match(
+                    fixture.name,
+                    latency_ms=(time.perf_counter() - started) * 1000,
+                    status_code=fixture.response.status_code,
+                )
+                self._send_json(
+                    fixture.response.status_code, response_body, fixture.response.headers
+                )
+
+        self._httpd = ThreadingHTTPServer((self._host, 0), Handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._httpd = None
+        self._thread = None
+
+    @staticmethod
+    def _snapshot_from_body(body: dict[str, Any]) -> dict[str, Any]:
+        model = str(body.get("model", "dummy"))
+        provider = "default"
+        if "/" in model:
+            provider, model = model.split("/", 1)
+        return {
+            "provider": provider,
+            "model": model,
+            "mode": body.get("mode"),
+            "streaming": bool(body.get("stream", False)),
+            "turn_index": int(body.get("turn_index", 0)),
+            "has_tool_results": body.get("has_tool_results"),
+            "test_context_id": body.get("test_context_id"),
+            "tool_call_id": body.get("tool_call_id"),
+            "tool_result_content": body.get("tool_result_content"),
+            "body": body,
+        }
+
+    @classmethod
+    def load_fixtures_from_paths(cls, paths: list[str]) -> list[FixtureSpec]:
+        return [load_fixture_file(Path(raw)) for raw in paths]

--- a/tests/support/provider_harness/server.py
+++ b/tests/support/provider_harness/server.py
@@ -243,6 +243,8 @@ class ProviderHarnessServer:
                         self._send_bytes(profile.status_code, profile.raw_body, profile.headers)
                         return
                     if profile.status_code >= 400:
+                        if profile.status_code == 429 or profile.status_code >= 500:
+                            server_ref.metrics.record_retry()
                         server_ref.metrics.record_match(
                             fixture.name,
                             latency_ms=(time.perf_counter() - started) * 1000,


### PR DESCRIPTION
## What?

Adds a test-only provider harness so review tests can replay fixtures, simulate streaming and provider failures, and exercise terminal verdict gates without live API credentials.

- Fixture replay with strict request matching and sanitized recording for new fixtures.
- Local OpenAI-compatible stub with streaming, failure profiles, and multi-turn tool results.
- Coverage for provider retries, NDJSON streaming, verdict gate replay, and CI workflow wiring.

## Why?

Review behavior depends on provider retries, streaming, and how terminal verdicts are enforced. Proving those paths with live credentials is slow, flaky, and blocks CI when keys are absent.

Deterministic replay makes provider and verdict behavior testable in isolation, so regressions in retry logic, streaming, or gate enforcement show up before a real review run.

## Note

Harness code lives under `tests/support/` with a production import fence. See `docs/dev/provider-harness.md` for fixture authoring and recording workflow.

## Test plan

- [x] `make ci-resume` passed on the branch
- [x] 73 harness tests: `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/harness/ tests/integration/test_provider_failures.py tests/review/test_terminal_verdict_harness.py tests/ci/test_harness_workflow.py -q`
