### PR TITLE
review: large-PR engine and finding lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`docs/dev/provider-harness.md`); opt-in sanitized capture under
   `.ignorelocal/provider-harness/records/`.
 - Per-run budgets, bounded external-operation timeouts, and honest large-diff degradation (`RunBounds`, scope reduction reports, downgraded outcomes) for offline and Action reviews
+- Large-PR review engine (DG2): cluster changed paths by dependency and intent, build hierarchical diff context (map → summaries → raw hunks) with token-budget scope reduction that reserves verbatim hunks for high-risk regions, record disputed/waived/stale finding lifecycle states, and emit advisory-only PR split recommendations from independent change groups
 - Finding precision pipeline (DG1): deduplicate agent/analyzer findings before publication, apply a code-defined severity rubric at the verifier seam, require structured causality on blocking findings, suppress pre-existing analyzer hits via baseline comparison, and classify generated/minified/vendored paths for review policy
 - DG1 precision corpus gate (`evaluate_dg1_precision_corpus`) proving recall holds while corpus-confirmed precision improves over the pre-DG1 baseline
 - `mergecraft mcp serve` and `mergecraft mcp list` expose the reviewer's MCP tool surface to external clients without widening trust tier or tool-class policy (D13)

--- a/docs/test-plans/review-depth-governance-dg2.md
+++ b/docs/test-plans/review-depth-governance-dg2.md
@@ -95,5 +95,5 @@ collection stays clean before implementation lands.
 
 ## Status
 
-DG2.1 RED suite authored 2026-08-18. Awaiting DG2.2 implementation and xfail
-reconciliation.
+DG2.1 RED suite committed 2026-08-18 @ `015d9d9` — 11 collected, 1 pass, 10 xfail.
+Awaiting DG2.2 implementation and xfail reconciliation.

--- a/docs/test-plans/review-depth-governance-dg2.md
+++ b/docs/test-plans/review-depth-governance-dg2.md
@@ -1,0 +1,99 @@
+# PR DG2 — large-PR engine and finding lifecycle — test plan (DG2.1)
+
+Wave plan: `.ignorelocal/waves/05-review-depth-governance-wave-plan.md` (PR DG2)
+Worktree: `../mergecraft-dg2-large-pr` @ `wave/dg2-large-pr` (based on DG1 @ c638a1f)
+Authoring wave: **DG2.1** (tests-first). Implementation: **DG2.2**.
+xfail-reconciliation: **post-DG2.2** (complete).
+
+Locked decisions: **convention 3** (review-only — split advice is text), file 2
+**D12** (reduced scope is reported, never silent).
+
+## xfail schedule
+
+Ten DG2.1 tests use `@pytest.mark.xfail(reason="green after DG2.2",
+strict=False)`. One regression pin passes today.
+
+| Test file | Tests | Marker | Status pre-DG2.2 |
+|-----------|-------|--------|------------------|
+| `tests/classify/test_change_clustering.py` | 2 | xfail | **RED** |
+| `tests/review/test_hierarchical_summaries.py` | 3 | xfail | **RED** |
+| `tests/findings/test_lifecycle.py` | 3 + 1 pin | xfail / none | **1 PASS, 3 RED** |
+| `tests/review/test_split_advisor.py` | 2 | xfail | **RED** |
+
+**Acceptance (DG2.1):** 11 collected; 1 pass; 10 xfail. `make lint` + `make typecheck`
+clean.
+
+## Target API DG2.2 must satisfy
+
+### `src/mergecraft/classify/change_clustering.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `cluster_changes(change, *, dependency_edges, intents)` | Group changed paths by dependency edges and declared intent; expose `clusters` and `independent_groups` for the split advisor. |
+
+### `src/mergecraft/review/hierarchical_summaries.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `build_hierarchical_context(diff_text, *, token_budget, risk_regions)` | Large diff → map + cluster summaries + raw hunks; `token_estimate` respects budget; high-risk paths keep verbatim hunks; `scope_reduction` is a `ScopeReduction` when scope is omitted (D12). |
+
+### `src/mergecraft/findings/lifecycle.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `dispute_finding(fingerprint, *, reason)` | Record `disputed` with reason (G7). |
+| `waive_finding(fingerprint, *, reason, expires_at)` | Record `waived` with reason and expiry. |
+| `lifecycle_state(record)` | Return canonical state string. |
+| `lifecycle_state_from_thread(thread)` | Map thread dict to `open` / `resolved-by-change` / `stale` / `disputed` / `waived`; must not break `findings/threads.py` normalization (regression pin). |
+
+Regression pin: `fetch_review_threads` + `carryover_findings` behavior for
+resolved/outdated threads (`test_resolved_by_change_still_works`).
+
+### `src/mergecraft/review/split_advisor.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `recommend_pr_split(independent_groups, *, output_path=None)` | When groups are unrelated, recommend ≥2 PRs with paths and summary text; `advisory_only=True`; never write `output_path` (convention 3). |
+
+## Contract → coverage matrix
+
+### Change clustering — `tests/classify/test_change_clustering.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_files_cluster_by_dependency_and_intent` | unit | happy | Dependency + intent clustering |
+| 2 | `test_independent_groups_are_identified` | unit | split input | Unrelated groups surfaced |
+
+### Hierarchical summaries — `tests/review/test_hierarchical_summaries.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 3 | `test_large_diff_reduces_to_map_then_summaries_then_hunks` | integration | happy | Map → summaries → hunks pipeline |
+| 4 | `test_high_risk_regions_keep_raw_tokens` | unit | edge | Risk paths keep raw hunks |
+| 5 | `test_reduced_scope_is_reported` | unit | D12 | Explicit `ScopeReduction` |
+
+### Finding lifecycle — `tests/findings/test_lifecycle.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 6 | `test_disputed_state_is_recorded` | unit | happy | G7 disputed + reason |
+| 7 | `test_waived_state_carries_reason_and_expiry` | unit | edge | Waived + expiry |
+| 8 | `test_resolved_by_change_still_works` | regression | pin | `threads.py` + carryover |
+| 9 | `test_stale_finding_is_distinguishable_from_resolved` | unit | edge | stale ≠ resolved-by-change |
+
+### Split advisor — `tests/review/test_split_advisor.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 10 | `test_unrelated_groups_produce_a_split_recommendation` | functional | happy | Split recommendation text |
+| 11 | `test_split_advice_is_advisory_only` | functional | convention 3 | No repo writes |
+
+## Imports of not-yet-existing symbols
+
+DG2.2 modules are imported **inside test bodies** (or via local helpers) so
+collection stays clean before implementation lands.
+
+## Status
+
+DG2.1 RED suite authored 2026-08-18. Awaiting DG2.2 implementation and xfail
+reconciliation.

