### PR TITLE
review: run the analyzer catalog once per offline review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transitive `h2` 4.4.0→4.4.1 in `uv.lock` for `pip-audit` (PYSEC-2026-3628)
 - `mergecraft init` no longer emits `uses: ./` in consumer repos — published Action ref instead (V8/D13)
 - `mergecraft init` scaffold drops comment triggers and unsafe `github.event.comment.body` prompt wiring; defaults to `CLAUDE_CODE_OAUTH_TOKEN` (README Example 1 parity)
+- Offline `mergecraft review` no longer runs the analyzer catalog twice: the pre-pass in
+  `run_offline_analyze` and the reviewing agent's `run_analyzers` call each provisioned tools and
+  executed every eligible analyzer over the same diff, doubling review time and duplicating the
+  skip block, sandbox probe, and semgrep/trufflehog output in the log. The pre-pass now records the
+  inputs it ran under (repo root, changed files, trust tier, shell, analyzer mode, inline budget,
+  offline flag, base ref, and a digest of the diff) and `run_analyzers` reuses that result when every
+  one of them matches; any difference — and the GitHub Action path, which has no pre-pass — runs the
+  pipeline exactly as before
 - Offline analyze stores ``AnalyzerRunState`` on the CLI tool context and merges analyzer findings into structured output so CC1 exit codes see Critical/Major hits the agent omitted; result-cache keys include mergeCraft version and a settings digest (#399)
 - Managed analyzer binaries are re-verified on every cache hit, not just at download time: the cache
   directory is keyed by the *archive* sha256, so a tool that rewrites itself in place was executed on

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from mergecraft.config import load_repo_settings
 from mergecraft.mcp.shared import ToolClass, execute, tool
-from mergecraft.mcp.tool_state import AnalyzerRunState, primary_repo_state
+from mergecraft.mcp.tool_state import AnalyzerRunState, analyzer_run_key, primary_repo_state
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -51,22 +51,44 @@ def run_analyzers_tool(ctx: ToolContext):
         if base_ref is not None:
             base_ref = str(base_ref).strip() or None
 
-        run_state = run_analyzer_pipeline(
+        # An offline `mergecraft review` already ran this pipeline as a pre-pass
+        # and recorded the inputs it used. Reuse that result when every keyed
+        # input matches, rather than provisioning and executing every analyzer a
+        # second time over the same diff. No recorded key — the GitHub Action
+        # path, which has no pre-pass — always runs the pipeline.
+        request_key = analyzer_run_key(
             repo_root=repo_root,
             changed_files=changed,
-            tier=_resolve_tier(ctx),  # type: ignore[arg-type]  # — _resolve_tier returns str; run_analyzer_pipeline expects AnalyzerTier literal
-            diff_text=diff_text,
+            tier=_resolve_tier(ctx),
+            shell=str(ctx.payload.shell),
+            mode=ctx.analyzers_mode,
             inline_budget=settings.inline_budget,
             offline=offline,
             base_ref=base_ref,
-            # #35 — the surface now registers under `shell: disabled`, so the
-            # shell has to reach manifest selection or the withhold is lost.
-            shell=str(ctx.payload.shell),
-            # #38 — likewise the mode: `untrusted-only` (and the `auto` that
-            # resolves to it on untrusted runs) only narrows selection if it
-            # actually reaches the pipeline.
-            mode=ctx.analyzers_mode,
+            diff_text=diff_text,
         )
+        prior = ctx.tool_state.analyzer_run
+        prior_key = prior.key if prior is not None else None
+        if prior is not None and prior_key is not None and prior_key.matches(request_key):
+            logger.info("analyzers: reusing pre-computed run (inputs unchanged)")
+            run_state = prior
+        else:
+            run_state = run_analyzer_pipeline(
+                repo_root=repo_root,
+                changed_files=changed,
+                tier=_resolve_tier(ctx),  # type: ignore[arg-type]  # — _resolve_tier returns str; run_analyzer_pipeline expects AnalyzerTier literal
+                diff_text=diff_text,
+                inline_budget=settings.inline_budget,
+                offline=offline,
+                base_ref=base_ref,
+                # #35 — the surface now registers under `shell: disabled`, so the
+                # shell has to reach manifest selection or the withhold is lost.
+                shell=str(ctx.payload.shell),
+                # #38 — likewise the mode: `untrusted-only` (and the `auto` that
+                # resolves to it on untrusted runs) only narrows selection if it
+                # actually reaches the pipeline.
+                mode=ctx.analyzers_mode,
+            )
         _store_run_state(ctx, run_state)
 
         payload: dict[str, Any] = {

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
@@ -164,6 +166,93 @@ class AnalyzerStatusRow:
     finding_count: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class AnalyzerRunKey:
+    """Identity of the inputs one analyzer-pipeline run was computed from.
+
+    An offline ``mergecraft review`` runs the catalog pipeline twice over the
+    same inputs: once as a pre-pass (``review/offline_stages.py``, whose result
+    feeds the structured findings and the exit code) and once when the
+    reviewing agent calls the ``run_analyzers`` MCP tool. Recording the pre-pass
+    inputs lets the tool reuse that result instead of provisioning and
+    executing every analyzer a second time.
+
+    Every field is an input that can change what the pipeline returns:
+    ``repo_root`` and ``changed_files`` decide which manifests are selected,
+    ``tier`` / ``shell`` / ``mode`` decide which of those may execute,
+    ``inline_budget`` decides the inline/mechanical split, ``offline`` gates
+    base-comparison work, ``base_ref`` picks the base for the differential
+    analyzers, and ``diff_digest`` covers the diff the findings are scoped to.
+    Anything not listed here must not differ between the two call sites.
+    """
+
+    repo_root: str
+    changed_files: tuple[str, ...]
+    tier: str
+    shell: str
+    mode: str
+    inline_budget: int
+    offline: bool
+    base_ref: str | None
+    diff_digest: str
+
+    def matches(self, request: AnalyzerRunKey) -> bool:
+        """Return True when ``request`` may reuse the run recorded under self.
+
+        ``request`` is the incoming ``run_analyzers`` call. Every field must be
+        equal, with one asymmetry: a ``request`` that omits ``base_ref``
+        (``None``) is compatible with a recorded run that named one. ``None`` is
+        the tool's "resolve a base yourself" sentinel, not a value — and because
+        ``diff_digest`` already had to match, the recorded ``base_ref`` is the
+        base of the very diff being scoped. A ``request`` that names a
+        *different* base is not compatible.
+        """
+        if request.base_ref is not None and request.base_ref != self.base_ref:
+            return False
+        return (
+            self.repo_root == request.repo_root
+            and self.changed_files == request.changed_files
+            and self.tier == request.tier
+            and self.shell == request.shell
+            and self.mode == request.mode
+            and self.inline_budget == request.inline_budget
+            and self.offline == request.offline
+            and self.diff_digest == request.diff_digest
+        )
+
+
+def analyzer_run_key(
+    *,
+    repo_root: Path | str,
+    changed_files: list[str],
+    tier: str,
+    shell: str,
+    mode: str,
+    inline_budget: int,
+    offline: bool,
+    base_ref: str | None,
+    diff_text: str,
+) -> AnalyzerRunKey:
+    """Build an :class:`AnalyzerRunKey` from one pipeline call's inputs.
+
+    Both call sites go through this helper so the normalisation stays identical:
+    ``repo_root`` is resolved, ``changed_files`` is de-duplicated and sorted
+    (order never changes the selected manifests), and the diff is reduced to a
+    SHA-256 digest rather than carried whole.
+    """
+    return AnalyzerRunKey(
+        repo_root=str(Path(repo_root).resolve()),
+        changed_files=tuple(sorted({str(path) for path in changed_files})),
+        tier=tier,
+        shell=shell,
+        mode=mode,
+        inline_budget=inline_budget,
+        offline=offline,
+        base_ref=base_ref,
+        diff_digest=hashlib.sha256(diff_text.encode("utf-8")).hexdigest(),
+    )
+
+
 @dataclass(slots=True)
 class AnalyzerRunState:
     ran: bool = False
@@ -175,6 +264,11 @@ class AnalyzerRunState:
     pre_merge_summary: str | None = None
     lockfile_digest: str | None = None
     verified_ids: set[str] = field(default_factory=set)
+    # Inputs this run was computed from, when they were recorded. Set only by
+    # the offline pre-pass (``review/offline_stages.py``); ``None`` everywhere
+    # else — including on the GitHub Action path, which has no pre-pass — so an
+    # unkeyed run is never reused by ``run_analyzers``.
+    key: AnalyzerRunKey | None = None
 
 
 @dataclass(slots=True)

--- a/src/mergecraft/review/offline_stages.py
+++ b/src/mergecraft/review/offline_stages.py
@@ -8,9 +8,11 @@ from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
+from mergecraft.analyzers.budget import default_inline_budget
 from mergecraft.analyzers.pipeline import run_analyzer_pipeline
+from mergecraft.config import load_repo_settings
 from mergecraft.mcp.checkout import changed_paths_in_diff
-from mergecraft.mcp.tool_state import AnalyzerRunState
+from mergecraft.mcp.tool_state import AnalyzerRunState, analyzer_run_key
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -42,15 +44,23 @@ async def run_offline_analyze(
     ``runtime: repo-native`` manifest (see
     :func:`mergecraft.analyzers.trust.evaluate_manifest_for_shell`); raising it
     lets those analyzers execute repo-provided tooling.
+
+    The returned state carries an :class:`~mergecraft.mcp.tool_state.AnalyzerRunKey`
+    describing the inputs it was computed from, so the ``run_analyzers`` MCP tool
+    can reuse this run instead of executing every analyzer a second time over the
+    same diff. A run that failed carries no key — reusing a failure would deny the
+    reviewing agent a retry that might succeed.
     """
     if not analyzers_enabled or materialization.empty:
         return None
     diff_text = materialization.path.read_text(encoding="utf-8")
+    changed_files = changed_paths_in_diff(diff_text)
+    tier = _as_trust_tier(trust_tier)
     pipeline = partial(
         run_analyzer_pipeline,
         repo_root=cwd,
-        changed_files=changed_paths_in_diff(diff_text),
-        tier=_as_trust_tier(trust_tier),
+        changed_files=changed_files,
+        tier=tier,
         diff_text=diff_text,
         offline=True,
         base_ref=materialization.base_ref,
@@ -58,7 +68,23 @@ async def run_offline_analyze(
         mode="auto",
     )
     try:
-        return await asyncio.to_thread(pipeline)
+        state = await asyncio.to_thread(pipeline)
     except Exception as exc:
         logger.warning("offline analyze: pipeline failed — {}", exc)
         return AnalyzerRunState(ran=False, reason=str(exc))
+    # ``inline_budget`` is left unset above, so record the budget the pipeline
+    # itself resolves — the tool passes ``settings.inline_budget`` explicitly and
+    # the two only agree when that value is truthy.
+    settings = load_repo_settings(root=cwd, load_learnings_files=False).analyzers
+    state.key = analyzer_run_key(
+        repo_root=cwd,
+        changed_files=changed_files,
+        tier=tier,
+        shell=str(shell),
+        mode="auto",
+        inline_budget=settings.inline_budget or default_inline_budget(),
+        offline=True,
+        base_ref=materialization.base_ref,
+        diff_text=diff_text,
+    )
+    return state

--- a/tests/mcp/test_analyzer_run_reuse.py
+++ b/tests/mcp/test_analyzer_run_reuse.py
@@ -1,0 +1,309 @@
+"""``run_analyzers`` reuses a recorded pre-pass instead of re-running the pipeline.
+
+An offline ``mergecraft review`` runs the catalog pipeline once as a pre-pass and
+once more when the reviewing agent calls ``run_analyzers``. These tests pin the
+reuse seam: identical inputs must not execute the pipeline twice, and *any*
+keyed input differing — or no pre-pass at all, which is the GitHub Action path —
+must run it exactly as before.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import (
+    AnalyzerRunState,
+    AnalyzerStatusRow,
+    analyzer_run_key,
+    init_tool_state,
+)
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DIFF_TEXT = """diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+
+CHANGED = ["app.py"]
+BASE_REF = "origin/main"
+# ``AnalyzerSettings.inline_budget`` default — no ``.mergecraft/config.yaml``
+# exists under the temporary repo root these tests use.
+INLINE_BUDGET = 8
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    shell: str = "restricted",
+    tier: str = "trusted",
+    mode: str = "auto",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        analyzers_settings_enabled=True,
+        analyzers_mode=mode,  # type: ignore[arg-type]
+        trust_tier=tier,  # type: ignore[arg-type]
+    )
+
+
+def _prepass_state(
+    tmp_path: Path,
+    *,
+    changed_files: list[str] | None = None,
+    tier: str = "trusted",
+    shell: str = "restricted",
+    mode: str = "auto",
+    diff_text: str = DIFF_TEXT,
+    base_ref: str | None = BASE_REF,
+) -> AnalyzerRunState:
+    """A recorded pre-pass result, keyed the way ``run_offline_analyze`` keys it."""
+    state = AnalyzerRunState(
+        ran=True,
+        analyzers=[AnalyzerStatusRow(id="actionlint", status="failed", finding_count=1)],
+        findings=[{"fingerprint": "fp-1", "severity": "Major"}],
+        inline=[{"finding": {"fingerprint": "fp-1"}, "path": "app.py"}],
+        mechanical_section="### 🔧 Mechanical findings",
+        pre_merge_summary="Analyzers | fail",
+        lockfile_digest="sha256:abc",
+    )
+    state.key = analyzer_run_key(
+        repo_root=tmp_path,
+        changed_files=CHANGED if changed_files is None else changed_files,
+        tier=tier,
+        shell=shell,
+        mode=mode,
+        inline_budget=INLINE_BUDGET,
+        offline=True,
+        base_ref=base_ref,
+        diff_text=diff_text,
+    )
+    return state
+
+
+@pytest.fixture
+def diff_path(tmp_path: Path) -> Path:
+    path = tmp_path / "review.diff"
+    path.write_text(DIFF_TEXT, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def pipeline_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Record every ``run_analyzer_pipeline`` invocation and return a fresh run."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake(**kwargs: Any) -> AnalyzerRunState:
+        calls.append(kwargs)
+        return AnalyzerRunState(
+            ran=True,
+            analyzers=[AnalyzerStatusRow(id="actionlint", status="failed", finding_count=1)],
+            findings=[{"fingerprint": "fp-1", "severity": "Major"}],
+            inline=[{"finding": {"fingerprint": "fp-1"}, "path": "app.py"}],
+            mechanical_section="### 🔧 Mechanical findings",
+            pre_merge_summary="Analyzers | fail",
+            lockfile_digest="sha256:abc",
+        )
+
+    monkeypatch.setattr("mergecraft.analyzers.pipeline.run_analyzer_pipeline", _fake)
+    return calls
+
+
+async def _run(ctx: ToolContext, **params: Any) -> dict[str, Any]:
+    from mergecraft.mcp.analyzers import run_analyzers_tool
+
+    result = await run_analyzers_tool(ctx).execute(params)
+    return json.loads(result.content[0]["text"])
+
+
+@pytest.mark.asyncio
+async def test_matching_prepass_is_reused_without_rerunning(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path)
+
+    payload = await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert pipeline_calls == []
+    assert payload["ran"] is True
+    assert payload["findingCount"] == 1
+    assert payload["preMergeSummary"] == "Analyzers | fail"
+    assert payload["lockfileDigest"] == "sha256:abc"
+
+
+@pytest.mark.asyncio
+async def test_changed_file_order_does_not_defeat_reuse(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path, changed_files=["b.py", "a.py"])
+
+    await _run(ctx, changed_files=["a.py", "b.py", "a.py"], diff_path=str(diff_path))
+
+    assert pipeline_calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_prepass_runs_the_pipeline(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    """The GitHub Action path records no pre-pass, so nothing is reused."""
+    ctx = _ctx(tmp_path)
+    assert ctx.tool_state.analyzer_run is None
+
+    payload = await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert len(pipeline_calls) == 1
+    assert pipeline_calls[0]["changed_files"] == CHANGED
+    assert pipeline_calls[0]["inline_budget"] == INLINE_BUDGET
+    assert payload["ran"] is True
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_prior_run_is_never_reused(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    """A run stored by the tool itself (or by ``confirm``) carries no key."""
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = AnalyzerRunState(ran=True)
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert len(pipeline_calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prepass_kwargs", "ctx_kwargs"),
+    [
+        pytest.param({"changed_files": ["other.py"]}, {}, id="changed-files"),
+        pytest.param({"tier": "untrusted"}, {}, id="tier"),
+        pytest.param({"shell": "disabled"}, {}, id="shell"),
+        pytest.param({"mode": "full"}, {}, id="mode"),
+        pytest.param({"diff_text": "diff --git a/other b/other\n"}, {}, id="diff-digest"),
+    ],
+)
+async def test_any_differing_keyed_input_reruns(
+    tmp_path: Path,
+    diff_path: Path,
+    pipeline_calls: list[dict[str, Any]],
+    prepass_kwargs: dict[str, Any],
+    ctx_kwargs: dict[str, Any],
+) -> None:
+    ctx = _ctx(tmp_path, **ctx_kwargs)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path, **prepass_kwargs)
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert len(pipeline_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_repo_root_reruns(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path)
+    other = tmp_path / "other"
+    other.mkdir()
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path), repo_root=str(other))
+
+    assert len(pipeline_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_matching_base_ref_reuses(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path)
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path), base_ref=BASE_REF)
+
+    assert pipeline_calls == []
+
+
+@pytest.mark.asyncio
+async def test_different_explicit_base_ref_reruns(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path)
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path), base_ref="origin/release")
+
+    assert len(pipeline_calls) == 1
+    assert pipeline_calls[0]["base_ref"] == "origin/release"
+
+
+@pytest.mark.asyncio
+async def test_prepass_without_base_ref_is_not_matched_by_an_explicit_one(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path, base_ref=None)
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path), base_ref=BASE_REF)
+
+    assert len(pipeline_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_reused_payload_matches_the_freshly_computed_one(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    fresh = await _run(_ctx(tmp_path), changed_files=CHANGED, diff_path=str(diff_path))
+    assert len(pipeline_calls) == 1
+
+    reusing = _ctx(tmp_path)
+    reusing.tool_state.analyzer_run = _prepass_state(tmp_path)
+    reused = await _run(reusing, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert len(pipeline_calls) == 1
+    assert reused == fresh
+
+
+@pytest.mark.asyncio
+async def test_reuse_preserves_session_verified_ids(
+    tmp_path: Path, diff_path: Path, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.analyzer_run = _prepass_state(tmp_path)
+    ctx.tool_state.verified_ids = {"fp-1"}
+
+    await _run(ctx, changed_files=CHANGED, diff_path=str(diff_path))
+
+    assert pipeline_calls == []
+    stored = ctx.tool_state.analyzer_run
+    assert stored is not None
+    assert "fp-1" in stored.verified_ids

--- a/tests/offline_review/test_result_cache.py
+++ b/tests/offline_review/test_result_cache.py
@@ -11,6 +11,7 @@ import pytest
 import mergecraft.offline_review as offline_mod
 from mergecraft.analyzers.finding import STRUCTURED_OUTPUT_REQUIRED_MSG, make_finding
 from mergecraft.config.settings import RepoSettings
+from mergecraft.mcp.tool_state import AnalyzerRunState
 from mergecraft.offline_review import OfflineReviewResult, _finish_offline_result
 from mergecraft.run_outcome import RunOutcome
 from mergecraft.utils.offline_diff import DiffMaterialization
@@ -77,7 +78,7 @@ def _patch_offline_harness(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "mergecraft.review.offline_stages.run_analyzer_pipeline",
-        lambda **_kwargs: None,
+        lambda **_kwargs: AnalyzerRunState(ran=False, reason="stubbed"),
     )
 
 

--- a/tests/review/test_analyzer_prepass_reuse.py
+++ b/tests/review/test_analyzer_prepass_reuse.py
@@ -1,0 +1,153 @@
+"""The offline pre-pass and the ``run_analyzers`` tool must run the pipeline once.
+
+``_OfflineDiffReviewRun.analyze`` runs the catalog pipeline before the agent
+starts, and the reviewing agent then calls ``run_analyzers`` over the same diff.
+This exercises both halves against one stub pipeline and asserts it executes a
+single time end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
+)
+from mergecraft.mcp.tool_state import AnalyzerRunState, AnalyzerStatusRow, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.review.offline_stages import run_offline_analyze
+from mergecraft.utils.github import GitHubClient
+from mergecraft.utils.offline_diff import DiffMaterialization
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PATCH = "diff --git a/demo.py b/demo.py\n--- a/demo.py\n+++ b/demo.py\n@@ -0,0 +1 @@\n+print(1)\n"
+
+
+def _materialization(out_dir: Path, *, base_ref: str | None = "origin/main") -> DiffMaterialization:
+    path = out_dir / "change.diff"
+    path.write_text(PATCH, encoding="utf-8")
+    return DiffMaterialization(
+        path=path,
+        base_ref=base_ref,
+        line_count=PATCH.count("\n"),
+        empty=False,
+    )
+
+
+def _tool_context(cwd: Path, *, shell: str) -> ToolContext:
+    """The context ``run_offline_agent_review`` builds for the offline agent."""
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="local", name=cwd.name),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown", title="offline diff-review"),
+            shell=shell,  # type: ignore[arg-type]
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="local", name=cwd.name, dir=str(cwd)),
+        mcp_server_url="",
+        tmpdir=str(cwd),
+        analyzers_settings_enabled=True,
+        analyzers_mode="auto",
+        trust_tier="trusted",
+    )
+
+
+@pytest.fixture
+def pipeline_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake(**kwargs: Any) -> AnalyzerRunState:
+        calls.append(kwargs)
+        return AnalyzerRunState(
+            ran=True,
+            analyzers=[AnalyzerStatusRow(id="ruff", status="failed", finding_count=1)],
+            findings=[{"fingerprint": "fp-1"}],
+            pre_merge_summary="Analyzers | fail",
+        )
+
+    monkeypatch.setattr("mergecraft.review.offline_stages.run_analyzer_pipeline", _fake)
+    monkeypatch.setattr("mergecraft.analyzers.pipeline.run_analyzer_pipeline", _fake)
+    return calls
+
+
+async def _call_tool(ctx: ToolContext, **params: Any) -> dict[str, Any]:
+    from mergecraft.mcp.analyzers import run_analyzers_tool
+
+    result = await run_analyzers_tool(ctx).execute(params)
+    return json.loads(result.content[0]["text"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shell", ["disabled", "restricted"])
+async def test_prepass_then_tool_runs_pipeline_once(
+    tmp_path: Path, pipeline_calls: list[dict[str, Any]], shell: str
+) -> None:
+    materialization = _materialization(tmp_path)
+    prepass = await run_offline_analyze(
+        cwd=tmp_path,
+        materialization=materialization,
+        trust_tier="trusted",
+        shell=shell,  # type: ignore[arg-type]
+    )
+    assert prepass is not None
+    assert prepass.key is not None
+    assert len(pipeline_calls) == 1
+
+    ctx = _tool_context(tmp_path, shell=shell)
+    # ``run_offline_agent_review`` hands the pre-pass over via ``_store_run_state``.
+    from mergecraft.mcp.analyzers import _store_run_state
+
+    _store_run_state(ctx, prepass)
+
+    payload = await _call_tool(
+        ctx,
+        changed_files=["demo.py"],
+        diff_path=str(materialization.path),
+    )
+
+    assert len(pipeline_calls) == 1, "the tool must reuse the pre-pass, not re-run the pipeline"
+    assert payload["ran"] is True
+    assert payload["findingCount"] == 1
+    assert payload["preMergeSummary"] == "Analyzers | fail"
+
+
+@pytest.mark.asyncio
+async def test_failed_prepass_is_not_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pipeline_calls: list[dict[str, Any]]
+) -> None:
+    """A pipeline that raised records no key, so the agent still gets a real run."""
+
+    def _boom(**_kwargs: Any) -> AnalyzerRunState:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("mergecraft.review.offline_stages.run_analyzer_pipeline", _boom)
+    materialization = _materialization(tmp_path)
+    prepass = await run_offline_analyze(
+        cwd=tmp_path,
+        materialization=materialization,
+        trust_tier="trusted",
+    )
+    assert prepass is not None
+    assert prepass.ran is False
+    assert prepass.key is None
+
+    ctx = _tool_context(tmp_path, shell="restricted")
+    from mergecraft.mcp.analyzers import _store_run_state
+
+    _store_run_state(ctx, prepass)
+    await _call_tool(ctx, changed_files=["demo.py"], diff_path=str(materialization.path))
+
+    assert len(pipeline_calls) == 1

--- a/tests/review/test_offline_shell_plumbing.py
+++ b/tests/review/test_offline_shell_plumbing.py
@@ -12,6 +12,7 @@ import pytest
 
 from mergecraft.analyzers.registry import load_catalog
 from mergecraft.analyzers.trust import evaluate_manifest_for_shell
+from mergecraft.mcp.tool_state import AnalyzerRunState
 from mergecraft.offline_review import _OfflineDiffReviewRun
 from mergecraft.review.offline_result import OfflineReviewResult
 from mergecraft.review.offline_stages import run_offline_analyze
@@ -35,8 +36,9 @@ def _materialization(tmp_path: Path) -> DiffMaterialization:
 def _capture_pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     seen: dict[str, Any] = {}
 
-    def fake_pipeline(**kwargs: Any) -> None:
+    def fake_pipeline(**kwargs: Any) -> AnalyzerRunState:
         seen.update(kwargs)
+        return AnalyzerRunState(ran=False, reason="stubbed")
 
     monkeypatch.setattr(
         "mergecraft.review.offline_stages.run_analyzer_pipeline",


### PR DESCRIPTION
## What?

An offline review runs the analyzer catalog once instead of twice.

## Why?

`mergecraft review` provisioned tools, executed every eligible analyzer, and produced findings, then did the whole thing again when the reviewing agent asked for analyzer results. The entire skip list, the sandbox capability probe, and each analyzer execution appear twice in the log of a single review. On a large diff that is a second full pass whose output is identical to the first.

The first pass was not wasted work that could simply be deleted. Its result feeds finding placement and the exit codes, so removing it would break severity-based exits. What was missing was any way for the second consumer to tell whether the stored result answered its question, so it recomputed rather than assume.

## Note

Reuse is keyed on everything that can change the outcome: repository root, the changed-file set, trust tier, shell permission, analyzer mode, resolved inline budget, offline flag, base ref, and a digest of the diff. Anything unequal re-runs, because serving a stale result would be worse than the duplicate pass this removes.

One asymmetry is deliberate and documented in the code: a request that omits a base ref matches a recorded run that named one, because omitting it is the tool's "resolve a base yourself" sentinel rather than a value, and the diff digest has already matched. Without that rule the reuse would almost never fire, since the offline prompt tells the agent to pass changed paths and a diff path but never a base ref.

The GitHub Action path has no first pass. Runs it computes itself are never marked reusable, so that path is byte-identical to before and is covered by tests.

Touches two files reserved by the review-convergence plan. Edits there are deliberately minimal, one import and one branch around the existing call, so that lane rebases cleanly.

## Test plan

- [x] `make typecheck` (440 source files) and `make pyright` (0 errors)
- [x] `make test` (5527 passed; the single failure is the generated-package drift that #428 fixes, present on `pre-0.0.1` and unrelated to this change)
- [x] `pytest tests/review tests/mcp tests/offline_review tests/cli -q` (1341 passed)

New tests cover reuse with a matching first pass and no second execution, the Action path running normally without one, a re-run when any keyed input differs, and identical payloads in both paths.

## Related PR(s)/Issue(s)

CI here stays red until #428 merges.
