### PR TITLE
test(harness): address final review nits from #243

### DIFF
--- a/docs/test-plans/review-harness-rh1.md
+++ b/docs/test-plans/review-harness-rh1.md
@@ -22,25 +22,23 @@ Target API (RH1.2):
 
 ## xfail schedule
 
-All RH1.2 markers use `strict=False` (`pyproject.toml` may set `xfail_strict =
-true`; an early-passing xfail becomes XPASS, not a silent pass). **Cleared after
-RH1.2** — twelve contract tests become real passes; three regression pins were
-never marked.
+RH1.2 shipped on branch `wave/review-harness` — all twelve contract tests pass
+without xfail markers. The three regression pins below were never marked.
 
-| Wave | Test | Marker reason | Status |
-|------|------|---------------|--------|
-| **RH1.2** | `test_fixture_requires_provider_and_model` | `green after RH1.2` | pending |
-| **RH1.2** | `test_fixture_requires_request_match_fields` | same | pending |
-| **RH1.2** | `test_fixture_accepts_json_response_and_metadata` | same | pending |
-| **RH1.2** | `test_fixture_accepts_ordered_response_blocks` | same | pending |
-| **RH1.2** | `test_malformed_fixture_is_rejected_with_path` | same | pending |
-| **RH1.2** | `test_matching_uses_provider_model_and_mode` | same | pending |
-| **RH1.2** | `test_streaming_flag_participates_in_matching` | same | pending |
-| **RH1.2** | `test_body_field_matchers_are_explicit` | same | pending |
-| **RH1.2** | `test_no_fixture_match_is_an_error_in_strict_mode` | same | pending |
-| **RH1.2** | `test_multiple_matches_are_an_error` | same | pending |
-| **RH1.2** | `test_unexpected_fixture_reuse_is_an_error` | same | pending |
-| **RH1.2** | `test_mismatch_includes_redacted_request_and_candidate_reasons` | same | pending |
+| Wave | Test | Status |
+|------|------|--------|
+| **RH1.2** | `test_fixture_requires_provider_and_model` | **passing** |
+| **RH1.2** | `test_fixture_requires_request_match_fields` | **passing** |
+| **RH1.2** | `test_fixture_accepts_json_response_and_metadata` | **passing** |
+| **RH1.2** | `test_fixture_accepts_ordered_response_blocks` | **passing** |
+| **RH1.2** | `test_malformed_fixture_is_rejected_with_path` | **passing** |
+| **RH1.2** | `test_matching_uses_provider_model_and_mode` | **passing** |
+| **RH1.2** | `test_streaming_flag_participates_in_matching` | **passing** |
+| **RH1.2** | `test_body_field_matchers_are_explicit` | **passing** |
+| **RH1.2** | `test_no_fixture_match_is_an_error_in_strict_mode` | **passing** |
+| **RH1.2** | `test_multiple_matches_are_an_error` | **passing** |
+| **RH1.2** | `test_unexpected_fixture_reuse_is_an_error` | **passing** |
+| **RH1.2** | `test_mismatch_includes_redacted_request_and_candidate_reasons` | **passing** |
 
 Regression pins (no xfail — must pass @ RH1.1):
 
@@ -69,12 +67,14 @@ Regression pins (no xfail — must pass @ RH1.1):
 | RH1.1m | D14 — redaction pin | pin | `redact_secrets` contract | `test_diagnostics_do_not_include_provider_keys_or_github_tokens` |
 | RH1.1n | D2 — production fence | pin | no prod import of harness | `test_src_mergecraft_does_not_import_provider_harness` |
 
-## RED acceptance (RH1.1)
+## RED acceptance (RH1.1 → RH1.2)
 
-- `uv run pytest --collect-only -q tests/harness/` → **15** collected, zero collection errors.
-- File run: **3 pass** (lenient pin, redaction pin, import fence) + **12 xfail** (schema,
-  matcher, diagnostics). Do not edit `tests/support/provider_harness/` or `src/` to green
-  the suite in RH1.1.
+RH1.2 is complete on `wave/review-harness`:
+
+- `uv run pytest -q tests/harness/` → **15** collected, all passing (12 contract +
+  3 regression pins).
+- Implementation lives under `tests/support/provider_harness/` with zero `src/`
+  edits (**D2**).
 
 ## Files
 

--- a/tests/harness/test_diagnostics.py
+++ b/tests/harness/test_diagnostics.py
@@ -41,8 +41,8 @@ def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
         },
     )
     fixtures = [
-        _fixture("candidate-a", model="other-a", body_fields={"api_key": "expected-a"}),
-        _fixture("candidate-b", model="other-b", body_fields={"api_key": "expected-b"}),
+        _fixture("candidate-a", body_fields={"api_key": "expected-a"}),
+        _fixture("candidate-b", body_fields={"api_key": "expected-b"}),
     ]
 
     try:
@@ -54,6 +54,7 @@ def test_mismatch_includes_redacted_request_and_candidate_reasons() -> None:
 
     assert "candidate-a" in diagnostic
     assert "candidate-b" in diagnostic
+    assert "body_fields" in diagnostic
     assert api_key not in diagnostic
     assert "[REDACTED]" in diagnostic or "<redacted>" in diagnostic
     assert "provider" in diagnostic.lower() or "default" in diagnostic

--- a/tests/harness/test_failure_profiles.py
+++ b/tests/harness/test_failure_profiles.py
@@ -77,6 +77,8 @@ def test_empty_stream_profile_completes_without_content(provider_harness) -> Non
         timeout=5.0,
     )
     assert response.status_code == 200
+    assert '"content"' not in response.text
+    assert "[DONE]" in response.text
 
 
 def test_http_401_profile_is_not_transient(provider_harness) -> None:

--- a/tests/support/provider_harness/server.py
+++ b/tests/support/provider_harness/server.py
@@ -256,7 +256,10 @@ class ProviderHarnessServer:
                 write_record(request=snapshot, fixture=fixture)
 
                 if streaming or (profile and profile.disconnect_after_chunk is not None):
-                    chunks = _sse_chunks(fixture)
+                    if profile is not None and profile.body == "":
+                        chunks = ["data: [DONE]\n\n"]
+                    else:
+                        chunks = _sse_chunks(fixture)
                     disconnect_at = profile.disconnect_after_chunk if profile else None
                     body_out = b""
                     for index, chunk in enumerate(chunks):
@@ -265,6 +268,8 @@ class ProviderHarnessServer:
                             break
                         body_out += chunk.encode("utf-8")
                     headers = {"Content-Type": "text/event-stream", **fixture.response.headers}
+                    if profile is not None:
+                        headers = {**headers, **profile.headers}
                     server_ref.metrics.record_match(
                         fixture.name,
                         latency_ms=(time.perf_counter() - started) * 1000,


### PR DESCRIPTION
## Summary

Follow-up to #243 — addresses the three remaining non-blocking review nits from the final mergecraft pass:

- Pin body-field secret redaction in `test_mismatch_includes_redacted_request_and_candidate_reasons` (match on `body_fields`, not model).
- Make `empty_stream` profile emit a true empty SSE stream (`[DONE]` only) and assert no content chunks.
- Update `docs/test-plans/review-harness-rh1.md` to reflect RH1.2 GREEN (no xfail markers).

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] 73 harness tests: `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/harness/ tests/integration/test_provider_failures.py tests/review/test_terminal_verdict_harness.py tests/ci/test_harness_workflow.py -q`