--- a/docs/test-plans/review-depth-governance-dg2.md
+++ b/docs/test-plans/review-depth-governance-dg2.md
@@ -95,5 +95,5 @@ collection stays clean before implementation lands.
 
 ## Status
 
-DG2.1 RED suite committed 2026-08-18 @ `015d9d9` — 11 collected, 1 pass, 10 xfail.
-Awaiting DG2.2 implementation and xfail reconciliation.
+DG2.2 implementation complete 2026-08-18 — 11/11 tests green (`--runxfail`), `make ci-resume` 11/11.
+Evidence: `.ignorelocal/waves/evidence/dg2-large-pr.txt`.

--- a/src/mergecraft/classify/change_clustering.py
+++ b/src/mergecraft/classify/change_clustering.py
@@ -1,0 +1,132 @@
+"""Change clustering for large PRs — dependency and intent groups (DG2, G6).
+
+Groups changed paths so hierarchical summarization and the split advisor can
+treat related edits together while surfacing wholly independent work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ChangeCluster:
+    """One cluster of related changed paths."""
+
+    id: str
+    paths: list[str] = field(default_factory=list)
+    intent: str | None = None
+
+
+@dataclass(slots=True)
+class ClusterResult:
+    """Clustering output for summarization and split advice."""
+
+    clusters: list[ChangeCluster] = field(default_factory=list)
+    independent_groups: list[ChangeCluster] = field(default_factory=list)
+
+
+def _union_find(parent: dict[str, str], path: str) -> str:
+    if parent[path] != path:
+        parent[path] = _union_find(parent, parent[path])
+    return parent[path]
+
+
+def _union(parent: dict[str, str], left: str, right: str) -> None:
+    root_left = _union_find(parent, left)
+    root_right = _union_find(parent, right)
+    if root_left != root_right:
+        parent[root_right] = root_left
+
+
+def _connected_components(
+    paths: list[str],
+    dependency_edges: list[tuple[str, str]],
+) -> list[list[str]]:
+    path_set = set(paths)
+    parent = {path: path for path in paths}
+    for left, right in dependency_edges:
+        if left in path_set and right in path_set:
+            _union(parent, left, right)
+    components: dict[str, list[str]] = {}
+    for path in paths:
+        root = _union_find(parent, path)
+        components.setdefault(root, []).append(path)
+    return [sorted(group) for group in components.values()]
+
+
+def _cluster_id(intent: str | None, paths: list[str]) -> str:
+    if intent:
+        return intent
+    if len(paths) == 1:
+        return paths[0]
+    return "+".join(paths[:2])
+
+
+def cluster_changes(
+    change: dict[str, Any],
+    *,
+    dependency_edges: list[tuple[str, str]] | None = None,
+    intents: dict[str, str] | None = None,
+) -> ClusterResult:
+    """Group changed paths by dependency edges and declared intent.
+
+    Args:
+        change: Side-effect-free change payload with ``changed_paths``.
+        dependency_edges: Directed dependency pairs among changed paths.
+        intents: Optional per-path intent labels.
+
+    Returns:
+        :class:`ClusterResult` with ``clusters`` and ``independent_groups``.
+    """
+    paths = list(change.get("changed_paths") or [])
+    if not paths:
+        return ClusterResult()
+
+    edges = dependency_edges or []
+    intent_map = intents or {}
+
+    components = _connected_components(paths, edges)
+    clusters: list[ChangeCluster] = []
+    independent_groups: list[ChangeCluster] = []
+
+    for component in components:
+        has_internal_edge = any(left in component and right in component for left, right in edges)
+        by_intent: dict[str, list[str]] = {}
+        for path in component:
+            intent = intent_map.get(path, "unclassified")
+            by_intent.setdefault(intent, []).append(path)
+
+        if len(by_intent) == 1:
+            intent, group_paths = next(iter(by_intent.items()))
+            cluster = ChangeCluster(
+                id=_cluster_id(None if intent == "unclassified" else intent, group_paths),
+                paths=sorted(group_paths),
+                intent=None if intent == "unclassified" else intent,
+            )
+            clusters.append(cluster)
+        else:
+            for intent, group_paths in sorted(by_intent.items()):
+                clusters.append(
+                    ChangeCluster(
+                        id=_cluster_id(None if intent == "unclassified" else intent, group_paths),
+                        paths=sorted(group_paths),
+                        intent=None if intent == "unclassified" else intent,
+                    )
+                )
+
+        if has_internal_edge and len(component) >= 2:
+            dominant_intent = intent_map.get(component[0])
+            independent_groups.append(
+                ChangeCluster(
+                    id=_cluster_id(dominant_intent, component),
+                    paths=sorted(component),
+                    intent=dominant_intent,
+                )
+            )
+
+    return ClusterResult(clusters=clusters, independent_groups=independent_groups)
+
+
+__all__ = ["ChangeCluster", "ClusterResult", "cluster_changes"]

--- a/src/mergecraft/classify/change_clustering.py
+++ b/src/mergecraft/classify/change_clustering.py
@@ -125,6 +125,25 @@ def cluster_changes(
                     intent=dominant_intent,
                 )
             )
+        elif len(component) == 1:
+            path = component[0]
+            path_intent = intent_map.get(path, "unclassified")
+            other_intents = {
+                intent_map.get(other_path, "unclassified")
+                for other_path in paths
+                if other_path != path
+            }
+            if path_intent not in other_intents:
+                independent_groups.append(
+                    ChangeCluster(
+                        id=_cluster_id(
+                            None if path_intent == "unclassified" else path_intent,
+                            component,
+                        ),
+                        paths=sorted(component),
+                        intent=None if path_intent == "unclassified" else path_intent,
+                    )
+                )
 
     return ClusterResult(clusters=clusters, independent_groups=independent_groups)
 

--- a/src/mergecraft/findings/lifecycle.py
+++ b/src/mergecraft/findings/lifecycle.py
@@ -1,0 +1,74 @@
+"""Finding lifecycle states beyond thread resolution (DG2, G7).
+
+Records disputed and waived findings with explicit reasons, and maps review
+threads to canonical lifecycle states without altering ``findings/threads.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+LifecycleState = Literal["open", "resolved-by-change", "stale", "disputed", "waived"]
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleRecord:
+    """A persisted lifecycle transition for a finding fingerprint."""
+
+    fingerprint: str
+    state: LifecycleState
+    reason: str | None = None
+    expires_at: str | None = None
+
+
+def dispute_finding(
+    fingerprint: str,
+    *,
+    reason: str,
+) -> LifecycleRecord:
+    """Record that a finding was challenged by the author or reviewer."""
+    return LifecycleRecord(fingerprint=fingerprint, state="disputed", reason=reason)
+
+
+def waive_finding(
+    fingerprint: str,
+    *,
+    reason: str,
+    expires_at: str,
+) -> LifecycleRecord:
+    """Record an explicit waiver with reason and expiry — not silent suppression."""
+    return LifecycleRecord(
+        fingerprint=fingerprint,
+        state="waived",
+        reason=reason,
+        expires_at=expires_at,
+    )
+
+
+def lifecycle_state(record: LifecycleRecord) -> LifecycleState:
+    """Return the canonical lifecycle state for a record."""
+    return record.state
+
+
+def lifecycle_state_from_thread(thread: dict[str, Any]) -> LifecycleState:
+    """Map a normalized review thread to a lifecycle state.
+
+    Stale anchors (outdated but unresolved) are distinguishable from findings
+    resolved by the change (outdated and resolved).
+    """
+    if thread.get("isResolved"):
+        return "resolved-by-change"
+    if thread.get("isOutdated"):
+        return "stale"
+    return "open"
+
+
+__all__ = [
+    "LifecycleRecord",
+    "LifecycleState",
+    "dispute_finding",
+    "lifecycle_state",
+    "lifecycle_state_from_thread",
+    "waive_finding",
+]

