### PR TITLE
docs: make generated skill packages environment-independent

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
       - name: make ci
         run: make ci

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,6 +31,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
       - name: make ci
         run: make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -51,11 +51,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -76,11 +76,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -98,11 +98,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -120,11 +120,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
         python: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -44,6 +50,12 @@ jobs:
         group: [1, 2]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -63,6 +75,12 @@ jobs:
         python: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -79,6 +97,12 @@ jobs:
         python: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
@@ -95,6 +119,12 @@ jobs:
         python: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
       - name: Integration suite
         run: make test-integration
@@ -91,11 +91,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag-resolution checks (README Action pin, D25) ask git whether
-          # the release tag exists. The default shallow fetch omits tags,
-          # so without this they fail on every branch build while passing
-          # on tag builds.
-          fetch-tags: true
+          # Ref-resolution checks ask git whether a tag or branch exists
+          # (README Action pin D25, tests/docs/support.py). A shallow fetch
+          # has neither, so they answer "no" on PR builds while passing on
+          # tag builds. Full history is what makes those answers truthful.
+          fetch-depth: 0
       - uses: ./.github/actions/bootstrap
       - name: Live-provider integration (${{ matrix.provider }})
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
       - name: Integration suite
         run: make test-integration
@@ -84,6 +90,12 @@ jobs:
         provider: [anthropic, openai, gemini, nous, github]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tag-resolution checks (README Action pin, D25) ask git whether
+          # the release tag exists. The default shallow fetch omits tags,
+          # so without this they fail on every branch build while passing
+          # on tag builds.
+          fetch-tags: true
       - uses: ./.github/actions/bootstrap
       - name: Live-provider integration (${{ matrix.provider }})
         env:

--- a/scripts/gen_agent_packages.py
+++ b/scripts/gen_agent_packages.py
@@ -49,10 +49,14 @@ def _blob_ref() -> str:
         if git_ref_exists(env_ref, cwd=REPO_ROOT):
             return env_ref
         return DEFAULT_BLOB_REF
-    pin = action_pin_minimal()
-    if git_ref_exists(pin, cwd=REPO_ROOT):
-        return pin
-    return DEFAULT_BLOB_REF
+    # The pin is used unconditionally. These refs become github.com blob URLs,
+    # and the tag resolves there whether or not this clone fetched it. Gating on
+    # local git state made the generated packages differ by environment: a tag
+    # build (checkout has the tag) emitted the pin while a branch build
+    # (`fetch-depth: 1`, no tags) emitted DEFAULT_BLOB_REF, so no committed
+    # output could satisfy both and one of the two always failed the drift gate.
+    # The gate existed only to survive the window before the tag was cut (#404).
+    return action_pin_minimal()
 
 
 def _blob_url(rel_path: str, *, ref: str) -> str:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -47,43 +47,43 @@
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/codex/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     },
     "mergecraft-cursor": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/cursor/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     },
     "mergecraft-opencode": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/opencode/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     },
     "mergecraft-gemini-cli": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/gemini-cli/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     },
     "mergecraft-openclaw": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/openclaw/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     },
     "mergecraft-hermes": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/hermes/mergecraft/SKILL.md",
-      "computedHash": "f75f9d252655b23a5a9f44a8729430cd56ef1299d230c26da68606c759c0edfb"
+      "computedHash": "24db042acec1ef20d7c5cccf989469e2cc017309282c145baaf37dd98942bb55"
     },
     "mergecraft-claude-code": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/claude-code/mergecraft/SKILL.md",
-      "computedHash": "d08f310fa2d8c9f4f3b5d992802c2ebb1729392e8a5a5f178fa0c211c8ac5c74"
+      "computedHash": "62bad704c1f65dfa2f4e542622ec02b3e8fa62c3ea26e9a48c6fb98d1a32722d"
     }
   }
 }

