### PR TITLE
analyzers: re-verify pinned binaries before executing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)
+- Managed analyzer binaries are re-verified on every cache hit, not just at download time: the cache
+  directory is keyed by the *archive* sha256, so a tool that rewrites itself in place was executed on
+  every subsequent run while the path implied the pinned contents. TruffleHog's built-in updater did
+  exactly that, silently replacing the pinned 3.96.0 binary with 3.97.0. Provisioning now records the
+  installed binary's sha256 beside it and refuses to reuse a cache entry that no longer matches —
+  discarding it (updater state included) and re-provisioning from the pin, or failing closed with a
+  truthful skip reason when the pinned source is unreachable. TruffleHog is additionally run with
+  `--no-update` so the updater never fires
 
 ### Changed
 

--- a/src/mergecraft/analyzers/catalog/trufflehog.yaml
+++ b/src/mergecraft/analyzers/catalog/trufflehog.yaml
@@ -8,6 +8,7 @@ command:
   - trufflehog
   - filesystem
   - -j
+  - --no-update
   - --no-verification
   - --config
   - "{trufflehog_config}"

--- a/src/mergecraft/analyzers/execution.py
+++ b/src/mergecraft/analyzers/execution.py
@@ -74,6 +74,12 @@ def finalize_plan(
     return replace(plan, argv=tuple(argv), cwd=repo_root, env=env)
 
 
+#: TruffleHog ships a self-updater that rewrites its own binary in place, which
+#: would silently replace the sha-pinned binary mergeCraft provisioned. ``--no-update``
+#: ("Don't check for updates") disables it; confirmed on the pinned 3.96.0 binary.
+TRUFFLEHOG_NO_UPDATE_FLAG = "--no-update"
+
+
 def _trufflehog_argv(
     argv: list[str],
     *,
@@ -84,6 +90,10 @@ def _trufflehog_argv(
     from mergecraft.analyzers.config import trufflehog_verify_enabled
 
     filtered = [arg for arg in argv if arg not in {"--no-verification", "--verification"}]
+    # Belt and braces: the manifest command carries the flag, but argv also arrives
+    # from MCP callers that assemble their own arguments (see ``run_argv``).
+    if TRUFFLEHOG_NO_UPDATE_FLAG not in filtered:
+        filtered.append(TRUFFLEHOG_NO_UPDATE_FLAG)
     if trufflehog_verify_enabled(repo_root=repo_root, tier=tier, event=event):
         if "--verification" not in filtered:
             filtered.append("--verification")
@@ -218,6 +228,7 @@ def run_argv(
 
 
 __all__ = [
+    "TRUFFLEHOG_NO_UPDATE_FLAG",
     "finalize_plan",
     "marker_only_lint_skip_reason",
     "provision_managed_argv",

--- a/src/mergecraft/analyzers/provision.py
+++ b/src/mergecraft/analyzers/provision.py
@@ -6,6 +6,7 @@ import contextlib
 import fcntl
 import hashlib
 import os
+import re
 import shutil
 import stat
 import sys
@@ -56,6 +57,82 @@ def _verify_sha256(path: Path, expected: str) -> None:
             "refusing to execute unpinned binary"
         )
         raise ProvisionError(msg)
+
+
+#: Sidecar recording the sha256 of the binary that was actually installed into a
+#: sha-keyed cache directory. The directory key is the *archive* pin, so it says
+#: nothing about the extracted binary once a tool rewrites itself in place (e.g.
+#: TruffleHog's built-in updater). The receipt closes that gap for every managed
+#: analyzer: a cached binary is only reused when it still hashes to what we wrote.
+RECEIPT_NAME = ".provisioned-sha256"
+
+_PROVISION_LOCK_NAME = ".provision.lock"
+_HEX64_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def _receipt_path(cache_root: Path) -> Path:
+    return cache_root / RECEIPT_NAME
+
+
+def read_provision_receipt(cache_root: Path) -> str | None:
+    """Return the recorded binary sha256 for a cache directory, or ``None``."""
+    try:
+        raw = _receipt_path(cache_root).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    candidate = raw.strip().casefold()
+    return candidate if _HEX64_RE.fullmatch(candidate) else None
+
+
+def _write_provision_receipt(cache_root: Path, digest: str) -> None:
+    receipt = _receipt_path(cache_root)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    staging = receipt.with_name(f".{receipt.name}.staging")
+    staging.write_text(f"{digest.casefold()}\n", encoding="utf-8")
+    os.replace(staging, receipt)
+
+
+def _verified_cache_hit(*, cached: Path, cache_root: Path, manifest_id: str) -> str | None:
+    """Return the cached binary's sha256 when it still matches its receipt.
+
+    Returns ``None`` when the cache entry is unusable — no receipt (provisioned by
+    an older mergeCraft, or the receipt was removed) or a digest that no longer
+    matches. Callers must re-provision instead of executing the file.
+    """
+    recorded = read_provision_receipt(cache_root)
+    if recorded is None:
+        logger.info(
+            "no provisioning receipt for cached {} binary at {} — re-provisioning from the pin",
+            manifest_id,
+            cached,
+        )
+        return None
+    actual = _sha256_file(cached)
+    if actual.casefold() != recorded:
+        logger.warning(
+            "cached {} binary changed after provisioning (recorded {}, found {}) — "
+            "discarding and re-provisioning from the pin",
+            manifest_id,
+            recorded,
+            actual,
+        )
+        return None
+    return actual
+
+
+def _purge_cache_entry(cache_root: Path) -> None:
+    """Drop everything in a cache directory except the lock we hold."""
+    for child in cache_root.iterdir():
+        if child.name == _PROVISION_LOCK_NAME:
+            continue
+        try:
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+        except OSError as exc:
+            msg = f"failed to discard untrusted cache entry {child}: {exc}"
+            raise ProvisionError(msg) from exc
 
 
 def _safe_archive_member_path(dest_dir: Path, member_name: str) -> Path:
@@ -160,7 +237,7 @@ def _extract_executable(archive: Path, dest_dir: Path, binary_name: str) -> Path
 def _cache_provision_lock(cache_root: Path) -> Iterator[None]:
     """Serialize cache writes so parallel workers cannot clobber a running binary."""
     cache_root.mkdir(parents=True, exist_ok=True)
-    lock_path = cache_root / ".provision.lock"
+    lock_path = cache_root / _PROVISION_LOCK_NAME
     with lock_path.open("a+", encoding="utf-8") as lock_file:
         if sys.platform != "win32":
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
@@ -171,12 +248,16 @@ def _cache_provision_lock(cache_root: Path) -> Iterator[None]:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
-def _install_cached_binary(*, staged: Path, cached: Path) -> None:
+def _install_cached_binary(*, staged: Path, cached: Path) -> str:
+    """Install the staged binary into the cache and record its sha256 receipt."""
     cached.parent.mkdir(parents=True, exist_ok=True)
     staging = cached.with_name(f".{cached.name}.staging")
     staging.write_bytes(staged.read_bytes())
     staging.chmod(staging.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    digest = _sha256_file(staging)
     os.replace(staging, cached)
+    _write_provision_receipt(cached.parent, digest)
+    return digest
 
 
 def fetch_unpinned(*, url: str, cache_dir: Path) -> None:
@@ -208,23 +289,33 @@ def provision_managed_binary(
     cache_root = _cache_path(cache_dir, manifest.id, platform, artifact_pin)
     cached = cache_root / binary_name
     if cached.is_file():
-        binary_sha = _sha256_file(cached)
-        return ProvisionResult(
-            resolved_path=cached,
-            sha256=binary_sha,
-            version=manifest.version,
-            source="cache",
+        verified = _verified_cache_hit(
+            cached=cached, cache_root=cache_root, manifest_id=manifest.id
         )
-
-    with _cache_provision_lock(cache_root):
-        if cached.is_file():
-            binary_sha = _sha256_file(cached)
+        if verified is not None:
             return ProvisionResult(
                 resolved_path=cached,
-                sha256=binary_sha,
+                sha256=verified,
                 version=manifest.version,
                 source="cache",
             )
+
+    with _cache_provision_lock(cache_root):
+        if cached.is_file():
+            verified = _verified_cache_hit(
+                cached=cached, cache_root=cache_root, manifest_id=manifest.id
+            )
+            if verified is not None:
+                return ProvisionResult(
+                    resolved_path=cached,
+                    sha256=verified,
+                    version=manifest.version,
+                    source="cache",
+                )
+            # Never execute a binary we cannot tie back to the pin: drop the whole
+            # entry (binary plus any updater state a self-updating tool left behind)
+            # and fall through to a fresh pinned download.
+            _purge_cache_entry(cache_root)
 
         logger.info("provisioning {} {} from pinned url", manifest.id, platform)
         with tempfile.TemporaryDirectory() as tmp:
@@ -246,9 +337,8 @@ def provision_managed_binary(
             else:
                 staged = download_path
 
-            _install_cached_binary(staged=staged, cached=cached)
+            binary_sha = _install_cached_binary(staged=staged, cached=cached)
 
-    binary_sha = _sha256_file(cached)
     return ProvisionResult(
         resolved_path=cached,
         sha256=binary_sha,
@@ -328,11 +418,13 @@ def platform_key() -> str:
 
 __all__ = [
     "BAKED_ANALYZER_ROOT",
+    "RECEIPT_NAME",
     "ProvisionError",
     "ProvisionResult",
     "fetch_unpinned",
     "platform_key",
     "provision_managed_binary",
+    "read_provision_receipt",
     "resolve_baked_binary",
     "resolve_with_lock",
 ]

--- a/tests/analyzers/test_provision_cache_integrity.py
+++ b/tests/analyzers/test_provision_cache_integrity.py
@@ -1,0 +1,207 @@
+"""Managed-binary cache integrity after provisioning (D10).
+
+The sha-keyed cache directory is keyed by the *archive* pin, so it proves nothing
+about the extracted binary on later runs. TruffleHog rewrites its own binary in
+place via its built-in updater; these tests cover both defences — the recorded
+receipt that stops a mutated binary from ever being executed, and the argv flag
+that stops the updater from firing in the first place.
+
+No test here touches the network: ``_download_pinned_url`` is always faked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.analyzers.support import import_module
+
+_PAYLOAD = b"#!/bin/sh\necho pinned-tool 1.0.0\n"
+_PAYLOAD_SHA = hashlib.sha256(_PAYLOAD).hexdigest()
+_PLATFORM = "linux-amd64"
+
+
+def _manifest(sha256: str = _PAYLOAD_SHA) -> Any:
+    """Build a managed manifest whose pinned artifact is the raw fake binary."""
+    manifest = import_module("mergecraft.analyzers.manifest")
+    return manifest.AnalyzerManifest.model_validate(
+        {
+            "id": "faketool",
+            "category": "ci",
+            "languages": [],
+            "detect": {"files": ["**/*"]},
+            "command": ["faketool", "{files}"],
+            "scope": "diff",
+            "parser": "sarif",
+            "supports_fix": False,
+            "default_enabled": "auto",
+            "version": "1.0.0",
+            "runtime": "managed",
+            "timeout_s": 60,
+            "trust": "untrusted",
+            "severity_map": {"error": "Major", "warning": "Minor", "note": "Trivial"},
+            "provenance": {
+                _PLATFORM: {"url": "https://example.invalid/faketool", "sha256": sha256}
+            },
+            "network_allowlist": [],
+        }
+    )
+
+
+@pytest.fixture
+def fake_download(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace the pinned download with a local write; return the call log."""
+    provision = import_module("mergecraft.analyzers.provision")
+    calls: list[str] = []
+
+    def _fake(url: str, dest: Path) -> None:
+        calls.append(url)
+        dest.write_bytes(_PAYLOAD)
+
+    monkeypatch.setattr(provision, "_download_pinned_url", _fake)
+    return calls
+
+
+def _provision(cache_dir: Path) -> Any:
+    provision = import_module("mergecraft.analyzers.provision")
+    return provision.provision_managed_binary(
+        manifest=_manifest(), platform=_PLATFORM, cache_dir=cache_dir
+    )
+
+
+def test_unmodified_cached_binary_is_reused_without_redownloading(
+    tmp_path: Path, fake_download: list[str]
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    second = _provision(cache_dir)
+
+    assert first.source == "download"
+    assert second.source == "cache"
+    assert second.resolved_path == first.resolved_path
+    assert second.sha256 == first.sha256 == _PAYLOAD_SHA
+    assert fake_download == ["https://example.invalid/faketool"]
+
+
+def test_receipt_records_the_installed_binary_digest(
+    tmp_path: Path, fake_download: list[str]
+) -> None:
+    provision = import_module("mergecraft.analyzers.provision")
+    result = _provision(tmp_path / "cache")
+    recorded = provision.read_provision_receipt(result.resolved_path.parent)
+
+    assert recorded == _PAYLOAD_SHA
+
+
+def test_binary_mutated_after_provisioning_is_never_executed(
+    tmp_path: Path, fake_download: list[str]
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    # Stand in for TruffleHog's self-updater: rewrite the binary in place and drop
+    # the updater's sibling state file next to it.
+    first.resolved_path.write_bytes(b"#!/bin/sh\necho attacker 9.9.9\n")
+    (first.resolved_path.parent / "faketool-updates.lock").write_text("stale", encoding="utf-8")
+
+    second = _provision(cache_dir)
+
+    assert second.source == "download", "mutated cache must not be served as a cache hit"
+    assert second.sha256 == _PAYLOAD_SHA
+    assert second.resolved_path.read_bytes() == _PAYLOAD
+    assert not (second.resolved_path.parent / "faketool-updates.lock").exists()
+    assert len(fake_download) == 2
+
+
+def test_mutated_binary_is_refused_when_repinning_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_download: list[str]
+) -> None:
+    provision = import_module("mergecraft.analyzers.provision")
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    first.resolved_path.write_bytes(b"#!/bin/sh\necho attacker 9.9.9\n")
+
+    def _offline(url: str, dest: Path) -> None:
+        msg = f"download failed for {url!r}: offline"
+        raise provision.ProvisionError(msg)
+
+    monkeypatch.setattr(provision, "_download_pinned_url", _offline)
+
+    with pytest.raises(provision.ProvisionError, match=r"download failed"):
+        _provision(cache_dir)
+
+    assert not first.resolved_path.exists(), "the mutated binary must not survive as runnable"
+
+
+def test_cache_without_a_receipt_is_reprovisioned(tmp_path: Path, fake_download: list[str]) -> None:
+    provision = import_module("mergecraft.analyzers.provision")
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    # A cache directory written by a mergeCraft that predates receipts.
+    (first.resolved_path.parent / provision.RECEIPT_NAME).unlink()
+
+    second = _provision(cache_dir)
+
+    assert second.source == "download"
+    assert len(fake_download) == 2
+
+
+def test_lock_resolution_reprovisions_a_mutated_cache(
+    tmp_path: Path, fake_download: list[str]
+) -> None:
+    provision = import_module("mergecraft.analyzers.provision")
+    cache_dir = tmp_path / "cache"
+    lock_path = tmp_path / ".mergecraft" / "analyzers.lock"
+    manifest = _manifest()
+    first = provision.resolve_with_lock(
+        manifest=manifest, lock_path=lock_path, cache_dir=cache_dir, platform=_PLATFORM
+    )
+    first.resolved_path.write_bytes(b"#!/bin/sh\necho attacker 9.9.9\n")
+
+    second = provision.resolve_with_lock(
+        manifest=manifest, lock_path=lock_path, cache_dir=cache_dir, platform=_PLATFORM
+    )
+
+    assert second.sha256 == _PAYLOAD_SHA
+    assert second.resolved_path.read_bytes() == _PAYLOAD
+    assert len(fake_download) == 2
+
+
+def _finalized_trufflehog_argv(repo_root: Path, argv: tuple[str, ...]) -> tuple[str, ...]:
+    execution = import_module("mergecraft.analyzers.execution")
+    registry = import_module("mergecraft.analyzers.registry")
+    resolve = import_module("mergecraft.analyzers.resolve")
+    manifest = registry.get_manifest("trufflehog")
+    plan = resolve.AnalyzerPlan(manifest_id="trufflehog", mode="managed", argv=argv)
+    finalized = execution.finalize_plan(
+        plan,
+        manifest=manifest,
+        repo_root=repo_root,
+        changed_files=["config/planted-secret.env"],
+        tier="untrusted",
+    )
+    return finalized.argv
+
+
+def test_trufflehog_manifest_command_disables_the_self_updater() -> None:
+    registry = import_module("mergecraft.analyzers.registry")
+    command = registry.get_manifest("trufflehog").command
+
+    assert "--no-update" in command
+
+
+def test_trufflehog_argv_carries_no_update_exactly_once(tmp_path: Path) -> None:
+    registry = import_module("mergecraft.analyzers.registry")
+    argv = _finalized_trufflehog_argv(tmp_path, tuple(registry.get_manifest("trufflehog").command))
+
+    assert argv.count("--no-update") == 1
+
+
+def test_trufflehog_custom_argv_still_disables_the_self_updater(tmp_path: Path) -> None:
+    # MCP callers assemble their own argv (see ``execution.run_argv``); the flag
+    # must be added there too, not only via the manifest command.
+    argv = _finalized_trufflehog_argv(tmp_path, ("trufflehog", "filesystem", "-j", "{files}"))
+
+    assert argv.count("--no-update") == 1


### PR DESCRIPTION
## What?

A pinned analyzer binary that changes on disk after it was verified is no longer executed. Every managed analyzer is covered, not just TruffleHog.

- Cached binaries are re-hashed on each cache hit and compared against a receipt written at install time.
- A mismatch purges the cache entry and re-provisions from the pinned source; if that fails, the analyzer skips rather than running unverified code.
- TruffleHog is launched with its updater disabled.

## Why?

mergeCraft pins managed binaries by URL and sha256, verifies the download, and caches it in a directory keyed by that hash. TruffleHog then rewrites its own binary in place. On a real checkout the cached file hashed differently from the pinned one, reported a different version, and sat beside the updater's own lock file. The hash was checked once at download and something else ran on every invocation afterwards, with the sha-keyed path implying otherwise.

`resolve_with_lock` did compare cached binaries against `analyzers.lock`, but on mismatch it fell through to the provisioning helper, which returned the same mutated file. The check existed and its own fallback defeated it. Recording the installed digest beside the binary repairs that path as well.

Disabling the updater alone would not be enough. It stops the one tool known to do this, and leaves the guarantee resting on a flag surviving every future manifest edit. Verifying on reuse holds regardless of which tool misbehaves or why the file changed.

## Note

The receipt lives beside the binary, so it stops a tool that rewrites itself, which is the observed threat. It does not stop an attacker with arbitrary write access to the cache tree, who could rewrite both. The `analyzers.lock` cross-check remains as a second record outside that directory.

The manifest pin was never wrong. Upstream's checksums file matches both provenance entries and a fresh download runs as the pinned version.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make pyright` (0 errors)
- [x] `make catalog-check`
- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/analyzers -q` (1290 passed, 3 skipped)

New tests cover a binary mutated after provisioning, a mutated binary with the pinned source unreachable, an unmodified cache reused without re-downloading, a legacy cache with no receipt, recovery through `resolve_with_lock`, and the updater flag reaching the argv on all three construction paths. None reach the network.
