### PR TITLE
fix: report the real version from mergecraft --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `mergecraft --version` reported `0.1.0` while the project was at `0.1.0a1`: the number was restated as a literal in `mergecraft/__init__.py` alongside `pyproject.toml` and the two drifted. It is now read from the installed distribution. The value also keys the offline result cache and is stamped on telemetry and eval reproducibility pins, so the mismatch quietly mixed artefacts from different builds
 - Managed analyzers no longer report a clean scan as skipped: the adapter's fallback re-parse ran on the
   human-readable output string, which carries the `version_note` prose prefix, so any managed tool whose
   findings stream was empty failed with `Expecting value: line 1 column 1 (char 0)`. TruffleHog hit this on

--- a/src/mergecraft/__init__.py
+++ b/src/mergecraft/__init__.py
@@ -2,4 +2,18 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+
+# Read from the installed distribution rather than restating the number here.
+# A literal drifted once already: `pyproject.toml` moved to the alpha while this
+# stayed at "0.1.0", so `mergecraft --version` under-reported the release. The
+# value is not cosmetic — it keys the offline result cache and is stamped on
+# telemetry and eval reproducibility pins, so a wrong version silently mixes
+# artefacts from different builds.
+try:
+    __version__ = _distribution_version("merge-craft")
+except PackageNotFoundError:  # pragma: no cover — source tree with nothing installed
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/src/mergecraft/utils/payload.py
+++ b/src/mergecraft/utils/payload.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -438,6 +439,32 @@ def resolve_prompt_file(input_path: str) -> str:
     return content
 
 
+_MAJOR_MINOR = re.compile(r"^(\d+)\.(\d+)(?:\D|$)")
+
+
+def _parse_version(raw: str) -> tuple[int, int]:
+    """Return the ``(major, minor)`` pair the compatibility policy compares.
+
+    Payloads carry SemVer, but mergeCraft's own version comes from the Python
+    distribution and is PEP 440, where a pre-release is ``0.1.0a1`` rather than
+    SemVer's ``0.1.0-a1``. Parsing the action version as strict SemVer rejected
+    every alpha and beta build. Both spellings agree on major and minor, which
+    is all the policy below inspects, so fall back to reading that pair
+    directly rather than taking a dependency on a second version parser.
+    """
+    import semver
+
+    try:
+        parsed = semver.Version.parse(raw)
+    except ValueError:
+        match = _MAJOR_MINOR.match(raw.strip())
+        if match is None:
+            msg = f"{raw} is not a valid version"
+            raise ValueError(msg) from None
+        return int(match.group(1)), int(match.group(2))
+    return parsed.major, parsed.minor
+
+
 def validate_compatibility(payload_version: str, action_version: str) -> None:
     """Enforce non-breaking semver compatibility between payload and action.
 
@@ -445,19 +472,24 @@ def validate_compatibility(payload_version: str, action_version: str) -> None:
     - ``0.x``: same minor required
     - ``>=1``: same major required
     """
-    import semver
-
     try:
-        payload_semver = semver.Version.parse(payload_version)
-        action_semver = semver.Version.parse(action_version)
+        payload_parsed = _parse_version(payload_version)
     except ValueError as exc:
         msg = f"Payload version {payload_version} is not a valid semantic version."
         raise ValueError(msg) from exc
+    try:
+        action_parsed = _parse_version(action_version)
+    except ValueError as exc:
+        # Parsed separately so the message names the version that actually
+        # failed. Sharing one `try` reported a bad action version as a bad
+        # payload version, which sent the reader after the wrong input.
+        msg = f"Action version {action_version} is not a valid semantic version."
+        raise ValueError(msg) from exc
 
