### PR TITLE
fix: post-#291 git guard and config cleanup

### DIFF
--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -168,14 +168,19 @@ def _codex_home(ctx: AgentRunContext) -> Path:
 def _toml_string(value: str) -> str:
     """Render ``value`` as a TOML basic string.
 
-    Control characters are escaped as well as ``\\`` and ``"``: TOML forbids a
-    raw newline or tab inside a basic string, so a value carrying one would
-    render a file ``tomllib`` refuses to parse. No current value contains any,
-    which is why this is a guard rather than a fix.
+    ``\\`` and ``"`` are escaped, and so is every control character TOML
+    forbids raw inside a basic string — U+0000 to U+0008, U+000A to U+001F,
+    and U+007F. The three with a named escape get it; the rest get ``\\uXXXX``,
+    which is what ``tomli_w`` emits. A value carrying any of them otherwise
+    renders a file ``tomllib`` refuses to parse, and ``base_url`` comes from a
+    consumer-supplied env var, so this is reachable rather than theoretical.
     """
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     for char, replacement in (("\n", "\\n"), ("\r", "\\r"), ("\t", "\\t")):
         escaped = escaped.replace(char, replacement)
+    escaped = "".join(
+        f"\\u{ord(char):04x}" if ord(char) < 0x20 or ord(char) == 0x7F else char for char in escaped
+    )
     return f'"{escaped}"'
 
 

--- a/src/mergecraft/cli/agents_cmd.py
+++ b/src/mergecraft/cli/agents_cmd.py
@@ -16,6 +16,7 @@ from mergecraft.agents.registry import (
     load_registry,
     resolve_prompt_text,
 )
+from mergecraft.cli.target_dir import target_dir as resolve_target_dir
 from mergecraft.config.settings import AgentBindingOverride, load_repo_settings
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -41,19 +42,8 @@ def _bail(msg: str) -> NoReturn:
     raise typer.Exit(1)
 
 