--- a/skills/claude-code/mergecraft/SKILL.md
+++ b/skills/claude-code/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/codex/mergecraft/SKILL.md
+++ b/skills/codex/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/cursor/mergecraft/SKILL.md
+++ b/skills/cursor/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/gemini-cli/mergecraft/SKILL.md
+++ b/skills/gemini-cli/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/hermes/mergecraft/SKILL.md
+++ b/skills/hermes/mergecraft/SKILL.md
@@ -19,7 +19,7 @@ Hermes Agent reads skills from ``~/.hermes/skills/`` or a category-nested projec
 ``skills/`` tree. Install this package with:
 
 ```bash
-hermes skills install https://github.com/alexhawat/mergeCraft/tree/pre-0.0.1/skills/hermes
+hermes skills install https://github.com/alexhawat/mergeCraft/tree/v0.1.0a1/skills/hermes
 ```
 
 mergeCraft ships a Nous provider (``mergecraft auth nous``,
@@ -36,7 +36,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -101,5 +101,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/openclaw/mergecraft/SKILL.md
+++ b/skills/openclaw/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/opencode/mergecraft/SKILL.md
+++ b/skills/opencode/mergecraft/SKILL.md
@@ -18,7 +18,7 @@ a read-only verifier; typed findings drive inline comments and the
 ## Setup checklist (new consumer repo)
 
 1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
-   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/install.md)).
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
 2. **Install:**
 
    ```bash
@@ -83,5 +83,5 @@ The reviewer role is served at `/mcp/reviewer`. Startup prints
   commenters are authorized; authorization reads `author_association` from the
   event payload, never the comment body.
 - **Model skipped** — no credential for that provider; run `mergecraft models list`.
-- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/AGENTS.md),
-  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/pre-0.0.1/docs/README.md).
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/tests/docs/test_gen_agent_packages_blob_ref.py
+++ b/tests/docs/test_gen_agent_packages_blob_ref.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 import subprocess
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mergecraft.pins import action_pin_minimal
 from tests.ci.workflow_support import REPO_ROOT
-from tests.docs.support import git_ref_exists, load_script_module
+from tests.docs.support import load_script_module
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -43,19 +41,37 @@ def test_blob_ref_uses_env_override(monkeypatch: MonkeyPatch) -> None:
     assert module._blob_ref() == override
 
 
-def test_blob_ref_returns_default_when_pin_tag_missing(
+def test_blob_ref_uses_the_pin_even_when_the_tag_is_absent_locally(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """When ``v0.1.0a1`` is absent locally, return ``pre-0.0.1`` — not the pin (D8)."""
+    """The pin is used regardless of local git state.
+
+    Replaces the old D8 assertion that a locally-missing tag falls back to
+    ``DEFAULT_BLOB_REF``. That behaviour made the generated packages depend on
+    whether the checkout happened to have fetched tags: a tag build emitted the
+    pin, a `fetch-depth: 1` branch build emitted the default, and whichever the
+    committed files matched, the other failed `agent-packages-check`. The refs
+    are github.com blob URLs, so the tag resolving locally is irrelevant.
+    """
     pin = action_pin_minimal()
     assert pin == "v0.1.0a1", "fixture assumes action_pin_minimal is v0.1.0a1"
-    if git_ref_exists(pin):
-        pytest.skip(f"G1: tag {pin!r} exists locally — skip missing-tag half of D8 test")
     monkeypatch.delenv(_ENV_KEY, raising=False)
     module = load_script_module(GEN_SCRIPT)
-    ref = module._blob_ref()
-    assert ref != pin, f"_blob_ref() must not return missing tag {pin!r} (D8)"
-    assert ref == _EXPECTED_DEFAULT
+    # Simulate a shallow checkout with no tags: every ref lookup fails.
+    monkeypatch.setattr(module, "git_ref_exists", lambda ref, *, cwd=None: False)
+    assert module._blob_ref() == pin
+
+
+def test_generated_packages_are_identical_without_local_tags(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Rendered output must not change with local git state (the drift bug)."""
+    module = load_script_module(GEN_SCRIPT)
+    monkeypatch.delenv(_ENV_KEY, raising=False)
+    with_tags = module.render_all()
+    monkeypatch.setattr(module, "git_ref_exists", lambda ref, *, cwd=None: False)
+    without_tags = module.render_all()
+    assert with_tags == without_tags
 
 
 def test_blob_ref_uses_action_pin_minimal_when_tag_exists(


### PR DESCRIPTION
## What?

Generated agent-skill packages now render the same in every environment, which unblocks the release build.

Documentation links in the packages point at the Action pin rather than at a branch.

## Why?

The release run for `v0.1.0a1` failed at its first job on `agent-packages-check`, reporting drift in all seven harness packages.

The generated content depended on the checkout. The ref was the Action pin when the tag resolved in the local clone and a branch name otherwise. A tag build has the tag and rendered `v0.1.0a1`; a branch build runs under `fetch-depth: 1` with no tags and rendered `pre-0.0.1`. Whichever one the committed files matched, the other failed the drift gate, so regenerating alone would only have moved the failure from the release to every pull request.

Those refs become github.com blob URLs. The tag resolves there whether or not a given clone fetched it, so gating on local git state bought nothing once the tag existed. The guard was written to survive the window before the tag was cut (#404), and cutting it made the guard the problem.

## Note

Package links now sit at the alpha tag until the pin moves, which is what pinning a release artifact means. Anyone reading a generated skill sees documentation as of that release rather than the branch tip.

The env override `MERGECRAFT_AGENT_PACKAGES_REF` keeps its existence check. It is a manual escape hatch where validating a typo locally is worth more than determinism.

## Test plan

- [x] `make ci-static`, including the `agent-packages-check` that was failing
- [x] `make test` (5512 passed, 43 skipped, 15 xfailed)
- [x] `pytest tests/docs -q` (143 passed)
- [x] New test asserts rendered output is byte-identical with local tags present and with every ref lookup failing

## Related PR(s)/Issue(s)

Unblocks the `v0.1.0a1` release build. Follows #424, which fixed the pipeline failing to start at all.

## Update: CI now fetches tags

The first push fixed the generator but left the suite red on every pull request, for the same underlying reason at a different call site.

`test_landing_keeps_example_one_workflow` asks git whether the README's Action pin resolves. `actions/checkout` fetches at depth 1 without tags, so on a branch or PR build the answer was no, while tag builds passed because those checkouts carry the tag. The pin is correct and the link works for any reader; only the local clone could not see it. That test lost its xfail in `e8343bf1`, so it had begun failing on every pull request regardless of content.

Fetching tags gives any ref-existence check a truthful answer instead of teaching this one test to lie. Applied to the jobs that run the suite: both `ci.yml` verify tiers, the `integration.yml` jobs that bootstrap and run tests, and `ci-cd.yml`'s full verify.
