### PR TITLE
ci: let the release pipeline start

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,12 @@ jobs:
   e2e-gate:
     name: Action-image E2E (release gate)
     needs: verify
+    # Required: the top-level `permissions: {}` grants this job nothing, and a
+    # called workflow may not request more than its caller holds. `e2e.yml`
+    # declares `contents: read`, so without this the whole run is rejected
+    # before any job starts (startup_failure), release included.
+    permissions:
+      contents: read
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 


### PR DESCRIPTION
## What?

Lets the release pipeline start. Every CI/CD run was rejected before any job ran, so no image has ever been built, signed, or attested.

## Why?

`ci-cd.yml` sets `permissions: {}` at the top level and has each job declare exactly what it needs. Six of the seven jobs do. `e2e-gate`, the only job that calls a reusable workflow, was missed, so it inherited no permissions at all. A called workflow may not request more than its caller holds, and `e2e.yml` declares `contents: read`. GitHub rejects that at startup rather than failing a job, which is why the runs show `startup_failure` with no logs to read.

The 40 most recent CI/CD runs failed this way, the `v0.1.0a1` tag push among them. The tag resolves, but nothing was published at it.

actionlint passes on both files before and after. The fault is a permissions relationship between two workflows, not something a single-file linter can see.

## Note

Merging this does not retroactively run the tag. Re-trigger it by deleting and re-pushing `v0.1.0a1`, or through `workflow_dispatch`, once this is on the default branch.

Worth a follow-up: nothing warns when a release pipeline never starts. A `startup_failure` produces no logs, no annotations, and no failed check to read, so this sat unnoticed across dozens of runs.

## Test plan

- [x] `actionlint` clean on all workflows
- [x] `make lint`
- [x] Confirmed the callee's permission set is now a subset of the caller's
