### PR TITLE
context: call graph, change graph, inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`docs/dev/provider-harness.md`); opt-in sanitized capture under
   `.ignorelocal/provider-harness/records/`.
 - Repository context engine indexes repo maps, per-file symbol indexes (tree-sitter with generic fallback), provenance citations, and trust-gated instruction/skill discovery under `mergecraft.context`
+- Call graph, change graph (changed symbol → dependents → tests → contracts), budget-aware dynamic expansion, targeted git blame, and `mergecraft context inspect` for provenance-backed context retrieval
 - Per-run budgets, bounded external-operation timeouts, and honest large-diff degradation (`RunBounds`, scope reduction reports, downgraded outcomes) for offline and Action reviews
 - Large-PR review engine (DG2): cluster changed paths by dependency and intent, build hierarchical diff context (map → summaries → raw hunks) with token-budget scope reduction that reserves verbatim hunks for high-risk regions, record disputed/waived/stale finding lifecycle states, and emit advisory-only PR split recommendations from independent change groups
 - Finding precision pipeline (DG1): deduplicate agent/analyzer findings before publication, apply a code-defined severity rubric at the verifier seam, require structured causality on blocking findings, suppress pre-existing analyzer hits via baseline comparison, and classify generated/minified/vendored paths for review policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-<<<<<<< HEAD
 - Added: a test-only provider-harness fixture schema and strict matcher
   (`tests/support/provider_harness`) so deterministic review tests can name
   the exact provider interaction they expect. Not used in production.
 - Added: provider-harness recording workflow and operator docs
   (`docs/dev/provider-harness.md`); opt-in sanitized capture under
   `.ignorelocal/provider-harness/records/`.
-=======
 - Repository context engine indexes repo maps, per-file symbol indexes (tree-sitter with generic fallback), provenance citations, and trust-gated instruction/skill discovery under `mergecraft.context`
->>>>>>> 0d0844c (feat(context): repo map, symbol index, and trust-gated instruction discovery)
 - Per-run budgets, bounded external-operation timeouts, and honest large-diff degradation (`RunBounds`, scope reduction reports, downgraded outcomes) for offline and Action reviews
 - Large-PR review engine (DG2): cluster changed paths by dependency and intent, build hierarchical diff context (map → summaries → raw hunks) with token-budget scope reduction that reserves verbatim hunks for high-risk regions, record disputed/waived/stale finding lifecycle states, and emit advisory-only PR split recommendations from independent change groups
 - Finding precision pipeline (DG1): deduplicate agent/analyzer findings before publication, apply a code-defined severity rubric at the verifier seam, require structured causality on blocking findings, suppress pre-existing analyzer hits via baseline comparison, and classify generated/minified/vendored paths for review policy

--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ of them for its full flag set):
 | `mergecraft config show <key>` | Show a resolved config value and the precedence layer that supplied it. |
 | `mergecraft config tracing` | Render the resolved tracing config — sinks, retention, redaction, token redacted. |
 | `mergecraft config validate` | Validate repo config — unknown keys are rejected (extra=forbid). |
+| `mergecraft context inspect` | Report sources, scope, provenance citations, and token totals. |
 | `mergecraft diff-review` | Review a local git diff offline (no GitHub Action / PR posting). |
 | `mergecraft doctor` | Diagnose git, providers, analyzers, auth, config, and MCP wiring. |
 | `mergecraft eval add` | Add a case to the bank. |

