### PR TITLE
chore: gate workflow pins and fix harness leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Checkout and packaged `defaults.yaml` copies drifted after README v2; `make pins-check` gates byte identity (#402, #414)
 - Hermes generated skill package lists `GEMINI_API_KEY` and `NOUS_API_KEY` (not `GOOGLE_API_KEY`) in `required_environment_variables`, matching `docs/authentication.md` (#415)
 - Coverage ratchet floor raised to 80% after new docs contract tests increased measured line coverage above the prior ceiling
+- Transitive `h2` 4.4.0→4.4.1 in `uv.lock` for `pip-audit` (PYSEC-2026-3628)
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Harbor `MergecraftReviewAgent` resolves the default `uv tool install` ref lazily via
-  `_default_install_ref()` instead of calling `action_pin_minimal()` at module import (#403)
+- Harbor `MergecraftReviewAgent` resolves the default `uv tool install` ref lazily in
+  `install()` via `action_pin_minimal()` instead of calling it at module import (#403)
 - Landing README promoted from `readme_test.md` draft: agent-first layout, glossary links,
   auth table with recommended models, CLI how-it-works section, and `v0.1.0a1` Action pin (RV6)
 - `mergecraft init` scaffolds a consumer-ready workflow (`alexhawat/mergeCraft@v0.1.0a1`,
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `route_model` routes security specialist at `critical` risk to the same capable model as `high` instead of Haiku (#394)
 - Checkout and packaged `defaults.yaml` copies drifted after README v2; `make pins-check` gates byte identity (#402, #414)
 - Hermes generated skill package lists `GEMINI_API_KEY` and `NOUS_API_KEY` (not `GOOGLE_API_KEY`) in `required_environment_variables`, matching `docs/authentication.md` (#415)
+- Coverage ratchet floor raised to 80% after new docs contract tests increased measured line coverage above the prior ceiling
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Harbor `MergecraftReviewAgent` resolves the default `uv tool install` ref lazily via
+  `_default_install_ref()` instead of calling `action_pin_minimal()` at module import (#403)
 - Landing README promoted from `readme_test.md` draft: agent-first layout, glossary links,
   auth table with recommended models, CLI how-it-works section, and `v0.1.0a1` Action pin (RV6)
 - `mergecraft init` scaffolds a consumer-ready workflow (`alexhawat/mergeCraft@v0.1.0a1`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `load_audit_events` skips malformed JSONL lines and non-dict payloads instead of raising (#398)
 - `route_model` routes security specialist at `critical` risk to the same capable model as `high` instead of Haiku (#394)
 - Checkout and packaged `defaults.yaml` copies drifted after README v2; `make pins-check` gates byte identity (#402, #414)
+- Hermes generated skill package lists `GEMINI_API_KEY` and `NOUS_API_KEY` (not `GOOGLE_API_KEY`) in `required_environment_variables`, matching `docs/authentication.md` (#415)
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `review --dry-run` skips the analyzer catalog while still materializing the diff and returning the review prompt (#401)
 - `load_audit_events` skips malformed JSONL lines and non-dict payloads instead of raising (#398)
 - `route_model` routes security specialist at `critical` risk to the same capable model as `high` instead of Haiku (#394)
+- Checkout and packaged `defaults.yaml` copies drifted after README v2; `make pins-check` gates byte identity (#402, #414)
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check reference-docs reference-docs-check bench-review eval-gate eval-replay \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check
+	lint-ruff-advisory hook-pins-check pins-check
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -144,6 +144,9 @@ examples: ## Render example workflow YAML from templates
 example-workflows-check: ## Fail when committed example workflows drift from templates
 	$(UV) run python scripts/render_example_workflows.py --check
 
+pins-check: ## Fail when packaged defaults.yaml drifts from checkout copy (#402, #414)
+	cmp -s scripts/example_workflows/defaults.yaml src/mergecraft/data/example_workflows/defaults.yaml || { echo "defaults.yaml copies drifted (edit scripts/example_workflows/defaults.yaml, sync packaged copy, then make pins-check)" >&2; exit 1; }
+
 agent-packages: ## Regenerate per-harness Agent Skills packages
 	$(UV) run python scripts/gen_agent_packages.py
 
@@ -193,11 +196,11 @@ reference-docs: docs ## Regenerate the README action + CLI reference tables (ali
 
 reference-docs-check: docs-check ## Fail when README reference tables drift (alias)
 
-ci-static: lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check ## Static/build tier
+ci-static: lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check ## Static/build tier
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check security coverage-gate
+CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check security coverage-gate
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ cli-examples-check: ## Fail when examples/cli fixtures drift from run.sh output
 docs: ## Regenerate generated doc pages (CLI, action ref, docs index, llms-full)
 	$(UV) run python scripts/gen_docs.py
 
-docs-check: llms-check diagrams-check ## Fail when generated docs drift
+docs-check: llms-check diagrams-check pins-check ## Fail when generated docs drift
 	$(UV) run python scripts/gen_docs.py --check
 
 llms: ## Regenerate llms-full.txt concatenation

--- a/README.md
+++ b/README.md
@@ -99,8 +99,19 @@ config keys, exit codes, and failure modes.
 1. Fetch the skill:
      git clone --depth 1 https://github.com/alexhawat/mergeCraft /tmp/mergecraft-src
 
-2. Copy skills/mergecraft/ to the path your agent reads. Almost every agent
-   now shares one location -- the Agent Skills standard path:
+2. Copy the generated harness package for your agent from
+   skills/<harness>/mergecraft/ (listed in skills/harnesses.yaml) to the path
+   your agent reads. Examples:
+
+     skills/cursor/mergecraft/     -> Cursor
+     skills/opencode/mergecraft/   -> OpenCode
+     skills/codex/mergecraft/      -> Codex CLI
+     skills/gemini-cli/mergecraft/ -> Gemini CLI
+     skills/openclaw/mergecraft/   -> OpenClaw
+     skills/hermes/mergecraft/     -> Hermes Agent
+
+   Almost every agent shares one install destination -- the Agent Skills
+   standard path:
 
      .agents/skills/mergecraft/   -> Codex, Cursor, OpenCode, Gemini CLI,
                                      OpenClaw
@@ -123,8 +134,6 @@ config keys, exit codes, and failure modes.
 <details>
 <summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
 
-<br/>
-
 **Claude Code** — the only *packaged* install. Skill + slash commands in one step:
 
 ```text
@@ -141,8 +150,9 @@ Read https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md and set
 mergeCraft up in this repo. Install the CLI with uv (uv fetches its own Python —
 do not install Python), run `mergecraft init`, wire .mergecraft/config.yaml, and
 open a PR with the workflow. Print the `mergecraft auth <provider>` command for
-me to run myself — never touch credentials. Then copy the repo's
-skills/mergecraft/ into .agents/skills/mergecraft/ so you keep the knowledge.
+me to run myself — never touch credentials. Then copy
+skills/cursor/mergecraft/ into .agents/skills/mergecraft/ so you keep the
+knowledge.
 ```
 
 **Codex CLI / ChatGPT cloud agent:**
@@ -170,7 +180,7 @@ harness. Install with uv, run `mergecraft init`, then set in
 Read docs/authentication.md and tell me exactly which
 MERGECRAFT_CUSTOM_PROVIDER_BASE_URL / MERGECRAFT_CUSTOM_PROVIDER_API_KEY pair
 to set as GitHub secrets for my endpoint. Do not handle the key yourself.
-Copy skills/mergecraft/ into .agents/skills/mergecraft/. Open a PR.
+Copy skills/opencode/mergecraft/ into .agents/skills/mergecraft/. Open a PR.
 ```
 
 **Gemini CLI:**

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ config keys, exit codes, and failure modes.
 1. Fetch the skill:
      git clone --depth 1 https://github.com/alexhawat/mergeCraft /tmp/mergecraft-src
 
-2. Copy the generated harness package for your agent from
+2. Copy the generated [harness](docs/glossary.md#harness) package for your agent from
    skills/<harness>/mergecraft/ (listed in skills/harnesses.yaml) to the path
    your agent reads. Examples:
 

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-ga.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-ga.md
@@ -1,0 +1,33 @@
+# Open issues sweep 2026-08-22b — Batch GA test plan
+
+Maps **W1 RED** contracts for #402 + #414 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D7 — checkout vs packaged `defaults.yaml` (#402, #414) → W2
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Checkout and packaged copies are byte-identical | `tests/pins/test_defaults_yaml_sync.py::test_checkout_and_packaged_defaults_yaml_are_byte_identical` | unit |
+| `make pins-check` target exists | `…::test_make_pins_check_target_exists` | integration |
+| `pins-check` in `CI_STEPS` | `…::test_make_pins_check_in_ci_steps` | integration |
+| `pins-check` in `ci-static` prerequisites | `…::test_make_pins_check_in_ci_static` | integration |
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W2 | all tests in `tests/pins/test_defaults_yaml_sync.py` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/pins/test_defaults_yaml_sync.py
+uv run pytest -q tests/pins/test_defaults_yaml_sync.py  # expect XFAIL until W2
+```
+
+## W1 evidence (2026-08-22)
+
+- Packaged copy differs on line 2 comment (`diff` shows checkout `# Edit here…` vs packaged `# Checkout copy…`).
+- `pins-check` target and `CI_STEPS` / `ci-static` wiring absent on base `bc76b1dc`.

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-ga.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-ga.md
@@ -24,7 +24,7 @@ Maps **W1 RED** contracts for #402 + #414 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/pins/test_defaults_yaml_sync.py
-uv run pytest -q tests/pins/test_defaults_yaml_sync.py  # expect XFAIL until W2
+uv run pytest -q tests/pins/test_defaults_yaml_sync.py  # green since W2 (808763ce)
 ```
 
 ## W1 evidence (2026-08-22)

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gb.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gb.md
@@ -8,15 +8,14 @@ Maps **W3 RED** contracts for #403 to the test suite. Source plan:
 | Contract | Tests | Layer |
 | --- | --- | --- |
 | Importing `mergecraft.harbor.agent` does not call `action_pin_minimal()` | `tests/harbor/test_agent.py::test_import_harbor_agent_does_not_resolve_pin` | unit |
-| Lazy accessor `_default_install_ref()` mirrors `init_cmd._workflow_template` | `…::test_default_install_ref_accessor_calls_action_pin_minimal` | unit |
-| `install()` resolves default ref via `action_pin_minimal()` when env unset | `…::test_install_resolves_default_ref_via_action_pin_minimal` | integration |
+| Lazy `install()` resolves default ref via `action_pin_minimal()` when env unset | `…::test_install_resolves_default_ref_via_action_pin_minimal` | integration |
 | Default ref pins a release tag (regression) | `…::test_default_install_ref_pins_a_release_tag_not_a_moving_branch` | unit |
 
 ## xfail reconciliation
 
 | Wave greens | Remove xfail from |
 | --- | --- |
-| W4 | `test_import_harbor_agent_does_not_resolve_pin`, `test_default_install_ref_accessor_calls_action_pin_minimal`, `test_install_resolves_default_ref_via_action_pin_minimal` |
+| W4 | `test_import_harbor_agent_does_not_resolve_pin`, `test_install_resolves_default_ref_via_action_pin_minimal` |
 
 ## Verification commands
 
@@ -24,10 +23,10 @@ Maps **W3 RED** contracts for #403 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/harbor/test_agent.py
-uv run pytest -q tests/harbor/test_agent.py  # expect 3 XFAIL until W4
+uv run pytest -q tests/harbor/test_agent.py  # green since W4 (808763ce)
 ```
 
 ## W3 evidence
 
-- `harbor/agent.py:22` eagerly assigns `DEFAULT_INSTALL_REF = action_pin_minimal()` at import.
+- `harbor/agent.py` now resolves `action_pin_minimal()` in `install()` only (no module-level pin).
 - `init_cmd._workflow_template()` already defers the same call (D9 mirror target).

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gb.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gb.md
@@ -1,0 +1,33 @@
+# Open issues sweep 2026-08-22b — Batch GB test plan
+
+Maps **W3 RED** contracts for #403 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D9 — lazy Harbor `DEFAULT_INSTALL_REF` (#403) → W4
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Importing `mergecraft.harbor.agent` does not call `action_pin_minimal()` | `tests/harbor/test_agent.py::test_import_harbor_agent_does_not_resolve_pin` | unit |
+| Lazy accessor `_default_install_ref()` mirrors `init_cmd._workflow_template` | `…::test_default_install_ref_accessor_calls_action_pin_minimal` | unit |
+| `install()` resolves default ref via `action_pin_minimal()` when env unset | `…::test_install_resolves_default_ref_via_action_pin_minimal` | integration |
+| Default ref pins a release tag (regression) | `…::test_default_install_ref_pins_a_release_tag_not_a_moving_branch` | unit |
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W4 | `test_import_harbor_agent_does_not_resolve_pin`, `test_default_install_ref_accessor_calls_action_pin_minimal`, `test_install_resolves_default_ref_via_action_pin_minimal` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/harbor/test_agent.py
+uv run pytest -q tests/harbor/test_agent.py  # expect 3 XFAIL until W4
+```
+
+## W3 evidence
+
+- `harbor/agent.py:22` eagerly assigns `DEFAULT_INSTALL_REF = action_pin_minimal()` at import.
+- `init_cmd._workflow_template()` already defers the same call (D9 mirror target).

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
@@ -1,0 +1,35 @@
+# Open issues sweep 2026-08-22b — Batch GC test plan
+
+Maps **W5 RED** contracts for #404 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D8 — `_blob_ref()` resolution (#404) → W6
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `DEFAULT_BLOB_REF` is `pre-0.0.1` | `tests/docs/test_gen_agent_packages_blob_ref.py::test_default_blob_ref_constant_is_pre_0_0_1` | unit |
+| `MERGECRAFT_AGENT_PACKAGES_REF` env override wins | `…::test_blob_ref_uses_env_override` | unit |
+| Missing `v0.1.0a1` tag → default, not pin | `…::test_blob_ref_returns_default_when_pin_tag_missing` | unit |
+| Present pin tag → `action_pin_minimal()` | `…::test_blob_ref_uses_action_pin_minimal_when_tag_exists` | unit |
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W6 | `test_default_blob_ref_constant_is_pre_0_0_1`, `test_blob_ref_returns_default_when_pin_tag_missing`, `test_blob_ref_uses_action_pin_minimal_when_tag_exists` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/docs/test_gen_agent_packages_blob_ref.py
+uv run pytest -q tests/docs/test_gen_agent_packages_blob_ref.py  # expect 3 XFAIL until W6
+```
+
+## W5 evidence
+
+- `scripts/gen_agent_packages.py` sets `DEFAULT_BLOB_REF = "main"` and `_blob_ref()` ignores
+  `action_pin_minimal()` (no git verify).
+- `git rev-parse --verify refs/tags/v0.1.0a1^{commit}` fails on this checkout (G1 tag not cut).
+- `pre-0.0.1` branch resolves locally (`bc76b1dc` at W0 base).

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
@@ -27,9 +27,9 @@ uv run pytest --collect-only -q tests/docs/test_gen_agent_packages_blob_ref.py
 uv run pytest -q tests/docs/test_gen_agent_packages_blob_ref.py  # green since W6 (808763ce)
 ```
 
-## W5 evidence (2026-08-22 ✅: 92ffc0b8)
+## W5 evidence (2026-08-22 ✅: 808763ce)
 
-- `scripts/gen_agent_packages.py` sets `DEFAULT_BLOB_REF = "main"` and `_blob_ref()` ignores
-  `action_pin_minimal()` (no git verify).
+- `scripts/gen_agent_packages.py` uses `DEFAULT_BLOB_REF = "pre-0.0.1"` and `_blob_ref()` falls back
+  when `action_pin_minimal()` tag is absent (`mergecraft.utils.git_ref.git_ref_exists`).
 - `git rev-parse --verify refs/tags/v0.1.0a1^{commit}` fails on this checkout (G1 tag not cut).
-- `pre-0.0.1` branch resolves locally (`bc76b1dc` at W0 base).
+- `pre-0.0.1` branch resolves locally.

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
@@ -24,7 +24,7 @@ Maps **W5 RED** contracts for #404 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/docs/test_gen_agent_packages_blob_ref.py
-uv run pytest -q tests/docs/test_gen_agent_packages_blob_ref.py  # expect 3 XFAIL until W6
+uv run pytest -q tests/docs/test_gen_agent_packages_blob_ref.py  # green since W6 (808763ce)
 ```
 
 ## W5 evidence (2026-08-22 ✅: 92ffc0b8)

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gc.md
@@ -27,7 +27,7 @@ uv run pytest --collect-only -q tests/docs/test_gen_agent_packages_blob_ref.py
 uv run pytest -q tests/docs/test_gen_agent_packages_blob_ref.py  # expect 3 XFAIL until W6
 ```
 
-## W5 evidence
+## W5 evidence (2026-08-22 ✅: 92ffc0b8)
 
 - `scripts/gen_agent_packages.py` sets `DEFAULT_BLOB_REF = "main"` and `_blob_ref()` ignores
   `action_pin_minimal()` (no git verify).

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gd.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gd.md
@@ -30,7 +30,7 @@ Maps **W7 RED** contracts for #413 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/docs/test_readme_harness_copy_prompts.py
-uv run pytest -q tests/docs/test_readme_harness_copy_prompts.py  # expect 1 PASS + 5 XFAIL until W8
+uv run pytest -q tests/docs/test_readme_harness_copy_prompts.py  # green since W8 (808763ce)
 ```
 
 ## W7 evidence

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gd.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gd.md
@@ -1,0 +1,41 @@
+# Open issues sweep 2026-08-22b — Batch GD test plan
+
+Maps **W7 RED** contracts for #413 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D10 — README generated-skill copy prompts (#413) → W8
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Jump-nav may keep `skills/mergecraft/SKILL.md` developer link | `tests/docs/test_readme_harness_copy_prompts.py::test_jump_nav_may_link_source_skill_developer_path` | functional |
+| "Also teach your agent" must not copy source `skills/mergecraft/` | `…::test_also_teach_agent_prompt_does_not_instruct_source_skill_copy` | functional |
+| "Also teach your agent" names harness package or install path | `…::test_also_teach_agent_prompt_references_generated_harness_packages` | functional |
+| Per-agent one-liners must not copy source `skills/mergecraft/` | `…::test_per_agent_one_liners_do_not_instruct_source_skill_copy` | functional |
+| Cursor / OpenCode one-liners name harness packages | `…::test_per_agent_skill_copy_prompts_reference_harness_packages` | functional |
+
+## Out of scope (D10)
+
+- Hero jump-nav `[Agent skill](skills/mergecraft/SKILL.md)` — allowed developer link.
+- "Why agents are good at this" table link to `skills/mergecraft/SKILL.md` — documentation, not a copy prompt.
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W8 | `test_also_teach_agent_prompt_does_not_instruct_source_skill_copy`, `test_also_teach_agent_prompt_references_generated_harness_packages`, `test_per_agent_one_liners_do_not_instruct_source_skill_copy`, `test_per_agent_skill_copy_prompts_reference_harness_packages` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/docs/test_readme_harness_copy_prompts.py
+uv run pytest -q tests/docs/test_readme_harness_copy_prompts.py  # expect 1 PASS + 5 XFAIL until W8
+```
+
+## W7 evidence
+
+- README "Also teach your agent" step 2: `Copy skills/mergecraft/` (source tree).
+- Cursor one-liner: `copy the repo's skills/mergecraft/ into .agents/skills/mergecraft/`.
+- OpenCode one-liner: `Copy skills/mergecraft/ into .agents/skills/mergecraft/`.
+- Generated harness packages exist under `skills/<harness>/mergecraft/` per `skills/harnesses.yaml`.

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-ge.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-ge.md
@@ -7,14 +7,8 @@ Maps **W9 RED** contracts for #415 to the test suite. Source plan:
 
 | Contract | Tests | Layer |
 | --- | --- | --- |
-| Hermes manifest lists `GEMINI_API_KEY` | `tests/docs/test_hermes_skill_env_vars.py::test_hermes_manifest_lists_gemini_api_key` | unit |
-| Hermes manifest lists `NOUS_API_KEY` | `…::test_hermes_manifest_lists_nous_api_key` | unit |
-| Hermes manifest excludes `GOOGLE_API_KEY` | `…::test_hermes_manifest_excludes_google_api_key` | unit |
-| Generated Hermes SKILL.md lists `GEMINI_API_KEY` | `…::test_hermes_skill_md_lists_gemini_api_key` | functional |
-| Generated Hermes SKILL.md lists `NOUS_API_KEY` | `…::test_hermes_skill_md_lists_nous_api_key` | functional |
-| Generated Hermes SKILL.md excludes `GOOGLE_API_KEY` | `…::test_hermes_skill_md_excludes_google_api_key` | functional |
-| Manifest env names match `docs/authentication.md` | `…::test_hermes_manifest_env_names_match_authentication_doc` | integration |
-| SKILL.md env names match `docs/authentication.md` | `…::test_hermes_skill_md_env_names_match_authentication_doc` | integration |
+| Hermes manifest/skill env var contracts (parametrized) | `…::test_hermes_required_env_var[*]` | unit/functional |
+| Manifest and SKILL.md env names match `docs/authentication.md` | `…::test_hermes_env_names_match_authentication_doc` | integration |
 
 ## xfail reconciliation
 
@@ -28,7 +22,7 @@ Maps **W9 RED** contracts for #415 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/docs/test_hermes_skill_env_vars.py
-uv run pytest -q tests/docs/test_hermes_skill_env_vars.py  # expect 8 XFAIL until W10
+uv run pytest -q tests/docs/test_hermes_skill_env_vars.py  # green since W10 (808763ce)
 ```
 
 ## W9 evidence (2026-08-22 ✅: 431b0518)

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-ge.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-ge.md
@@ -1,0 +1,40 @@
+# Open issues sweep 2026-08-22b — Batch GE test plan
+
+Maps **W9 RED** contracts for #415 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D11 — Hermes env names (#415) → W10
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Hermes manifest lists `GEMINI_API_KEY` | `tests/docs/test_hermes_skill_env_vars.py::test_hermes_manifest_lists_gemini_api_key` | unit |
+| Hermes manifest lists `NOUS_API_KEY` | `…::test_hermes_manifest_lists_nous_api_key` | unit |
+| Hermes manifest excludes `GOOGLE_API_KEY` | `…::test_hermes_manifest_excludes_google_api_key` | unit |
+| Generated Hermes SKILL.md lists `GEMINI_API_KEY` | `…::test_hermes_skill_md_lists_gemini_api_key` | functional |
+| Generated Hermes SKILL.md lists `NOUS_API_KEY` | `…::test_hermes_skill_md_lists_nous_api_key` | functional |
+| Generated Hermes SKILL.md excludes `GOOGLE_API_KEY` | `…::test_hermes_skill_md_excludes_google_api_key` | functional |
+| Manifest env names match `docs/authentication.md` | `…::test_hermes_manifest_env_names_match_authentication_doc` | integration |
+| SKILL.md env names match `docs/authentication.md` | `…::test_hermes_skill_md_env_names_match_authentication_doc` | integration |
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W10 | all tests in `tests/docs/test_hermes_skill_env_vars.py` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/docs/test_hermes_skill_env_vars.py
+uv run pytest -q tests/docs/test_hermes_skill_env_vars.py  # expect 8 XFAIL until W10
+```
+
+## W9 evidence (2026-08-22 ✅: 431b0518)
+
+- `skills/harnesses.yaml` Hermes `required_environment_variables` lists `GOOGLE_API_KEY`, omits
+  `GEMINI_API_KEY` and `NOUS_API_KEY` (`skills/harnesses.yaml:38-41`).
+- Generated `skills/hermes/mergecraft/SKILL.md` frontmatter mirrors the same list.
+- `docs/authentication.md` documents `GEMINI_API_KEY` for Google Gemini and `NOUS_API_KEY` for
+  Nous Portal (`docs/authentication.md:7-8`).

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
@@ -23,7 +23,7 @@ Maps **W11 RED** contracts for #405 to the test suite. Source plan:
 | --- | --- | --- |
 | `_git_ref_exists()` | `test_landing_readme.py`, `test_agent_surfaces.py` | `git_ref_exists` |
 | `_ACTION_USES` regex | `test_landing_readme.py`, `test_docs_gate.py`, `test_agent_surfaces.py` | `action_uses_pattern` |
-| `_ci_steps()` / inline `CI_STEPS` scrape | `test_agent_packages.py`, `test_docs_manifest.py`, `test_docs_gate.py` | `ci_steps` |
+| `load_harness_manifest()` / `makefile_prerequisite_tokens()` shared exports | `tests/docs/support.py` | `load_harness_manifest`, `makefile_prerequisite_tokens` |
 | `importlib.util` script loading | `test_cli_examples.py`, `test_agent_packages.py`, `test_docs_gate.py`, `test_gen_agent_packages_blob_ref.py`, `test_reference_docs.py` | `load_script_module` |
 
 ## xfail reconciliation
@@ -38,7 +38,7 @@ Maps **W11 RED** contracts for #405 to the test suite. Source plan:
 make lint
 make typecheck
 uv run pytest --collect-only -q tests/docs/
-uv run pytest -q tests/docs/test_support.py  # expect XFAIL until W12
+uv run pytest -q tests/docs/test_support.py  # green since W12 (808763ce)
 ```
 
 ## W11 evidence (2026-08-22 ✅: ec6390c4)

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
@@ -41,7 +41,7 @@ uv run pytest --collect-only -q tests/docs/
 uv run pytest -q tests/docs/test_support.py  # expect XFAIL until W12
 ```
 
-## W11 evidence
+## W11 evidence (2026-08-22 ✅: ec6390c4)
 
 - `tests/docs/support.py` absent on base `6c135d27` (D12: W12 creates the module).
 - Four helper patterns duplicated across ~8 `tests/docs/test_*.py` modules per #405.

--- a/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-22b-gf.md
@@ -1,0 +1,48 @@
+# Open issues sweep 2026-08-22b — Batch GF test plan
+
+Maps **W11 RED** contracts for #405 to the test suite. Source plan:
+`.ignorelocal/waves/open-issues-sweep-2026-08-22b-wave-plan.md`.
+
+## D12 — `tests/docs/support.py` (#405) → W12
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `tests.docs.support` importable | `tests/docs/test_support.py::test_support_module_is_importable` | unit |
+| `git_ref_exists(ref)` resolves tags/branches/SHAs | `…::test_support_exports_git_ref_exists` | unit |
+| `git_ref_exists` shallow-checkout SHA fetch | `…::test_git_ref_exists_fetches_shallow_checkout_sha` | unit |
+| `action_uses_pattern` shared regex (case-insensitive) | `…::test_support_exports_action_uses_pattern` | unit |
+| `ci_steps()` parses Makefile `CI_STEPS` | `…::test_support_exports_ci_steps` | integration |
+| `load_script_module(path)` loads repo scripts | `…::test_support_exports_load_script_module` | integration |
+| `load_script_module` accepts repo-relative paths | `…::test_load_script_module_accepts_relative_path` | unit |
+| Listed modules import shared helpers (no local dupes) | `…::test_migration_module_imports_shared_support[*]` | integration |
+| Existing `tests/docs/test_*.py` still collect | `…::test_docs_contract_modules_still_collect[*]` | smoke |
+
+### Dedup patterns (#405) → W12 migration targets
+
+| Pattern | Current locations | Shared export |
+| --- | --- | --- |
+| `_git_ref_exists()` | `test_landing_readme.py`, `test_agent_surfaces.py` | `git_ref_exists` |
+| `_ACTION_USES` regex | `test_landing_readme.py`, `test_docs_gate.py`, `test_agent_surfaces.py` | `action_uses_pattern` |
+| `_ci_steps()` / inline `CI_STEPS` scrape | `test_agent_packages.py`, `test_docs_manifest.py`, `test_docs_gate.py` | `ci_steps` |
+| `importlib.util` script loading | `test_cli_examples.py`, `test_agent_packages.py`, `test_docs_gate.py`, `test_gen_agent_packages_blob_ref.py`, `test_reference_docs.py` | `load_script_module` |
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| W12 | all `xfail` tests in `tests/docs/test_support.py` except `test_docs_contract_modules_still_collect` (stays green) |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/docs/
+uv run pytest -q tests/docs/test_support.py  # expect XFAIL until W12
+```
+
+## W11 evidence
+
+- `tests/docs/support.py` absent on base `6c135d27` (D12: W12 creates the module).
+- Four helper patterns duplicated across ~8 `tests/docs/test_*.py` modules per #405.
+- `tests/ci/workflow_support.py` exists for CI workflow YAML only — docs-contract helpers belong in `tests/docs/support.py` (D12).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,8 +103,19 @@ config keys, exit codes, and failure modes.
 1. Fetch the skill:
      git clone --depth 1 https://github.com/alexhawat/mergeCraft /tmp/mergecraft-src
 
-2. Copy skills/mergecraft/ to the path your agent reads. Almost every agent
-   now shares one location -- the Agent Skills standard path:
+2. Copy the generated [harness](docs/glossary.md#harness) package for your agent from
+   skills/<harness>/mergecraft/ (listed in skills/harnesses.yaml) to the path
+   your agent reads. Examples:
+
+     skills/cursor/mergecraft/     -> Cursor
+     skills/opencode/mergecraft/   -> OpenCode
+     skills/codex/mergecraft/      -> Codex CLI
+     skills/gemini-cli/mergecraft/ -> Gemini CLI
+     skills/openclaw/mergecraft/   -> OpenClaw
+     skills/hermes/mergecraft/     -> Hermes Agent
+
+   Almost every agent shares one install destination -- the Agent Skills
+   standard path:
 
      .agents/skills/mergecraft/   -> Codex, Cursor, OpenCode, Gemini CLI,
                                      OpenClaw
@@ -127,8 +138,6 @@ config keys, exit codes, and failure modes.
 <details>
 <summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
 
-<br/>
-
 **Claude Code** — the only *packaged* install. Skill + slash commands in one step:
 
 ```text
@@ -145,8 +154,9 @@ Read https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md and set
 mergeCraft up in this repo. Install the CLI with uv (uv fetches its own Python —
 do not install Python), run `mergecraft init`, wire .mergecraft/config.yaml, and
 open a PR with the workflow. Print the `mergecraft auth <provider>` command for
-me to run myself — never touch credentials. Then copy the repo's
-skills/mergecraft/ into .agents/skills/mergecraft/ so you keep the knowledge.
+me to run myself — never touch credentials. Then copy
+skills/cursor/mergecraft/ into .agents/skills/mergecraft/ so you keep the
+knowledge.
 ```
 
 **Codex CLI / ChatGPT cloud agent:**
@@ -174,7 +184,7 @@ harness. Install with uv, run `mergecraft init`, then set in
 Read docs/authentication.md and tell me exactly which
 MERGECRAFT_CUSTOM_PROVIDER_BASE_URL / MERGECRAFT_CUSTOM_PROVIDER_API_KEY pair
 to set as GitHub secrets for my endpoint. Do not handle the key yourself.
-Copy skills/mergecraft/ into .agents/skills/mergecraft/. Open a PR.
+Copy skills/opencode/mergecraft/ into .agents/skills/mergecraft/. Open a PR.
 ```
 
 **Gemini CLI:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ branch = true
 omit = ["*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 75
+fail_under = 80
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/scripts/example_workflows/defaults.yaml
+++ b/scripts/example_workflows/defaults.yaml
@@ -1,5 +1,7 @@
 # Shared placeholders for rendered example workflows.
-# Edit here (or override via env) then run: make examples
+# Source of truth: scripts/example_workflows/defaults.yaml — copy byte-identical
+# to src/mergecraft/data/example_workflows/defaults.yaml, then make pins-check.
+# Override via env when generating examples: make examples
 action_repo: alexhawat/mergeCraft
 # A tagged release ref is fine for the minimal getting-started example.
 action_pin_minimal: v0.1.0a1

--- a/scripts/gen_agent_packages.py
+++ b/scripts/gen_agent_packages.py
@@ -6,8 +6,8 @@ Depends: argparse, hashlib, json, os, re, subprocess, sys, pathlib
 
 Reads ``skills/harnesses.yaml``, renders ``skills/<harness-id>/SKILL.md`` for every
 verified harness row, and rewrites ``../../`` relative links to absolute GitHub blob
-URLs so copied skills still resolve. ``make agent-packages`` / ``agent-packages-check``
-call this entry point.
+URLs so copied skills still resolve. ``make agent-packages`` / ``agent-packages-check`` call this entry point via
+``uv run python`` (requires the ``mergecraft`` package on ``PYTHONPATH``).
 
 Exports:
     main — regenerate (default) or ``--check`` per-harness packages.

--- a/scripts/gen_agent_packages.py
+++ b/scripts/gen_agent_packages.py
@@ -30,6 +30,7 @@ from typing import Any
 import yaml
 
 from mergecraft.pins import action_pin_minimal
+from mergecraft.utils.git_ref import git_ref_exists
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_SKILL = REPO_ROOT / "skills" / "mergecraft" / "SKILL.md"
@@ -42,25 +43,12 @@ _FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 DEFAULT_BLOB_REF = "pre-0.0.1"
 
 
-def _git_ref_exists(ref: str) -> bool:
-    """Return True when ``ref`` resolves in this checkout."""
-    return (
-        subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", ref],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-        ).returncode
-        == 0
-    )
-
-
 def _blob_ref() -> str:
     env_ref = os.environ.get("MERGECRAFT_AGENT_PACKAGES_REF", "").strip()
     if env_ref:
         return env_ref
     pin = action_pin_minimal()
-    if _git_ref_exists(pin):
+    if git_ref_exists(pin, cwd=REPO_ROOT):
         return pin
     return DEFAULT_BLOB_REF
 

--- a/scripts/gen_agent_packages.py
+++ b/scripts/gen_agent_packages.py
@@ -46,7 +46,9 @@ DEFAULT_BLOB_REF = "pre-0.0.1"
 def _blob_ref() -> str:
     env_ref = os.environ.get("MERGECRAFT_AGENT_PACKAGES_REF", "").strip()
     if env_ref:
-        return env_ref
+        if git_ref_exists(env_ref, cwd=REPO_ROOT):
+            return env_ref
+        return DEFAULT_BLOB_REF
     pin = action_pin_minimal()
     if git_ref_exists(pin, cwd=REPO_ROOT):
         return pin

--- a/scripts/gen_agent_packages.py
+++ b/scripts/gen_agent_packages.py
@@ -29,6 +29,8 @@ from typing import Any
 
 import yaml
 
+from mergecraft.pins import action_pin_minimal
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_SKILL = REPO_ROOT / "skills" / "mergecraft" / "SKILL.md"
 HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
@@ -37,13 +39,29 @@ GITHUB_REPO = "alexhawat/mergeCraft"
 _RELATIVE_LINK = re.compile(r"\(\.\./\.\./([^)]+)\)")
 _FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
-DEFAULT_BLOB_REF = "main"
+DEFAULT_BLOB_REF = "pre-0.0.1"
+
+
+def _git_ref_exists(ref: str) -> bool:
+    """Return True when ``ref`` resolves in this checkout."""
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", ref],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
 
 
 def _blob_ref() -> str:
     env_ref = os.environ.get("MERGECRAFT_AGENT_PACKAGES_REF", "").strip()
     if env_ref:
         return env_ref
+    pin = action_pin_minimal()
+    if _git_ref_exists(pin):
+        return pin
     return DEFAULT_BLOB_REF
 
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -47,43 +47,43 @@
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/codex/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     },
     "mergecraft-cursor": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/cursor/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     },
     "mergecraft-opencode": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/opencode/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     },
     "mergecraft-gemini-cli": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/gemini-cli/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     },
     "mergecraft-openclaw": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/openclaw/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     },
     "mergecraft-hermes": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/hermes/mergecraft/SKILL.md",
-      "computedHash": "0216ac38336e40da13158bcc0c0270f8e74b4ddc519669167a24e9cfae71994d"
+      "computedHash": "f75f9d252655b23a5a9f44a8729430cd56ef1299d230c26da68606c759c0edfb"
     },
     "mergecraft-claude-code": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/claude-code/mergecraft/SKILL.md",
-      "computedHash": "d2b15d6ace8b98364d642079c5d80bc99375fa262990d7fd6a7b606dcdbde982"
+      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
     }
   }
 }

--- a/skills/claude-code/mergecraft/SKILL.md
+++ b/skills/claude-code/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/codex/mergecraft/SKILL.md
+++ b/skills/codex/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/cursor/mergecraft/SKILL.md
+++ b/skills/cursor/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/gemini-cli/mergecraft/SKILL.md
+++ b/skills/gemini-cli/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/harnesses.yaml
+++ b/skills/harnesses.yaml
@@ -38,7 +38,8 @@ harnesses:
     required_environment_variables:
       - ANTHROPIC_API_KEY
       - OPENAI_API_KEY
-      - GOOGLE_API_KEY
+      - GEMINI_API_KEY
+      - NOUS_API_KEY
       - CURSOR_API_KEY
     install_section: |
       ## Hermes install

--- a/skills/hermes/mergecraft/SKILL.md
+++ b/skills/hermes/mergecraft/SKILL.md
@@ -9,7 +9,8 @@ compatibility: Requires uv; gh CLI optional
 required_environment_variables:
 - ANTHROPIC_API_KEY
 - OPENAI_API_KEY
-- GOOGLE_API_KEY
+- GEMINI_API_KEY
+- NOUS_API_KEY
 - CURSOR_API_KEY
 ---
 ## Hermes install
@@ -18,7 +19,7 @@ Hermes Agent reads skills from ``~/.hermes/skills/`` or a category-nested projec
 ``skills/`` tree. Install this package with:
 
 ```bash
-hermes skills install https://github.com/alexhawat/mergeCraft/tree/main/skills/hermes
+hermes skills install https://github.com/alexhawat/mergeCraft/tree/pre-0.0.1/skills/hermes
 ```
 
 mergeCraft ships a Nous provider (``mergecraft auth nous``,
@@ -35,7 +36,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -100,5 +101,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/openclaw/mergecraft/SKILL.md
+++ b/skills/openclaw/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/skills/opencode/mergecraft/SKILL.md
+++ b/skills/opencode/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/main/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/main/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/main/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/main/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).

--- a/src/mergecraft/data/example_workflows/defaults.yaml
+++ b/src/mergecraft/data/example_workflows/defaults.yaml
@@ -1,5 +1,5 @@
 # Shared placeholders for rendered example workflows.
-# Checkout copy: scripts/example_workflows/defaults.yaml (edit there, then sync here).
+# Edit here (or override via env) then run: make examples
 action_repo: alexhawat/mergeCraft
 # A tagged release ref is fine for the minimal getting-started example.
 action_pin_minimal: v0.1.0a1

--- a/src/mergecraft/data/example_workflows/defaults.yaml
+++ b/src/mergecraft/data/example_workflows/defaults.yaml
@@ -1,5 +1,7 @@
 # Shared placeholders for rendered example workflows.
-# Edit here (or override via env) then run: make examples
+# Source of truth: scripts/example_workflows/defaults.yaml — copy byte-identical
+# to src/mergecraft/data/example_workflows/defaults.yaml, then make pins-check.
+# Override via env when generating examples: make examples
 action_repo: alexhawat/mergeCraft
 # A tagged release ref is fine for the minimal getting-started example.
 action_pin_minimal: v0.1.0a1

--- a/src/mergecraft/harbor/agent.py
+++ b/src/mergecraft/harbor/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import re
@@ -19,10 +20,15 @@ if TYPE_CHECKING:
 
 from mergecraft.pins import action_pin_minimal
 
-DEFAULT_INSTALL_REF = action_pin_minimal()
 MERGECRAFT_GIT_URL = "git+https://github.com/alexhawat/mergeCraft"
 FINDINGS_FILENAME = "findings.json"
 _PATCH_CANDIDATES = ("task.patch", "changes.patch", "diff.patch", "review.patch")
+
+
+@functools.cache
+def _default_install_ref() -> str:
+    """Return the Harbor default install ref without resolving at module import."""
+    return action_pin_minimal()
 
 
 def _path_env() -> str:
@@ -62,7 +68,7 @@ class MergecraftReviewAgent(BaseInstalledAgent):
         return text or "unknown"
 
     async def install(self, environment: BaseEnvironment) -> None:
-        install_ref = self._get_env("MERGECRAFT_INSTALL_REF") or DEFAULT_INSTALL_REF
+        install_ref = self._get_env("MERGECRAFT_INSTALL_REF") or _default_install_ref()
         install_spec = f"{MERGECRAFT_GIT_URL}@{install_ref}"
 
         await self.exec_as_root(

--- a/src/mergecraft/harbor/agent.py
+++ b/src/mergecraft/harbor/agent.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import os
 import re
@@ -23,12 +22,6 @@ from mergecraft.pins import action_pin_minimal
 MERGECRAFT_GIT_URL = "git+https://github.com/alexhawat/mergeCraft"
 FINDINGS_FILENAME = "findings.json"
 _PATCH_CANDIDATES = ("task.patch", "changes.patch", "diff.patch", "review.patch")
-
-
-@functools.cache
-def _default_install_ref() -> str:
-    """Return the Harbor default install ref without resolving at module import."""
-    return action_pin_minimal()
 
 
 def _path_env() -> str:
@@ -68,7 +61,7 @@ class MergecraftReviewAgent(BaseInstalledAgent):
         return text or "unknown"
 
     async def install(self, environment: BaseEnvironment) -> None:
-        install_ref = self._get_env("MERGECRAFT_INSTALL_REF") or _default_install_ref()
+        install_ref = self._get_env("MERGECRAFT_INSTALL_REF") or action_pin_minimal()
         install_spec = f"{MERGECRAFT_GIT_URL}@{install_ref}"
 
         await self.exec_as_root(

--- a/src/mergecraft/pins.py
+++ b/src/mergecraft/pins.py
@@ -14,6 +14,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CHECKOUT_DEFAULTS_PATH: Final[Path] = (
     _REPO_ROOT / "scripts" / "example_workflows" / "defaults.yaml"
 )
+# Sync rule: edit scripts/example_workflows/defaults.yaml, copy byte-identical to packaged path, then make pins-check.
 _PACKAGED_DEFAULTS_PATH: Final[str] = "example_workflows/defaults.yaml"
 
 # G1 option B — embedded fallback when neither checkout nor wheel data is present.

--- a/src/mergecraft/utils/git_ref.py
+++ b/src/mergecraft/utils/git_ref.py
@@ -6,13 +6,28 @@ import re
 import subprocess
 from pathlib import Path
 
-_SHA_REF = re.compile(r"^[0-9a-f]{40}$")
+_SHA_REF = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+_GIT_FETCH_TIMEOUT_S = 30.0
+
+
+def _default_repo_root() -> Path:
+    """Return the git worktree root, or editable-layout repo root as fallback."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_GIT_FETCH_TIMEOUT_S,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path(__file__).resolve().parents[3]
 
 
 def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     """Return whether *ref* resolves as a tag, branch, or commit in the checkout."""
     ref = ref.rstrip("#").strip()
-    workdir = cwd or Path(__file__).resolve().parents[3]
+    workdir = cwd or _default_repo_root()
     candidates: list[list[str]]
     if _SHA_REF.fullmatch(ref):
         candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
@@ -22,9 +37,19 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
         candidates = [
             ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
             ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
+            ["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"],
         ]
     for cmd in candidates:
-        if subprocess.run(cmd, cwd=workdir, capture_output=True, check=False).returncode == 0:
+        if (
+            subprocess.run(
+                cmd,
+                cwd=workdir,
+                capture_output=True,
+                check=False,
+                timeout=_GIT_FETCH_TIMEOUT_S,
+            ).returncode
+            == 0
+        ):
             return True
     if not _SHA_REF.fullmatch(ref):
         return False
@@ -34,6 +59,7 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
         cwd=workdir,
         capture_output=True,
         check=False,
+        timeout=_GIT_FETCH_TIMEOUT_S,
     )
     if fetch.returncode != 0:
         return False
@@ -42,5 +68,6 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
         cwd=workdir,
         capture_output=True,
         check=False,
+        timeout=_GIT_FETCH_TIMEOUT_S,
     )
     return verify.returncode == 0

--- a/src/mergecraft/utils/git_ref.py
+++ b/src/mergecraft/utils/git_ref.py
@@ -1,0 +1,46 @@
+"""Git ref resolution helpers shared by scripts and tests."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_SHA_REF = re.compile(r"^[0-9a-f]{40}$")
+
+
+def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
+    """Return whether *ref* resolves as a tag, branch, or commit in the checkout."""
+    ref = ref.rstrip("#").strip()
+    workdir = cwd or Path(__file__).resolve().parents[2]
+    candidates: list[list[str]]
+    if _SHA_REF.fullmatch(ref):
+        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
+    elif ref.startswith("v"):
+        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
+    else:
+        candidates = [
+            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
+            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
+        ]
+    for cmd in candidates:
+        if subprocess.run(cmd, cwd=workdir, capture_output=True, check=False).returncode == 0:
+            return True
+    if not _SHA_REF.fullmatch(ref):
+        return False
+    # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", ref, "--depth=1"],
+        cwd=workdir,
+        capture_output=True,
+        check=False,
+    )
+    if fetch.returncode != 0:
+        return False
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=workdir,
+        capture_output=True,
+        check=False,
+    )
+    return verify.returncode == 0

--- a/src/mergecraft/utils/git_ref.py
+++ b/src/mergecraft/utils/git_ref.py
@@ -12,7 +12,7 @@ _SHA_REF = re.compile(r"^[0-9a-f]{40}$")
 def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     """Return whether *ref* resolves as a tag, branch, or commit in the checkout."""
     ref = ref.rstrip("#").strip()
-    workdir = cwd or Path(__file__).resolve().parents[2]
+    workdir = cwd or Path(__file__).resolve().parents[3]
     candidates: list[list[str]]
     if _SHA_REF.fullmatch(ref):
         candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]

--- a/tests/docs/support.py
+++ b/tests/docs/support.py
@@ -4,54 +4,45 @@ from __future__ import annotations
 
 import importlib.util
 import re
-import subprocess
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
+import yaml
+
+from mergecraft.utils.git_ref import git_ref_exists
 from tests.ci.workflow_support import REPO_ROOT
 
-_SHA_REF = re.compile(r"^[0-9a-f]{40}$")
+__all__ = [
+    "action_uses_pattern",
+    "ci_steps",
+    "git_ref_exists",
+    "load_harness_manifest",
+    "load_script_module",
+    "makefile_prerequisite_tokens",
+]
 
 action_uses_pattern = re.compile(
     r"uses:\s*alexhawat/mergeCraft@(\S+)",
     re.IGNORECASE,
 )
 
+HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
 
-def git_ref_exists(ref: str) -> bool:
-    """Return whether *ref* resolves as a tag, branch, or commit in this checkout."""
-    ref = ref.rstrip("#").strip()
-    candidates: list[list[str]]
-    if _SHA_REF.fullmatch(ref):
-        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
-    elif ref.startswith("v"):
-        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
-    else:
-        candidates = [
-            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
-        ]
-    for cmd in candidates:
-        if subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0:
-            return True
-    if not _SHA_REF.fullmatch(ref):
-        return False
-    # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
-    fetch = subprocess.run(
-        ["git", "fetch", "origin", ref, "--depth=1"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=False,
-    )
-    if fetch.returncode != 0:
-        return False
-    verify = subprocess.run(
-        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=False,
-    )
-    return verify.returncode == 0
+
+def load_harness_manifest() -> dict[str, Any]:
+    """Parse ``skills/harnesses.yaml`` as a mapping."""
+    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)}"
+    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
+    return data
+
+
+def makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
+    """Return Makefile prerequisite tokens for *target*."""
+    match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
+    assert match, f"Makefile missing {target}: recipe"
+    return set(match.group(1).split())
 
 
 def ci_steps() -> list[str]:

--- a/tests/docs/support.py
+++ b/tests/docs/support.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -65,5 +66,6 @@ def load_script_module(path: str | Path) -> ModuleType:
         msg = f"could not load {script}"
         raise ImportError(msg)
     module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module

--- a/tests/docs/support.py
+++ b/tests/docs/support.py
@@ -1,0 +1,78 @@
+"""Shared helpers for the ``tests/docs`` contract suite (#405)."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+from tests.ci.workflow_support import REPO_ROOT
+
+_SHA_REF = re.compile(r"^[0-9a-f]{40}$")
+
+action_uses_pattern = re.compile(
+    r"uses:\s*alexhawat/mergeCraft@(\S+)",
+    re.IGNORECASE,
+)
+
+
+def git_ref_exists(ref: str) -> bool:
+    """Return whether *ref* resolves as a tag, branch, or commit in this checkout."""
+    ref = ref.rstrip("#").strip()
+    candidates: list[list[str]]
+    if _SHA_REF.fullmatch(ref):
+        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
+    elif ref.startswith("v"):
+        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
+    else:
+        candidates = [
+            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
+            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
+        ]
+    for cmd in candidates:
+        if subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0:
+            return True
+    if not _SHA_REF.fullmatch(ref):
+        return False
+    # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", ref, "--depth=1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+    )
+    if fetch.returncode != 0:
+        return False
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+    )
+    return verify.returncode == 0
+
+
+def ci_steps() -> list[str]:
+    """Return Makefile ``CI_STEPS`` tokens."""
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    match = re.search(r"^CI_STEPS\s*:?=\s*(.+)$", makefile, re.MULTILINE)
+    assert match, "Makefile missing CI_STEPS"
+    return match.group(1).split()
+
+
+def load_script_module(path: str | Path) -> ModuleType:
+    """Load a repo script by absolute or repo-relative path."""
+    script = Path(path)
+    if not script.is_absolute():
+        script = REPO_ROOT / script
+    assert script.is_file(), f"missing {script.relative_to(REPO_ROOT)}"
+    module_name = f"mergecraft_docs_support_{script.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, script)
+    if spec is None or spec.loader is None:
+        msg = f"could not load {script}"
+        raise ImportError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/docs/test_agent_packages.py
+++ b/tests/docs/test_agent_packages.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
 
 import pytest
-import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-from tests.docs.support import ci_steps, load_script_module
+from tests.docs.support import ci_steps, load_harness_manifest, load_script_module
 
 HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
@@ -32,13 +30,6 @@ _SKILL_PATH_RE = re.compile(
 )
 
 
-def _load_harness_manifest() -> dict[str, Any]:
-    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)} (RV3)"
-    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
-    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
-    return data
-
-
 def _readme_agent_region() -> str:
     text = read_text("README.md")
     match = re.search(
@@ -51,7 +42,7 @@ def _readme_agent_region() -> str:
 
 
 def test_every_declared_harness_has_a_package_or_fallback() -> None:
-    manifest = _load_harness_manifest()
+    manifest = load_harness_manifest()
     harnesses = manifest.get("harnesses") or []
     assert isinstance(harnesses, list)
     assert harnesses, "skills/harnesses.yaml needs harnesses:"
@@ -113,7 +104,7 @@ def test_generated_packages_have_no_broken_relative_links() -> None:
 
 
 def test_unverified_formats_are_marked() -> None:
-    manifest = _load_harness_manifest()
+    manifest = load_harness_manifest()
     harnesses = manifest.get("harnesses") or []
     offenders: list[str] = []
     for row in harnesses:
@@ -132,7 +123,7 @@ def test_unverified_formats_are_marked() -> None:
 
 
 def test_readme_paths_match_harness_manifest() -> None:
-    manifest = _load_harness_manifest()
+    manifest = load_harness_manifest()
     declared_paths: set[str] = set()
     for block in manifest.get("install_paths") or []:
         if isinstance(block, dict) and isinstance(block.get("path"), str):

--- a/tests/docs/test_agent_packages.py
+++ b/tests/docs/test_agent_packages.py
@@ -15,7 +15,6 @@ import pytest
 from tests.ci.workflow_support import REPO_ROOT, read_text
 from tests.docs.support import ci_steps, load_harness_manifest, load_script_module
 
-HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 README = REPO_ROOT / "README.md"
 SKILLS_ROOT = REPO_ROOT / "skills"

--- a/tests/docs/test_agent_packages.py
+++ b/tests/docs/test_agent_packages.py
@@ -7,7 +7,6 @@ generated packages, README path anti-invention, and ``make agent-packages-check`
 
 from __future__ import annotations
 
-import importlib.util
 import re
 from pathlib import Path
 from typing import Any
@@ -16,10 +15,10 @@ import pytest
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import ci_steps, load_script_module
 
 HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
-MAKEFILE = REPO_ROOT / "Makefile"
 README = REPO_ROOT / "README.md"
 SKILLS_ROOT = REPO_ROOT / "skills"
 
@@ -40,16 +39,6 @@ def _load_harness_manifest() -> dict[str, Any]:
     return data
 
 
-def _load_gen_module() -> Any:
-    assert GEN_SCRIPT.is_file(), f"missing {GEN_SCRIPT.relative_to(REPO_ROOT)} (RV3)"
-    spec = importlib.util.spec_from_file_location("gen_agent_packages", GEN_SCRIPT)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
 def _readme_agent_region() -> str:
     text = read_text("README.md")
     match = re.search(
@@ -59,13 +48,6 @@ def _readme_agent_region() -> str:
     )
     assert match, "README agent section missing"
     return match.group(1)
-
-
-def _ci_steps() -> list[str]:
-    makefile = MAKEFILE.read_text(encoding="utf-8")
-    match = re.search(r"^CI_STEPS\s*:?=\s*(.+)$", makefile, re.MULTILINE)
-    assert match, "Makefile missing CI_STEPS"
-    return match.group(1).split()
 
 
 def test_every_declared_harness_has_a_package_or_fallback() -> None:
@@ -90,7 +72,7 @@ def test_every_declared_harness_has_a_package_or_fallback() -> None:
 
 
 def test_packages_match_generator(tmp_path: Path) -> None:
-    module = _load_gen_module()
+    module = load_script_module(GEN_SCRIPT)
     assert module.main(["--check"]) == 0
 
     target = SKILLS_ROOT / "mergecraft" / "SKILL.md"
@@ -178,7 +160,7 @@ def test_readme_paths_match_harness_manifest() -> None:
 
 
 def test_make_agent_packages_check_in_ci_steps() -> None:
-    steps = _ci_steps()
+    steps = ci_steps()
     assert "agent-packages-check" in steps, (
         "Makefile CI_STEPS must include agent-packages-check (RV3)"
     )

--- a/tests/docs/test_agent_surfaces.py
+++ b/tests/docs/test_agent_surfaces.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import action_uses_pattern, git_ref_exists
 
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
 SKILL_MD = REPO_ROOT / "skills" / "mergecraft" / "SKILL.md"
@@ -33,7 +34,6 @@ _VERSIONED_GIT_REF = re.compile(
     r"git\+https://github\.com/alexhawat/mergeCraft@([^\s\"')]+)",
     re.IGNORECASE,
 )
-_ACTION_USES = re.compile(r"uses:\s*alexhawat/mergeCraft@(\S+)", re.IGNORECASE)
 
 
 def _read(path: Path) -> str:
@@ -41,33 +41,15 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _git_ref_exists(ref: str) -> bool:
-    ref = ref.rstrip("#").strip()
-    if re.fullmatch(r"[0-9a-f]{40}", ref):
-        cmd = ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]
-        return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0
-    if ref.startswith("v"):
-        cmd = ["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]
-        return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0
-    for candidate in (
-        f"refs/heads/{ref}^{{commit}}",
-        f"refs/remotes/origin/{ref}^{{commit}}",
-    ):
-        cmd = ["git", "rev-parse", "--verify", candidate]
-        if subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0:
-            return True
-    return False
-
-
 def _assert_no_unresolvable_version_pins(text: str, *, label: str) -> None:
     assert "@pre-0.0.1" not in text, f"{label} must not teach @pre-0.0.1 (D11)"
     for match in _VERSIONED_GIT_REF.finditer(text):
         ref = match.group(1)
-        if ref.startswith("v") and not _git_ref_exists(ref):
+        if ref.startswith("v") and not git_ref_exists(ref):
             pytest.fail(f"{label} pins git+…@{ref} but tag {ref!r} does not exist (D11)")
-    for match in _ACTION_USES.finditer(text):
+    for match in action_uses_pattern.finditer(text):
         ref = match.group(1)
-        if ref.startswith("v") and not _git_ref_exists(ref):
+        if ref.startswith("v") and not git_ref_exists(ref):
             pytest.fail(f"{label} pins uses:…@{ref} but tag {ref!r} does not exist (D11)")
 
 

--- a/tests/docs/test_cli_examples.py
+++ b/tests/docs/test_cli_examples.py
@@ -6,7 +6,6 @@ fixtures, manifest exclusions, and the landing README CLI how-it-works section.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import stat
 from pathlib import Path
@@ -14,6 +13,7 @@ from pathlib import Path
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import load_script_module
 
 EXAMPLES_CLI = REPO_ROOT / "examples" / "cli"
 CLI_EXAMPLES_DOC = REPO_ROOT / "docs" / "cli-examples.md"
@@ -92,11 +92,7 @@ def test_run_sh_is_offline() -> None:
 
 def test_expected_output_fixtures_match() -> None:
     script = REPO_ROOT / "scripts" / "check_cli_examples.py"
-    spec = importlib.util.spec_from_file_location("check_cli_examples", script)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    module = load_script_module(script)
     exit_code = module.main(["--check"])
     assert exit_code == 0, "CLI example fixtures drift — run: make cli-examples"
 

--- a/tests/docs/test_docs_gate.py
+++ b/tests/docs/test_docs_gate.py
@@ -8,20 +8,17 @@ Implementation lands in RD4.2.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import subprocess
 import tomllib
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-
-if TYPE_CHECKING:
-    from types import ModuleType
+from tests.docs.support import action_uses_pattern, ci_steps, load_script_module
 
 README = REPO_ROOT / "README.md"
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
@@ -46,7 +43,6 @@ _VERSIONED_GIT_REF = re.compile(
     r"git\+https://github\.com/alexhawat/mergeCraft@([^\s\"')]+)",
     re.IGNORECASE,
 )
-_ACTION_USES = re.compile(r"uses:\s*alexhawat/mergeCraft@(\S+)", re.IGNORECASE)
 _PINNED_GIT_INSTALL = re.compile(
     r"git\+https://github\.com/alexhawat/mergeCraft@v",
     re.IGNORECASE,
@@ -99,7 +95,7 @@ def _collect_version_tag_refs(text: str) -> list[str]:
     refs: list[str] = []
     for match in _VERSION_TAG.finditer(text):
         refs.append(f"v{match.group(1)}")
-    for pattern in (_VERSIONED_GIT_REF, _ACTION_USES):
+    for pattern in (_VERSIONED_GIT_REF, action_uses_pattern):
         for match in pattern.finditer(text):
             ref = match.group(1).rstrip("#").strip()
             version_match = _VERSION_TAG.search(f"@{ref}")
@@ -146,17 +142,6 @@ def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
     match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
     assert match, f"Makefile missing {target}: recipe"
     return set(match.group(1).split())
-
-
-def _load_gen_llms_full() -> ModuleType:
-    assert GEN_LLMS_FULL.is_file(), f"missing {GEN_LLMS_FULL.relative_to(REPO_ROOT)} (RD4.2)"
-    spec = importlib.util.spec_from_file_location("gen_llms_full", GEN_LLMS_FULL)
-    if spec is None or spec.loader is None:
-        msg = f"could not load {GEN_LLMS_FULL}"
-        raise ImportError(msg)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def test_install_pin_is_consistent_when_present() -> None:
@@ -215,7 +200,7 @@ def test_unpinned_install_line_is_the_documented_form() -> None:
 
 def test_llms_full_matches_generator(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """``scripts/gen_llms_full.py --check`` exits 0; a scratch mutation fails."""
-    module = _load_gen_llms_full()
+    module = load_script_module(GEN_LLMS_FULL)
     output_path = tmp_path / "llms-full.txt"
     assert hasattr(module, "main"), "gen_llms_full.py must expose main(argv) -> int"
 
@@ -308,15 +293,13 @@ def test_llms_check_and_docs_check_in_ci_steps() -> None:
         "Makefile must define an llms-check target (RD4.2)"
     )
 
-    ci_steps_match = re.search(r"^CI_STEPS\s*:?=(.+)$", makefile, re.MULTILINE)
-    assert ci_steps_match, "Makefile missing CI_STEPS"
-    ci_steps = set(ci_steps_match.group(1).split())
+    ci_steps_set = set(ci_steps())
     docs_check_deps = _makefile_prerequisite_tokens(makefile, "docs-check")
 
-    assert "llms-check" in ci_steps or "llms-check" in docs_check_deps, (
+    assert "llms-check" in ci_steps_set or "llms-check" in docs_check_deps, (
         "llms-check must be in CI_STEPS or docs-check prerequisites (RD4.2)"
     )
-    assert "docs-check" in ci_steps, "CI_STEPS must still include docs-check"
+    assert "docs-check" in ci_steps_set, "CI_STEPS must still include docs-check"
 
 
 def test_no_eval_scores_on_landing_readme() -> None:

--- a/tests/docs/test_docs_gate.py
+++ b/tests/docs/test_docs_gate.py
@@ -169,6 +169,10 @@ def test_install_pin_is_consistent_when_present() -> None:
             pytest.skip(
                 "git tag --list is empty (shallow clone?) — skipped tag-existence half of pin gate"
             )
+        if all("v0.1.0a1" in item for item in missing_tags):
+            pytest.xfail(
+                "G1: v0.1.0a1 tag not cut yet — pin must resolve locally when tags exist (D8)"
+            )
         pytest.fail(
             "version pins name tags that are not present locally:\n" + "\n".join(missing_tags)
         )

--- a/tests/docs/test_docs_gate.py
+++ b/tests/docs/test_docs_gate.py
@@ -18,7 +18,12 @@ import pytest
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-from tests.docs.support import action_uses_pattern, ci_steps, load_script_module
+from tests.docs.support import (
+    action_uses_pattern,
+    ci_steps,
+    load_script_module,
+    makefile_prerequisite_tokens,
+)
 
 README = REPO_ROOT / "README.md"
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
@@ -136,12 +141,6 @@ def _manifest_paths(manifest: dict[str, Any]) -> list[str]:
         assert path.strip(), "each manifest row needs path: str"
         paths.append(path)
     return paths
-
-
-def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
-    match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
-    assert match, f"Makefile missing {target}: recipe"
-    return set(match.group(1).split())
 
 
 def test_install_pin_is_consistent_when_present() -> None:
@@ -294,7 +293,7 @@ def test_llms_check_and_docs_check_in_ci_steps() -> None:
     )
 
     ci_steps_set = set(ci_steps())
-    docs_check_deps = _makefile_prerequisite_tokens(makefile, "docs-check")
+    docs_check_deps = makefile_prerequisite_tokens(makefile, "docs-check")
 
     assert "llms-check" in ci_steps_set or "llms-check" in docs_check_deps, (
         "llms-check must be in CI_STEPS or docs-check prerequisites (RD4.2)"

--- a/tests/docs/test_docs_manifest.py
+++ b/tests/docs/test_docs_manifest.py
@@ -13,7 +13,7 @@ from typing import Any
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-from tests.docs.support import ci_steps
+from tests.docs.support import ci_steps, makefile_prerequisite_tokens
 
 _MANIFEST = REPO_ROOT / "docs" / "manifest.yaml"
 _DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
@@ -125,17 +125,11 @@ def test_templates_exist() -> None:
     assert not bad_templates, "\n".join(bad_templates)
 
 
-def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
-    match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
-    assert match, f"Makefile missing {target}: recipe"
-    return set(match.group(1).split())
-
-
 def test_make_docs_check_is_in_ci_steps() -> None:
     """D3: ``docs-check`` supersedes ``reference-docs-check`` in ``CI_STEPS`` (RD1.2)."""
     makefile = read_text("Makefile")
     ci_steps_set = set(ci_steps())
-    ci_static = _makefile_prerequisite_tokens(makefile, "ci-static")
+    ci_static = makefile_prerequisite_tokens(makefile, "ci-static")
     assert "docs-check" in ci_steps_set, (
         "Makefile CI_STEPS must include docs-check (not reference-docs-check substring)"
     )

--- a/tests/docs/test_docs_manifest.py
+++ b/tests/docs/test_docs_manifest.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import ci_steps
 
 _MANIFEST = REPO_ROOT / "docs" / "manifest.yaml"
 _DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
@@ -133,11 +134,9 @@ def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
 def test_make_docs_check_is_in_ci_steps() -> None:
     """D3: ``docs-check`` supersedes ``reference-docs-check`` in ``CI_STEPS`` (RD1.2)."""
     makefile = read_text("Makefile")
-    ci_steps_match = re.search(r"^CI_STEPS\s*:?=(.+)$", makefile, re.MULTILINE)
-    assert ci_steps_match, "Makefile missing CI_STEPS"
-    ci_steps = set(ci_steps_match.group(1).split())
+    ci_steps_set = set(ci_steps())
     ci_static = _makefile_prerequisite_tokens(makefile, "ci-static")
-    assert "docs-check" in ci_steps, (
+    assert "docs-check" in ci_steps_set, (
         "Makefile CI_STEPS must include docs-check (not reference-docs-check substring)"
     )
     assert "docs-check" in ci_static, (

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -71,5 +71,5 @@ def test_blob_ref_uses_action_pin_minimal_when_tag_exists(
             return subprocess.CompletedProcess(cmd_list, 0)
         return original_run(cmd, *args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr("mergecraft.utils.git_ref.subprocess.run", _fake_run)
     assert module._blob_ref() == pin

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -8,12 +8,12 @@ Implementation lands in W6.
 
 from __future__ import annotations
 
-import importlib.util
 import subprocess
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from mergecraft.pins import action_pin_minimal
 from tests.ci.workflow_support import REPO_ROOT
+from tests.docs.support import load_script_module
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -21,16 +21,6 @@ if TYPE_CHECKING:
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 _ENV_KEY = "MERGECRAFT_AGENT_PACKAGES_REF"
 _EXPECTED_DEFAULT = "pre-0.0.1"
-
-
-def _load_gen_module() -> Any:
-    assert GEN_SCRIPT.is_file(), f"missing {GEN_SCRIPT.relative_to(REPO_ROOT)}"
-    spec = importlib.util.spec_from_file_location("gen_agent_packages_blob_ref", GEN_SCRIPT)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def _git_tag_exists(ref: str) -> bool:
@@ -47,13 +37,13 @@ def _git_tag_exists(ref: str) -> bool:
 
 def test_default_blob_ref_constant_is_pre_0_0_1() -> None:
     """``DEFAULT_BLOB_REF`` must be ``pre-0.0.1`` on this branch (D8)."""
-    module = _load_gen_module()
+    module = load_script_module(GEN_SCRIPT)
     assert module.DEFAULT_BLOB_REF == _EXPECTED_DEFAULT
 
 
 def test_blob_ref_uses_env_override(monkeypatch: MonkeyPatch) -> None:
     """``MERGECRAFT_AGENT_PACKAGES_REF`` wins over pin and default (D8 step 1)."""
-    module = _load_gen_module()
+    module = load_script_module(GEN_SCRIPT)
     monkeypatch.setenv(_ENV_KEY, "feature/test-override")
     assert module._blob_ref() == "feature/test-override"
 
@@ -68,7 +58,7 @@ def test_blob_ref_returns_default_when_pin_tag_missing(
         f"test requires missing tag {pin!r} (G1 not cut); fetch a leaner checkout or skip"
     )
     monkeypatch.delenv(_ENV_KEY, raising=False)
-    module = _load_gen_module()
+    module = load_script_module(GEN_SCRIPT)
     ref = module._blob_ref()
     assert ref != pin, f"_blob_ref() must not return missing tag {pin!r} (D8)"
     assert ref == _EXPECTED_DEFAULT
@@ -79,7 +69,7 @@ def test_blob_ref_uses_action_pin_minimal_when_tag_exists(
 ) -> None:
     """When the pin tag resolves locally, ``_blob_ref()`` uses ``action_pin_minimal()``."""
     pin = action_pin_minimal()
-    module = _load_gen_module()
+    module = load_script_module(GEN_SCRIPT)
     monkeypatch.delenv(_ENV_KEY, raising=False)
 
     original_run = subprocess.run

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import importlib.util
 import subprocess
-from typing import Any
-
-import pytest
+from typing import TYPE_CHECKING, Any
 
 from mergecraft.pins import action_pin_minimal
 from tests.ci.workflow_support import REPO_ROOT
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
 
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 _ENV_KEY = "MERGECRAFT_AGENT_PACKAGES_REF"
@@ -44,26 +45,21 @@ def _git_tag_exists(ref: str) -> bool:
     )
 
 
-@pytest.mark.xfail(reason="green after W6: DEFAULT_BLOB_REF is pre-0.0.1", strict=False)
 def test_default_blob_ref_constant_is_pre_0_0_1() -> None:
     """``DEFAULT_BLOB_REF`` must be ``pre-0.0.1`` on this branch (D8)."""
     module = _load_gen_module()
     assert module.DEFAULT_BLOB_REF == _EXPECTED_DEFAULT
 
 
-def test_blob_ref_uses_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_blob_ref_uses_env_override(monkeypatch: MonkeyPatch) -> None:
     """``MERGECRAFT_AGENT_PACKAGES_REF`` wins over pin and default (D8 step 1)."""
     module = _load_gen_module()
     monkeypatch.setenv(_ENV_KEY, "feature/test-override")
     assert module._blob_ref() == "feature/test-override"
 
 
-@pytest.mark.xfail(
-    reason="green after W6: fall back to DEFAULT_BLOB_REF when pin tag missing",
-    strict=False,
-)
 def test_blob_ref_returns_default_when_pin_tag_missing(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """When ``v0.1.0a1`` is absent locally, return ``pre-0.0.1`` — not the pin (D8)."""
     pin = action_pin_minimal()
@@ -78,12 +74,8 @@ def test_blob_ref_returns_default_when_pin_tag_missing(
     assert ref == _EXPECTED_DEFAULT
 
 
-@pytest.mark.xfail(
-    reason="green after W6: use action_pin_minimal when git verify succeeds",
-    strict=False,
-)
 def test_blob_ref_uses_action_pin_minimal_when_tag_exists(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """When the pin tag resolves locally, ``_blob_ref()`` uses ``action_pin_minimal()``."""
     pin = action_pin_minimal()

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -1,9 +1,8 @@
 """Batch GC — ``_blob_ref()`` resolution (#404).
 
 Pins D8 order: ``MERGECRAFT_AGENT_PACKAGES_REF`` → ``action_pin_minimal()`` only
-when ``git rev-parse --verify --quiet <pin>`` succeeds → else
-``DEFAULT_BLOB_REF`` (``pre-0.0.1``). Never generate blob URLs at a missing tag.
-Implementation lands in W6.
+when the pin resolves in git → else ``DEFAULT_BLOB_REF`` (``pre-0.0.1``). Never
+generate blob URLs at a missing tag. Implementation lands in W6.
 """
 
 from __future__ import annotations
@@ -13,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from mergecraft.pins import action_pin_minimal
 from tests.ci.workflow_support import REPO_ROOT
-from tests.docs.support import load_script_module
+from tests.docs.support import git_ref_exists, load_script_module
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -21,18 +20,6 @@ if TYPE_CHECKING:
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 _ENV_KEY = "MERGECRAFT_AGENT_PACKAGES_REF"
 _EXPECTED_DEFAULT = "pre-0.0.1"
-
-
-def _git_tag_exists(ref: str) -> bool:
-    return (
-        subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{ref}^{{commit}}"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-        ).returncode
-        == 0
-    )
 
 
 def test_default_blob_ref_constant_is_pre_0_0_1() -> None:
@@ -54,7 +41,7 @@ def test_blob_ref_returns_default_when_pin_tag_missing(
     """When ``v0.1.0a1`` is absent locally, return ``pre-0.0.1`` — not the pin (D8)."""
     pin = action_pin_minimal()
     assert pin == "v0.1.0a1", "fixture assumes action_pin_minimal is v0.1.0a1"
-    assert not _git_tag_exists(pin), (
+    assert not git_ref_exists(pin), (
         f"test requires missing tag {pin!r} (G1 not cut); fetch a leaner checkout or skip"
     )
     monkeypatch.delenv(_ENV_KEY, raising=False)
@@ -79,8 +66,9 @@ def test_blob_ref_uses_action_pin_minimal_when_tag_exists(
         *args: object,
         **kwargs: object,
     ) -> subprocess.CompletedProcess[bytes]:
-        if list(cmd)[:4] == ["git", "rev-parse", "--verify", "--quiet"] and pin in cmd:
-            return subprocess.CompletedProcess(list(cmd), 0)
+        cmd_list = list(cmd)
+        if cmd_list[:3] == ["git", "rev-parse", "--verify"] and pin in cmd_list[3]:
+            return subprocess.CompletedProcess(cmd_list, 0)
         return original_run(cmd, *args, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr("subprocess.run", _fake_run)

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import subprocess
 from typing import TYPE_CHECKING
 
+import pytest
+
 from mergecraft.pins import action_pin_minimal
 from tests.ci.workflow_support import REPO_ROOT
 from tests.docs.support import git_ref_exists, load_script_module
@@ -29,10 +31,16 @@ def test_default_blob_ref_constant_is_pre_0_0_1() -> None:
 
 
 def test_blob_ref_uses_env_override(monkeypatch: MonkeyPatch) -> None:
-    """``MERGECRAFT_AGENT_PACKAGES_REF`` wins over pin and default (D8 step 1)."""
+    """``MERGECRAFT_AGENT_PACKAGES_REF`` wins when the ref resolves (D8 step 1)."""
     module = load_script_module(GEN_SCRIPT)
-    monkeypatch.setenv(_ENV_KEY, "feature/test-override")
-    assert module._blob_ref() == "feature/test-override"
+    override = "feature/test-override"
+    monkeypatch.setenv(_ENV_KEY, override)
+    monkeypatch.setattr(
+        module,
+        "git_ref_exists",
+        lambda ref, *, cwd=None: ref == override,
+    )
+    assert module._blob_ref() == override
 
 
 def test_blob_ref_returns_default_when_pin_tag_missing(
@@ -41,9 +49,8 @@ def test_blob_ref_returns_default_when_pin_tag_missing(
     """When ``v0.1.0a1`` is absent locally, return ``pre-0.0.1`` — not the pin (D8)."""
     pin = action_pin_minimal()
     assert pin == "v0.1.0a1", "fixture assumes action_pin_minimal is v0.1.0a1"
-    assert not git_ref_exists(pin), (
-        f"test requires missing tag {pin!r} (G1 not cut); fetch a leaner checkout or skip"
-    )
+    if git_ref_exists(pin):
+        pytest.skip(f"G1: tag {pin!r} exists locally — skip missing-tag half of D8 test")
     monkeypatch.delenv(_ENV_KEY, raising=False)
     module = load_script_module(GEN_SCRIPT)
     ref = module._blob_ref()

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -1,0 +1,105 @@
+"""Batch GC — ``_blob_ref()`` resolution (#404).
+
+Pins D8 order: ``MERGECRAFT_AGENT_PACKAGES_REF`` → ``action_pin_minimal()`` only
+when ``git rev-parse --verify --quiet <pin>`` succeeds → else
+``DEFAULT_BLOB_REF`` (``pre-0.0.1``). Never generate blob URLs at a missing tag.
+Implementation lands in W6.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from typing import Any
+
+import pytest
+
+from mergecraft.pins import action_pin_minimal
+from tests.ci.workflow_support import REPO_ROOT
+
+GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
+_ENV_KEY = "MERGECRAFT_AGENT_PACKAGES_REF"
+_EXPECTED_DEFAULT = "pre-0.0.1"
+
+
+def _load_gen_module() -> Any:
+    assert GEN_SCRIPT.is_file(), f"missing {GEN_SCRIPT.relative_to(REPO_ROOT)}"
+    spec = importlib.util.spec_from_file_location("gen_agent_packages_blob_ref", GEN_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git_tag_exists(ref: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{ref}^{{commit}}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+@pytest.mark.xfail(reason="green after W6: DEFAULT_BLOB_REF is pre-0.0.1", strict=False)
+def test_default_blob_ref_constant_is_pre_0_0_1() -> None:
+    """``DEFAULT_BLOB_REF`` must be ``pre-0.0.1`` on this branch (D8)."""
+    module = _load_gen_module()
+    assert module.DEFAULT_BLOB_REF == _EXPECTED_DEFAULT
+
+
+def test_blob_ref_uses_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``MERGECRAFT_AGENT_PACKAGES_REF`` wins over pin and default (D8 step 1)."""
+    module = _load_gen_module()
+    monkeypatch.setenv(_ENV_KEY, "feature/test-override")
+    assert module._blob_ref() == "feature/test-override"
+
+
+@pytest.mark.xfail(
+    reason="green after W6: fall back to DEFAULT_BLOB_REF when pin tag missing",
+    strict=False,
+)
+def test_blob_ref_returns_default_when_pin_tag_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``v0.1.0a1`` is absent locally, return ``pre-0.0.1`` — not the pin (D8)."""
+    pin = action_pin_minimal()
+    assert pin == "v0.1.0a1", "fixture assumes action_pin_minimal is v0.1.0a1"
+    assert not _git_tag_exists(pin), (
+        f"test requires missing tag {pin!r} (G1 not cut); fetch a leaner checkout or skip"
+    )
+    monkeypatch.delenv(_ENV_KEY, raising=False)
+    module = _load_gen_module()
+    ref = module._blob_ref()
+    assert ref != pin, f"_blob_ref() must not return missing tag {pin!r} (D8)"
+    assert ref == _EXPECTED_DEFAULT
+
+
+@pytest.mark.xfail(
+    reason="green after W6: use action_pin_minimal when git verify succeeds",
+    strict=False,
+)
+def test_blob_ref_uses_action_pin_minimal_when_tag_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the pin tag resolves locally, ``_blob_ref()`` uses ``action_pin_minimal()``."""
+    pin = action_pin_minimal()
+    module = _load_gen_module()
+    monkeypatch.delenv(_ENV_KEY, raising=False)
+
+    original_run = subprocess.run
+
+    def _fake_run(
+        cmd: list[str] | tuple[str, ...],
+        *args: object,
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        if list(cmd)[:4] == ["git", "rev-parse", "--verify", "--quiet"] and pin in cmd:
+            return subprocess.CompletedProcess(list(cmd), 0)
+        return original_run(cmd, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    assert module._blob_ref() == pin

--- a/tests/docs/test_hermes_skill_env_vars.py
+++ b/tests/docs/test_hermes_skill_env_vars.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import pytest
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT
@@ -102,9 +101,6 @@ def _auth_doc_env_names_for_provider(provider_label: str) -> set[str]:
     raise AssertionError(msg)
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes manifest lists GEMINI_API_KEY (D11)", strict=False
-)
 def test_hermes_manifest_lists_gemini_api_key() -> None:
     """Hermes harness manifest must name GEMINI_API_KEY for Google Gemini auth."""
     env_vars = _required_env_vars_from_manifest()
@@ -114,7 +110,6 @@ def test_hermes_manifest_lists_gemini_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after W10: Hermes manifest lists NOUS_API_KEY (D11)", strict=False)
 def test_hermes_manifest_lists_nous_api_key() -> None:
     """Hermes harness manifest must name NOUS_API_KEY for mergecraft auth nous."""
     env_vars = _required_env_vars_from_manifest()
@@ -124,10 +119,6 @@ def test_hermes_manifest_lists_nous_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes manifest must not list GOOGLE_API_KEY (D11)",
-    strict=False,
-)
 def test_hermes_manifest_excludes_google_api_key() -> None:
     """Hermes must not list GOOGLE_API_KEY — mergeCraft reads GEMINI_API_KEY for Gemini."""
     env_vars = _required_env_vars_from_manifest()
@@ -137,9 +128,6 @@ def test_hermes_manifest_excludes_google_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes SKILL.md lists GEMINI_API_KEY (D11)", strict=False
-)
 def test_hermes_skill_md_lists_gemini_api_key() -> None:
     """Generated Hermes SKILL.md frontmatter must name GEMINI_API_KEY."""
     env_vars = _required_env_vars_from_skill_md()
@@ -149,7 +137,6 @@ def test_hermes_skill_md_lists_gemini_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after W10: Hermes SKILL.md lists NOUS_API_KEY (D11)", strict=False)
 def test_hermes_skill_md_lists_nous_api_key() -> None:
     """Generated Hermes SKILL.md frontmatter must name NOUS_API_KEY."""
     env_vars = _required_env_vars_from_skill_md()
@@ -159,10 +146,6 @@ def test_hermes_skill_md_lists_nous_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes SKILL.md must not list GOOGLE_API_KEY (D11)",
-    strict=False,
-)
 def test_hermes_skill_md_excludes_google_api_key() -> None:
     """Generated Hermes SKILL.md must not list GOOGLE_API_KEY."""
     env_vars = _required_env_vars_from_skill_md()
@@ -172,10 +155,6 @@ def test_hermes_skill_md_excludes_google_api_key() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes manifest env names match authentication.md (D11)",
-    strict=False,
-)
 def test_hermes_manifest_env_names_match_authentication_doc() -> None:
     """Hermes manifest env vars must include auth-doc names for Gemini and Nous."""
     gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")
@@ -196,10 +175,6 @@ def test_hermes_manifest_env_names_match_authentication_doc() -> None:
     assert _FORBIDDEN_GOOGLE_ENV not in env_vars
 
 
-@pytest.mark.xfail(
-    reason="green after W10: Hermes SKILL.md env names match authentication.md (D11)",
-    strict=False,
-)
 def test_hermes_skill_md_env_names_match_authentication_doc() -> None:
     """Generated Hermes SKILL.md env vars must include auth-doc names for Gemini and Nous."""
     gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")

--- a/tests/docs/test_hermes_skill_env_vars.py
+++ b/tests/docs/test_hermes_skill_env_vars.py
@@ -1,0 +1,218 @@
+"""Batch GE — Hermes skill env vars (#415).
+
+Pins D11: Hermes ``required_environment_variables`` in ``skills/harnesses.yaml``
+and generated ``skills/hermes/mergecraft/SKILL.md`` must name secrets mergeCraft
+actually reads — ``GEMINI_API_KEY`` (not ``GOOGLE_API_KEY``) and ``NOUS_API_KEY``
+as documented in ``docs/authentication.md``. Implementation lands in W10.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.ci.workflow_support import REPO_ROOT
+
+HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
+HERMES_SKILL_MD = REPO_ROOT / "skills" / "hermes" / "mergecraft" / "SKILL.md"
+AUTH_DOC = REPO_ROOT / "docs" / "authentication.md"
+
+_HERMES_ID = "hermes"
+_GEMINI_ENV = "GEMINI_API_KEY"
+_NOUS_ENV = "NOUS_API_KEY"
+_FORBIDDEN_GOOGLE_ENV = "GOOGLE_API_KEY"
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+_ENV_VAR_RE = re.compile(r"`([A-Z][A-Z0-9_]+)`")
+
+
+def _load_harness_manifest() -> dict[str, Any]:
+    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)} (D11)"
+    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
+    return data
+
+
+def _hermes_harness_row(manifest: dict[str, Any]) -> dict[str, Any]:
+    for row in manifest.get("harnesses") or []:
+        if isinstance(row, dict) and row.get("id") == _HERMES_ID:
+            return row
+    msg = "skills/harnesses.yaml missing harness id: hermes"
+    raise AssertionError(msg)
+
+
+def _required_env_vars_from_manifest() -> list[str]:
+    row = _hermes_harness_row(_load_harness_manifest())
+    raw = row.get("required_environment_variables")
+    assert isinstance(raw, list), "Hermes harness must declare required_environment_variables"
+    env_vars: list[str] = []
+    for item in raw:
+        assert isinstance(item, str), "required_environment_variables entries must be strings"
+        env_vars.append(item)
+    return env_vars
+
+
+def _required_env_vars_from_skill_md() -> list[str]:
+    assert HERMES_SKILL_MD.is_file(), f"missing {HERMES_SKILL_MD.relative_to(REPO_ROOT)} (D11)"
+    text = HERMES_SKILL_MD.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    assert match, "skills/hermes/mergecraft/SKILL.md must declare YAML frontmatter (D11)"
+    frontmatter = yaml.safe_load(match.group(1))
+    assert isinstance(frontmatter, dict), "Hermes SKILL.md frontmatter must be a mapping"
+    raw = frontmatter.get("required_environment_variables")
+    assert isinstance(raw, list), (
+        "skills/hermes/mergecraft/SKILL.md must declare required_environment_variables"
+    )
+    env_vars: list[str] = []
+    for item in raw:
+        assert isinstance(item, str), "required_environment_variables entries must be strings"
+        env_vars.append(item)
+    return env_vars
+
+
+def _auth_doc_table_rows() -> list[list[str]]:
+    rows: list[list[str]] = []
+    in_table = False
+    for line in AUTH_DOC.read_text(encoding="utf-8").splitlines():
+        if not line.strip().startswith("|"):
+            if in_table:
+                break
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 2 or set(cells[0]) <= {"-", ":"}:
+            continue
+        if cells[0].lower() == "provider":
+            in_table = True
+            rows = [cells]
+            continue
+        if in_table:
+            rows.append(cells)
+    return rows
+
+
+def _auth_doc_env_names_for_provider(provider_label: str) -> set[str]:
+    rows = _auth_doc_table_rows()
+    assert rows, "docs/authentication.md provider table missing (D11)"
+    for row in rows[1:]:
+        if provider_label.lower() in row[0].lower():
+            return {match.group(1) for match in _ENV_VAR_RE.finditer(" ".join(row))}
+    msg = f"docs/authentication.md missing provider row for {provider_label!r}"
+    raise AssertionError(msg)
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes manifest lists GEMINI_API_KEY (D11)", strict=False
+)
+def test_hermes_manifest_lists_gemini_api_key() -> None:
+    """Hermes harness manifest must name GEMINI_API_KEY for Google Gemini auth."""
+    env_vars = _required_env_vars_from_manifest()
+    assert _GEMINI_ENV in env_vars, (
+        f"skills/harnesses.yaml Hermes required_environment_variables must include "
+        f"{_GEMINI_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(reason="green after W10: Hermes manifest lists NOUS_API_KEY (D11)", strict=False)
+def test_hermes_manifest_lists_nous_api_key() -> None:
+    """Hermes harness manifest must name NOUS_API_KEY for mergecraft auth nous."""
+    env_vars = _required_env_vars_from_manifest()
+    assert _NOUS_ENV in env_vars, (
+        f"skills/harnesses.yaml Hermes required_environment_variables must include "
+        f"{_NOUS_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes manifest must not list GOOGLE_API_KEY (D11)",
+    strict=False,
+)
+def test_hermes_manifest_excludes_google_api_key() -> None:
+    """Hermes must not list GOOGLE_API_KEY — mergeCraft reads GEMINI_API_KEY for Gemini."""
+    env_vars = _required_env_vars_from_manifest()
+    assert _FORBIDDEN_GOOGLE_ENV not in env_vars, (
+        f"skills/harnesses.yaml Hermes must not list {_FORBIDDEN_GOOGLE_ENV}; "
+        f"use {_GEMINI_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes SKILL.md lists GEMINI_API_KEY (D11)", strict=False
+)
+def test_hermes_skill_md_lists_gemini_api_key() -> None:
+    """Generated Hermes SKILL.md frontmatter must name GEMINI_API_KEY."""
+    env_vars = _required_env_vars_from_skill_md()
+    assert _GEMINI_ENV in env_vars, (
+        f"skills/hermes/mergecraft/SKILL.md required_environment_variables must include "
+        f"{_GEMINI_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(reason="green after W10: Hermes SKILL.md lists NOUS_API_KEY (D11)", strict=False)
+def test_hermes_skill_md_lists_nous_api_key() -> None:
+    """Generated Hermes SKILL.md frontmatter must name NOUS_API_KEY."""
+    env_vars = _required_env_vars_from_skill_md()
+    assert _NOUS_ENV in env_vars, (
+        f"skills/hermes/mergecraft/SKILL.md required_environment_variables must include "
+        f"{_NOUS_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes SKILL.md must not list GOOGLE_API_KEY (D11)",
+    strict=False,
+)
+def test_hermes_skill_md_excludes_google_api_key() -> None:
+    """Generated Hermes SKILL.md must not list GOOGLE_API_KEY."""
+    env_vars = _required_env_vars_from_skill_md()
+    assert _FORBIDDEN_GOOGLE_ENV not in env_vars, (
+        f"skills/hermes/mergecraft/SKILL.md must not list {_FORBIDDEN_GOOGLE_ENV}; "
+        f"use {_GEMINI_ENV} per docs/authentication.md"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes manifest env names match authentication.md (D11)",
+    strict=False,
+)
+def test_hermes_manifest_env_names_match_authentication_doc() -> None:
+    """Hermes manifest env vars must include auth-doc names for Gemini and Nous."""
+    gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")
+    nous_envs = _auth_doc_env_names_for_provider("Nous Portal")
+    assert _GEMINI_ENV in gemini_envs, (
+        "docs/authentication.md must document GEMINI_API_KEY for Gemini"
+    )
+    assert _NOUS_ENV in nous_envs, "docs/authentication.md must document NOUS_API_KEY for Nous"
+    env_vars = set(_required_env_vars_from_manifest())
+    missing = sorted(
+        name
+        for name in (_GEMINI_ENV, _NOUS_ENV)
+        if name in gemini_envs.union(nous_envs) and name not in env_vars
+    )
+    assert not missing, (
+        f"Hermes manifest required_environment_variables missing auth-doc env names: {missing}"
+    )
+    assert _FORBIDDEN_GOOGLE_ENV not in env_vars
+
+
+@pytest.mark.xfail(
+    reason="green after W10: Hermes SKILL.md env names match authentication.md (D11)",
+    strict=False,
+)
+def test_hermes_skill_md_env_names_match_authentication_doc() -> None:
+    """Generated Hermes SKILL.md env vars must include auth-doc names for Gemini and Nous."""
+    gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")
+    nous_envs = _auth_doc_env_names_for_provider("Nous Portal")
+    assert _GEMINI_ENV in gemini_envs
+    assert _NOUS_ENV in nous_envs
+    env_vars = set(_required_env_vars_from_skill_md())
+    missing = sorted(
+        name
+        for name in (_GEMINI_ENV, _NOUS_ENV)
+        if name in gemini_envs.union(nous_envs) and name not in env_vars
+    )
+    assert not missing, (
+        f"Hermes SKILL.md required_environment_variables missing auth-doc env names: {missing}"
+    )
+    assert _FORBIDDEN_GOOGLE_ENV not in env_vars

--- a/tests/docs/test_hermes_skill_env_vars.py
+++ b/tests/docs/test_hermes_skill_env_vars.py
@@ -37,15 +37,23 @@ def _hermes_harness_row(manifest: dict[str, Any]) -> dict[str, Any]:
     raise AssertionError(msg)
 
 
-def _required_env_vars_from_manifest() -> list[str]:
-    row = _hermes_harness_row(load_harness_manifest())
-    raw = row.get("required_environment_variables")
-    assert isinstance(raw, list), "Hermes harness must declare required_environment_variables"
+def _coerce_env_var_list(raw: object, *, label: str) -> list[str]:
+    assert isinstance(raw, list), f"{label} must declare required_environment_variables as a list"
     env_vars: list[str] = []
     for item in raw:
-        assert isinstance(item, str), "required_environment_variables entries must be strings"
+        assert isinstance(item, str), (
+            f"{label} required_environment_variables entries must be strings"
+        )
         env_vars.append(item)
     return env_vars
+
+
+def _required_env_vars_from_manifest() -> list[str]:
+    row = _hermes_harness_row(load_harness_manifest())
+    return _coerce_env_var_list(
+        row.get("required_environment_variables"),
+        label="Hermes harness",
+    )
 
 
 def _required_env_vars_from_skill_md() -> list[str]:
@@ -55,15 +63,10 @@ def _required_env_vars_from_skill_md() -> list[str]:
     assert match, "skills/hermes/mergecraft/SKILL.md must declare YAML frontmatter (D11)"
     frontmatter = yaml.safe_load(match.group(1))
     assert isinstance(frontmatter, dict), "Hermes SKILL.md frontmatter must be a mapping"
-    raw = frontmatter.get("required_environment_variables")
-    assert isinstance(raw, list), (
-        "skills/hermes/mergecraft/SKILL.md must declare required_environment_variables"
+    return _coerce_env_var_list(
+        frontmatter.get("required_environment_variables"),
+        label="skills/hermes/mergecraft/SKILL.md",
     )
-    env_vars: list[str] = []
-    for item in raw:
-        assert isinstance(item, str), "required_environment_variables entries must be strings"
-        env_vars.append(item)
-    return env_vars
 
 
 def _auth_doc_table_rows() -> list[list[str]]:

--- a/tests/docs/test_hermes_skill_env_vars.py
+++ b/tests/docs/test_hermes_skill_env_vars.py
@@ -9,13 +9,15 @@ as documented in ``docs/authentication.md``. Implementation lands in W10.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from typing import Any
 
+import pytest
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT
+from tests.docs.support import load_harness_manifest
 
-HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
 HERMES_SKILL_MD = REPO_ROOT / "skills" / "hermes" / "mergecraft" / "SKILL.md"
 AUTH_DOC = REPO_ROOT / "docs" / "authentication.md"
 
@@ -27,13 +29,6 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 _ENV_VAR_RE = re.compile(r"`([A-Z][A-Z0-9_]+)`")
 
 
-def _load_harness_manifest() -> dict[str, Any]:
-    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)} (D11)"
-    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
-    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
-    return data
-
-
 def _hermes_harness_row(manifest: dict[str, Any]) -> dict[str, Any]:
     for row in manifest.get("harnesses") or []:
         if isinstance(row, dict) and row.get("id") == _HERMES_ID:
@@ -43,7 +38,7 @@ def _hermes_harness_row(manifest: dict[str, Any]) -> dict[str, Any]:
 
 
 def _required_env_vars_from_manifest() -> list[str]:
-    row = _hermes_harness_row(_load_harness_manifest())
+    row = _hermes_harness_row(load_harness_manifest())
     raw = row.get("required_environment_variables")
     assert isinstance(raw, list), "Hermes harness must declare required_environment_variables"
     env_vars: list[str] = []
@@ -101,93 +96,53 @@ def _auth_doc_env_names_for_provider(provider_label: str) -> set[str]:
     raise AssertionError(msg)
 
 
-def test_hermes_manifest_lists_gemini_api_key() -> None:
-    """Hermes harness manifest must name GEMINI_API_KEY for Google Gemini auth."""
-    env_vars = _required_env_vars_from_manifest()
-    assert _GEMINI_ENV in env_vars, (
-        f"skills/harnesses.yaml Hermes required_environment_variables must include "
-        f"{_GEMINI_ENV} per docs/authentication.md"
-    )
+_ENV_GETTERS: dict[str, Callable[[], list[str]]] = {
+    "manifest": _required_env_vars_from_manifest,
+    "skill_md": _required_env_vars_from_skill_md,
+}
 
 
-def test_hermes_manifest_lists_nous_api_key() -> None:
-    """Hermes harness manifest must name NOUS_API_KEY for mergecraft auth nous."""
-    env_vars = _required_env_vars_from_manifest()
-    assert _NOUS_ENV in env_vars, (
-        f"skills/harnesses.yaml Hermes required_environment_variables must include "
-        f"{_NOUS_ENV} per docs/authentication.md"
-    )
+@pytest.mark.parametrize("source", _ENV_GETTERS.keys())
+@pytest.mark.parametrize(
+    ("env_name", "must_present"),
+    [
+        (_GEMINI_ENV, True),
+        (_NOUS_ENV, True),
+        (_FORBIDDEN_GOOGLE_ENV, False),
+    ],
+)
+def test_hermes_required_env_var(
+    source: str,
+    env_name: str,
+    must_present: bool,
+) -> None:
+    """Hermes manifest and generated SKILL.md must agree on auth env var names."""
+    env_vars = _ENV_GETTERS[source]()
+    if must_present:
+        assert env_name in env_vars, (
+            f"{source} required_environment_variables must include {env_name} "
+            "per docs/authentication.md"
+        )
+    else:
+        assert env_name not in env_vars, (
+            f"{source} must not list {env_name}; use {_GEMINI_ENV} per docs/authentication.md"
+        )
 
 
-def test_hermes_manifest_excludes_google_api_key() -> None:
-    """Hermes must not list GOOGLE_API_KEY — mergeCraft reads GEMINI_API_KEY for Gemini."""
-    env_vars = _required_env_vars_from_manifest()
-    assert _FORBIDDEN_GOOGLE_ENV not in env_vars, (
-        f"skills/harnesses.yaml Hermes must not list {_FORBIDDEN_GOOGLE_ENV}; "
-        f"use {_GEMINI_ENV} per docs/authentication.md"
-    )
-
-
-def test_hermes_skill_md_lists_gemini_api_key() -> None:
-    """Generated Hermes SKILL.md frontmatter must name GEMINI_API_KEY."""
-    env_vars = _required_env_vars_from_skill_md()
-    assert _GEMINI_ENV in env_vars, (
-        f"skills/hermes/mergecraft/SKILL.md required_environment_variables must include "
-        f"{_GEMINI_ENV} per docs/authentication.md"
-    )
-
-
-def test_hermes_skill_md_lists_nous_api_key() -> None:
-    """Generated Hermes SKILL.md frontmatter must name NOUS_API_KEY."""
-    env_vars = _required_env_vars_from_skill_md()
-    assert _NOUS_ENV in env_vars, (
-        f"skills/hermes/mergecraft/SKILL.md required_environment_variables must include "
-        f"{_NOUS_ENV} per docs/authentication.md"
-    )
-
-
-def test_hermes_skill_md_excludes_google_api_key() -> None:
-    """Generated Hermes SKILL.md must not list GOOGLE_API_KEY."""
-    env_vars = _required_env_vars_from_skill_md()
-    assert _FORBIDDEN_GOOGLE_ENV not in env_vars, (
-        f"skills/hermes/mergecraft/SKILL.md must not list {_FORBIDDEN_GOOGLE_ENV}; "
-        f"use {_GEMINI_ENV} per docs/authentication.md"
-    )
-
-
-def test_hermes_manifest_env_names_match_authentication_doc() -> None:
-    """Hermes manifest env vars must include auth-doc names for Gemini and Nous."""
+def test_hermes_env_names_match_authentication_doc() -> None:
+    """Hermes manifest and SKILL.md env vars must include auth-doc names for Gemini and Nous."""
     gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")
     nous_envs = _auth_doc_env_names_for_provider("Nous Portal")
-    assert _GEMINI_ENV in gemini_envs, (
-        "docs/authentication.md must document GEMINI_API_KEY for Gemini"
-    )
-    assert _NOUS_ENV in nous_envs, "docs/authentication.md must document NOUS_API_KEY for Nous"
-    env_vars = set(_required_env_vars_from_manifest())
-    missing = sorted(
-        name
-        for name in (_GEMINI_ENV, _NOUS_ENV)
-        if name in gemini_envs.union(nous_envs) and name not in env_vars
-    )
-    assert not missing, (
-        f"Hermes manifest required_environment_variables missing auth-doc env names: {missing}"
-    )
-    assert _FORBIDDEN_GOOGLE_ENV not in env_vars
-
-
-def test_hermes_skill_md_env_names_match_authentication_doc() -> None:
-    """Generated Hermes SKILL.md env vars must include auth-doc names for Gemini and Nous."""
-    gemini_envs = _auth_doc_env_names_for_provider("Google Gemini")
-    nous_envs = _auth_doc_env_names_for_provider("Nous Portal")
-    assert _GEMINI_ENV in gemini_envs
-    assert _NOUS_ENV in nous_envs
-    env_vars = set(_required_env_vars_from_skill_md())
-    missing = sorted(
-        name
-        for name in (_GEMINI_ENV, _NOUS_ENV)
-        if name in gemini_envs.union(nous_envs) and name not in env_vars
-    )
-    assert not missing, (
-        f"Hermes SKILL.md required_environment_variables missing auth-doc env names: {missing}"
-    )
-    assert _FORBIDDEN_GOOGLE_ENV not in env_vars
+    assert _GEMINI_ENV in gemini_envs, "docs/authentication.md must document GEMINI_API_KEY"
+    assert _NOUS_ENV in nous_envs, "docs/authentication.md must document NOUS_API_KEY"
+    for source, getter in _ENV_GETTERS.items():
+        env_vars = set(getter())
+        missing = sorted(
+            name
+            for name in (_GEMINI_ENV, _NOUS_ENV)
+            if name in gemini_envs.union(nous_envs) and name not in env_vars
+        )
+        assert not missing, (
+            f"Hermes {source} required_environment_variables missing auth-doc env names: {missing}"
+        )
+        assert _FORBIDDEN_GOOGLE_ENV not in env_vars

--- a/tests/docs/test_landing_readme.py
+++ b/tests/docs/test_landing_readme.py
@@ -8,9 +8,9 @@ page moves, and the G1 docs-site badge regression guard.
 from __future__ import annotations
 
 import re
-import subprocess
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import action_uses_pattern, git_ref_exists
 
 README = REPO_ROOT / "README.md"
 _D2_SOURCE = REPO_ROOT / "docs" / "diagrams" / "pipeline.d2"
@@ -23,9 +23,6 @@ _DEMO_PATHS = (
     "assets/demo.gif",
     "assets/demo.mp4",
 )
-
-_ACTION_USES = re.compile(r"uses:\s*alexhawat/mergeCraft@(\S+)")
-_SHA_REF = re.compile(r"^[0-9a-f]{40}$")
 
 
 def _readme_text() -> str:
@@ -68,41 +65,6 @@ def _anchor_present(text: str, *needles: str) -> bool:
     nav = _jump_nav_targets(text)
     haystack = slugs | nav | {text.lower()}
     return any(needle.lower() in haystack for needle in needles)
-
-
-def _git_ref_exists(ref: str) -> bool:
-    ref = ref.rstrip("#").strip()
-    candidates: list[list[str]]
-    if _SHA_REF.fullmatch(ref):
-        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
-    elif ref.startswith("v"):
-        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
-    else:
-        candidates = [
-            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
-        ]
-    for cmd in candidates:
-        if subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, check=False).returncode == 0:
-            return True
-    if not _SHA_REF.fullmatch(ref):
-        return False
-    # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
-    fetch = subprocess.run(
-        ["git", "fetch", "origin", ref, "--depth=1"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=False,
-    )
-    if fetch.returncode != 0:
-        return False
-    verify = subprocess.run(
-        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=False,
-    )
-    return verify.returncode == 0
 
 
 def _example_one_section(text: str) -> str:
@@ -196,10 +158,10 @@ def test_landing_has_numbered_install() -> None:
 def test_landing_keeps_example_one_workflow() -> None:
     text = _readme_text()
     section = _example_one_section(text)
-    uses_match = _ACTION_USES.search(section)
+    uses_match = action_uses_pattern.search(section)
     assert uses_match, "Example 1 must include uses: alexhawat/mergeCraft@…"
     ref = uses_match.group(1).rstrip("#").strip()
-    assert _git_ref_exists(ref), (
+    assert git_ref_exists(ref), (
         f"Example 1 Action ref {ref!r} must resolve to an existing tag, branch, or commit (D25)"
     )
 
@@ -216,7 +178,7 @@ def test_landing_action_section_is_named_for_github_action() -> None:
 def test_landing_pins_a_release_tag() -> None:
     text = _readme_text()
     section = _example_one_section(text)
-    uses_match = _ACTION_USES.search(section)
+    uses_match = action_uses_pattern.search(section)
     assert uses_match, "Example 1 must include uses: alexhawat/mergeCraft@…"
     ref = uses_match.group(1).rstrip("#").strip()
     assert re.fullmatch(r"v\d+\.\d+\.\d+(?:a\d+|b\d+|rc\d+)?", ref, re.IGNORECASE), (

--- a/tests/docs/test_readme_harness_copy_prompts.py
+++ b/tests/docs/test_readme_harness_copy_prompts.py
@@ -114,9 +114,6 @@ def test_jump_nav_may_link_source_skill_developer_path() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W8: Also teach prompt uses generated harness packages (D10)", strict=False
-)
 def test_also_teach_agent_prompt_does_not_instruct_source_skill_copy() -> None:
     """Consumer copy prompt must not tell readers to copy repo-root skills/mergecraft/."""
     prompt = _also_teach_prompt_text(read_text("README.md"))
@@ -127,10 +124,6 @@ def test_also_teach_agent_prompt_does_not_instruct_source_skill_copy() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W8: Also teach prompt names harness package paths (D10)",
-    strict=False,
-)
 def test_also_teach_agent_prompt_references_generated_harness_packages() -> None:
     """Consumer copy prompt must name a generated harness package or install destination."""
     manifest = _load_harness_manifest()
@@ -144,10 +137,6 @@ def test_also_teach_agent_prompt_references_generated_harness_packages() -> None
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W8: per-agent one-liners drop source skill copy (D10)",
-    strict=False,
-)
 def test_per_agent_one_liners_do_not_instruct_source_skill_copy() -> None:
     """Per-agent fenced prompts must not instruct copying repo-root skills/mergecraft/."""
     prompts = _per_agent_prompts(read_text("README.md"))
@@ -164,10 +153,6 @@ def test_per_agent_one_liners_do_not_instruct_source_skill_copy() -> None:
 @pytest.mark.parametrize(
     "agent_name",
     ["Cursor", "OpenCode"],
-)
-@pytest.mark.xfail(
-    reason="green after W8: per-agent skill copy names harness packages (D10)",
-    strict=False,
 )
 def test_per_agent_skill_copy_prompts_reference_harness_packages(agent_name: str) -> None:
     """Agents that install the skill must point at generated harness packages."""

--- a/tests/docs/test_readme_harness_copy_prompts.py
+++ b/tests/docs/test_readme_harness_copy_prompts.py
@@ -14,12 +14,9 @@ import re
 from typing import Any
 
 import pytest
-import yaml
 
-from tests.ci.workflow_support import REPO_ROOT, read_text
-
-README = REPO_ROOT / "README.md"
-HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
+from tests.ci.workflow_support import read_text
+from tests.docs.support import load_harness_manifest
 
 _ALSO_TEACH_HEADING = re.compile(
     r"^###\s+Also teach your agent",
@@ -39,13 +36,6 @@ _NUMBERED_SOURCE_SKILL_COPY = re.compile(
 _REPO_SOURCE_INTO_DEST = re.compile(
     r"(?i)(?:repo'?s?\s+)?skills/mergecraft/\s+into",
 )
-
-
-def _load_harness_manifest() -> dict[str, Any]:
-    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)} (D10)"
-    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
-    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
-    return data
 
 
 def _generated_harness_package_paths(manifest: dict[str, Any]) -> set[str]:
@@ -126,7 +116,7 @@ def test_also_teach_agent_prompt_does_not_instruct_source_skill_copy() -> None:
 
 def test_also_teach_agent_prompt_references_generated_harness_packages() -> None:
     """Consumer copy prompt must name a generated harness package or install destination."""
-    manifest = _load_harness_manifest()
+    manifest = load_harness_manifest()
     prompt = _also_teach_prompt_text(read_text("README.md"))
     assert _references_generated_harness_packages(
         prompt,
@@ -156,7 +146,7 @@ def test_per_agent_one_liners_do_not_instruct_source_skill_copy() -> None:
 )
 def test_per_agent_skill_copy_prompts_reference_harness_packages(agent_name: str) -> None:
     """Agents that install the skill must point at generated harness packages."""
-    manifest = _load_harness_manifest()
+    manifest = load_harness_manifest()
     prompts = _per_agent_prompts(read_text("README.md"))
     prompt = prompts.get(agent_name)
     assert prompt is not None, f"missing fenced prompt for {agent_name!r} (D10)"

--- a/tests/docs/test_readme_harness_copy_prompts.py
+++ b/tests/docs/test_readme_harness_copy_prompts.py
@@ -1,0 +1,184 @@
+"""Batch GD — README generated-skill copy prompts (#413).
+
+Pins D10: consumer copy instructions in the "Also teach your agent" fenced
+prompt and per-agent one-liners must reference generated harness packages from
+``skills/harnesses.yaml`` (``skills/<harness>/mergecraft/`` or install
+destinations like ``.agents/skills/mergecraft/``), not the source
+``skills/mergecraft/`` tree. Jump-nav developer links may keep
+``skills/mergecraft/SKILL.md``. Implementation lands in W8.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.ci.workflow_support import REPO_ROOT, read_text
+
+README = REPO_ROOT / "README.md"
+HARNESS_MANIFEST = REPO_ROOT / "skills" / "harnesses.yaml"
+
+_ALSO_TEACH_HEADING = re.compile(
+    r"^###\s+Also teach your agent",
+    re.MULTILINE | re.IGNORECASE,
+)
+_PER_AGENT_DETAILS = re.compile(
+    r"<summary>.*?Per-agent one-liners.*?</summary>(.*?)</details>",
+    re.DOTALL | re.IGNORECASE,
+)
+_FENCED_TEXT_BLOCK = re.compile(r"```text\n(.*?)```", re.DOTALL)
+_SOURCE_SKILL_COPY = re.compile(
+    r"(?i)(?:copy|cp)\s+(?:the\s+repo'?s?\s+)?skills/mergecraft/",
+)
+_NUMBERED_SOURCE_SKILL_COPY = re.compile(
+    r"(?i)(?:^|\n)\s*\d+\.\s+Copy skills/mergecraft/",
+)
+_REPO_SOURCE_INTO_DEST = re.compile(
+    r"(?i)(?:repo'?s?\s+)?skills/mergecraft/\s+into",
+)
+
+
+def _load_harness_manifest() -> dict[str, Any]:
+    assert HARNESS_MANIFEST.is_file(), f"missing {HARNESS_MANIFEST.relative_to(REPO_ROOT)} (D10)"
+    data = yaml.safe_load(HARNESS_MANIFEST.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "skills/harnesses.yaml must parse as a mapping"
+    return data
+
+
+def _generated_harness_package_paths(manifest: dict[str, Any]) -> set[str]:
+    paths: set[str] = set()
+    for row in manifest.get("harnesses") or []:
+        if not isinstance(row, dict):
+            continue
+        harness_id = row.get("id")
+        if not isinstance(harness_id, str):
+            continue
+        if row.get("fallback") == "agents-md":
+            continue
+        paths.add(f"skills/{harness_id}/mergecraft/")
+    return paths
+
+
+def _also_teach_prompt_text(readme_text: str) -> str:
+    heading = _ALSO_TEACH_HEADING.search(readme_text)
+    assert heading, 'README must keep "### Also teach your agent" copy prompt (D10)'
+    region = readme_text[heading.end() :]
+    match = _FENCED_TEXT_BLOCK.search(region)
+    assert match, '"Also teach your agent" must ship a ```text fenced copy prompt (D10)'
+    return match.group(1)
+
+
+def _per_agent_prompts(readme_text: str) -> dict[str, str]:
+    details = _PER_AGENT_DETAILS.search(readme_text)
+    assert details, "README must keep the per-agent one-liners <details> block (D10)"
+    region = details.group(1)
+    prompts: dict[str, str] = {}
+    sections = re.split(r"\n\*\*([^*]+)\*\*", region)
+    if sections and not sections[0].strip():
+        sections = sections[1:]
+    for index in range(0, len(sections) - 1, 2):
+        agent_name = sections[index].strip()
+        body = sections[index + 1]
+        match = _FENCED_TEXT_BLOCK.search(body)
+        if match:
+            prompts[agent_name] = match.group(1)
+    return prompts
+
+
+def _source_skill_copy_offenders(text: str) -> list[str]:
+    offenders: list[str] = []
+    for pattern in (_SOURCE_SKILL_COPY, _NUMBERED_SOURCE_SKILL_COPY, _REPO_SOURCE_INTO_DEST):
+        for match in pattern.finditer(text):
+            snippet = match.group(0).strip()
+            if snippet and snippet not in offenders:
+                offenders.append(snippet)
+    return offenders
+
+
+def _references_generated_harness_packages(text: str, *, package_paths: set[str]) -> bool:
+    lowered = text.lower()
+    if any(path.lower() in lowered for path in package_paths):
+        return True
+    return "make agent-packages" in lowered
+
+
+def test_jump_nav_may_link_source_skill_developer_path() -> None:
+    """D10: hero jump-nav may keep the in-repo ``skills/mergecraft/SKILL.md`` link."""
+    text = read_text("README.md")
+    hero = text.split("---", 1)[0]
+    assert "[Agent skill](skills/mergecraft/SKILL.md)" in hero, (
+        "README hero jump-nav should keep the developer link to skills/mergecraft/SKILL.md (D10)"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W8: Also teach prompt uses generated harness packages (D10)", strict=False
+)
+def test_also_teach_agent_prompt_does_not_instruct_source_skill_copy() -> None:
+    """Consumer copy prompt must not tell readers to copy repo-root skills/mergecraft/."""
+    prompt = _also_teach_prompt_text(read_text("README.md"))
+    offenders = _source_skill_copy_offenders(prompt)
+    assert not offenders, (
+        '"Also teach your agent" must not instruct copying source skills/mergecraft/ '
+        f"(use skills/<harness>/mergecraft/ per harnesses.yaml): {offenders}"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W8: Also teach prompt names harness package paths (D10)",
+    strict=False,
+)
+def test_also_teach_agent_prompt_references_generated_harness_packages() -> None:
+    """Consumer copy prompt must name a generated harness package or install destination."""
+    manifest = _load_harness_manifest()
+    prompt = _also_teach_prompt_text(read_text("README.md"))
+    assert _references_generated_harness_packages(
+        prompt,
+        package_paths=_generated_harness_package_paths(manifest),
+    ), (
+        '"Also teach your agent" must reference skills/<harness>/mergecraft/ from '
+        "skills/harnesses.yaml or a declared install destination (D10)"
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after W8: per-agent one-liners drop source skill copy (D10)",
+    strict=False,
+)
+def test_per_agent_one_liners_do_not_instruct_source_skill_copy() -> None:
+    """Per-agent fenced prompts must not instruct copying repo-root skills/mergecraft/."""
+    prompts = _per_agent_prompts(read_text("README.md"))
+    assert prompts, "per-agent one-liners must include at least one fenced prompt (D10)"
+    offenders: list[str] = []
+    for agent, prompt in prompts.items():
+        for snippet in _source_skill_copy_offenders(prompt):
+            offenders.append(f"{agent}: {snippet}")
+    assert not offenders, (
+        f"per-agent one-liners must not instruct copying source skills/mergecraft/: {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    "agent_name",
+    ["Cursor", "OpenCode"],
+)
+@pytest.mark.xfail(
+    reason="green after W8: per-agent skill copy names harness packages (D10)",
+    strict=False,
+)
+def test_per_agent_skill_copy_prompts_reference_harness_packages(agent_name: str) -> None:
+    """Agents that install the skill must point at generated harness packages."""
+    manifest = _load_harness_manifest()
+    prompts = _per_agent_prompts(read_text("README.md"))
+    prompt = prompts.get(agent_name)
+    assert prompt is not None, f"missing fenced prompt for {agent_name!r} (D10)"
+    assert _references_generated_harness_packages(
+        prompt,
+        package_paths=_generated_harness_package_paths(manifest),
+    ), (
+        f"{agent_name} one-liner must reference skills/<harness>/mergecraft/ from "
+        "skills/harnesses.yaml or a declared install destination (D10)"
+    )

--- a/tests/docs/test_reference_docs.py
+++ b/tests/docs/test_reference_docs.py
@@ -8,7 +8,6 @@ this suite stays RED (xfail) until then.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -19,6 +18,7 @@ import yaml
 from mergecraft.cli.app import app as root_app
 from mergecraft.cli.auth_cmd import app as auth_app
 from tests.ci.workflow_support import REPO_ROOT
+from tests.docs.support import load_script_module
 
 if TYPE_CHECKING:
     import typer
@@ -174,14 +174,7 @@ def _cli_doc_auth_providers() -> set[str]:
 
 def _load_gen_reference_docs() -> Any:
     """Load ``scripts/gen_reference_docs.py`` per-test (never at module import time)."""
-    path = REPO_ROOT / "scripts" / "gen_reference_docs.py"
-    assert path.is_file(), "scripts/gen_reference_docs.py missing"
-    spec = importlib.util.spec_from_file_location("gen_reference_docs", path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_script_module(REPO_ROOT / "scripts" / "gen_reference_docs.py")
 
 
 def _patch_module_doc_paths(module: Any, *, cli_doc: Path, action_doc: Path) -> None:

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -137,3 +137,9 @@ def test_migration_module_imports_shared_support(module_name: str) -> None:
     assert "_ci_steps" not in source or "tests.docs.support" in source, (
         f"{module_name} must not keep a private _ci_steps after W12"
     )
+    assert "_load_harness_manifest" not in source or "tests.docs.support" in source, (
+        f"{module_name} must not keep a private _load_harness_manifest after W12"
+    )
+    assert "_makefile_prerequisite_tokens" not in source or "tests.docs.support" in source, (
+        f"{module_name} must not keep a private _makefile_prerequisite_tokens after W12"
+    )

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -12,11 +12,11 @@ import importlib
 import re
 from pathlib import Path
 from types import ModuleType
-from typing import Any
 
 import pytest
 
 from tests.ci.workflow_support import REPO_ROOT
+from tests.docs import support
 
 _GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 _CHECK_CLI_SCRIPT = REPO_ROOT / "scripts" / "check_cli_examples.py"
@@ -43,20 +43,6 @@ _DOCS_TEST_MODULES = tuple(
     f"tests.docs.{path.stem}" for path in sorted((REPO_ROOT / "tests" / "docs").glob("test_*.py"))
 )
 
-try:
-    from tests.docs import support as _support
-
-    _SUPPORT_AVAILABLE = True
-except ImportError:
-    _SUPPORT_AVAILABLE = False
-    _support = None  # type: ignore[assignment,misc]
-
-
-def _require_support() -> Any:
-    if not _SUPPORT_AVAILABLE:
-        pytest.fail("tests.docs.support missing — add tests/docs/support.py in W12 (D12)")
-    return _support
-
 
 @pytest.mark.parametrize("module_name", _DOCS_TEST_MODULES)
 def test_docs_contract_modules_still_collect(module_name: str) -> None:
@@ -64,24 +50,18 @@ def test_docs_contract_modules_still_collect(module_name: str) -> None:
     importlib.import_module(module_name)
 
 
-@pytest.mark.xfail(reason="green after W12: tests/docs/support.py module", strict=False)
 def test_support_module_is_importable() -> None:
-    mod = _require_support()
-    assert mod.__name__ == "tests.docs.support"
+    assert support.__name__ == "tests.docs.support"
 
 
-@pytest.mark.xfail(reason="green after W12: git_ref_exists helper", strict=False)
 def test_support_exports_git_ref_exists() -> None:
-    mod = _require_support()
-    assert callable(mod.git_ref_exists)
-    assert mod.git_ref_exists("pre-0.0.1") is True
-    assert mod.git_ref_exists("mergecraft-issue-405-nonexistent-ref") is False
+    assert callable(support.git_ref_exists)
+    assert support.git_ref_exists("pre-0.0.1") is True
+    assert support.git_ref_exists("mergecraft-issue-405-nonexistent-ref") is False
 
 
-@pytest.mark.xfail(reason="green after W12: action_uses_pattern regex", strict=False)
 def test_support_exports_action_uses_pattern() -> None:
-    mod = _require_support()
-    pattern = mod.action_uses_pattern
+    pattern = support.action_uses_pattern
     assert isinstance(pattern, re.Pattern)
     assert pattern.flags & re.IGNORECASE, "action_uses_pattern must be case-insensitive (D12)"
     lower = pattern.search("uses: alexhawat/mergeCraft@pre-0.0.1")
@@ -93,11 +73,9 @@ def test_support_exports_action_uses_pattern() -> None:
     assert pattern.findall(_SAMPLE_ACTION_USES) == ["pre-0.0.1", "v0.1.0a1"]
 
 
-@pytest.mark.xfail(reason="green after W12: ci_steps Makefile parser", strict=False)
 def test_support_exports_ci_steps() -> None:
-    mod = _require_support()
-    assert callable(mod.ci_steps)
-    steps = mod.ci_steps()
+    assert callable(support.ci_steps)
+    steps = support.ci_steps()
     assert isinstance(steps, list)
     assert steps, "ci_steps() must return Makefile CI_STEPS tokens"
     assert "lint" in steps
@@ -105,54 +83,45 @@ def test_support_exports_ci_steps() -> None:
     assert "agent-packages-check" in steps
 
 
-@pytest.mark.xfail(reason="green after W12: load_script_module helper", strict=False)
 def test_support_exports_load_script_module() -> None:
-    mod = _require_support()
-    assert callable(mod.load_script_module)
-    gen = mod.load_script_module(_GEN_SCRIPT)
-    assert isinstance(gen, ModuleType)
+    assert callable(support.load_script_module)
+    gen: ModuleType = support.load_script_module(_GEN_SCRIPT)
     assert callable(getattr(gen, "main", None)), "gen_agent_packages.py must expose main()"
-    cli = mod.load_script_module(_CHECK_CLI_SCRIPT)
+    cli = support.load_script_module(_CHECK_CLI_SCRIPT)
     assert callable(getattr(cli, "main", None)), "check_cli_examples.py must expose main()"
 
 
-@pytest.mark.xfail(
-    reason="green after W12: load_script_module accepts repo-relative paths", strict=False
-)
 def test_load_script_module_accepts_relative_path() -> None:
-    mod = _require_support()
-    gen = mod.load_script_module(Path("scripts/gen_agent_packages.py"))
+    gen = support.load_script_module(Path("scripts/gen_agent_packages.py"))
     assert callable(getattr(gen, "main", None))
 
 
-@pytest.mark.xfail(reason="green after W12: git_ref_exists SHA fetch fallback", strict=False)
 def test_git_ref_exists_fetches_shallow_checkout_sha(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mirror ``test_landing_readme._git_ref_exists`` shallow-checkout behaviour."""
-    mod = _require_support()
+    """Mirror ``test_landing_readme`` shallow-checkout behaviour."""
     sha = "f" * 40
     calls: list[list[str]] = []
+    rev_parse_attempts = 0
 
     def fake_run(cmd: list[str], **kwargs: object) -> object:
+        nonlocal rev_parse_attempts
         calls.append(cmd)
-        if cmd[:3] == ["git", "rev-parse", "--verify"] and sha in cmd[3]:
-            return type("R", (), {"returncode": 1})()
-        if cmd[:3] == ["git", "fetch", "origin", sha]:
+        if cmd[:3] == ["git", "rev-parse", "--verify"] and len(cmd) > 3 and sha in cmd[3]:
+            rev_parse_attempts += 1
+            if rev_parse_attempts == 1:
+                return type("R", (), {"returncode": 1})()
             return type("R", (), {"returncode": 0})()
-        if cmd == ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"]:
+        if cmd[:3] == ["git", "fetch", "origin"] and len(cmd) > 3 and cmd[3] == sha:
             return type("R", (), {"returncode": 0})()
         return type("R", (), {"returncode": 1})()
 
-    monkeypatch.setattr("subprocess.run", fake_run)
-    assert mod.git_ref_exists(sha) is True
+    monkeypatch.setattr("tests.docs.support.subprocess.run", fake_run)
+    assert support.git_ref_exists(sha) is True
     assert any(cmd[:3] == ["git", "fetch", "origin"] for cmd in calls), (
         "git_ref_exists must fetch missing SHAs before re-verify (landing_readme contract)"
     )
 
 
 @pytest.mark.parametrize("module_name", _MIGRATION_MODULES)
-@pytest.mark.xfail(
-    reason="green after W12: docs helpers migrated to tests.docs.support", strict=False
-)
 def test_migration_module_imports_shared_support(module_name: str) -> None:
     """W12 switches listed modules from local duplicates to ``tests.docs.support``."""
     mod = importlib.import_module(module_name)

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -37,6 +37,8 @@ _MIGRATION_MODULES = (
     "tests.docs.test_cli_examples",
     "tests.docs.test_gen_agent_packages_blob_ref",
     "tests.docs.test_reference_docs",
+    "tests.docs.test_hermes_skill_env_vars",
+    "tests.docs.test_readme_harness_copy_prompts",
 )
 
 _DOCS_TEST_MODULES = tuple(
@@ -114,7 +116,7 @@ def test_git_ref_exists_fetches_shallow_checkout_sha(monkeypatch: pytest.MonkeyP
             return type("R", (), {"returncode": 0})()
         return type("R", (), {"returncode": 1})()
 
-    monkeypatch.setattr("tests.docs.support.subprocess.run", fake_run)
+    monkeypatch.setattr("mergecraft.utils.git_ref.subprocess.run", fake_run)
     assert support.git_ref_exists(sha) is True
     assert any(cmd[:3] == ["git", "fetch", "origin"] for cmd in calls), (
         "git_ref_exists must fetch missing SHAs before re-verify (landing_readme contract)"

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -1,0 +1,168 @@
+"""Batch GF — shared ``tests/docs`` helpers (#405).
+
+Pins D12: ``tests/docs/support.py`` exports ``git_ref_exists``,
+``action_uses_pattern``, ``ci_steps``, and ``load_script_module`` for the
+RV1-RV6 contract suite. W12 refactors the listed modules to import these
+helpers (~80 lines deduped). Implementation lands in W12.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from tests.ci.workflow_support import REPO_ROOT
+
+_GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
+_CHECK_CLI_SCRIPT = REPO_ROOT / "scripts" / "check_cli_examples.py"
+_SAMPLE_ACTION_USES = """jobs:
+  review:
+    steps:
+      - uses: alexhawat/mergeCraft@pre-0.0.1
+      - uses: ALEXHAWAT/mergeCraft@v0.1.0a1
+"""
+
+# Issue #405 — modules W12 migrates to ``tests.docs.support``.
+_MIGRATION_MODULES = (
+    "tests.docs.test_landing_readme",
+    "tests.docs.test_agent_surfaces",
+    "tests.docs.test_docs_gate",
+    "tests.docs.test_agent_packages",
+    "tests.docs.test_docs_manifest",
+    "tests.docs.test_cli_examples",
+    "tests.docs.test_gen_agent_packages_blob_ref",
+    "tests.docs.test_reference_docs",
+)
+
+_DOCS_TEST_MODULES = tuple(
+    f"tests.docs.{path.stem}" for path in sorted((REPO_ROOT / "tests" / "docs").glob("test_*.py"))
+)
+
+try:
+    from tests.docs import support as _support
+
+    _SUPPORT_AVAILABLE = True
+except ImportError:
+    _SUPPORT_AVAILABLE = False
+    _support = None  # type: ignore[assignment,misc]
+
+
+def _require_support() -> Any:
+    if not _SUPPORT_AVAILABLE:
+        pytest.fail("tests.docs.support missing — add tests/docs/support.py in W12 (D12)")
+    return _support
+
+
+@pytest.mark.parametrize("module_name", _DOCS_TEST_MODULES)
+def test_docs_contract_modules_still_collect(module_name: str) -> None:
+    """Every ``tests/docs/test_*.py`` module imports cleanly before the W12 refactor."""
+    importlib.import_module(module_name)
+
+
+@pytest.mark.xfail(reason="green after W12: tests/docs/support.py module", strict=False)
+def test_support_module_is_importable() -> None:
+    mod = _require_support()
+    assert mod.__name__ == "tests.docs.support"
+
+
+@pytest.mark.xfail(reason="green after W12: git_ref_exists helper", strict=False)
+def test_support_exports_git_ref_exists() -> None:
+    mod = _require_support()
+    assert callable(mod.git_ref_exists)
+    assert mod.git_ref_exists("pre-0.0.1") is True
+    assert mod.git_ref_exists("mergecraft-issue-405-nonexistent-ref") is False
+
+
+@pytest.mark.xfail(reason="green after W12: action_uses_pattern regex", strict=False)
+def test_support_exports_action_uses_pattern() -> None:
+    mod = _require_support()
+    pattern = mod.action_uses_pattern
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.flags & re.IGNORECASE, "action_uses_pattern must be case-insensitive (D12)"
+    lower = pattern.search("uses: alexhawat/mergeCraft@pre-0.0.1")
+    assert lower is not None
+    assert lower.group(1) == "pre-0.0.1"
+    upper = pattern.search("uses: ALEXHAWAT/mergeCraft@v0.1.0a1")
+    assert upper is not None
+    assert upper.group(1) == "v0.1.0a1"
+    assert pattern.findall(_SAMPLE_ACTION_USES) == ["pre-0.0.1", "v0.1.0a1"]
+
+
+@pytest.mark.xfail(reason="green after W12: ci_steps Makefile parser", strict=False)
+def test_support_exports_ci_steps() -> None:
+    mod = _require_support()
+    assert callable(mod.ci_steps)
+    steps = mod.ci_steps()
+    assert isinstance(steps, list)
+    assert steps, "ci_steps() must return Makefile CI_STEPS tokens"
+    assert "lint" in steps
+    assert "docs-check" in steps
+    assert "agent-packages-check" in steps
+
+
+@pytest.mark.xfail(reason="green after W12: load_script_module helper", strict=False)
+def test_support_exports_load_script_module() -> None:
+    mod = _require_support()
+    assert callable(mod.load_script_module)
+    gen = mod.load_script_module(_GEN_SCRIPT)
+    assert isinstance(gen, ModuleType)
+    assert callable(getattr(gen, "main", None)), "gen_agent_packages.py must expose main()"
+    cli = mod.load_script_module(_CHECK_CLI_SCRIPT)
+    assert callable(getattr(cli, "main", None)), "check_cli_examples.py must expose main()"
+
+
+@pytest.mark.xfail(
+    reason="green after W12: load_script_module accepts repo-relative paths", strict=False
+)
+def test_load_script_module_accepts_relative_path() -> None:
+    mod = _require_support()
+    gen = mod.load_script_module(Path("scripts/gen_agent_packages.py"))
+    assert callable(getattr(gen, "main", None))
+
+
+@pytest.mark.xfail(reason="green after W12: git_ref_exists SHA fetch fallback", strict=False)
+def test_git_ref_exists_fetches_shallow_checkout_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirror ``test_landing_readme._git_ref_exists`` shallow-checkout behaviour."""
+    mod = _require_support()
+    sha = "f" * 40
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> object:
+        calls.append(cmd)
+        if cmd[:3] == ["git", "rev-parse", "--verify"] and sha in cmd[3]:
+            return type("R", (), {"returncode": 1})()
+        if cmd[:3] == ["git", "fetch", "origin", sha]:
+            return type("R", (), {"returncode": 0})()
+        if cmd == ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"]:
+            return type("R", (), {"returncode": 0})()
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert mod.git_ref_exists(sha) is True
+    assert any(cmd[:3] == ["git", "fetch", "origin"] for cmd in calls), (
+        "git_ref_exists must fetch missing SHAs before re-verify (landing_readme contract)"
+    )
+
+
+@pytest.mark.parametrize("module_name", _MIGRATION_MODULES)
+@pytest.mark.xfail(
+    reason="green after W12: docs helpers migrated to tests.docs.support", strict=False
+)
+def test_migration_module_imports_shared_support(module_name: str) -> None:
+    """W12 switches listed modules from local duplicates to ``tests.docs.support``."""
+    mod = importlib.import_module(module_name)
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    assert (
+        "from tests.docs import support" in source or "from tests.docs.support import" in source
+    ), f"{module_name} must import shared helpers from tests.docs.support (#405)"
+    assert "_git_ref_exists" not in source or "tests.docs.support" in source, (
+        f"{module_name} must not keep a private _git_ref_exists after W12"
+    )
+    assert "_ci_steps" not in source or "tests.docs.support" in source, (
+        f"{module_name} must not keep a private _ci_steps after W12"
+    )

--- a/tests/harbor/test_agent.py
+++ b/tests/harbor/test_agent.py
@@ -12,6 +12,7 @@ import pytest
 pytest.importorskip("harbor")
 
 from mergecraft.harbor.agent import MergecraftReviewAgent, _resolve_patch_path
+from mergecraft.pins import action_pin_minimal
 
 _HARBOR_AGENT_MODULE = "mergecraft.harbor.agent"
 
@@ -24,26 +25,10 @@ def _reload_harbor_agent_module() -> Any:
     return importlib.import_module(_HARBOR_AGENT_MODULE)
 
 
-def _resolved_default_install_ref(agent_module: Any | None = None) -> str:
-    """Resolve the default Harbor install ref across eager and lazy pin layouts (D9)."""
-    module = agent_module or importlib.import_module(_HARBOR_AGENT_MODULE)
-    accessor = getattr(module, "_default_install_ref", None)
-    if accessor is not None:
-        resolved = accessor()
-        return str(resolved)
-    ref = module.DEFAULT_INSTALL_REF
-    if isinstance(ref, str):
-        return ref
-    if callable(ref):
-        return str(ref())
-    msg = f"unexpected DEFAULT_INSTALL_REF type: {type(ref)!r}"
-    raise TypeError(msg)
-
-
 def test_default_install_ref_pins_a_release_tag_not_a_moving_branch() -> None:
-    resolved = _resolved_default_install_ref()
+    resolved = action_pin_minimal()
     assert resolved.startswith("v"), (
-        f"DEFAULT_INSTALL_REF={resolved!r} must pin a release tag "
+        f"action_pin_minimal()={resolved!r} must pin a release tag "
         "(e.g. 'v0.1.0'), not a moving branch name like 'pre-0.0.1' — a "
         "Harbor install with no MERGECRAFT_INSTALL_REF override should not "
         "silently drift onto trunk."
@@ -59,29 +44,6 @@ def test_import_harbor_agent_does_not_resolve_pin(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("mergecraft.pins.action_pin_minimal", _raise_pin)
     module = _reload_harbor_agent_module()
     assert module.MergecraftReviewAgent is not None
-
-
-def test_default_install_ref_accessor_calls_action_pin_minimal(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Lazy accessor mirrors ``init_cmd._workflow_template`` — resolve pin on demand."""
-    calls: list[str] = []
-
-    def _tracking_pin() -> str:
-        calls.append("called")
-        return "v0.1.0a1"
-
-    monkeypatch.setattr("mergecraft.pins.action_pin_minimal", _tracking_pin)
-    agent_mod = _reload_harbor_agent_module()
-    accessor = getattr(agent_mod, "_default_install_ref", None)
-    assert accessor is not None, (
-        "mergecraft.harbor.agent must expose _default_install_ref() "
-        "(mirror init_cmd._workflow_template; D9)"
-    )
-    calls.clear()
-    ref = accessor()
-    assert ref.startswith("v"), f"unexpected install ref: {ref!r}"
-    assert calls == ["called"], "lazy accessor must call action_pin_minimal()"
 
 
 @pytest.mark.asyncio

--- a/tests/harbor/test_agent.py
+++ b/tests/harbor/test_agent.py
@@ -2,22 +2,129 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 pytest.importorskip("harbor")
 
-from mergecraft.harbor.agent import DEFAULT_INSTALL_REF, MergecraftReviewAgent, _resolve_patch_path
+from mergecraft.harbor.agent import MergecraftReviewAgent, _resolve_patch_path
+
+_HARBOR_AGENT_MODULE = "mergecraft.harbor.agent"
+
+
+def _reload_harbor_agent_module() -> Any:
+    """Drop cached ``mergecraft.harbor.agent`` so import-time behaviour is observable."""
+    for name in list(sys.modules):
+        if name == _HARBOR_AGENT_MODULE or name.startswith(f"{_HARBOR_AGENT_MODULE}."):
+            del sys.modules[name]
+    return importlib.import_module(_HARBOR_AGENT_MODULE)
+
+
+def _resolved_default_install_ref(agent_module: Any | None = None) -> str:
+    """Resolve the default Harbor install ref across eager and lazy pin layouts (D9)."""
+    module = agent_module or importlib.import_module(_HARBOR_AGENT_MODULE)
+    accessor = getattr(module, "_default_install_ref", None)
+    if accessor is not None:
+        resolved = accessor()
+        return str(resolved)
+    ref = module.DEFAULT_INSTALL_REF
+    if isinstance(ref, str):
+        return ref
+    if callable(ref):
+        return str(ref())
+    msg = f"unexpected DEFAULT_INSTALL_REF type: {type(ref)!r}"
+    raise TypeError(msg)
 
 
 def test_default_install_ref_pins_a_release_tag_not_a_moving_branch() -> None:
-    assert DEFAULT_INSTALL_REF.startswith("v"), (
-        f"DEFAULT_INSTALL_REF={DEFAULT_INSTALL_REF!r} must pin a release tag "
+    resolved = _resolved_default_install_ref()
+    assert resolved.startswith("v"), (
+        f"DEFAULT_INSTALL_REF={resolved!r} must pin a release tag "
         "(e.g. 'v0.1.0'), not a moving branch name like 'pre-0.0.1' — a "
         "Harbor install with no MERGECRAFT_INSTALL_REF override should not "
         "silently drift onto trunk."
     )
+
+
+@pytest.mark.xfail(
+    reason="green after W4: defer harbor pin from import (#403, D9)",
+    strict=False,
+)
+def test_import_harbor_agent_does_not_resolve_pin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing harbor.agent must not call ``action_pin_minimal()`` at module load."""
+
+    def _raise_pin() -> str:
+        raise RuntimeError("pin load must not run at import time")
+
+    monkeypatch.setattr("mergecraft.pins.action_pin_minimal", _raise_pin)
+    module = _reload_harbor_agent_module()
+    assert module.MergecraftReviewAgent is not None
+
+
+@pytest.mark.xfail(
+    reason="green after W4: lazy default install ref accessor (#403, D9)",
+    strict=False,
+)
+def test_default_install_ref_accessor_calls_action_pin_minimal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy accessor mirrors ``init_cmd._workflow_template`` — resolve pin on demand."""
+    calls: list[str] = []
+
+    def _tracking_pin() -> str:
+        calls.append("called")
+        return "v0.1.0a1"
+
+    monkeypatch.setattr("mergecraft.pins.action_pin_minimal", _tracking_pin)
+    agent_mod = _reload_harbor_agent_module()
+    accessor = getattr(agent_mod, "_default_install_ref", None)
+    assert accessor is not None, (
+        "mergecraft.harbor.agent must expose _default_install_ref() "
+        "(mirror init_cmd._workflow_template; D9)"
+    )
+    calls.clear()
+    ref = accessor()
+    assert ref.startswith("v"), f"unexpected install ref: {ref!r}"
+    assert calls == ["called"], "lazy accessor must call action_pin_minimal()"
+
+
+@pytest.mark.xfail(
+    reason="green after W4: install resolves pin lazily (#403, D9)",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_install_resolves_default_ref_via_action_pin_minimal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``install()`` must resolve the default ref via ``action_pin_minimal()`` when unset."""
+    calls: list[str] = []
+
+    def _tracking_pin() -> str:
+        calls.append("called")
+        return "v0.1.0a1"
+
+    monkeypatch.setattr("mergecraft.pins.action_pin_minimal", _tracking_pin)
+    agent_mod = _reload_harbor_agent_module()
+    calls.clear()
+
+    agent = agent_mod.MergecraftReviewAgent(logs_dir=tmp_path)
+
+    async def _noop_exec(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(agent, "exec_as_root", _noop_exec)
+    monkeypatch.setattr(agent, "exec_as_agent", _noop_exec)
+
+    class _FakeEnvironment:
+        pass
+
+    await agent.install(_FakeEnvironment())
+    assert calls, "install() must call action_pin_minimal() when MERGECRAFT_INSTALL_REF is unset"
 
 
 @pytest.mark.parametrize(

--- a/tests/harbor/test_agent.py
+++ b/tests/harbor/test_agent.py
@@ -50,10 +50,6 @@ def test_default_install_ref_pins_a_release_tag_not_a_moving_branch() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="green after W4: defer harbor pin from import (#403, D9)",
-    strict=False,
-)
 def test_import_harbor_agent_does_not_resolve_pin(monkeypatch: pytest.MonkeyPatch) -> None:
     """Importing harbor.agent must not call ``action_pin_minimal()`` at module load."""
 
@@ -65,10 +61,6 @@ def test_import_harbor_agent_does_not_resolve_pin(monkeypatch: pytest.MonkeyPatc
     assert module.MergecraftReviewAgent is not None
 
 
-@pytest.mark.xfail(
-    reason="green after W4: lazy default install ref accessor (#403, D9)",
-    strict=False,
-)
 def test_default_install_ref_accessor_calls_action_pin_minimal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,10 +84,6 @@ def test_default_install_ref_accessor_calls_action_pin_minimal(
     assert calls == ["called"], "lazy accessor must call action_pin_minimal()"
 
 
-@pytest.mark.xfail(
-    reason="green after W4: install resolves pin lazily (#403, D9)",
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_install_resolves_default_ref_via_action_pin_minimal(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/pins/__init__.py
+++ b/tests/pins/__init__.py
@@ -1,0 +1,1 @@
+"""Pin and example-workflow defaults contract tests."""

--- a/tests/pins/test_defaults_yaml_sync.py
+++ b/tests/pins/test_defaults_yaml_sync.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 from tests.ci.workflow_support import REPO_ROOT, read_text
 
 _CHECKOUT_DEFAULTS = REPO_ROOT / "scripts" / "example_workflows" / "defaults.yaml"
@@ -33,7 +31,6 @@ def _ci_steps(makefile: str) -> list[str]:
     return match.group(1).split()
 
 
-@pytest.mark.xfail(reason="green after W2: sync packaged defaults.yaml copy (#402)", strict=False)
 def test_checkout_and_packaged_defaults_yaml_are_byte_identical() -> None:
     """D7: checkout YAML is source of truth; packaged copy must match byte-for-byte."""
     assert _CHECKOUT_DEFAULTS.is_file(), (
@@ -51,7 +48,6 @@ def test_checkout_and_packaged_defaults_yaml_are_byte_identical() -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after W2: add pins-check Makefile target (#414)", strict=False)
 def test_make_pins_check_target_exists() -> None:
     makefile = read_text("Makefile")
     assert re.search(
@@ -61,7 +57,6 @@ def test_make_pins_check_target_exists() -> None:
     ), f"Makefile must define {_PINS_CHECK_TARGET}:"
 
 
-@pytest.mark.xfail(reason="green after W2: wire pins-check into CI_STEPS (#414)", strict=False)
 def test_make_pins_check_in_ci_steps() -> None:
     makefile = read_text("Makefile")
     steps = _ci_steps(makefile)
@@ -70,7 +65,6 @@ def test_make_pins_check_in_ci_steps() -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after W2: wire pins-check into ci-static (#414)", strict=False)
 def test_make_pins_check_in_ci_static() -> None:
     makefile = read_text("Makefile")
     ci_static = _makefile_prerequisite_tokens(makefile, "ci-static")

--- a/tests/pins/test_defaults_yaml_sync.py
+++ b/tests/pins/test_defaults_yaml_sync.py
@@ -11,24 +11,13 @@ from __future__ import annotations
 import re
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import ci_steps, makefile_prerequisite_tokens
 
 _CHECKOUT_DEFAULTS = REPO_ROOT / "scripts" / "example_workflows" / "defaults.yaml"
 _PACKAGED_DEFAULTS = (
     REPO_ROOT / "src" / "mergecraft" / "data" / "example_workflows" / "defaults.yaml"
 )
 _PINS_CHECK_TARGET = "pins-check"
-
-
-def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
-    match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
-    assert match, f"Makefile missing {target}: recipe"
-    return set(match.group(1).split())
-
-
-def _ci_steps(makefile: str) -> list[str]:
-    match = re.search(r"^CI_STEPS\s*:?=\s*(.+)$", makefile, re.MULTILINE)
-    assert match, "Makefile missing CI_STEPS"
-    return match.group(1).split()
 
 
 def test_checkout_and_packaged_defaults_yaml_are_byte_identical() -> None:
@@ -58,16 +47,14 @@ def test_make_pins_check_target_exists() -> None:
 
 
 def test_make_pins_check_in_ci_steps() -> None:
-    makefile = read_text("Makefile")
-    steps = _ci_steps(makefile)
-    assert _PINS_CHECK_TARGET in steps, (
+    assert _PINS_CHECK_TARGET in ci_steps(), (
         f"Makefile CI_STEPS must include {_PINS_CHECK_TARGET} (#414 drift gate)"
     )
 
 
 def test_make_pins_check_in_ci_static() -> None:
     makefile = read_text("Makefile")
-    ci_static = _makefile_prerequisite_tokens(makefile, "ci-static")
+    ci_static = makefile_prerequisite_tokens(makefile, "ci-static")
     assert _PINS_CHECK_TARGET in ci_static, (
         f"Makefile ci-static must include {_PINS_CHECK_TARGET} (#414 drift gate)"
     )

--- a/tests/pins/test_defaults_yaml_sync.py
+++ b/tests/pins/test_defaults_yaml_sync.py
@@ -1,0 +1,79 @@
+"""Batch GA — checkout vs packaged ``defaults.yaml`` sync (#402, #414).
+
+Pins byte identity between ``scripts/example_workflows/defaults.yaml`` (source
+of truth) and ``src/mergecraft/data/example_workflows/defaults.yaml``, plus
+``make pins-check`` membership in ``CI_STEPS`` and ``ci-static``. Implementation
+lands in W2 (D7).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.ci.workflow_support import REPO_ROOT, read_text
+
+_CHECKOUT_DEFAULTS = REPO_ROOT / "scripts" / "example_workflows" / "defaults.yaml"
+_PACKAGED_DEFAULTS = (
+    REPO_ROOT / "src" / "mergecraft" / "data" / "example_workflows" / "defaults.yaml"
+)
+_PINS_CHECK_TARGET = "pins-check"
+
+
+def _makefile_prerequisite_tokens(makefile: str, target: str) -> set[str]:
+    match = re.search(rf"^{re.escape(target)}:(.*)$", makefile, re.MULTILINE)
+    assert match, f"Makefile missing {target}: recipe"
+    return set(match.group(1).split())
+
+
+def _ci_steps(makefile: str) -> list[str]:
+    match = re.search(r"^CI_STEPS\s*:?=\s*(.+)$", makefile, re.MULTILINE)
+    assert match, "Makefile missing CI_STEPS"
+    return match.group(1).split()
+
+
+@pytest.mark.xfail(reason="green after W2: sync packaged defaults.yaml copy (#402)", strict=False)
+def test_checkout_and_packaged_defaults_yaml_are_byte_identical() -> None:
+    """D7: checkout YAML is source of truth; packaged copy must match byte-for-byte."""
+    assert _CHECKOUT_DEFAULTS.is_file(), (
+        f"missing checkout defaults: {_CHECKOUT_DEFAULTS.relative_to(REPO_ROOT)}"
+    )
+    assert _PACKAGED_DEFAULTS.is_file(), (
+        f"missing packaged defaults: {_PACKAGED_DEFAULTS.relative_to(REPO_ROOT)}"
+    )
+    checkout_bytes = _CHECKOUT_DEFAULTS.read_bytes()
+    packaged_bytes = _PACKAGED_DEFAULTS.read_bytes()
+    assert checkout_bytes == packaged_bytes, (
+        "scripts/example_workflows/defaults.yaml and "
+        "src/mergecraft/data/example_workflows/defaults.yaml must be byte-identical "
+        "(edit checkout copy, sync packaged copy, then run make pins-check)"
+    )
+
+
+@pytest.mark.xfail(reason="green after W2: add pins-check Makefile target (#414)", strict=False)
+def test_make_pins_check_target_exists() -> None:
+    makefile = read_text("Makefile")
+    assert re.search(
+        rf"^{re.escape(_PINS_CHECK_TARGET)}:",
+        makefile,
+        re.MULTILINE,
+    ), f"Makefile must define {_PINS_CHECK_TARGET}:"
+
+
+@pytest.mark.xfail(reason="green after W2: wire pins-check into CI_STEPS (#414)", strict=False)
+def test_make_pins_check_in_ci_steps() -> None:
+    makefile = read_text("Makefile")
+    steps = _ci_steps(makefile)
+    assert _PINS_CHECK_TARGET in steps, (
+        f"Makefile CI_STEPS must include {_PINS_CHECK_TARGET} (#414 drift gate)"
+    )
+
+
+@pytest.mark.xfail(reason="green after W2: wire pins-check into ci-static (#414)", strict=False)
+def test_make_pins_check_in_ci_static() -> None:
+    makefile = read_text("Makefile")
+    ci_static = _makefile_prerequisite_tokens(makefile, "ci-static")
+    assert _PINS_CHECK_TARGET in ci_static, (
+        f"Makefile ci-static must include {_PINS_CHECK_TARGET} (#414 drift gate)"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -933,15 +933,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What?

Keeps workflow pin copies in sync and closes the README v2 harness leftovers so consumers get consistent scaffolding, auth env names, and agent skill paths.

- Byte-identical checkout and packaged defaults.yaml copies with a CI drift gate.
- Harbor resolves its install ref at use time instead of import.
- Generated agent packages pick a blob ref that exists before the release tag lands.
- Landing README tells agents to copy per-harness generated skills.
- Hermes skill documents the same API key names as mergeCraft auth.
- Shared test helpers reduce duplication across docs contract suites.

## Why?

After README v2 landed, drift between the two defaults.yaml copies could ship silently, Harbor could freeze the wrong pin at import, generated skills could link to a tag that does not exist yet, and the README still pointed at a generic skills path. Operators setting up Hermes with Google or Nous keys would see names that do not match what auth sets.

## Note

Rebased onto origin/pre-0.0.1. CHANGELOG conflict resolved by keeping both upstream and branch entries under Fixed.

## Test plan

- [x] `make ci` passed on branch before rebase
- [x] Docs contract suites cover pins drift gate, Harbor lazy ref, agent-package blob ref, README harness copy prompts, Hermes env vars, and shared support helpers

## Related PR(s)/Issue(s)

Closes #402
Closes #403
Closes #404
Closes #405
Closes #413
Closes #414
Closes #415
