### PR TITLE
antislop: tighten alias binding and wire orphaned fixtures

### DIFF
--- a/src/mergecraft/analyzers/antislop/matcher.py
+++ b/src/mergecraft/analyzers/antislop/matcher.py
@@ -29,6 +29,15 @@ class RuleMatch:
     snippet: str
 
 
+@dataclass(frozen=True, slots=True)
+class _ImportBinding:
+    """One imported name plus every spelling that counts as a use of it."""
+
+    name: str
+    usage_names: tuple[str, ...]
+    line: int
+
+
 def apply_rules(
     *,
     rel_path: str,
@@ -232,26 +241,18 @@ def _python_pass_through_wrapper_matches(source: str) -> Iterable[tuple[int, int
 
 
 def _python_phantom_import_matches(source: str) -> Iterable[tuple[int, int, str]]:
-    import_names: list[tuple[str, int]] = []
+    bindings: list[_ImportBinding] = []
     for node in _walk_python_nodes(source):
         if node.type == "import_statement":
+            line_no = node.start_point[0] + 1
             for child in node.children:
                 if child.type == "dotted_name":
-                    import_names.append(
-                        (_node_text(source, child).split(".", 1)[0], node.start_point[0] + 1)
-                    )
+                    root = _node_text(source, child).split(".", 1)[0]
+                    bindings.append(_ImportBinding(name=root, usage_names=(root,), line=line_no))
                 elif child.type == "aliased_import":
-                    alias = child.child_by_field_name("alias")
-                    name_node = child.child_by_field_name("name")
-                    if alias is not None:
-                        import_names.append((_node_text(source, alias), node.start_point[0] + 1))
-                    elif name_node is not None:
-                        import_names.append(
-                            (
-                                _node_text(source, name_node).split(".", 1)[0],
-                                node.start_point[0] + 1,
-                            )
-                        )
+                    binding = _aliased_module_binding(source, child, line_no=line_no)
+                    if binding is not None:
+                        bindings.append(binding)
         elif node.type == "import_from_statement":
             seen_import_keyword = False
             for child in node.children:
@@ -263,26 +264,62 @@ def _python_phantom_import_matches(source: str) -> Iterable[tuple[int, int, str]
                 if child.type == "aliased_import":
                     alias = child.child_by_field_name("alias")
                     name_node = child.child_by_field_name("name")
+                    line_no = node.start_point[0] + 1
                     if alias is not None:
-                        import_names.append((_node_text(source, alias), node.start_point[0] + 1))
+                        bound = _node_text(source, alias)
+                        bindings.append(
+                            _ImportBinding(name=bound, usage_names=(bound,), line=line_no)
+                        )
                     elif name_node is not None:
-                        import_names.append(
-                            (_node_text(source, name_node), node.start_point[0] + 1)
+                        bound = _node_text(source, name_node)
+                        bindings.append(
+                            _ImportBinding(name=bound, usage_names=(bound,), line=line_no)
                         )
                 elif child.type in {"dotted_name", "identifier"}:
-                    import_names.append((_node_text(source, child), child.start_point[0] + 1))
+                    bound = _node_text(source, child)
+                    bindings.append(
+                        _ImportBinding(
+                            name=bound,
+                            usage_names=(bound,),
+                            line=child.start_point[0] + 1,
+                        )
+                    )
 
-    if not import_names:
+    if not bindings:
         return
 
     type_checking_only = _type_checking_only_imports(source)
     body_without_imports = _strip_python_imports(source)
-    for name, line_no in import_names:
-        if name in type_checking_only:
+    for binding in bindings:
+        if any(name in type_checking_only for name in binding.usage_names):
             continue
-        if re.search(rf"\b{re.escape(name)}\b", body_without_imports):
+        if any(
+            re.search(rf"\b{re.escape(name)}\b", body_without_imports)
+            for name in binding.usage_names
+        ):
             continue
-        yield line_no, line_no, f"import {name} is unused"
+        yield binding.line, binding.line, f"import {binding.name} is unused"
+
+
+def _aliased_module_binding(source: str, node: Node, *, line_no: int) -> _ImportBinding | None:
+    """Build the binding for ``import x.y as z``.
+
+    ``import x.y as z`` binds ``z`` and nothing else — the module name is not
+    in scope afterwards, so ``x.y.thing()`` would raise ``NameError``. The
+    alias is therefore the only spelling that can count as a use; treating the
+    module root as one too would suppress a genuinely dead import whenever the
+    body happens to mention it in a docstring or comment. Without an alias the
+    plain ``import x.y`` form binds the root instead.
+    """
+    name_node = node.child_by_field_name("name")
+    alias_node = node.child_by_field_name("alias")
+    if alias_node is not None:
+        alias = _node_text(source, alias_node)
+        return _ImportBinding(name=alias, usage_names=(alias,), line=line_no)
+    if name_node is None:
+        return None
+    root = _node_text(source, name_node).split(".", 1)[0]
+    return _ImportBinding(name=root, usage_names=(root,), line=line_no)
 
 
 def _js_empty_error_handler_matches(*, source: str) -> Iterable[tuple[int, int, str]]:
@@ -331,6 +368,13 @@ def _collect_import_names(source: str, node: Node) -> set[str]:
             if child.type == "dotted_name":
                 collected.add(_node_text(source, child).split(".", 1)[0])
             elif child.type == "aliased_import":
+                # Mirror `_aliased_module_binding`: `import x.y as z` binds `z`
+                # alone. This set suppresses phantom-import findings, so adding
+                # the module root as well would silence a real one.
+                alias_node = child.child_by_field_name("alias")
+                if alias_node is not None:
+                    collected.add(_node_text(source, alias_node))
+                    continue
                 name_node = child.child_by_field_name("name")
                 if name_node is not None:
                     collected.add(_node_text(source, name_node).split(".", 1)[0])

--- a/tests/analyzers/fixtures/antislop/false-positive/phantom-import-aliased.py
+++ b/tests/analyzers/fixtures/antislop/false-positive/phantom-import-aliased.py
@@ -1,0 +1,6 @@
+import numpy as np
+from os.path import join as path_join
+
+
+def build(path: str) -> object:
+    return np.array([path_join(path, "file")])

--- a/tests/analyzers/fixtures/antislop/positive/phantom-import-aliased.py
+++ b/tests/analyzers/fixtures/antislop/positive/phantom-import-aliased.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+
+def run() -> str:
+    return "ok"

--- a/tests/analyzers/test_antislop.py
+++ b/tests/analyzers/test_antislop.py
@@ -46,7 +46,8 @@ def _rule_stem(rule_id: str) -> str:
 def _fixture_paths(kind: str, rule_id: str) -> list[Path]:
     stem = _rule_stem(rule_id)
     root = _POSITIVE if kind == "positive" else _FALSE_POSITIVE
-    return sorted(root.glob(f"{stem}.*"))
+    # `<stem>-<variant>.<ext>` fixtures cover extra cases for the same rule.
+    return sorted({*root.glob(f"{stem}.*"), *root.glob(f"{stem}-*.*")})
 
 
 def _copy_fixture_repo(tmp_path: Path, relative_paths: list[str]) -> Path:
@@ -183,6 +184,65 @@ def test_false_positive_fixture_is_clean(tmp_path: Path, rule_id: str) -> None:
         result = antislop.scan_changed_files(repo_root=repo, changed_files=[rel])
         matched = [finding for finding in result.findings if finding.rule_id == rule_id]
         assert not matched, f"{rule_id} must not fire on {fixture.name}"
+
+
+def test_aliased_import_used_via_alias_is_not_phantom(tmp_path: Path) -> None:
+    antislop = _antislop()
+    rel = "src/aliased.py"
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / rel).write_text(
+        "import numpy as np\n"
+        "from os.path import join as path_join\n"
+        "\n\n"
+        "def build(path: str) -> object:\n"
+        '    return np.array([path_join(path, "file")])\n',
+        encoding="utf-8",
+    )
+    result = antislop.scan_changed_files(repo_root=repo, changed_files=[rel])
+    assert not result.skipped, result.skip_reason
+    assert not [f for f in result.findings if f.rule_id == "antislop/phantom-import"]
+
+
+def test_aliased_import_is_phantom_when_only_module_name_appears(tmp_path: Path) -> None:
+    """`import x as y` binds `y` alone, so a stray `x` must not count as a use.
+
+    `numpy.array(...)` after `import numpy as np` is a NameError, not a
+    reference. Counting the module name as a use would silence a genuinely
+    dead import whenever the body mentions it in prose.
+    """
+    antislop = _antislop()
+    rel = "src/module_name_only.py"
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / rel).write_text(
+        "import numpy as np\n"
+        "\n\n"
+        "def build() -> str:\n"
+        '    """Returns a label. Does not use numpy."""\n'
+        '    return "numpy"\n',
+        encoding="utf-8",
+    )
+    result = antislop.scan_changed_files(repo_root=repo, changed_files=[rel])
+    assert not result.skipped, result.skip_reason
+    phantom = [f for f in result.findings if f.rule_id == "antislop/phantom-import"]
+    assert phantom, "unused aliased import must still be reported"
+
+
+def test_non_utf8_file_is_skipped_without_disabling_run(tmp_path: Path) -> None:
+    antislop = _antislop()
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "binary.py").write_bytes(b"\xff\xfe\x00# import os\n")
+    shutil.copyfile(_POSITIVE / "step-comment.py", repo / "src" / "step-comment.py")
+
+    result = antislop.scan_changed_files(
+        repo_root=repo,
+        changed_files=["src/binary.py", "src/step-comment.py"],
+    )
+    assert not result.skipped, result.skip_reason
+    assert any(finding.rule_id == "antislop/step-comment" for finding in result.findings)
+    assert all(finding.path != "src/binary.py" for finding in result.findings)
 
 
 def test_per_rule_off_honoured(tmp_path: Path) -> None:


### PR DESCRIPTION
## What?

Follows `6cc3efaf`, which already fixed the two findings reported on #419. Three gaps remained after it.

- A stray mention of a module name no longer suppresses a genuinely unused aliased import.
- A fixture that had never executed is now wired into the suite.
- Adds coverage for the aliased paths that were untested.

## Why?

`import x.y as z` binds `z` and nothing else. The module name is not in scope afterwards, so `x.y.thing()` would raise `NameError` and a bare mention of `x` in the body is prose, not a reference. `_collect_import_names`, which feeds the TYPE_CHECKING skip set, still recorded the module root for aliased imports. Because that set suppresses phantom-import findings, a docstring mentioning the module would have silenced a real dead import. It now mirrors the binding rule applied to the matcher.

Fixture discovery globbed `{stem}.*`. That pattern never matches a name carrying a suffix after the stem, so `false-positive/phantom-import-type-checking.py` sat in the tree and never ran. Discovery now covers `{stem}-*.*` as well, which wires that file in along with the new fixtures.

Coverage was thin on the aliased paths: `from x import y as z` was untested, as was an unused aliased import, and nothing pinned the direction that matters most, that an aliased import whose module name appears only in prose must still be reported.

## Note

The non-UTF-8 fix and the matcher alias fix from the original review both landed in `6cc3efaf` and are not duplicated here.

## Test plan

- [x] `make ci-static`
- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/analyzers -q` (1275 passed, 2 skipped)