--- a/src/mergecraft/review/hierarchical_summaries.py
+++ b/src/mergecraft/review/hierarchical_summaries.py
@@ -131,19 +131,6 @@ def build_hierarchical_context(
             omitted_paths.remove(path)
 
     total_lines = sum(_line_count(block) for _, block in blocks)
-    kept_lines = sum(_line_count(hunk.raw) for hunk in hunks)
-    scope_reduction: ScopeReduction | None = None
-    if omitted_paths:
-        reason = (
-            f"token budget reduced scope ({token_budget} tokens); "
-            f"{len(omitted_paths)} file(s) summarized only"
-        )
-        scope_reduction = ScopeReduction(
-            original_lines=total_lines,
-            kept_lines=kept_lines,
-            omitted_paths=sorted(omitted_paths),
-            reason=reason,
-        )
 
     rendered_parts = [
         *(f"{entry.path} ({entry.lines_changed} lines)" for entry in map_entries),
@@ -155,7 +142,7 @@ def build_hierarchical_context(
     if token_estimate > token_budget and hunks:
         while hunks and token_estimate > token_budget:
             dropped = hunks.pop()
-            if dropped.path not in risk and dropped.path not in omitted_paths:
+            if dropped.path not in omitted_paths:
                 omitted_paths.append(dropped.path)
             rendered_parts = [
                 *(f"{entry.path} ({entry.lines_changed} lines)" for entry in map_entries),
@@ -163,16 +150,19 @@ def build_hierarchical_context(
                 *(hunk.raw for hunk in hunks),
             ]
             token_estimate = sum(_estimate_tokens(part) for part in rendered_parts)
-        if omitted_paths and scope_reduction is None:
-            scope_reduction = ScopeReduction(
-                original_lines=total_lines,
-                kept_lines=sum(_line_count(hunk.raw) for hunk in hunks),
-                omitted_paths=sorted(set(omitted_paths)),
-                reason=(
-                    f"token budget reduced scope ({token_budget} tokens); "
-                    f"{len(omitted_paths)} file(s) summarized only"
-                ),
-            )
+
+    scope_reduction: ScopeReduction | None = None
+    if omitted_paths:
+        unique_omitted = sorted(set(omitted_paths))
+        scope_reduction = ScopeReduction(
+            original_lines=total_lines,
+            kept_lines=sum(_line_count(hunk.raw) for hunk in hunks),
+            omitted_paths=unique_omitted,
+            reason=(
+                f"token budget reduced scope ({token_budget} tokens); "
+                f"{len(unique_omitted)} file(s) summarized only"
+            ),
+        )
 
     return HierarchicalContext(
         map=map_entries,

--- a/src/mergecraft/review/hierarchical_summaries.py
+++ b/src/mergecraft/review/hierarchical_summaries.py
@@ -1,0 +1,192 @@
+"""Hierarchical diff summarization for large pull requests (DG2, G6).
+
+Large diffs degrade into a navigable map, cluster summaries, and selected raw
+hunks. High-risk regions keep verbatim tokens; reduced scope is always reported.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mergecraft.utils.run_bounds import ScopeReduction, _diff_file_blocks
+
+
+@dataclass(slots=True)
+class FileMapEntry:
+    """One file in the navigable diff map."""
+
+    path: str
+    lines_changed: int
+
+
+@dataclass(slots=True)
+class ClusterSummary:
+    """Abbreviated summary for one changed file or cluster."""
+
+    path: str
+    summary: str
+    lines_changed: int
+
+
+@dataclass(slots=True)
+class DiffHunk:
+    """A verbatim diff hunk retained in the context payload."""
+
+    path: str
+    raw: str
+
+
+@dataclass(slots=True)
+class HierarchicalContext:
+    """Map → summaries → hunks context for a large diff."""
+
+    map: list[FileMapEntry] = field(default_factory=list)
+    summaries: list[ClusterSummary] = field(default_factory=list)
+    hunks: list[DiffHunk] = field(default_factory=list)
+    token_estimate: int = 0
+    scope_reduction: ScopeReduction | None = None
+
+
+def _estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+def _line_count(block: str) -> int:
+    if not block:
+        return 0
+    return block.count("\n") + (0 if block.endswith("\n") else 1)
+
+
+def build_hierarchical_context(
+    diff_text: str,
+    *,
+    token_budget: int,
+    risk_regions: set[str] | None = None,
+) -> HierarchicalContext:
+    """Build hierarchical review context within a token budget.
+
+    Args:
+        diff_text: Unified diff text for the pull request.
+        token_budget: Maximum estimated tokens for the rendered context.
+        risk_regions: Paths that must retain verbatim diff hunks.
+
+    Returns:
+        :class:`HierarchicalContext` with map, summaries, hunks, and any
+        recorded :class:`ScopeReduction`.
+    """
+    risk = risk_regions or set()
+    blocks = _diff_file_blocks(diff_text)
+    if not blocks:
+        return HierarchicalContext()
+
+    map_entries: list[FileMapEntry] = []
+    summaries: list[ClusterSummary] = []
+    for path, block in blocks:
+        lines = _line_count(block)
+        map_entries.append(FileMapEntry(path=path, lines_changed=lines))
+        summaries.append(
+            ClusterSummary(
+                path=path,
+                summary=f"{path}: {lines} line(s) changed",
+                lines_changed=lines,
+            )
+        )
+
+    map_tokens = sum(
+        _estimate_tokens(f"{entry.path} ({entry.lines_changed} lines)") for entry in map_entries
+    )
+    summary_tokens = sum(_estimate_tokens(summary.summary) for summary in summaries)
+    overhead = map_tokens + summary_tokens
+    remaining = max(0, token_budget - overhead)
+
+    hunks: list[DiffHunk] = []
+    included_paths: set[str] = set()
+    omitted_paths: list[str] = []
+
+    risk_blocks = [(path, block) for path, block in blocks if path in risk]
+    other_blocks = [(path, block) for path, block in blocks if path not in risk]
+
+    for path, block in risk_blocks:
+        cost = _estimate_tokens(block)
+        hunks.append(DiffHunk(path=path, raw=block))
+        included_paths.add(path)
+        remaining = max(0, remaining - cost)
+
+    for path, block in other_blocks:
+        cost = _estimate_tokens(block)
+        if cost <= remaining or not hunks:
+            hunks.append(DiffHunk(path=path, raw=block))
+            included_paths.add(path)
+            remaining = max(0, remaining - cost)
+        else:
+            omitted_paths.append(path)
+
+    if not hunks and blocks:
+        path, block = blocks[0]
+        hunks.append(DiffHunk(path=path, raw=block))
+        included_paths.add(path)
+        if path in omitted_paths:
+            omitted_paths.remove(path)
+
+    total_lines = sum(_line_count(block) for _, block in blocks)
+    kept_lines = sum(_line_count(hunk.raw) for hunk in hunks)
+    scope_reduction: ScopeReduction | None = None
+    if omitted_paths:
+        reason = (
+            f"token budget reduced scope ({token_budget} tokens); "
+            f"{len(omitted_paths)} file(s) summarized only"
+        )
+        scope_reduction = ScopeReduction(
+            original_lines=total_lines,
+            kept_lines=kept_lines,
+            omitted_paths=sorted(omitted_paths),
+            reason=reason,
+        )
+
+    rendered_parts = [
+        *(f"{entry.path} ({entry.lines_changed} lines)" for entry in map_entries),
+        *(summary.summary for summary in summaries),
+        *(hunk.raw for hunk in hunks),
+    ]
+    token_estimate = sum(_estimate_tokens(part) for part in rendered_parts)
+
+    if token_estimate > token_budget and hunks:
+        while hunks and token_estimate > token_budget:
+            dropped = hunks.pop()
+            if dropped.path not in risk and dropped.path not in omitted_paths:
+                omitted_paths.append(dropped.path)
+            rendered_parts = [
+                *(f"{entry.path} ({entry.lines_changed} lines)" for entry in map_entries),
+                *(summary.summary for summary in summaries),
+                *(hunk.raw for hunk in hunks),
+            ]
+            token_estimate = sum(_estimate_tokens(part) for part in rendered_parts)
+        if omitted_paths and scope_reduction is None:
+            scope_reduction = ScopeReduction(
+                original_lines=total_lines,
+                kept_lines=sum(_line_count(hunk.raw) for hunk in hunks),
+                omitted_paths=sorted(set(omitted_paths)),
+                reason=(
+                    f"token budget reduced scope ({token_budget} tokens); "
+                    f"{len(omitted_paths)} file(s) summarized only"
+                ),
+            )
+
+    return HierarchicalContext(
+        map=map_entries,
+        summaries=summaries,
+        hunks=hunks,
+        token_estimate=token_estimate,
+        scope_reduction=scope_reduction,
+    )
+
+
+__all__ = [
+    "ClusterSummary",
+    "DiffHunk",
+    "FileMapEntry",
+    "HierarchicalContext",
+    "build_hierarchical_context",
+]

--- a/src/mergecraft/review/split_advisor.py
+++ b/src/mergecraft/review/split_advisor.py
@@ -1,0 +1,80 @@
+"""Advisory PR split recommendations from change clusters (DG2, G6).
+
+Split advice is text-only — convention 3 forbids writes to the reviewed tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(slots=True)
+class SuggestedPR:
+    """One suggested pull request in a split recommendation."""
+
+    paths: list[str] = field(default_factory=list)
+    intent: str | None = None
+    label: str | None = None
+
+
+@dataclass(slots=True)
+class SplitAdvice:
+    """Advisory split recommendation — never mutates the repository."""
+
+    recommend_split: bool
+    suggested_prs: list[SuggestedPR] = field(default_factory=list)
+    summary: str = ""
+    advisory_only: bool = True
+
+
+def recommend_pr_split(
+    independent_groups: list[dict[str, Any]],
+    *,
+    output_path: Path | None = None,
+) -> SplitAdvice:
+    """Recommend splitting unrelated change groups into separate pull requests.
+
+    Args:
+        independent_groups: Cluster dicts with ``paths`` and optional ``intent``.
+        output_path: Ignored for writes — split advice is advisory only.
+
+    Returns:
+        :class:`SplitAdvice` with human-readable summary text.
+    """
+    if output_path is not None:
+        # Convention 3: never write to the reviewed tree.
+        _ = output_path
+
+    if len(independent_groups) < 2:
+        return SplitAdvice(
+            recommend_split=False,
+            summary="Changes appear cohesive; no split recommended.",
+            advisory_only=True,
+        )
+
+    suggested: list[SuggestedPR] = []
+    labels: list[str] = []
+    for group in independent_groups:
+        paths = list(group.get("paths") or [])
+        intent = group.get("intent")
+        group_id = str(group.get("id") or intent or paths[0])
+        suggested.append(SuggestedPR(paths=paths, intent=intent, label=group_id))
+        labels.append(group_id)
+
+    summary = (
+        "Recommend splitting this pull request into "
+        f"{len(suggested)} independent PRs: {', '.join(labels)}."
+    )
+    return SplitAdvice(
+        recommend_split=True,
+        suggested_prs=suggested,
+        summary=summary,
+        advisory_only=True,
+    )
+
+
+__all__ = ["SplitAdvice", "SuggestedPR", "recommend_pr_split"]

--- a/tests/analyzers/test_adapters_supply_chain.py
+++ b/tests/analyzers/test_adapters_supply_chain.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -30,6 +32,28 @@ def _run(tool_id: str, repo_root: Path, changed_files: list[str], *, tier: str =
     )
 
 
+def _run_expecting_cve(
+    tool_id: str, repo_root: Path, changed_files: list[str], *, tier: str = "trusted"
+) -> Any:
+    """Run a supply-chain adapter that must report the planted CVE.
+
+    Trivy fetches its vulnerability DB over the network; a slow download can
+    yield valid JSON with zero findings before the DB is ready (see
+    ``supply_chain._run_trivy_and_parse``). Retry only in this fixture test —
+    production scans must not treat every empty result as transient.
+    """
+    supply_chain = import_module("mergecraft.analyzers.supply_chain")
+    result = _run(tool_id, repo_root, changed_files, tier=tier)
+    if tool_id != "trivy" or result.skipped or result.findings:
+        return result
+    for _ in range(1, supply_chain._TRIVY_MAX_ATTEMPTS):
+        time.sleep(supply_chain._TRIVY_RETRY_DELAY_S)
+        result = _run(tool_id, repo_root, changed_files, tier=tier)
+        if result.skipped or result.findings:
+            return result
+    return result
+
+
 @pytest.mark.parametrize("tool_id", ["osv-scanner", "trivy"])
 def test_newly_introduced_cve_reported_with_fix_and_transitive_status(
     tool_id: str, adapter_fixture_repo: Path
@@ -37,7 +61,7 @@ def test_newly_introduced_cve_reported_with_fix_and_transitive_status(
     if tool_id not in _catalog_ids():
         pytest.fail(f"{tool_id} manifest missing from catalog")
 
-    result = _run(
+    result = _run_expecting_cve(
         tool_id,
         adapter_fixture_repo,
         ["requirements.txt"],

--- a/tests/classify/test_change_clustering.py
+++ b/tests/classify/test_change_clustering.py
@@ -1,0 +1,79 @@
+"""DG2 change clustering — dependency and intent groups (G6).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG2).
+Implementation: **DG2.2** — cluster large diffs by dependency and intent; feed
+the split advisor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _change(*paths: str, **signals: object) -> dict[str, object]:
+    return {"changed_paths": list(paths), "diff_stats": signals}
+
+
+def _cluster_change(change: dict[str, object], **kwargs: Any) -> Any:
+    from mergecraft.classify.change_clustering import cluster_changes
+
+    return cluster_changes(change, **kwargs)
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_files_cluster_by_dependency_and_intent() -> None:
+    """Related files cluster together; unrelated paths land in separate groups."""
+    change = _change(
+        "src/api/handlers.py",
+        "src/api/routes.py",
+        "src/billing/invoice.py",
+        "docs/guide.md",
+        files_changed=4,
+    )
+    dependency_edges = [
+        ("src/api/routes.py", "src/api/handlers.py"),
+    ]
+    intents = {
+        "src/api/handlers.py": "api-refactor",
+        "src/api/routes.py": "api-refactor",
+        "src/billing/invoice.py": "billing-fix",
+        "docs/guide.md": "docs-only",
+    }
+
+    result = _cluster_change(change, dependency_edges=dependency_edges, intents=intents)
+
+    cluster_for = {path: group.id for group in result.clusters for path in group.paths}
+    assert cluster_for["src/api/handlers.py"] == cluster_for["src/api/routes.py"]
+    assert cluster_for["src/billing/invoice.py"] != cluster_for["src/api/handlers.py"]
+    assert cluster_for["docs/guide.md"] != cluster_for["src/billing/invoice.py"]
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_independent_groups_are_identified() -> None:
+    """Wholly unrelated change groups are surfaced for the split advisor."""
+    change = _change(
+        "frontend/app.tsx",
+        "frontend/router.tsx",
+        "infra/terraform/main.tf",
+        "infra/terraform/variables.tf",
+        files_changed=4,
+    )
+    dependency_edges = [
+        ("frontend/app.tsx", "frontend/router.tsx"),
+        ("infra/terraform/main.tf", "infra/terraform/variables.tf"),
+    ]
+    intents = {
+        "frontend/app.tsx": "ui",
+        "frontend/router.tsx": "ui",
+        "infra/terraform/main.tf": "infra",
+        "infra/terraform/variables.tf": "infra",
+    }
+
+    result = _cluster_change(change, dependency_edges=dependency_edges, intents=intents)
+
+    assert len(result.independent_groups) >= 2
+    group_paths = [frozenset(group.paths) for group in result.independent_groups]
+    assert frozenset({"frontend/app.tsx", "frontend/router.tsx"}) in group_paths
+    assert frozenset({"infra/terraform/main.tf", "infra/terraform/variables.tf"}) in group_paths

--- a/tests/classify/test_change_clustering.py
+++ b/tests/classify/test_change_clustering.py
@@ -73,3 +73,39 @@ def test_independent_groups_are_identified() -> None:
     group_paths = [frozenset(group.paths) for group in result.independent_groups]
     assert frozenset({"frontend/app.tsx", "frontend/router.tsx"}) in group_paths
     assert frozenset({"infra/terraform/main.tf", "infra/terraform/variables.tf"}) in group_paths
+
+
+def test_singleton_with_distinct_intent_surfaces_for_split() -> None:
+    """A lone file whose intent differs from a cluster enables split advice."""
+    change = _change(
+        "src/api/handlers.py",
+        "src/api/routes.py",
+        "docs/guide.md",
+        files_changed=3,
+    )
+    dependency_edges = [
+        ("src/api/routes.py", "src/api/handlers.py"),
+    ]
+    intents = {
+        "src/api/handlers.py": "api-refactor",
+        "src/api/routes.py": "api-refactor",
+        "docs/guide.md": "docs-only",
+    }
+
+    result = _cluster_change(change, dependency_edges=dependency_edges, intents=intents)
+
+    assert len(result.independent_groups) >= 2
+    group_paths = [frozenset(group.paths) for group in result.independent_groups]
+    assert frozenset({"src/api/handlers.py", "src/api/routes.py"}) in group_paths
+    assert frozenset({"docs/guide.md"}) in group_paths
+
+    from mergecraft.review.split_advisor import recommend_pr_split
+
+    advice = recommend_pr_split(
+        [
+            {"id": group.id, "paths": group.paths, "intent": group.intent}
+            for group in result.independent_groups
+        ]
+    )
+    assert advice.recommend_split is True
+    assert len(advice.suggested_prs) >= 2

--- a/tests/classify/test_change_clustering.py
+++ b/tests/classify/test_change_clustering.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 
 def _change(*paths: str, **signals: object) -> dict[str, object]:
     return {"changed_paths": list(paths), "diff_stats": signals}
@@ -22,7 +20,6 @@ def _cluster_change(change: dict[str, object], **kwargs: Any) -> Any:
     return cluster_changes(change, **kwargs)
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_files_cluster_by_dependency_and_intent() -> None:
     """Related files cluster together; unrelated paths land in separate groups."""
     change = _change(
@@ -50,7 +47,6 @@ def test_files_cluster_by_dependency_and_intent() -> None:
     assert cluster_for["docs/guide.md"] != cluster_for["src/billing/invoice.py"]
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_independent_groups_are_identified() -> None:
     """Wholly unrelated change groups are surfaced for the split advisor."""
     change = _change(

--- a/tests/findings/test_lifecycle.py
+++ b/tests/findings/test_lifecycle.py
@@ -52,7 +52,6 @@ class _FakeGitHub:
         }
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_disputed_state_is_recorded() -> None:
     """A challenged finding records ``disputed`` with a reason (G7)."""
     from mergecraft.findings.lifecycle import dispute_finding, lifecycle_state
@@ -67,7 +66,6 @@ def test_disputed_state_is_recorded() -> None:
     assert lifecycle_state(record) == "disputed"
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_waived_state_carries_reason_and_expiry() -> None:
     """Waivers carry an explicit reason and expiry — not a silent suppression."""
     from mergecraft.findings.lifecycle import waive_finding
@@ -128,7 +126,6 @@ async def test_resolved_by_change_still_works() -> None:
     assert carryover_findings(normalized) == []
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_stale_finding_is_distinguishable_from_resolved() -> None:
     """Stale anchors are not conflated with findings resolved by the change."""
     from mergecraft.findings.lifecycle import lifecycle_state_from_thread

--- a/tests/findings/test_lifecycle.py
+++ b/tests/findings/test_lifecycle.py
@@ -1,0 +1,140 @@
+"""DG2 finding lifecycle — disputed, waived, stale, resolved-by-change (G7).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG2).
+Implementation: **DG2.2** — lifecycle states on top of ``findings/threads.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mergecraft.findings.select import carryover_findings
+from mergecraft.review_taxonomy import stamp_finding_fingerprint
+
+_PATH = "src/app.py"
+_BODY = stamp_finding_fingerprint(path=_PATH, body="Missing timeout on the retry loop.")
+
+
+def _thread(*, resolved: bool = False, outdated: bool = False) -> dict[str, Any]:
+    return {
+        "threadId": "T1",
+        "isResolved": resolved,
+        "isOutdated": outdated,
+        "comments": [
+            {
+                "id": 1,
+                "body": _BODY,
+                "path": _PATH,
+                "line": 42,
+                "author": "mergecraft[bot]",
+                "url": "https://github.com/o/r/pull/7#discussion_r1",
+                "createdAt": "2026-08-13T07:13:58Z",
+            }
+        ],
+    }
+
+
+class _FakeGitHub:
+    """Minimal GraphQL stub for ``fetch_review_threads``."""
+
+    def __init__(self, *, nodes: list[dict[str, Any]]) -> None:
+        self._nodes = nodes
+
+    async def graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {"totalCount": len(self._nodes), "nodes": self._nodes}
+                }
+            }
+        }
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_disputed_state_is_recorded() -> None:
+    """A challenged finding records ``disputed`` with a reason (G7)."""
+    from mergecraft.findings.lifecycle import dispute_finding, lifecycle_state
+
+    record = dispute_finding(
+        fingerprint="abc123",
+        reason="The caller already retries with backoff.",
+    )
+
+    assert record.state == "disputed"
+    assert record.reason == "The caller already retries with backoff."
+    assert lifecycle_state(record) == "disputed"
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_waived_state_carries_reason_and_expiry() -> None:
+    """Waivers carry an explicit reason and expiry — not a silent suppression."""
+    from mergecraft.findings.lifecycle import waive_finding
+
+    record = waive_finding(
+        fingerprint="def456",
+        reason="Accepted risk for this release train.",
+        expires_at="2026-12-31T23:59:59Z",
+    )
+
+    assert record.state == "waived"
+    assert record.reason == "Accepted risk for this release train."
+    assert record.expires_at == "2026-12-31T23:59:59Z"
+
+
+@pytest.mark.asyncio
+async def test_resolved_by_change_still_works() -> None:
+    """Regression pin: resolved threads stay normalized and out of carryover."""
+    from mergecraft.findings.threads import fetch_review_threads
+
+    resolved_node = {
+        "id": "T-resolved",
+        "isResolved": True,
+        "isOutdated": True,
+        "comments": {
+            "nodes": [
+                {
+                    "databaseId": 9,
+                    "body": _BODY,
+                    "author": {"login": "mergecraft[bot]"},
+                    "path": _PATH,
+                    "line": 42,
+                    "originalLine": 40,
+                    "url": "https://github.com/o/r/pull/7#discussion_r9",
+                    "createdAt": "2026-08-14T07:13:58Z",
+                }
+            ]
+        },
+    }
+    github = _FakeGitHub(nodes=[resolved_node])
+
+    page = await fetch_review_threads(github, "o", "r", 7, include_resolved=False)
+    assert page.threads == []
+
+    page_resolved = await fetch_review_threads(github, "o", "r", 7, include_resolved=True)
+    thread = page_resolved.threads[0]
+    assert thread["isResolved"] is True
+    assert thread["isOutdated"] is True
+
+    normalized = [
+        {
+            "threadId": thread["threadId"],
+            "isResolved": thread["isResolved"],
+            "isOutdated": thread["isOutdated"],
+            "comments": thread["comments"],
+        }
+    ]
+    assert carryover_findings(normalized) == []
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_stale_finding_is_distinguishable_from_resolved() -> None:
+    """Stale anchors are not conflated with findings resolved by the change."""
+    from mergecraft.findings.lifecycle import lifecycle_state_from_thread
+
+    stale = _thread(outdated=True, resolved=False)
+    resolved = _thread(outdated=True, resolved=True)
+
+    assert lifecycle_state_from_thread(stale) == "stale"
+    assert lifecycle_state_from_thread(resolved) == "resolved-by-change"

--- a/tests/review/test_hierarchical_summaries.py
+++ b/tests/review/test_hierarchical_summaries.py
@@ -1,0 +1,83 @@
+"""DG2 hierarchical summarization — large-PR context engine (G6).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG2).
+Implementation: **DG2.2** — map → summaries → hunks with raw tokens reserved for
+high-risk regions; reduced scope is always reported (file 2 D12).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.utils.run_bounds import ScopeReduction
+
+
+def _synthetic_diff(*, files: int, lines_per_file: int) -> str:
+    chunks: list[str] = []
+    for index in range(files):
+        path = f"src/module_{index:04d}.py"
+        body = "\n".join(f"+line {line}" for line in range(lines_per_file))
+        chunks.append(
+            f"diff --git a/{path} b/{path}\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            f"@@ -0,0 +1,{lines_per_file} @@\n"
+            f"{body}\n"
+        )
+    return "".join(chunks)
+
+
+def _build_hierarchical_context(*args: object, **kwargs: object) -> object:
+    from mergecraft.review.hierarchical_summaries import build_hierarchical_context
+
+    return build_hierarchical_context(*args, **kwargs)
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_large_diff_reduces_to_map_then_summaries_then_hunks() -> None:
+    """A large diff becomes a map, cluster summaries, and selected raw hunks."""
+    diff_text = _synthetic_diff(files=40, lines_per_file=200)
+    risk_regions = {"src/module_0001.py", "migrations/001_init.sql"}
+
+    result = _build_hierarchical_context(
+        diff_text,
+        token_budget=8_000,
+        risk_regions=risk_regions,
+    )
+
+    assert result.map, "large diffs must emit a navigable map"
+    assert result.summaries, "clusters must be summarized before raw hunks"
+    assert result.hunks, "some raw hunks must survive the budget"
+    assert result.token_estimate <= 8_000
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_high_risk_regions_keep_raw_tokens() -> None:
+    """High-risk paths keep verbatim diff tokens even under a tight budget."""
+    diff_text = _synthetic_diff(files=30, lines_per_file=150)
+    risk_path = "src/module_0007.py"
+    risk_regions = {risk_path}
+
+    result = _build_hierarchical_context(
+        diff_text,
+        token_budget=2_000,
+        risk_regions=risk_regions,
+    )
+
+    preserved = {hunk.path for hunk in result.hunks}
+    assert risk_path in preserved
+    assert any(hunk.raw for hunk in result.hunks if hunk.path == risk_path)
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_reduced_scope_is_reported() -> None:
+    """Scope reduction is explicit — large-PR summarization never truncates silently."""
+    diff_text = _synthetic_diff(files=60, lines_per_file=500)
+
+    result = _build_hierarchical_context(diff_text, token_budget=4_000)
+
+    assert result.scope_reduction is not None
+    assert isinstance(result.scope_reduction, ScopeReduction)
+    assert result.scope_reduction.omitted_paths, "reduced scope must name omitted paths"
+    reason = result.scope_reduction.reason.lower()
+    assert "scope" in reason or "reduced" in reason or "budget" in reason

--- a/tests/review/test_hierarchical_summaries.py
+++ b/tests/review/test_hierarchical_summaries.py
@@ -7,7 +7,7 @@ high-risk regions; reduced scope is always reported (file 2 D12).
 
 from __future__ import annotations
 
-from mergecraft.utils.run_bounds import ScopeReduction
+from mergecraft.utils.run_bounds import ScopeReduction, _diff_file_blocks
 
 
 def _synthetic_diff(*, files: int, lines_per_file: int) -> str:
@@ -49,7 +49,7 @@ def test_large_diff_reduces_to_map_then_summaries_then_hunks() -> None:
 
 
 def test_high_risk_regions_keep_raw_tokens() -> None:
-    """High-risk paths keep verbatim diff tokens even under a tight budget."""
+    """High-risk paths keep verbatim diff tokens when the budget allows."""
     diff_text = _synthetic_diff(files=30, lines_per_file=150)
     risk_path = "src/module_0007.py"
     risk_regions = {risk_path}
@@ -63,6 +63,40 @@ def test_high_risk_regions_keep_raw_tokens() -> None:
     preserved = {hunk.path for hunk in result.hunks}
     assert risk_path in preserved
     assert any(hunk.raw for hunk in result.hunks if hunk.path == risk_path)
+
+
+def test_high_risk_drop_reported_when_budget_forces_omission() -> None:
+    """Dropped high-risk hunks are recorded in scope reduction — never silent (D12)."""
+    diff_text = _synthetic_diff(files=20, lines_per_file=200)
+    risk_paths = {f"src/module_{index:04d}.py" for index in range(5)}
+    risk_block = next(block for path, block in _diff_file_blocks(diff_text) if path in risk_paths)
+    risk_tokens = max(1, len(risk_block) // 4)
+    tight_budget = risk_tokens + 50
+
+    result = _build_hierarchical_context(
+        diff_text,
+        token_budget=tight_budget,
+        risk_regions=risk_paths,
+    )
+
+    assert result.scope_reduction is not None
+    omitted = set(result.scope_reduction.omitted_paths)
+    assert omitted & risk_paths, "dropped risk paths must appear in omitted_paths"
+    assert result.scope_reduction.kept_lines < result.scope_reduction.original_lines
+
+
+def test_scope_reduction_reflects_post_trim_state() -> None:
+    """ScopeReduction uses final kept hunks after budget trimming — not pre-trim counts."""
+    diff_text = _synthetic_diff(files=25, lines_per_file=180)
+
+    result = _build_hierarchical_context(diff_text, token_budget=500)
+
+    assert result.scope_reduction is not None
+    final_kept_lines = sum(
+        hunk.raw.count("\n") + (0 if hunk.raw.endswith("\n") else 1) for hunk in result.hunks
+    )
+    assert result.scope_reduction.kept_lines == final_kept_lines
+    assert result.token_estimate <= 500
 
 
 def test_reduced_scope_is_reported() -> None:

--- a/tests/review/test_hierarchical_summaries.py
+++ b/tests/review/test_hierarchical_summaries.py
@@ -7,8 +7,6 @@ high-risk regions; reduced scope is always reported (file 2 D12).
 
 from __future__ import annotations
 
-import pytest
-
 from mergecraft.utils.run_bounds import ScopeReduction
 
 
@@ -33,7 +31,6 @@ def _build_hierarchical_context(*args: object, **kwargs: object) -> object:
     return build_hierarchical_context(*args, **kwargs)
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_large_diff_reduces_to_map_then_summaries_then_hunks() -> None:
     """A large diff becomes a map, cluster summaries, and selected raw hunks."""
     diff_text = _synthetic_diff(files=40, lines_per_file=200)
@@ -51,7 +48,6 @@ def test_large_diff_reduces_to_map_then_summaries_then_hunks() -> None:
     assert result.token_estimate <= 8_000
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_high_risk_regions_keep_raw_tokens() -> None:
     """High-risk paths keep verbatim diff tokens even under a tight budget."""
     diff_text = _synthetic_diff(files=30, lines_per_file=150)
@@ -69,7 +65,6 @@ def test_high_risk_regions_keep_raw_tokens() -> None:
     assert any(hunk.raw for hunk in result.hunks if hunk.path == risk_path)
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_reduced_scope_is_reported() -> None:
     """Scope reduction is explicit — large-PR summarization never truncates silently."""
     diff_text = _synthetic_diff(files=60, lines_per_file=500)

--- a/tests/review/test_split_advisor.py
+++ b/tests/review/test_split_advisor.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 
 def _independent_groups() -> list[dict[str, Any]]:
     return [
@@ -33,7 +31,6 @@ def _recommend_split(groups: list[dict[str, Any]], **kwargs: Any) -> Any:
     return recommend_pr_split(groups, **kwargs)
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_unrelated_groups_produce_a_split_recommendation() -> None:
     """Independent clusters yield a concrete split recommendation."""
     advice = _recommend_split(_independent_groups())
@@ -46,7 +43,6 @@ def test_unrelated_groups_produce_a_split_recommendation() -> None:
     assert advice.summary.strip()
 
 
-@pytest.mark.xfail(reason="green after DG2.2", strict=False)
 def test_split_advice_is_advisory_only(tmp_path: Path) -> None:
     """Split advice is text-only — convention 3 forbids repo writes."""
     target = tmp_path / "would-be-split-plan.md"

--- a/tests/review/test_split_advisor.py
+++ b/tests/review/test_split_advisor.py
@@ -1,0 +1,58 @@
+"""DG2 split advisor — advisory PR split recommendations (G6, convention 3).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG2).
+Implementation: **DG2.2** — consume change clusters; output text only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _independent_groups() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "ui",
+            "paths": ["frontend/app.tsx", "frontend/router.tsx"],
+            "intent": "ui-refactor",
+        },
+        {
+            "id": "infra",
+            "paths": ["infra/terraform/main.tf", "infra/terraform/variables.tf"],
+            "intent": "infra",
+        },
+    ]
+
+
+def _recommend_split(groups: list[dict[str, Any]], **kwargs: Any) -> Any:
+    from mergecraft.review.split_advisor import recommend_pr_split
+
+    return recommend_pr_split(groups, **kwargs)
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_unrelated_groups_produce_a_split_recommendation() -> None:
+    """Independent clusters yield a concrete split recommendation."""
+    advice = _recommend_split(_independent_groups())
+
+    assert advice.recommend_split is True
+    assert len(advice.suggested_prs) >= 2
+    suggested_paths = {path for pr in advice.suggested_prs for path in pr.paths}
+    assert "frontend/app.tsx" in suggested_paths
+    assert "infra/terraform/main.tf" in suggested_paths
+    assert advice.summary.strip()
+
+
+@pytest.mark.xfail(reason="green after DG2.2", strict=False)
+def test_split_advice_is_advisory_only(tmp_path: Path) -> None:
+    """Split advice is text-only — convention 3 forbids repo writes."""
+    target = tmp_path / "would-be-split-plan.md"
+    advice = _recommend_split(_independent_groups(), output_path=target)
+
+    assert advice.advisory_only is True
+    assert not target.exists(), "split advice must not write to the reviewed tree"
+    assert isinstance(advice.summary, str)
+    assert advice.summary.strip()


### PR DESCRIPTION
## What?

Large pull requests get structured context instead of silent truncation, and findings can move through disputed and waived states with advisory split guidance.

## Why?

Monolithic diffs overwhelm context windows and hide high-risk regions. Reviewers need hierarchy, lifecycle tracking, and split hints without the tool ever editing the repo.

## Note

Rebased onto `pre-0.0.1` @ a5c50f3. Builds on DG1 clustering signals; merge after #245.

## Test plan

- [x] `make ci-static`
- [x] DG2 suite: `tests/classify/test_change_clustering.py`, `tests/review/`, `tests/findings/test_lifecycle.py` (58 passed)

## Related PR(s)/Issue(s)

Depends on #245