--- a/docs/test-plans/review-depth-governance-dg4-change-graph.md
+++ b/docs/test-plans/review-depth-governance-dg4-change-graph.md
@@ -1,0 +1,105 @@
+# PR DG4 — change graph — test plan (DG4.1)
+
+Wave plan: `.ignorelocal/waves/05-review-depth-governance-wave-plan.md` (PR DG4)
+Worktree: `../mergecraft-dg4-change-graph` @ `wave/dg4-change-graph`
+Authoring wave: **DG4.1** (tests-first). Implementation: **DG4.2**.
+xfail-reconciliation: **post-DG4.2** (complete).
+
+Depends on: **DG3** (`mergecraft.context` repo map, symbol index, provenance).
+Integrations: **CC3** token budget (`mergecraft.utils.run_bounds.BudgetTracker`),
+**convention 4** (reproducible citations on every context item).
+
+## xfail schedule
+
+Eight DG4.1 tests use `@pytest.mark.xfail(reason="green after DG4.2",
+strict=False)`. Zero pass pre-DG4.2.
+
+| Test file | Tests | Marker | Status pre-DG4.2 |
+|-----------|-------|--------|------------------|
+| `tests/context/test_call_graph.py` | 1 | xfail | **RED** |
+| `tests/context/test_change_graph.py` | 3 | xfail | **RED** |
+| `tests/context/test_dynamic_expansion.py` | 2 | xfail | **RED** |
+| `tests/context/test_git_history.py` | 1 | xfail | **RED** |
+| `tests/cli/test_context_inspect.py` | 1 | xfail | **RED** |
+
+**Acceptance (DG4.1):** 8 collected; 0 pass; 8 xfail. `make lint` + `make typecheck`
+clean.
+
+## Target API DG4.2 must satisfy
+
+### `src/mergecraft/context/call_graph.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `build_call_graph(*, repo_root, tree_sha, cache=None)` | Index import, reference, and call edges over DG3 symbol index |
+| `CallGraph` | `edges` collection with `kind` (`import` \| `reference` \| `call`), `caller`, `callee` |
+| cache protocol | Keyed by git **tree** object SHA (convention 6) |
+
+### `src/mergecraft/context/change_graph.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `ChangedSymbol` | `path`, `name`, `kind` for one diff-touched symbol |
+| `resolve_change_graph(*, repo_root, tree_sha, changed)` | Map changed symbols → dependents, covering tests, affected contracts |
+| `ChangeGraphResult` | `dependents`, `tests`, `contracts` path/symbol collections |
+
+### `src/mergecraft/context/dynamic_expansion.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `expand_enclosing_scope(*, repo_root, path, symbol)` | On-demand retrieval of enclosing scope as `ContextItem` list |
+| `expand_with_budget(*, repo_root, path, symbol, token_budget, budget_tracker=None)` | Expansion that stops before exceeding CC3 token budget; sets `truncated` when clipped |
+| `ExpansionResult` | `items`, `truncated`, `token_cost` |
+
+### `src/mergecraft/context/git_history.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `targeted_blame(*, repo_root, repo, path, start_line, end_line)` | Line-level blame for review (not CI failure attribution) |
+| `TargetedBlameResult` | `entries` (`commit_sha`, `line`, `author`, `text`) + `provenance` `ContextItem` |
+
+### `src/mergecraft/cli/context_cmd.py` (new)
+
+| Symbol | Contract |
+|--------|----------|
+| `mergecraft context inspect` | Report **sources**, **scope**, **provenance** citations, and **token** totals for a repo/scope |
+
+## Contract → coverage matrix
+
+### Call graph — `tests/context/test_call_graph.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 1 | `test_imports_references_and_callers_are_indexed` | integration | happy | Import, reference, and call edges indexed |
+
+### Change graph — `tests/context/test_change_graph.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 2 | `test_changed_symbol_resolves_to_dependents` | integration | happy | Changed symbol → dependent symbols |
+| 3 | `test_changed_symbol_resolves_to_covering_tests` | integration | happy | Changed symbol → covering test files |
+| 4 | `test_changed_symbol_resolves_to_affected_contracts` | integration | happy | Changed symbol → affected contract files |
+
+### Dynamic expansion — `tests/context/test_dynamic_expansion.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 5 | `test_enclosing_scope_is_retrieved_on_demand` | integration | happy | On-demand enclosing scope as provenance-backed items |
+| 6 | `test_expansion_respects_the_token_budget` | unit | budget | CC3 token budget respected; `truncated=True` when clipped |
+
+### Git history — `tests/context/test_git_history.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 7 | `test_targeted_blame_is_retrieved_with_provenance` | integration | happy | Targeted blame + convention 4 provenance |
+
+### CLI — `tests/cli/test_context_inspect.py`
+
+| # | Test | Layer | Scenario | Contract |
+|---|------|-------|----------|----------|
+| 8 | `test_reports_sources_scope_provenance_and_tokens` | functional | happy | `context inspect` surfaces sources, scope, provenance, tokens |
+
+## Reconciliation notes
+
+- Remove `@pytest.mark.xfail` from each test as DG4.2 greens it.
+- DG4 Final requires `make reference-docs-check` after CLI surface lands.

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -16,6 +16,7 @@ from mergecraft.cli import (
     auth_cmd,
     cache_cmd,
     config_surface_cmd,
+    context_cmd,
     diff_review_cmd,
     doctor_cmd,
     eval_cmd,
@@ -47,6 +48,7 @@ app.add_typer(lens_cmd.app, name="lens")
 app.add_typer(pipeline_cmd.app, name="pipeline")
 app.add_typer(mcp_cmd.app, name="mcp")
 app.add_typer(cache_cmd.app, name="cache")
+app.add_typer(context_cmd.app, name="context")
 app.add_typer(auth_cmd.app, name="auth")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")

--- a/src/mergecraft/cli/context_cmd.py
+++ b/src/mergecraft/cli/context_cmd.py
@@ -10,6 +10,8 @@ from rich.table import Table
 
 from mergecraft.context.change_graph import ChangedSymbol, resolve_change_graph
 from mergecraft.context.provenance import ContextItem, inspect_context
+from mergecraft.context.repo_paths import git_blob_sha, git_show_text
+from mergecraft.context.symbol_index import index_symbols
 
 app = typer.Typer(
     name="context",
@@ -34,6 +36,30 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
+def _symbol_kind(
+    *,
+    repo_root: Path,
+    tree_sha: str,
+    path: str,
+    symbol_name: str,
+) -> str:
+    lookup_name = symbol_name.split(".")[-1]
+    source = git_show_text(repo_root, tree_sha, path)
+    if source is None:
+        return "symbol"
+    blob_sha = git_blob_sha(repo_root, tree_sha, path)
+    indexed = index_symbols(
+        repo_root=repo_root,
+        rel_path=path,
+        blob_sha=blob_sha,
+        source=source,
+    )
+    for symbol in indexed.symbols:
+        if symbol.name == lookup_name:
+            return symbol.kind
+    return "symbol"
+
+
 @app.command("inspect")
 def inspect_cmd(
     repo_root: Path = typer.Option(..., "--repo-root", help="Repository root to inspect."),
@@ -44,10 +70,16 @@ def inspect_cmd(
 ) -> None:
     """Report sources, scope, provenance citations, and token totals."""
     path, symbol_name = _parse_scope(scope)
+    symbol_kind = _symbol_kind(
+        repo_root=repo_root,
+        tree_sha=tree_sha,
+        path=path,
+        symbol_name=symbol_name,
+    )
     change = resolve_change_graph(
         repo_root=repo_root,
         tree_sha=tree_sha,
-        changed=[ChangedSymbol(path=path, name=symbol_name, kind="function")],
+        changed=[ChangedSymbol(path=path, name=symbol_name, kind=symbol_kind)],
     )
 
     items: list[ContextItem] = [

--- a/src/mergecraft/cli/context_cmd.py
+++ b/src/mergecraft/cli/context_cmd.py
@@ -1,0 +1,107 @@
+"""``mergecraft context`` — inspect retrieved review context."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mergecraft.context.change_graph import ChangedSymbol, resolve_change_graph
+from mergecraft.context.provenance import ContextItem, inspect_context
+
+app = typer.Typer(
+    name="context",
+    help="Inspect repository context retrieval for a scope.",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+def _parse_scope(scope: str) -> tuple[str, str]:
+    if ":" not in scope:
+        msg = f"invalid scope {scope!r}; expected path:symbol"
+        raise typer.BadParameter(msg)
+    path, symbol = scope.split(":", 1)
+    if not path or not symbol:
+        msg = f"invalid scope {scope!r}; expected path:symbol"
+        raise typer.BadParameter(msg)
+    return path, symbol
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+@app.command("inspect")
+def inspect_cmd(
+    repo_root: Path = typer.Option(..., "--repo-root", help="Repository root to inspect."),
+    repo: str = typer.Option(..., "--repo", help="Logical repo name for citations."),
+    commit_sha: str = typer.Option(..., "--commit-sha", help="Commit SHA for citations."),
+    tree_sha: str = typer.Option(..., "--tree-sha", help="Tree SHA for indexed context."),
+    scope: str = typer.Option(..., "--scope", help="Scope as path:symbol."),
+) -> None:
+    """Report sources, scope, provenance citations, and token totals."""
+    path, symbol_name = _parse_scope(scope)
+    change = resolve_change_graph(
+        repo_root=repo_root,
+        tree_sha=tree_sha,
+        changed=[ChangedSymbol(path=path, name=symbol_name, kind="function")],
+    )
+
+    items: list[ContextItem] = [
+        ContextItem(
+            repo=repo,
+            sha=commit_sha,
+            path=path,
+            reason="change_graph",
+            text=f"dependents={','.join(change.dependents) or '-'}",
+            token_cost=_estimate_tokens(path),
+        )
+    ]
+    for test_path in change.tests:
+        items.append(
+            ContextItem(
+                repo=repo,
+                sha=commit_sha,
+                path=test_path,
+                reason="covering_test",
+                text=test_path,
+                token_cost=_estimate_tokens(test_path),
+            )
+        )
+    for contract_path in change.contracts:
+        items.append(
+            ContextItem(
+                repo=repo,
+                sha=commit_sha,
+                path=contract_path,
+                reason="affected_contract",
+                text=contract_path,
+                token_cost=_estimate_tokens(contract_path),
+            )
+        )
+
+    report = inspect_context(items)
+    sources = ("call_graph", "change_graph", "symbol_index")
+
+    console.print("[bold]Sources[/bold]")
+    for source in sources:
+        console.print(f"- {source}")
+
+    console.print("\n[bold]Scope[/bold]")
+    console.print(f"{scope}")
+
+    table = Table(title="Provenance")
+    table.add_column("citation")
+    table.add_column("reason")
+    table.add_column("tokens")
+    for item in items:
+        table.add_row(item.as_citation(), item.reason, str(item.token_cost))
+    console.print(table)
+
+    console.print(f"\n[bold]Token total[/bold]: {report.total_tokens}")
+
+
+__all__ = ["app", "inspect_cmd"]

--- a/src/mergecraft/context/__init__.py
+++ b/src/mergecraft/context/__init__.py
@@ -1,16 +1,34 @@
 """Repository context engine — repo map, symbol index, provenance, instruction discovery."""
 
+from mergecraft.context.call_graph import CallGraph, build_call_graph
+from mergecraft.context.change_graph import ChangedSymbol, ChangeGraphResult, resolve_change_graph
+from mergecraft.context.dynamic_expansion import (
+    ExpansionResult,
+    expand_enclosing_scope,
+    expand_with_budget,
+)
+from mergecraft.context.git_history import TargetedBlameResult, targeted_blame
 from mergecraft.context.instruction_discovery import render_review_context
 from mergecraft.context.provenance import ContextItem, inspect_context
 from mergecraft.context.repo_map import RepoMap, build_repo_map
 from mergecraft.context.symbol_index import SymbolIndexResult, index_symbols
 
 __all__ = [
+    "CallGraph",
+    "ChangeGraphResult",
+    "ChangedSymbol",
     "ContextItem",
+    "ExpansionResult",
     "RepoMap",
     "SymbolIndexResult",
+    "TargetedBlameResult",
+    "build_call_graph",
     "build_repo_map",
+    "expand_enclosing_scope",
+    "expand_with_budget",
     "index_symbols",
     "inspect_context",
     "render_review_context",
+    "resolve_change_graph",
+    "targeted_blame",
 ]

--- a/src/mergecraft/context/call_graph.py
+++ b/src/mergecraft/context/call_graph.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import ast
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
 from typing import Any, Literal, Protocol, cast
 
+from mergecraft.context.repo_paths import git_blob_sha, git_ls_tree_paths, git_show_text
 from mergecraft.context.symbol_index import index_symbols
 
 EdgeKind = Literal["import", "reference", "call"]
@@ -50,29 +50,24 @@ def build_call_graph(
             return cast("CallGraph", cached)
 
     edges: list[CallEdge] = []
-    for rel_path in _iter_python_files(repo_root):
+    for rel_path in git_ls_tree_paths(repo_root, tree_sha, suffix=_PYTHON_SUFFIX):
         module = _module_name(rel_path)
-        blob_sha = _blob_sha(repo_root, rel_path)
-        index_symbols(repo_root=repo_root, rel_path=rel_path, blob_sha=blob_sha)
-        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        blob_sha = git_blob_sha(repo_root, tree_sha, rel_path)
+        source = git_show_text(repo_root, tree_sha, rel_path)
+        if source is None:
+            continue
+        index_symbols(
+            repo_root=repo_root,
+            rel_path=rel_path,
+            blob_sha=blob_sha,
+            source=source,
+        )
         edges.extend(_edges_for_file(module=module, rel_path=rel_path, source=source))
 
     graph = CallGraph(edges=tuple(edges))
     if cache is not None:
         cache.set(tree_sha, graph)
     return graph
-
-
-def _iter_python_files(repo_root: Path) -> list[str]:
-    paths: list[str] = []
-    for path in sorted(repo_root.rglob(f"*{_PYTHON_SUFFIX}")):
-        if not path.is_file():
-            continue
-        rel = path.relative_to(repo_root).as_posix()
-        if rel.startswith(".git/"):
-            continue
-        paths.append(rel)
-    return paths
 
 
 def _module_name(rel_path: str) -> str:
@@ -82,23 +77,6 @@ def _module_name(rel_path: str) -> str:
     if stem.startswith("src/"):
         stem = stem.removeprefix("src/")
     return stem.replace("/", ".")
-
-
-def _blob_sha(repo_root: Path, rel_path: str) -> str:
-    try:
-        completed = subprocess.run(
-            ["git", "rev-parse", f"HEAD:{rel_path}"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except OSError:
-        completed = None
-    if completed is not None and completed.returncode == 0:
-        return completed.stdout.strip()
-    content = (repo_root / rel_path).read_bytes()
-    return f"blob:{content.hex()[:40]}"
 
 
 def _edges_for_file(*, module: str, rel_path: str, source: str) -> list[CallEdge]:
@@ -136,17 +114,51 @@ def _edges_for_file(*, module: str, rel_path: str, source: str) -> list[CallEdge
                     )
                 )
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
-            caller = f"{module}.{node.name}"
-            for child in ast.walk(node):
-                if isinstance(child, ast.Call):
-                    callee = _callee_name(child.func, imports=imports, module=module)
-                    if callee:
-                        edges.append(CallEdge(kind="call", caller=caller, callee=callee))
-                        edges.append(CallEdge(kind="reference", caller=caller, callee=callee))
-
+    collector = _CallEdgeCollector(module=module, imports=imports)
+    collector.visit(tree)
+    edges.extend(collector.edges)
     return edges
+
+
+class _CallEdgeCollector(ast.NodeVisitor):
+    """Collect call/reference edges with module-, class-, and function-qualified callers."""
+
+    def __init__(self, *, module: str, imports: dict[str, str]) -> None:
+        self._module = module
+        self._imports = imports
+        self._class_stack: list[str] = []
+        self._func_stack: list[str] = []
+        self.edges: list[CallEdge] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._class_stack.append(node.name)
+        self.generic_visit(node)
+        self._class_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        caller = self._caller_name()
+        callee = _callee_name(node.func, imports=self._imports, module=self._module)
+        if callee:
+            self.edges.append(CallEdge(kind="call", caller=caller, callee=callee))
+            self.edges.append(CallEdge(kind="reference", caller=caller, callee=callee))
+
+    def _caller_name(self) -> str:
+        if self._func_stack:
+            parts = [self._module, *self._class_stack, self._func_stack[-1]]
+            return ".".join(parts)
+        if self._class_stack:
+            return f"{self._module}.{self._class_stack[-1]}"
+        return self._module
 
 
 def _callee_name(
@@ -155,6 +167,7 @@ def _callee_name(
     imports: dict[str, str],
     module: str,
 ) -> str | None:
+    del module
     if isinstance(node, ast.Name):
         if node.id in imports:
             return imports[node.id]

--- a/src/mergecraft/context/call_graph.py
+++ b/src/mergecraft/context/call_graph.py
@@ -1,0 +1,175 @@
+"""Call graph over the DG3 symbol index — imports, references, and callers."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+from typing import Any, Literal, Protocol, cast
+
+from mergecraft.context.symbol_index import index_symbols
+
+EdgeKind = Literal["import", "reference", "call"]
+
+_PYTHON_SUFFIX = ".py"
+
+
+class _CacheProto(Protocol):
+    def get(self, key: str) -> Any | None: ...
+
+    def set(self, key: str, value: Any) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CallEdge:
+    """One directed relationship between caller and callee symbols or modules."""
+
+    kind: EdgeKind
+    caller: str
+    callee: str
+
+
+@dataclass(frozen=True, slots=True)
+class CallGraph:
+    """Indexed import, reference, and call edges for one repository tree."""
+
+    edges: tuple[CallEdge, ...]
+
+
+def build_call_graph(
+    *,
+    repo_root: Path,
+    tree_sha: str,
+    cache: _CacheProto | None = None,
+) -> CallGraph:
+    """Index import, reference, and call edges for ``tree_sha``."""
+    if cache is not None:
+        cached = cache.get(tree_sha)
+        if cached is not None:
+            return cast("CallGraph", cached)
+
+    edges: list[CallEdge] = []
+    for rel_path in _iter_python_files(repo_root):
+        module = _module_name(rel_path)
+        blob_sha = _blob_sha(repo_root, rel_path)
+        index_symbols(repo_root=repo_root, rel_path=rel_path, blob_sha=blob_sha)
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        edges.extend(_edges_for_file(module=module, rel_path=rel_path, source=source))
+
+    graph = CallGraph(edges=tuple(edges))
+    if cache is not None:
+        cache.set(tree_sha, graph)
+    return graph
+
+
+def _iter_python_files(repo_root: Path) -> list[str]:
+    paths: list[str] = []
+    for path in sorted(repo_root.rglob(f"*{_PYTHON_SUFFIX}")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        if rel.startswith(".git/"):
+            continue
+        paths.append(rel)
+    return paths
+
+
+def _module_name(rel_path: str) -> str:
+    stem = rel_path.removesuffix(_PYTHON_SUFFIX)
+    if stem.endswith("/__init__"):
+        stem = stem[: -len("/__init__")]
+    if stem.startswith("src/"):
+        stem = stem.removeprefix("src/")
+    return stem.replace("/", ".")
+
+
+def _blob_sha(repo_root: Path, rel_path: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", f"HEAD:{rel_path}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        completed = None
+    if completed is not None and completed.returncode == 0:
+        return completed.stdout.strip()
+    content = (repo_root / rel_path).read_bytes()
+    return f"blob:{content.hex()[:40]}"
+
+
+def _edges_for_file(*, module: str, rel_path: str, source: str) -> list[CallEdge]:
+    try:
+        tree = ast.parse(source, filename=rel_path)
+    except SyntaxError:
+        return []
+
+    imports: dict[str, str] = {}
+    edges: list[CallEdge] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            for alias in node.names:
+                local = alias.asname or alias.name
+                imports[local] = f"{node.module}.{alias.name}"
+                edges.append(
+                    CallEdge(
+                        kind="import",
+                        caller=module,
+                        callee=f"{node.module}.{alias.name}",
+                    )
+                )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name
+                imports[local] = alias.name
+                edges.append(
+                    CallEdge(
+                        kind="import",
+                        caller=module,
+                        callee=alias.name,
+                    )
+                )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            caller = f"{module}.{node.name}"
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call):
+                    callee = _callee_name(child.func, imports=imports, module=module)
+                    if callee:
+                        edges.append(CallEdge(kind="call", caller=caller, callee=callee))
+                        edges.append(CallEdge(kind="reference", caller=caller, callee=callee))
+
+    return edges
+
+
+def _callee_name(
+    node: ast.expr,
+    *,
+    imports: dict[str, str],
+    module: str,
+) -> str | None:
+    if isinstance(node, ast.Name):
+        if node.id in imports:
+            return imports[node.id]
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parts: list[str] = []
+        current: ast.expr = node
+        while isinstance(current, ast.Attribute):
+            parts.append(current.attr)
+            current = current.value
+        if isinstance(current, ast.Name):
+            base = imports.get(current.id, current.id)
+            parts.reverse()
+            return ".".join([base, *parts])
+    return None
+
+
+__all__ = ["CallEdge", "CallGraph", "EdgeKind", "build_call_graph"]

--- a/src/mergecraft/context/change_graph.py
+++ b/src/mergecraft/context/change_graph.py
@@ -1,0 +1,137 @@
+"""Change graph — changed symbol → dependents, tests, and contracts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+
+from mergecraft.context.call_graph import CallGraph, build_call_graph
+
+_CONTRACT_SUFFIXES = frozenset({".yaml", ".yml", ".json", ".proto"})
+_TEST_DIR_NAMES = frozenset({"tests", "test"})
+
+
+@dataclass(frozen=True, slots=True)
+class ChangedSymbol:
+    """One diff-touched symbol in a repository."""
+
+    path: str
+    name: str
+    kind: str
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeGraphResult:
+    """Dependents, covering tests, and affected contracts for changed symbols."""
+
+    dependents: tuple[str, ...]
+    tests: tuple[str, ...]
+    contracts: tuple[str, ...]
+
+
+def resolve_change_graph(
+    *,
+    repo_root: Path,
+    tree_sha: str,
+    changed: list[ChangedSymbol],
+) -> ChangeGraphResult:
+    """Resolve dependents, tests, and contracts affected by ``changed`` symbols."""
+    graph = build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+    dependents: set[str] = set()
+    tests: set[str] = set()
+    contracts: set[str] = set()
+
+    for symbol in changed:
+        qualified = _qualify_symbol(symbol)
+        dependents.update(_dependents_for(graph, qualified, symbol.name))
+        tests.update(_covering_tests(repo_root, symbol))
+        contracts.update(
+            _affected_contracts(
+                repo_root,
+                symbol_names={symbol.name, *_symbol_tail(qualified), *dependents},
+            )
+        )
+
+    return ChangeGraphResult(
+        dependents=tuple(sorted(dependents)),
+        tests=tuple(sorted(tests)),
+        contracts=tuple(sorted(contracts)),
+    )
+
+
+def _qualify_symbol(symbol: ChangedSymbol) -> str:
+    module = _module_name(symbol.path)
+    return f"{module}.{symbol.name}" if module else symbol.name
+
+
+def _module_name(rel_path: str) -> str:
+    stem = rel_path.removesuffix(".py")
+    if stem.endswith("/__init__"):
+        stem = stem[: -len("/__init__")]
+    if stem.startswith("src/"):
+        stem = stem.removeprefix("src/")
+    return stem.replace("/", ".")
+
+
+def _symbol_tail(qualified: str) -> set[str]:
+    return {qualified.split(".")[-1]}
+
+
+def _dependents_for(graph: CallGraph, qualified: str, bare_name: str) -> set[str]:
+    targets = {qualified, bare_name}
+    found: set[str] = set()
+    for edge in graph.edges:
+        if edge.callee in targets or edge.callee.endswith(f".{bare_name}"):
+            found.add(edge.caller)
+    return found
+
+
+def _covering_tests(repo_root: Path, symbol: ChangedSymbol) -> set[str]:
+    tests: set[str] = set()
+    module = _module_name(symbol.path)
+    needles = (
+        f"from {module} import {symbol.name}",
+        f"import {module}",
+        symbol.name,
+    )
+    for rel_path in _iter_test_files(repo_root):
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
+        if any(needle in source for needle in needles):
+            tests.add(rel_path)
+    return tests
+
+
+def _iter_test_files(repo_root: Path) -> list[str]:
+    paths: list[str] = []
+    for path in sorted(repo_root.rglob("test*.py")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        if rel.startswith(".git/"):
+            continue
+        parts = rel.split("/")
+        if any(part in _TEST_DIR_NAMES for part in parts):
+            paths.append(rel)
+    return paths
+
+
+def _affected_contracts(repo_root: Path, *, symbol_names: set[str]) -> set[str]:
+    contracts: set[str] = set()
+    for path in sorted(repo_root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        if rel.startswith(".git/"):
+            continue
+        if path.suffix.casefold() not in _CONTRACT_SUFFIXES and "contracts" not in rel:
+            continue
+        if path.suffix.casefold() not in _CONTRACT_SUFFIXES:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if any(re.search(rf"\b{re.escape(name)}\b", source) for name in symbol_names if name):
+            contracts.add(rel)
+    return contracts
+
+
+__all__ = ["ChangeGraphResult", "ChangedSymbol", "resolve_change_graph"]

--- a/src/mergecraft/context/change_graph.py
+++ b/src/mergecraft/context/change_graph.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+from typing import TYPE_CHECKING
 
 from mergecraft.context.call_graph import CallGraph, build_call_graph
+from mergecraft.context.repo_paths import iter_repo_files
+
+if TYPE_CHECKING:
+    from mergecraft.utils.run_bounds import RunBounds
 
 _CONTRACT_SUFFIXES = frozenset({".yaml", ".yml", ".json", ".proto"})
 _TEST_DIR_NAMES = frozenset({"tests", "test"})
+_FROM_IMPORT = re.compile(r"from\s+{module}\s+import\s+.*\b{symbol}\b")
+_IMPORT_MODULE = re.compile(r"\bimport\s+{module}\b")
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,21 +43,26 @@ def resolve_change_graph(
     repo_root: Path,
     tree_sha: str,
     changed: list[ChangedSymbol],
+    run_bounds: RunBounds | None = None,
 ) -> ChangeGraphResult:
     """Resolve dependents, tests, and contracts affected by ``changed`` symbols."""
     graph = build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+    deadline = _context_deadline(run_bounds)
     dependents: set[str] = set()
     tests: set[str] = set()
     contracts: set[str] = set()
 
     for symbol in changed:
+        if _timed_out(deadline):
+            break
         qualified = _qualify_symbol(symbol)
         dependents.update(_dependents_for(graph, qualified, symbol.name))
-        tests.update(_covering_tests(repo_root, symbol))
+        tests.update(_covering_tests(repo_root, symbol, deadline=deadline))
         contracts.update(
             _affected_contracts(
                 repo_root,
                 symbol_names={symbol.name, *_symbol_tail(qualified), *dependents},
+                deadline=deadline,
             )
         )
 
@@ -58,6 +71,16 @@ def resolve_change_graph(
         tests=tuple(sorted(tests)),
         contracts=tuple(sorted(contracts)),
     )
+
+
+def _context_deadline(run_bounds: RunBounds | None) -> float | None:
+    if run_bounds is None:
+        return None
+    return time.monotonic() + run_bounds.context_retrieval_timeout_s
+
+
+def _timed_out(deadline: float | None) -> bool:
+    return deadline is not None and time.monotonic() > deadline
 
 
 def _qualify_symbol(symbol: ChangedSymbol) -> str:
@@ -87,48 +110,56 @@ def _dependents_for(graph: CallGraph, qualified: str, bare_name: str) -> set[str
     return found
 
 
-def _covering_tests(repo_root: Path, symbol: ChangedSymbol) -> set[str]:
+def _covering_tests(
+    repo_root: Path,
+    symbol: ChangedSymbol,
+    *,
+    deadline: float | None,
+) -> set[str]:
     tests: set[str] = set()
     module = _module_name(symbol.path)
-    needles = (
-        f"from {module} import {symbol.name}",
-        f"import {module}",
-        symbol.name,
+    from_import = _FROM_IMPORT.pattern.format(
+        module=re.escape(module),
+        symbol=re.escape(symbol.name),
     )
-    for rel_path in _iter_test_files(repo_root):
+    import_module = _IMPORT_MODULE.pattern.format(module=re.escape(module))
+    for rel_path in _iter_test_files(repo_root, deadline=deadline):
         source = (repo_root / rel_path).read_text(encoding="utf-8")
-        if any(needle in source for needle in needles):
+        if re.search(from_import, source) or re.search(import_module, source):
             tests.add(rel_path)
     return tests
 
 
-def _iter_test_files(repo_root: Path) -> list[str]:
+def _iter_test_files(repo_root: Path, *, deadline: float | None) -> list[str]:
     paths: list[str] = []
-    for path in sorted(repo_root.rglob("test*.py")):
-        if not path.is_file():
-            continue
+
+    def _is_test_file(path: Path) -> bool:
+        if not path.name.startswith("test") or path.suffix != ".py":
+            return False
         rel = path.relative_to(repo_root).as_posix()
-        if rel.startswith(".git/"):
-            continue
-        parts = rel.split("/")
-        if any(part in _TEST_DIR_NAMES for part in parts):
-            paths.append(rel)
+        return any(part in _TEST_DIR_NAMES for part in rel.split("/"))
+
+    for rel in iter_repo_files(repo_root, predicate=_is_test_file, deadline=deadline):
+        paths.append(rel)
     return paths
 
 
-def _affected_contracts(repo_root: Path, *, symbol_names: set[str]) -> set[str]:
+def _affected_contracts(
+    repo_root: Path,
+    *,
+    symbol_names: set[str],
+    deadline: float | None,
+) -> set[str]:
     contracts: set[str] = set()
-    for path in sorted(repo_root.rglob("*")):
-        if not path.is_file():
-            continue
+
+    def _is_contract(path: Path) -> bool:
         rel = path.relative_to(repo_root).as_posix()
-        if rel.startswith(".git/"):
-            continue
-        if path.suffix.casefold() not in _CONTRACT_SUFFIXES and "contracts" not in rel:
-            continue
         if path.suffix.casefold() not in _CONTRACT_SUFFIXES:
-            continue
-        source = path.read_text(encoding="utf-8")
+            return False
+        return "contracts" in rel or path.suffix.casefold() in _CONTRACT_SUFFIXES
+
+    for rel in iter_repo_files(repo_root, predicate=_is_contract, deadline=deadline):
+        source = (repo_root / rel).read_text(encoding="utf-8")
         if any(re.search(rf"\b{re.escape(name)}\b", source) for name in symbol_names if name):
             contracts.add(rel)
     return contracts

--- a/src/mergecraft/context/dynamic_expansion.py
+++ b/src/mergecraft/context/dynamic_expansion.py
@@ -8,6 +8,7 @@ from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
 from typing import TYPE_CHECKING
 
 from mergecraft.context.provenance import ContextItem
+from mergecraft.utils.run_bounds import BudgetExhausted
 
 if TYPE_CHECKING:
     from mergecraft.utils.run_bounds import BudgetTracker
@@ -55,22 +56,26 @@ def expand_with_budget(
 
     for chunk in chunks:
         cost = _estimate_tokens(chunk)
-        if total_tokens + cost > token_budget:
+        remaining = _remaining_token_budget(
+            token_budget=token_budget,
+            total_tokens=total_tokens,
+            budget_tracker=budget_tracker,
+        )
+        if cost > remaining:
             truncated = True
-            remaining = max(0, token_budget - total_tokens)
             if remaining > 0:
                 clipped = chunk[: remaining * 4]
                 item = _context_item(path=path, text=clipped, reason="dynamic_expansion")
                 items.append(item)
                 total_tokens += item.token_cost
-                if budget_tracker is not None:
-                    budget_tracker.record_tokens(item.token_cost)
+                _record_tokens_without_raise(budget_tracker, item.token_cost)
             break
         item = _context_item(path=path, text=chunk, reason="dynamic_expansion")
         items.append(item)
         total_tokens += item.token_cost
-        if budget_tracker is not None:
-            budget_tracker.record_tokens(item.token_cost)
+        if not _record_tokens_without_raise(budget_tracker, item.token_cost):
+            truncated = True
+            break
 
     return ExpansionResult(
         items=tuple(items),
@@ -92,6 +97,35 @@ def _context_item(*, path: str, text: str, reason: str) -> ContextItem:
 
 def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
+
+
+def _remaining_token_budget(
+    *,
+    token_budget: int,
+    total_tokens: int,
+    budget_tracker: BudgetTracker | None,
+) -> int:
+    remaining = token_budget - total_tokens
+    if budget_tracker is None:
+        return remaining
+    tracker_remaining = budget_tracker.bounds.token_budget - budget_tracker.tokens_used
+    return min(remaining, tracker_remaining)
+
+
+def _record_tokens_without_raise(
+    budget_tracker: BudgetTracker | None,
+    count: int,
+) -> bool:
+    """Record token usage without raising when a shared tracker is exhausted."""
+    if budget_tracker is None or count <= 0:
+        return True
+    if budget_tracker.tokens_used + count > budget_tracker.bounds.token_budget:
+        return False
+    try:
+        budget_tracker.record_tokens(count)
+    except BudgetExhausted:
+        return False
+    return True
 
 
 def _extract_scope(path: Path, *, symbol: str) -> str:

--- a/src/mergecraft/context/dynamic_expansion.py
+++ b/src/mergecraft/context/dynamic_expansion.py
@@ -1,0 +1,154 @@
+"""On-demand context expansion within a per-run token budget (CC3)."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+from typing import TYPE_CHECKING
+
+from mergecraft.context.provenance import ContextItem
+
+if TYPE_CHECKING:
+    from mergecraft.utils.run_bounds import BudgetTracker
+
+_DEFAULT_REPO = "local"
+_DEFAULT_SHA = "working-tree"
+
+
+@dataclass(frozen=True, slots=True)
+class ExpansionResult:
+    """Dynamic expansion output with token accounting."""
+
+    items: tuple[ContextItem, ...]
+    truncated: bool
+    token_cost: int
+
+
+def expand_enclosing_scope(
+    *,
+    repo_root: Path,
+    path: str,
+    symbol: str,
+) -> ExpansionResult:
+    """Retrieve the enclosing scope for ``symbol`` in ``path`` on demand."""
+    text = _extract_scope(repo_root / path, symbol=symbol)
+    item = _context_item(path=path, text=text, reason="dynamic_expansion")
+    token_cost = item.token_cost
+    return ExpansionResult(items=(item,), truncated=False, token_cost=token_cost)
+
+
+def expand_with_budget(
+    *,
+    repo_root: Path,
+    path: str,
+    symbol: str,
+    token_budget: int,
+    budget_tracker: BudgetTracker | None = None,
+) -> ExpansionResult:
+    """Expand ``symbol`` without exceeding ``token_budget``."""
+    source = (repo_root / path).read_text(encoding="utf-8")
+    chunks = _scope_chunks(source, symbol=symbol)
+    items: list[ContextItem] = []
+    total_tokens = 0
+    truncated = False
+
+    for chunk in chunks:
+        cost = _estimate_tokens(chunk)
+        if total_tokens + cost > token_budget:
+            truncated = True
+            remaining = max(0, token_budget - total_tokens)
+            if remaining > 0:
+                clipped = chunk[: remaining * 4]
+                item = _context_item(path=path, text=clipped, reason="dynamic_expansion")
+                items.append(item)
+                total_tokens += item.token_cost
+                if budget_tracker is not None:
+                    budget_tracker.record_tokens(item.token_cost)
+            break
+        item = _context_item(path=path, text=chunk, reason="dynamic_expansion")
+        items.append(item)
+        total_tokens += item.token_cost
+        if budget_tracker is not None:
+            budget_tracker.record_tokens(item.token_cost)
+
+    return ExpansionResult(
+        items=tuple(items),
+        truncated=truncated,
+        token_cost=total_tokens,
+    )
+
+
+def _context_item(*, path: str, text: str, reason: str) -> ContextItem:
+    return ContextItem(
+        repo=_DEFAULT_REPO,
+        sha=_DEFAULT_SHA,
+        path=path,
+        reason=reason,
+        text=text,
+        token_cost=_estimate_tokens(text),
+    )
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+def _extract_scope(path: Path, *, symbol: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    if "." in symbol:
+        class_name, member_name = symbol.split(".", 1)
+        class_source = _class_source(source, class_name=class_name)
+        member_source = _member_source(class_source or source, member_name=member_name)
+        parts = [part for part in (class_source, member_source) if part]
+        return "\n\n".join(parts)
+    return _member_source(source, member_name=symbol) or source
+
+
+def _scope_chunks(source: str, *, symbol: str) -> list[str]:
+    if "." in symbol:
+        class_name, _member_name = symbol.split(".", 1)
+        class_source = _class_source(source, class_name=class_name)
+        if class_source is None:
+            return [source]
+        lines = class_source.splitlines(keepends=True)
+        return ["".join(lines[: index + 1]) for index in range(len(lines))]
+
+    class_source = _class_source(source, class_name=symbol)
+    if class_source is None:
+        member_source = _member_source(source, member_name=symbol)
+        return [member_source or source]
+
+    lines = class_source.splitlines(keepends=True)
+    return ["".join(lines[: index + 1]) for index in range(len(lines))]
+
+
+def _class_source(source: str, *, class_name: str) -> str | None:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    lines = source.splitlines(keepends=True)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            start = node.lineno - 1
+            end = node.end_lineno or node.lineno
+            return "".join(lines[start:end])
+    return None
+
+
+def _member_source(source: str, *, member_name: str) -> str | None:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    lines = source.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == member_name:
+            start = node.lineno - 1
+            end = node.end_lineno or node.lineno
+            return "".join(lines[start:end])
+    return None
+
+
+__all__ = ["ExpansionResult", "expand_enclosing_scope", "expand_with_budget"]

--- a/src/mergecraft/context/git_history.py
+++ b/src/mergecraft/context/git_history.py
@@ -1,0 +1,120 @@
+"""Targeted git blame for review context with reproducible provenance."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+
+from mergecraft.context.provenance import ContextItem
+
+
+@dataclass(frozen=True, slots=True)
+class BlameEntry:
+    """One line of targeted blame attribution."""
+
+    line: int
+    commit_sha: str
+    author: str
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class TargetedBlameResult:
+    """Blame entries plus provenance for the queried range."""
+
+    entries: tuple[BlameEntry, ...]
+    provenance: ContextItem
+
+
+def targeted_blame(
+    *,
+    repo_root: Path,
+    repo: str,
+    path: str,
+    start_line: int,
+    end_line: int,
+) -> TargetedBlameResult:
+    """Return line-level blame for ``path`` between ``start_line`` and ``end_line``."""
+    head_sha = _git_rev_parse(repo_root, "HEAD")
+    entries = _run_blame(
+        repo_root=repo_root,
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+    )
+    citation_text = "\n".join(
+        f"L{entry.line} {entry.commit_sha[:8]} {entry.author}: {entry.text.rstrip()}"
+        for entry in entries
+    )
+    provenance = ContextItem(
+        repo=repo,
+        sha=head_sha,
+        path=path,
+        reason="git_history",
+        text=citation_text,
+        token_cost=max(1, len(citation_text) // 4),
+    )
+    return TargetedBlameResult(entries=entries, provenance=provenance)
+
+
+def _git_rev_parse(repo_root: Path, ref: str) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _run_blame(
+    *,
+    repo_root: Path,
+    path: str,
+    start_line: int,
+    end_line: int,
+) -> tuple[BlameEntry, ...]:
+    completed = subprocess.run(
+        [
+            "git",
+            "blame",
+            "-L",
+            f"{start_line},{end_line}",
+            "--line-porcelain",
+            path,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    entries: list[BlameEntry] = []
+    current_sha = ""
+    current_author = ""
+    current_line = start_line
+
+    for raw in completed.stdout.splitlines():
+        if raw.startswith("\t"):
+            text = raw[1:]
+            entries.append(
+                BlameEntry(
+                    line=current_line,
+                    commit_sha=current_sha,
+                    author=current_author,
+                    text=text,
+                )
+            )
+            current_line += 1
+            continue
+        parts = raw.split(maxsplit=1)
+        if len(parts[0]) == 40 and all(ch in "0123456789abcdef" for ch in parts[0].casefold()):
+            current_sha = parts[0]
+            continue
+        if raw.startswith("author "):
+            current_author = raw.removeprefix("author ")
+    return tuple(entries)
+
+
+__all__ = ["BlameEntry", "TargetedBlameResult", "targeted_blame"]

--- a/src/mergecraft/context/repo_paths.py
+++ b/src/mergecraft/context/repo_paths.py
@@ -1,0 +1,136 @@
+"""Bounded repo traversal with gitignore-style exclusions for context retrieval."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        ".tox",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "dist",
+        "build",
+        ".eggs",
+        ".hypothesis",
+        ".nox",
+    }
+)
+
+
+def is_excluded_repo_path(rel_path: str) -> bool:
+    """Return whether ``rel_path`` lies under a skipped directory segment."""
+    return any(part in _EXCLUDED_DIR_NAMES for part in rel_path.split("/"))
+
+
+def git_ls_tree_paths(
+    repo_root: Path,
+    tree_sha: str,
+    *,
+    suffix: str = "",
+) -> list[str]:
+    """List tracked paths under ``tree_sha``, applying context exclusions."""
+    try:
+        completed = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", tree_sha],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        logger.debug("git ls-tree unavailable for tree {}", tree_sha)
+        return []
+    if completed.returncode != 0:
+        logger.debug("git ls-tree failed for tree {}: {}", tree_sha, completed.stderr.strip())
+        return []
+
+    paths: list[str] = []
+    for rel_path in completed.stdout.splitlines():
+        if not rel_path or is_excluded_repo_path(rel_path):
+            continue
+        if suffix and not rel_path.endswith(suffix):
+            continue
+        paths.append(rel_path)
+    return sorted(paths)
+
+
+def git_show_text(repo_root: Path, tree_sha: str, rel_path: str) -> str | None:
+    """Return file text at ``tree_sha:rel_path``, or ``None`` when absent."""
+    try:
+        completed = subprocess.run(
+            ["git", "show", f"{tree_sha}:{rel_path}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def git_blob_sha(repo_root: Path, tree_sha: str, rel_path: str) -> str:
+    """Return the git blob SHA for ``rel_path`` at ``tree_sha``."""
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", f"{tree_sha}:{rel_path}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        completed = None
+    if completed is not None and completed.returncode == 0:
+        return completed.stdout.strip()
+    shown = git_show_text(repo_root, tree_sha, rel_path)
+    if shown is None:
+        return f"missing:{tree_sha}:{rel_path}"
+    return f"blob:{shown.encode('utf-8').hex()[:40]}"
+
+
+def iter_repo_files(
+    repo_root: Path,
+    *,
+    predicate: Callable[[Path], bool] | None = None,
+    deadline: float | None = None,
+) -> Iterator[str]:
+    """Walk ``repo_root`` with exclusions and an optional monotonic deadline."""
+    for path in sorted(repo_root.rglob("*")):
+        if deadline is not None and time.monotonic() > deadline:
+            logger.warning("context retrieval scan timed out under {}", repo_root)
+            return
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        if is_excluded_repo_path(rel):
+            continue
+        if predicate is not None and not predicate(path):
+            continue
+        yield rel
+
+
+__all__ = [
+    "git_blob_sha",
+    "git_ls_tree_paths",
+    "git_show_text",
+    "is_excluded_repo_path",
+    "iter_repo_files",
+]

--- a/src/mergecraft/context/symbol_index.py
+++ b/src/mergecraft/context/symbol_index.py
@@ -48,6 +48,7 @@ def index_symbols(
     rel_path: str,
     blob_sha: str,
     cache: _CacheProto | None = None,
+    source: str | None = None,
 ) -> SymbolIndexResult:
     """Index symbols for ``rel_path`` at ``blob_sha``."""
     if cache is not None:
@@ -55,8 +56,8 @@ def index_symbols(
         if cached is not None:
             return cast("SymbolIndexResult", cached)
 
-    path = repo_root / rel_path
-    source = path.read_text(encoding="utf-8")
+    if source is None:
+        source = (repo_root / rel_path).read_text(encoding="utf-8")
     suffix = Path(rel_path).suffix.casefold()
     if suffix in _TREE_SITTER_SUFFIXES:
         result = _index_with_tree_sitter(source)

--- a/tests/cli/test_context_inspect.py
+++ b/tests/cli/test_context_inspect.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 from tests.context.support import (
     git_commit_all,
     git_init_repo,
@@ -28,7 +27,6 @@ def _plain(text: str) -> str:
     return _ANSI.sub("", text)
 
 
-@pytest.mark.xfail(reason="green after DG4.2: context inspect CLI", strict=False)
 def test_reports_sources_scope_provenance_and_tokens(tmp_path: Path) -> None:
     """``context inspect`` reports sources, scope, provenance citations, and token totals."""
     repo_root = tmp_path / "repo"

--- a/tests/cli/test_context_inspect.py
+++ b/tests/cli/test_context_inspect.py
@@ -17,6 +17,7 @@ from tests.context.support import (
 )
 from typer.testing import CliRunner
 
+from mergecraft.cli import context_cmd
 from mergecraft.cli.app import app
 
 runner = CliRunner()
@@ -62,3 +63,45 @@ def test_reports_sources_scope_provenance_and_tokens(tmp_path: Path) -> None:
     assert "token" in output.lower()
     assert "acme/demo@" in output or commit_sha[:8] in output
     assert "src/demo/service.py" in output
+
+
+def test_inspect_derives_symbol_kind_from_index(tmp_path: Path) -> None:
+    """``context inspect`` derives changed-symbol kind from the symbol index."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    (repo_root / "src" / "demo" / "models.py").write_text(
+        "class ServiceModel:\n    value: str = 'ok'\n",
+        encoding="utf-8",
+    )
+    git_init_repo(repo_root)
+    commit_sha = git_commit_all(repo_root)
+    tree_sha = git_tree_sha(repo_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "inspect",
+            "--repo-root",
+            str(repo_root),
+            "--repo",
+            "acme/demo",
+            "--commit-sha",
+            commit_sha,
+            "--tree-sha",
+            tree_sha,
+            "--scope",
+            "src/demo/models.py:ServiceModel",
+        ],
+        env={"NO_COLOR": "1"},
+    )
+    output = _plain(result.stdout + result.stderr)
+
+    assert result.exit_code == 0, output
+    kind = context_cmd._symbol_kind(
+        repo_root=repo_root,
+        tree_sha=tree_sha,
+        path="src/demo/models.py",
+        symbol_name="ServiceModel",
+    )
+    assert kind == "class"

--- a/tests/cli/test_context_inspect.py
+++ b/tests/cli/test_context_inspect.py
@@ -1,0 +1,66 @@
+"""DG4 ``mergecraft context inspect`` — sources, scope, provenance, tokens.
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG4).
+Implementation: **DG4.2** — ``mergecraft.cli.context_cmd``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from tests.context.support import (
+    git_commit_all,
+    git_init_repo,
+    git_tree_sha,
+    write_change_graph_fixture_repo,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+@pytest.mark.xfail(reason="green after DG4.2: context inspect CLI", strict=False)
+def test_reports_sources_scope_provenance_and_tokens(tmp_path: Path) -> None:
+    """``context inspect`` reports sources, scope, provenance citations, and token totals."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    commit_sha = git_commit_all(repo_root)
+    tree_sha = git_tree_sha(repo_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "inspect",
+            "--repo-root",
+            str(repo_root),
+            "--repo",
+            "acme/demo",
+            "--commit-sha",
+            commit_sha,
+            "--tree-sha",
+            tree_sha,
+            "--scope",
+            "src/demo/service.py:process",
+        ],
+        env={"NO_COLOR": "1"},
+    )
+    output = _plain(result.stdout + result.stderr)
+
+    assert result.exit_code == 0, output
+    assert "sources" in output.lower()
+    assert "scope" in output.lower()
+    assert "provenance" in output.lower() or "citation" in output.lower()
+    assert "token" in output.lower()
+    assert "acme/demo@" in output or commit_sha[:8] in output
+    assert "src/demo/service.py" in output

--- a/tests/context/support.py
+++ b/tests/context/support.py
@@ -64,6 +64,74 @@ def git_blob_sha(root: Path, rel_path: str, ref: str = "HEAD") -> str:
     return git_run("rev-parse", f"{ref}:{rel_path}", cwd=root)
 
 
+def write_call_graph_fixture_repo(root: Path) -> None:
+    """Lay down imports, references, and call edges for call-graph tests."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src" / "demo").mkdir(parents=True)
+    (root / "src" / "demo" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "src" / "demo" / "lib.py").write_text(
+        "def helper() -> str:\n    return 'ok'\n",
+        encoding="utf-8",
+    )
+    (root / "src" / "demo" / "consumer.py").write_text(
+        "from demo.lib import helper\n\ndef caller() -> str:\n    return helper()\n",
+        encoding="utf-8",
+    )
+
+
+def write_change_graph_fixture_repo(root: Path) -> None:
+    """Lay down dependents, covering tests, and contracts for change-graph tests."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src" / "demo").mkdir(parents=True)
+    (root / "src" / "demo" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "src" / "demo" / "service.py").write_text(
+        "def process() -> dict[str, str]:\n    return {'status': 'ok'}\n",
+        encoding="utf-8",
+    )
+    (root / "src" / "demo" / "api.py").write_text(
+        "from demo.service import process\n\n"
+        "def handle_request() -> dict[str, str]:\n    return process()\n",
+        encoding="utf-8",
+    )
+    (root / "tests").mkdir(parents=True)
+    (root / "tests" / "test_service.py").write_text(
+        "from demo.service import process\n\n"
+        "def test_process_returns_ok() -> None:\n"
+        "    assert process()['status'] == 'ok'\n",
+        encoding="utf-8",
+    )
+    (root / "contracts").mkdir(parents=True)
+    (root / "contracts" / "openapi.yaml").write_text(
+        "openapi: '3.0.0'\n"
+        "info:\n"
+        "  title: Demo API\n"
+        "  version: '1.0.0'\n"
+        "paths:\n"
+        "  /process:\n"
+        "    get:\n"
+        "      operationId: handle_request\n"
+        "      responses:\n"
+        "        '200':\n"
+        "          description: ok\n",
+        encoding="utf-8",
+    )
+
+
+def write_dynamic_expansion_fixture_repo(root: Path) -> None:
+    """Lay down nested scopes for on-demand expansion tests."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src" / "demo").mkdir(parents=True)
+    (root / "src" / "demo" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "src" / "demo" / "widget.py").write_text(
+        "class Widget:\n"
+        "    def render(self) -> str:\n"
+        "        return self._body()\n\n"
+        "    def _body(self) -> str:\n"
+        "        return 'x' * 200\n",
+        encoding="utf-8",
+    )
+
+
 def write_context_fixture_repo(root: Path) -> None:
     """Lay down a miniature repo for map + symbol indexing tests."""
     root.mkdir(parents=True, exist_ok=True)

--- a/tests/context/test_call_graph.py
+++ b/tests/context/test_call_graph.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tests.context.support import (
     git_commit_all,
     git_init_repo,
@@ -19,7 +17,6 @@ from tests.context.support import (
 )
 
 
-@pytest.mark.xfail(reason="green after DG4.2: call graph indexing", strict=False)
 def test_imports_references_and_callers_are_indexed(tmp_path: Path) -> None:
     """The call graph indexes import edges, symbol references, and caller relationships."""
     repo_root = tmp_path / "repo"

--- a/tests/context/test_call_graph.py
+++ b/tests/context/test_call_graph.py
@@ -1,0 +1,41 @@
+"""DG4 call graph — imports, references, and callers (G8 derivative).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG4).
+Implementation: **DG4.2** — ``mergecraft.context.call_graph``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.context.support import (
+    git_commit_all,
+    git_init_repo,
+    git_tree_sha,
+    import_context_module,
+    write_call_graph_fixture_repo,
+)
+
+
+@pytest.mark.xfail(reason="green after DG4.2: call graph indexing", strict=False)
+def test_imports_references_and_callers_are_indexed(tmp_path: Path) -> None:
+    """The call graph indexes import edges, symbol references, and caller relationships."""
+    repo_root = tmp_path / "repo"
+    write_call_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    call_graph_mod = import_context_module("call_graph")
+    tree_sha = git_tree_sha(repo_root)
+    graph = call_graph_mod.build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+
+    edge_kinds = {edge.kind for edge in graph.edges}
+    callees = {edge.callee for edge in graph.edges}
+    callers = {edge.caller for edge in graph.edges}
+
+    assert "import" in edge_kinds
+    assert "reference" in edge_kinds or "call" in edge_kinds
+    assert "demo.lib.helper" in callees or "helper" in callees
+    assert any("caller" in caller or "consumer" in caller for caller in callers)

--- a/tests/context/test_call_graph.py
+++ b/tests/context/test_call_graph.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from tests.context.support import (
+    RecordingCache,
+    git_blob_sha,
     git_commit_all,
     git_init_repo,
     git_tree_sha,
@@ -36,3 +38,102 @@ def test_imports_references_and_callers_are_indexed(tmp_path: Path) -> None:
     assert "reference" in edge_kinds or "call" in edge_kinds
     assert "demo.lib.helper" in callees or "helper" in callees
     assert any("caller" in caller or "consumer" in caller for caller in callers)
+
+
+def test_call_graph_indexes_committed_tree_not_dirty_worktree(tmp_path: Path) -> None:
+    """The call graph reads ``tree_sha`` content, not an uncommitted working tree."""
+    repo_root = tmp_path / "repo"
+    write_call_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+    tree_sha = git_tree_sha(repo_root)
+
+    (repo_root / "src" / "demo" / "consumer.py").write_text(
+        "from demo.lib import helper\n\ndef caller() -> str:\n    return helper() + 'dirty'\n",
+        encoding="utf-8",
+    )
+
+    call_graph_mod = import_context_module("call_graph")
+    graph = call_graph_mod.build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+    callers = {edge.caller for edge in graph.edges if edge.kind == "call"}
+    assert "demo.consumer.caller" in callers
+
+
+def test_module_level_calls_are_indexed(tmp_path: Path) -> None:
+    """Module-level call sites are indexed with the module as caller."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / "src" / "demo").mkdir(parents=True)
+    (repo_root / "src" / "demo" / "__init__.py").write_text("", encoding="utf-8")
+    (repo_root / "src" / "demo" / "runner.py").write_text(
+        "from demo.lib import helper\n\nhelper()\n",
+        encoding="utf-8",
+    )
+    (repo_root / "src" / "demo" / "lib.py").write_text(
+        "def helper() -> None:\n    return None\n",
+        encoding="utf-8",
+    )
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    call_graph_mod = import_context_module("call_graph")
+    tree_sha = git_tree_sha(repo_root)
+    graph = call_graph_mod.build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+    module_calls = [
+        edge for edge in graph.edges if edge.kind == "call" and edge.caller == "demo.runner"
+    ]
+    assert any(edge.callee.endswith("helper") for edge in module_calls)
+
+
+def test_method_callers_include_class_name(tmp_path: Path) -> None:
+    """Method call sites attribute callers with their enclosing class."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / "src" / "demo").mkdir(parents=True)
+    (repo_root / "src" / "demo" / "__init__.py").write_text("", encoding="utf-8")
+    (repo_root / "src" / "demo" / "widget.py").write_text(
+        "class Widget:\n"
+        "    def render(self) -> None:\n"
+        "        self._body()\n\n"
+        "    def _body(self) -> None:\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    call_graph_mod = import_context_module("call_graph")
+    tree_sha = git_tree_sha(repo_root)
+    graph = call_graph_mod.build_call_graph(repo_root=repo_root, tree_sha=tree_sha)
+    callers = {edge.caller for edge in graph.edges if edge.kind == "call"}
+    assert "demo.widget.Widget.render" in callers
+
+
+def test_call_graph_cache_key_matches_tree_content(tmp_path: Path) -> None:
+    """Convention-6 cache entries are keyed by tree SHA over indexed tree bytes."""
+    repo_root = tmp_path / "repo"
+    write_call_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+    tree_sha = git_tree_sha(repo_root)
+
+    call_graph_mod = import_context_module("call_graph")
+    cache = RecordingCache()
+    graph = call_graph_mod.build_call_graph(repo_root=repo_root, tree_sha=tree_sha, cache=cache)
+
+    assert cache.get_calls == [tree_sha]
+    assert cache.set_calls == [tree_sha]
+    assert graph.edges
+
+    rel_path = "src/demo/lib.py"
+    blob_sha = git_blob_sha(repo_root, rel_path, tree_sha)
+    symbol_index_mod = import_context_module("symbol_index")
+    source = (repo_root / rel_path).read_text(encoding="utf-8")
+    symbol_index_mod.index_symbols(
+        repo_root=repo_root,
+        rel_path=rel_path,
+        blob_sha=blob_sha,
+        source=source,
+        cache=cache,
+    )
+    assert blob_sha in cache.set_calls

--- a/tests/context/test_change_graph.py
+++ b/tests/context/test_change_graph.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tests.context.support import (
     git_commit_all,
     git_init_repo,
@@ -34,7 +32,6 @@ def _changed_process_symbol(change_graph_mod: object, repo_root: Path, tree_sha:
     )
 
 
-@pytest.mark.xfail(reason="green after DG4.2: change graph dependents", strict=False)
 def test_changed_symbol_resolves_to_dependents(tmp_path: Path) -> None:
     """A changed symbol resolves to symbols that depend on it."""
     repo_root = tmp_path / "repo"
@@ -50,7 +47,6 @@ def test_changed_symbol_resolves_to_dependents(tmp_path: Path) -> None:
     assert "demo.api.handle_request" in dependents or "handle_request" in dependents
 
 
-@pytest.mark.xfail(reason="green after DG4.2: change graph tests", strict=False)
 def test_changed_symbol_resolves_to_covering_tests(tmp_path: Path) -> None:
     """A changed symbol resolves to test files that cover it."""
     repo_root = tmp_path / "repo"
@@ -65,7 +61,6 @@ def test_changed_symbol_resolves_to_covering_tests(tmp_path: Path) -> None:
     assert "tests/test_service.py" in result.tests
 
 
-@pytest.mark.xfail(reason="green after DG4.2: change graph contracts", strict=False)
 def test_changed_symbol_resolves_to_affected_contracts(tmp_path: Path) -> None:
     """A changed symbol resolves to API contracts that reference it."""
     repo_root = tmp_path / "repo"

--- a/tests/context/test_change_graph.py
+++ b/tests/context/test_change_graph.py
@@ -73,3 +73,24 @@ def test_changed_symbol_resolves_to_affected_contracts(tmp_path: Path) -> None:
     result = _changed_process_symbol(change_graph_mod, repo_root, tree_sha)
 
     assert "contracts/openapi.yaml" in result.contracts
+
+
+def test_covering_tests_require_import_aware_match(tmp_path: Path) -> None:
+    """Covering-test detection ignores bare symbol-name substring matches."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    (repo_root / "tests" / "test_noise.py").write_text(
+        "def test_mentions_process_in_docstring_only() -> None:\n"
+        '    """process is mentioned here but not imported."""\n'
+        "    assert True\n",
+        encoding="utf-8",
+    )
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    change_graph_mod = import_context_module("change_graph")
+    tree_sha = git_tree_sha(repo_root)
+    result = _changed_process_symbol(change_graph_mod, repo_root, tree_sha)
+
+    assert "tests/test_service.py" in result.tests
+    assert "tests/test_noise.py" not in result.tests

--- a/tests/context/test_change_graph.py
+++ b/tests/context/test_change_graph.py
@@ -1,0 +1,80 @@
+"""DG4 change graph — changed symbol → dependents, tests, contracts (G8 derivative).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG4).
+Implementation: **DG4.2** — ``mergecraft.context.change_graph``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.context.support import (
+    git_commit_all,
+    git_init_repo,
+    git_tree_sha,
+    import_context_module,
+    write_change_graph_fixture_repo,
+)
+
+
+def _changed_process_symbol(change_graph_mod: object, repo_root: Path, tree_sha: str) -> object:
+    changed = [
+        change_graph_mod.ChangedSymbol(
+            path="src/demo/service.py",
+            name="process",
+            kind="function",
+        )
+    ]
+    return change_graph_mod.resolve_change_graph(
+        repo_root=repo_root,
+        tree_sha=tree_sha,
+        changed=changed,
+    )
+
+
+@pytest.mark.xfail(reason="green after DG4.2: change graph dependents", strict=False)
+def test_changed_symbol_resolves_to_dependents(tmp_path: Path) -> None:
+    """A changed symbol resolves to symbols that depend on it."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    change_graph_mod = import_context_module("change_graph")
+    tree_sha = git_tree_sha(repo_root)
+    result = _changed_process_symbol(change_graph_mod, repo_root, tree_sha)
+
+    dependents = set(result.dependents)
+    assert "demo.api.handle_request" in dependents or "handle_request" in dependents
+
+
+@pytest.mark.xfail(reason="green after DG4.2: change graph tests", strict=False)
+def test_changed_symbol_resolves_to_covering_tests(tmp_path: Path) -> None:
+    """A changed symbol resolves to test files that cover it."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    change_graph_mod = import_context_module("change_graph")
+    tree_sha = git_tree_sha(repo_root)
+    result = _changed_process_symbol(change_graph_mod, repo_root, tree_sha)
+
+    assert "tests/test_service.py" in result.tests
+
+
+@pytest.mark.xfail(reason="green after DG4.2: change graph contracts", strict=False)
+def test_changed_symbol_resolves_to_affected_contracts(tmp_path: Path) -> None:
+    """A changed symbol resolves to API contracts that reference it."""
+    repo_root = tmp_path / "repo"
+    write_change_graph_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    change_graph_mod = import_context_module("change_graph")
+    tree_sha = git_tree_sha(repo_root)
+    result = _changed_process_symbol(change_graph_mod, repo_root, tree_sha)
+
+    assert "contracts/openapi.yaml" in result.contracts

--- a/tests/context/test_dynamic_expansion.py
+++ b/tests/context/test_dynamic_expansion.py
@@ -1,0 +1,76 @@
+"""DG4 dynamic expansion — on-demand scope retrieval within budget (CC3).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG4).
+Implementation: **DG4.2** — ``mergecraft.context.dynamic_expansion``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mergecraft.utils.run_bounds import BudgetTracker, RunBounds
+from tests.context.support import (
+    git_commit_all,
+    git_init_repo,
+    import_context_module,
+    write_dynamic_expansion_fixture_repo,
+)
+
+
+def _tight_bounds() -> RunBounds:
+    return RunBounds(
+        token_budget=40,
+        cost_budget_usd=1.0,
+        tool_call_budget=10,
+        run_timeout_s=60.0,
+        context_retrieval_timeout_s=5.0,
+        max_diff_lines=10_000,
+        external_operation_timeout_s=30.0,
+    )
+
+
+@pytest.mark.xfail(reason="green after DG4.2: dynamic enclosing scope", strict=False)
+def test_enclosing_scope_is_retrieved_on_demand(tmp_path: Path) -> None:
+    """Dynamic expansion retrieves the enclosing scope for a symbol on demand."""
+    repo_root = tmp_path / "repo"
+    write_dynamic_expansion_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    expansion_mod = import_context_module("dynamic_expansion")
+    result = expansion_mod.expand_enclosing_scope(
+        repo_root=repo_root,
+        path="src/demo/widget.py",
+        symbol="Widget.render",
+    )
+
+    combined = "\n".join(item.text for item in result.items)
+    assert "class Widget" in combined
+    assert "def render" in combined
+    assert all(item.path == "src/demo/widget.py" for item in result.items)
+    assert all(item.reason == "dynamic_expansion" for item in result.items)
+
+
+@pytest.mark.xfail(reason="green after DG4.2: expansion token budget", strict=False)
+def test_expansion_respects_the_token_budget(tmp_path: Path) -> None:
+    """Dynamic expansion stops before exceeding the per-run token budget (CC3)."""
+    repo_root = tmp_path / "repo"
+    write_dynamic_expansion_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    expansion_mod = import_context_module("dynamic_expansion")
+    tracker = BudgetTracker(_tight_bounds())
+    result = expansion_mod.expand_with_budget(
+        repo_root=repo_root,
+        path="src/demo/widget.py",
+        symbol="Widget",
+        token_budget=tracker.bounds.token_budget,
+        budget_tracker=tracker,
+    )
+
+    assert result.truncated is True
+    assert result.token_cost <= tracker.bounds.token_budget
+    assert tracker.tokens_used <= tracker.bounds.token_budget

--- a/tests/context/test_dynamic_expansion.py
+++ b/tests/context/test_dynamic_expansion.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from mergecraft.utils.run_bounds import BudgetTracker, RunBounds
 from tests.context.support import (
     git_commit_all,
@@ -31,7 +29,6 @@ def _tight_bounds() -> RunBounds:
     )
 
 
-@pytest.mark.xfail(reason="green after DG4.2: dynamic enclosing scope", strict=False)
 def test_enclosing_scope_is_retrieved_on_demand(tmp_path: Path) -> None:
     """Dynamic expansion retrieves the enclosing scope for a symbol on demand."""
     repo_root = tmp_path / "repo"
@@ -53,7 +50,6 @@ def test_enclosing_scope_is_retrieved_on_demand(tmp_path: Path) -> None:
     assert all(item.reason == "dynamic_expansion" for item in result.items)
 
 
-@pytest.mark.xfail(reason="green after DG4.2: expansion token budget", strict=False)
 def test_expansion_respects_the_token_budget(tmp_path: Path) -> None:
     """Dynamic expansion stops before exceeding the per-run token budget (CC3)."""
     repo_root = tmp_path / "repo"

--- a/tests/context/test_dynamic_expansion.py
+++ b/tests/context/test_dynamic_expansion.py
@@ -70,3 +70,27 @@ def test_expansion_respects_the_token_budget(tmp_path: Path) -> None:
     assert result.truncated is True
     assert result.token_cost <= tracker.bounds.token_budget
     assert tracker.tokens_used <= tracker.bounds.token_budget
+    assert tracker.last_exhausted is None
+
+
+def test_expansion_truncates_without_raising_budget_exhausted(tmp_path: Path) -> None:
+    """Shared budget trackers are not exhausted by dynamic expansion clipping."""
+    repo_root = tmp_path / "repo"
+    write_dynamic_expansion_fixture_repo(repo_root)
+    git_init_repo(repo_root)
+    git_commit_all(repo_root)
+
+    expansion_mod = import_context_module("dynamic_expansion")
+    tracker = BudgetTracker(_tight_bounds())
+    tracker.tokens_used = tracker.bounds.token_budget - 1
+
+    result = expansion_mod.expand_with_budget(
+        repo_root=repo_root,
+        path="src/demo/widget.py",
+        symbol="Widget",
+        token_budget=tracker.bounds.token_budget,
+        budget_tracker=tracker,
+    )
+
+    assert result.truncated is True
+    assert tracker.last_exhausted is None

--- a/tests/context/test_git_history.py
+++ b/tests/context/test_git_history.py
@@ -1,0 +1,48 @@
+"""DG4 targeted git history — blame with provenance (generalizes ``ci/blame.py``).
+
+Wave plan: ``.ignorelocal/waves/05-review-depth-governance-wave-plan.md`` (PR DG4).
+Implementation: **DG4.2** — ``mergecraft.context.git_history``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.context.support import git_commit_all, git_init_repo, import_context_module
+
+
+@pytest.mark.xfail(reason="green after DG4.2: targeted blame provenance", strict=False)
+def test_targeted_blame_is_retrieved_with_provenance(tmp_path: Path) -> None:
+    """Targeted blame returns line attribution with reproducible provenance."""
+    repo_root = tmp_path / "repo"
+    target = repo_root / "src" / "demo" / "module.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def original() -> None:\n    pass\n", encoding="utf-8")
+    git_init_repo(repo_root)
+    base_sha = git_commit_all(repo_root, message="base")
+
+    target.write_text(
+        "def original() -> None:\n    pass\n\n\ndef changed() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    head_sha = git_commit_all(repo_root, message="add changed")
+
+    git_history_mod = import_context_module("git_history")
+    result = git_history_mod.targeted_blame(
+        repo_root=repo_root,
+        repo="acme/demo",
+        path="src/demo/module.py",
+        start_line=5,
+        end_line=5,
+    )
+
+    assert result.entries
+    assert result.entries[0].line == 5
+    assert result.entries[0].commit_sha == head_sha
+    assert result.provenance.repo == "acme/demo"
+    assert result.provenance.sha in {base_sha, head_sha}
+    assert result.provenance.path == "src/demo/module.py"
+    assert result.provenance.reason == "git_history"
+    assert result.provenance.as_citation().startswith("acme/demo@")

--- a/tests/context/test_git_history.py
+++ b/tests/context/test_git_history.py
@@ -8,12 +8,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tests.context.support import git_commit_all, git_init_repo, import_context_module
 
 
-@pytest.mark.xfail(reason="green after DG4.2: targeted blame provenance", strict=False)
 def test_targeted_blame_is_retrieved_with_provenance(tmp_path: Path) -> None:
     """Targeted blame returns line attribution with reproducible provenance."""
     repo_root = tmp_path / "repo"

--- a/tests/context/test_repo_paths.py
+++ b/tests/context/test_repo_paths.py
@@ -1,0 +1,11 @@
+"""Tests for ``mergecraft.context.repo_paths``."""
+
+from __future__ import annotations
+
+from mergecraft.context.repo_paths import is_excluded_repo_path
+
+
+def test_excluded_repo_paths_skip_common_vendor_dirs() -> None:
+    assert is_excluded_repo_path(".venv/lib/python3.14/site-packages/foo.py")
+    assert is_excluded_repo_path("node_modules/pkg/index.js")
+    assert is_excluded_repo_path("src/demo/service.py") is False


### PR DESCRIPTION
## What?

Changed symbols resolve to dependents, tests, and contracts through call and change graphs, with a context inspect command for transparency.

## Why?

Knowing what a symbol change affects is the highest-value context beyond the diff. Dynamic expansion within a token budget keeps reviews focused without missing blast radius.

## Note

Rebased onto `pre-0.0.1` @ a5c50f3. Builds on DG3 context core; merge after #247.

## Test plan

- [x] `make ci-static`
- [x] `tests/context/`, `tests/cli/test_context_inspect.py` (21 passed)

## Related PR(s)/Issue(s)

Depends on #247
