### PR TITLE
analyzers: restore offline analyzer coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Managed analyzers no longer report a clean scan as skipped: the adapter's fallback re-parse ran on the
+  human-readable output string, which carries the `version_note` prose prefix, so any managed tool whose
+  findings stream was empty failed with `Expecting value: line 1 column 1 (char 0)`. TruffleHog hit this on
+  every secret-free scan, making a passing scan indistinguishable from a broken analyzer. The fallback is
+  removed (it could only duplicate the file parse, and bypassed finding redaction when it did), the output
+  read is classified separately so an undecodable file no longer raises `UnboundLocalError`, and analyzer
+  output is persisted only from the raw stream
+- `staticChecks` withholding no longer depends on how a gate was declared: with `shell: disabled` on an
+  untrusted run, gates discovered from the repo's Makefile executed while configured ones were correctly
+  withheld — meaning commands from a Makefile that is itself part of the diff under review could run.
+  Both routes now go through the same cannot-run reporting, each with a truthful reason
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)
@@ -32,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mergecraft review --shell {disabled,restricted,enabled}` — operator opt-in that makes the seven
+  `runtime: repo-native` analyzers (ruff, mypy, bandit, vulture, typos, jscpd, markdownlint) reachable from
+  the offline CLI. The offline path previously hardcoded `shell: disabled` at three sites, so those tools
+  could never run locally under any configuration and a full local review exercised only the two managed
+  analyzers. Defaults to `disabled`, so runs that omit the flag are unchanged; raising it lets analyzers
+  execute tooling supplied by the repository under review and is unsafe for untrusted code
 - Consumer glossary (`docs/glossary.md`) — plain-language definitions for trust tier, typed
   findings, blast radius, and related landing-page terms; manifest row and `llms.txt` entry.
 - Per-harness Agent Skills packages generated from `skills/mergecraft/SKILL.md` via

--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -11,7 +11,6 @@ from loguru import logger
 
 from mergecraft.analyzers.execution import finalize_plan, provision_managed_argv
 from mergecraft.analyzers.parse import parse_output_file
-from mergecraft.analyzers.parsers import parse_output
 from mergecraft.analyzers.parsers._common import resolve_repo_relative_path
 from mergecraft.analyzers.registry import filter_changed_files_for_manifest, get_manifest
 from mergecraft.analyzers.resolve import AnalyzerPlan, expand_analyzer_argv, resolve_analyzer
@@ -407,24 +406,32 @@ def run_adapter(
         reason = outcome.output or f"skipped {tool_id}: analyzer did not run"
         return AdapterRunResult(findings=[], skipped=True, skip_reason=reason)
 
+    output_file = Path(outcome.output_path)
     try:
-        raw = (
-            Path(outcome.output_path).read_text(encoding="utf-8")
-            if outcome.output_path
-            else outcome.output
-        )
+        raw = output_file.read_text(encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        # ``UnicodeDecodeError`` is a ``ValueError``: output we cannot even read
+        # is unreadable, not unparsable — and reading it must happen outside the
+        # parse ``try`` so the handler below never sees an unbound ``raw``.
+        reason = f"skipped {tool_id}: could not read analyzer output ({exc})"
+        logger.info("{}", reason)
+        return AdapterRunResult(findings=[], skipped=True, skip_reason=reason)
+
+    try:
+        # Parse only the persisted raw output. ``outcome.output`` is the
+        # human-readable rendering — for every managed analyzer it carries
+        # ``plan.version_note`` prose ahead of the payload, which no parser can
+        # read (a clean trufflehog scan was reported as "failed to parse").
         findings = parse_output_file(
-            Path(outcome.output_path),
+            output_file,
             manifest=manifest,
             repo_root=repo_root,
         )
-        if not findings and outcome.output.strip():
-            findings = parse_output(outcome.output, manifest=manifest, repo_root=repo_root)
     except (ValueError, KeyError) as exc:
         # Classify the failure: empty output means the analyzer never produced
         # anything (sandbox unavailable outside CI), not that it emitted garbage
         # we could not parse.
-        if not (raw or "").strip():
+        if not raw.strip():
             reason = (
                 f"skipped {tool_id}: no output (analyzer did not run — "
                 "likely sandbox unavailable outside CI)"

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -202,8 +202,10 @@ def _outcome_from_completed(
     if plan.version_note:
         combined = f"{plan.version_note}\n{combined}".strip()
     redacted = redact_analyzer_output(combined, tool_id=plan.manifest_id)
-    persist_source = raw_for_parser or combined
-    output_path = _persist_output(persist_source, plan=plan)
+    # Persist only what a parser can read. ``combined`` is the display string and
+    # may be nothing but ``plan.version_note`` prose when the analyzer wrote to
+    # neither stream; persisting that turned a clean run into "failed to parse".
+    output_path = _persist_output(raw_for_parser, plan=plan)
     return AnalyzerOutcome(
         name=plan.manifest_id,
         command=command,

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -26,6 +26,7 @@ from mergecraft.offline_review import (
 )
 from mergecraft.review.engine import ReviewEngine
 from mergecraft.review.snapshot import ReviewSnapshot, ReviewStageName, canonical_review_snapshot
+from mergecraft.types import ShellPermission  # noqa: TC001
 from mergecraft.utils.log import configure_logging
 from mergecraft.utils.source_resolve import SourceResolverSpec
 
@@ -67,6 +68,8 @@ Required vs optional:
 * credentials — required for a live review; skip with --dry-run
 * --base / --head / --range / --staged / --unstaged — optional diff selectors
 * --token — only for private --repo clones (else GH_TOKEN, GITHUB_TOKEN, or `gh auth token`)
+* --shell — optional opt-in that lets analyzers run repo-provided tooling (unsafe
+  for untrusted code); default disabled
 
 Examples — local checkout / worktree vs a GitHub branch:
 
@@ -371,6 +374,18 @@ def run(
         ),
         rich_help_panel=_PANEL_TRACING,
     ),
+    shell: ShellPermission = typer.Option(
+        "disabled",
+        "--shell",
+        help=(
+            "Shell permission for this review: disabled (default), restricted, or enabled. "
+            "Raising it lets analyzers execute tooling provided by the repository under "
+            "review (ruff, mypy, bandit, vulture and the other repo-native analyzers, which "
+            "are withheld at disabled). Unsafe for untrusted code — an opt-in for repos you "
+            "trust. Operator flag only; never read from repo config."
+        ),
+        rich_help_panel=_PANEL_TRUST,
+    ),
     trust: str | None = typer.Option(
         None,
         "--trust",
@@ -539,6 +554,7 @@ def run(
                     tracing_cli=tracing_cli,
                     invocation_root=invocation_root,
                     trust_override=trust_override,
+                    shell=shell,
                     source_spec=source_spec,
                     on_finding=_on_finding if agent_mode else None,
                     use_cache=read_cache,

--- a/src/mergecraft/mcp/static_checks.py
+++ b/src/mergecraft/mcp/static_checks.py
@@ -150,10 +150,23 @@ def run_static_checks_tool(ctx: ToolContext):
                 "checks": [],
             }
 
-        if ctx.payload.shell == "disabled" and ctx.static_checks and ctx.trust_tier != "trusted":
+        # The withhold decision is about execution, not provenance: a gate
+        # discovered from the repo's Makefile shell-executes exactly like a
+        # declared one, and on an untrusted event that Makefile is part of the
+        # diff under review. Both are withheld; only the wording differs.
+        if ctx.payload.shell == "disabled" and ctx.trust_tier != "trusted":
             reason = (
-                "staticChecks are configured but cannot run in this environment — "
-                "shell is disabled on pull-request events"
+                (
+                    "staticChecks are configured but cannot run in this environment — "
+                    "shell is disabled on pull-request events"
+                )
+                if ctx.static_checks
+                else (
+                    "this repo declares no `staticChecks`; its mechanical gates were "
+                    "discovered from the Makefile, and they cannot run in this "
+                    "environment — shell is disabled on pull-request events, where the "
+                    "Makefile is itself part of the diff under review"
+                )
             )
             declared = declared_cannot_run_outcomes(checks, reason=reason)
             outcomes, substitutions = await _apply_ci_evidence(ctx, declared)

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from mergecraft.mcp.tool_state import AnalyzerRunState
     from mergecraft.review.engine import ReviewEngine
     from mergecraft.tracing.review_context import ReviewContext
+    from mergecraft.types import ShellPermission
     from mergecraft.utils.source_resolve import ResolvedWorkspace
 
 
@@ -356,6 +357,7 @@ async def run_offline_diff_review(
     json_path: Path | None = None,
     evidence_packet_path: Path | None = None,
     tracing_cli: list[str] | None = None,
+    shell: ShellPermission = "disabled",
     invocation_root: Path | None = None,
     trust_override: CliTrustOverride | None = None,
     cloned: bool = False,
@@ -398,6 +400,7 @@ async def run_offline_diff_review(
             json_path=json_path,
             evidence_packet_path=evidence_packet_path,
             tracing_cli=tracing_cli,
+            shell=shell,
             workspace=workspace,
             spec=spec,
             review_root=review_root,
@@ -461,6 +464,10 @@ class _OfflineDiffReviewRun:
     evidence_packet_path: Path | None
     on_finding: Callable[[dict[str, Any]], None] | None
     read_cache: bool
+    # Operator opt-in (#1). Defaults to the historical hardcoded value so any
+    # caller that omits it keeps the pre-flag behaviour: repo-native analyzers
+    # stay withheld unless `mergecraft review --shell` explicitly raises this.
+    shell: ShellPermission = "disabled"
     materialization: DiffMaterialization | None = None
     scope_reduction: ScopeReduction | None = None
     cache_key: str | None = None
@@ -511,6 +518,7 @@ class _OfflineDiffReviewRun:
             cwd=self.cwd,
             materialization=self.materialization,
             trust_tier=self.trust_tier,
+            shell=self.shell,
             analyzers_enabled=self.analyzers_enabled,
         )
 
@@ -586,6 +594,7 @@ class _OfflineDiffReviewRun:
             output_schema=output_schema,
             evidence_packet_path=self.evidence_packet_path,
             trust_tier=self.trust_tier,
+            shell=self.shell,
             run_bounds=self.run_bounds,
             on_finding=self.on_finding,
             analyzer_run=self.analyzer_run,
@@ -617,6 +626,7 @@ async def _run_offline_diff_review(
     json_path: Path | None = None,
     evidence_packet_path: Path | None = None,
     tracing_cli: list[str] | None = None,
+    shell: ShellPermission = "disabled",
     workspace: ResolvedWorkspace,
     spec: SourceResolverSpec,
     review_root: Path,
@@ -668,6 +678,7 @@ async def _run_offline_diff_review(
         out_dir=out_dir,
         diff_file=diff_file,
         trust_tier=trust_tier,
+        shell=shell,
         run_bounds=run_bounds,
         analyzers_enabled=settings.analyzers.enabled,
         json_path=json_path,

--- a/src/mergecraft/review/offline_agent.py
+++ b/src/mergecraft/review/offline_agent.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from mergecraft.mcp.tool_state import AnalyzerRunState
+    from mergecraft.types import ShellPermission
     from mergecraft.utils.offline_diff import DiffMaterialization
     from mergecraft.utils.run_bounds import RunBounds
 
@@ -61,11 +62,18 @@ async def run_offline_agent_review(
     output_schema: dict[str, Any] | None = None,
     evidence_packet_path: Path | None = None,
     trust_tier: str = "trusted",
+    shell: ShellPermission = "disabled",
     run_bounds: RunBounds | None = None,
     on_finding: Callable[[dict[str, Any]], None] | None = None,
     analyzer_run: AnalyzerRunState | None = None,
 ) -> OfflineReviewResult:
-    """Run the Review agent against a materialized local diff."""
+    """Run the Review agent against a materialized local diff.
+
+    ``shell`` is the operator-resolved shell permission (``--shell`` on
+    ``mergecraft review``). It reaches both the resolved payload the MCP tool
+    surface reads and the agent instructions, so the tool surface and the
+    analyzer pipeline agree on one value. Default ``disabled``.
+    """
     resolved_tier: Literal["trusted", "untrusted"] = (
         "trusted" if trust_tier == "trusted" else "untrusted"
     )
@@ -101,7 +109,7 @@ async def run_offline_agent_review(
 
         payload = ResolvedPayload(
             event=PayloadEvent(trigger="unknown", title="offline diff-review"),
-            shell="disabled",
+            shell=shell,
             push="disabled",
             model=model,
             cwd=str(cwd),
@@ -156,7 +164,7 @@ async def run_offline_agent_review(
         instructions = resolve_instructions(
             payload={
                 "event": {"trigger": "unknown", "title": "offline diff-review"},
-                "shell": "disabled",
+                "shell": shell,
                 "push": "disabled",
                 "prompt": prompt,
             },

--- a/src/mergecraft/review/offline_stages.py
+++ b/src/mergecraft/review/offline_stages.py
@@ -15,6 +15,7 @@ from mergecraft.mcp.tool_state import AnalyzerRunState
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mergecraft.types import ShellPermission
     from mergecraft.utils.offline_diff import DiffMaterialization
 
 TrustTier = Literal["trusted", "untrusted"]
@@ -31,9 +32,17 @@ async def run_offline_analyze(
     cwd: Path,
     materialization: DiffMaterialization,
     trust_tier: str,
+    shell: ShellPermission = "disabled",
     analyzers_enabled: bool = True,
 ) -> AnalyzerRunState | None:
-    """Run the catalog analyzer pipeline and return its state for the driver."""
+    """Run the catalog analyzer pipeline and return its state for the driver.
+
+    ``shell`` is the operator-resolved shell permission for this run (``--shell``
+    on ``mergecraft review``). It defaults to ``disabled``, which withholds every
+    ``runtime: repo-native`` manifest (see
+    :func:`mergecraft.analyzers.trust.evaluate_manifest_for_shell`); raising it
+    lets those analyzers execute repo-provided tooling.
+    """
     if not analyzers_enabled or materialization.empty:
         return None
     diff_text = materialization.path.read_text(encoding="utf-8")
@@ -45,7 +54,7 @@ async def run_offline_analyze(
         diff_text=diff_text,
         offline=True,
         base_ref=materialization.base_ref,
-        shell="disabled",
+        shell=shell,
         mode="auto",
     )
     try:

--- a/tests/analyzers/test_adapters_version_note_parse.py
+++ b/tests/analyzers/test_adapters_version_note_parse.py
@@ -1,0 +1,227 @@
+"""Regression tests for the parse surface of a managed analyzer run.
+
+``plan.version_note`` prose is prepended to the human-readable
+``AnalyzerOutcome.output`` for every ``managed`` analyzer. It must never reach a
+parser: a clean trufflehog scan (empty stdout, JSONL progress logs on stderr)
+was being reported as ``skipped … failed to parse analyzer output`` on every
+platform, which made a working scan indistinguishable from a broken one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.adapters import run_adapter
+from mergecraft.analyzers.resolve import AnalyzerPlan
+from mergecraft.analyzers.run import AnalyzerOutcome, _outcome_from_completed
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_VERSION_NOTE = "ran mergeCraft's pinned trufflehog 3.96.0; your repo pins none"
+
+# What trufflehog actually writes on a clean scan: nothing on stdout, structured
+# progress logs on stderr.
+_CLEAN_STDERR = (
+    '{"level":"info-0","ts":"2026-08-22T10:02:00Z","logger":"trufflehog",'
+    '"msg":"running source","source_name":"filesystem"}\n'
+    '{"level":"info-0","ts":"2026-08-22T10:02:01Z","logger":"trufflehog",'
+    '"msg":"finished scanning","chunks":3,"bytes":91}\n'
+)
+
+
+def _manifest(tool_id: str) -> Any:
+    from mergecraft.analyzers.registry import load_catalog
+
+    for manifest in load_catalog():
+        if manifest.id == tool_id:
+            return manifest
+    raise AssertionError(f"no manifest for {tool_id}")
+
+
+def _stub_chain(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    plan: AnalyzerPlan,
+    outcome_factory: Any,
+) -> None:
+    """Stub everything between manifest resolution and ``run_plan``."""
+    from mergecraft.analyzers import adapters as adapters_mod
+
+    monkeypatch.setattr(adapters_mod, "get_manifest", _manifest)
+    monkeypatch.setattr(
+        "mergecraft.analyzers.registry.filter_changed_files_for_manifest",
+        lambda _manifest, changed_files: list(changed_files),
+    )
+    monkeypatch.setattr(adapters_mod, "resolve_analyzer", lambda **_kwargs: plan)
+    monkeypatch.setattr(adapters_mod, "provision_managed_argv", lambda _plan, **_kwargs: plan)
+    monkeypatch.setattr(
+        adapters_mod,
+        "plan_sandbox",
+        lambda **_kwargs: type("D", (), {"can_run": True, "skip_reason": None, "context": None})(),
+    )
+    monkeypatch.setattr(adapters_mod, "finalize_plan", lambda _plan, **_kwargs: plan)
+    monkeypatch.setattr(adapters_mod, "run_plan", outcome_factory)
+
+
+def _record_parser_inputs(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture every raw string handed to a parser through ``parse_output_file``."""
+    from mergecraft.analyzers import parse as parse_mod
+
+    seen: list[str] = []
+    real = parse_mod.parse_output
+
+    def _spy(raw: str, **kwargs: Any) -> Any:
+        seen.append(raw)
+        return real(raw, **kwargs)
+
+    monkeypatch.setattr(parse_mod, "parse_output", _spy)
+    return seen
+
+
+def _clean_managed_plan(tmp_path: Path) -> AnalyzerPlan:
+    return AnalyzerPlan(
+        manifest_id="trufflehog",
+        mode="managed",
+        argv=("trufflehog", "filesystem", "-j"),
+        cwd=tmp_path,
+        version_note=_VERSION_NOTE,
+    )
+
+
+def _clean_outcome(plan: AnalyzerPlan) -> AnalyzerOutcome:
+    """Build the outcome through the real ``run.py`` seam, not a hand-rolled stub."""
+    completed = subprocess.CompletedProcess(
+        args=list(plan.argv), returncode=0, stdout="", stderr=_CLEAN_STDERR
+    )
+    return _outcome_from_completed(completed, plan=plan, command="trufflehog filesystem -j")
+
+
+def test_clean_managed_scan_is_ran_and_clean_not_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty stdout + JSONL log lines on stderr = zero findings, never a skip."""
+    plan = _clean_managed_plan(tmp_path)
+    outcome = _clean_outcome(plan)
+    assert outcome.ran is True
+    assert outcome.output.startswith(_VERSION_NOTE), "display output still carries the note"
+
+    _stub_chain(monkeypatch, plan=plan, outcome_factory=lambda _plan, **_kwargs: outcome)
+
+    result = run_adapter(
+        tool_id="trufflehog",
+        repo_root=tmp_path,
+        changed_files=["src/app.py"],
+        tier="trusted",
+    )
+
+    assert result.skipped is False, result.skip_reason
+    assert result.skip_reason is None
+    assert result.findings == []
+    assert result.version_note == _VERSION_NOTE
+
+
+def test_version_note_never_reaches_a_parser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _clean_managed_plan(tmp_path)
+    outcome = _clean_outcome(plan)
+    seen = _record_parser_inputs(monkeypatch)
+    _stub_chain(monkeypatch, plan=plan, outcome_factory=lambda _plan, **_kwargs: outcome)
+
+    result = run_adapter(
+        tool_id="trufflehog",
+        repo_root=tmp_path,
+        changed_files=["src/app.py"],
+        tier="trusted",
+    )
+
+    assert result.skipped is False, result.skip_reason
+    assert seen, "the persisted output should have been parsed at least once"
+    for raw in seen:
+        assert _VERSION_NOTE not in raw
+        assert "mergeCraft's pinned" not in raw
+
+
+def test_persisted_output_excludes_the_version_note(tmp_path: Path) -> None:
+    """``run.py`` persists the parse surface, not the display string."""
+    from pathlib import Path as _Path
+
+    plan = _clean_managed_plan(tmp_path)
+    outcome = _clean_outcome(plan)
+
+    assert outcome.output_path is not None
+    persisted = _Path(outcome.output_path).read_text(encoding="utf-8")
+    assert _VERSION_NOTE not in persisted
+    assert '"msg":"finished scanning"' in persisted
+
+
+def test_silent_managed_run_persists_nothing_and_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exit-0 run with both streams empty is a clean pass, not prose to parse."""
+    plan = _clean_managed_plan(tmp_path)
+    completed = subprocess.CompletedProcess(
+        args=list(plan.argv), returncode=0, stdout="", stderr=""
+    )
+    outcome = _outcome_from_completed(completed, plan=plan, command="trufflehog filesystem -j")
+
+    assert outcome.output_path is None, "version-note prose must never be persisted alone"
+
+    _stub_chain(monkeypatch, plan=plan, outcome_factory=lambda _plan, **_kwargs: outcome)
+    result = run_adapter(
+        tool_id="trufflehog",
+        repo_root=tmp_path,
+        changed_files=["src/app.py"],
+        tier="trusted",
+    )
+
+    assert result.skipped is False, result.skip_reason
+    assert result.findings == []
+
+
+def test_undecodable_output_file_skips_instead_of_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``UnicodeDecodeError`` is a ``ValueError``; the handler must not read unbound ``raw``."""
+    out_path = tmp_path / "trufflehog.out"
+    out_path.write_bytes(b"\xff\xfe\x00binary garbage")
+    plan = _clean_managed_plan(tmp_path)
+    outcome = AnalyzerOutcome(
+        name="trufflehog",
+        command="trufflehog filesystem -j",
+        status="passed",
+        output=f"{_VERSION_NOTE}\n<binary>",
+        exit_code=0,
+        output_path=str(out_path),
+    )
+    _stub_chain(monkeypatch, plan=plan, outcome_factory=lambda _plan, **_kwargs: outcome)
+
+    result = run_adapter(
+        tool_id="trufflehog",
+        repo_root=tmp_path,
+        changed_files=["src/app.py"],
+        tier="trusted",
+    )
+
+    assert result.skipped is True
+    assert "could not read analyzer output" in (result.skip_reason or "")
+    assert result.findings == []
+
+
+@pytest.mark.parametrize("tool_id", ["semgrep", "trufflehog"])
+def test_managed_plan_always_sets_a_version_note(tool_id: str, tmp_path: Path) -> None:
+    """The defect is generic to ``managed``: every such plan carries the note."""
+    from mergecraft.analyzers.resolve import resolve_analyzer
+
+    plan = resolve_analyzer(
+        manifest=_manifest(tool_id),
+        repo_root=tmp_path,
+        managed_available=True,
+    )
+    if plan.mode != "managed":
+        pytest.skip(f"{tool_id} did not resolve to managed in this environment")
+    assert plan.version_note

--- a/tests/cli/test_review_shell_flag.py
+++ b/tests/cli/test_review_shell_flag.py
@@ -1,0 +1,87 @@
+"""``mergecraft review --shell`` — operator opt-in for repo-provided tooling."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.offline_review import OfflineReviewResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+@pytest.fixture
+def captured_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the offline review entrypoint and capture the kwargs the CLI sends."""
+    seen: dict[str, Any] = {}
+
+    async def fake_run_offline_diff_review(**kwargs: Any) -> OfflineReviewResult:
+        seen.update(kwargs)
+        return OfflineReviewResult(success=True, output="ok")
+
+    monkeypatch.setattr(
+        "mergecraft.cli.diff_review_cmd.run_offline_diff_review",
+        fake_run_offline_diff_review,
+    )
+    return seen
+
+
+@pytest.fixture
+def diff_file(tmp_path: Path) -> Path:
+    path = tmp_path / "changes.patch"
+    path.write_text("diff --git a/a.py b/a.py\n", encoding="utf-8")
+    return path
+
+
+def test_review_shell_defaults_to_disabled(
+    captured_kwargs: dict[str, Any], diff_file: Path
+) -> None:
+    """Absent ``--shell`` keeps today's safe default (regression lock)."""
+    runner.invoke(app, ["review", "--diff", str(diff_file), "--dry-run"])
+    assert captured_kwargs["shell"] == "disabled"
+
+
+@pytest.mark.parametrize("value", ["restricted", "enabled"])
+def test_review_shell_flag_forwarded(
+    value: str, captured_kwargs: dict[str, Any], diff_file: Path
+) -> None:
+    runner.invoke(app, ["review", "--diff", str(diff_file), "--dry-run", "--shell", value])
+    assert captured_kwargs["shell"] == value
+
+
+def test_review_shell_rejects_unknown_value(
+    captured_kwargs: dict[str, Any], diff_file: Path
+) -> None:
+    result = runner.invoke(
+        app, ["review", "--diff", str(diff_file), "--dry-run", "--shell", "everything"]
+    )
+    assert result.exit_code != 0
+    assert captured_kwargs == {}
+
+
+def test_review_help_documents_shell_opt_in() -> None:
+    result = runner.invoke(
+        app,
+        ["review", "--help"],
+        env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"},
+    )
+    assert result.exit_code == 0
+    out = " ".join(_plain(result.stdout).replace("│", " ").split())
+    assert "--shell" in out
+    assert "disabled" in out
+    assert "restricted" in out
+    assert "enabled" in out
+    assert "tooling provided by the repository under review" in out
+    assert "Unsafe for untrusted code" in out

--- a/tests/mcp/test_static_checks.py
+++ b/tests/mcp/test_static_checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -150,3 +151,72 @@ async def test_static_checks_run_when_shell_disabled_but_trusted_offline(
     assert payload["ran"] is True
     assert payload["allPassed"] is True
     assert payload["checks"][0]["status"] == "passed"
+
+
+def _write_makefile(tmp_path: Path) -> None:
+    """Give the repo a discoverable `lint` gate that succeeds when it runs."""
+    (tmp_path / "Makefile").write_text("lint:\n\t@true\n", encoding="utf-8")
+
+
+requires_make = pytest.mark.skipif(
+    shutil.which("make") is None, reason="Makefile gate discovery requires `make` on PATH"
+)
+
+
+@requires_make
+@pytest.mark.asyncio
+async def test_discovered_makefile_gates_withheld_when_shell_disabled(tmp_path: Path) -> None:
+    """The gap: undeclared repos fall back to Makefile gates, which must be withheld too."""
+    _write_makefile(tmp_path)
+    ctx = _ctx(tmp_path, shell="disabled", static_checks=[], enabled=True)
+    ctx.trust_tier = "untrusted"
+    payload = await _run(ctx)
+    assert payload["ran"] is False
+    checks = payload.get("checks") or []
+    assert [check["status"] for check in checks] == ["declared-but-cannot-run"]
+    assert checks[0]["name"] == "lint"
+    reason = str(payload["reason"])
+    assert "shell is disabled" in reason
+    # Truthful wording: nothing was *configured*, the gate came from the Makefile.
+    assert "Makefile" in reason
+    assert "staticChecks are configured" not in reason
+
+
+@requires_make
+@pytest.mark.asyncio
+async def test_discovered_makefile_gates_run_when_shell_disabled_but_trusted(
+    tmp_path: Path,
+) -> None:
+    """The trusted carve-out is unchanged: offline review still runs discovered gates."""
+    _write_makefile(tmp_path)
+    ctx = _ctx(tmp_path, shell="disabled", static_checks=[], enabled=True)
+    ctx.trust_tier = "trusted"
+    payload = await _run(ctx)
+    assert payload["ran"] is True
+    assert payload["allPassed"] is True
+    assert payload["checks"][0]["status"] == "passed"
+
+
+@requires_make
+@pytest.mark.asyncio
+async def test_discovered_makefile_gates_run_under_permissive_shell(tmp_path: Path) -> None:
+    """An untrusted event with shell available keeps running discovered gates."""
+    _write_makefile(tmp_path)
+    ctx = _ctx(tmp_path, shell="restricted", static_checks=[], enabled=True)
+    ctx.trust_tier = "untrusted"
+    payload = await _run(ctx)
+    assert payload["ran"] is True
+    assert payload["allPassed"] is True
+    assert payload["checks"][0]["status"] == "passed"
+
+
+@pytest.mark.asyncio
+async def test_no_gate_at_all_keeps_early_return_when_shell_disabled(tmp_path: Path) -> None:
+    """No declared and no discoverable gate: the untouched 'no mechanical gate' return."""
+    ctx = _ctx(tmp_path, shell="disabled", static_checks=[], enabled=True)
+    ctx.trust_tier = "untrusted"
+    payload = await _run(ctx)
+    assert payload["ran"] is False
+    assert "declares no mechanical gate" in payload["reason"]
+    assert payload["checks"] == []
+    assert ctx.tool_state.static_checks_ran is True

--- a/tests/review/test_offline_shell_plumbing.py
+++ b/tests/review/test_offline_shell_plumbing.py
@@ -1,0 +1,197 @@
+"""The ``--shell`` value must reach the analyzer pipeline *and* the MCP payload.
+
+A split brain — pipeline sees ``enabled`` while the resolved payload still says
+``disabled`` (or the reverse) — is the bug these tests lock out.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers.registry import load_catalog
+from mergecraft.analyzers.trust import evaluate_manifest_for_shell
+from mergecraft.offline_review import _OfflineDiffReviewRun
+from mergecraft.review.offline_result import OfflineReviewResult
+from mergecraft.review.offline_stages import run_offline_analyze
+from mergecraft.utils.offline_diff import DiffMaterialization
+from mergecraft.utils.run_bounds import resolve_run_bounds
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.analyzers.manifest import AnalyzerManifest
+
+_DIFF = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1 @@\n+import os\n"
+
+
+def _materialization(tmp_path: Path) -> DiffMaterialization:
+    path = tmp_path / "changes.patch"
+    path.write_text(_DIFF, encoding="utf-8")
+    return DiffMaterialization(path=path, base_ref="main", line_count=5, empty=False)
+
+
+def _capture_pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    seen: dict[str, Any] = {}
+
+    def fake_pipeline(**kwargs: Any) -> None:
+        seen.update(kwargs)
+
+    monkeypatch.setattr(
+        "mergecraft.review.offline_stages.run_analyzer_pipeline",
+        fake_pipeline,
+    )
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_run_offline_analyze_defaults_to_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen = _capture_pipeline(monkeypatch)
+    await run_offline_analyze(
+        cwd=tmp_path,
+        materialization=_materialization(tmp_path),
+        trust_tier="trusted",
+    )
+    assert seen["shell"] == "disabled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["restricted", "enabled"])
+async def test_run_offline_analyze_forwards_shell(
+    value: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen = _capture_pipeline(monkeypatch)
+    await run_offline_analyze(
+        cwd=tmp_path,
+        materialization=_materialization(tmp_path),
+        trust_tier="trusted",
+        shell=value,  # type: ignore[arg-type]
+    )
+    assert seen["shell"] == value
+
+
+def _driver(tmp_path: Path, shell: str) -> _OfflineDiffReviewRun:
+    driver = _OfflineDiffReviewRun(
+        cwd=tmp_path,
+        workspace=None,  # type: ignore[arg-type]
+        spec=None,  # type: ignore[arg-type]
+        out_dir=tmp_path,
+        diff_file=None,
+        trust_tier="trusted",
+        shell=shell,  # type: ignore[arg-type]
+        run_bounds=resolve_run_bounds(),
+        analyzers_enabled=True,
+        json_path=None,
+        prompt_extra=None,
+        dry_run=False,
+        model=None,
+        evidence_packet_path=None,
+        on_finding=None,
+        read_cache=False,
+    )
+    driver.materialization = _materialization(tmp_path)
+    return driver
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shell", ["disabled", "enabled"])
+async def test_driver_sends_one_shell_value_to_both_sites(
+    shell: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Analyzer pipeline and agent (ResolvedPayload owner) get the same value."""
+    analyze_seen: dict[str, Any] = {}
+    agent_seen: dict[str, Any] = {}
+
+    async def fake_analyze(**kwargs: Any) -> None:
+        analyze_seen.update(kwargs)
+
+    async def fake_agent_review(**kwargs: Any) -> OfflineReviewResult:
+        agent_seen.update(kwargs)
+        return OfflineReviewResult(success=True, output="ok")
+
+    monkeypatch.setattr(
+        "mergecraft.review.offline_stages.run_offline_analyze",
+        fake_analyze,
+    )
+    monkeypatch.setattr(
+        "mergecraft.offline_review.run_offline_agent_review",
+        fake_agent_review,
+    )
+    monkeypatch.setattr("mergecraft.offline_review.resolve_model", lambda **_: "test-model")
+
+    driver = _driver(tmp_path, shell)
+    await driver.analyze()
+    await driver.review()
+
+    assert analyze_seen["shell"] == shell
+    assert agent_seen["shell"] == shell
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shell", ["disabled", "enabled"])
+async def test_agent_review_puts_shell_on_resolved_payload(
+    shell: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_offline_agent_review`` stamps the resolved value onto the payload."""
+    from mergecraft.mcp.context import ResolvedPayload
+
+    seen: dict[str, Any] = {}
+
+    def capture_payload(**kwargs: Any) -> ResolvedPayload:
+        seen.update(kwargs)
+        return ResolvedPayload(**kwargs)
+
+    class _FakeAgent:
+        name = "claude"
+
+    monkeypatch.setattr("mergecraft.review.offline_agent.ResolvedPayload", capture_payload)
+    monkeypatch.setattr(
+        "mergecraft.review.offline_agent.resolve_runtime_agent",
+        lambda **_: _FakeAgent(),
+    )
+    monkeypatch.setattr("mergecraft.review.offline_agent.resolve_model", lambda **_: "test-model")
+
+    def _stop_after_payload(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("stop after payload construction")
+
+    monkeypatch.setattr(
+        "mergecraft.review.offline_agent.start_mcp_http_server",
+        _stop_after_payload,
+    )
+
+    from mergecraft.review.offline_agent import run_offline_agent_review
+
+    result = await run_offline_agent_review(
+        cwd=tmp_path,
+        materialization=_materialization(tmp_path),
+        prompt="review this",
+        model=None,
+        tmpdir=tmp_path,
+        shell=shell,  # type: ignore[arg-type]
+    )
+    assert not result.success
+    assert seen["shell"] == shell
+
+
+def _manifest(analyzer_id: str) -> AnalyzerManifest:
+    for manifest in load_catalog():
+        if manifest.id == analyzer_id:
+            return manifest
+    pytest.skip(f"catalog manifest {analyzer_id} not present")
+
+
+@pytest.mark.parametrize("analyzer_id", ["ruff", "mypy"])
+def test_repo_native_manifest_gate_follows_shell(analyzer_id: str) -> None:
+    """A repo-native analyzer is withheld at ``disabled`` and eligible above it."""
+    manifest = _manifest(analyzer_id)
+    assert manifest.runtime == "repo-native"
+
+    withheld = evaluate_manifest_for_shell(manifest=manifest, shell="disabled")
+    assert withheld.skipped
+    assert "shell: disabled" in (withheld.reason or "")
+
+    for permissive in ("restricted", "enabled"):
+        assert not evaluate_manifest_for_shell(manifest=manifest, shell=permissive).skipped


### PR DESCRIPTION
## What?

Restores analyzer coverage for local reviews and stops a clean secrets scan from being reported as a broken one.

- A managed analyzer that finds nothing is now reported as clean rather than skipped.
- `mergecraft review --shell {disabled,restricted,enabled}` makes the seven repo-native analyzers reachable from the CLI. Defaults to `disabled`, so existing runs behave exactly as before.
- Mechanical gates discovered from a repo's Makefile are withheld under `shell: disabled` on untrusted runs, matching how declared gates already behaved.

## Why?

A full local review was quietly exercising two of the nine catalog analyzers.

Seven of them are `runtime: repo-native`, and the offline path pinned shell permission to `disabled` in three places. Nothing in the CLI or repo config could override it, so ruff, mypy, bandit, vulture, typos, jscpd and markdownlint were unreachable on every machine. A review that looked like it passed had never run them. Against a real 919-line diff, bandit, mypy and ruff now execute; the three that still skip say plainly that the tool is not installed, instead of reporting a policy withhold.

That left secrets scanning as the only other coverage, and it was reporting `skipped trufflehog: failed to parse analyzer output`. TruffleHog writes findings to stdout and progress logs to stderr, so a scan with no secrets has an empty findings stream. The adapter then fell back to re-parsing the human-readable output string, which carries a version-note prose prefix, and the parse died on the first character. Every secret-free scan looked identical to a genuinely broken analyzer, in CI as well as locally. The fallback also bypassed finding redaction on the rare occasions it produced anything, so removing it closes that too.

The static-check gap is smaller but points the wrong way for trust. Withholding keyed on whether gates were declared in config, not on whether anything would actually execute. A repo that declares none falls back to gates discovered from its Makefile, so on an untrusted run those ran while declared gates were correctly held back, executing commands from a Makefile that is itself part of the diff under review.

## Note

Not included, and worth its own issue: TruffleHog self-updates inside the sha-keyed provisioning cache. The manifest pin is correct, upstream checksums match both provenance entries, and a fresh download runs as 3.96.0. But the cached binary hashes differently from the pinned one and sits beside a `trufflehog-updates.lock`, so the hash is verified at download time and something else is executed afterwards. That belongs in the argv construction, outside these files.

`execution.py`, `supply_chain.py:301` and `supply_chain.py:346` still use the `read_text() if output_path else outcome.output` idiom that caused the parse failure. The persist change makes their fallback branch unreachable with prose in it, so they are not broken today.

`--shell` lifts only the shell gate. Whether a given analyzer then runs still depends on the tier and mode axes and on the tool being installed.

## Test plan

- [x] `make ci-static`
- [x] `make test` (5368 passed, 43 skipped, 16 xfailed)
- [x] `make catalog-check`
- [x] Ran `mergecraft review --unstaged --dry-run` with and without `--shell restricted` against a 919-line diff, confirming bandit, mypy and ruff move from withheld to executing and that TruffleHog no longer reports a parse skip.
