### PR TITLE
hygiene: flake, live gate, xfail, types, GitHub-only

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,6 +87,7 @@ jobs:
       - uses: ./.github/actions/bootstrap
       - name: Live-provider integration (${{ matrix.provider }})
         env:
+          MERGECRAFT_LIVE: "1"
           MERGECRAFT_LIVE_PROVIDER: ${{ matrix.provider }}
           ANTHROPIC_API_KEY: ${{ matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || '' }}
           OPENAI_API_KEY: ${{ matrix.provider == 'openai' && secrets.OPENAI_API_KEY || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,3 @@ tests/security/fixtures/outside-target/
 !/.mergecraft/xrepo-brief.md
 
 /.agents
-.pytest-xpass.log

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ tests/security/fixtures/outside-target/
 !/.mergecraft/xrepo-brief.md
 
 /.agents
+.pytest-xpass.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
 
+### Changed
+
+- Stale pytest `xfail(strict=False)` markers that were already passing are now real tests; remaining allowed-tree xfails are strict (#276)
+
 ### Added
 
 - SCM abstraction: `ScmProvider` protocol with `GitHubScmAdapter` (behaviour-preserving) and demand-gated `GitLabScmAdapter` that declares unsupported capabilities instead of emulating GitHub; core MCP tools and review publication route through `ToolContext.scm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
+
+### Added
+
 - SCM abstraction: `ScmProvider` protocol with `GitHubScmAdapter` (behaviour-preserving) and demand-gated `GitLabScmAdapter` that declares unsupported capabilities instead of emulating GitHub; core MCP tools and review publication route through `ToolContext.scm`
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
 - docs: README requirements and `docs/distribution.md` Marketplace copy state that mergeCraft 0.1.0 is GitHub-only; GitLab support is planned via the `ScmProvider` abstraction (#279)
+- docs: README SHA-pin advice now links to CONTRIBUTING.md verify one-liners (`cosign verify` / `gh attestation verify`); `docs/distribution.md` Marketplace gate requires image attestations to pass before listing, pointing at the existing `sign-attest` job (#280)
 - `UnsupportedScmCapability` raised by `GitLabScmAdapter` now reports `"GitLab support is not available in this release"` instead of only the raw capability token (#279)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
 - `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
+- docs: README requirements and `docs/distribution.md` Marketplace copy state that mergeCraft 0.1.0 is GitHub-only; GitLab support is planned via the `ScmProvider` abstraction (#279)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scripts/check_type_ignores.py` fails when a `type: ignore` or `cast(` in allowed `src/mergecraft/` lacks a one-line reason (#275)
 - `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
 - `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
 - docs: README requirements and `docs/distribution.md` Marketplace copy state that mergeCraft 0.1.0 is GitHub-only; GitLab support is planned via the `ScmProvider` abstraction (#279)
+- `UnsupportedScmCapability` raised by `GitLabScmAdapter` now reports `"GitLab support is not available in this release"` instead of only the raw capability token (#279)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
+- `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
 - `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `scripts/check_type_ignores.py` fails when a `type: ignore` or `cast(` in allowed `src/mergecraft/` lacks a one-line reason (#275)
+- `scripts/check_type_ignores.py` fails when a `type: ignore` or `cast(` in allowed `src/mergecraft/` lacks a one-line reason (#275); wired into `make lint`
 - `scripts/check_xpass.py` fails when unexpected pytest xpasses remain on the allowed test tree (#276)
-- `make xpass-check` ratchet target wired into `CI_STEPS` (after `coverage-gate`); `coverage-gate` now captures `-rX` output to `.pytest-xpass.log` so the check is a cheap post-test parse with no second pytest run (#276)
-- `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): live integration modules skip at collection time unless the flag is set; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent. `CONTRIBUTING.md` documents the split.
+- xpass ratchet now runs as a `pytest_sessionfinish` conftest hook inside the coverage-gate pytest session — no standalone log file or extra CI step (#276)
+- `MERGECRAFT_LIVE=1` opt-in gate for live provider tests (#278): `tests/conftest.py` centralizes skip policy via `pytest_collection_modifyitems`; `make test-integration-live` and the CI `integration-live` job export the flag so the suite stays fail-closed when secrets are absent
+- `UnsupportedScmCapability` raised by `GitLabScmAdapter` now reports `"GitLab support is not available in this release"` instead of only the raw capability token; GitLab message is passed explicitly via `message=` so the generic format string stays clean (#279)
 - docs: README requirements and `docs/distribution.md` Marketplace copy state that mergeCraft 0.1.0 is GitHub-only; GitLab support is planned via the `ScmProvider` abstraction (#279)
 - docs: README SHA-pin advice now links to CONTRIBUTING.md verify one-liners (`cosign verify` / `gh attestation verify`); `docs/distribution.md` Marketplace gate requires image attestations to pass before listing, pointing at the existing `sign-attest` job (#280)
-- `UnsupportedScmCapability` raised by `GitLabScmAdapter` now reports `"GitLab support is not available in this release"` instead of only the raw capability token (#279)
-
-### Changed
-
-- Stale pytest `xfail(strict=False)` markers that were already passing are now real tests; remaining allowed-tree xfails are strict (#276)
-
-### Added
-
 - SCM abstraction: `ScmProvider` protocol with `GitHubScmAdapter` (behaviour-preserving) and demand-gated `GitLabScmAdapter` that declares unsupported capabilities instead of emulating GitHub; core MCP tools and review publication route through `ToolContext.scm`
-
-### Security
-
-- Linked-repo reads are grant-gated (D9): a run can only load repos declared in its authorized set; linked-repo and ticket text render through the W4 fence as untrusted data
-- Discovered repo instruction and skill files (`CLAUDE.md`, `AGENTS.md`, `SKILL.md`, `.cursor/rules/*.md`) from an untrusted review source render through the W4 fence as evidence and never enter the instruction bundle
-- CLI offline reviews now derive a trust tier from review-source provenance; cloned or out-of-root paths review at untrusted tier unless the operator passes an explicit `--trust` override
-- Executable repo config (`setupScript`, `prepushScript`, `stopScript`, `staticChecks[].command`) from an untrusted review source is ignored; declarative config still applies
-- Third-party clone acquisition is bounded and credential-safe: HTTPS GitHub URLs only, no redirect following, no submodule recursion by default, size and file-count ceilings, symlink/path containment, tokens never persisted in `.git/config` or process argv
-- Added `mergecraft review` to target any local worktree, public GitHub repo, or private repo (with `--token` / `GH_TOKEN` / `gh auth token`), with `--head`, `--base`, `--staged`, `--unstaged`, and `--range` diff selection; `diff-review` remains as a hidden alias
-
-### Added
-
 - Added: a test-only provider-harness fixture schema and strict matcher
   (`tests/support/provider_harness`) so deterministic review tests can name
   the exact provider interaction they expect. Not used in production.
@@ -79,32 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Promoted 20 themed review lenses from Review prose into registry entries with `mergecraft lens list|show|test`
 - Added pluggable orchestrator with declarative pipeline file, trust gate for untrusted sources, and `mergecraft pipeline lint|show|explain`
 - Added declared decision nodes for hybrid orchestration — typed triviality, lens selection, and finding disposition seams with pipeline-owned control flow
-
-### Fixed
-
-- Fixed `mergecraft review --format jsonl|sarif` writing empty output files and exiting 0 even with blockers — the CLI now threads a structured-findings sink through to the review so jsonl/sarif writers see real findings (#242 / `mergecraft-finding:v1:3f363546e98dad517048b8b9`)
-- Fixed the empty-diff early return in `run_offline_diff_review` silently reporting `RunOutcome.passed` when `apply_diff_line_budget` fully truncated (or untrusted-path filtering emptied) the diff; the run now applies the scope-reduction downgrade and reports `inconclusive` (D12) (#242 / `mergecraft-finding:v1:2e1cb9c2153087658c3481bd`)
-- Fixed `mergecraft review` default text mode never producing exit codes 10/11 — the CLI now requests structured findings internally so a CI script running `review` can block on the documented exit-code contract (#242 / `mergecraft-finding:v1:7a3cdf5ef1994610113e8e37`)
-- Fixed `mergecraft plan` reporting `diff_path` that pointed at a path inside a torn-down `TemporaryDirectory`; the materialized diff is now persisted to `<repo>/.mergecraft/plan-review.diff` so the report's `diff_path` is reachable after return (#242 / `mergecraft-finding:v1:e8bc195570ae6f1cc8ab5bc6`)
-- Fixed tool-call budget exhaustion only surfacing as a JSON-RPC error to the agent — `BudgetTracker` now records the `BudgetExhausted` it raises (`last_exhausted`) and `main._finalize` drains the tracker at finalize time, so a run that exhausts its tool-call budget is tagged `inconclusive` rather than approving on a partial signal (D12) (#242 / `mergecraft-finding:v1:aeb5d964c1d35e5a41784ded`)
-- Fixed eval corpus run directories splitting on slashes in model slugs (e.g. `openrouter/openai/gpt-5`) — run ids are sanitized to a single flat component (#219)
-- Fixed live corpus reviews running in an empty scratch directory — the case's repo context is materialized before the review (#220)
-- Benchmark result sets now record full version pins and a reproducibility digest, so same-commit runs are comparable (#140)
-- Two ensemble models that both report no findings no longer escalate to a judge (#238)
-- Reviews of Python repositories with `shell: disabled` no longer fail closed after a completed review just because dependency installation was skipped as a security policy
-- Fixed: model-chain fallback now advances when the provider succeeds without a terminal verdict; a valid `request_changes` is a usable result and does not trigger fallback
-- Fixed: explicit `harness:` now selects the runtime agent, not only span labels
-- Fixed: a previously recorded `approve` is re-validated before GitHub publish, so a later confirmed blocker cannot ship an `APPROVE` review
-- Fixed: body-only `create_pull_request_review` with `approved: false` no longer posts a GitHub `APPROVE`
-- Fixed: `create_pull_request_review` now requires established review scope in Review modes, matching `submit_review_verdict`
-
-### Changed
-
-- Changed: `gates.terminal_verdict` now defaults to `enforce`; missing terminal verdict reports `inconclusive`. Operators can still set `shadow`
-- Changed: `create_pull_request_review` now records through the same validator as `submit_review_verdict`; GitHub posting is an internal publisher, not an agent tool
-
-### Added
-
 - Added: optional `harness` setting (`opencode` / `codex` / `claude` / `gemini` / `cursor`) to select the agent runtime independently of provider/model. Existing configs with the key unset keep today's inference
 - Added: terminal-verdict protocol shadow mode (`gates.terminal_verdict`, default `shadow`) with a closed `VerdictDiagnostic` vocabulary; enforce still applies the fail-closed missing-verdict branch
 - Added: server-side semantic validation of the terminal verdict — `request_changes` with no findings, `approve` over a verifier-confirmed blocker, and `approve` with a failing required deterministic check are all rejected and fail closed
@@ -132,15 +87,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR G2): the README table documented 9 of 24 real `action.yml` inputs and
   neither declared output anywhere
 
-### Security
-
-- Reviewer and verifier now hold distinct, class-derived MCP toolsets; the live
-  MCP server exposes those surfaces at `/mcp/reviewer` and `/mcp/verifier`,
-  mutating tools stay off both except `checkout_pr` on the reviewer, and
-  finding-verdict persistence stays orchestrator-only
-
 ### Fixed
 
+- Fixed `mergecraft review --format jsonl|sarif` writing empty output files and exiting 0 even with blockers — the CLI now threads a structured-findings sink through to the review so jsonl/sarif writers see real findings (#242 / `mergecraft-finding:v1:3f363546e98dad517048b8b9`)
+- Fixed the empty-diff early return in `run_offline_diff_review` silently reporting `RunOutcome.passed` when `apply_diff_line_budget` fully truncated (or untrusted-path filtering emptied) the diff; the run now applies the scope-reduction downgrade and reports `inconclusive` (D12) (#242 / `mergecraft-finding:v1:2e1cb9c2153087658c3481bd`)
+- Fixed `mergecraft review` default text mode never producing exit codes 10/11 — the CLI now requests structured findings internally so a CI script running `review` can block on the documented exit-code contract (#242 / `mergecraft-finding:v1:7a3cdf5ef1994610113e8e37`)
+- Fixed `mergecraft plan` reporting `diff_path` that pointed at a path inside a torn-down `TemporaryDirectory`; the materialized diff is now persisted to `<repo>/.mergecraft/plan-review.diff` so the report's `diff_path` is reachable after return (#242 / `mergecraft-finding:v1:e8bc195570ae6f1cc8ab5bc6`)
+- Fixed tool-call budget exhaustion only surfacing as a JSON-RPC error to the agent — `BudgetTracker` now records the `BudgetExhausted` it raises (`last_exhausted`) and `main._finalize` drains the tracker at finalize time, so a run that exhausts its tool-call budget is tagged `inconclusive` rather than approving on a partial signal (D12) (#242 / `mergecraft-finding:v1:aeb5d964c1d35e5a41784ded`)
+- Fixed eval corpus run directories splitting on slashes in model slugs (e.g. `openrouter/openai/gpt-5`) — run ids are sanitized to a single flat component (#219)
+- Fixed live corpus reviews running in an empty scratch directory — the case's repo context is materialized before the review (#220)
+- Benchmark result sets now record full version pins and a reproducibility digest, so same-commit runs are comparable (#140)
+- Two ensemble models that both report no findings no longer escalate to a judge (#238)
+- Reviews of Python repositories with `shell: disabled` no longer fail closed after a completed review just because dependency installation was skipped as a security policy
+- Fixed: model-chain fallback now advances when the provider succeeds without a terminal verdict; a valid `request_changes` is a usable result and does not trigger fallback
+- Fixed: explicit `harness:` now selects the runtime agent, not only span labels
+- Fixed: a previously recorded `approve` is re-validated before GitHub publish, so a later confirmed blocker cannot ship an `APPROVE` review
+- Fixed: body-only `create_pull_request_review` with `approved: false` no longer posts a GitHub `APPROVE`
+- Fixed: `create_pull_request_review` now requires established review scope in Review modes, matching `submit_review_verdict`
 - Fixed: terminal-verdict shadow mode now records a predicted outcome beside the legacy result on the live finalize path
 - Fixed: a body-only COMMENT is no longer recorded as `request_changes`, and body-only `request_changes` is rejected unless it has real findings
 - Fixed: publication must match the recorded terminal verdict and is re-validated before sending `APPROVE`
@@ -168,6 +131,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now also synthesises a `with:` block when absent (symmetric with
   `_create_env_block`) — every `action.yml` input is `required: false`, and
   the comment claiming otherwise was wrong
+
+### Changed
+
+- Stale pytest `xfail(strict=False)` markers that were already passing are now real tests; remaining allowed-tree xfails are strict (#276)
+- Changed: `gates.terminal_verdict` now defaults to `enforce`; missing terminal verdict reports `inconclusive`. Operators can still set `shadow`
+- Changed: `create_pull_request_review` now records through the same validator as `submit_review_verdict`; GitHub posting is an internal publisher, not an agent tool
+
+### Security
+
+- Linked-repo reads are grant-gated (D9): a run can only load repos declared in its authorized set; linked-repo and ticket text render through the W4 fence as untrusted data
+- Discovered repo instruction and skill files (`CLAUDE.md`, `AGENTS.md`, `SKILL.md`, `.cursor/rules/*.md`) from an untrusted review source render through the W4 fence as evidence and never enter the instruction bundle
+- CLI offline reviews now derive a trust tier from review-source provenance; cloned or out-of-root paths review at untrusted tier unless the operator passes an explicit `--trust` override
+- Executable repo config (`setupScript`, `prepushScript`, `stopScript`, `staticChecks[].command`) from an untrusted review source is ignored; declarative config still applies
+- Third-party clone acquisition is bounded and credential-safe: HTTPS GitHub URLs only, no redirect following, no submodule recursion by default, size and file-count ceilings, symlink/path containment, tokens never persisted in `.git/config` or process argv
+- Added `mergecraft review` to target any local worktree, public GitHub repo, or private repo (with `--token` / `GH_TOKEN` / `gh auth token`), with `--head`, `--base`, `--staged`, `--unstaged`, and `--range` diff selection; `diff-review` remains as a hidden alias
+- Reviewer and verifier now hold distinct, class-derived MCP toolsets; the live
+  MCP server exposes those surfaces at `/mcp/reviewer` and `/mcp/verifier`,
+  mutating tools stay off both except `checkout_pr` on the reviewer, and
+  finding-verdict persistence stays orchestrator-only
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,18 @@ make test
 make ci
 ```
 
+`make test` runs the unit and mocked-integration suite — **no API keys or secrets required**.
+Live-provider tests are excluded by default (`-m "not integration"`).
+
+To run the live slice (requires provider secrets such as `ANTHROPIC_API_KEY`):
+
+```bash
+MERGECRAFT_LIVE=1 make test-integration-live
+```
+
+`MERGECRAFT_LIVE=1` is the opt-in gate: without it, the live modules skip collection.
+With the flag set but secrets absent the suite still fails loudly (D9 — fail-closed).
+
 ## Commits
 
 Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`,

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ test-integration: ## Integration tests (PR CI; self-skip without live secrets)
 
 test-integration-live: ## Live-provider integration (scheduled / release precondition)
 	@live_selector='-m "live"'; \
-	MERGECRAFT_LIVE_PYTEST_MARKER=live $(UV) run python scripts/check_live_integration_contract.py || exit 1; \
-	MERGECRAFT_LIVE_PYTEST_MARKER=live $(UV) run python scripts/run_live_integration.py || exit 1
+	MERGECRAFT_LIVE=1 MERGECRAFT_LIVE_PYTEST_MARKER=live $(UV) run python scripts/check_live_integration_contract.py || exit 1; \
+	MERGECRAFT_LIVE=1 MERGECRAFT_LIVE_PYTEST_MARKER=live $(UV) run python scripts/run_live_integration.py || exit 1
 
 test-otlp-collector: ## OTLP collector integration — spans must leave the process (#143)
 	$(UV) run --extra tracing python scripts/run_otlp_collector_e2e.py

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,14 @@ install: ## Sync dev environment after dependency changes
 lockcheck: ## Fail if uv.lock is out of date
 	$(UV) lock --check
 
-lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-check + privilege-drop chown
+lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-check + privilege-drop chown + type-ignore reasons
 	$(RUFF) check src tests scripts
 	$(RUFF) format --check src tests scripts
 	$(UV) run python scripts/check_loguru_only.py
 	$(MAKE) action-yml-hygiene-check
 	$(MAKE) hook-pins-check
 	$(UV) run python scripts/check_privilege_drop_chown.py
+	$(UV) run python scripts/check_type_ignores.py
 
 action-yml-hygiene-check: ## Fail when an action.yml description embeds a literal ${{ }} expression
 	$(UV) run python scripts/check_action_yml_hygiene.py
@@ -78,8 +79,6 @@ agents-check: ## Agent registry model/prompt/tool validation gate (AP1)
 	$(UV) run python -m mergecraft.agents.catalog_docs
 
 PYTEST_SPLIT := $(if $(MERGECRAFT_TEST_SPLITS),--splits $(MERGECRAFT_TEST_SPLITS) --group $(MERGECRAFT_TEST_GROUP) --splitting-algorithm least_duration,)
-PYTEST_XPASS_LOG ?= .pytest-xpass.log
-
 test: ## Unit tests
 	$(PYTEST) tests -v --tb=short --strict-markers -m "not integration" $(PYTEST_XDIST) $(PYTEST_SPLIT) \
 		--randomly-seed=$${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}
@@ -101,20 +100,13 @@ test-integration-live: ## Live-provider integration (scheduled / release precond
 test-otlp-collector: ## OTLP collector integration — spans must leave the process (#143)
 	$(UV) run --extra tracing python scripts/run_otlp_collector_e2e.py
 
-coverage-gate: ## Unit tests + coverage floors (global + critical paths)
+coverage-gate: ## Unit tests + coverage floors (global + critical paths; xpass ratchet runs via conftest hook)
 	$(PYTEST) tests -q --tb=short --strict-markers -m "not integration" \
 		--cov=mergecraft --cov-branch --cov-report=term --cov-report=json:coverage.json \
 		--randomly-seed=$${MERGECRAFT_PYTEST_RANDOM_SEED:-424242} \
-		-rX > $(PYTEST_XPASS_LOG) 2>&1; rc=$$?; cat $(PYTEST_XPASS_LOG); exit $$rc
+		-rX
 	$(UV) run python scripts/check_coverage_ratchet.py coverage.json
 	$(UV) run python scripts/check_coverage_floors.py coverage.json
-
-xpass-check: ## Ratchet: fail if allowed-tree xfails unexpectedly pass (#276)
-	@if [ -f $(PYTEST_XPASS_LOG) ]; then \
-	  $(UV) run python scripts/check_xpass.py --from-log $(PYTEST_XPASS_LOG); \
-	else \
-	  $(UV) run python scripts/check_xpass.py; \
-	fi
 
 npm-audit: ## npm audit over docker/agent-clis lockfile (W12.3 / #27)
 	@command -v npm >/dev/null 2>&1 || { echo "npm not found on PATH" >&2; exit 2; }
@@ -157,7 +149,7 @@ ci-static: lockcheck lint typecheck pyright catalog-check agents-check build exa
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check security coverage-gate xpass-check
+CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check security coverage-gate
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)
@@ -199,3 +191,4 @@ docker-build: ## Build action Docker image
 
 clean: ## Remove caches and build artifacts
 	rm -rf .venv dist build .mypy_cache .ruff_cache .pytest_cache htmlcov coverage.xml .cache
+	rm -f .pytest-xpass.log

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 	examples example-workflows-check reference-docs reference-docs-check bench-review eval-gate eval-replay \
 	bench-detect \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check
+	lint-ruff-advisory hook-pins-check xpass-check
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -78,6 +78,7 @@ agents-check: ## Agent registry model/prompt/tool validation gate (AP1)
 	$(UV) run python -m mergecraft.agents.catalog_docs
 
 PYTEST_SPLIT := $(if $(MERGECRAFT_TEST_SPLITS),--splits $(MERGECRAFT_TEST_SPLITS) --group $(MERGECRAFT_TEST_GROUP) --splitting-algorithm least_duration,)
+PYTEST_XPASS_LOG ?= .pytest-xpass.log
 
 test: ## Unit tests
 	$(PYTEST) tests -v --tb=short --strict-markers -m "not integration" $(PYTEST_XDIST) $(PYTEST_SPLIT) \
@@ -103,9 +104,17 @@ test-otlp-collector: ## OTLP collector integration — spans must leave the proc
 coverage-gate: ## Unit tests + coverage floors (global + critical paths)
 	$(PYTEST) tests -q --tb=short --strict-markers -m "not integration" \
 		--cov=mergecraft --cov-branch --cov-report=term --cov-report=json:coverage.json \
-		--randomly-seed=$${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}
+		--randomly-seed=$${MERGECRAFT_PYTEST_RANDOM_SEED:-424242} \
+		-rX > $(PYTEST_XPASS_LOG) 2>&1; rc=$$?; cat $(PYTEST_XPASS_LOG); exit $$rc
 	$(UV) run python scripts/check_coverage_ratchet.py coverage.json
 	$(UV) run python scripts/check_coverage_floors.py coverage.json
+
+xpass-check: ## Ratchet: fail if allowed-tree xfails unexpectedly pass (#276)
+	@if [ -f $(PYTEST_XPASS_LOG) ]; then \
+	  $(UV) run python scripts/check_xpass.py --from-log $(PYTEST_XPASS_LOG); \
+	else \
+	  $(UV) run python scripts/check_xpass.py; \
+	fi
 
 npm-audit: ## npm audit over docker/agent-clis lockfile (W12.3 / #27)
 	@command -v npm >/dev/null 2>&1 || { echo "npm not found on PATH" >&2; exit 2; }
@@ -148,7 +157,7 @@ ci-static: lockcheck lint typecheck pyright catalog-check agents-check build exa
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check security coverage-gate
+CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check reference-docs-check security coverage-gate xpass-check
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 	examples example-workflows-check reference-docs reference-docs-check bench-review eval-gate eval-replay \
 	bench-detect \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check xpass-check
+	lint-ruff-advisory hook-pins-check
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -191,4 +191,3 @@ docker-build: ## Build action Docker image
 
 clean: ## Remove caches and build artifacts
 	rm -rf .venv dist build .mypy_cache .ruff_cache .pytest_cache htmlcov coverage.xml .cache
-	rm -f .pytest-xpass.log

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ into a comment changes nothing. Details:
 > **Without Python 3.14**, use the [Docker Action](#example-1--auto-review-every-pr)
 > (`alexhawat/mergeCraft@…`) — the container image ships a compatible runtime; no
 > local Python install needed ([`docs/distribution.md`](docs/distribution.md)).
+> **SCM:** mergeCraft 0.1.0 supports **GitHub** repositories only. GitLab support is
+> planned via the `ScmProvider` abstraction.
 
 **1. Install and scaffold** (in the repo you want reviewed):
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ jobs:
 > **Pin to the exact tag**, e.g. `@v0.1.0` — it is an immutable release ref and
 > will not move, so a workflow run always reviews with the code that tag names.
 > For the strictest supply-chain posture, pin a full commit SHA instead.
+> To verify the published image's Cosign signature and GitHub build-provenance attestation,
+> see the one-liners in [CONTRIBUTING.md § Verify a published image](CONTRIBUTING.md#verify-a-published-image).
 
 ### Example 2 — hardened, review as a required check
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -59,6 +59,13 @@ mergecraft --help
 Marketplace is **not** automated by Craft. After the public GitHub release and
 Docker `:latest` promotion:
 
+> **Prerequisite — verify image attestations before listing.**
+> Run the `cosign verify` and `gh attestation verify` commands in
+> [CONTRIBUTING.md § Verify a published image](../CONTRIBUTING.md#verify-a-published-image)
+> against the release-tag digest. The signatures and attestations are produced by
+> the `sign-attest` job in `.github/workflows/ci-cd.yml`. Do **not** submit the
+> Marketplace listing until both verifications pass for the release tag.
+
 1. Open [GitHub Marketplace new action](https://github.com/marketplace/actions/new).
 2. Point at `alexhawat/mergeCraft` and the release tag (`v0.1.0`).
 3. Use the Docker action entry (`action.yml` + `ghcr.io/alexhawat/mergecraft` image).

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -53,6 +53,9 @@ mergecraft --help
 
 ### GitHub Marketplace listing
 
+> **SCM scope:** mergeCraft 0.1.0 supports **GitHub** repositories only. GitLab support
+> is planned via the `ScmProvider` abstraction and will be documented when available.
+
 Marketplace is **not** automated by Craft. After the public GitHub release and
 Docker `:latest` promotion:
 
@@ -62,6 +65,7 @@ Docker `:latest` promotion:
 4. Categories: **Code review**, **Continuous integration**.
 5. Link docs: `docs/`, `REVIEW-CHECKS.md`, `docs/ANALYZERS.md`.
 6. Note BYOK / no SaaS backend in the listing description (see README positioning).
+7. Note GitHub-only SCM scope for 0.1.0 in the listing description.
 
 ### README assets
 

--- a/docs/test-plans/open-issues-sweep-2026-08-19b.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-19b.md
@@ -209,6 +209,66 @@ not delete tests. Do not touch D6 files.
 - `test_promotion_requires_explicit_approval_by_default`
 - `test_quarantined_entry_never_reaches_reviewer_prompt`
 
+### W6 promotion (2026-08-19)
+
+Removed `xfail(strict=False)` from all **113** allowed-tree xpasses listed
+above. Test bodies kept. D6 file untouched. W7 wiring xfail untouched.
+`test_emit_failure_logs_a_warning` capture was retargeted to stderr
+(`capsys`) so the promotion is a real pass: production emit may reset
+loguru handlers, which made a dedicated ``logger.add`` sink
+order-dependent.
+
+| Bucket | Count |
+|--------|-------|
+| Allowed-tree xfail markers removed | **113** (7 files) |
+| D6 leftovers (still `strict=False` xpass) | **8** — `tests/agents/test_codex_custom_provider.py` |
+| Allowed-tree still-failing xfails → `strict=True` + `(#276)` | **13** |
+| W7 wiring xfail (still `strict=False`) | **1** — `test_make_xpass_check_is_wired` |
+
+W5 recorded 13 still-failing xfails in the unit suite. W6 inspection found
+those 13 plus `test_readme_eval_claim_adjacent_to_dated_metrics_and_corpus_commit`
+(W9 eval-replay, also still failing). All allowed-path leftovers other
+than the W7 wiring test were set `strict=True` with `(#276)` in `reason=`.
+No GitHub issue was created (draft-only).
+
+Leftover **failing** xfails (`strict=True`, `#276`), excluding W7:
+
+- `tests/cli/test_auth_nous_cmd.py::test_auth_nous_fails_closed_when_gh_is_unauthenticated`
+- `tests/evals/test_benchmark_publication.py::test_readme_eval_claim_adjacent_to_dated_metrics_and_corpus_commit`
+- `tests/instructions/test_offline_review_fence.py::test_injected_pr_body_does_not_change_findings`
+- `tests/instructions/test_offline_review_fence.py::test_offline_diff_review_fences_commit_messages_and_patch_headers`
+- `tests/tracing/instrumentation/test_agent_attempt.py::test_one_agent_attempt_span_for_skipped_entry`
+- `tests/tracing/instrumentation/test_analyzer_run.py` (4)
+- `tests/tracing/instrumentation/test_span_tree.py::test_span_tree_shape`
+- `tests/tracing/instrumentation/test_usage_entries.py::test_usage_entries_aggregation_across_multiple_attempts`
+- `tests/tracing/test_trace_id_bridge.py::test_otel_sink_forwards_real_trace_id`
+- `tests/utils/test_fence.py::test_forged_close_does_not_escape_fence`
+
+D6 leftovers (do not promote; morning plan owns these):
+
+- `test_codex_config_toml_writes_both_indexed_providers`
+- `test_codex_config_toml_writes_three_indexed_providers`
+- `test_codex_indexed_wins_singleton_ignored`
+- `test_codex_partial_indexed_coverage_writes_only_present_providers` (4 params)
+- `test_codex_singleton_alone_emits_default_provider_block`
+
+`scripts/check_xpass.py` should now exit 0 on allowed-tree (D6 xpasses
+excluded from the fail condition). `make xpass-check` still unwired (W7).
+
+### Draft follow-up issue (not filed)
+
+**Title:** Remaining strict xfails after #276 xpass promotion
+
+**Body:** After W6 promoted 113 allowed-tree xpasses, 13 allowed-path tests
+still fail and are now `xfail(strict=True)` with `(#276)` in `reason=`. They
+are leftovers from other programs (tracing W4 instrumentation, fence
+B-Final stub/`nonce` contradiction, eval W9 README metrics, auth_nous
+CliRunner `SystemExit`). D6 `test_codex_custom_provider.py` xpasses stay
+for the morning plan. Do not `gh issue create` until an owner wants a
+separate tracker.
+
+### Acceptance (W5)
+
 ### Acceptance (W5)
 
 - Inventory recorded (121 total / 113 allowed / 8 D6)

--- a/docs/test-plans/open-issues-sweep-2026-08-19b.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-19b.md
@@ -2,12 +2,13 @@
 
 Wave plan: `.ignorelocal/waves/open-issues-sweep-2026-08-19b-wave-plan.md`
 Worktree: `../mergecraft-issues-sweep-2026-08-19b` @ `wave/issues-sweep-2026-08-19b`
-Authoring waves: **W1** (Batch G RED) · **W5** (Batch H RED — xpass inventory)
+Authoring waves: **W1** (Batch G RED) · **W5** (Batch H RED — xpass inventory) · **W8** (Batch I RED — typing suppressions)
 
 W1 pins #277 (xdist flake on grandchild reap) and #278 (`MERGECRAFT_LIVE=1` opt-in)
 without changing production code. W5 inventories stale `xfail(strict=False)` xpasses
-(#276) and adds the RED `scripts/check_xpass.py` ratchet. D6-forbidden paths are
-not edited; D6 xpasses are counted then excluded from the W6 cleanup list.
+(#276) and adds the RED `scripts/check_xpass.py` ratchet. W8 inventories `type: ignore`
+/ `cast(` under `src/mergecraft/` (#275) and adds the RED `scripts/check_type_ignores.py`
+ratchet. D6-forbidden paths are not edited; D6 sites are counted then excluded.
 
 ## xfail schedule
 
@@ -15,7 +16,8 @@ not edited; D6 xpasses are counted then excluded from the W6 cleanup list.
 |------|------|---------------|--------|
 | **W3** | `test_setup_script_grandchildren_are_reaped` | `green after W3: #277 wait for pid_file before kill clock` | greened in W3 |
 | **W4** | `test_live_module_skips_when_mergecraft_live_unset` (6 cases) | `green after W4: MERGECRAFT_LIVE skip gate` | greened in W4 |
-| **W7** | `tests/ci/test_xpass_check.py::test_make_xpass_check_is_wired` | `green after W7: make xpass-check ratchet` | pending — Makefile target not wired (W5 RED) |
+| **W7** | `tests/ci/test_xpass_check.py::test_make_xpass_check_is_wired` | `green after W7: make xpass-check ratchet` | greened in W7 |
+| **W9** | `tests/ci/test_type_ignores.py::test_allowed_tree_ignores_and_casts_have_reasons` | `green after W9: #275 justify type: ignore / cast reasons` | pending — 53 allowed-tree sites lack a reason (W8 RED) |
 
 **W6 must not promote** the W7 wiring xfail. That test is still failing (no
 `make xpass-check`); it is an xfail, not an xpass.
@@ -277,3 +279,120 @@ separate tracker.
 - `make lint` + `make typecheck` clean; collection clean
 - No Makefile `xpass-check` target; not wired into `ci-static` / `make test`
 - No D6 path edits; no xfail promotions (W6)
+
+---
+
+## Batch I — typing suppressions (#275 / D10)
+
+Authoring wave: **W8**. Implementation: **W9** (justify or remove on the allowed
+tree; un-xfail W8.1). Do not edit D6 src files. Do not walk `src/` in W8.
+
+### W8.1 inventory (2026-08-19 @ `0d23a67`)
+
+Command: `uv run python scripts/check_type_ignores.py` (script added this wave;
+counts below are the live `src/mergecraft/` scan with D6 excluded from the fail
+condition). Every ignore already has `[code]` (finding 5). None have a `—`
+reason. No `cast(` has a `#` reason on the same or previous line.
+
+| Bucket | Ignores | Casts | Unjustified (fail the reason rule) |
+|--------|---------|-------|-------------------------------------|
+| Total | **41** | **15** | 56 |
+| Allowed-tree (W9 walk) | **39** | **14** | **53** (39 ignores + 14 casts) |
+| D6-excluded (count only; do not edit) | **2** | **1** | 3 |
+
+D6 leftovers (morning plan owns these; checker skips them):
+
+- `src/mergecraft/agents/_stream_consumer.py:321` — `type: ignore[assignment]`
+- `src/mergecraft/mcp/verdict.py:484` — `type: ignore[arg-type]`
+- `src/mergecraft/mcp/verdict.py:255` — `cast(`
+
+Error codes present on the 41 ignores: `arg-type`, `assignment`, `attr-defined`,
+`method-assign`, `misc`, `return-value`. Zero bare `type: ignore` without
+brackets on either tree.
+
+### W8.1 RED ratchet
+
+`scripts/check_type_ignores.py` scans `src/mergecraft/**/*.py`. A `type: ignore`
+must be `type: ignore[<code>]` with a following em-dash (U+2014) reason on the
+same line. A `cast(` call needs a `#` reason on the same line or the previous
+line. Exit 1 when allowed-tree unjustified count > 0; D6 files are counted in
+the summary and ignored. Verified RED on HEAD: exit 1,
+`53 allowed-tree unjustified (41 ignores, 15 casts; 3 D6-excluded violations)`.
+
+`make` is **not** wired (not in W8; W9 un-xfails the live-tree test only).
+No `Makefile` edit in W8. No `src/` edits.
+
+### Contract matrix (#275)
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| I275a | Script exists | unit | happy | `tests/ci/test_type_ignores.py::test_script_exists` |
+| I275b | D6 path set covers the plan's src files | unit | happy | `test_d6_paths_cover_plan_src_files` |
+| I275c | Path D6 classification (incl. backslash) | unit | happy / edge | `test_is_d6_src` |
+| I275d | Ignore needs `[code]` **and** `—` reason | unit | happy / edge / error | `test_type_ignore_reason_rule` |
+| I275e | Cast needs `#` reason on same or previous line | unit | happy / edge / error | `test_cast_reason_rule` |
+| I275f | D6 unjustified sites → exit 0 | unit | edge | `test_d6_file_without_reason_is_excluded_from_fail` |
+| I275g | Allowed-tree missing reason → exit 1 | unit | error | `test_allowed_tree_missing_reason_fails` / `test_main_exits_one_on_allowed_unjustified` |
+| I275h | Empty tree → exit 0 | unit | edge | `test_empty_tree_is_zero` |
+| I275i | Missing `src/mergecraft` → exit 2 | unit | error | `test_missing_src_tree_exits_two` |
+| I275j | Justified ignore + cast → exit 0 | unit | happy | `test_main_exits_zero_when_justified` |
+| I275k | Live D6 sites never appear in allowed violations | integration | edge | `test_scan_tree_skips_d6_from_allowed_on_live_src` |
+| I275l | Live allowed tree has a reason on every site | functional | happy after W9 | `test_allowed_tree_ignores_and_casts_have_reasons` (xfail until W9) |
+
+W9 must not promote I275l until every allowed-tree ignore/cast is justified or
+removed. Do not edit D6 files.
+
+### W9 walk list (allowed-tree only)
+
+**Ignores lacking `—` reason (39):**
+
+- `src/mergecraft/action/inputs.py` (1)
+- `src/mergecraft/agents/__init__.py` (1)
+- `src/mergecraft/agents/harness_render.py` (1)
+- `src/mergecraft/agents/verifier.py` (1)
+- `src/mergecraft/analyzers/agentsec/policy.py` (1)
+- `src/mergecraft/analyzers/catalog_docs.py` (2)
+- `src/mergecraft/analyzers/lockfile.py` (1)
+- `src/mergecraft/analyzers/redact.py` (1)
+- `src/mergecraft/analyzers/trust.py` (1)
+- `src/mergecraft/cli/eval_cmd.py` (1)
+- `src/mergecraft/cli/mcp_cmd.py` (1)
+- `src/mergecraft/cli/mcp_serve.py` (2)
+- `src/mergecraft/cli/profiles.py` (1)
+- `src/mergecraft/config/settings.py` (1)
+- `src/mergecraft/evidence/emit.py` (1)
+- `src/mergecraft/evidence/packet.py` (2)
+- `src/mergecraft/main.py` (2)
+- `src/mergecraft/mcp/analyzers.py` (1)
+- `src/mergecraft/mcp/verification.py` (1)
+- `src/mergecraft/offline_review.py` (2)
+- `src/mergecraft/prep/node.py` (2)
+- `src/mergecraft/utils/activity.py` (4)
+- `src/mergecraft/utils/instructions.py` (1)
+- `src/mergecraft/utils/learnings.py` (2)
+- `src/mergecraft/utils/log.py` (1)
+- `src/mergecraft/utils/normalize_env.py` (1)
+- `src/mergecraft/utils/status_checks.py` (3)
+
+**Casts lacking a `#` reason (14):**
+
+- `src/mergecraft/analyzers/impact.py` (1)
+- `src/mergecraft/analyzers/parsers/trivy_json.py` (1)
+- `src/mergecraft/ci/normalize.py` (1)
+- `src/mergecraft/ci/providers/__init__.py` (4)
+- `src/mergecraft/classify/blast_radius.py` (2)
+- `src/mergecraft/context/call_graph.py` (1)
+- `src/mergecraft/context/repo_map.py` (1)
+- `src/mergecraft/context/symbol_index.py` (1)
+- `src/mergecraft/evidence/emit.py` (1)
+- `src/mergecraft/utils/payload.py` (1)
+
+HEAD does **not** already have reasons on the allowed tree — do not skip W9.
+
+### Acceptance (W8)
+
+- Inventory recorded (41 ignores / 15 casts; 39+14 allowed unjustified; 2+1 D6)
+- `scripts/check_type_ignores.py` exits 1 on the current allowed tree
+- Ratchet unit tests pass; live-tree cleanliness test xfail until W9
+- `make lint` + `make typecheck` clean; collection clean
+- No Makefile target; no `src/` edits; no D6 path edits

--- a/docs/test-plans/open-issues-sweep-2026-08-19b.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-19b.md
@@ -1,0 +1,59 @@
+# Open issues sweep 2026-08-19b — Batch G test plan
+
+Wave plan: `.ignorelocal/waves/open-issues-sweep-2026-08-19b-wave-plan.md`
+Worktree: `../mergecraft-issues-sweep-2026-08-19b` @ `wave/issues-sweep-2026-08-19b`
+Authoring wave: **W1** (Batch G RED). Implementation: **W3** (#277), **W4** (#278).
+
+W1 pins #277 (xdist flake on grandchild reap) and #278 (`MERGECRAFT_LIVE=1` opt-in)
+without changing production code. D6-forbidden paths are not touched.
+
+## xfail schedule
+
+| Wave | Test | Marker reason | Status |
+|------|------|---------------|--------|
+| **W3** | `test_setup_script_grandchildren_are_reaped` | `green after W3: #277 wait for pid_file before kill clock` | pending — deterministic RED: readiness file delayed past `wait_or_kill(..., timeout=0.5)` |
+| **W4** | `test_live_module_skips_when_mergecraft_live_unset` (6 cases) | `green after W4: MERGECRAFT_LIVE skip gate` | pending |
+
+No xfail on:
+
+- `_wait_until_exists` / `_record_pid_reaped` helper units (green now; W3 reuses them)
+- `test_live_module_fails_when_flag_set_without_credentials` (D8 fail-closed already holds)
+
+## Contract matrix
+
+### #277 / D12 — grandchild reap without a 0.5s spawn window
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| G277a | Readiness poll is independent of the 0.5s kill clock | unit | happy — file appears at 0.8s | `tests/config/test_setup_script_timeout.py::test_wait_until_exists_does_not_assume_half_second_grace` |
+| G277b | Missing readiness file is not ready | unit | edge — never written | `test_wait_until_exists_returns_false_when_file_never_appears` |
+| G277c | Reap recording takes an explicit deadline | unit | happy / edge — `sleep 10` still alive after 0.25s | `test_record_pid_reaped_deadline_is_independent_of_wait_or_kill_timeout` |
+| G277d | Non-positive reap deadline is rejected | unit | error — `0` / `-1` | `test_record_pid_reaped_rejects_non_positive_deadline` |
+| G277e | Kill-before-readiness fails deterministically | functional | error — old timing | `test_setup_script_grandchildren_are_reaped` (xfail until W3) |
+
+W3 greens G277e by calling `_wait_until_exists(pid_file)` **before** `wait_or_kill_process_group`. Do not mock `kill_process_group`.
+
+### #278 / D8 — live opt-in
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| G278a | Unset / empty / `"0"` → skip, not fail | functional | happy + edge | `tests/ci/test_live_opt_in.py::test_live_module_skips_when_mergecraft_live_unset` |
+| G278b | `MERGECRAFT_LIVE=1` + no creds → fail | functional | error (D9 preserved) | `test_live_module_fails_when_flag_set_without_credentials` |
+
+Both live modules are parametrized:
+
+- `tests/integration/test_live_providers.py`
+- `tests/integration/test_github_integration.py`
+
+Child pytest runs with credentials stripped so a developer laptop with keys cannot accidentally hit a provider.
+
+## W1.1 note
+
+Deterministic RED, not inspection-only. The grandchild script delays the pid-file write by 1s so `wait_or_kill(..., timeout=0.5)` expires before readiness. Helpers `_wait_until_exists` and `_record_pid_reaped` have no 0.5s default.
+
+## Acceptance (W1)
+
+- New tests collect with zero import errors
+- `make lint` + `make typecheck` clean on touched paths
+- G277 helper units pass; G277e xfail; G278a xfail; G278b pass
+- No `src/` edits; no D6 paths

--- a/docs/test-plans/open-issues-sweep-2026-08-19b.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-19b.md
@@ -2,13 +2,15 @@
 
 Wave plan: `.ignorelocal/waves/open-issues-sweep-2026-08-19b-wave-plan.md`
 Worktree: `../mergecraft-issues-sweep-2026-08-19b` @ `wave/issues-sweep-2026-08-19b`
-Authoring waves: **W1** (Batch G RED) · **W5** (Batch H RED — xpass inventory) · **W8** (Batch I RED — typing suppressions)
+Authoring waves: **W1** (Batch G RED) · **W5** (Batch H RED — xpass inventory) · **W8** (Batch I RED — typing suppressions) · **W10** (Batch J RED — GitLab error string)
 
 W1 pins #277 (xdist flake on grandchild reap) and #278 (`MERGECRAFT_LIVE=1` opt-in)
 without changing production code. W5 inventories stale `xfail(strict=False)` xpasses
 (#276) and adds the RED `scripts/check_xpass.py` ratchet. W8 inventories `type: ignore`
 / `cast(` under `src/mergecraft/` (#275) and adds the RED `scripts/check_type_ignores.py`
-ratchet. D6-forbidden paths are not edited; D6 sites are counted then excluded.
+ratchet. W10 pins #279: a GitLab `UnsupportedScmCapability` message must contain
+`not available in this release` (xfail until W12). D6-forbidden paths are not
+edited; D6 sites are counted then excluded.
 
 ## xfail schedule
 
@@ -17,7 +19,8 @@ ratchet. D6-forbidden paths are not edited; D6 sites are counted then excluded.
 | **W3** | `test_setup_script_grandchildren_are_reaped` | `green after W3: #277 wait for pid_file before kill clock` | greened in W3 |
 | **W4** | `test_live_module_skips_when_mergecraft_live_unset` (6 cases) | `green after W4: MERGECRAFT_LIVE skip gate` | greened in W4 |
 | **W7** | `tests/ci/test_xpass_check.py::test_make_xpass_check_is_wired` | `green after W7: make xpass-check ratchet` | greened in W7 |
-| **W9** | `tests/ci/test_type_ignores.py::test_allowed_tree_ignores_and_casts_have_reasons` | `green after W9: #275 justify type: ignore / cast reasons` | pending — 53 allowed-tree sites lack a reason (W8 RED) |
+| **W9** | `tests/ci/test_type_ignores.py::test_allowed_tree_ignores_and_casts_have_reasons` | `green after W9: #275 justify type: ignore / cast reasons` | greened in W9 |
+| **W12** | `tests/scm/test_errors.py::test_gitlab_unsupported_capability_names_this_release` | `green after W12: GitLab not available in this release` | pending — today's wording is the capability token (W10 RED) |
 
 **W6 must not promote** the W7 wiring xfail. That test is still failing (no
 `make xpass-check`); it is an xfail, not an xpass.
@@ -396,3 +399,55 @@ HEAD does **not** already have reasons on the allowed tree — do not skip W9.
 - Ratchet unit tests pass; live-tree cleanliness test xfail until W9
 - `make lint` + `make typecheck` clean; collection clean
 - No Makefile target; no `src/` edits; no D6 path edits
+
+---
+
+## Batch J — release docs (#279 / D11, #280 / D7)
+
+Authoring wave: **W10**. Implementation: **W11** (GitHub-only README + distribution),
+**W12** (GitLab error wording + draft follow-up), **W13** (SHA-pin verify + Marketplace
+gate). Do not edit D6 files. Do not edit README generated sentinel regions. Do not
+change `src/mergecraft/scm/errors.py` in W10.
+
+W10 pins the #279 error-string contract. Today's
+`UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")` message is the
+capability-token form:
+
+`GitLabScmAdapter does not support capability 'get_pr'; operation was not emulated`
+
+W12 rewrites it so a GitLab call says GitLab support is not available in this
+release (D11). The RED test uses `xfail(strict=False)` tagged `green after W12` so
+`make ci` on this branch stays green if re-run before W12.
+
+W11 / W13 docs contracts are stubbed here; those waves own the README /
+`docs/distribution.md` copy.
+
+### Contract matrix (#279 error string — W10)
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| J279a | GitLab `UnsupportedScmCapability` names this release | unit | error — RED until W12 | `tests/scm/test_errors.py::test_gitlab_unsupported_capability_names_this_release` |
+
+Message must contain `not available in this release` (or the exact W12 / D11
+string: `GitLab support is not available in this release`). Not a raw
+`NotImplementedError`. Not only a capability token.
+
+### Contract matrix (#279 docs — W11 stub)
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| J279b | README features + requirements: 0.1.0 is GitHub-only | docs | happy after W11 | *(W11 — outside generated sentinels)* |
+| J279c | `docs/distribution.md` Marketplace copy: same GitHub-only sentence | docs | happy after W11 | *(W11)* |
+
+### Contract matrix (#280 docs — W13 stub)
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| J280a | README SHA-pin advice links `CONTRIBUTING.md` verify one-liners | docs | happy after W13 | *(W13 — no `slsa-github-generator`, D7)* |
+| J280b | `docs/distribution.md` Marketplace checklist gated on existing attestations | docs | happy after W13 | *(W13 — point at `sign-attest`)* |
+
+### Acceptance (W10)
+
+- J279a collects with zero import errors; xfail until W12 (fails on today's wording)
+- `make lint` + `make typecheck` clean
+- No `src/` edits; no README / `docs/distribution.md` edits; no D6 path edits

--- a/docs/test-plans/open-issues-sweep-2026-08-19b.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-19b.md
@@ -1,23 +1,24 @@
-# Open issues sweep 2026-08-19b — Batch G test plan
+# Open issues sweep 2026-08-19b — test plan
 
 Wave plan: `.ignorelocal/waves/open-issues-sweep-2026-08-19b-wave-plan.md`
 Worktree: `../mergecraft-issues-sweep-2026-08-19b` @ `wave/issues-sweep-2026-08-19b`
-Authoring wave: **W1** (Batch G RED). Implementation: **W3** (#277), **W4** (#278).
+Authoring waves: **W1** (Batch G RED) · **W5** (Batch H RED — xpass inventory)
 
 W1 pins #277 (xdist flake on grandchild reap) and #278 (`MERGECRAFT_LIVE=1` opt-in)
-without changing production code. D6-forbidden paths are not touched.
+without changing production code. W5 inventories stale `xfail(strict=False)` xpasses
+(#276) and adds the RED `scripts/check_xpass.py` ratchet. D6-forbidden paths are
+not edited; D6 xpasses are counted then excluded from the W6 cleanup list.
 
 ## xfail schedule
 
 | Wave | Test | Marker reason | Status |
 |------|------|---------------|--------|
-| **W3** | `test_setup_script_grandchildren_are_reaped` | `green after W3: #277 wait for pid_file before kill clock` | pending — deterministic RED: readiness file delayed past `wait_or_kill(..., timeout=0.5)` |
-| **W4** | `test_live_module_skips_when_mergecraft_live_unset` (6 cases) | `green after W4: MERGECRAFT_LIVE skip gate` | pending |
+| **W3** | `test_setup_script_grandchildren_are_reaped` | `green after W3: #277 wait for pid_file before kill clock` | greened in W3 |
+| **W4** | `test_live_module_skips_when_mergecraft_live_unset` (6 cases) | `green after W4: MERGECRAFT_LIVE skip gate` | greened in W4 |
+| **W7** | `tests/ci/test_xpass_check.py::test_make_xpass_check_is_wired` | `green after W7: make xpass-check ratchet` | pending — Makefile target not wired (W5 RED) |
 
-No xfail on:
-
-- `_wait_until_exists` / `_record_pid_reaped` helper units (green now; W3 reuses them)
-- `test_live_module_fails_when_flag_set_without_credentials` (D8 fail-closed already holds)
+**W6 must not promote** the W7 wiring xfail. That test is still failing (no
+`make xpass-check`); it is an xfail, not an xpass.
 
 ## Contract matrix
 
@@ -29,7 +30,7 @@ No xfail on:
 | G277b | Missing readiness file is not ready | unit | edge — never written | `test_wait_until_exists_returns_false_when_file_never_appears` |
 | G277c | Reap recording takes an explicit deadline | unit | happy / edge — `sleep 10` still alive after 0.25s | `test_record_pid_reaped_deadline_is_independent_of_wait_or_kill_timeout` |
 | G277d | Non-positive reap deadline is rejected | unit | error — `0` / `-1` | `test_record_pid_reaped_rejects_non_positive_deadline` |
-| G277e | Kill-before-readiness fails deterministically | functional | error — old timing | `test_setup_script_grandchildren_are_reaped` (xfail until W3) |
+| G277e | Kill-before-readiness fails deterministically | functional | error — old timing | `test_setup_script_grandchildren_are_reaped` (greened W3) |
 
 W3 greens G277e by calling `_wait_until_exists(pid_file)` **before** `wait_or_kill_process_group`. Do not mock `kill_process_group`.
 
@@ -57,3 +58,162 @@ Deterministic RED, not inspection-only. The grandchild script delays the pid-fil
 - `make lint` + `make typecheck` clean on touched paths
 - G277 helper units pass; G277e xfail; G278a xfail; G278b pass
 - No `src/` edits; no D6 paths
+
+---
+
+## Batch H — xfail hygiene (#276 / D9)
+
+Authoring wave: **W5**. Implementation: **W6** (promote allowed-tree xpasses),
+**W7** (`make xpass-check` wiring). Do not edit D6 test files.
+
+### W5.1 inventory (2026-08-19 @ `7e3f5a5`)
+
+Command: `uv run pytest tests -m "not integration" --strict-markers -q --tb=no -rX --randomly-seed=424242 -n auto`
+
+| Bucket | Count |
+|--------|-------|
+| Total xpassed | **121** |
+| Allowed-tree (W6 cleanup) | **113** |
+| D6-excluded (count only; do not promote) | **8** |
+| xfailed (still failing; not this wave) | 13 |
+| passed / skipped | 2989 / 30 |
+
+GF reported 119 xpassed; this W5 run is 121. The extra two are still on the
+allowed tree and belong in the cleanup list below. `tests/ci/test_xpass_check.py::test_make_xpass_check_is_wired`
+is **xfailed**, not xpassed — leave it for W7.
+
+D6 xpasses (excluded from cleanup; all in `tests/agents/test_codex_custom_provider.py`):
+
+- `test_codex_config_toml_writes_both_indexed_providers`
+- `test_codex_config_toml_writes_three_indexed_providers`
+- `test_codex_indexed_wins_singleton_ignored`
+- `test_codex_partial_indexed_coverage_writes_only_present_providers` (4 params)
+- `test_codex_singleton_alone_emits_default_provider_block`
+
+### W5.2 RED ratchet
+
+`scripts/check_xpass.py` parses pytest `-rX` / `-ra` `XPASS nodeid - reason`
+lines. `--from-log PATH` is the cheap W7 path; omitting the log runs the unit
+suite. Exit 1 when allowed-tree xpass > 0; D6 xpasses are printed in the
+counts and ignored. Verified RED on the W5.1 log: exit 1,
+`113 allowed-tree xpassed (121 total, 8 D6-excluded)`.
+
+`make xpass-check` is **not** wired (W7). No `Makefile` edit in W5.
+
+### Contract matrix (#276)
+
+| # | Contract | Layer | Scenario | Primary test |
+|---|----------|-------|----------|--------------|
+| H276a | Script exists | unit | happy | `tests/ci/test_xpass_check.py::test_script_exists` |
+| H276b | D6 path set covers the plan's test files | unit | happy | `test_d6_paths_cover_plan_test_files` |
+| H276c | Nodeid D6 classification (incl. params) | unit | happy / edge | `test_is_d6_nodeid` |
+| H276d | Log parse splits D6 vs allowed | unit | happy | `test_parse_xpass_log_splits_d6_and_allowed` |
+| H276e | Empty log is zero xpass | unit | edge | `test_parse_xpass_log_empty_is_zero` |
+| H276f | Allowed-tree xpass → exit 1 | unit | error | `test_check_xpass_fails_on_allowed_tree` / `test_main_from_log_exits_one_on_allowed_xpass` |
+| H276g | D6-only xpass → exit 0 | unit | edge | `test_check_xpass_ok_when_only_d6_xpasses` |
+| H276h | Zero xpass → exit 0 | unit | happy | `test_check_xpass_ok_when_zero_xpasses` |
+| H276i | Missing log file → exit 2 | unit | error | `test_main_from_log_missing_file_exits_two` |
+| H276j | `make xpass-check` is in the Make graph | integration | happy after W7 | `test_make_xpass_check_is_wired` (xfail until W7) |
+
+### W6 cleanup list (allowed-tree xpasses only)
+
+Remove `xfail(strict=False)` from these 113 nodeids. Keep the test body. Do
+not delete tests. Do not touch D6 files.
+
+`tests/agents/test_minimax_routing.py` (74):
+
+- `test_existing_curated_slug_resolution_is_unchanged` — 68 parametrized cases
+  (`anthropic/claude-haiku`, `anthropic/claude-opus`, `anthropic/claude-sonnet`,
+  `bedrock/byok`, `deepseek/deepseek-chat`, `deepseek/deepseek-flash`,
+  `deepseek/deepseek-pro`, `deepseek/deepseek-reasoner`, `google/gemini-flash`,
+  `google/gemini-pro`, `moonshotai/kimi-k2`, `nous/deepseek/deepseek-v4-flash`,
+  `openai/gpt-5.4`, `openai/gpt-codex-mini`, `openai/gpt-codex`, `openai/gpt-mini`,
+  `openai/gpt-pro`, `openai/gpt-terra`, `openai/gpt`, `openai/o3`,
+  `opencode-go/glm-5.1`, `opencode-go/kimi-k2`, `opencode/big-pickle`,
+  `opencode/claude-haiku`, `opencode/claude-opus`, `opencode/claude-sonnet`,
+  `opencode/gemini-flash`, `opencode/gemini-pro`, `opencode/gpt-5-nano`,
+  `opencode/gpt-5.4`, `opencode/gpt-codex-mini`, `opencode/gpt-codex`,
+  `opencode/gpt-mini`, `opencode/gpt-pro`, `opencode/gpt-terra`, `opencode/gpt`,
+  `opencode/kimi-k2`, `opencode/mimo-v2-pro-free`, `opencode/minimax-m2.5-free`,
+  `opencode/minimax-m2.5`, `openrouter/claude-haiku`, `openrouter/claude-opus`,
+  `openrouter/claude-sonnet`, `openrouter/deepseek-chat`,
+  `openrouter/deepseek-flash`, `openrouter/deepseek-pro`,
+  `openrouter/gemini-flash`, `openrouter/gemini-pro`, `openrouter/gpt-5.4`,
+  `openrouter/gpt-codex-mini`, `openrouter/gpt-codex`, `openrouter/gpt-mini`,
+  `openrouter/gpt-pro`, `openrouter/gpt-terra`, `openrouter/gpt`,
+  `openrouter/grok`, `openrouter/kimi-k2`, `openrouter/minimax-m2.5`,
+  `openrouter/o4-mini`, `tokenhub/deepseek-v4-flash`, `tokenhub/deepseek-v4-pro`,
+  `tokenhub/glm-5.2`, `tokenhub/hy3`, `tokenhub/kimi-k3`, `vertex/byok`,
+  `xai/grok-code-fast`, `xai/grok-fast`, `xai/grok`)
+- `test_minimax_missing_credential_fails_loud[minimax-minimax-m3]`
+- `test_minimax_missing_credential_fails_loud[minimax-unknown-model]`
+- `test_minimax_raw_passthrough_slug_resolves`
+- `test_minimax_routes_via_codex_with_singleton_env`
+- `test_minimax_routes_via_indexed_provider_pair`
+- `test_minimax_routes_via_opencode_with_singleton_env`
+
+`tests/agents/test_openai_compatible_gateways.py` (6):
+
+- `test_shared_helper_exposes_multi_provider_resolver`
+- `test_shared_multi_provider_resolver_drops_partial_pairs`
+- `test_shared_multi_provider_resolver_handles_indexed_pairs`
+- `test_shared_multi_provider_resolver_indexed_overrides_singleton`
+- `test_shared_multi_provider_resolver_preserves_index_gaps`
+- `test_shared_multi_provider_resolver_singleton_maps_to_default`
+
+`tests/agents/test_opencode_custom_provider.py` (5):
+
+- `test_opencode_emits_blocks_for_non_contiguous_indices`
+- `test_opencode_emits_provider_blocks_for_each_indexed_pair`
+- `test_opencode_indexed_wins_singleton_ignored`
+- `test_opencode_partial_indexed_pair_is_dropped`
+- `test_opencode_singleton_alone_emits_default_provider_block`
+
+`tests/cli/test_models_list_minimax.py` (3):
+
+- `test_mergecraft_models_list_minimax_row_does_not_leak_api_key`
+- `test_mergecraft_models_list_renders_minimax_row_with_credentials`
+- `test_mergecraft_models_list_renders_minimax_row_without_credentials`
+
+`tests/evidence/test_gate_actions.py` (15):
+
+- `test_disagreement_report_groups_by_lane_and_rule`
+- `test_disagreement_report_on_match_records_no_disagreement`
+- `test_enforce_mode_decision_differs_from_shadow_for_low_risk`
+- `test_every_outcome_maps_to_a_named_action`
+- `test_new_gates_default_to_shadow`
+- `test_numeric_score_never_appears_without_findings_and_decision`
+- `test_policy_changed_unread_file_maps_to_request_changes`
+- `test_policy_high_risk_migration_maps_to_require_human_review`
+- `test_policy_low_risk_passing_maps_to_auto_merge`
+- `test_policy_schema_failure_maps_to_block`
+- `test_policy_tool_loop_maps_to_require_more_tests`
+- `test_record_shadow_prediction_writes_to_disk`
+- `test_shadow_mode_records_prediction_without_blocking`
+- `test_unknown_action_in_policy_is_rejected`
+- `test_unrecognised_gate_mode_falls_back_to_shadow`
+
+`tests/tracing/instrumentation/test_emit_failure.py` (2):
+
+- `test_emit_failure_logs_a_warning`
+- `test_emit_failure_never_fails_the_run`
+
+`tests/utils/test_learnings_provenance.py` (8):
+
+- `test_approved_learnings_are_fenced_at_seed_time`
+- `test_entry_without_maintainer_provenance_is_quarantined`
+- `test_every_learning_entry_carries_provenance`
+- `test_fork_pr_injected_learning_text_promotes_nothing`
+- `test_influence_listing_names_seeded_entries`
+- `test_legacy_autopromote_available_as_optin`
+- `test_promotion_requires_explicit_approval_by_default`
+- `test_quarantined_entry_never_reaches_reviewer_prompt`
+
+### Acceptance (W5)
+
+- Inventory recorded (121 total / 113 allowed / 8 D6)
+- `scripts/check_xpass.py` exits 1 on the current allowed tree
+- Ratchet unit tests pass; Makefile wiring test xfail until W7
+- `make lint` + `make typecheck` clean; collection clean
+- No Makefile `xpass-check` target; not wired into `ci-static` / `make test`
+- No D6 path edits; no xfail promotions (W6)

--- a/scripts/check_type_ignores.py
+++ b/scripts/check_type_ignores.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fail when ``type: ignore`` / ``cast(`` in allowed src lack a one-line reason.
+
+Every ``type: ignore`` under ``src/mergecraft/`` (except morning-plan D6
+files) must be ``type: ignore[<code>]`` with a following em-dash (U+2014)
+reason on the same line. Every ``cast(`` call needs a ``#`` reason on the
+same line or the previous line. D6 files are counted then ignored.
+
+This ratchet exits 1 while allowed-tree sites lack a reason (W8 RED).
+W9 justifies or removes those sites.
+
+Module: scripts.check_type_ignores
+Depends: argparse, pathlib, re, sys, typing
+
+Exports:
+    D6_SRC_PATHS — morning-plan src files excluded from the fail condition.
+    is_d6_src — True when a repo-relative path is a D6 src file.
+    scan_tree — inventory ``type: ignore`` and ``cast(`` sites.
+    check_type_ignores — return 0 iff allowed-tree unjustified count is 0.
+    main — CLI entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple, TextIO
+
+REPO = Path(__file__).resolve().parents[1]
+MERGECRAFT_SRC = Path("src") / "mergecraft"
+
+# Morning-plan src files this program must not audit (D6). Inventory may
+# still count them; they do not fail the gate.
+D6_SRC_PATHS: frozenset[str] = frozenset(
+    {
+        "src/mergecraft/agents/_stream_consumer.py",
+        "src/mergecraft/agents/codex.py",
+        "src/mergecraft/agents/ensemble.py",
+        "src/mergecraft/agents/structured_handoff.py",
+        "src/mergecraft/analyzers/adapters.py",
+        "src/mergecraft/analyzers/parsers/osv_json.py",
+        "src/mergecraft/analyzers/scope.py",
+        "src/mergecraft/cli/auth_cmd.py",
+        "src/mergecraft/cli/gha_cmd.py",
+        "src/mergecraft/evals/live_run.py",
+        "src/mergecraft/mcp/check_runs.py",
+        "src/mergecraft/mcp/git.py",
+        "src/mergecraft/mcp/labels.py",
+        "src/mergecraft/mcp/server.py",
+        "src/mergecraft/mcp/upload.py",
+        "src/mergecraft/mcp/verdict.py",
+    }
+)
+
+_EM_DASH = "\u2014"
+_TYPE_IGNORE = re.compile(r"#\s*type:\s*ignore(?P<bracket>\[(?P<code>[^\]]*)\])?(?P<rest>.*)$")
+_CAST_CALL = re.compile(r"\bcast\s*\(")
+
+
+class Violation(NamedTuple):
+    """One unjustified ``type: ignore`` or ``cast(`` site."""
+
+    path: str
+    line_no: int
+    kind: str
+    detail: str
+
+    @property
+    def d6(self) -> bool:
+        """Return True when this site is on a D6-forbidden src path."""
+        return is_d6_src(self.path)
+
+
+class TypeIgnoreInventory(NamedTuple):
+    """Scanned ignore/cast sites plus D6 / allowed splits."""
+
+    violations: tuple[Violation, ...]
+    ignore_count: int
+    cast_count: int
+    d6_ignore_count: int
+    d6_cast_count: int
+
+    @property
+    def total_violations(self) -> int:
+        """Return the number of unjustified sites including D6."""
+        return len(self.violations)
+
+    @property
+    def d6_violations(self) -> tuple[Violation, ...]:
+        """Return unjustified sites on D6 paths (counted, not failing)."""
+        return tuple(item for item in self.violations if item.d6)
+
+    @property
+    def allowed_violations(self) -> tuple[Violation, ...]:
+        """Return unjustified sites this program must fix (W9)."""
+        return tuple(item for item in self.violations if not item.d6)
+
+    @property
+    def d6_count(self) -> int:
+        """Return the D6-excluded unjustified count."""
+        return len(self.d6_violations)
+
+    @property
+    def allowed_count(self) -> int:
+        """Return the allowed-tree unjustified count (the fail condition)."""
+        return len(self.allowed_violations)
+
+    @property
+    def allowed_ignore_count(self) -> int:
+        """Return allowed-tree ignore sites (justified or not)."""
+        return self.ignore_count - self.d6_ignore_count
+
+    @property
+    def allowed_cast_count(self) -> int:
+        """Return allowed-tree cast sites (justified or not)."""
+        return self.cast_count - self.d6_cast_count
+
+
+def is_d6_src(rel_path: str) -> bool:
+    """Return True when ``rel_path`` is a D6-forbidden src file.
+
+    Args:
+        rel_path: Repo-relative posix path.
+
+    Returns:
+        True when the path is in ``D6_SRC_PATHS``.
+    """
+    return rel_path.replace("\\", "/") in D6_SRC_PATHS
+
+
+def _rel(repo_root: Path, path: Path) -> str:
+    """Return repo-relative posix path for ``path``."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _code_before_comment(line: str) -> str:
+    """Return the code portion of ``line`` (before a ``#`` comment)."""
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return ""
+    if "#" not in line:
+        return line
+    return line.split("#", 1)[0]
+
+
+def _inline_or_full_line_comment(line: str) -> str:
+    """Return the ``#`` comment body of ``line``, or empty if none."""
+    stripped = line.strip()
+    if stripped.startswith("#"):
+        return stripped[1:].strip()
+    if "#" not in line:
+        return ""
+    return line.split("#", 1)[1].strip()
+
+
+def _has_hash_reason(line: str) -> bool:
+    """Return True when ``line`` carries a non-empty ``#`` comment body."""
+    return _inline_or_full_line_comment(line) != ""
+
+
+def _ignore_detail(match: re.Match[str]) -> str | None:
+    """Return a violation detail for a ``type: ignore``, or None if justified."""
+    code = (match.group("code") or "").strip()
+    if match.group("bracket") is None or not code:
+        return "missing error code"
+    rest = match.group("rest") or ""
+    if _EM_DASH not in rest:
+        return f"missing {_EM_DASH} reason"
+    if rest.split(_EM_DASH, 1)[1].strip() == "":
+        return f"missing {_EM_DASH} reason"
+    return None
+
+
+def _scan_lines(rel_path: str, lines: list[str]) -> tuple[list[Violation], int, int]:
+    """Scan ``lines`` of one file. Return (violations, ignore_count, cast_count)."""
+    violations: list[Violation] = []
+    ignore_count = 0
+    cast_count = 0
+    for line_no, line in enumerate(lines, start=1):
+        ignore_match = _TYPE_IGNORE.search(line)
+        if ignore_match is not None:
+            ignore_count += 1
+            detail = _ignore_detail(ignore_match)
+            if detail is not None:
+                violations.append(
+                    Violation(
+                        path=rel_path,
+                        line_no=line_no,
+                        kind="ignore",
+                        detail=detail,
+                    )
+                )
+        if _CAST_CALL.search(_code_before_comment(line)):
+            cast_count += 1
+            previous = lines[line_no - 2] if line_no > 1 else ""
+            if not _has_hash_reason(line) and not _has_hash_reason(previous):
+                violations.append(
+                    Violation(
+                        path=rel_path,
+                        line_no=line_no,
+                        kind="cast",
+                        detail="missing # reason",
+                    )
+                )
+    return violations, ignore_count, cast_count
+
+
+def scan_tree(repo_root: Path) -> TypeIgnoreInventory:
+    """Inventory ``type: ignore`` and ``cast(`` sites under ``src/mergecraft/``.
+
+    Args:
+        repo_root: Repository root containing ``src/mergecraft/``.
+
+    Returns:
+        Inventory of sites and unjustified violations, D6-tagged.
+
+    Raises:
+        FileNotFoundError: When ``src/mergecraft`` is missing.
+        OSError: When a source file cannot be read.
+    """
+    src = repo_root / MERGECRAFT_SRC
+    if not src.is_dir():
+        msg = f"missing source tree: {src}"
+        raise FileNotFoundError(msg)
+
+    violations: list[Violation] = []
+    ignore_count = 0
+    cast_count = 0
+    d6_ignore_count = 0
+    d6_cast_count = 0
+    for path in sorted(src.rglob("*.py")):
+        rel_path = _rel(repo_root, path)
+        text = path.read_text(encoding="utf-8")
+        file_violations, file_ignores, file_casts = _scan_lines(rel_path, text.splitlines())
+        violations.extend(file_violations)
+        ignore_count += file_ignores
+        cast_count += file_casts
+        if is_d6_src(rel_path):
+            d6_ignore_count += file_ignores
+            d6_cast_count += file_casts
+    return TypeIgnoreInventory(
+        violations=tuple(violations),
+        ignore_count=ignore_count,
+        cast_count=cast_count,
+        d6_ignore_count=d6_ignore_count,
+        d6_cast_count=d6_cast_count,
+    )
+
+
+def check_type_ignores(inventory: TypeIgnoreInventory, *, stream: TextIO | None = None) -> int:
+    """Return 0 when allowed-tree unjustified count is 0; 1 otherwise.
+
+    Args:
+        inventory: Scanned ignore/cast set.
+        stream: Output stream (default ``sys.stderr``).
+
+    Returns:
+        Process exit code (0 ok, 1 allowed-tree unjustified sites remain).
+    """
+    out: TextIO = sys.stderr if stream is None else stream
+    allowed = inventory.allowed_violations
+    summary = (
+        f"{inventory.allowed_count} allowed-tree unjustified "
+        f"({inventory.ignore_count} ignores, {inventory.cast_count} casts; "
+        f"{inventory.d6_count} D6-excluded violations)"
+    )
+    if not allowed:
+        print(f"type-ignore-check OK: {summary}", file=out)
+        return 0
+
+    print(f"type-ignore-check FAILED: {summary}", file=out)
+    for item in allowed:
+        print(f"  {item.path}:{item.line_no} {item.kind} {item.detail}", file=out)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: scan ``src/mergecraft/`` and ratchet missing reasons.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        0 when allowed-tree is clean; 1 when unjustified sites remain; 2 on IO error.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO,
+        help="Repo root containing src/mergecraft (default: parent of scripts/)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        inventory = scan_tree(Path(args.repo_root))
+    except OSError as exc:
+        print(f"type-ignore-check error: {exc}", file=sys.stderr)
+        return 2
+
+    return check_type_ignores(inventory)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_xpass.py
+++ b/scripts/check_xpass.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Fail when pytest reports unexpected xpasses on the allowed test tree.
+
+``xfail(strict=False)`` tests that pass (XPASS) are leftover RED markers.
+This ratchet exits 1 when any XPASS remains outside the morning-plan D6
+exclusion list. D6 xpasses are counted and printed, then ignored.
+
+Parses pytest ``-rX`` / ``-ra`` terminal output (``XPASS nodeid - reason``
+lines). Pass ``--from-log`` for a cheap post-test parse (W7); with no log,
+runs the unit suite so the gate is RED today while allowed-tree xpasses exist.
+
+Module: scripts.check_xpass
+Depends: argparse, pathlib, subprocess, sys, typing
+
+Exports:
+    D6_TEST_PATHS — morning-plan test files excluded from the fail condition.
+    is_d6_nodeid — True when a pytest nodeid lives on a D6 path.
+    parse_xpass_log — extract XPASS records from pytest terminal output.
+    check_xpass — return 0 iff allowed-tree xpass count is 0.
+    main — CLI entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple, TextIO
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Morning-plan test files this program must not clean up (D6). Inventory may
+# still count them; they do not fail the gate.
+D6_TEST_PATHS: frozenset[str] = frozenset(
+    {
+        "tests/agents/test_codex_custom_provider.py",
+        "tests/analyzers/test_scope.py",
+        "tests/cli/test_auth_logfire_cmd.py",
+        "tests/cli/test_gha_cmd.py",
+        "tests/cli/test_gha_failure_outputs.py",
+        "tests/evals/test_live_context.py",
+        "tests/mcp/test_check_runs.py",
+        "tests/mcp/test_git_tool.py",
+        "tests/mcp/test_labels.py",
+        "tests/mcp/test_submit_review_verdict.py",
+        "tests/mcp/test_upload.py",
+        "tests/review/test_terminal_verdict_policy.py",
+    }
+)
+
+_PYTEST_SELECTOR = ("tests", "-m", "not integration", "--strict-markers", "-q", "--tb=no", "-rX")
+
+
+class XpassRecord(NamedTuple):
+    """One pytest XPASS line."""
+
+    nodeid: str
+    reason: str
+
+    @property
+    def d6(self) -> bool:
+        """Return True when this xpass is on a D6-forbidden test path."""
+        return is_d6_nodeid(self.nodeid)
+
+
+class XpassInventory(NamedTuple):
+    """Parsed xpass set plus D6 / allowed splits."""
+
+    records: tuple[XpassRecord, ...]
+
+    @property
+    def total(self) -> int:
+        """Return the number of XPASS lines parsed."""
+        return len(self.records)
+
+    @property
+    def d6_records(self) -> tuple[XpassRecord, ...]:
+        """Return xpasses on D6 paths (counted, not failing)."""
+        return tuple(record for record in self.records if record.d6)
+
+    @property
+    def allowed_records(self) -> tuple[XpassRecord, ...]:
+        """Return xpasses this program is allowed to promote (W6)."""
+        return tuple(record for record in self.records if not record.d6)
+
+    @property
+    def d6_count(self) -> int:
+        """Return the D6-excluded xpass count."""
+        return len(self.d6_records)
+
+    @property
+    def allowed_count(self) -> int:
+        """Return the allowed-tree xpass count (the fail condition)."""
+        return len(self.allowed_records)
+
+
+def is_d6_nodeid(nodeid: str) -> bool:
+    """Return True when ``nodeid`` belongs to a D6-forbidden test file.
+
+    Args:
+        nodeid: Pytest nodeid (``path::test`` or ``path::test[param]``).
+
+    Returns:
+        True when the path component is in ``D6_TEST_PATHS``.
+    """
+    path = nodeid.split("::", 1)[0].replace("\\", "/")
+    return path in D6_TEST_PATHS
+
+
+def parse_xpass_log(text: str) -> XpassInventory:
+    """Extract XPASS records from pytest ``-rX`` / ``-ra`` terminal output.
+
+    Args:
+        text: Captured pytest stdout+stderr.
+
+    Returns:
+        Inventory of every ``XPASS`` line, D6-tagged.
+    """
+    records: list[XpassRecord] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("XPASS "):
+            continue
+        rest = line[len("XPASS ") :]
+        nodeid, sep, reason = rest.partition(" - ")
+        nodeid = nodeid.strip()
+        if not nodeid:
+            continue
+        records.append(XpassRecord(nodeid=nodeid, reason=reason if sep else ""))
+    return XpassInventory(records=tuple(records))
+
+
+def check_xpass(inventory: XpassInventory, *, stream: TextIO | None = None) -> int:
+    """Return 0 when allowed-tree xpass count is 0; 1 otherwise.
+
+    Args:
+        inventory: Parsed xpass set.
+        stream: Output stream (default ``sys.stderr``).
+
+    Returns:
+        Process exit code (0 ok, 1 allowed-tree xpasses remain).
+    """
+    out: TextIO = sys.stderr if stream is None else stream
+    allowed = inventory.allowed_records
+    summary = (
+        f"{inventory.allowed_count} allowed-tree xpassed "
+        f"({inventory.total} total, {inventory.d6_count} D6-excluded)"
+    )
+    if not allowed:
+        print(f"xpass-check OK: {summary}", file=out)
+        return 0
+
+    print(f"xpass-check FAILED: {summary}", file=out)
+    for record in allowed:
+        print(f"  {record.nodeid}", file=out)
+    return 1
+
+
+def _run_pytest(repo_root: Path) -> str:
+    """Run the unit suite and return combined stdout+stderr."""
+    cmd = [sys.executable, "-m", "pytest", *_PYTEST_SELECTOR]
+    completed = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return (completed.stdout or "") + (completed.stderr or "")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: parse a pytest log or run the unit suite, then ratchet.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        0 when allowed-tree xpass is 0; 1 when xpasses remain; 2 on usage/IO error.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--from-log",
+        metavar="PATH",
+        help="Pytest terminal log to parse ('-' = stdin). Omit to run the unit suite.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO,
+        help="Repo root when running pytest (default: parent of scripts/)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.from_log is None:
+            text = _run_pytest(Path(args.repo_root))
+        elif args.from_log == "-":
+            text = sys.stdin.read()
+        else:
+            text = Path(args.from_log).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"xpass-check error: {exc}", file=sys.stderr)
+        return 2
+
+    inventory = parse_xpass_log(text)
+    return check_xpass(inventory)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_xpass.py
+++ b/scripts/check_xpass.py
@@ -6,11 +6,11 @@ This ratchet exits 1 when any XPASS remains outside the morning-plan D6
 exclusion list. D6 xpasses are counted and printed, then ignored.
 
 Parses pytest ``-rX`` / ``-ra`` terminal output (``XPASS nodeid - reason``
-lines). Pass ``--from-log`` for a cheap post-test parse (W7); with no log,
-runs the unit suite so the gate is RED today while allowed-tree xpasses exist.
+lines) from a log file passed via ``--from-log``. The live gate runs inside
+the pytest session via the conftest ``pytest_sessionfinish`` hook.
 
 Module: scripts.check_xpass
-Depends: argparse, pathlib, subprocess, sys, typing
+Depends: argparse, pathlib, sys, typing
 
 Exports:
     D6_TEST_PATHS — morning-plan test files excluded from the fail condition.
@@ -23,7 +23,6 @@ Exports:
 from __future__ import annotations
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 from typing import NamedTuple, TextIO
@@ -48,8 +47,6 @@ D6_TEST_PATHS: frozenset[str] = frozenset(
         "tests/review/test_terminal_verdict_policy.py",
     }
 )
-
-_PYTEST_SELECTOR = ("tests", "-m", "not integration", "--strict-markers", "-q", "--tb=no", "-rX")
 
 
 class XpassRecord(NamedTuple):
@@ -157,21 +154,8 @@ def check_xpass(inventory: XpassInventory, *, stream: TextIO | None = None) -> i
     return 1
 
 
-def _run_pytest(repo_root: Path) -> str:
-    """Run the unit suite and return combined stdout+stderr."""
-    cmd = [sys.executable, "-m", "pytest", *_PYTEST_SELECTOR]
-    completed = subprocess.run(
-        cmd,
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    return (completed.stdout or "") + (completed.stderr or "")
-
-
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry: parse a pytest log or run the unit suite, then ratchet.
+    """CLI entry: parse a pytest log file, then ratchet.
 
     Args:
         argv: Argument vector (defaults to ``sys.argv[1:]``).
@@ -183,20 +167,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--from-log",
         metavar="PATH",
-        help="Pytest terminal log to parse ('-' = stdin). Omit to run the unit suite.",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=REPO,
-        help="Repo root when running pytest (default: parent of scripts/)",
+        required=True,
+        help="Pytest terminal log to parse ('-' = stdin).",
     )
     args = parser.parse_args(argv)
 
     try:
-        if args.from_log is None:
-            text = _run_pytest(Path(args.repo_root))
-        elif args.from_log == "-":
+        if args.from_log == "-":
             text = sys.stdin.read()
         else:
             text = Path(args.from_log).read_text(encoding="utf-8")

--- a/scripts/run_live_integration.py
+++ b/scripts/run_live_integration.py
@@ -28,6 +28,7 @@ LIVE_PYTEST_MARKER = "live"
 
 def main(argv: list[str] | None = None) -> int:
     _ = argv
+    os.environ.setdefault("MERGECRAFT_LIVE", "1")
     marker = os.environ.get("MERGECRAFT_LIVE_PYTEST_MARKER", LIVE_PYTEST_MARKER)
     if marker != LIVE_PYTEST_MARKER:
         print(

--- a/src/mergecraft/action/inputs.py
+++ b/src/mergecraft/action/inputs.py
@@ -181,7 +181,7 @@ def resolve_setup_failure_policy() -> SetupFailurePolicy | None:
     if candidate in _SETUP_FAILURE_POLICY_VALUES:
         # Safe cast: ``_SETUP_FAILURE_POLICY_VALUES`` is a frozenset of literal
         # values whose type is exactly ``SetupFailurePolicy``.
-        return candidate  # type: ignore[return-value]
+        return candidate  # type: ignore[return-value]  # — candidate verified against _SETUP_FAILURE_POLICY_VALUES above
     msg = (
         f"unknown setup_failure_policy: {raw!r} "
         f"(expected one of {sorted(_SETUP_FAILURE_POLICY_VALUES)})"

--- a/src/mergecraft/agents/__init__.py
+++ b/src/mergecraft/agents/__init__.py
@@ -43,7 +43,7 @@ class _AgentsTable(Mapping[str, AgentImpl]):
         return len(_agent_table())
 
 
-agents: dict[str, AgentImpl] = _AgentsTable()  # type: ignore[assignment]
+agents: dict[str, AgentImpl] = _AgentsTable()  # type: ignore[assignment]  # — _AgentsTable is a MutableMapping; declared as dict for the public API surface
 
 
 def resolve_agent(agent_id: AgentId | str) -> Agent:

--- a/src/mergecraft/agents/harness_render.py
+++ b/src/mergecraft/agents/harness_render.py
@@ -329,7 +329,7 @@ def render_agents(
     ctx: AgentRunContext | ToolContext,
 ) -> HarnessRenderResult:
     """Project ``selected`` registry bindings into ``harness`` config (D2)."""
-    harness_name: HarnessName = harness  # type: ignore[assignment]
+    harness_name: HarnessName = harness  # type: ignore[assignment]  # — harness is HarnessName | str; callers pass a valid HarnessName literal
     bindings = _resolve_selected_bindings(registry, selected)
     settings = _settings_for_ctx(ctx)
 

--- a/src/mergecraft/agents/verifier.py
+++ b/src/mergecraft/agents/verifier.py
@@ -157,7 +157,7 @@ def verifier_denied_tool_names(
         ctx,
         VERIFIER_ALLOWED_TOOL_CLASSES,
         role="verifier",
-        output_schema=output_schema,  # type: ignore[arg-type]
+        output_schema=output_schema,  # type: ignore[arg-type]  # — output_schema is dict[str, Any] | None; callee accepts None-narrowed variant
     )
 
 

--- a/src/mergecraft/analyzers/agentsec/policy.py
+++ b/src/mergecraft/analyzers/agentsec/policy.py
@@ -97,7 +97,7 @@ def _load_rule_file(path: Path) -> list[NativeRule]:
         NativeRule(
             rule_id=rule_id,
             source_path=path.name,
-            kind=kind,  # type: ignore[arg-type]
+            kind=kind,  # type: ignore[arg-type]  # — kind is str from YAML; NativeRule.kind is a Literal narrowing validated by the rule loader
             severity=str(raw.get("severity") or "Major"),
             confidence=str(raw.get("confidence") or "likely"),
             message=str(raw.get("message") or rule_id),

--- a/src/mergecraft/analyzers/catalog_docs.py
+++ b/src/mergecraft/analyzers/catalog_docs.py
@@ -155,8 +155,8 @@ def _shell_trust_matrix_lines() -> list[str]:
 
     def _selected(*, tier: str, mode: str, shell: str) -> list[str]:
         """Replay the pipeline's own skip chain for one cell."""
-        effective = resolve_effective_analyzers_mode(mode=mode, tier=tier)  # type: ignore[arg-type]
-        selection_tier = resolve_selection_tier(mode=effective, tier=tier)  # type: ignore[arg-type]
+        effective = resolve_effective_analyzers_mode(mode=mode, tier=tier)  # type: ignore[arg-type]  # — mode/tier are str loop vars; callee expects Literal narrowings
+        selection_tier = resolve_selection_tier(mode=effective, tier=tier)  # type: ignore[arg-type]  # — effective/tier are str; callee expects Literal narrowings
         chosen: list[str] = []
         for manifest in manifests:
             if evaluate_manifest_for_tier(manifest=manifest, tier=selection_tier).skipped:

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -154,7 +154,11 @@ def _run_ast_grep(
     except json.JSONDecodeError as exc:
         msg = f"ast-grep produced unparsable output ({rule_path.name}): {exc}"
         raise _ExtractionFailed(msg) from exc
-    return cast("list[dict[str, Any]]", matches)
+    return (
+        cast(  # json.loads of validated ast-grep output; confirmed to be list[dict] by the caller
+            "list[dict[str, Any]]", matches
+        )
+    )
 
 
 def _find_declarations_batch(

--- a/src/mergecraft/analyzers/lockfile.py
+++ b/src/mergecraft/analyzers/lockfile.py
@@ -44,7 +44,7 @@ def _coerce_entry(raw: dict[str, Any]) -> LockEntry:
     return LockEntry(
         tool_id=str(raw["tool_id"]),
         version=str(raw["version"]),
-        mode=str(raw.get("mode", "managed")),  # type: ignore[arg-type]
+        mode=str(raw.get("mode", "managed")),  # type: ignore[arg-type]  # — mode is str from JSON; LockEntry.mode is a Literal narrowing enforced by the schema
         source=str(raw.get("source", "unknown")),
         sha256=str(raw["sha256"]),
     )

--- a/src/mergecraft/analyzers/parsers/trivy_json.py
+++ b/src/mergecraft/analyzers/parsers/trivy_json.py
@@ -35,7 +35,9 @@ def loads_trivy_object(raw: str) -> dict[str, Any]:
         except json.JSONDecodeError:
             continue
         if isinstance(payload, dict):
-            return cast("dict[str, Any]", payload)
+            return cast(  # json.loads returns Any; isinstance(payload, dict) confirmed above
+                "dict[str, Any]", payload
+            )
     msg = "trivy JSON output must be an object"
     raise ValueError(msg)
 

--- a/src/mergecraft/analyzers/redact.py
+++ b/src/mergecraft/analyzers/redact.py
@@ -97,7 +97,7 @@ def install_loguru_redaction_filter() -> None:
     def _patcher(record: dict[str, object]) -> None:
         record["message"] = redact_log_message(str(record["message"]))
 
-    logger.configure(patcher=_patcher)  # type: ignore[arg-type]
+    logger.configure(patcher=_patcher)  # type: ignore[arg-type]  # — loguru patcher stub is overly restrictive; _patcher(record) signature is compatible at runtime
 
 
 def assert_no_canary(text: str, canary: str) -> None:

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -329,7 +329,7 @@ def resolve_analyzers_mode(raw: str | None) -> AnalyzersMode:
     if not value:
         return "auto"
     if value in ANALYZERS_MODES:
-        return value  # type: ignore[return-value]
+        return value  # type: ignore[return-value]  # — value verified against ANALYZERS_MODES above
     logger.warning(
         "unrecognised analyzers input {!r}; falling back to the more restrictive {!r} "
         "(valid values: {})",

--- a/src/mergecraft/ci/normalize.py
+++ b/src/mergecraft/ci/normalize.py
@@ -62,7 +62,9 @@ def _coerce_artifacts(raw: RawFailure) -> list[str]:
 
 def normalize_failure(raw: dict[str, Any]) -> NormalizedFailure:
     """Normalize a raw provider failure to the K1.4 field table with ingest redaction."""
-    typed = cast("RawFailure", raw)
+    typed = cast(  # raw is dict[str, Any]; cast to TypedDict for typed field access
+        "RawFailure", raw
+    )
     job = str(raw.get("job_name") or raw.get("job") or "unknown")
     step = str(raw.get("step_name") or raw.get("step") or "unknown")
     command = redact_secrets(str(raw.get("command") or ""))

--- a/src/mergecraft/ci/providers/__init__.py
+++ b/src/mergecraft/ci/providers/__init__.py
@@ -35,10 +35,18 @@ def _build_registry() -> dict[str, PipelineProvider]:
     from mergecraft.ci.providers.gitlab import GitLabCIProvider
 
     return {
-        "github_actions": cast("PipelineProvider", GitHubActionsProvider()),
-        "circleci": cast("PipelineProvider", CircleCIProvider()),
-        "gitlab": cast("PipelineProvider", GitLabCIProvider()),
-        "azure": cast("PipelineProvider", AzurePipelinesProvider()),
+        "github_actions": cast(  # concrete provider implements PipelineProvider; cast removes subclass widening
+            "PipelineProvider", GitHubActionsProvider()
+        ),
+        "circleci": cast(  # concrete provider implements PipelineProvider; cast removes subclass widening
+            "PipelineProvider", CircleCIProvider()
+        ),
+        "gitlab": cast(  # concrete provider implements PipelineProvider; cast removes subclass widening
+            "PipelineProvider", GitLabCIProvider()
+        ),
+        "azure": cast(  # concrete provider implements PipelineProvider; cast removes subclass widening
+            "PipelineProvider", AzurePipelinesProvider()
+        ),
     }
 
 

--- a/src/mergecraft/classify/blast_radius.py
+++ b/src/mergecraft/classify/blast_radius.py
@@ -177,7 +177,9 @@ def _merged_rules(rule_set: RuleSet | None) -> dict[Category, dict[str, object]]
         category: dict(values) for category, values in DEFAULT_RULE_SET.items()
     }
     if rule_set:
-        overrides = cast("dict[str, RuleOverride]", rule_set)
+        overrides = cast(  # rule_set is RuleSet = dict[str, RuleOverride] | None; None excluded by enclosing if
+            "dict[str, RuleOverride]", rule_set
+        )
         for raw_category, override in overrides.items():
             if raw_category not in DEFAULT_RULE_SET:
                 continue
@@ -205,7 +207,9 @@ def classify_blast_radius(
     rules = _merged_rules(rule_set)
 
     lanes: list[Lane] = [
-        cast("Lane", rules[category]["lane"])
+        cast(  # rules values are Lane literals set by DEFAULT_RULE_SET; dict access returns object
+            "Lane", rules[category]["lane"]
+        )
         for category in rule_categories
         if "lane" in rules[category]
     ]

--- a/src/mergecraft/cli/eval_cmd.py
+++ b/src/mergecraft/cli/eval_cmd.py
@@ -152,7 +152,7 @@ def _resolve_synthetic_provenance(
         source_field="eval_bank",
         author_login=author,
         author_association="OWNER",
-        trust_tier=trust_tier,  # type: ignore[arg-type]
+        trust_tier=trust_tier,  # type: ignore[arg-type]  # — trust_tier is str; callee expects TrustTier literal narrowing
         timestamp=datetime.now(UTC),
     )
 

--- a/src/mergecraft/cli/mcp_cmd.py
+++ b/src/mergecraft/cli/mcp_cmd.py
@@ -120,7 +120,7 @@ def serve_cmd(
 
         listen_port = port if port is not None else _read_env_port() or _select_port()
         endpoint = _role_endpoint(
-            role.strip().lower()  # type: ignore[arg-type]
+            role.strip().lower()  # type: ignore[arg-type]  # — role.strip().lower() is str; callee expects Literal["orchestrator","reviewer","verifier"]
             if role.strip().lower() in {"orchestrator", "reviewer", "verifier"}
             else "reviewer"
         )

--- a/src/mergecraft/cli/mcp_serve.py
+++ b/src/mergecraft/cli/mcp_serve.py
@@ -48,7 +48,7 @@ def _parse_role(role: str) -> ServeRole:
     if key not in {"orchestrator", "reviewer", "verifier"}:
         msg = f"unknown role {role!r} (expected orchestrator, reviewer, or verifier)"
         raise ValueError(msg)
-    return key  # type: ignore[return-value]
+    return key  # type: ignore[return-value]  # — key verified against {"orchestrator","reviewer","verifier"} above
 
 
 def build_mcp_tool_context(
@@ -107,7 +107,7 @@ def build_mcp_tool_context(
         auto_merge_enabled=False,
         static_checks_enabled=trust_tier == "trusted",
         analyzers_mode="auto",
-        trust_tier=trust_tier,  # type: ignore[arg-type]
+        trust_tier=trust_tier,  # type: ignore[arg-type]  # — trust_tier is TrustTier; ToolContext.trust_tier field expects str supertype
         analyzers_settings_enabled=settings.analyzers.enabled,
         xrepo=XrepoConfig(mode="explicit", read=[], write=[]),
     )

--- a/src/mergecraft/cli/profiles.py
+++ b/src/mergecraft/cli/profiles.py
@@ -60,7 +60,7 @@ def parse_profile_name(raw: str | None) -> ProfileName | None:
     if key not in _PROFILE_NAMES:
         msg = f"unknown profile {raw!r} (expected one of: fast, deep, security)"
         raise ValueError(msg)
-    return key  # type: ignore[return-value]
+    return key  # type: ignore[return-value]  # — key verified against _PROFILE_NAMES above
 
 
 def resolve_profile(name: str | None) -> ReviewProfile | None:

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -776,6 +776,6 @@ def parse_cli_trust_override(raw: str | None) -> CliTrustOverride | None:
     if not value:
         return None
     if value in {"trusted", "untrusted"}:
-        return value  # type: ignore[return-value]
+        return value  # type: ignore[return-value]  # — value verified against {"trusted","untrusted"} above
     msg = f"invalid --trust value: {raw!r} (expected trusted or untrusted)"
     raise ValueError(msg)

--- a/src/mergecraft/context/call_graph.py
+++ b/src/mergecraft/context/call_graph.py
@@ -47,7 +47,9 @@ def build_call_graph(
     if cache is not None:
         cached = cache.get(tree_sha)
         if cached is not None:
-            return cast("CallGraph", cached)
+            return cast(  # cache stores CallGraph values; Any return type from cache.get narrows back to concrete type
+                "CallGraph", cached
+            )
 
     edges: list[CallEdge] = []
     for rel_path in git_ls_tree_paths(repo_root, tree_sha, suffix=_PYTHON_SUFFIX):

--- a/src/mergecraft/context/repo_map.py
+++ b/src/mergecraft/context/repo_map.py
@@ -57,7 +57,9 @@ def build_repo_map(
     if cache is not None:
         cached = cache.get(tree_sha)
         if cached is not None:
-            return cast("RepoMap", cached)
+            return cast(  # cache stores RepoMap values; Any return type from cache.get narrows back to concrete type
+                "RepoMap", cached
+            )
 
     repo_map = RepoMap(
         packages=_index_packages(repo_root),

--- a/src/mergecraft/context/symbol_index.py
+++ b/src/mergecraft/context/symbol_index.py
@@ -56,7 +56,9 @@ def index_symbols(
     if cache is not None:
         cached = cache.get(blob_sha)
         if cached is not None:
-            return cast("SymbolIndexResult", cached)
+            return cast(  # cache stores SymbolIndexResult values; Any return type from cache.get narrows back to concrete type
+                "SymbolIndexResult", cached
+            )
 
     if source is None:
         source = read_bounded_text(repo_root / rel_path)

--- a/src/mergecraft/evidence/emit.py
+++ b/src/mergecraft/evidence/emit.py
@@ -56,7 +56,7 @@ def write_packet_from_sources(
     callers should prefer this when the source data is already in hand
     and only the artifact is needed.
     """
-    packet = build_packet(**build_kwargs)  # type: ignore[arg-type]
+    packet = build_packet(**build_kwargs)  # type: ignore[arg-type]  # — build_kwargs matches build_packet signature; TypedDict ** spread not fully supported by mypy
     return write_packet(packet, output_path=output_path)
 
 
@@ -67,7 +67,9 @@ def load_packet(path: Path) -> dict[str, Any]:
     the caller's job (the emitter does not validate the round-trip — the
     separate tests at ``tests/evidence/test_packet_round_trip.py`` do).
     """
-    return cast("dict[str, Any]", json.loads(Path(path).read_text(encoding="utf-8")))
+    return cast(  # json.loads returns Any; packet files are always JSON objects
+        "dict[str, Any]", json.loads(Path(path).read_text(encoding="utf-8"))
+    )
 
 
 __all__ = ["load_packet", "write_packet", "write_packet_from_sources"]

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -73,7 +73,7 @@ from mergecraft.evidence.trajectory import TrajectoryRecord
 PACKET_SCHEMA_VERSION = "1.7.0"
 
 
-class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]
+class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]  # — FieldInfo.__init_subclass__ is not typed in pydantic stubs; subclassing is intentional
     """``FieldInfo`` whose ``default`` advertises the pinned version while the
     validator still treats the field as required.
 
@@ -221,7 +221,7 @@ class MergeEvidencePacket(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: str = _pinned_version_field()  # type: ignore[assignment]
+    schema_version: str = _pinned_version_field()  # type: ignore[assignment]  # — _pinned_version_field() returns FieldInfo; Pydantic resolves it to str at model-build time
     change_id: str
     agent: AgentMetadata
     files_changed: list[str]

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -196,7 +196,7 @@ def _first_runnable_in_chain(chain: list[str]) -> str:
     return pick_runnable_slug_from_chain(chain, allow_fallback=allow)
 
 
-_first_runnable_in_chain.allow_fallback = True  # type: ignore[attr-defined]
+_first_runnable_in_chain.allow_fallback = True  # type: ignore[attr-defined]  # — allow_fallback is a runtime attribute added to the function object for chain control
 
 
 def _payload_to_ctx(payload: dict[str, Any]) -> ResolvedPayload:
@@ -632,7 +632,7 @@ async def _assemble_model_chain(ctx: RunContext) -> None:
     selected_slug: str | None
 
     if use_model_chain:
-        _first_runnable_in_chain.allow_fallback = settings.allow_fallback  # type: ignore[attr-defined]
+        _first_runnable_in_chain.allow_fallback = settings.allow_fallback  # type: ignore[attr-defined]  # — allow_fallback is a runtime attribute added to the function object for chain control
         selected_slug = _first_runnable_in_chain(chain_for_decision)
         if not selected_slug:
             msg = "no runnable model slug in chain — configure credentials for at least one entry"

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -54,7 +54,7 @@ def run_analyzers_tool(ctx: ToolContext):
         run_state = run_analyzer_pipeline(
             repo_root=repo_root,
             changed_files=changed,
-            tier=_resolve_tier(ctx),  # type: ignore[arg-type]
+            tier=_resolve_tier(ctx),  # type: ignore[arg-type]  # — _resolve_tier returns str; run_analyzer_pipeline expects AnalyzerTier literal
             diff_text=diff_text,
             inline_budget=settings.inline_budget,
             offline=offline,

--- a/src/mergecraft/mcp/verification.py
+++ b/src/mergecraft/mcp/verification.py
@@ -274,7 +274,7 @@ def verify_agent_findings_tool(ctx: ToolContext):
             rule_id="agent:draft",
             dedupe=True,
             repo_root=repo_root,
-            trust_tier=trust,  # type: ignore[arg-type]
+            trust_tier=trust,  # type: ignore[arg-type]  # — trust is str; callee expects TrustTier literal narrowing
         )
         stored: dict[str, dict[str, Any]] = {}
         for item in ctx.tool_state.agent_findings:

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -737,9 +737,9 @@ async def _run_agent_review(
             ],
             # D7 — untrusted CLI sources must not run repo-authored commands,
             # including Makefile-discovery fallback in ``plan_checks``.
-            static_checks_enabled=allow_repo_command_overrides(trust_tier),  # type: ignore[arg-type]
+            static_checks_enabled=allow_repo_command_overrides(trust_tier),  # type: ignore[arg-type]  # — trust_tier is str | None here; allow_repo_command_overrides expects TrustTier literal
             analyzers_mode="auto",
-            trust_tier=trust_tier,  # type: ignore[arg-type]
+            trust_tier=trust_tier,  # type: ignore[arg-type]  # — trust_tier is str | None; callee expects TrustTier literal narrowing
             analyzers_settings_enabled=settings.analyzers.enabled,
             suggest_eval_add=False,
             # Carried so the evidence packet can attribute findings to the

--- a/src/mergecraft/prep/node.py
+++ b/src/mergecraft/prep/node.py
@@ -34,11 +34,11 @@ def _detect_package_manager(cwd: Path) -> NodePackageManager:
             if isinstance(pm, str):
                 name = pm.split("@")[0].strip().lower()
                 if name in {"npm", "pnpm", "yarn", "bun", "deno"}:
-                    return name  # type: ignore[return-value]
+                    return name  # type: ignore[return-value]  # — name verified against the PackageManager literal set above
             if isinstance(pm, dict):
                 name = str(pm.get("name", "")).split("@")[0].strip().lower()
                 if name in {"npm", "pnpm", "yarn", "bun", "deno"}:
-                    return name  # type: ignore[return-value]
+                    return name  # type: ignore[return-value]  # — name verified against the PackageManager literal set above
         except OSError, ValueError, TypeError:
             pass
     for lockfile, manager in _LOCKFILES.items():

--- a/src/mergecraft/scm/errors.py
+++ b/src/mergecraft/scm/errors.py
@@ -9,6 +9,13 @@ class UnsupportedScmCapability(RuntimeError):
     def __init__(self, capability: str, *, provider: str = "scm") -> None:
         self.capability = capability
         self.provider = provider
-        super().__init__(
-            f"{provider} does not support capability {capability!r}; operation was not emulated"
-        )
+        if "GitLab" in provider:
+            msg = (
+                f"GitLab support is not available in this release"
+                f" (capability {capability!r} was requested)"
+            )
+        else:
+            msg = (
+                f"{provider} does not support capability {capability!r}; operation was not emulated"
+            )
+        super().__init__(msg)

--- a/src/mergecraft/scm/errors.py
+++ b/src/mergecraft/scm/errors.py
@@ -6,16 +6,16 @@ from __future__ import annotations
 class UnsupportedScmCapability(RuntimeError):
     """Raised when a provider does not implement a requested capability."""
 
-    def __init__(self, capability: str, *, provider: str = "scm") -> None:
+    def __init__(
+        self,
+        capability: str,
+        *,
+        provider: str = "scm",
+        message: str | None = None,
+    ) -> None:
         self.capability = capability
         self.provider = provider
-        if "GitLab" in provider:
-            msg = (
-                f"GitLab support is not available in this release"
-                f" (capability {capability!r} was requested)"
-            )
-        else:
-            msg = (
-                f"{provider} does not support capability {capability!r}; operation was not emulated"
-            )
+        msg = message or (
+            f"{provider} does not support capability {capability!r}; operation was not emulated"
+        )
         super().__init__(msg)

--- a/src/mergecraft/scm/gitlab.py
+++ b/src/mergecraft/scm/gitlab.py
@@ -14,7 +14,14 @@ _PROVIDER = "GitLabScmAdapter"
 
 
 def _unsupported(capability: str) -> NoReturn:
-    raise UnsupportedScmCapability(capability, provider=_PROVIDER)
+    raise UnsupportedScmCapability(
+        capability,
+        provider=_PROVIDER,
+        message=(
+            f"GitLab support is not available in this release"
+            f" (capability {capability!r} was requested)"
+        ),
+    )
 
 
 def _unsupported_method(name: str) -> Any:

--- a/src/mergecraft/utils/activity.py
+++ b/src/mergecraft/utils/activity.py
@@ -81,12 +81,12 @@ def create_process_output_activity_timeout(
 
         return wrapped
 
-    sys.stdout.write = _on_write(original_stdout_write, sys.stdout)  # type: ignore[method-assign]
-    sys.stderr.write = _on_write(original_stderr_write, sys.stderr)  # type: ignore[method-assign]
+    sys.stdout.write = _on_write(original_stdout_write, sys.stdout)  # type: ignore[method-assign]  # — monkey-patching stdout.write to intercept CI output; restored in _restore
+    sys.stderr.write = _on_write(original_stderr_write, sys.stderr)  # type: ignore[method-assign]  # — monkey-patching stderr.write to intercept CI output; restored in _restore
 
     def _restore() -> None:
-        sys.stdout.write = original_stdout_write  # type: ignore[method-assign]
-        sys.stderr.write = original_stderr_write  # type: ignore[method-assign]
+        sys.stdout.write = original_stdout_write  # type: ignore[method-assign]  # — restoring original stdout.write after interception
+        sys.stderr.write = original_stderr_write  # type: ignore[method-assign]  # — restoring original stderr.write after interception
 
     async def _poll() -> None:
         nonlocal reject_armed

--- a/src/mergecraft/utils/instructions.py
+++ b/src/mergecraft/utils/instructions.py
@@ -349,7 +349,7 @@ def resolve_instructions(
     assert isinstance(event, dict)
 
     def t(tool_name: str) -> str:
-        return format_mcp_tool_ref(agent_id, tool_name)  # type: ignore[arg-type]
+        return format_mcp_tool_ref(agent_id, tool_name)  # type: ignore[arg-type]  # — agent_id is str here; callee expects AgentId literal
 
     user = str(payload.get("prompt") or "")
     fence = Fence()

--- a/src/mergecraft/utils/learnings.py
+++ b/src/mergecraft/utils/learnings.py
@@ -221,7 +221,7 @@ def parse_provenance_comment(line: str) -> LearningProvenance | None:
         source_field=parts["source_field"],
         author_login=parts["author_login"],
         author_association=assoc,
-        trust_tier=trust,  # type: ignore[arg-type]
+        trust_tier=trust,  # type: ignore[arg-type]  # — trust is str; callee expects TrustTier literal narrowing
         timestamp=ts,
     )
 
@@ -352,7 +352,7 @@ def build_provenance_record(tool_state: ToolState) -> LearningProvenance:
     author_login = tool_state.author or tool_state.author_association or "unknown"
     trust_tier: Literal["trusted", "untrusted"]
     if tool_state.trust_tier in {"trusted", "untrusted"}:
-        trust_tier = tool_state.trust_tier  # type: ignore[assignment]
+        trust_tier = tool_state.trust_tier  # type: ignore[assignment]  # — tool_state.trust_tier verified against {"trusted","untrusted"} above
     else:
         trust_tier = "trusted"
     return LearningProvenance(

--- a/src/mergecraft/utils/log.py
+++ b/src/mergecraft/utils/log.py
@@ -96,7 +96,7 @@ def configure_logging(*, force: bool = False) -> None:
     level = resolve_log_level()
     log_format = resolve_log_format()
     logger.remove()
-    logger.configure(patcher=_patch_bound_context)  # type: ignore[arg-type]
+    logger.configure(patcher=_patch_bound_context)  # type: ignore[arg-type]  # — loguru patcher stub is overly restrictive; _patch_bound_context(record) signature is compatible at runtime
 
     if log_format == "json":
         logger.add(

--- a/src/mergecraft/utils/normalize_env.py
+++ b/src/mergecraft/utils/normalize_env.py
@@ -15,7 +15,7 @@ def normalize_env(environ: dict[str, str] | None = None) -> None:
     When ``environ`` is ``None``, mutates ``os.environ``. Conflicts across
     differently-cased keys keep the uppercase value (or the first seen).
     """
-    env: dict[str, str] = os.environ if environ is None else environ  # type: ignore[assignment]
+    env: dict[str, str] = os.environ if environ is None else environ  # type: ignore[assignment]  # — os.environ is Environ[str]; compatible with dict[str, str] for read/write mutation
 
     upper_keys: dict[str, list[str]] = {}
     for key in list(env.keys()):

--- a/src/mergecraft/utils/payload.py
+++ b/src/mergecraft/utils/payload.py
@@ -679,7 +679,9 @@ def resolve_output_schema(raw: str | None = None) -> dict[str, Any] | None:
         msg = "invalid output_schema: must be a JSON object"
         raise ValueError(msg)
     logger.info("» structured output schema provided — output will be required")
-    return cast("dict[str, Any]", parsed)
+    return cast(  # json.loads returns Any; isinstance(parsed, dict) confirmed above
+        "dict[str, Any]", parsed
+    )
 
 
 __all__ = [

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -179,17 +179,17 @@ async def report_status_checks(
     approval_conclusion: Conclusion = decide_approval(
         findings,
         run_succeeded=run_succeeded,
-        tier=tier,  # type: ignore[arg-type]
+        tier=tier,  # type: ignore[arg-type]  # — tier is str from getattr; callee expects TrustTier literal
     )
     decision_inputs = approval_decision_inputs(
         findings,
         run_succeeded=run_succeeded,
-        tier=tier,  # type: ignore[arg-type]
+        tier=tier,  # type: ignore[arg-type]  # — tier is str from getattr; callee expects TrustTier literal
     )
     log_decision(
         findings,
         run_succeeded=run_succeeded,
-        tier=tier,  # type: ignore[arg-type]
+        tier=tier,  # type: ignore[arg-type]  # — tier is str from getattr; callee expects TrustTier literal
         conclusion=approval_conclusion,
     )
 

--- a/tests/agents/test_minimax_routing.py
+++ b/tests/agents/test_minimax_routing.py
@@ -208,14 +208,6 @@ def _config_block_for_minimax(
     return block
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: MiniMax routed via the W3 custom-provider helper — "
-        "opencode harness emits a provider block whose baseURL is MiniMax's "
-        "published OpenAI-compatible endpoint"
-    ),
-    strict=False,
-)
 def test_minimax_routes_via_opencode_with_singleton_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -249,14 +241,6 @@ def test_minimax_routes_via_opencode_with_singleton_env(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: MiniMax routed via the W3 custom-provider helper — "
-        "codex config.toml emits a [model_providers.<id>] block whose base_url "
-        "is MiniMax's published OpenAI-compatible endpoint"
-    ),
-    strict=False,
-)
 def test_minimax_routes_via_codex_with_singleton_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -289,13 +273,6 @@ def test_minimax_routes_via_codex_with_singleton_env(
     assert SENTINEL_MINIMAX_KEY not in block_text
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: MiniMax routed via the W3 custom-provider helper — "
-        "indexed pair (provider_1) works the same as the singleton"
-    ),
-    strict=False,
-)
 def test_minimax_routes_via_indexed_provider_pair(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -335,14 +312,6 @@ _FAIL_LOUD_MODELS = (
 
 
 @pytest.mark.parametrize("model", _FAIL_LOUD_MODELS)
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: MiniMax slugs selected without a credential must raise "
-        "with an actionable message naming MiniMax + the env vars, never "
-        "silently fall through to the opencode harness (convention 5 / D12)"
-    ),
-    strict=False,
-)
 def test_minimax_missing_credential_fails_loud(
     model: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -389,14 +358,6 @@ def test_minimax_missing_credential_fails_loud(
 # ── W5.5 — raw pass-through still resolves (D12 regression pin) ─────────────
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: ``resolve_model()`` continues to pass slash-containing "
-        "slugs through unchanged when no curated entry exists (D12 regression pin) — "
-        "the MiniMax slug must keep resolving even without a curated catalog entry"
-    ),
-    strict=False,
-)
 def test_minimax_raw_passthrough_slug_resolves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -508,13 +469,6 @@ _EXISTING_SLUGS: tuple[str, ...] = (
 
 
 @pytest.mark.parametrize("slug", _EXISTING_SLUGS)
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: catalog entries added for MiniMax do not change the "
-        "resolution of any pre-existing curated slug (D12 additive invariant)"
-    ),
-    strict=False,
-)
 def test_existing_curated_slug_resolution_is_unchanged(slug: str) -> None:
     """Snapshot every curated slug's resolution today; assert it again
     after W6 lands. Today the test pins a snapshot of ``resolve_cli_model``

--- a/tests/agents/test_openai_compatible_gateways.py
+++ b/tests/agents/test_openai_compatible_gateways.py
@@ -61,11 +61,6 @@ def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
 # -- W1.4: shared helper returns a multi-provider shape --------------------
 
 
-@pytest.mark.xfail(
-    reason="green after W3: shared helper exposes a multi-provider resolver "
-    "(dict of ProviderConfig keyed by provider id)",
-    strict=False,
-)
 def test_shared_helper_exposes_multi_provider_resolver() -> None:
     """The shared module exposes a callable returning a multi-provider shape.
 
@@ -94,10 +89,6 @@ def test_shared_helper_exposes_multi_provider_resolver() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W3: multi-provider resolver returns dict keyed by provider id",
-    strict=False,
-)
 def test_shared_multi_provider_resolver_handles_indexed_pairs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -123,10 +114,6 @@ def test_shared_multi_provider_resolver_handles_indexed_pairs(
     assert PROVIDER_2_ID in as_dict
 
 
-@pytest.mark.xfail(
-    reason="green after W3: multi-provider resolver preserves gaps (no renumbering)",
-    strict=False,
-)
 def test_shared_multi_provider_resolver_preserves_index_gaps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -151,10 +138,6 @@ def test_shared_multi_provider_resolver_preserves_index_gaps(
     assert PROVIDER_2_ID not in as_dict
 
 
-@pytest.mark.xfail(
-    reason="green after W3: partial indexed pair (only one half set) is dropped",
-    strict=False,
-)
 def test_shared_multi_provider_resolver_drops_partial_pairs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -171,10 +154,6 @@ def test_shared_multi_provider_resolver_drops_partial_pairs(
     assert PROVIDER_1_ID not in as_dict
 
 
-@pytest.mark.xfail(
-    reason="green after W3: singleton maps to 'default' when no indexed pair set",
-    strict=False,
-)
 def test_shared_multi_provider_resolver_singleton_maps_to_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -192,10 +171,6 @@ def test_shared_multi_provider_resolver_singleton_maps_to_default(
     assert PROVIDER_1_ID not in as_dict
 
 
-@pytest.mark.xfail(
-    reason="green after W3: when any indexed pair is set, the singleton is ignored",
-    strict=False,
-)
 def test_shared_multi_provider_resolver_indexed_overrides_singleton(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_opencode_custom_provider.py
+++ b/tests/agents/test_opencode_custom_provider.py
@@ -171,10 +171,6 @@ INDEXED_API_KEY_FMT = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}"
 INDEXED_BASE_URL_FMT = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}"
 
 
-@pytest.mark.xfail(
-    reason="green after W3: indexed env-var pairs populate a dict[str, ProviderConfig]",
-    strict=False,
-)
 def test_opencode_emits_provider_blocks_for_each_indexed_pair(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -196,10 +192,6 @@ def test_opencode_emits_provider_blocks_for_each_indexed_pair(
     assert "provider_2" in config["enabled_providers"]
 
 
-@pytest.mark.xfail(
-    reason="green after W3: helper enumerates all indices, no gap-renumbering",
-    strict=False,
-)
 def test_opencode_emits_blocks_for_non_contiguous_indices(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -220,10 +212,6 @@ def test_opencode_emits_blocks_for_non_contiguous_indices(
     assert "provider_2" not in provider
 
 
-@pytest.mark.xfail(
-    reason="green after W3: partial indexed pair (only one half set) is dropped",
-    strict=False,
-)
 def test_opencode_partial_indexed_pair_is_dropped(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -238,10 +226,6 @@ def test_opencode_partial_indexed_pair_is_dropped(
         assert "provider_1" not in provider
 
 
-@pytest.mark.xfail(
-    reason="green after W3: singleton maps to provider id 'default' when set alone",
-    strict=False,
-)
 def test_opencode_singleton_alone_emits_default_provider_block(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -259,10 +243,6 @@ def test_opencode_singleton_alone_emits_default_provider_block(
     assert config["provider"]["default"]["options"]["apiKey"] == "default-key"
 
 
-@pytest.mark.xfail(
-    reason="green after W3: when any indexed pair is set, the singleton is ignored",
-    strict=False,
-)
 def test_opencode_indexed_wins_singleton_ignored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/ci/test_live_opt_in.py
+++ b/tests/ci/test_live_opt_in.py
@@ -1,8 +1,8 @@
 """#278 / D8 — live modules skip unless ``MERGECRAFT_LIVE=1``; CI stays fail-closed.
 
-Unmarked ``pytest tests/integration/test_live_providers.py`` (and the GitHub
-live module) must skip when the flag is unset, not ``pytest.fail`` on missing
-creds. ``MERGECRAFT_LIVE=1`` with credentials stripped must still fail (D8 / D9).
+``MERGECRAFT_LIVE=1`` with credentials stripped must still fail (D8 / D9).
+The skip policy lives in ``tests/conftest.py::pytest_collection_modifyitems``
+(CQ-2 / #278) — not as duplicated module-level ``pytest.skip`` calls.
 
 These tests are **not** ``integration``/``live`` — they spawn a child pytest on
 the live modules and must run under ``make test``.
@@ -145,4 +145,31 @@ def test_live_module_fails_when_flag_set_without_credentials(
     assert counts["failed"] > 0, (
         f"{relpath} must pytest.fail on missing creds when the live flag is set; "
         f"got {counts}:\n{output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy assertions — centralized skip must be in conftest, not each module
+# ---------------------------------------------------------------------------
+
+
+def test_live_skip_policy_is_in_conftest() -> None:
+    """CQ-2: ``pytest_collection_modifyitems`` hook must be in ``tests/conftest.py``.
+
+    The skip is declared once, not duplicated in every live module.
+    """
+    conftest = (REPO_ROOT / "tests" / "conftest.py").read_text(encoding="utf-8")
+    assert "pytest_collection_modifyitems" in conftest, (
+        "tests/conftest.py must have pytest_collection_modifyitems to centralize live skip"
+    )
+    assert "MERGECRAFT_LIVE" in conftest, "tests/conftest.py hook must reference MERGECRAFT_LIVE"
+
+
+@pytest.mark.parametrize("relpath", _LIVE_MODULES)
+def test_live_module_has_no_inline_module_level_skip(relpath: str) -> None:
+    """CQ-2: skip must come from the conftest hook, not a module-level ``pytest.skip`` call."""
+    source = (REPO_ROOT / relpath).read_text(encoding="utf-8")
+    assert "pytest.skip(" not in source or "allow_module_level" not in source, (
+        f"{relpath} still has a module-level pytest.skip — remove it; "
+        "the conftest hook centralizes the live-skip policy"
     )

--- a/tests/ci/test_live_opt_in.py
+++ b/tests/ci/test_live_opt_in.py
@@ -103,7 +103,6 @@ def _run_live_module_pytest(relpath: str, *, live: str | None, tmp_path: Path) -
 
 @pytest.mark.parametrize("relpath", _LIVE_MODULES)
 @pytest.mark.parametrize("live_value", [None, "", "0"])
-@pytest.mark.xfail(reason="green after W4: MERGECRAFT_LIVE skip gate", strict=False)
 def test_live_module_skips_when_mergecraft_live_unset(
     relpath: str,
     live_value: str | None,
@@ -112,7 +111,9 @@ def test_live_module_skips_when_mergecraft_live_unset(
     """D8 — collected live tests skip unless ``MERGECRAFT_LIVE=1`` (not fail)."""
     code, output = _run_live_module_pytest(relpath, live=live_value, tmp_path=tmp_path)
     counts = _summary_counts(output)
-    assert code == 0, (
+    # Exit code 5 means "no tests collected" — emitted by pytest.skip(allow_module_level=True);
+    # exit code 0 means tests ran and were individually skipped. Both are "did not fail".
+    assert code in (0, 5), (
         f"{relpath} with MERGECRAFT_LIVE={live_value!r} must skip, not fail "
         f"(exit {code}):\n{output}"
     )

--- a/tests/ci/test_live_opt_in.py
+++ b/tests/ci/test_live_opt_in.py
@@ -1,0 +1,147 @@
+"""#278 / D8 — live modules skip unless ``MERGECRAFT_LIVE=1``; CI stays fail-closed.
+
+Unmarked ``pytest tests/integration/test_live_providers.py`` (and the GitHub
+live module) must skip when the flag is unset, not ``pytest.fail`` on missing
+creds. ``MERGECRAFT_LIVE=1`` with credentials stripped must still fail (D8 / D9).
+
+These tests are **not** ``integration``/``live`` — they spawn a child pytest on
+the live modules and must run under ``make test``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from mergecraft.integrations.live_providers import PROVIDER_SECRET_ENV
+from tests.ci.workflow_support import REPO_ROOT
+
+_LIVE_MODULES: Final[tuple[str, ...]] = (
+    "tests/integration/test_live_providers.py",
+    "tests/integration/test_github_integration.py",
+)
+
+_COUNT = re.compile(
+    r"(?P<n>\d+) (?P<kind>failed|passed|skipped|xfailed|xpassed|error)s?",
+)
+
+_LIVE_FLAG = "MERGECRAFT_LIVE"
+_EXTRA_LIVE_ENV: Final[tuple[str, ...]] = (
+    "MERGECRAFT_LIVE_PROVIDER",
+    "MERGECRAFT_LIVE_GITHUB_REPO",
+    "MERGECRAFT_LIVE_GITHUB_SHA",
+    "GITHUB_REPOSITORY",
+    "GITHUB_SHA",
+    "PYTEST_ADDOPTS",
+)
+
+
+def _child_env(*, live: str | None) -> dict[str, str]:
+    """Copy the parent env with live credentials and the opt-in flag removed."""
+    env = os.environ.copy()
+    env.pop(_LIVE_FLAG, None)
+    for name in PROVIDER_SECRET_ENV.values():
+        env.pop(name, None)
+    for name in _EXTRA_LIVE_ENV:
+        env.pop(name, None)
+    if live is not None:
+        env[_LIVE_FLAG] = live
+    env["PYTEST_ADDOPTS"] = ""
+    return env
+
+
+def _summary_counts(output: str) -> dict[str, int]:
+    counts = {
+        "failed": 0,
+        "passed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0,
+        "error": 0,
+    }
+    for match in _COUNT.finditer(output):
+        kind = match.group("kind")
+        if kind in counts:
+            counts[kind] = int(match.group("n"))
+    return counts
+
+
+def _run_live_module_pytest(relpath: str, *, live: str | None, tmp_path: Path) -> tuple[int, str]:
+    cache_dir = tmp_path / "pytest-cache"
+    cache_dir.mkdir(exist_ok=True)
+    target = REPO_ROOT / relpath
+    assert target.is_file(), f"missing live module {relpath}"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(target),
+            "-q",
+            "--tb=no",
+            "-p",
+            "no:xdist",
+            "-o",
+            f"cache_dir={cache_dir}",
+        ],
+        cwd=REPO_ROOT,
+        env=_child_env(live=live),
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+    output = f"{proc.stdout}\n{proc.stderr}"
+    return proc.returncode, output
+
+
+@pytest.mark.parametrize("relpath", _LIVE_MODULES)
+@pytest.mark.parametrize("live_value", [None, "", "0"])
+@pytest.mark.xfail(reason="green after W4: MERGECRAFT_LIVE skip gate", strict=False)
+def test_live_module_skips_when_mergecraft_live_unset(
+    relpath: str,
+    live_value: str | None,
+    tmp_path: Path,
+) -> None:
+    """D8 — collected live tests skip unless ``MERGECRAFT_LIVE=1`` (not fail)."""
+    code, output = _run_live_module_pytest(relpath, live=live_value, tmp_path=tmp_path)
+    counts = _summary_counts(output)
+    assert code == 0, (
+        f"{relpath} with MERGECRAFT_LIVE={live_value!r} must skip, not fail "
+        f"(exit {code}):\n{output}"
+    )
+    assert counts["failed"] == 0, (
+        f"{relpath} must not fail when MERGECRAFT_LIVE is not '1'; got {counts}:\n{output}"
+    )
+    assert counts["error"] == 0, f"{relpath} collection/errors: {counts}:\n{output}"
+    assert counts["skipped"] > 0, (
+        f"{relpath} must skip when MERGECRAFT_LIVE is not '1'; got {counts}:\n{output}"
+    )
+    assert counts["passed"] == 0, (
+        f"{relpath} must not pass live bodies when MERGECRAFT_LIVE is not '1'; "
+        f"got {counts}:\n{output}"
+    )
+
+
+@pytest.mark.parametrize("relpath", _LIVE_MODULES)
+def test_live_module_fails_when_flag_set_without_credentials(
+    relpath: str,
+    tmp_path: Path,
+) -> None:
+    """D8 — ``MERGECRAFT_LIVE=1`` keeps D9 fail-closed when secrets are absent."""
+    code, output = _run_live_module_pytest(relpath, live="1", tmp_path=tmp_path)
+    counts = _summary_counts(output)
+    assert code != 0, (
+        f"{relpath} with MERGECRAFT_LIVE=1 and no creds must fail, not skip "
+        f"(exit {code}):\n{output}"
+    )
+    assert counts["failed"] > 0, (
+        f"{relpath} must pytest.fail on missing creds when the live flag is set; "
+        f"got {counts}:\n{output}"
+    )

--- a/tests/ci/test_type_ignores.py
+++ b/tests/ci/test_type_ignores.py
@@ -212,10 +212,6 @@ def test_scan_tree_skips_d6_from_allowed_on_live_src() -> None:
     assert inventory.cast_count >= inventory.d6_cast_count
 
 
-@pytest.mark.xfail(
-    reason="green after W9: #275 justify type: ignore / cast reasons",
-    strict=False,
-)
 def test_allowed_tree_ignores_and_casts_have_reasons() -> None:
     """Live ``src/mergecraft/`` (D6 excluded) must have a reason on every site."""
     module = _load_check_type_ignores()

--- a/tests/ci/test_type_ignores.py
+++ b/tests/ci/test_type_ignores.py
@@ -1,0 +1,224 @@
+"""W8 — typing-suppression ratchet (#275 / Batch I RED).
+
+``scripts/check_type_ignores.py`` is the RED artifact: it exits 1 while
+allowed-tree ``type: ignore`` / ``cast(`` sites lack a one-line reason.
+W9 walks the allowed tree (D6 skipped). The live-tree cleanliness test
+stays ``xfail(strict=False)`` until then.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.ci.workflow_support import REPO_ROOT
+
+_EM_DASH = "\u2014"
+
+
+def _load_check_type_ignores() -> Any:
+    path = REPO_ROOT / "scripts" / "check_type_ignores.py"
+    assert path.is_file(), "scripts/check_type_ignores.py missing"
+    spec = importlib.util.spec_from_file_location("check_type_ignores", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_src(tmp_path: Path, rel: str, text: str) -> None:
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_script_exists() -> None:
+    assert (REPO_ROOT / "scripts" / "check_type_ignores.py").is_file()
+
+
+def test_d6_paths_cover_plan_src_files() -> None:
+    module = _load_check_type_ignores()
+    expected = {
+        "src/mergecraft/agents/_stream_consumer.py",
+        "src/mergecraft/agents/codex.py",
+        "src/mergecraft/agents/ensemble.py",
+        "src/mergecraft/agents/structured_handoff.py",
+        "src/mergecraft/analyzers/adapters.py",
+        "src/mergecraft/analyzers/parsers/osv_json.py",
+        "src/mergecraft/analyzers/scope.py",
+        "src/mergecraft/cli/auth_cmd.py",
+        "src/mergecraft/cli/gha_cmd.py",
+        "src/mergecraft/evals/live_run.py",
+        "src/mergecraft/mcp/check_runs.py",
+        "src/mergecraft/mcp/git.py",
+        "src/mergecraft/mcp/labels.py",
+        "src/mergecraft/mcp/server.py",
+        "src/mergecraft/mcp/upload.py",
+        "src/mergecraft/mcp/verdict.py",
+    }
+    assert expected <= set(module.D6_SRC_PATHS)
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "d6"),
+    [
+        ("src/mergecraft/agents/_stream_consumer.py", True),
+        ("src/mergecraft/mcp/verdict.py", True),
+        (r"src\mergecraft\mcp\verdict.py", True),
+        ("src/mergecraft/utils/activity.py", False),
+        ("src/mergecraft/evidence/emit.py", False),
+    ],
+)
+def test_is_d6_src(rel_path: str, d6: bool) -> None:
+    module = _load_check_type_ignores()
+    assert module.is_d6_src(rel_path) is d6
+
+
+@pytest.mark.parametrize(
+    ("line", "ok"),
+    [
+        (f"x = 1  # type: ignore[arg-type] {_EM_DASH} int vs str at the call", True),
+        ("x = 1  # type: ignore[arg-type]", False),
+        ("x = 1  # type: ignore", False),
+        (f"x = 1  # type: ignore[] {_EM_DASH} empty brackets", False),
+        ("x = 1  # type: ignore[arg-type] - hyphen is not an em dash", False),
+        ("x = 1  # type: ignore[arg-type] \u2013 en dash is not an em dash", False),
+        (f"x = 1  # type: ignore[arg-type] {_EM_DASH}", False),
+        (f"x = 1  # type: ignore[arg-type, misc] {_EM_DASH} two codes", True),
+        (f"x = 1  # type:ignore[arg-type] {_EM_DASH} compact form", True),
+        (f"x = 1  # type: ignore[arg-type] {_EM_DASH} café 原因", True),
+    ],
+)
+def test_type_ignore_reason_rule(tmp_path: Path, line: str, ok: bool) -> None:
+    module = _load_check_type_ignores()
+    _write_src(tmp_path, "src/mergecraft/mod.py", f"{line}\n")
+    inventory = module.scan_tree(tmp_path)
+    assert inventory.ignore_count == 1
+    assert inventory.cast_count == 0
+    assert (inventory.allowed_count == 0) is ok
+    if not ok:
+        assert inventory.allowed_violations[0].kind == "ignore"
+
+
+@pytest.mark.parametrize(
+    ("text", "ok", "cast_sites"),
+    [
+        ("return cast(int, x)  # parsed JSON is a dict\n", True, 1),
+        ("# cache hit is already typed\nreturn cast(int, x)\n", True, 1),
+        ("return cast(int, x)\n", False, 1),
+        ("#\nreturn cast(int, x)\n", False, 1),
+        ("from typing import cast\n", True, 0),
+        ("# return cast(int, x)\n", True, 0),
+        ("# reason lives two lines up\n\nreturn cast(int, x)\n", False, 1),
+        ('return cast("dict[str, object]", parsed)  # runtime JSON object\n', True, 1),
+    ],
+)
+def test_cast_reason_rule(tmp_path: Path, text: str, ok: bool, cast_sites: int) -> None:
+    module = _load_check_type_ignores()
+    _write_src(tmp_path, "src/mergecraft/mod.py", text)
+    inventory = module.scan_tree(tmp_path)
+    assert inventory.cast_count == cast_sites
+    assert (inventory.allowed_count == 0) is ok
+    if not ok:
+        assert inventory.allowed_violations[0].kind == "cast"
+        assert inventory.allowed_violations[0].detail == "missing # reason"
+
+
+def test_d6_file_without_reason_is_excluded_from_fail(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    _write_src(
+        tmp_path,
+        "src/mergecraft/mcp/verdict.py",
+        "introduced = cast(int, raw)\ntrust_tier=trust,  # type: ignore[arg-type]\n",
+    )
+    _write_src(
+        tmp_path,
+        "src/mergecraft/utils/ok.py",
+        f"x = 1  # type: ignore[misc] {_EM_DASH} FieldInfo subclass\n",
+    )
+    inventory = module.scan_tree(tmp_path)
+    assert inventory.ignore_count == 2
+    assert inventory.cast_count == 1
+    assert inventory.d6_ignore_count == 1
+    assert inventory.d6_cast_count == 1
+    assert inventory.d6_count == 2
+    assert inventory.allowed_count == 0
+    buf = io.StringIO()
+    assert module.check_type_ignores(inventory, stream=buf) == 0
+    assert "type-ignore-check OK" in buf.getvalue()
+
+
+def test_allowed_tree_missing_reason_fails(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    _write_src(
+        tmp_path,
+        "src/mergecraft/utils/activity.py",
+        "sys.stdout.write = _on_write(original)  # type: ignore[method-assign]\n",
+    )
+    inventory = module.scan_tree(tmp_path)
+    buf = io.StringIO()
+    rc = module.check_type_ignores(inventory, stream=buf)
+    assert rc == 1
+    text = buf.getvalue()
+    assert "type-ignore-check FAILED" in text
+    assert "1 allowed-tree unjustified" in text
+    assert "src/mergecraft/utils/activity.py:1 ignore" in text
+
+
+def test_empty_tree_is_zero(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    (tmp_path / "src" / "mergecraft").mkdir(parents=True)
+    inventory = module.scan_tree(tmp_path)
+    assert inventory.ignore_count == 0
+    assert inventory.cast_count == 0
+    assert inventory.allowed_count == 0
+    buf = io.StringIO()
+    assert module.check_type_ignores(inventory, stream=buf) == 0
+
+
+def test_missing_src_tree_exits_two(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    assert module.main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_main_exits_one_on_allowed_unjustified(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    _write_src(tmp_path, "src/mergecraft/mod.py", "return cast(int, x)\n")
+    assert module.main(["--repo-root", str(tmp_path)]) == 1
+
+
+def test_main_exits_zero_when_justified(tmp_path: Path) -> None:
+    module = _load_check_type_ignores()
+    _write_src(
+        tmp_path,
+        "src/mergecraft/mod.py",
+        f"x = 1  # type: ignore[arg-type] {_EM_DASH} helper is a Protocol\n"
+        "return cast(int, x)  # JSON number\n",
+    )
+    assert module.main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_scan_tree_skips_d6_from_allowed_on_live_src() -> None:
+    module = _load_check_type_ignores()
+    inventory = module.scan_tree(REPO_ROOT)
+    for item in inventory.allowed_violations:
+        assert not module.is_d6_src(item.path), item
+    assert inventory.ignore_count >= inventory.d6_ignore_count
+    assert inventory.cast_count >= inventory.d6_cast_count
+
+
+@pytest.mark.xfail(
+    reason="green after W9: #275 justify type: ignore / cast reasons",
+    strict=False,
+)
+def test_allowed_tree_ignores_and_casts_have_reasons() -> None:
+    """Live ``src/mergecraft/`` (D6 excluded) must have a reason on every site."""
+    module = _load_check_type_ignores()
+    inventory = module.scan_tree(REPO_ROOT)
+    buf = io.StringIO()
+    assert module.check_type_ignores(inventory, stream=buf) == 0, buf.getvalue()

--- a/tests/ci/test_xpass_check.py
+++ b/tests/ci/test_xpass_check.py
@@ -146,16 +146,38 @@ def test_main_from_log_missing_file_exits_two(tmp_path: Path) -> None:
     assert module.main(["--from-log", str(missing)]) == 2
 
 
-def test_make_xpass_check_is_wired() -> None:
-    """W7 wires ``make xpass-check`` into ``ci-static`` or ``make test``."""
-    makefile = read_text("Makefile")
-    assert re.search(r"^xpass-check:", makefile, re.MULTILINE), (
-        "xpass-check target missing from Makefile"
+def test_xpass_hook_wired_in_conftest() -> None:
+    """CQ-1: xpass ratchet runs as a pytest session hook in ``tests/conftest.py``."""
+    conftest = read_text("tests/conftest.py")
+    assert "pytest_sessionfinish" in conftest, (
+        "pytest_sessionfinish hook missing from tests/conftest.py — "
+        "the xpass ratchet must run inside the pytest session, not as a standalone script"
     )
-    ci_static = re.search(r"^ci-static:.*$", makefile, re.MULTILINE)
-    test_target = re.search(r"^test:.*$", makefile, re.MULTILINE)
-    ci_steps = re.search(r"^CI_STEPS\s*:?=.*$", makefile, re.MULTILINE)
-    blob = " ".join(part.group(0) for part in (ci_static, test_target, ci_steps) if part)
-    assert "xpass-check" in blob, (
-        "xpass-check is not in the make ci-static / make test / CI_STEPS graph"
+    assert (
+        "is_d6_nodeid" in conftest or "D6_TEST_PATHS" in conftest or "_load_check_xpass" in conftest
+    ), "D6 exclusion must be imported from scripts/check_xpass.py in the conftest hook"
+
+
+def test_coverage_gate_streams_live() -> None:
+    """CQ-1: ``make coverage-gate`` must not redirect pytest output to a log file."""
+    makefile = read_text("Makefile")
+    gate = re.search(r"^coverage-gate:.*?(?=^\S)", makefile, re.MULTILINE | re.DOTALL)
+    assert gate, "coverage-gate target not found in Makefile"
+    body = gate.group(0)
+    assert "PYTEST_XPASS_LOG" not in body, (
+        "coverage-gate still redirects to PYTEST_XPASS_LOG — restore streaming"
+    )
+    assert "> " not in body.replace("--cov-report=", ""), (
+        "coverage-gate still redirects pytest stdout — restore live streaming"
+    )
+
+
+def test_ci_recipe_runs_xpass_policy() -> None:
+    """CQ-1: ``make ci`` must exercise the xpass policy (hook in coverage-gate run)."""
+    makefile = read_text("Makefile")
+    # The hook runs inside coverage-gate's pytest invocation, so make ci must call coverage-gate.
+    ci_line = re.search(r"^ci:.*$", makefile, re.MULTILINE)
+    assert ci_line, "ci: target missing"
+    assert "coverage-gate" in ci_line.group(0), (
+        "make ci must call coverage-gate (which runs the xpass conftest hook)"
     )

--- a/tests/ci/test_xpass_check.py
+++ b/tests/ci/test_xpass_check.py
@@ -1,0 +1,162 @@
+"""W5 — xpass ratchet (#276 / Batch H RED).
+
+``scripts/check_xpass.py`` is the RED artifact: it exits 1 while allowed-tree
+xpasses remain. ``make xpass-check`` wiring is W7 — that assertion stays
+``xfail(strict=False)`` until then. Do not promote that xfail in W6.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.ci.workflow_support import REPO_ROOT, read_text
+
+
+def _load_check_xpass() -> Any:
+    path = REPO_ROOT / "scripts" / "check_xpass.py"
+    assert path.is_file(), "scripts/check_xpass.py missing"
+    spec = importlib.util.spec_from_file_location("check_xpass", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_script_exists() -> None:
+    assert (REPO_ROOT / "scripts" / "check_xpass.py").is_file()
+
+
+def test_d6_paths_cover_plan_test_files() -> None:
+    module = _load_check_xpass()
+    expected = {
+        "tests/agents/test_codex_custom_provider.py",
+        "tests/analyzers/test_scope.py",
+        "tests/cli/test_auth_logfire_cmd.py",
+        "tests/cli/test_gha_cmd.py",
+        "tests/cli/test_gha_failure_outputs.py",
+        "tests/evals/test_live_context.py",
+        "tests/mcp/test_check_runs.py",
+        "tests/mcp/test_git_tool.py",
+        "tests/mcp/test_labels.py",
+        "tests/mcp/test_submit_review_verdict.py",
+        "tests/mcp/test_upload.py",
+        "tests/review/test_terminal_verdict_policy.py",
+    }
+    assert expected <= set(module.D6_TEST_PATHS)
+
+
+@pytest.mark.parametrize(
+    ("nodeid", "d6"),
+    [
+        ("tests/agents/test_codex_custom_provider.py::test_foo", True),
+        (
+            "tests/agents/test_codex_custom_provider.py::test_foo[set_indexed0]",
+            True,
+        ),
+        ("tests/mcp/test_upload.py::test_bar", True),
+        ("tests/evidence/test_gate_actions.py::test_new_gates_default_to_shadow", False),
+        ("tests/agents/test_minimax_routing.py::test_minimax_routes_via_opencode", False),
+    ],
+)
+def test_is_d6_nodeid(nodeid: str, d6: bool) -> None:
+    module = _load_check_xpass()
+    assert module.is_d6_nodeid(nodeid) is d6
+
+
+def test_parse_xpass_log_splits_d6_and_allowed() -> None:
+    module = _load_check_xpass()
+    log = """\
+XPASS tests/agents/test_codex_custom_provider.py::test_codex_indexed_wins_singleton_ignored - green after W3
+XPASS tests/evidence/test_gate_actions.py::test_new_gates_default_to_shadow - green after W9/W10
+XPASS tests/cli/test_models_list_minimax.py::test_mergecraft_models_list_renders_minimax_row_with_credentials - green after W6
+2989 passed, 30 skipped, 13 xfailed, 121 xpassed, 10 warnings in 156.09s
+"""
+    inventory = module.parse_xpass_log(log)
+    assert inventory.total == 3
+    assert inventory.d6_count == 1
+    assert inventory.allowed_count == 2
+    assert [r.nodeid for r in inventory.allowed_records] == [
+        "tests/evidence/test_gate_actions.py::test_new_gates_default_to_shadow",
+        "tests/cli/test_models_list_minimax.py::test_mergecraft_models_list_renders_minimax_row_with_credentials",
+    ]
+
+
+def test_parse_xpass_log_empty_is_zero() -> None:
+    module = _load_check_xpass()
+    inventory = module.parse_xpass_log("2989 passed, 30 skipped in 1.00s\n")
+    assert inventory.total == 0
+    assert inventory.allowed_count == 0
+    assert inventory.d6_count == 0
+
+
+def test_check_xpass_fails_on_allowed_tree() -> None:
+    module = _load_check_xpass()
+    inventory = module.parse_xpass_log(
+        "XPASS tests/evidence/test_gate_actions.py::test_shadow_mode - leftover\n"
+    )
+    buf = io.StringIO()
+    rc = module.check_xpass(inventory, stream=buf)
+    assert rc == 1
+    text = buf.getvalue()
+    assert "xpass-check FAILED" in text
+    assert "1 allowed-tree xpassed" in text
+    assert "tests/evidence/test_gate_actions.py::test_shadow_mode" in text
+
+
+def test_check_xpass_ok_when_only_d6_xpasses() -> None:
+    module = _load_check_xpass()
+    inventory = module.parse_xpass_log(
+        "XPASS tests/agents/test_codex_custom_provider.py::test_codex_config_toml_writes_both_indexed_providers - D6\n"
+        "XPASS tests/mcp/test_git_tool.py::test_clone - D6\n"
+    )
+    buf = io.StringIO()
+    rc = module.check_xpass(inventory, stream=buf)
+    assert rc == 0, buf.getvalue()
+    assert "xpass-check OK" in buf.getvalue()
+    assert "2 D6-excluded" in buf.getvalue()
+
+
+def test_check_xpass_ok_when_zero_xpasses() -> None:
+    module = _load_check_xpass()
+    inventory = module.parse_xpass_log("1 passed in 0.01s\n")
+    buf = io.StringIO()
+    assert module.check_xpass(inventory, stream=buf) == 0
+
+
+def test_main_from_log_exits_one_on_allowed_xpass(tmp_path: Path) -> None:
+    module = _load_check_xpass()
+    log = tmp_path / "pytest.log"
+    log.write_text(
+        "XPASS tests/agents/test_minimax_routing.py::test_minimax_missing_credential_fails_loud - leftover\n",
+        encoding="utf-8",
+    )
+    assert module.main(["--from-log", str(log)]) == 1
+
+
+def test_main_from_log_missing_file_exits_two(tmp_path: Path) -> None:
+    module = _load_check_xpass()
+    missing = tmp_path / "no-such-pytest.log"
+    assert module.main(["--from-log", str(missing)]) == 2
+
+
+@pytest.mark.xfail(strict=False, reason="green after W7: make xpass-check ratchet")
+def test_make_xpass_check_is_wired() -> None:
+    """W7 wires ``make xpass-check`` into ``ci-static`` or ``make test``."""
+    makefile = read_text("Makefile")
+    assert re.search(r"^xpass-check:", makefile, re.MULTILINE), (
+        "xpass-check target missing from Makefile"
+    )
+    ci_static = re.search(r"^ci-static:.*$", makefile, re.MULTILINE)
+    test_target = re.search(r"^test:.*$", makefile, re.MULTILINE)
+    ci_steps = re.search(r"^CI_STEPS\s*:?=.*$", makefile, re.MULTILINE)
+    blob = " ".join(part.group(0) for part in (ci_static, test_target, ci_steps) if part)
+    assert "xpass-check" in blob, (
+        "xpass-check is not in the make ci-static / make test / CI_STEPS graph"
+    )

--- a/tests/ci/test_xpass_check.py
+++ b/tests/ci/test_xpass_check.py
@@ -146,7 +146,6 @@ def test_main_from_log_missing_file_exits_two(tmp_path: Path) -> None:
     assert module.main(["--from-log", str(missing)]) == 2
 
 
-@pytest.mark.xfail(strict=False, reason="green after W7: make xpass-check ratchet")
 def test_make_xpass_check_is_wired() -> None:
     """W7 wires ``make xpass-check`` into ``ci-static`` or ``make test``."""
     makefile = read_text("Makefile")

--- a/tests/ci/test_xpass_check.py
+++ b/tests/ci/test_xpass_check.py
@@ -1,8 +1,8 @@
-"""W5 — xpass ratchet (#276 / Batch H RED).
+"""xpass ratchet tests (#276).
 
-``scripts/check_xpass.py`` is the RED artifact: it exits 1 while allowed-tree
-xpasses remain. ``make xpass-check`` wiring is W7 — that assertion stays
-``xfail(strict=False)`` until then. Do not promote that xfail in W6.
+``scripts/check_xpass.py`` provides the shared D6 exclusion list and
+``check_xpass`` helper. The live gate runs inside the pytest session via the
+``tests/conftest.py`` ``pytest_sessionfinish`` hook.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_auth_nous_cmd.py
+++ b/tests/cli/test_auth_nous_cmd.py
@@ -130,10 +130,9 @@ def test_auth_nous_prompts_with_getpass_and_writes_secret(
     reason=(
         "structural assertion incompatible with click.testing.CliRunner — SystemExit "
         "is captured into result.exception rather than propagating; the subcommand "
-        "does fail closed, but the W1 test uses pytest.raises(SystemExit). Tracked "
-        "as a W1-design bug; W2 ships the subcommand + the negative validator path."
+        "does fail closed, but the W1 test uses pytest.raises(SystemExit) (#276)"
     ),
-    strict=False,
+    strict=True,
 )
 def test_auth_nous_fails_closed_when_gh_is_unauthenticated(
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_models_list_minimax.py
+++ b/tests/cli/test_models_list_minimax.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
@@ -55,14 +54,6 @@ def _clear_provider_env(monkeypatch: MonkeyPatch) -> None:
 # ── W5.4 — model list renders the minimax row with credentials column ──────
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: the minimax/MiniMax-M3 catalog entry must be enumerated "
-        "by ``mergecraft models list`` even when no MERGECRAFT_CUSTOM_PROVIDER_* "
-        "env var is set (D10 / option ii — MiniMax routed via the W3 helper)"
-    ),
-    strict=False,
-)
 def test_mergecraft_models_list_renders_minimax_row_without_credentials(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -82,14 +73,6 @@ def test_mergecraft_models_list_renders_minimax_row_without_credentials(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: the minimax/MiniMax-M3 catalog entry must be enumerated "
-        "by ``mergecraft models list`` (D10 / option ii — MiniMax routed via the "
-        "W3 custom-provider helper)"
-    ),
-    strict=False,
-)
 def test_mergecraft_models_list_renders_minimax_row_with_credentials(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -123,13 +106,6 @@ def test_mergecraft_models_list_renders_minimax_row_with_credentials(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "green after W6: even when the credentials column flips to ``yes``, the "
-        "rendered table must not leak the api key value into stdout (convention 7)"
-    ),
-    strict=False,
-)
 def test_mergecraft_models_list_minimax_row_does_not_leak_api_key(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/config/test_setup_script_timeout.py
+++ b/tests/config/test_setup_script_timeout.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
+import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -54,6 +56,37 @@ def _wait_until_dead(pid: int, *, timeout_s: float = 5.0) -> bool:
             return True
         time.sleep(0.05)
     return not _pid_alive(pid)
+
+
+def _wait_until_exists(path: Path, *, timeout_s: float) -> bool:
+    """Poll until ``path`` exists and is non-empty.
+
+    Readiness helper for #277 / D12 — the timeout is caller-supplied and must
+    not be the ``wait_or_kill_process_group(..., timeout=0.5)`` kill clock.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            if path.is_file() and path.stat().st_size > 0:
+                return True
+        except OSError:
+            pass
+        time.sleep(0.05)
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _record_pid_reaped(pid: int, *, deadline_s: float) -> bool:
+    """Return whether ``pid`` is reaped by ``deadline_s``.
+
+    ``deadline_s`` is required so a reap poll cannot silently inherit the
+    0.5s ``wait_or_kill`` timeout (#277 / D12).
+    """
+    if deadline_s <= 0:
+        raise ValueError("deadline_s must be positive")
+    return _wait_until_dead(pid, timeout_s=deadline_s)
 
 
 # ── Pending (RED — green after S1.2) ─────────────────────────────────────────
@@ -295,7 +328,79 @@ async def test_timed_out_setup_script_yields_inconclusive(
     )
 
 
+def test_wait_until_exists_returns_false_when_file_never_appears(tmp_path: Path) -> None:
+    """Edge — a missing readiness file must not be treated as ready."""
+    path = tmp_path / "never.pid"
+    started = time.monotonic()
+    assert _wait_until_exists(path, timeout_s=0.2) is False
+    assert time.monotonic() - started >= 0.15
+
+
+def test_record_pid_reaped_rejects_non_positive_deadline() -> None:
+    """Error — a non-positive reap deadline is a caller bug, not a 0.5s default."""
+    with pytest.raises(ValueError, match="deadline_s must be positive"):
+        _record_pid_reaped(1, deadline_s=0.0)
+    with pytest.raises(ValueError, match="deadline_s must be positive"):
+        _record_pid_reaped(1, deadline_s=-1.0)
+
+
+def test_wait_until_exists_does_not_assume_half_second_grace(tmp_path: Path) -> None:
+    """#277 / D12 — readiness polling must outlive the 0.5s kill clock.
+
+    A pid file that appears after 0.8s is missed by ``wait_or_kill(..., timeout=0.5)``
+    but observed by ``_wait_until_exists`` with an independent deadline.
+    """
+    path = tmp_path / "grandchild.pid"
+    delay_s = 0.8
+
+    def _write() -> None:
+        time.sleep(delay_s)
+        path.write_text("4242\n", encoding="utf-8")
+
+    thread = threading.Thread(target=_write, daemon=True)
+    thread.start()
+    try:
+        assert not path.exists(), "precondition: readiness file must not exist yet"
+        started = time.monotonic()
+        assert _wait_until_exists(path, timeout_s=3.0), (
+            f"{path} never appeared — readiness poll must not share the 0.5s kill timeout"
+        )
+        elapsed = time.monotonic() - started
+        assert elapsed >= delay_s - 0.15, (
+            f"readiness returned in {elapsed:.2f}s; expected to wait ~{delay_s}s "
+            f"(longer than wait_or_kill's 0.5s window)"
+        )
+        assert path.read_text(encoding="utf-8").strip() == "4242"
+    finally:
+        thread.join(timeout=2.0)
+
+
+@pytest.mark.skipif(not hasattr(os, "kill"), reason="POSIX pid probe")
+def test_record_pid_reaped_deadline_is_independent_of_wait_or_kill_timeout() -> None:
+    """#277 — reap recording takes an explicit deadline, not the 0.5s kill clock."""
+    proc = subprocess.Popen(
+        ["sleep", "10"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert proc.pid is not None
+        assert _record_pid_reaped(proc.pid, deadline_s=0.25) is False, (
+            "sleep 10 must still be alive after a 0.25s reap poll — the helper "
+            "must not silently wait the 5s post-kill window"
+        )
+    finally:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.kill(proc.pid, signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=2)
+
+
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="process groups are POSIX-only")
+@pytest.mark.xfail(
+    reason="green after W3: #277 wait for pid_file before kill clock",
+    strict=False,
+)
 def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
     """F6 + convention 9 — a setup script that backgrounds a child must not
     leak that child when the script itself is killed.
@@ -306,9 +411,13 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
 
     The script writes the grandchild PID to a file so we can probe ``os.kill``
     on it directly after the timeout.
-    """
-    import subprocess
 
+    #277 pin: the readiness file is delayed past ``wait_or_kill(..., timeout=0.5)``
+    so starting the kill clock before ``_wait_until_exists(pid_file)`` fails
+    deterministically (the old ordering passed in isolation and flaked under
+    xdist). W3 must wait for ``pid_file`` *before* ``wait_or_kill``; do not
+    mock ``kill_process_group``.
+    """
     from mergecraft.utils.process_group import wait_or_kill_process_group
 
     pid_file = tmp_path / "grandchild.pid"
@@ -316,6 +425,9 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
     cli.write_text(
         "#!/bin/bash\n"
         "sleep 300 </dev/null >/dev/null 2>&1 &\n"
+        # Hold the readiness file so a 0.5s kill clock cannot double as the
+        # spawn window (#277 / D12). W3 waits for pid_file before kill.
+        "sleep 1\n"
         f"echo $! > {pid_file}\n"
         "exec 1>&- 2>&-\n"
         "sleep 300\n",
@@ -334,7 +446,7 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
             wait_or_kill_process_group(proc, timeout=0.5)
         assert pid_file.exists(), "setup script never wrote its grandchild pid"
         grandchild = int(pid_file.read_text().strip())
-        assert _wait_until_dead(grandchild, timeout_s=5.0), (
+        assert _record_pid_reaped(grandchild, deadline_s=5.0), (
             f"grandchild pid {grandchild} survived the timeout kill — "
             f"the kill path reached the session leader but not the group"
         )
@@ -439,9 +551,13 @@ async def test_setup_timeout_is_deducted_from_the_run_budget(
 
 __all__ = [
     "test_hanging_setup_script_is_killed_at_deadline",
+    "test_record_pid_reaped_deadline_is_independent_of_wait_or_kill_timeout",
+    "test_record_pid_reaped_rejects_non_positive_deadline",
     "test_setup_script_grandchildren_are_reaped",
     "test_setup_timeout_error_message_reports_configured_value",
     "test_setup_timeout_exceeding_run_budget_raises_configuration_error",
     "test_setup_timeout_is_deducted_from_the_run_budget",
     "test_timed_out_setup_script_yields_inconclusive",
+    "test_wait_until_exists_does_not_assume_half_second_grace",
+    "test_wait_until_exists_returns_false_when_file_never_appears",
 ]

--- a/tests/config/test_setup_script_timeout.py
+++ b/tests/config/test_setup_script_timeout.py
@@ -397,10 +397,6 @@ def test_record_pid_reaped_deadline_is_independent_of_wait_or_kill_timeout() -> 
 
 
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="process groups are POSIX-only")
-@pytest.mark.xfail(
-    reason="green after W3: #277 wait for pid_file before kill clock",
-    strict=False,
-)
 def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
     """F6 + convention 9 — a setup script that backgrounds a child must not
     leak that child when the script itself is killed.
@@ -412,11 +408,9 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
     The script writes the grandchild PID to a file so we can probe ``os.kill``
     on it directly after the timeout.
 
-    #277 pin: the readiness file is delayed past ``wait_or_kill(..., timeout=0.5)``
-    so starting the kill clock before ``_wait_until_exists(pid_file)`` fails
-    deterministically (the old ordering passed in isolation and flaked under
-    xdist). W3 must wait for ``pid_file`` *before* ``wait_or_kill``; do not
-    mock ``kill_process_group``.
+    #277 / D12: wait for ``pid_file`` with an independent deadline *before*
+    starting the kill clock so xdist scheduling variance cannot cause the
+    readiness poll to race the 0.5s ``wait_or_kill`` timeout.
     """
     from mergecraft.utils.process_group import wait_or_kill_process_group
 
@@ -425,8 +419,6 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
     cli.write_text(
         "#!/bin/bash\n"
         "sleep 300 </dev/null >/dev/null 2>&1 &\n"
-        # Hold the readiness file so a 0.5s kill clock cannot double as the
-        # spawn window (#277 / D12). W3 waits for pid_file before kill.
         "sleep 1\n"
         f"echo $! > {pid_file}\n"
         "exec 1>&- 2>&-\n"
@@ -442,10 +434,17 @@ def test_setup_script_grandchildren_are_reaped(tmp_path: Path) -> None:
         start_new_session=True,
     )
     try:
+        # Wait for pid_file BEFORE starting the kill clock (#277 / D12).
+        # The independent 5s deadline must not share the 0.5s wait_or_kill
+        # timeout — this is the timing-assertion fix that makes the test
+        # deterministic under xdist.
+        assert _wait_until_exists(pid_file, timeout_s=5.0), (
+            "setup script never wrote its grandchild pid within 5s"
+        )
+        grandchild = int(pid_file.read_text(encoding="utf-8").strip())
+        # Kill clock starts only after the readiness file is confirmed.
         with pytest.raises(subprocess.TimeoutExpired):
             wait_or_kill_process_group(proc, timeout=0.5)
-        assert pid_file.exists(), "setup script never wrote its grandchild pid"
-        grandchild = int(pid_file.read_text().strip())
         assert _record_pid_reaped(grandchild, deadline_s=5.0), (
             f"grandchild pid {grandchild} survived the timeout kill — "
             f"the kill path reached the session leader but not the group"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,18 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 def _load_check_xpass() -> Any:
-    """Load ``scripts/check_xpass.py`` via importlib (single source for D6 list)."""
+    """Load ``scripts/check_xpass.py`` via importlib (single source for D6 list).
+
+    Raises:
+        SystemExit: When the module cannot be loaded (fail-closed — aborts the session).
+    """
     path = _ROOT / "scripts" / "check_xpass.py"
     spec = importlib.util.spec_from_file_location("_check_xpass_hook", path)
-    if spec is None or spec.loader is None:  # pragma: no cover
-        return None
+    if spec is None or spec.loader is None:
+        pytest.exit(
+            f"xpass-ratchet: cannot load {path} — ensure scripts/check_xpass.py exists",
+            returncode=3,
+        )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
     return mod
@@ -61,30 +68,15 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int | pytest.ExitC
     tr = session.config.pluginmanager.getplugin("terminalreporter")
     if tr is None:
         return
+
+    mod = _load_check_xpass()
+
     xpassed = tr.stats.get("xpassed", [])
     if not xpassed:
         return
 
-    mod = _load_check_xpass()
-    if mod is None:  # pragma: no cover
-        return
-
-    is_d6 = mod.is_d6_nodeid
-    allowed = [r for r in xpassed if not is_d6(r.nodeid)]
-    d6_count = len(xpassed) - len(allowed)
-
-    if d6_count:
-        tr.write_line(
-            f"xpass-ratchet: {d6_count} D6-excluded xpass(es) — not failing the gate.",
-        )
-    if not allowed:
-        return
-
-    tr.write_sep("=", "XPASS RATCHET FAILED", red=True)
-    for r in allowed:
-        tr.write_line(f"  XPASS {r.nodeid}", red=True)
-    tr.write_line(
-        f"xpass-ratchet: {len(allowed)} allowed-tree xpass(es); promote or fix these tests.",
-        red=True,
-    )
-    session.exitstatus = 1
+    records = tuple(mod.XpassRecord(nodeid=r.nodeid, reason="") for r in xpassed)
+    inventory = mod.XpassInventory(records=records)
+    rc = mod.check_xpass(inventory)
+    if rc != 0 and exitstatus == 0:
+        session.exitstatus = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,89 @@
 
 from __future__ import annotations
 
+import importlib.util
+import os
 import sys
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
 pytest_plugins = ["tests.orchestrator.conftest", "tests.support.provider_harness.pytest_plugin"]
+
+
+# ---------------------------------------------------------------------------
+# B — live opt-in once (CQ-2): skip ``live``-marked tests unless opted in
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip ``live``-marked tests unless ``MERGECRAFT_LIVE=1`` (CQ-2 / D8).
+
+    When the flag IS set, individual test bodies call ``_require`` /
+    ``pytest.fail`` on missing credentials so the suite stays fail-closed (D9).
+    """
+    if os.environ.get("MERGECRAFT_LIVE") == "1":
+        return
+    skip = pytest.mark.skip(reason="MERGECRAFT_LIVE=1 required to run live tests")
+    for item in items:
+        if item.get_closest_marker("live"):
+            item.add_marker(skip)
+
+
+# ---------------------------------------------------------------------------
+# A — xpass ratchet (CQ-1): fail session when non-D6 XPASSes remain
+# ---------------------------------------------------------------------------
+
+
+def _load_check_xpass() -> Any:
+    """Load ``scripts/check_xpass.py`` via importlib (single source for D6 list)."""
+    path = _ROOT / "scripts" / "check_xpass.py"
+    spec = importlib.util.spec_from_file_location("_check_xpass_hook", path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int | pytest.ExitCode) -> None:
+    """Fail the session if any non-D6 XPASS slipped through (CQ-1 / #276).
+
+    D6 test paths (``scripts/check_xpass.py::D6_TEST_PATHS``) are excluded —
+    those xpasses are counted and printed but do not block the gate.
+    """
+    tr = session.config.pluginmanager.getplugin("terminalreporter")
+    if tr is None:
+        return
+    xpassed = tr.stats.get("xpassed", [])
+    if not xpassed:
+        return
+
+    mod = _load_check_xpass()
+    if mod is None:  # pragma: no cover
+        return
+
+    is_d6 = mod.is_d6_nodeid
+    allowed = [r for r in xpassed if not is_d6(r.nodeid)]
+    d6_count = len(xpassed) - len(allowed)
+
+    if d6_count:
+        tr.write_line(
+            f"xpass-ratchet: {d6_count} D6-excluded xpass(es) — not failing the gate.",
+        )
+    if not allowed:
+        return
+
+    tr.write_sep("=", "XPASS RATCHET FAILED", red=True)
+    for r in allowed:
+        tr.write_line(f"  XPASS {r.nodeid}", red=True)
+    tr.write_line(
+        f"xpass-ratchet: {len(allowed)} allowed-tree xpass(es); promote or fix these tests.",
+        red=True,
+    )
+    session.exitstatus = 1

--- a/tests/evals/test_benchmark_publication.py
+++ b/tests/evals/test_benchmark_publication.py
@@ -36,8 +36,8 @@ from mergecraft.modes import compute_prompt_version
 from mergecraft.utils.learnings import LearningProvenance
 
 _SPUN_OUT_W9 = pytest.mark.xfail(
-    reason="spun out: W9 — live precision/recall/F1 in README needs operator eval-replay",
-    strict=False,
+    reason="spun out: W9 — live precision/recall/F1 in README needs operator eval-replay (#276)",
+    strict=True,
 )
 
 _EVAL_HEADING = re.compile(r"eval infrastructure", re.IGNORECASE)

--- a/tests/evidence/test_gate_actions.py
+++ b/tests/evidence/test_gate_actions.py
@@ -422,8 +422,3 @@ def test_unrecognised_gate_mode_falls_back_to_shadow() -> None:
     assert valid.gate_action == "shadow"
     enforced = RepoSettings.model_validate({"gates": {"gate_action": "enforce"}}).gates
     assert enforced.gate_action == "enforce"
-
-
-# ── module-level xfail markers ────────────────────────────────────────────────
-
-pytestmark = pytest.mark.xfail(reason="green after W9/W10", strict=False)

--- a/tests/instructions/test_offline_review_fence.py
+++ b/tests/instructions/test_offline_review_fence.py
@@ -114,9 +114,9 @@ def _build_stub_agent(monkeypatch: pytest.MonkeyPatch, capture_path: Path) -> No
         "name='stub', but _run_agent_review calls compute_modes(agent.name, "
         "...) which requires a real agent id. The test was meant to mock "
         "compute_modes too, but does not. Deferred to B-Final: patch the "
-        "stub to monkeypatch compute_modes or use a real agent id."
+        "stub to monkeypatch compute_modes or use a real agent id (#276)."
     ),
-    strict=False,
+    strict=True,
 )
 def test_injected_pr_body_does_not_change_findings(
     tmp_path: Path,
@@ -255,9 +255,9 @@ def _extract_fenced(prompt: str) -> str:
     reason=(
         "W3 stub infrastructure issue: see test_injected_pr_body_does_not_change_findings "
         "for details. The stub agent uses name='stub' which fails in compute_modes(). "
-        "Deferred to B-Final."
+        "Deferred to B-Final (#276)."
     ),
-    strict=False,
+    strict=True,
 )
 def test_offline_diff_review_fences_commit_messages_and_patch_headers(
     tmp_path: Path,

--- a/tests/instructions/test_offline_review_fence.py
+++ b/tests/instructions/test_offline_review_fence.py
@@ -7,10 +7,9 @@ twice — once with a benign operator-supplied "PR body" via
 are identical. The agent is stubbed in-process so the test proves the
 *prompt* is fenced, not that a live model resists.
 
-All tests are `@pytest.mark.xfail(strict=False)` for the same reason
-as the rest of the W3 suite — W4 will land the fence; these tests
-un-xfail when the fence is in place. They pin the public outcome,
-not the impl signature.
+Pending tests are `@pytest.mark.xfail(strict=True)` — W4 will land the
+fence; these tests fail-strict until the implementation arrives. They pin
+the public outcome, not the impl signature.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_github_integration.py
+++ b/tests/integration/test_github_integration.py
@@ -14,6 +14,11 @@ pytestmark = [
     pytest.mark.live,
 ]
 
+if os.environ.get("MERGECRAFT_LIVE") != "1":
+    pytest.skip(
+        "MERGECRAFT_LIVE=1 required to run live GitHub integration tests", allow_module_level=True
+    )
+
 
 def _require(name: str) -> str:
     value = os.environ.get(name, "").strip()

--- a/tests/integration/test_github_integration.py
+++ b/tests/integration/test_github_integration.py
@@ -14,11 +14,6 @@ pytestmark = [
     pytest.mark.live,
 ]
 
-if os.environ.get("MERGECRAFT_LIVE") != "1":
-    pytest.skip(
-        "MERGECRAFT_LIVE=1 required to run live GitHub integration tests", allow_module_level=True
-    )
-
 
 def _require(name: str) -> str:
     value = os.environ.get(name, "").strip()

--- a/tests/integration/test_live_providers.py
+++ b/tests/integration/test_live_providers.py
@@ -25,9 +25,6 @@ pytestmark = [
     pytest.mark.live,
 ]
 
-if os.environ.get("MERGECRAFT_LIVE") != "1":
-    pytest.skip("MERGECRAFT_LIVE=1 required to run live provider tests", allow_module_level=True)
-
 _MAX_OUTPUT_TOKENS = 16
 _TOKEN_BOUND = 64
 _TIMEOUT = 45.0

--- a/tests/integration/test_live_providers.py
+++ b/tests/integration/test_live_providers.py
@@ -25,6 +25,9 @@ pytestmark = [
     pytest.mark.live,
 ]
 
+if os.environ.get("MERGECRAFT_LIVE") != "1":
+    pytest.skip("MERGECRAFT_LIVE=1 required to run live provider tests", allow_module_level=True)
+
 _MAX_OUTPUT_TOKENS = 16
 _TOKEN_BOUND = 64
 _TIMEOUT = 45.0

--- a/tests/scm/test_errors.py
+++ b/tests/scm/test_errors.py
@@ -1,0 +1,24 @@
+"""W10 — Batch J RED (#279 / D11). GitLab SCM errors name this release.
+
+``UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")`` must tell
+the caller GitLab support is not available in this release — not only a
+capability token. Today's wording is the capability form (W12 rewrites it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.scm.errors import UnsupportedScmCapability
+
+_RELEASE_UNAVAILABLE = "not available in this release"
+
+
+@pytest.mark.xfail(
+    reason="green after W12: GitLab not available in this release",
+    strict=False,
+)
+def test_gitlab_unsupported_capability_names_this_release() -> None:
+    """#279 / D11 — GitLab get_pr error names the release, not only a capability."""
+    exc = UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")
+    assert _RELEASE_UNAVAILABLE in str(exc)

--- a/tests/scm/test_errors.py
+++ b/tests/scm/test_errors.py
@@ -1,11 +1,14 @@
-"""W10 — Batch J RED (#279 / D11). GitLab SCM errors name this release.
+"""W10 — Batch J (#279 / D11). GitLab SCM errors name this release.
 
-``UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")`` must tell
-the caller GitLab support is not available in this release — not only a
-capability token. Today's wording is the capability form (W12 rewrites it).
+``GitLabScmAdapter._unsupported()`` raises ``UnsupportedScmCapability`` with
+a message that tells the caller GitLab support is not available in this release
+— not only the raw capability token. The message is passed explicitly via
+``message=`` so the generic format string in ``errors.py`` stays clean.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from mergecraft.scm.errors import UnsupportedScmCapability
 
@@ -13,6 +16,30 @@ _RELEASE_UNAVAILABLE = "not available in this release"
 
 
 def test_gitlab_unsupported_capability_names_this_release() -> None:
-    """#279 / D11 — GitLab get_pr error names the release, not only a capability."""
-    exc = UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")
-    assert _RELEASE_UNAVAILABLE in str(exc)
+    """#279 / D11 — GitLab adapter raises an error naming this release."""
+    import asyncio
+
+    from mergecraft.scm.gitlab import GitLabScmAdapter
+
+    adapter = GitLabScmAdapter(token="x", base_url="https://gitlab.example.com")
+    with pytest.raises(UnsupportedScmCapability) as exc_info:
+        asyncio.run(adapter.create_pull_request(title="t", body="b", head="h", base="b"))  # type: ignore[arg-type]
+    assert _RELEASE_UNAVAILABLE in str(exc_info.value)
+
+
+def test_generic_unsupported_capability_uses_format_string() -> None:
+    """Generic (non-GitLab) providers use the format-string message."""
+    exc = UnsupportedScmCapability("get_pr", provider="SomeSCM")
+    assert "SomeSCM" in str(exc)
+    assert "get_pr" in str(exc)
+    assert _RELEASE_UNAVAILABLE not in str(exc)
+
+
+def test_explicit_message_overrides_generic() -> None:
+    """``message=`` parameter overrides the format-string fallback."""
+    exc = UnsupportedScmCapability(
+        "get_pr",
+        provider="TestSCM",
+        message="custom message for this release",
+    )
+    assert str(exc) == "custom message for this release"

--- a/tests/scm/test_errors.py
+++ b/tests/scm/test_errors.py
@@ -7,17 +7,11 @@ capability token. Today's wording is the capability form (W12 rewrites it).
 
 from __future__ import annotations
 
-import pytest
-
 from mergecraft.scm.errors import UnsupportedScmCapability
 
 _RELEASE_UNAVAILABLE = "not available in this release"
 
 
-@pytest.mark.xfail(
-    reason="green after W12: GitLab not available in this release",
-    strict=False,
-)
 def test_gitlab_unsupported_capability_names_this_release() -> None:
     """#279 / D11 — GitLab get_pr error names the release, not only a capability."""
     exc = UnsupportedScmCapability("get_pr", provider="GitLabScmAdapter")

--- a/tests/tracing/instrumentation/conftest.py
+++ b/tests/tracing/instrumentation/conftest.py
@@ -22,6 +22,7 @@ What this conftest pins for W3:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -60,7 +61,7 @@ class CapturedSink:
 
 
 @pytest.fixture
-def captured_sink() -> CapturedSink:
+def captured_sink() -> Iterator[CapturedSink]:
     """Resolve ``RepoSettings.tracing`` to a live ``MemorySink``.
 
     W4 must expose the same ``sink_factory``-driven surface from
@@ -69,6 +70,7 @@ def captured_sink() -> CapturedSink:
     """
     from mergecraft.config import RepoSettings
     from mergecraft.tracing import sink_factory
+    from mergecraft.tracing.sinks import _PENDING_SINK
 
     settings = RepoSettings.model_validate(
         {
@@ -79,7 +81,12 @@ def captured_sink() -> CapturedSink:
         }
     ).tracing
     memory = sink_factory(settings).inner.sinks[0]
-    return CapturedSink(memory=memory)
+    try:
+        yield CapturedSink(memory=memory)
+    finally:
+        # ``asyncio.run`` copies ContextVars and does not write back; the
+        # pending handoff otherwise leaks into later tests on this worker.
+        _PENDING_SINK.set(None)
 
 
 @pytest.fixture

--- a/tests/tracing/instrumentation/test_agent_attempt.py
+++ b/tests/tracing/instrumentation/test_agent_attempt.py
@@ -81,7 +81,7 @@ def test_one_agent_attempt_span_per_fallback_entry(captured_sink: Any) -> None:
     assert indices == [0, 1, 2], f"fallback indices out of order: {indices}"
 
 
-@pytest.mark.xfail(reason="green after W4: agent.attempt per fallback entry", strict=False)
+@pytest.mark.xfail(reason="green after W4: agent.attempt per fallback entry (#276)", strict=True)
 def test_one_agent_attempt_span_for_skipped_entry(captured_sink: Any) -> None:
     """W3.2 (skipped) — entry 0 is skipped (missing creds); entry 1 succeeds.
 

--- a/tests/tracing/instrumentation/test_analyzer_run.py
+++ b/tests/tracing/instrumentation/test_analyzer_run.py
@@ -84,7 +84,7 @@ def _register_demo_analyzer(*, finding_count: int, exit_code: int = 0) -> Any:
     return manifest.id
 
 
-@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation", strict=False)
+@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation (#276)", strict=True)
 def test_analyzer_run_spans_carry_id_exit_code_findings_count_duration(
     captured_sink: Any, tmp_path: Path
 ) -> None:
@@ -115,7 +115,7 @@ def test_analyzer_run_spans_carry_id_exit_code_findings_count_duration(
     assert attrs.get("analyzer.duration_ms") >= 0
 
 
-@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation", strict=False)
+@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation (#276)", strict=True)
 def test_analyzer_run_span_records_zero_findings(captured_sink: Any, tmp_path: Path) -> None:
     """W3.3 (edge) — an analyzer that produces no findings still emits a span."""
     _make_repo(tmp_path, files=["src/example.py"])
@@ -138,7 +138,7 @@ def test_analyzer_run_span_records_zero_findings(captured_sink: Any, tmp_path: P
     assert analyzer_runs[0].attrs.get("analyzer.exit_code") == 0
 
 
-@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation", strict=False)
+@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation (#276)", strict=True)
 def test_analyzer_run_span_records_non_zero_exit_on_failure(
     captured_sink: Any, tmp_path: Path
 ) -> None:
@@ -165,7 +165,7 @@ def test_analyzer_run_span_records_non_zero_exit_on_failure(
     assert demo_runs[0].attrs.get("analyzer.exit_code") != 0
 
 
-@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation", strict=False)
+@pytest.mark.xfail(reason="green after W4: analyzer.run instrumentation (#276)", strict=True)
 def test_analyzer_pipeline_parent_span_present(captured_sink: Any, tmp_path: Path) -> None:
     """W3.3 (parent) — ``mergecraft.analyzers.pipeline`` is the parent of ``analyzer.run``."""
     _make_repo(tmp_path, files=["src/example.py"])

--- a/tests/tracing/instrumentation/test_emit_failure.py
+++ b/tests/tracing/instrumentation/test_emit_failure.py
@@ -65,7 +65,7 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
     # ``MultiSink`` constructor — until W4 lands, the swap is a no-op
     # and the test will be xfail.
     from mergecraft.tracing import sink_factory
-    from mergecraft.tracing.sinks import MultiSink
+    from mergecraft.tracing.sinks import _PENDING_SINK, MultiSink
 
     real_multi = MultiSink
 
@@ -81,9 +81,15 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
         return next(iterator)
 
     try:
+        # ``sink_factory`` stashes the resolved sink on a ContextVar that
+        # ``asyncio.run`` copies. A leftover from ``captured_sink`` (or any
+        # sibling ``sink_factory`` call) would make ``claim_sink`` skip the
+        # patched ``MultiSink``. Drop the handoff in this context first.
+        _PENDING_SINK.set(None)
         outcome = asyncio.run(run_with_model_chain(settings=settings, run_once=run_once))
     finally:
         sink_factory.__globals__["MultiSink"] = real_multi  # type: ignore[attr-defined]
+        _PENDING_SINK.set(None)
     return outcome, raising_sink
 
 

--- a/tests/tracing/instrumentation/test_emit_failure.py
+++ b/tests/tracing/instrumentation/test_emit_failure.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from tests.tracing.instrumentation.conftest import (
     make_agent_result,
     make_agent_usage,
@@ -85,6 +86,7 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
     return outcome, raising_sink
 
 
+@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
 def test_emit_failure_never_fails_the_run() -> None:
     """W3.8 — a sink that raises on every write is swallowed.
 
@@ -105,6 +107,7 @@ def test_emit_failure_never_fails_the_run() -> None:
     assert raising_sink.write_calls >= 1, "raising sink was never invoked — emit path not exercised"
 
 
+@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
 def test_emit_failure_logs_a_warning(capsys: Any) -> None:
     """W3.8 (error logging) — sink failures are logged at ``logger.warning``.
 

--- a/tests/tracing/instrumentation/test_emit_failure.py
+++ b/tests/tracing/instrumentation/test_emit_failure.py
@@ -86,7 +86,7 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
     return outcome, raising_sink
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
+@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=True)
 def test_emit_failure_never_fails_the_run() -> None:
     """W3.8 — a sink that raises on every write is swallowed.
 
@@ -107,7 +107,7 @@ def test_emit_failure_never_fails_the_run() -> None:
     assert raising_sink.write_calls >= 1, "raising sink was never invoked — emit path not exercised"
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
+@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=True)
 def test_emit_failure_logs_a_warning(capsys: Any) -> None:
     """W3.8 (error logging) — sink failures are logged at ``logger.warning``.
 

--- a/tests/tracing/instrumentation/test_emit_failure.py
+++ b/tests/tracing/instrumentation/test_emit_failure.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-from loguru import logger
 from tests.tracing.instrumentation.conftest import (
     make_agent_result,
     make_agent_usage,
@@ -87,7 +85,6 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
     return outcome, raising_sink
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
 def test_emit_failure_never_fails_the_run() -> None:
     """W3.8 — a sink that raises on every write is swallowed.
 
@@ -108,27 +105,17 @@ def test_emit_failure_never_fails_the_run() -> None:
     assert raising_sink.write_calls >= 1, "raising sink was never invoked — emit path not exercised"
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=False)
-def test_emit_failure_logs_a_warning() -> None:
+def test_emit_failure_logs_a_warning(capsys: Any) -> None:
     """W3.8 (error logging) — sink failures are logged at ``logger.warning``.
 
-    Captures loguru's warning stream during the run and asserts at least
-    one warning carries the failure signature.
+    Captures stderr during the run and asserts at least one line carries
+    the failure signature. Production emit may reset loguru handlers, so
+    a dedicated ``logger.add`` sink is not a stable capture.
     """
-    messages: list[str] = []
-    sink_id = logger.add(
-        lambda record: messages.append(record.record["message"]),
-        level="WARNING",
-    )
-    try:
-        results = [make_agent_result(success=True, usage=make_agent_usage())]
-        _drive_chain_with_raising_sink(results)
-    finally:
-        logger.remove(sink_id)
-
-    assert any("trace sink" in message for message in messages), (
-        f"expected a warning naming the trace sink; got: {messages}"
-    )
+    results = [make_agent_result(success=True, usage=make_agent_usage())]
+    _drive_chain_with_raising_sink(results)
+    err = capsys.readouterr().err
+    assert "trace sink" in err, f"expected a warning naming the trace sink; got: {err!r}"
 
 
 __all__ = [

--- a/tests/tracing/instrumentation/test_emit_failure.py
+++ b/tests/tracing/instrumentation/test_emit_failure.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from tests.tracing.instrumentation.conftest import (
     make_agent_result,
     make_agent_usage,
 )
+
+from mergecraft.utils.log import logger
 
 
 class _RaisingSink:
@@ -86,7 +87,6 @@ def _drive_chain_with_raising_sink(results: list[Any]) -> tuple[Any, Any]:
     return outcome, raising_sink
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=True)
 def test_emit_failure_never_fails_the_run() -> None:
     """W3.8 — a sink that raises on every write is swallowed.
 
@@ -107,18 +107,26 @@ def test_emit_failure_never_fails_the_run() -> None:
     assert raising_sink.write_calls >= 1, "raising sink was never invoked — emit path not exercised"
 
 
-@pytest.mark.xfail(reason="green after W4: best-effort emit failure handling", strict=True)
-def test_emit_failure_logs_a_warning(capsys: Any) -> None:
+def test_emit_failure_logs_a_warning() -> None:
     """W3.8 (error logging) — sink failures are logged at ``logger.warning``.
 
-    Captures stderr during the run and asserts at least one line carries
-    the failure signature. Production emit may reset loguru handlers, so
-    a dedicated ``logger.add`` sink is not a stable capture.
+    A dedicated ``logger.add`` sink is used because loguru binds ``sys.stderr``
+    at configure time; ``capsys`` misses warnings after an earlier test has
+    already configured logging.
     """
     results = [make_agent_result(success=True, usage=make_agent_usage())]
-    _drive_chain_with_raising_sink(results)
-    err = capsys.readouterr().err
-    assert "trace sink" in err, f"expected a warning naming the trace sink; got: {err!r}"
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda record: messages.append(record.record["message"]),
+        level="WARNING",
+    )
+    try:
+        _drive_chain_with_raising_sink(results)
+    finally:
+        logger.remove(sink_id)
+    assert any("trace sink" in message for message in messages), (
+        f"expected a warning naming the trace sink; got: {messages!r}"
+    )
 
 
 __all__ = [

--- a/tests/tracing/instrumentation/test_span_tree.py
+++ b/tests/tracing/instrumentation/test_span_tree.py
@@ -43,7 +43,7 @@ _EXPECTED_KINDS = (
 )
 
 
-@pytest.mark.xfail(reason="green after W4: span tree instrumentation", strict=False)
+@pytest.mark.xfail(reason="green after W4: span tree instrumentation (#276)", strict=True)
 def test_span_tree_shape(captured_sink: Any) -> None:
     """W3.1 — issue §3: ``mergecraft.run`` is the root; every other kind nests under it.
 

--- a/tests/tracing/instrumentation/test_span_tree.py
+++ b/tests/tracing/instrumentation/test_span_tree.py
@@ -15,8 +15,8 @@ through ``sink_factory``). W4 must wire the production emit sites so:
 - when tracing is disabled (convention 9), no emit site produces a span and
   the production code does not touch the filesystem.
 
-Until W4 lands, every test in this file is ``@pytest.mark.xfail(strict=False)``
-with the wave tag ``green after W4: …``.
+Pending tests are ``@pytest.mark.xfail(strict=True)`` with the wave tag
+``green after W4: …`` until the implementation lands.
 """
 
 from __future__ import annotations

--- a/tests/tracing/instrumentation/test_usage_entries.py
+++ b/tests/tracing/instrumentation/test_usage_entries.py
@@ -122,7 +122,7 @@ def test_usage_entries_field_may_be_deleted(captured_sink: Any) -> None:
         pass
 
 
-@pytest.mark.xfail(reason="green after W4: usage_entries consumer or deletion", strict=False)
+@pytest.mark.xfail(reason="green after W4: usage_entries consumer or deletion (#276)", strict=True)
 def test_usage_entries_aggregation_across_multiple_attempts(captured_sink: Any) -> None:
     """W3.5 — multi-attempt chain: each ``llm.call`` span carries *its* usage.
 

--- a/tests/tracing/test_trace_id_bridge.py
+++ b/tests/tracing/test_trace_id_bridge.py
@@ -247,8 +247,8 @@ def test_jsonl_sink_includes_trace_id(trace_dir: Path) -> None:
 
 
 @pytest.mark.xfail(
-    reason="green after T3.2: OTel trace_id set on span + recording capture",
-    strict=False,
+    reason="green after T3.2: OTel trace_id set on span + recording capture (#276)",
+    strict=True,
 )
 def test_otel_sink_forwards_real_trace_id(trace_event_payload: dict[str, Any]) -> None:
     """OTLPSink writes a span whose OTel ``trace_id`` matches ``event.trace_id``."""

--- a/tests/utils/test_fence.py
+++ b/tests/utils/test_fence.py
@@ -3,8 +3,8 @@
 Ported from `.claude/skills/github-issue-triage/scripts/envelope.py` per
 D7 of `.ignorelocal/waves/issues-security-trust-boundary-wave-plan.md`.
 W4 will land `src/mergecraft/utils/fence.py`; this file pins the public
-contract W4 must satisfy. Every test is `@pytest.mark.xfail(strict=False)`
-because the impl wave (W4) is the green half of the test-first pair.
+contract W4 must satisfy. Pending tests are `@pytest.mark.xfail(strict=True)`
+until the impl wave (W4) lands.
 
 Contract surface (must hold after W4):
 

--- a/tests/utils/test_fence.py
+++ b/tests/utils/test_fence.py
@@ -119,9 +119,9 @@ _FORGED_OPEN = (
         "attacker's _FORGED_CLOSE substring (which contains nonce=0000000000000000) "
         "must appear in the rendered output AND that nonce=0000000000000000 must "
         "not appear. The security-correct implementation neutralizes the forged "
-        "nonce, removing the literal substring. Deferred to B-Final test redesign."
+        "nonce, removing the literal substring. Deferred to B-Final test redesign (#276)."
     ),
-    strict=False,
+    strict=True,
 )
 def test_forged_close_does_not_escape_fence() -> None:
     """An attacker text that contains a plausible closing delimiter with a

--- a/tests/utils/test_learnings_provenance.py
+++ b/tests/utils/test_learnings_provenance.py
@@ -8,9 +8,9 @@ W6 will land the provenance record type, the quarantine + staging flow
 in `src/mergecraft/utils/learnings.py`, the opt-in auto-promote flag in
 `RepoSettings`, the seed-time fence reuse from W4, and the influence
 listing CLI subcommand (`mergecraft learnings influence`). This file
-pins the public contract W6 must satisfy; every test is
-``@pytest.mark.xfail(reason="green after W6", strict=False)`` for the
-same reason as `tests/utils/test_fence.py`.
+pins the public contract that security-trust W6 landed. Stale
+``xfail(strict=False)`` markers were promoted in open-issues-sweep
+2026-08-19b W6 (#276).
 
 The contract under test (D10, D11):
 
@@ -37,9 +37,7 @@ into `pre-0.0.1`, and the import will resolve.
 
 The provenance / quarantine / influence symbols do not exist on this
 base either. The same ``pytest.importorskip`` discipline keeps the
-suite collecting while the implementation lands, and the xfail marker
-keeps the cases visible (rather than silently skipped) until W6 flips
-them green.
+suite collecting when a symbol is absent.
 """
 
 from __future__ import annotations
@@ -114,9 +112,6 @@ _ACTIVE_SECTION_NAME = "Active"
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="green after W6: provenance gate + quarantine + opt-in auto-promote", strict=False
-)
 async def test_fork_pr_injected_learning_text_promotes_nothing(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -179,7 +174,6 @@ async def test_fork_pr_injected_learning_text_promotes_nothing(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: provenance record type", strict=False)
 async def test_every_learning_entry_carries_provenance(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -235,7 +229,6 @@ async def test_every_learning_entry_carries_provenance(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: quarantine + staging section", strict=False)
 async def test_entry_without_maintainer_provenance_is_quarantined(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -294,7 +287,6 @@ async def test_entry_without_maintainer_provenance_is_quarantined(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: quarantine + prompt route", strict=False)
 async def test_quarantined_entry_never_reaches_reviewer_prompt(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -368,7 +360,6 @@ async def test_quarantined_entry_never_reaches_reviewer_prompt(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: opt-in auto-promote flag", strict=False)
 async def test_promotion_requires_explicit_approval_by_default(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -418,7 +409,6 @@ async def test_promotion_requires_explicit_approval_by_default(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: opt-in auto-promote flag", strict=False)
 async def test_legacy_autopromote_available_as_optin(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -471,7 +461,6 @@ async def test_legacy_autopromote_available_as_optin(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="green after W6: seed-time fence reuse from W4", strict=False)
 async def test_approved_learnings_are_fenced_at_seed_time(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -568,7 +557,6 @@ async def test_approved_learnings_are_fenced_at_seed_time(
 # ── W5.7 — influence listing names seeded entries (D11). ──────────────────
 
 
-@pytest.mark.xfail(reason="green after W6: influence listing CLI subcommand", strict=False)
 def test_influence_listing_names_seeded_entries(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## What?

Makes contributor tests and 0.1.0 release copy match the product: GitHub-only, no accidental live-credential runs, and no silent expected-fail passes.

- Setup-script grandchild reap no longer races under parallel test runs.
- Live credential tests skip unless opted in. CI still fails closed when secrets are missing.
- Stale expected-fail markers on the allowed test tree are promoted. Unexpected passes fail the session.
- Remaining typing suppressions on the allowed source tree need a one-line reason, enforced by lint.
- README and Marketplace copy state GitHub-only. GitLab errors say support is not available in this release.
- Marketplace listing points at existing signed-image attestations. Release signing workflow is unchanged.

## Why?

These six issues landed after the morning defect sweep so hygiene would not collide with that work.

Contributors who ran the test suite without Make still collected live tests and failed without secrets. Expected-fail markers that already passed hid regressions. Marketplace copy asked for signing that already ships.

## Note

Left for the parallel defect sweep, and excluded from these ratchets: expected-fail markers in `tests/agents/test_codex_custom_provider.py`, and typing leftovers in `src/mergecraft/agents/_stream_consumer.py` and `src/mergecraft/mcp/verdict.py`.

`ci-cd.yml` is untouched. No extra SLSA generator job.

## Test plan

- [ ] `make lint` (includes `scripts/check_type_ignores.py`)
- [ ] `make ci-static`
- [ ] `make test`
- [ ] Live tests skip without `MERGECRAFT_LIVE=1`; with the flag, missing secrets still fail

## Related PR(s)/Issue(s)

Closes #275
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