-def _target_dir(cwd: Path) -> Path:
-    """The directory this command operates on — ``cwd``, resolved.
-
-    Deliberately not ``git_repo_root``: these commands act on whatever tree they
-    are pointed at, including one that is not a git checkout at all. Named for
-    that so it cannot be mistaken for the canonical repo-root helper in
-    ``utils/workspace.py``.
-    """
-    return cwd.resolve()
-
-
-def _tool_ctx(repo_root: Path) -> ToolContext:
-    state = init_tool_state(owner="acme", name="demo", dir=str(repo_root))
+def _tool_ctx(target_dir: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(target_dir))
     return ToolContext(
         agent_id="claude",
         repo=RepoIdentity(owner="acme", name="demo"),
@@ -69,7 +59,7 @@ def _tool_ctx(repo_root: Path) -> ToolContext:
         modes=compute_modes("claude"),
         tool_state=state,
         mcp_server_url="",
-        tmpdir=str(repo_root),
+        tmpdir=str(target_dir),
         signed_commits=True,
         xrepo=XrepoConfig(mode="explicit", read=[], write=[]),
         static_checks_enabled=True,
@@ -78,16 +68,16 @@ def _tool_ctx(repo_root: Path) -> ToolContext:
 
 @app.command("list")
 def list_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """List agent bindings with model chain, prompt id, and tool count."""
-    repo_root = _target_dir(cwd)
-    settings = load_repo_settings(root=repo_root)
+    target_dir = resolve_target_dir(cwd)
+    settings = load_repo_settings(root=target_dir)
     try:
-        registry = load_registry(settings=settings, repo_root=repo_root)
+        registry = load_registry(settings=settings, repo_root=target_dir)
     except RegistryValidationError as exc:
         _bail(str(exc))
-    ctx = _tool_ctx(repo_root)
+    ctx = _tool_ctx(target_dir)
 
     table = Table(title="Agent registry")
     table.add_column("role")
@@ -113,18 +103,18 @@ def list_cmd(
 @app.command("show")
 def show_cmd(
     role: str = typer.Argument(..., help="Agent role (e.g. reviewer)."),
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """Show resolved prompt text and MCP tool names for one role."""
-    repo_root = _target_dir(cwd)
+    target_dir = resolve_target_dir(cwd)
     try:
         AgentRole(role)
     except ValueError:
         _bail(f"unknown role: {role!r}")
 
-    settings = load_repo_settings(root=repo_root)
+    settings = load_repo_settings(root=target_dir)
     try:
-        registry = load_registry(settings=settings, repo_root=repo_root)
+        registry = load_registry(settings=settings, repo_root=target_dir)
         binding = registry.resolve_role(role)
     except RegistryValidationError as exc:
         _bail(str(exc))
@@ -132,7 +122,7 @@ def show_cmd(
         _bail(f"unknown role: {role!r}")
 
     prompt = resolve_prompt_text(binding.prompt_id, version=binding.prompt_version)
-    tools = registry.resolve_tool_names(binding, _tool_ctx(repo_root))
+    tools = registry.resolve_tool_names(binding, _tool_ctx(target_dir))
 
     console.print(f"[bold]{binding.role.value}[/bold] ({binding.agent_id})")
     console.print(f"model chain: {', '.join(binding.model_chain)}")
@@ -149,7 +139,7 @@ def show_cmd(
 def set_cmd(
     role: str = typer.Argument(..., help="Agent role to override."),
     model: str | None = typer.Option(None, "--model", help="Primary model slug override."),
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """Write a single agent binding override into ``.mergecraft/config.yaml``."""
     if model is None:
@@ -162,8 +152,8 @@ def set_cmd(
         known = ", ".join(item.value for item in AgentRole)
         _bail(f"unknown role: {role!r} (expected one of: {known})")
 
-    repo_root = _target_dir(cwd)
-    config_path = repo_root / ".mergecraft" / "config.yaml"
+    target_dir = resolve_target_dir(cwd)
+    config_path = target_dir / ".mergecraft" / "config.yaml"
     if not config_path.is_file():
         _bail(f"no config at {config_path} — run mergecraft init first")
 

--- a/src/mergecraft/cli/analyzers_cmd.py
+++ b/src/mergecraft/cli/analyzers_cmd.py
@@ -17,6 +17,7 @@ from mergecraft.analyzers.lockfile import LockEntry, read_lock, write_lock
 from mergecraft.analyzers.provision import resolve_with_lock
 from mergecraft.analyzers.registry import detect_enabled, load_catalog
 from mergecraft.analyzers.sarif import export_sarif
+from mergecraft.cli.target_dir import target_dir as resolve_target_dir
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import AnalyzerManifest
@@ -34,22 +35,11 @@ def _bail(msg: str) -> NoReturn:
     raise typer.Exit(1)
 
 
-def _target_dir(cwd: Path) -> Path:
-    """The directory this command operates on — ``cwd``, resolved.
-
-    Deliberately not ``git_repo_root``: these commands act on whatever tree they
-    are pointed at, including one that is not a git checkout at all. Named for
-    that so it cannot be mistaken for the canonical repo-root helper in
-    ``utils/workspace.py``.
-    """
-    return cwd.resolve()
-
-
-def _git_changed_files(repo_root: Path) -> list[str]:
+def _git_changed_files(target_dir: Path) -> list[str]:
     try:
         completed = subprocess.run(
             ["git", "diff", "--name-only", "HEAD"],
-            cwd=repo_root,
+            cwd=target_dir,
             capture_output=True,
             text=True,
             check=False,
@@ -70,12 +60,12 @@ def _manifest_by_id(analyzer_id: str) -> AnalyzerManifest:
 
 @app.command("list")
 def list_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """List catalog analyzers and whether they would enable here."""
-    repo_root = _target_dir(cwd)
-    changed = _git_changed_files(repo_root) or ["."]
-    enabled = {m.id for m in detect_enabled(repo_root=repo_root, changed_files=changed)}
+    target_dir = resolve_target_dir(cwd)
+    changed = _git_changed_files(target_dir) or ["."]
+    enabled = {m.id for m in detect_enabled(repo_root=target_dir, changed_files=changed)}
     table = Table(title="Analyzer catalog")
     table.add_column("id")
     table.add_column("category")
@@ -90,15 +80,15 @@ def list_cmd(
 
 @app.command("detect")
 def detect_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
     files: list[str] = typer.Option(None, "--file", "-f", help="Changed paths (repeatable)."),
 ) -> None:
     """Show analyzers that would run for changed paths in this repo."""
-    repo_root = _target_dir(cwd)
-    changed = files or _git_changed_files(repo_root)
+    target_dir = resolve_target_dir(cwd)
+    changed = files or _git_changed_files(target_dir)
     if not changed:
         _bail("no changed files — pass --file or run inside a git repo with local changes")
-    enabled = detect_enabled(repo_root=repo_root, changed_files=changed)
+    enabled = detect_enabled(repo_root=target_dir, changed_files=changed)
     for manifest in enabled:
         console.print(f"{manifest.id} ({manifest.category}, {manifest.runtime})")
 
@@ -106,17 +96,17 @@ def detect_cmd(
 @app.command("run")
 def run_cmd(
     analyzer_id: str = typer.Argument(..., help="Catalog analyzer id."),
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
     files: list[str] = typer.Option(None, "--file", "-f", help="Changed paths (repeatable)."),
 ) -> None:
     """Execute one analyzer against the working tree."""
-    repo_root = _target_dir(cwd)
-    changed = files or _git_changed_files(repo_root)
+    target_dir = resolve_target_dir(cwd)
+    changed = files or _git_changed_files(target_dir)
     if not changed:
         _bail("no changed files — pass --file or run inside a git repo with local changes")
     result = run_adapter(
         tool_id=analyzer_id,
-        repo_root=repo_root,
+        repo_root=target_dir,
         changed_files=changed,
         tier="trusted",
     )
@@ -153,7 +143,7 @@ def explain_cmd(analyzer_id: str = typer.Argument(..., help="Catalog analyzer id
 @app.command("export")
 def export_cmd(
     analyzer_id: str = typer.Argument(..., help="Catalog analyzer id."),
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
     files: list[str] = typer.Option(None, "--file", "-f", help="Changed paths (repeatable)."),
     sarif: bool = typer.Option(False, "--sarif", help="Write SARIF 2.1.0 JSON to stdout."),
     output: Path | None = typer.Option(None, "--output", "-o", help="Write SARIF to this file."),
@@ -161,13 +151,13 @@ def export_cmd(
     """Run one analyzer and export findings as SARIF."""
     if not sarif and output is None:
         _bail("pass --sarif or --output")
-    repo_root = _target_dir(cwd)
-    changed = files or _git_changed_files(repo_root)
+    target_dir = resolve_target_dir(cwd)
+    changed = files or _git_changed_files(target_dir)
     if not changed:
         _bail("no changed files — pass --file or run inside a git repo with local changes")
     result = run_adapter(
         tool_id=analyzer_id,
-        repo_root=repo_root,
+        repo_root=target_dir,
         changed_files=changed,
         tier="trusted",
     )
@@ -184,16 +174,16 @@ def export_cmd(
 
 @app.command("lock")
 def lock_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
     refresh: bool = typer.Option(False, "--refresh", help="Re-resolve managed binaries."),
 ) -> None:
     """Write or refresh ``.mergecraft/analyzers.lock`` for managed tools."""
     import platform
     import sys
 
-    repo_root = _target_dir(cwd)
-    lock_path = repo_root / ".mergecraft" / "analyzers.lock"
-    cache_dir = repo_root / ".mergecraft" / "analyzer-cache"
+    target_dir = resolve_target_dir(cwd)
+    lock_path = target_dir / ".mergecraft" / "analyzers.lock"
+    cache_dir = target_dir / ".mergecraft" / "analyzer-cache"
     machine = platform.machine().casefold()
     if sys.platform == "darwin":
         plat = "darwin-arm64" if machine in {"arm64", "aarch64"} else "darwin-amd64"

--- a/src/mergecraft/cli/pipeline_cmd.py
+++ b/src/mergecraft/cli/pipeline_cmd.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from mergecraft.agents.registry import load_registry
+from mergecraft.cli.target_dir import target_dir as resolve_target_dir
 from mergecraft.config.settings import load_repo_settings
 from mergecraft.orchestrator.executor import PipelineExecutor
 from mergecraft.orchestrator.pipeline import (
@@ -31,28 +32,17 @@ def _bail(msg: str) -> NoReturn:
     raise typer.Exit(1)
 
 
-def _target_dir(cwd: Path) -> Path:
-    """The directory this command operates on — ``cwd``, resolved.
-
-    Deliberately not ``git_repo_root``: these commands act on whatever tree they
-    are pointed at, including one that is not a git checkout at all. Named for
-    that so it cannot be mistaken for the canonical repo-root helper in
-    ``utils/workspace.py``.
-    """
-    return cwd.resolve()
-
-
-def _default_pipeline_path(repo_root: Path, settings: object) -> Path:
+def _default_pipeline_path(target_dir: Path, settings: object) -> Path:
     configured = getattr(settings, "pipeline", None)
     if configured:
         path = Path(configured)
-        return path if path.is_absolute() else repo_root / path
-    return repo_root / ".mergecraft" / "pipeline.yaml"
+        return path if path.is_absolute() else target_dir / path
+    return target_dir / ".mergecraft" / "pipeline.yaml"
 
 
-def _load_pipeline(repo_root: Path) -> tuple[PipelineDefinition, Path]:
-    settings = load_repo_settings(root=repo_root)
-    path = _default_pipeline_path(repo_root, settings)
+def _load_pipeline(target_dir: Path) -> tuple[PipelineDefinition, Path]:
+    settings = load_repo_settings(root=target_dir)
+    path = _default_pipeline_path(target_dir, settings)
     if not path.is_file():
         _bail(f"pipeline file not found: {path}")
     text = path.read_text(encoding="utf-8")
@@ -61,13 +51,13 @@ def _load_pipeline(repo_root: Path) -> tuple[PipelineDefinition, Path]:
 
 @app.command("lint")
 def lint_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """Validate the pipeline file and registry agent references."""
-    repo_root = _target_dir(cwd)
-    settings = load_repo_settings(root=repo_root)
-    pipeline, path = _load_pipeline(repo_root)
-    registry = load_registry(settings=settings, repo_root=repo_root)
+    target_dir = resolve_target_dir(cwd)
+    settings = load_repo_settings(root=target_dir)
+    pipeline, path = _load_pipeline(target_dir)
+    registry = load_registry(settings=settings, repo_root=target_dir)
     errors = lint_pipeline_agents(pipeline, registry)
     if errors:
         for err in errors:
@@ -79,17 +69,17 @@ def lint_cmd(
 @app.command("show")
 def show_cmd(
     diff: Path = typer.Option(..., "--diff", help="Unified diff to preview against."),
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """Preview which pipeline steps would run or skip for a diff."""
-    repo_root = _target_dir(cwd)
-    settings = load_repo_settings(root=repo_root)
-    pipeline, _path = _load_pipeline(repo_root)
-    registry = load_registry(settings=settings, repo_root=repo_root)
+    target_dir = resolve_target_dir(cwd)
+    settings = load_repo_settings(root=target_dir)
+    pipeline, _path = _load_pipeline(target_dir)
+    registry = load_registry(settings=settings, repo_root=target_dir)
     executor = PipelineExecutor(registry=registry, settings=settings)
     result = executor.run(
         pipeline,
-        repo_root=repo_root,
+        repo_root=target_dir,
         diff_path=diff.resolve(),
     )
     table = Table(title="Pipeline preview")
@@ -104,11 +94,11 @@ def show_cmd(
 
 @app.command("explain")
 def explain_cmd(
-    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
 ) -> None:
     """Print pipeline step ids and predicate vocabulary."""
-    repo_root = _target_dir(cwd)
-    pipeline, path = _load_pipeline(repo_root)
+    target_dir = resolve_target_dir(cwd)
+    pipeline, path = _load_pipeline(target_dir)
     console.print(f"pipeline: {path}")
     for step_id in pipeline.step_ids():
         console.print(f"  - {step_id}")

--- a/src/mergecraft/cli/target_dir.py
+++ b/src/mergecraft/cli/target_dir.py
@@ -1,0 +1,16 @@
+"""Resolve the working directory for CLI commands that take ``--cwd``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def target_dir(cwd: Path) -> Path:
+    """The directory this command operates on — ``cwd``, resolved.
+
+    Deliberately not ``git_repo_root``: these commands act on whatever tree they
+    are pointed at, including one that is not a git checkout at all. Named for
+    that so it cannot be mistaken for the canonical repo-root helper in
+    ``utils/workspace.py``.
+    """
+    return cwd.resolve()

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -178,18 +178,38 @@ def _config_flag_message(token: str) -> str:
     return f"Blocked: '{token}' can execute arbitrary code via git alias expansion."
 
 
+def _bare_dash_c_message(subcommand: str) -> str:
+    """Explain a refused bare ``-c`` without claiming the token is the config flag.
+
+    A bare ``-c`` carries no key=value, so nothing in it says whether it is
+    git's config flag misplaced after the verb or the subcommand's own short
+    flag. The guard refuses it on that ambiguity, not on evidence of an alias
+    payload, and the message has to say so: ``git blame -c`` is a real
+    read-only invocation and ``git diff -c`` is one git accepts silently.
+    """
+    forwarded = ", ".join(
+        sorted(name for name, shorts in _SUBCOMMAND_SHORT_FLAGS.items() if "c" in shorts)
+    )
+    return (
+        f"Blocked: '{subcommand} -c' — a bare '-c' cannot be told apart from git's own "
+        f"config flag at this position, and '{subcommand}' is not recorded as defining "
+        f"'-c', so it is refused rather than forwarded. Subcommands whose '-c' is "
+        f"forwarded: {forwarded}."
+    )
+
+
 def _reject_config_flags(tokens: list[str], *, subcommand: str = "") -> None:
-    """Reject git's config flag, and any ``-c`` bundle *subcommand* cannot own.
+    """Reject git's config flag, and any ``-c`` token *subcommand* cannot own.
 
     ``-c`` / ``--config-env`` let an agent inject an alias-expansion shell
     command regardless of ``payload.shell``, and rejection is unconditional —
-    there is no safe-key allowlist for ``-c``. A ``-c``-shaped token the
-    subcommand does not define is refused too, but for the other reason and
-    with its own message: it is an unrecognised short bundle, not proof of an
-    alias payload.
+    there is no safe-key allowlist for ``-c``. Two other ``-c``-shaped tokens
+    are refused for their own reasons and with their own messages: a bare
+    ``-c`` after a subcommand that does not declare it, which is ambiguous
+    rather than proven hostile, and an unrecognised short bundle.
 
     Raises:
-        ValueError: on either refusal.
+        ValueError: on any of the three refusals.
     """
     for tok in tokens:
         if tok.startswith("--"):
@@ -198,12 +218,11 @@ def _reject_config_flags(tokens: list[str], *, subcommand: str = "") -> None:
             continue
         if not tok.startswith("-c") or _subcommand_declares_shorts(tok, subcommand):
             continue
+        if tok == "-c" and subcommand:
+            raise ValueError(_bare_dash_c_message(subcommand))
         if _is_config_flag(tok):
             raise ValueError(_config_flag_message(tok))
-        msg = (
-            f"Blocked: '{tok}' bundles short flags {subcommand or 'git'} does not "
-            "define — only each subcommand's own read-only short flags are forwarded."
-        )
+        msg = f"Blocked: '{tok}' bundles short flags {subcommand or 'git'} does not define."
         raise ValueError(msg)
 
 

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -161,7 +161,8 @@ _NUMERIC_ARG = re.compile(r"^\d+(?:\.\d+)?[smhd]?$")
 # git status`, `doas -g devs git …`. The user name is neither path-shaped nor
 # numeric, so without this it reads as the command word and ends the segment
 # before the git behind it is inspected. Glued spellings (`--user=ci`) already
-# fall out as flags.
+# fall out as flags. The set is not per-wrapper, so the skip yields to a token
+# that names git — see the operand branch in ``_is_git_command``.
 _WRAPPER_FLAG_TAKES_VALUE = frozenset({"-u", "--user", "-g", "--group"})
 
 
@@ -207,7 +208,13 @@ def _is_git_command(command: str) -> bool:
         for token in segment.split():
             if skip_operand:
                 skip_operand = False
-                continue
+                # The same letter takes an operand to one wrapper and none to
+                # the next — `-u` is the target user to `sudo` but `--ungroup`
+                # to `parallel` and `set -u` to `sh`, where the token behind it
+                # is the command. Reading a git there costs a false positive on
+                # `sudo -u git ls`, which is the cheaper side to be wrong on.
+                if not _names_git(token):
+                    continue
             if _ENV_ASSIGNMENT.match(token) or _NUMERIC_ARG.match(token) or token.startswith("-"):
                 skip_operand = token in _WRAPPER_FLAG_TAKES_VALUE
                 continue

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -116,10 +116,7 @@ def stamp_review_phase_on_active_span(phase: ReviewPhase) -> None:
 
 
 def _current_review_phase(tool_state: ToolState) -> ReviewPhase:
-    raw = tool_state.review_phase
-    if isinstance(raw, ReviewPhase):
-        return raw
-    return ReviewPhase(str(raw))
+    return ReviewPhase(tool_state.review_phase)
 
 
 def ensure_review_scope_for_terminal(tool_state: ToolState, tool_name: str) -> None:

--- a/tests/agents/test_codex_custom_provider.py
+++ b/tests/agents/test_codex_custom_provider.py
@@ -652,3 +652,91 @@ def test_custom_provider_blocks_keep_their_own_keys(
     assert block.get("env_key") == INDEXED_API_KEY_FMT.format(n=1)
     # Convention 7 — the env-var *name* is written, never the resolved value.
     assert PROVIDER_1_API_KEY not in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        pytest.param("\x1b", id="escape"),
+        pytest.param("\x01", id="start-of-heading"),
+        pytest.param("\x08", id="backspace"),
+        pytest.param("\x7f", id="delete"),
+    ],
+)
+def test_control_character_in_a_base_url_still_parses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    control: str,
+) -> None:
+    """A consumer-supplied control character must not render an unparseable file.
+
+    ``base_url`` reaches the renderer straight from the environment, and TOML
+    forbids every control character in a basic string, not just the three with
+    a named escape. A raw one lands in ``config.toml`` and ``tomllib`` refuses
+    the whole file — the failure the escaping was added to prevent.
+    """
+    hostile = f"{PROVIDER_1_BASE_URL}{control}"
+    monkeypatch.setenv(INDEXED_BASE_URL_FMT.format(n=1), hostile)
+    monkeypatch.setenv(INDEXED_API_KEY_FMT.format(n=1), PROVIDER_1_API_KEY)
+
+    parsed = _parse_toml(_write_config(tmp_path, model="openai/gpt-5.3-codex"))
+
+    providers = parsed.get("model_providers")
+    assert isinstance(providers, dict)
+    block = providers.get(PROVIDER_1_ID)
+    assert isinstance(block, dict)
+    assert block.get("base_url") == hostile
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        pytest.param({}, id="bare"),
+        pytest.param(
+            {INDEXED_API_KEY_FMT.format(n=1): PROVIDER_1_API_KEY}, id="empty-model-providers"
+        ),
+        pytest.param(
+            {
+                INDEXED_BASE_URL_FMT.format(n=1): PROVIDER_1_BASE_URL,
+                INDEXED_API_KEY_FMT.format(n=1): PROVIDER_1_API_KEY,
+            },
+            id="indexed-provider",
+        ),
+    ],
+)
+def test_rendered_codex_config_matches_tomli_w_byte_for_byte(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    env: dict[str, str],
+) -> None:
+    """The hand-rolled renderer stays byte-identical to ``tomli_w`` on real shapes.
+
+    Covers the no-provider path, the empty ``[model_providers]`` table a
+    partial pair emits, and a full provider block with the quoted
+    ``127.0.0.1`` domain key the permission profile carries.
+    """
+    import tomli_w
+
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    text = _write_config(tmp_path, model=_CODEX_MODEL).read_text(encoding="utf-8")
+    parsed = tomllib.loads(text)
+    redump = tomli_w.dumps(parsed)
+
+    assert text == redump
+
+
+@pytest.mark.parametrize("codepoint", [*range(0x01, 0x20), 0x7F])
+def test_toml_string_escapes_every_forbidden_control_character(codepoint: int) -> None:
+    """Each control character TOML forbids must survive a ``tomllib`` round-trip.
+
+    U+0000 is excluded because the OS refuses it in an env var, so it cannot
+    reach the renderer; every other code point below U+0020, plus U+007F, can.
+    """
+    codex_module = _load_codex_module()
+    value = f"a{chr(codepoint)}b"
+
+    rendered = codex_module._toml_string(value)
+
+    assert tomllib.loads(f"k = {rendered}")["k"] == value

--- a/tests/mcp/test_git_tool.py
+++ b/tests/mcp/test_git_tool.py
@@ -741,14 +741,18 @@ async def test_known_config_flag_spellings_still_rejected(
     `--config-env` is accepted by git both as `--config-env <name>=<envvar>` and
     as `--config-env=<name>=<envvar>`; the bare token covers the separate-value
     form. `-c` is exact-match only upstream, so `-c` and `-c=…` are the whole
-    short-flag surface the guard has to keep refusing.
+    short-flag surface the guard has to keep refusing. The bare `-c` is refused
+    on ambiguity rather than on an alias claim, so only the refusal is asserted
+    here; its message is pinned in
+    `test_bare_dash_c_after_subcommand_is_refused_without_an_alias_claim`.
     """
     recorder = _RunGitRecorder()
     monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
 
     result = await git_tool(_ctx(tmp_path)).execute({"command": "status", "args": [token]})
     assert result.is_error is True, result.content[0]["text"]
-    assert CONFIG_FLAG_MESSAGE in result.content[0]["text"]
+    if token != "-c":
+        assert CONFIG_FLAG_MESSAGE in result.content[0]["text"]
     assert recorder.calls == []
 
 
@@ -765,7 +769,51 @@ async def test_spaced_config_flag_rejection_message_names_the_token(
     assert result.is_error is True
     text = result.content[0]["text"]
     assert "'-c'" in text
-    assert CONFIG_FLAG_MESSAGE in text
+    assert recorder.calls == []
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    [
+        pytest.param("blame", id="blame-annotate-output"),
+        pytest.param("diff", id="diff-combined"),
+        pytest.param("status", id="status-owns-no-dash-c"),
+    ],
+)
+async def test_bare_dash_c_after_subcommand_is_refused_without_an_alias_claim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, subcommand: str
+) -> None:
+    """A bare `-c` stays refused, but the message must stop lying about why.
+
+    git's config flag must precede the subcommand, so a `-c` sitting after one
+    cannot be it: `git blame -c` selects git-annotate output and `git diff -c`
+    is accepted silently. The guard cannot tell those from a misplaced config
+    flag and keeps refusing them — what it must not do is assert alias
+    execution about a token that carries no payload.
+    """
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute({"command": subcommand, "args": ["-c"]})
+    assert result.is_error is True, result.content[0]["text"]
+    text = result.content[0]["text"]
+    assert CONFIG_FLAG_MESSAGE not in text
+    assert "cannot be told apart from git's own config flag" in text
+    assert recorder.calls == []
+
+
+async def test_glued_alias_payload_still_claims_alias_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The honest alias claim survives where it is true: `-c<key>=<value>`."""
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute(
+        {"command": "status", "args": ["-calias.x=!true"]}
+    )
+    assert result.is_error is True, result.content[0]["text"]
+    assert CONFIG_FLAG_MESSAGE in result.content[0]["text"]
     assert recorder.calls == []
 
 

--- a/tests/mcp/test_shell_git_guard.py
+++ b/tests/mcp/test_shell_git_guard.py
@@ -104,6 +104,15 @@ BYPASSES = [
     pytest.param("sudo -g devs git status", id="sudo-target-group"),
     pytest.param("sudo -u ci -g devs git clean -fdx", id="sudo-user-and-group"),
     pytest.param("doas -u ci git status", id="doas-target-user"),
+    # `-u` takes an operand to `sudo` but not to every wrapper: to `parallel` it
+    # is `--ungroup` and to `sh`/`bash` it is `set -u`, so the token behind it is
+    # the command. Skipping the operand unconditionally swallowed that git.
+    pytest.param("parallel -u git clean -fdx", id="parallel-ungroup-then-git"),
+    pytest.param("parallel -u " + ALIAS_PAYLOAD, id="parallel-ungroup-then-alias-payload"),
+    pytest.param("sh -u git", id="sh-nounset-then-git"),
+    pytest.param("bash -u git status", id="bash-nounset-then-git"),
+    pytest.param("env -u GIT_DIR -u HOME git status", id="env-unset-then-git"),
+    pytest.param("strace -u ci git status", id="strace-target-user"),
 ]
 
 # Separator spellings the original class did cover — regression guards, so a


### PR DESCRIPTION
## What?

Closes the post-merge sign-off cleanup left out of #291: git refusal messages that match what the guard actually knows, a shell wrapper regression fix, full TOML control-character escaping for custom provider config, and small CLI/verdict hygiene.

## Why?

#291 merged the security surface both audits signed off on, but two Low findings and several quality nits were deliberately held for a follow-up so the merge did not churn guard code and message text in the same branch that changed guard behaviour. The false bare `-c` alias wording was the quality audit's one sign-off condition; the rest is polish that keeps refusal-side guards honest and the Codex config renderer parseable under hostile env input.

## Note

The deferred `mcp/git_guards.py` extraction is tracked in #300 rather than attempted here — moving a security-sensitive guard block in the same PR that touches guard messages is how meaning drifts between review and merge.

## Test plan

- `make ci` on a clean tree: 3845 passed, 0 xpassed, 13 xfailed (pre-existing), coverage 78.02%

## Related PR(s)/Issue(s)

Follow-up to #291 (merge `4c039cb`)
Tracks #300