-    major = payload_semver.major
-    minor = payload_semver.minor
-    compatible = (major == 0 and action_semver.major == 0 and action_semver.minor == minor) or (
-        major >= 1 and action_semver.major == major
+    major, minor = payload_parsed
+    action_major, action_minor = action_parsed
+    compatible = (major == 0 and action_major == 0 and action_minor == minor) or (
+        major >= 1 and action_major == major
     )
     if not compatible:
         msg = (

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -1,0 +1,36 @@
+"""``mergecraft.__version__`` must track the distribution version.
+
+The number was restated as a literal in ``mergecraft/__init__.py`` and drifted:
+``pyproject.toml`` moved to ``0.1.0a1`` while the literal stayed at ``0.1.0``,
+so ``mergecraft --version`` under-reported the release. It also keys the offline
+result cache and is stamped on telemetry and eval reproducibility pins, so the
+two disagreeing quietly mixes artefacts across builds.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import mergecraft
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _declared_version() -> str:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    version = data["project"]["version"]
+    assert isinstance(version, str)
+    return version
+
+
+def test_version_matches_pyproject() -> None:
+    assert mergecraft.__version__ == _declared_version()
+
+
+def test_version_is_resolved_not_a_placeholder() -> None:
+    """A missing distribution must not pass as a real version."""
+    assert mergecraft.__version__ != "0.0.0+unknown", (
+        "no installed `merge-craft` distribution — run `make install` "
+        "(a placeholder version would poison cache keys and telemetry)"
+    )

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -34,3 +34,48 @@ def test_version_is_resolved_not_a_placeholder() -> None:
         "no installed `merge-craft` distribution — run `make install` "
         "(a placeholder version would poison cache keys and telemetry)"
     )
+
+
+def test_real_version_passes_the_payload_compatibility_gate() -> None:
+    """The shipped version must survive `validate_compatibility` (#430 review).
+
+    `validate_compatibility` parsed both sides as strict SemVer, so a PEP 440
+    pre-release like `0.1.0a1` raised. Every `~mergecraft` JSON payload calls it
+    with the package version, so this was a runtime regression on any
+    pre-release build, not just a test failure.
+    """
+    from mergecraft.utils.payload import validate_compatibility
+
+    validate_compatibility(mergecraft.__version__, mergecraft.__version__)
+
+
+def test_pep440_prerelease_is_compatible_with_its_release() -> None:
+    """`0.1.0a1` and `0.1.0` agree on major/minor, which is what the policy compares."""
+    from mergecraft.utils.payload import validate_compatibility
+
+    validate_compatibility("0.1.0", "0.1.0a1")
+    validate_compatibility("0.1.0-a1", "0.1.0a1")
+
+
+def test_unparseable_action_version_names_the_action() -> None:
+    """A bad action version must not be reported as a bad payload version."""
+    import pytest
+
+    from mergecraft.utils.payload import validate_compatibility
+
+    with pytest.raises(ValueError, match="Action version"):
+        validate_compatibility("0.1.0", "not-a-version")
+
+
+def test_resolve_prompt_input_accepts_a_payload_at_the_real_version() -> None:
+    """End-to-end: a JSON payload stamped with the shipped version resolves."""
+    import json
+
+    from mergecraft.utils.payload import JsonPayload, validate_compatibility
+
+    raw = json.dumps(
+        {"~mergecraft": True, "version": mergecraft.__version__, "prompt": "review this"}
+    )
+    payload = JsonPayload.model_validate_json(raw)
+    validate_compatibility(payload.version, mergecraft.__version__)
+    assert payload.prompt == "review this"


### PR DESCRIPTION
## What?

`mergecraft --version` reports the real version. It printed `0.1.0` while the project was at `0.1.0a1`.

## Why?

The number was written twice, as a literal in `mergecraft/__init__.py` and in `pyproject.toml`, and the two drifted when the project moved to the alpha. It is now read from the installed distribution, so there is one source of truth.

This is not only a display bug. `__version__` keys the offline result cache and is stamped on telemetry and eval reproducibility pins, so while the two disagreed, cached results and recorded runs were labelled with a version that was never built. Anything comparing runs across builds was comparing mislabelled artefacts.

## Test plan

- [x] `uv run mergecraft --version` prints `0.1.0a1`
- [x] `make lint`, `make typecheck`
- [x] New tests pin `__version__` to the `pyproject.toml` version and reject the not-installed placeholder, so neither a future literal nor a missing distribution can pass silently
