### PR TITLE
tests: raise coverage to 82%

### DIFF
--- a/tests/agents/test_cov_codex_paths.py
+++ b/tests/agents/test_cov_codex_paths.py
@@ -1,0 +1,929 @@
+"""Error, fallback and guard-clause paths of the Codex harness (issue #431).
+
+Every test here drives the *second* way out of a decision in
+``mergecraft.agents.codex``: a failing subprocess, an unusable credential, a
+skipped fallback candidate, or a malformed provider stream.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from loguru import logger
+from tests.agents.conftest import make_agent_run_context
+
+from mergecraft.agents import codex as codex_module
+from mergecraft.agents._stream_consumer import StreamSpanAccumulator
+from mergecraft.tracing.content import ContentCapture
+from mergecraft.tracing.sinks import MemorySink
+from mergecraft.tracing.tracer import Tracer
+from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+    from mergecraft.agents.shared import AgentRunContext
+
+_HOME_PARENT_ENV = ("MERGECRAFT_CODEX_HOME_PARENT", "RUNNER_TEMP", "GITHUB_WORKSPACE")
+
+
+class _FakeProcess:
+    """``subprocess.Popen`` stand-in delivering a recorded stdout/stderr pair."""
+
+    def __init__(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+        timeout: bool = False,
+    ) -> None:
+        self.stdout: list[str] = stdout.splitlines(keepends=True)
+        self.stderr: Any = self
+        self._stderr_text = stderr
+        self._returncode = returncode
+        self._timeout = timeout
+        self.pid = None
+
+    def read(self) -> str:
+        return self._stderr_text
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self._timeout:
+            raise subprocess.TimeoutExpired(cmd="codex", timeout=1)
+        return self._returncode
+
+
+def _capture_logs() -> tuple[list[tuple[str, str]], int]:
+    records: list[tuple[str, str]] = []
+
+    def _sink(record: Any) -> None:
+        entry = record.record
+        records.append((entry["level"].name, entry["message"]))
+
+    return records, logger.add(_sink, level="DEBUG")
+
+
+def _clear_home_parent_env(monkeypatch: MonkeyPatch) -> None:
+    for key in (*_HOME_PARENT_ENV, "XDG_CACHE_HOME"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _temp_rooted_ctx(tmp_path: Path) -> AgentRunContext:
+    """Context whose tmpdir sits under ``/tmp`` — the relocation trigger."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    ctx.tmpdir = "/tmp/mergecraft-cov431-run"
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# $CODEX_HOME relocation — the fallback ladder when tmpdir is world-writable
+# ---------------------------------------------------------------------------
+
+
+def test_codex_home_keeps_run_tmpdir_when_it_is_not_world_writable(tmp_path: Path) -> None:
+    """A tmpdir outside ``/tmp`` needs no relocation: home is ``<tmpdir>/.codex``."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    assert codex_module._codex_home(ctx) == tmp_path / ".codex"
+
+
+def test_codex_home_parent_skips_env_candidate_that_is_also_world_writable(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A ``/tmp``-rooted override is rejected, not used: Codex would refuse it too."""
+    _clear_home_parent_env(monkeypatch)
+    safe = tmp_path / "runner-temp"
+    monkeypatch.setenv("MERGECRAFT_CODEX_HOME_PARENT", "/tmp/still-world-writable")
+    monkeypatch.setenv("RUNNER_TEMP", str(safe))
+
+    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path))
+
+    assert resolved == safe / "mergecraft-cov431-run"
+
+
+def test_codex_home_parent_skips_candidate_whose_mkdir_fails(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An unusable override (its parent is a regular file) falls through to the next key."""
+    _clear_home_parent_env(monkeypatch)
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("regular file", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("MERGECRAFT_CODEX_HOME_PARENT", str(blocker / "child"))
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path))
+
+    assert resolved == workspace / "mergecraft-cov431-run"
+    assert workspace.is_dir()
+
+
+def test_codex_home_parent_falls_back_to_xdg_cache_when_no_override_is_set(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """With every override empty, home lands under ``$XDG_CACHE_HOME/mergecraft``."""
+    _clear_home_parent_env(monkeypatch)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("RUNNER_TEMP", "   ")
+
+    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path))
+
+    assert resolved == tmp_path / "cache" / "mergecraft" / "mergecraft-cov431-run"
+    assert (tmp_path / "cache" / "mergecraft").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution — malformed, partial and absent CODEX_AUTH_JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("not json at all", None),
+        ('["refresh_token"]', None),
+        ('{"tokens": {"refresh_token": "rt-nested"}}', "rt-nested"),
+        ('{"tokens": {"refresh": "rt-alias"}}', "rt-alias"),
+        ('{"tokens": {"refresh_token": ""}, "refresh": "rt-top"}', "rt-top"),
+        ('{"refresh_token": "rt-flat"}', "rt-flat"),
+        ('{"tokens": {"access_token": "at"}}', None),
+        ('{"refresh_token": 12345}', None),
+    ],
+)
+def test_extract_refresh_token_shapes(raw: str, expected: str | None) -> None:
+    """Refresh extraction reads nested tokens, top-level aliases, and rejects non-strings."""
+    assert codex_module._extract_refresh_token(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "usable"),
+    [
+        ("{not json", False),
+        ('"a string"', False),
+        ("{}", False),
+        ('{"tokens": {}}', False),
+        ('{"tokens": {"access_token": "   "}}', False),
+        ('{"tokens": {"access": "at"}}', True),
+        ('{"access_token": "at"}', True),
+        ('{"refresh_token": "rt"}', True),
+    ],
+)
+def test_codex_subscription_auth_usable_shapes(raw: str, usable: bool) -> None:
+    """Only JSON objects carrying a non-blank access/refresh token count as usable."""
+    assert codex_module._codex_subscription_auth_usable(raw) is usable
+
+
+def test_setup_codex_auth_writes_auth_json_and_records_writeback_state(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Usable subscription JSON is persisted and its refresh token recorded for post-run."""
+    state_file = tmp_path / "github-state"
+    state_file.write_text("", encoding="utf-8")
+    raw = json.dumps({"tokens": {"refresh_token": "rt-1", "access_token": "at-1"}})
+    monkeypatch.setenv(codex_module.CODEX_AUTH_ENV, raw)
+    monkeypatch.setenv("GITHUB_STATE", str(state_file))
+    monkeypatch.setenv("STATE_codex_writeback", "")
+
+    codex_home = tmp_path / "home"
+    codex_module._setup_codex_auth(
+        make_agent_run_context(tmp_path, resolved_model=None), codex_home=codex_home
+    )
+
+    assert json.loads((codex_home / "auth.json").read_text(encoding="utf-8")) == json.loads(raw)
+    line = state_file.read_text(encoding="utf-8").strip()
+    assert line.startswith("codex_writeback=")
+    payload = json.loads(line.removeprefix("codex_writeback="))
+    assert payload == {
+        "authPath": str(codex_home / "auth.json"),
+        "originalRefresh": "rt-1",
+    }
+    import os
+
+    assert json.loads(os.environ["STATE_codex_writeback"]) == payload  # noqa: SIM112
+
+
+def test_setup_codex_auth_skips_writeback_when_auth_has_no_refresh_token(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Access-token-only auth is written, but nothing is staged for the post-run writeback."""
+    state_file = tmp_path / "github-state"
+    state_file.write_text("", encoding="utf-8")
+    monkeypatch.setenv(codex_module.CODEX_AUTH_ENV, '{"access_token": "at-only"}')
+    monkeypatch.setenv("GITHUB_STATE", str(state_file))
+
+    codex_home = tmp_path / "home"
+    codex_module._setup_codex_auth(
+        make_agent_run_context(tmp_path, resolved_model=None), codex_home=codex_home
+    )
+
+    assert (codex_home / "auth.json").read_text(encoding="utf-8") == '{"access_token": "at-only"}'
+    assert state_file.read_text(encoding="utf-8") == ""
+
+
+def test_setup_codex_auth_warns_and_writes_nothing_for_unusable_auth_json(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A set-but-unusable ``CODEX_AUTH_JSON`` must not produce an ``auth.json`` Codex rejects."""
+    monkeypatch.setenv(codex_module.CODEX_AUTH_ENV, "{}")
+    monkeypatch.setenv(codex_module.OPENAI_API_KEY_ENV, "sk-test")
+    records, sink_id = _capture_logs()
+    codex_home = tmp_path / "home"
+    try:
+        codex_module._setup_codex_auth(
+            make_agent_run_context(tmp_path, resolved_model=None), codex_home=codex_home
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert not (codex_home / "auth.json").exists()
+    assert any(
+        level == "WARNING" and codex_module.CODEX_AUTH_ENV in message for level, message in records
+    )
+    assert any(
+        level == "INFO" and codex_module.OPENAI_API_KEY_ENV in message for level, message in records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sandbox selection — operator override, typos, and shell mode
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognised_sandbox_override_is_ignored_with_a_warning(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A typo must not widen the sandbox: the value is dropped, not passed through."""
+    monkeypatch.setenv(codex_module.CODEX_SANDBOX_ENV, "danger-full-acces")
+    records, sink_id = _capture_logs()
+    try:
+        override = codex_module._operator_sandbox_override()
+        mode = codex_module._sandbox_mode(make_agent_run_context(tmp_path, resolved_model=None))
+    finally:
+        logger.remove(sink_id)
+
+    assert override is None
+    assert mode == "read-only"
+    assert any(level == "WARNING" and "ignoring" in message for level, message in records)
+
+
+def test_operator_sandbox_override_accepts_the_documented_value(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The documented opt-out (case-insensitive) disables the nested sandbox."""
+    monkeypatch.setenv(codex_module.CODEX_SANDBOX_ENV, "DANGER-FULL-ACCESS")
+
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    assert codex_module._sandbox_mode(ctx) == codex_module.CODEX_SANDBOX_UNSANDBOXED
+    assert codex_module._codex_use_permission_profiles(ctx) is False
+
+
+def test_shell_enabled_selects_workspace_write_sandbox(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """shell=enabled + MCP → workspace-write with network access, not permission profiles."""
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    ctx.payload.shell = "enabled"
+
+    config = tomllib.loads(
+        Path(codex_module.write_mcp_config(ctx)).read_text(encoding="utf-8"),
+    )
+
+    assert config["sandbox_mode"] == "workspace-write"
+    assert config["sandbox_workspace_write"] == {"network_access": True}
+    assert "permissions" not in config
+
+
+def test_write_mcp_config_without_mcp_url_emits_no_server_table(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No MCP endpoint → legacy read-only sandbox, no server table, no tool preamble."""
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+    monkeypatch.setenv("CI", "true")
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    ctx.mcp_server_url = ""
+    ctx.instructions.system = "SYSTEM PROMPT MARKER"
+
+    config_path = Path(codex_module.write_mcp_config(ctx))
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    instructions = (config_path.parent / "mergecraft-instructions.md").read_text(encoding="utf-8")
+
+    assert config["sandbox_mode"] == "read-only"
+    assert config["approval_policy"] == "never"
+    assert "mcp_servers" not in config
+    assert "sandbox_workspace_write" not in config
+    assert instructions.startswith("SYSTEM PROMPT MARKER")
+    assert "mergeCraft MCP tools (Codex)" not in instructions
+
+
+def test_write_mcp_config_outside_ci_keeps_on_request_approval(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Off the Action path, approvals stay interactive rather than silently ``never``."""
+    monkeypatch.delenv("CI", raising=False)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    config = tomllib.loads(
+        Path(codex_module.write_mcp_config(ctx)).read_text(encoding="utf-8"),
+    )
+
+    assert config["approval_policy"] == "on-request"
+    assert config["mcp_servers"][MERGECRAFT_MCP_NAME]["url"].endswith("/mcp/reviewer")
+    assert config["mcp_servers"][MERGECRAFT_VERIFIER_MCP_NAME]["url"].endswith("/mcp/verifier")
+
+
+def test_empty_custom_provider_env_does_not_emit_a_model_providers_table(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A set-but-empty singleton gateway var is not a configured provider."""
+    monkeypatch.setenv(codex_module.CUSTOM_PROVIDER_BASE_URL_ENV, "")
+    monkeypatch.setenv(codex_module.CUSTOM_PROVIDER_API_KEY_ENV, "   ")
+
+    assert codex_module._has_any_custom_provider_env() is False
+
+    config = tomllib.loads(
+        Path(
+            codex_module.write_mcp_config(make_agent_run_context(tmp_path, resolved_model=None))
+        ).read_text(encoding="utf-8"),
+    )
+
+    assert "model_providers" not in config
+
+
+# ---------------------------------------------------------------------------
+# TOML rendering — hostile values from consumer-supplied env vars
+# ---------------------------------------------------------------------------
+
+
+def test_render_toml_escapes_control_characters_so_the_file_still_parses() -> None:
+    """A control char in a consumer-supplied value must not produce unparseable TOML."""
+    rendered = "\n".join(
+        codex_module._render_toml(
+            {"model_providers": {"gw": {"base_url": 'https://x/\n\t\x07\x7f"q"\\'}}}
+        )
+    )
+
+    assert tomllib.loads(rendered)["model_providers"]["gw"]["base_url"] == (
+        'https://x/\n\t\x07\x7f"q"\\'
+    )
+
+
+def test_render_toml_keeps_scalars_under_their_own_table_header() -> None:
+    """Scalars declared after a nested table stay in the parent table (#222)."""
+    rendered = "\n".join(
+        codex_module._render_toml(
+            {
+                "permissions": {
+                    "network": {"enabled": True},
+                    "extends": ":read-only",
+                    "dotted.key": "quoted",
+                }
+            }
+        )
+    )
+
+    assert tomllib.loads(rendered) == {
+        "permissions": {
+            "extends": ":read-only",
+            "dotted.key": "quoted",
+            "network": {"enabled": True},
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Legacy stdout parsing — empty, non-object and partially malformed streams
+# ---------------------------------------------------------------------------
+
+
+def test_parse_codex_stdout_returns_no_usage_for_an_empty_stream() -> None:
+    """An empty stream is not a zero-token run — usage stays ``None``."""
+    assert codex_module._parse_codex_stdout("   \n  ") == ("", None)
+
+
+def test_parse_codex_stdout_keeps_raw_text_when_the_blob_is_not_an_object() -> None:
+    """A JSON array is not a result payload; the raw text survives as the output."""
+    output, usage = codex_module._parse_codex_stdout("[1, 2]")
+
+    assert output == "[1, 2]"
+    assert usage is None
+
+
+def test_parse_codex_stdout_skips_malformed_lines_and_reads_the_terminal_event() -> None:
+    """Non-JSON noise and non-object lines are skipped; the last event wins."""
+    stdout = "\n".join(
+        [
+            "not json",
+            "[]",
+            "",
+            json.dumps({"type": "message", "content": "ignored earlier message"}),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "result": "final answer",
+                    "usage": {"input_tokens": 10, "cache_read_input_tokens": 5},
+                    "total_cost_usd": 0.25,
+                }
+            ),
+        ]
+    )
+
+    output, usage = codex_module._parse_codex_stdout(stdout)
+
+    assert output == "final answer"
+    assert usage is not None
+    assert usage.input_tokens == 15
+    assert usage.cache_read_tokens == 5
+    assert usage.cost_usd == 0.25
+
+
+def test_parse_codex_payload_reports_cost_only_runs() -> None:
+    """A payload with cost but no token counts still yields usage, not ``None``."""
+    output, usage = codex_module._parse_codex_payload({"message": "done", "total_cost_usd": 0.5})
+
+    assert output == "done"
+    assert usage is not None
+    assert usage.cost_usd == 0.5
+    assert usage.input_tokens == 0
+    assert usage.cache_read_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# Subprocess failure handling
+# ---------------------------------------------------------------------------
+
+
+def _run_once(
+    ctx: AgentRunContext,
+    monkeypatch: MonkeyPatch,
+    process: _FakeProcess | Exception,
+    *,
+    continue_session: bool = False,
+) -> tuple[Any, list[list[str]]]:
+    captured: list[list[str]] = []
+
+    def _fake_spawn(cmd: list[str], **kwargs: object) -> Any:
+        captured.append(list(cmd))
+        if isinstance(process, Exception):
+            raise process
+        return process
+
+    monkeypatch.setattr(codex_module, "spawn_agent_cli", _fake_spawn)
+    result = codex_module._run_codex_once(
+        cli="/usr/bin/codex",
+        prompt="",
+        ctx=ctx,
+        mcp_config="unused",
+        continue_session=continue_session,
+    )
+    return result, captured
+
+
+def test_missing_codex_binary_surfaces_the_spawn_error(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A missing binary is a failed result carrying the OS error, not an exception."""
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        FileNotFoundError("no such file: codex"),
+    )
+
+    assert result.success is False
+    assert result.error == "no such file: codex"
+    assert result.output is None
+
+
+def test_nonzero_exit_without_stderr_names_the_exit_code(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """With no stderr to quote, the error still identifies the failing exit code."""
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        _FakeProcess(stdout="", stderr="   \n", returncode=3),
+    )
+
+    assert result.success is False
+    assert result.error == "codex exited 3"
+    assert result.metadata == {}
+
+
+def test_rate_limited_exit_is_marked_retryable_and_keeps_partial_output(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A 429 exit must be flagged retryable so the chain re-dispatches instead of failing."""
+    stdout = json.dumps({"type": "message.completed", "message": {"content": "partial review"}})
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        _FakeProcess(stdout=stdout, stderr="429 Too Many Requests", returncode=1),
+    )
+
+    assert result.success is False
+    assert result.metadata == {"retryable": True}
+    assert result.error == "429 Too Many Requests"
+    assert result.output == "partial review"
+
+
+def test_nested_sandbox_failure_adds_the_operator_remedy(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """bubblewrap's namespace error is environmental — the error must say how to fix it."""
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        _FakeProcess(
+            stdout="",
+            stderr="bwrap: No permissions to create a new namespace",
+            returncode=1,
+        ),
+    )
+
+    assert result.success is False
+    assert result.error is not None
+    assert codex_module.CODEX_SANDBOX_ENV in result.error
+    assert codex_module.CODEX_SANDBOX_UNSANDBOXED in result.error
+    assert "No permissions to create a new namespace" in result.error
+    assert result.error.startswith("Codex could not start its Linux platform sandbox")
+
+
+def test_codex_timeout_returns_a_timeout_result(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A hung CLI is reported as a timeout rather than raising into the review loop."""
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        _FakeProcess(stdout="", stderr="", returncode=0, timeout=True),
+    )
+
+    assert result.success is False
+    assert result.error == "codex CLI timed out"
+    assert result.usage is None
+
+
+def test_clean_exit_with_no_events_reports_success_and_no_output(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An empty-but-clean stream yields ``output=None``, never an empty-string review."""
+    result, _ = _run_once(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        monkeypatch,
+        _FakeProcess(stdout="\n \n", stderr="", returncode=0),
+    )
+
+    assert result.success is True
+    assert result.output is None
+    assert result.usage is None
+
+
+def test_resume_argv_omits_model_and_carries_the_sandbox_flag(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Without a resolved model and without MCP, argv resumes the last session bare."""
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    ctx.mcp_server_url = ""
+    ctx.instructions.user = "fallback prompt"
+
+    _, captured = _run_once(
+        ctx,
+        monkeypatch,
+        _FakeProcess(stdout="", stderr="", returncode=0),
+        continue_session=True,
+    )
+
+    assert captured[0] == [
+        "/usr/bin/codex",
+        "exec",
+        "--json",
+        "--sandbox",
+        "read-only",
+        "resume",
+        "--last",
+        "fallback prompt",
+    ]
+
+
+def test_permission_profile_runs_omit_the_sandbox_flag(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Read-only + MCP is owned by the config profile: ``--sandbox`` must not be passed."""
+    monkeypatch.delenv(codex_module.CODEX_SANDBOX_ENV, raising=False)
+    ctx = make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+    _, captured = _run_once(ctx, monkeypatch, _FakeProcess(stdout="", stderr="", returncode=0))
+
+    assert "--sandbox" not in captured[0]
+    assert captured[0][:6] == [
+        "/usr/bin/codex",
+        "exec",
+        "--json",
+        "--model",
+        "gpt-5.3-codex",
+        "review this diff",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI discovery
+# ---------------------------------------------------------------------------
+
+
+async def test_install_falls_back_to_a_locally_installed_binary(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No ``codex`` on PATH → the node_modules binary under the temp dir is used."""
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", str(tmp_path))
+    local = tmp_path / "node_modules" / ".bin" / "codex"
+    local.parent.mkdir(parents=True)
+    local.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    assert await codex_module._install(None) == str(local)
+
+
+async def test_install_raises_an_actionable_error_when_no_binary_exists(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """With no binary anywhere, the error names the package to install."""
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", str(tmp_path))
+
+    with pytest.raises(FileNotFoundError, match="@openai/codex"):
+        await codex_module._install(None)
+
+
+# ---------------------------------------------------------------------------
+# NDJSON event handler — tracer-live and tracer-absent decision paths
+# ---------------------------------------------------------------------------
+
+
+def _events_of(sink: MemorySink, kind: str) -> list[dict[str, Any]]:
+    return [event.attrs for event in sink.events if event.kind == kind]
+
+
+def _handler_with_tracer(
+    *,
+    capture_policy: ContentCapture | None = None,
+) -> tuple[Any, Any, MemorySink, StreamSpanAccumulator]:
+    sink = MemorySink()
+    tracer = Tracer(sink=sink, session_id="session-431", run_id="run-431")
+    handler, close_all = codex_module._codex_stream_event_handler(
+        tracer=tracer,
+        model_id="gpt-5.3-codex",
+        capture_policy=capture_policy,
+    )
+    return handler, close_all, sink, StreamSpanAccumulator(agent_name="codex")
+
+
+def test_handler_without_a_tracer_still_accumulates_output_and_usage() -> None:
+    """Tracing off must not cost the run its output: the accumulator is still fed."""
+    handler, close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(accumulator, {"type": "item.started", "item": {"type": "tool_call", "id": "c1"}})
+    handler(accumulator, {"type": "message.completed", "message": {"content": "verdict"}})
+    handler(
+        accumulator,
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 7, "output_tokens": 3},
+            "total_cost_usd": 0.125,
+        },
+    )
+    close_all()
+
+    usage = accumulator.to_usage()
+    assert accumulator.final_output == "verdict"
+    assert usage is not None
+    assert (usage.input_tokens, usage.output_tokens, usage.cost_usd) == (7, 3, 0.125)
+
+
+def test_handler_reads_a_legacy_untyped_result_blob() -> None:
+    """A pre-streaming single-blob payload (no ``type``) still yields output and usage."""
+    handler, close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+
+    handler(
+        accumulator,
+        {"result": "legacy verdict", "usage": {"input_tokens": 4, "output_tokens": 2}},
+    )
+    close_all()
+
+    usage = accumulator.to_usage()
+    assert accumulator.final_output == "legacy verdict"
+    assert usage is not None
+    assert (usage.input_tokens, usage.output_tokens) == (4, 2)
+
+
+def test_tool_call_span_carries_the_name_and_input_from_the_completed_event() -> None:
+    """codex sends the tool input on ``item.completed``; the span must pick it up there."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(
+        accumulator,
+        {"type": "item.started", "item": {"type": "tool_call", "id": "call-1", "name": "shell"}},
+    )
+    handler(
+        accumulator,
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "tool_call",
+                "id": "call-1",
+                "name": "mergecraft_checkout_pr",
+                "input": '{"pr": 431}',
+            },
+        },
+    )
+    handler(accumulator, {"type": "item.completed", "item": {"type": "tool_result", "id": "x"}})
+    close_all()
+
+    tool_spans = _events_of(sink, "tool.call")
+    assert len(tool_spans) == 1
+    attrs = tool_spans[0]
+    assert attrs["tool.name"] == "mergecraft_checkout_pr"
+    assert attrs["gen_ai.tool.name"] == "mergecraft_checkout_pr"
+    assert attrs["gen_ai.tool.call.id"] == "call-1"
+    assert attrs["tool.input"] == '{"pr": 431}'
+
+
+def test_tool_call_without_an_id_opens_no_span() -> None:
+    """An id-less tool_call cannot be correlated to its result — it must be dropped."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "item.started", "item": {"type": "tool_call", "name": "shell"}})
+    handler(accumulator, {"type": "item.started", "item": "not-a-dict"})
+    handler(accumulator, {"type": "item.started", "item": {"type": "reasoning"}})
+    close_all()
+
+    assert _events_of(sink, "tool.call") == []
+
+
+def test_completed_tool_call_with_no_open_span_is_ignored() -> None:
+    """A completion for a tool call we never saw start must not fabricate a span."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+
+    handler(
+        accumulator,
+        {"type": "item.completed", "item": {"type": "tool_call", "id": "ghost"}},
+    )
+    close_all()
+
+    assert _events_of(sink, "tool.call") == []
+
+
+def test_repeated_thread_started_does_not_open_a_second_llm_span() -> None:
+    """One thread means one ``llm.call`` row, however many ``thread.started`` events arrive."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(accumulator, {"type": "turn.completed", "usage": {"input_tokens": 1}})
+    close_all()
+
+    llm_spans = _events_of(sink, "llm.call")
+    assert len(llm_spans) == 1
+    assert llm_spans[0]["gen_ai.request.model"] == "gpt-5.3-codex"
+    assert llm_spans[0]["mergecraft.reasoning_effort"] == "high"
+    assert len(_events_of(sink, "provider.call")) == 1
+
+
+def test_turn_completed_records_reasoning_tokens_and_replaces_usage() -> None:
+    """Reasoning tokens are usage metadata and must survive onto the llm span."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+    accumulator.absorb_usage({"input_tokens": 999})
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(
+        accumulator,
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 5,
+                "output_tokens_details": {"reasoning_tokens": 4},
+            },
+            "total_cost_usd": 0.75,
+        },
+    )
+    close_all()
+
+    usage = accumulator.to_usage()
+    assert usage is not None
+    assert usage.input_tokens == 20
+    assert usage.cost_usd == 0.75
+    assert _events_of(sink, "llm.call")[0]["mergecraft.usage.reasoning_tokens"] == 4
+
+
+def test_turn_completed_ignores_a_cost_without_usage() -> None:
+    """A cost with no usage payload is not authoritative and must not be recorded."""
+    handler, close_all, _sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(accumulator, {"type": "turn.completed", "total_cost_usd": 9.99})
+    close_all()
+
+    assert accumulator.cost_usd is None
+
+
+def test_reasoning_and_output_are_captured_only_under_a_content_policy() -> None:
+    """``capture_policy=None`` keeps payload attrs off the span; FULL turns them on."""
+    handler, close_all, sink, accumulator = _handler_with_tracer(capture_policy=None)
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(
+        accumulator,
+        {"type": "item.completed", "item": {"type": "reasoning", "text": "secret plan"}},
+    )
+    handler(accumulator, {"type": "message.completed", "message": {"content": "verdict"}})
+    handler(accumulator, {"type": "turn.completed", "usage": {"input_tokens": 1}})
+    close_all()
+
+    ungated = _events_of(sink, "llm.call")[0]
+    assert "mergecraft.thinking" not in ungated
+    assert "gen_ai.output.messages" not in ungated
+
+    handler, close_all, sink, accumulator = _handler_with_tracer(capture_policy=ContentCapture.FULL)
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(
+        accumulator,
+        {"type": "item.completed", "item": {"type": "reasoning", "text": "secret plan"}},
+    )
+    handler(accumulator, {"type": "item.completed", "item": {"type": "reasoning", "text": 17}})
+    handler(accumulator, {"type": "message.completed", "message": {"content": "verdict"}})
+    handler(accumulator, {"type": "turn.completed", "usage": {"input_tokens": 1}})
+    close_all()
+
+    gated = _events_of(sink, "llm.call")[0]
+    assert gated["mergecraft.thinking"] == "secret plan"
+    assert "verdict" in json.dumps(gated["gen_ai.output.messages"])
+    assert accumulator.final_output == "verdict"
+
+
+def test_empty_message_completed_does_not_overwrite_the_output() -> None:
+    """A blank ``message.completed`` must not erase the text already accumulated."""
+    handler, close_all, _sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "message.completed", "message": {"content": "real verdict"}})
+    handler(accumulator, {"type": "message.completed", "message": {"content": ""}})
+    handler(accumulator, {"type": "message.completed", "message": "not-a-dict"})
+    close_all()
+
+    assert accumulator.final_output == "real verdict"
+
+
+def test_close_all_flushes_spans_left_open_by_a_truncated_stream() -> None:
+    """A stream that dies mid-tool-call still emits both spans, not a silent gap."""
+    handler, close_all, sink, accumulator = _handler_with_tracer()
+
+    handler(accumulator, {"type": "thread.started", "thread_id": "t1"})
+    handler(
+        accumulator,
+        {"type": "item.started", "item": {"type": "tool_call", "id": "call-1", "name": "shell"}},
+    )
+    assert _events_of(sink, "tool.call") == []
+
+    close_all()
+
+    assert [attrs["tool.name"] for attrs in _events_of(sink, "tool.call")] == ["shell"]
+    assert len(_events_of(sink, "llm.call")) == 1

--- a/tests/agents/test_cov_codex_paths.py
+++ b/tests/agents/test_cov_codex_paths.py
@@ -75,10 +75,24 @@ def _clear_home_parent_env(monkeypatch: MonkeyPatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
-def _temp_rooted_ctx(tmp_path: Path) -> AgentRunContext:
-    """Context whose tmpdir sits under ``/tmp`` — the relocation trigger."""
+def _pin_forbidden_root(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    """Treat only ``tmp_path/forbidden-tmp`` as world-writable.
+
+    Pytest's ``tmp_path`` lives under ``/tmp`` on GitHub Actions, so the
+    production forbidden-root list would also reject a *safe* candidate
+    placed next to it. A synthetic root keeps both sides of the ladder
+    inside ``tmp_path``.
+    """
+    root = tmp_path / "forbidden-tmp"
+    root.mkdir()
+    monkeypatch.setattr(codex_module, "_FORBIDDEN_TEMP_ROOTS", (str(root),))
+    return root
+
+
+def _temp_rooted_ctx(tmp_path: Path, *, tmpdir: Path | None = None) -> AgentRunContext:
+    """Context whose tmpdir sits under a forbidden temp root."""
     ctx = make_agent_run_context(tmp_path, resolved_model=None)
-    ctx.tmpdir = "/tmp/mergecraft-cov431-run"
+    ctx.tmpdir = str(tmpdir) if tmpdir is not None else "/tmp/mergecraft-cov431-run"
     return ctx
 
 
@@ -87,8 +101,11 @@ def _temp_rooted_ctx(tmp_path: Path) -> AgentRunContext:
 # ---------------------------------------------------------------------------
 
 
-def test_codex_home_keeps_run_tmpdir_when_it_is_not_world_writable(tmp_path: Path) -> None:
-    """A tmpdir outside ``/tmp`` needs no relocation: home is ``<tmpdir>/.codex``."""
+def test_codex_home_keeps_run_tmpdir_when_it_is_not_world_writable(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A tmpdir outside a forbidden root needs no relocation: home is ``<tmpdir>/.codex``."""
+    monkeypatch.setattr(codex_module, "_FORBIDDEN_TEMP_ROOTS", ())
     ctx = make_agent_run_context(tmp_path, resolved_model=None)
 
     assert codex_module._codex_home(ctx) == tmp_path / ".codex"
@@ -98,13 +115,18 @@ def test_codex_home_parent_skips_env_candidate_that_is_also_world_writable(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """A ``/tmp``-rooted override is rejected, not used: Codex would refuse it too."""
+    """A forbidden-root override is rejected, not used: Codex would refuse it too."""
     _clear_home_parent_env(monkeypatch)
+    forbidden = _pin_forbidden_root(tmp_path, monkeypatch)
+    run_dir = forbidden / "mergecraft-cov431-run"
+    run_dir.mkdir()
+    override = forbidden / "still-world-writable"
+    override.mkdir()
     safe = tmp_path / "runner-temp"
-    monkeypatch.setenv("MERGECRAFT_CODEX_HOME_PARENT", "/tmp/still-world-writable")
+    monkeypatch.setenv("MERGECRAFT_CODEX_HOME_PARENT", str(override))
     monkeypatch.setenv("RUNNER_TEMP", str(safe))
 
-    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path))
+    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path, tmpdir=run_dir))
 
     assert resolved == safe / "mergecraft-cov431-run"
 
@@ -115,13 +137,16 @@ def test_codex_home_parent_skips_candidate_whose_mkdir_fails(
 ) -> None:
     """An unusable override (its parent is a regular file) falls through to the next key."""
     _clear_home_parent_env(monkeypatch)
+    forbidden = _pin_forbidden_root(tmp_path, monkeypatch)
+    run_dir = forbidden / "mergecraft-cov431-run"
+    run_dir.mkdir()
     blocker = tmp_path / "not-a-dir"
     blocker.write_text("regular file", encoding="utf-8")
     workspace = tmp_path / "workspace"
     monkeypatch.setenv("MERGECRAFT_CODEX_HOME_PARENT", str(blocker / "child"))
     monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
 
-    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path))
+    resolved = codex_module._safe_codex_home_parent(_temp_rooted_ctx(tmp_path, tmpdir=run_dir))
 
     assert resolved == workspace / "mergecraft-cov431-run"
     assert workspace.is_dir()

--- a/tests/agents/test_cov_gemini_paths.py
+++ b/tests/agents/test_cov_gemini_paths.py
@@ -1,0 +1,845 @@
+"""Error, guard, and degraded-output paths in ``mergecraft.agents.gemini``.
+
+The existing gemini suite drives the happy path (CLI on PATH, well-formed
+single-blob JSON, exit 0). This module drives the other way out of each
+decision: missing/blank/malformed credentials, a CLI that is not installed,
+a non-zero exit, a timeout, truncated or non-object stream output, and every
+stream event shape whose tracer-disabled branch was never exercised.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+from mergecraft.agents import gemini as gemini_mod
+from mergecraft.agents._stream_consumer import StreamSpanAccumulator
+from mergecraft.types import MERGECRAFT_MCP_NAME
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+class _FakeStderr:
+    """Stand-in for ``Popen.stderr`` — a single blocking ``read()``."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+class _FakeProcess:
+    """``subprocess.Popen`` look-alike for the gemini streaming read loop."""
+
+    def __init__(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+    ) -> None:
+        self.stdout: list[str] = stdout.splitlines(keepends=True)
+        self.stderr = _FakeStderr(stderr)
+        self.returncode = returncode
+        self.pid = 999_001
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self.returncode
+
+
+def _spawn(process: _FakeProcess) -> Any:
+    def _fake_spawn(cmd: list[str], **kwargs: object) -> _FakeProcess:
+        del cmd, kwargs
+        return process
+
+    return _fake_spawn
+
+
+@pytest.fixture
+def disable_tracing(monkeypatch: MonkeyPatch) -> None:
+    """Force the tracer-disabled branch of ``_run_gemini_streaming``."""
+    monkeypatch.setattr(
+        "mergecraft.tracing.sinks.claim_sink",
+        lambda _resolved: None,
+    )
+
+
+def _tracer() -> tuple[Any, Any]:
+    from mergecraft.tracing import MemorySink, Tracer
+
+    sink = MemorySink()
+    return sink, Tracer(sink=sink, session_id="gem-session", run_id="gem-run")
+
+
+def _spans(sink: Any, kind: str) -> list[Any]:
+    return [event for event in sink.events if getattr(event, "kind", None) == kind]
+
+
+def _written_settings(config_path: str) -> dict[str, Any]:
+    """Load the ``settings.json`` ``write_mcp_config`` reports it wrote."""
+    from pathlib import Path as _Path
+
+    loaded: Any = json.loads(_Path(config_path).read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+# ---------------------------------------------------------------------------
+# _strip_provider_prefix — the `slash > 0` guard
+# ---------------------------------------------------------------------------
+
+
+def test_strip_provider_prefix_only_strips_a_real_provider_segment() -> None:
+    """A leading slash is not a provider prefix, so the specifier survives whole."""
+    assert gemini_mod._strip_provider_prefix("google/gemini-3.1-pro") == "gemini-3.1-pro"
+    assert gemini_mod._strip_provider_prefix("gemini-3.1-pro") == "gemini-3.1-pro"
+    # slash at index 0 → `slash > 0` is False; stripping here would produce
+    # the model id "gemini-3.1-pro" from a specifier with an empty provider.
+    assert gemini_mod._strip_provider_prefix("/gemini-3.1-pro") == "/gemini-3.1-pro"
+
+
+def test_strip_provider_prefix_keeps_nested_model_ids_intact() -> None:
+    """Only the first segment is a provider — nested ids keep their slashes."""
+    assert gemini_mod._strip_provider_prefix("vertex/publishers/google/gemini") == (
+        "publishers/google/gemini"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _install / ctx_tmpdir_fallback — CLI absent from PATH
+# ---------------------------------------------------------------------------
+
+
+async def test_install_falls_back_to_a_locally_vendored_cli(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``gemini`` off PATH but vendored under the temp dir resolves to the vendored path."""
+    monkeypatch.setattr(gemini_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", str(tmp_path))
+    local = tmp_path / "node_modules" / ".bin" / "gemini"
+    local.parent.mkdir(parents=True)
+    local.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    assert await gemini_mod._install(None) == str(local)
+
+
+async def test_install_raises_with_an_actionable_message_when_cli_is_absent(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Neither PATH nor the vendored path resolves → a named install instruction."""
+    monkeypatch.setattr(gemini_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", str(tmp_path))
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        await gemini_mod._install(None)
+
+    assert "@google/gemini-cli" in str(excinfo.value)
+
+
+def test_ctx_tmpdir_fallback_prefers_the_configured_temp_dir(monkeypatch: MonkeyPatch) -> None:
+    """An empty ``MERGECRAFT_TEMP_DIR`` is treated as unset, not as an empty path."""
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", "/scratch/run-1")
+    assert gemini_mod.ctx_tmpdir_fallback() == "/scratch/run-1"
+
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", "")
+    assert gemini_mod.ctx_tmpdir_fallback() == "/tmp"
+
+    monkeypatch.delenv("MERGECRAFT_TEMP_DIR", raising=False)
+    assert gemini_mod.ctx_tmpdir_fallback() == "/tmp"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_gemini_api_key — credential resolution when the primary is
+# absent, blank, or whitespace-only
+# ---------------------------------------------------------------------------
+
+
+def test_blank_gemini_key_is_replaced_by_the_google_alias() -> None:
+    """A whitespace-only primary key must not shadow a usable alias."""
+    env = {
+        gemini_mod.GEMINI_API_KEY_ENV: "   ",
+        gemini_mod.GOOGLE_GENERATIVE_AI_API_KEY_ENV: "alias-key",
+    }
+    gemini_mod._normalize_gemini_api_key(env)
+    assert env[gemini_mod.GEMINI_API_KEY_ENV] == "alias-key"
+
+
+def test_present_gemini_key_wins_over_the_google_alias() -> None:
+    """A real primary key is never overwritten by the alias."""
+    env = {
+        gemini_mod.GEMINI_API_KEY_ENV: "primary-key",
+        gemini_mod.GOOGLE_GENERATIVE_AI_API_KEY_ENV: "alias-key",
+    }
+    gemini_mod._normalize_gemini_api_key(env)
+    assert env[gemini_mod.GEMINI_API_KEY_ENV] == "primary-key"
+
+
+def test_no_credential_at_all_leaves_the_key_unset() -> None:
+    """A blank alias must not materialise an empty ``GEMINI_API_KEY`` entry."""
+    env = {gemini_mod.GOOGLE_GENERATIVE_AI_API_KEY_ENV: "  "}
+    gemini_mod._normalize_gemini_api_key(env)
+    assert gemini_mod.GEMINI_API_KEY_ENV not in env
+
+
+def test_build_env_normalizes_the_alias_into_the_child_env(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``_build_env`` hands the child a HOME under the run dir and a resolved key."""
+    monkeypatch.delenv(gemini_mod.GEMINI_API_KEY_ENV, raising=False)
+    monkeypatch.setenv(gemini_mod.GOOGLE_GENERATIVE_AI_API_KEY_ENV, "alias-key")
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    env = gemini_mod._build_env(ctx)
+
+    assert env["HOME"] == str(tmp_path)
+    assert env[gemini_mod.GEMINI_API_KEY_ENV] == "alias-key"
+
+
+# ---------------------------------------------------------------------------
+# _parse_gemini_payload / _parse_gemini_stdout — malformed and partial output
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stdout_yields_no_output_and_no_usage() -> None:
+    """A provider that printed nothing must not fabricate an empty-string usage record."""
+    assert gemini_mod._parse_gemini_stdout("   \n  \n") == ("", None)
+
+
+def test_truncated_json_is_returned_verbatim_without_usage() -> None:
+    """A cut-off blob is surfaced as raw text, not silently dropped."""
+    truncated = '{"result": "half a rev'
+    output, usage = gemini_mod._parse_gemini_stdout(truncated)
+    assert output == truncated
+    assert usage is None
+
+
+def test_non_object_json_stdout_is_treated_as_plain_text() -> None:
+    """A top-level JSON array is not a payload — the raw text stands in."""
+    output, usage = gemini_mod._parse_gemini_stdout('["a", "b"]')
+    assert output == '["a", "b"]'
+    assert usage is None
+
+
+def test_ndjson_scan_stops_at_the_terminal_result_event() -> None:
+    """The last terminal event wins; malformed and blank lines are skipped."""
+    stdout = "\n".join(
+        [
+            "not json at all",
+            "",
+            json.dumps({"result": "earlier", "usage": {"input_tokens": 1}}),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "result": "final answer",
+                    "usage": {"input_tokens": 11, "output_tokens": 7},
+                }
+            ),
+        ]
+    )
+    output, usage = gemini_mod._parse_gemini_stdout(stdout)
+
+    assert output == "final answer"
+    assert usage is not None
+    assert usage.input_tokens == 11
+    assert usage.output_tokens == 7
+
+
+def test_ndjson_event_without_text_leaves_the_raw_transcript_as_output() -> None:
+    """A usage-only trailing event must not blank the output."""
+    stdout = json.dumps({"type": "result", "usage": {"output_tokens": 3}})
+    output, usage = gemini_mod._parse_gemini_stdout(stdout)
+
+    # Single-line stdout parses as a dict on the fast path, so `result`/
+    # `output`/`response` are all absent and the output is the empty string.
+    assert output == ""
+    assert usage is not None
+    assert usage.output_tokens == 3
+
+
+def test_payload_camel_case_usage_aliases_are_summed_into_input_tokens() -> None:
+    """camelCase aliases feed the same totals as the snake_case fields."""
+    output, usage = gemini_mod._parse_gemini_payload(
+        {
+            "response": "camel review",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 4,
+                "cacheReadTokens": 5,
+                "cacheWriteTokens": 2,
+            },
+        }
+    )
+
+    assert output == "camel review"
+    assert usage is not None
+    assert usage.input_tokens == 17  # 10 + 5 + 2
+    assert usage.output_tokens == 4
+    assert usage.cache_read_tokens == 5
+    assert usage.cache_write_tokens == 2
+    assert usage.cost_usd is None
+
+
+def test_payload_with_cost_only_still_reports_usage() -> None:
+    """A cost-bearing payload with no token counts is a usage record, not ``None``."""
+    _output, usage = gemini_mod._parse_gemini_payload({"total_cost_usd": 0.25})
+
+    assert usage is not None
+    assert usage.cost_usd == pytest.approx(0.25)
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+    assert usage.cache_read_tokens is None
+
+
+def test_payload_without_usage_or_cost_reports_no_usage() -> None:
+    """No usage and no cost → ``None``, never a zeroed record."""
+    output, usage = gemini_mod._parse_gemini_payload({"output": "text only"})
+    assert output == "text only"
+    assert usage is None
+
+
+# ---------------------------------------------------------------------------
+# write_mcp_config — the empty-deny-list and no-auth-token branches
+# ---------------------------------------------------------------------------
+
+
+def test_settings_omit_exclude_tools_when_nothing_is_denied(tmp_path: Path) -> None:
+    """An empty deny list must not emit an empty ``excludeTools`` array.
+
+    An empty array is a different instruction to the CLI than an absent key.
+    """
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    settings = _written_settings(gemini_mod.write_mcp_config(ctx))
+    server = settings["mcpServers"][MERGECRAFT_MCP_NAME]
+
+    assert "excludeTools" not in server
+    assert server["trust"] is True
+    assert server["httpUrl"] == ctx.mcp_server_url
+    assert settings["context"]["fileName"] == "GEMINI.md"
+
+
+def test_settings_omit_headers_when_no_mcp_token_was_issued(tmp_path: Path) -> None:
+    """A dev run without a per-run MCP token emits no ``headers`` block at all."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    assert not ctx.mcp_auth_token
+
+    settings = _written_settings(gemini_mod.write_mcp_config(ctx))
+
+    assert "headers" not in settings["mcpServers"][MERGECRAFT_MCP_NAME]
+
+
+def test_settings_carry_the_bearer_header_when_a_token_is_issued(tmp_path: Path) -> None:
+    """A per-run token becomes the MCP ``Authorization`` header."""
+    from dataclasses import replace
+
+    ctx = replace(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        mcp_auth_token="run-token",
+    )
+    settings = _written_settings(gemini_mod.write_mcp_config(ctx))
+
+    assert settings["mcpServers"][MERGECRAFT_MCP_NAME]["headers"] == {
+        "Authorization": "Bearer run-token"
+    }
+
+
+def test_rendered_subagent_block_replaces_the_built_in_roster(tmp_path: Path) -> None:
+    """A rendered roster is written verbatim — the default prompts are not appended."""
+    from dataclasses import replace
+
+    ctx = replace(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        instructions=_instructions("SYSTEM RULES"),
+    )
+    gemini_mod.write_mcp_config(ctx, subagent_block="ROSTER BLOCK")
+    written = (tmp_path / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
+
+    assert written == "SYSTEM RULES\n\nROSTER BLOCK"
+    assert "mergecraft-reviewer" not in written
+
+
+def _instructions(system: str) -> Any:
+    from mergecraft.agents.shared import ResolvedInstructions
+
+    return ResolvedInstructions(system=system, user="review this diff")
+
+
+def test_default_instruction_text_lists_both_read_only_subagents(tmp_path: Path) -> None:
+    """With no rendered roster, the built-in reviewer + verifier prompts are written."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    gemini_mod.write_mcp_config(ctx)
+    written = (tmp_path / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
+
+    assert gemini_mod.REVIEWER_AGENT_NAME in written
+    assert gemini_mod.VERIFIER_AGENT_NAME in written
+    assert written.startswith("Registered read-only subagents")
+
+
+# ---------------------------------------------------------------------------
+# _run_gemini_once — argv assembly under flag combinations
+# ---------------------------------------------------------------------------
+
+
+def test_argv_omits_model_and_yes_flag_and_adds_resume_for_a_session_continuation(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """No resolved model + not CI + resume → no ``-m``, no ``-y``, ``--resume latest``."""
+    monkeypatch.delenv("CI", raising=False)
+    captured: dict[str, Any] = {}
+
+    def _fake_streaming(*, cmd: list[str], ctx: Any, model: str | None) -> Any:
+        captured["cmd"] = cmd
+        captured["model"] = model
+        return gemini_mod.AgentResult(success=True, output="ok")
+
+    monkeypatch.setattr(gemini_mod, "_run_gemini_streaming", _fake_streaming)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_once(
+        cli="/usr/bin/gemini",
+        prompt="follow up please",
+        ctx=ctx,
+        mcp_config="",
+        continue_session=True,
+    )
+
+    cmd = captured["cmd"]
+    assert captured["model"] is None
+    assert "-m" not in cmd
+    assert "-y" not in cmd
+    assert cmd[cmd.index("--resume") + 1] == "latest"
+    assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+    assert "follow up please" in cmd[cmd.index("-p") + 1]
+    assert result.success is True
+
+
+def test_argv_strips_the_provider_prefix_from_the_model_flag(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """The CLI receives the bare model id, not the ``provider/model`` specifier."""
+    monkeypatch.setenv("CI", "true")
+    captured: dict[str, Any] = {}
+
+    def _fake_streaming(*, cmd: list[str], ctx: Any, model: str | None) -> Any:
+        captured["cmd"] = cmd
+        return gemini_mod.AgentResult(success=True)
+
+    monkeypatch.setattr(gemini_mod, "_run_gemini_streaming", _fake_streaming)
+    ctx = make_agent_run_context(tmp_path, resolved_model="google/gemini-3.1-pro")
+
+    gemini_mod._run_gemini_once(cli="gemini", prompt="", ctx=ctx, mcp_config="")
+
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("-m") + 1] == "gemini-3.1-pro"
+    assert "-y" in cmd
+
+
+def test_empty_prompt_falls_back_to_the_context_user_instruction(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """An empty ``prompt`` argument reuses ``ctx.instructions.user``."""
+    monkeypatch.delenv("CI", raising=False)
+    captured: dict[str, Any] = {}
+
+    def _fake_streaming(*, cmd: list[str], ctx: Any, model: str | None) -> Any:
+        captured["cmd"] = cmd
+        return gemini_mod.AgentResult(success=True)
+
+    monkeypatch.setattr(gemini_mod, "_run_gemini_streaming", _fake_streaming)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    gemini_mod._run_gemini_once(cli="gemini", prompt="", ctx=ctx, mcp_config="")
+
+    assert "review this diff" in captured["cmd"][captured["cmd"].index("-p") + 1]
+
+
+# ---------------------------------------------------------------------------
+# _run_gemini_streaming — spawn failure, timeout, non-zero exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_streaming_returns_a_failed_result_when_the_cli_cannot_be_spawned(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A missing binary is a failed ``AgentResult``, never a raised ``FileNotFoundError``."""
+
+    def _boom(cmd: list[str], **kwargs: object) -> Any:
+        del cmd, kwargs
+        msg = "no such file: gemini"
+        raise FileNotFoundError(msg)
+
+    monkeypatch.setattr(gemini_mod, "spawn_agent_cli", _boom)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is False
+    assert result.error == "no such file: gemini"
+    assert result.output is None
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_streaming_reports_a_timeout_as_a_clean_failed_result(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``TimeoutExpired`` from the group wait becomes a named failure, not a traceback."""
+    monkeypatch.setattr(gemini_mod, "spawn_agent_cli", _spawn(_FakeProcess(stdout="")))
+
+    def _timeout(process: Any, *, timeout: float | None) -> int:
+        del process, timeout
+        raise subprocess.TimeoutExpired(cmd="gemini", timeout=1)
+
+    monkeypatch.setattr(gemini_mod, "wait_or_kill_process_group", _timeout)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is False
+    assert result.error == "gemini CLI timed out"
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_nonzero_exit_with_rate_limit_stderr_is_marked_retryable(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A 429-shaped stderr must set ``metadata['retryable']`` so the chain retries."""
+    process = _FakeProcess(
+        stdout=json.dumps({"type": "message", "role": "assistant", "content": "partial"}) + "\n",
+        stderr="Error: 429 Too Many Requests\n",
+        returncode=1,
+    )
+    monkeypatch.setattr(gemini_mod, "spawn_agent_cli", _spawn(process))
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is False
+    assert result.metadata == {"retryable": True}
+    assert result.error == "Error: 429 Too Many Requests"
+    # Partial output produced before the failure is preserved for the caller.
+    assert result.output == "partial"
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_nonzero_exit_without_stderr_names_the_exit_code(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A silent non-zero exit still produces a diagnosable error string."""
+    monkeypatch.setattr(
+        gemini_mod,
+        "spawn_agent_cli",
+        _spawn(_FakeProcess(stdout="", stderr="   \n", returncode=7)),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is False
+    assert result.error == "gemini exited 7"
+    assert result.metadata == {}
+    assert result.output is None
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_successful_run_with_no_stream_output_reports_none_not_empty_string(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """An empty stream on a clean exit is ``output=None``, not ``""``."""
+    monkeypatch.setattr(
+        gemini_mod,
+        "spawn_agent_cli",
+        _spawn(_FakeProcess(stdout="\n\n", stderr="", returncode=0)),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is True
+    assert result.output is None
+    assert result.usage is None
+
+
+@pytest.mark.usefixtures("disable_tracing")
+def test_span_cleanup_failure_does_not_fail_an_otherwise_successful_run(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Tracing must never fail a review — a raising ``close_all`` is swallowed."""
+
+    def _handler_factory(**kwargs: object) -> Any:
+        del kwargs
+
+        def _handler(accumulator: StreamSpanAccumulator, event: dict[str, Any]) -> None:
+            accumulator.set_output(str(event.get("content") or ""))
+
+        def _close_all() -> None:
+            msg = "sink already closed"
+            raise RuntimeError(msg)
+
+        return _handler, _close_all
+
+    monkeypatch.setattr(gemini_mod, "_gemini_stream_event_handler", _handler_factory)
+    monkeypatch.setattr(
+        gemini_mod,
+        "spawn_agent_cli",
+        _spawn(_FakeProcess(stdout=json.dumps({"content": "done"}) + "\n", returncode=0)),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = gemini_mod._run_gemini_streaming(cmd=["gemini"], ctx=ctx, model=None)
+
+    assert result.success is True
+    assert result.output == "done"
+
+
+# ---------------------------------------------------------------------------
+# _gemini_stream_event_handler — tracer-disabled branches and guard clauses
+# ---------------------------------------------------------------------------
+
+
+def test_handler_without_a_tracer_still_accumulates_output_and_usage() -> None:
+    """Tracing off must not cost the caller its output or token totals."""
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    for event in (
+        {"type": "init"},
+        {"type": "message", "role": "assistant", "content": "reviewed"},
+        {"type": "tool_use", "id": "t1", "name": "browser", "input": {"q": "x"}},
+        {"type": "tool_result", "tool_use_id": "t1", "output": "page"},
+        {"type": "result", "usage": {"input_tokens": 9, "output_tokens": 2}},
+    ):
+        handler(acc, event)
+    close_all()
+
+    assert acc.final_output == "reviewed"
+    usage = acc.to_usage()
+    assert usage is not None
+    assert usage.input_tokens == 9
+    assert usage.output_tokens == 2
+
+
+def test_untyped_legacy_blob_event_replaces_accumulated_usage() -> None:
+    """An older single-blob event still populates output and authoritative usage."""
+    handler, _close = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+    acc.absorb_usage({"input_tokens": 500, "output_tokens": 500})
+
+    handler(
+        acc,
+        {
+            "result": "legacy blob answer",
+            "usage": {"input_tokens": 12, "output_tokens": 3},
+            "total_cost_usd": 0.5,
+        },
+    )
+
+    assert acc.final_output == "legacy blob answer"
+    usage = acc.to_usage()
+    assert usage is not None
+    assert usage.input_tokens == 12  # replaced, not added to the earlier 500
+    assert usage.output_tokens == 3
+    assert usage.cost_usd == pytest.approx(0.5)
+
+
+def test_untyped_event_without_payload_leaves_the_accumulator_untouched() -> None:
+    """A typeless heartbeat with no result/usage must not blank prior output."""
+    handler, _close = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+    acc.set_output("earlier")
+
+    handler(acc, {"noise": True})
+
+    assert acc.final_output == "earlier"
+    assert acc.to_usage() is None
+
+
+def test_non_assistant_message_is_not_taken_as_the_run_output() -> None:
+    """A user/system echo must never become the review output."""
+    handler, _close = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "message", "role": "user", "content": "the diff"})
+    handler(acc, {"type": "message", "role": "assistant", "content": ""})
+
+    assert acc.final_output is None
+
+
+def test_tool_use_without_an_id_opens_no_span() -> None:
+    """An id-less ``tool_use`` cannot be correlated to a result — it is dropped."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "tool_use", "name": "browser", "input": {"q": "x"}})
+    close_all()
+
+    assert _spans(sink, "tool.call") == []
+
+
+def test_duplicate_tool_use_id_does_not_open_a_second_span() -> None:
+    """A replayed ``tool_use`` must not leak a second, never-closed span."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "tool_use", "id": "t1", "name": "browser"})
+    handler(acc, {"type": "tool_use", "id": "t1", "name": "shell"})
+    handler(acc, {"type": "tool_result", "tool_use_id": "t1", "output": "ok"})
+    close_all()
+
+    tool_calls = _spans(sink, "tool.call")
+    assert len(tool_calls) == 1
+    assert tool_calls[0].attrs["tool.name"] == "browser"
+    # No ``input`` on the event → no request payload attrs are invented.
+    assert "tool.input" not in tool_calls[0].attrs
+
+
+def test_tool_result_for_an_unknown_id_is_ignored() -> None:
+    """An orphan ``tool_result`` closes nothing and emits nothing."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "tool_result", "tool_use_id": "never-opened", "output": "ok"})
+    close_all()
+
+    assert _spans(sink, "tool.call") == []
+
+
+def test_error_event_closes_open_tool_spans_and_surfaces_the_message() -> None:
+    """A provider error closes the in-flight tool span and becomes the output."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "init"})
+    handler(acc, {"type": "tool_use", "id": "t1", "name": "browser"})
+    handler(acc, {"type": "error", "message": "provider refused the request"})
+    close_all()
+
+    assert acc.final_output == "provider refused the request"
+    assert len(_spans(sink, "tool.call")) == 1
+    # The init-opened provider/llm pair is closed by the error path too, so
+    # close_all() has nothing left to emit and cannot double-close.
+    assert len(_spans(sink, "provider.call")) == 1
+    assert len(_spans(sink, "llm.call")) == 1
+
+
+def test_error_event_with_a_non_string_message_leaves_output_untouched() -> None:
+    """A structured error body is not coerced into the review output."""
+    handler, _close = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+    acc.set_output("earlier answer")
+
+    handler(acc, {"type": "error", "message": {"code": 500}})
+
+    assert acc.final_output == "earlier answer"
+
+
+def test_result_event_ignores_a_non_mapping_usage_and_non_string_response() -> None:
+    """Malformed terminal fields degrade to "no usage recorded", not a crash."""
+    handler, _close = gemini_mod._gemini_stream_event_handler(tracer=None, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+    acc.set_output("earlier answer")
+
+    handler(acc, {"type": "result", "usage": "n/a", "response": {"text": "nope"}})
+
+    assert acc.final_output == "earlier answer"
+    assert acc.to_usage() is None
+
+
+def test_result_event_closes_the_pair_and_records_the_terminal_response() -> None:
+    """The terminal event closes exactly one provider/llm pair and sets the output."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "init"})
+    handler(acc, {"type": "result", "usage": {"input_tokens": 40}, "response": "done"})
+    close_all()
+
+    llm_spans = _spans(sink, "llm.call")
+    assert len(llm_spans) == 1
+    assert llm_spans[0].attrs["gen_ai.request.model"] == "gemini-3"
+    assert llm_spans[0].attrs["gen_ai.system"] == "google"
+    assert acc.final_output == "done"
+    accumulated = acc.to_usage()
+    assert accumulated is not None
+    assert accumulated.input_tokens == 40
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: gemini's stream handler seeds open_pair_bookkeeping to "
+        "{'tokens_in': 0, 'tokens_out': 0} on the `init` event and never updates it. "
+        "The `result` handler reads that dict to stamp cost.tokens_in/out and "
+        "gen_ai.usage.input_tokens/output_tokens on the llm.call span, so every "
+        "gemini llm.call span reports zero tokens even when the terminal event "
+        "carries real counts (which _do_ reach AgentUsage via "
+        "accumulator.replace_usage). claude.py populates the same bookkeeping from "
+        "message_start/message_delta; gemini.py (and codex.py) never do. Fix: have "
+        "the `result` branch fold the event's usage into the bookkeeping entry "
+        "before stamping. Do not fix production code from the coverage batch."
+    ),
+    strict=True,
+)
+def test_result_event_usage_reaches_the_llm_span_token_attrs() -> None:
+    """Token counts reported by the provider must land on the traced llm.call span."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "init"})
+    handler(
+        acc,
+        {"type": "result", "usage": {"input_tokens": 40, "output_tokens": 9}, "response": "done"},
+    )
+    close_all()
+
+    attrs = _spans(sink, "llm.call")[0].attrs
+    assert attrs["gen_ai.usage.input_tokens"] == 40
+    assert attrs["gen_ai.usage.output_tokens"] == 9
+    assert attrs["cost.tokens_in"] == 40
+    assert attrs["cost.tokens_out"] == 9
+
+
+def test_close_all_closes_spans_left_open_by_a_truncated_stream() -> None:
+    """A stream that dies mid-tool still emits its open spans exactly once."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(tracer=tracer, model_id="gemini-3")
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "init"})
+    handler(acc, {"type": "tool_use", "id": "t1", "name": "browser"})
+    close_all()
+
+    assert len(_spans(sink, "tool.call")) == 1
+    assert len(_spans(sink, "provider.call")) == 1
+    assert len(_spans(sink, "llm.call")) == 1
+
+
+def test_assistant_message_is_not_captured_without_a_capture_policy() -> None:
+    """``capture_policy=None`` keeps message bodies off the span (pre-OB3 surface)."""
+    sink, tracer = _tracer()
+    handler, close_all = gemini_mod._gemini_stream_event_handler(
+        tracer=tracer, model_id="gemini-3", capture_policy=None
+    )
+    acc = StreamSpanAccumulator(agent_name="gemini")
+
+    handler(acc, {"type": "init"})
+    handler(acc, {"type": "message", "role": "assistant", "content": "secret body"})
+    handler(acc, {"type": "result"})
+    close_all()
+
+    attrs = _spans(sink, "llm.call")[0].attrs
+    assert not any(key.startswith("gen_ai.output.messages") for key in attrs)
+    assert acc.final_output == "secret body"

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -1,0 +1,1100 @@
+"""Error, guard, and fallback paths in ``mergecraft.agents.opencode``.
+
+The existing opencode suite pins the happy paths: a provider block built
+from well-formed env, a 200 session response, a clean exit. This module
+drives the other way out of each decision — the serve boot failing, the
+HTTP session endpoint 4xx-ing, the CLI fallback exiting non-zero or timing
+out, and every numeric/model guard that currently only ever sees valid input.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from tests.agents.conftest import make_agent_run_context
+
+from mergecraft.agents import opencode as oc
+from mergecraft.agents.openai_compatible_gateways import ProviderConfig
+from mergecraft.tracing.genai import ModelParams
+from mergecraft.types import MERGECRAFT_MCP_NAME
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_BASE_URL = "https://gateway.example.com/v1"
+
+
+@pytest.fixture(autouse=True)
+def _clear_gateway_env(monkeypatch: MonkeyPatch) -> None:
+    """Keep operator gateway env out of every case in this module."""
+    for name in (
+        oc.CUSTOM_PROVIDER_BASE_URL_ENV,
+        oc.CUSTOM_PROVIDER_API_KEY_ENV,
+        "NOUS_API_KEY",
+        "NOUS_BASE_URL",
+        "TOKENHUB_API_KEY",
+        "TOKENHUB_BASE_URL",
+        "BEDROCK_MODEL_ID",
+        "VERTEX_MODEL_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for index in range(1, 8):
+        monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{index}", raising=False)
+        monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{index}", raising=False)
+
+
+def _config(**overrides: Any) -> ProviderConfig:
+    base: dict[str, Any] = {
+        "provider_id": "gw",
+        "base_url": _BASE_URL,
+        "api_key_env": "GW_KEY",
+    }
+    base.update(overrides)
+    return ProviderConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# _api_key_from_env / _positive_int — value guards
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_is_read_at_emit_time_and_whitespace_trimmed(monkeypatch: MonkeyPatch) -> None:
+    """The key is not captured at config build time and is stripped when read."""
+    monkeypatch.delenv("GW_KEY", raising=False)
+    assert oc._api_key_from_env("GW_KEY") == ""
+
+    monkeypatch.setenv("GW_KEY", "  secret-key \n")
+    assert oc._api_key_from_env("GW_KEY") == "secret-key"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        (True, None),  # bool is an int subclass — must not become 1
+        (False, None),
+        (0, None),
+        (-5, None),
+        (7, 7),
+        (8.0, 8),  # integral float from JSON
+        (8.5, None),  # non-integral float is not a token budget
+        ("9", None),  # a string is not a number here
+        (float("nan"), None),
+    ],
+)
+def test_positive_int_accepts_only_positive_whole_numbers(value: Any, expected: int | None) -> None:
+    """Each rejected shape would otherwise become a bogus ``limit``/``max_tokens``."""
+    assert oc._positive_int(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# option splitting — transport keys vs generation knobs
+# ---------------------------------------------------------------------------
+
+
+def test_provider_options_carry_transport_keys_only() -> None:
+    """Generation knobs must not leak into OpenCode's ``provider.options``."""
+    config = _config(
+        extra_options={
+            "timeout": 900,
+            "headerTimeout": 30,
+            "temperature": 0.2,
+            "max_tokens": 4096,
+            "setCacheKey": None,
+        }
+    )
+    options = oc._opencode_provider_options(config)
+
+    assert options == {
+        "baseURL": _BASE_URL,
+        "apiKey": "",
+        "timeout": 900,
+        "headerTimeout": 30,
+    }
+
+
+def test_generation_options_drop_reserved_keys_and_none_values() -> None:
+    """Transport keys, limit sources, and unset values are all excluded."""
+    result = oc._opencode_generation_options(
+        {
+            "timeout": 900,
+            "context_limit": 100_000,
+            "max_tokens": 4096,
+            "temperature": 0.2,
+            "top_p": None,
+        }
+    )
+
+    assert result == {"temperature": 0.2}
+
+
+# ---------------------------------------------------------------------------
+# context limit / model entry — the "both values known" requirement
+# ---------------------------------------------------------------------------
+
+
+def test_typed_context_limit_wins_over_extra_options() -> None:
+    """A declared ``context_limit`` field beats the loose ``extra_options`` copies."""
+    config = _config(context_limit=200_000, extra_options={"context_limit": 1, "context": 2})
+    assert oc._opencode_model_context_limit(config) == 200_000
+
+
+def test_non_positive_typed_context_limit_falls_through_to_extra_options() -> None:
+    """``context_limit=0`` is not a window — the loose keys are consulted in order."""
+    assert oc._opencode_model_context_limit(_config(extra_options={"context": 64_000})) == 64_000
+    assert (
+        oc._opencode_model_context_limit(
+            _config(extra_options={"context_limit": 32_000, "context": 64_000})
+        )
+        == 32_000
+    )
+
+
+def test_unknown_context_window_yields_no_limit() -> None:
+    """Nothing to resolve → ``None``, so no partial ``limit`` object is emitted."""
+    assert oc._opencode_model_context_limit(_config(extra_options={"context": 0})) is None
+    assert oc._opencode_model_context_limit(_config()) is None
+
+
+def test_model_entry_omits_limit_when_only_max_tokens_is_known() -> None:
+    """OpenCode 1.18.x rejects a ``limit`` missing ``context`` — emit neither half."""
+    entry = oc._opencode_model_entry("m1", _config(extra_options={"max_tokens": 4096}))
+
+    assert entry == {"name": "m1"}
+
+
+def test_model_entry_omits_limit_when_only_the_context_window_is_known() -> None:
+    """The mirror case: a context window with no output cap emits no ``limit``."""
+    entry = oc._opencode_model_entry("m1", _config(context_limit=128_000))
+
+    assert entry == {"name": "m1"}
+
+
+def test_model_entry_emits_both_limit_halves_and_generation_options() -> None:
+    """Both values known → a complete ``limit`` plus the generation knobs."""
+    entry = oc._opencode_model_entry(
+        "m1",
+        _config(context_limit=128_000, extra_options={"max_tokens": 4096, "temperature": 0.1}),
+    )
+
+    assert entry == {
+        "name": "m1",
+        "limit": {"context": 128_000, "output": 4096},
+        "options": {"temperature": 0.1},
+    }
+
+
+# ---------------------------------------------------------------------------
+# applied ModelParams / build-agent overrides
+# ---------------------------------------------------------------------------
+
+
+def test_applied_model_params_is_none_without_a_config_or_options() -> None:
+    """No config, or a config with no extra options, applies no parameters."""
+    assert oc._opencode_applied_model_params_from_config(None) is None
+    assert oc._opencode_applied_model_params_from_config(_config()) is None
+
+
+def test_unrecognised_extra_options_apply_no_model_params() -> None:
+    """Options OpenCode does not map to a knob must not be reported as applied."""
+    config = _config(extra_options={"someVendorFlag": "on"})
+    assert oc._opencode_applied_model_params_from_config(config) is None
+
+
+def test_max_tokens_is_only_reported_as_applied_when_a_context_window_is_known() -> None:
+    """``max_tokens`` reaches the model entry only alongside ``context`` — mirror that."""
+    without_context = oc._opencode_applied_model_params_from_config(
+        _config(extra_options={"max_tokens": 4096, "temperature": 0.3})
+    )
+    assert without_context == ModelParams(temperature=0.3)
+
+    with_context = oc._opencode_applied_model_params_from_config(
+        _config(context_limit=128_000, extra_options={"max_tokens": 4096, "temperature": 0.3})
+    )
+    assert with_context == ModelParams(temperature=0.3, max_tokens=4096)
+
+
+def test_applied_model_params_for_an_unconfigured_model_is_none() -> None:
+    """No model slug and no gateway env → nothing applied."""
+    assert oc.opencode_applied_model_params(None) is None
+    assert oc.opencode_applied_model_params("nous/some-model") is None
+
+
+def test_build_agent_overrides_only_carry_the_knobs_that_are_set() -> None:
+    """``top_p`` alone must not drag a ``temperature`` key into the build agent."""
+    assert oc._opencode_build_agent_overrides(None) == {}
+    assert oc._opencode_build_agent_overrides(_config()) == {}
+    assert oc._opencode_build_agent_overrides(_config(extra_options={"top_p": 0.9})) == {
+        "top_p": 0.9
+    }
+    assert oc._opencode_build_agent_overrides(
+        _config(extra_options={"temperature": 0.4, "top_p": 0.9})
+    ) == {"temperature": 0.4, "top_p": 0.9}
+
+
+# ---------------------------------------------------------------------------
+# _parse_model — the slug guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, "", "gpt-5", "/leading-slash"])
+def test_unprefixed_model_slugs_yield_no_model_object(value: str | None) -> None:
+    """Without a real ``provider/model`` split there is no provider id to send."""
+    assert oc._parse_model(value) is None
+
+
+def test_only_the_first_slash_splits_the_model_slug() -> None:
+    """Nested model ids keep their slashes in ``modelID``."""
+    assert oc._parse_model("nous/deepseek/deepseek-v4") == {
+        "providerID": "nous",
+        "modelID": "deepseek/deepseek-v4",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _custom_provider_ids / build_custom_provider — unconfigured environment
+# ---------------------------------------------------------------------------
+
+
+def test_no_provider_ids_without_a_resolvable_gateway() -> None:
+    """An unconfigured environment registers no ``enabled_providers``."""
+    assert oc._custom_provider_ids(None) == []
+    assert oc._custom_provider_ids("nous/deepseek-v4") == []
+
+
+def test_custom_provider_is_none_without_a_model() -> None:
+    """No model → no provider block, even with the singleton env set."""
+    assert oc.build_custom_provider(None) is None
+
+
+# ---------------------------------------------------------------------------
+# build_security_config — model-shape branches
+# ---------------------------------------------------------------------------
+
+
+def test_security_config_without_a_model_omits_model_and_provider_keys(tmp_path: Path) -> None:
+    """A run with no resolved model still emits the deny-by-default permissions."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    config = json.loads(oc.build_security_config(ctx, None))
+
+    assert "model" not in config
+    assert "enabled_providers" not in config
+    assert "provider" not in config
+    assert config["permission"]["bash"] == "deny"
+    assert config["permission"]["webfetch"] == "allow"
+
+
+def test_unprefixed_model_registers_no_enabled_providers(tmp_path: Path) -> None:
+    """A bare model id has no provider segment to enable."""
+    ctx = make_agent_run_context(tmp_path, resolved_model="gpt-5")
+    config = json.loads(oc.build_security_config(ctx, "gpt-5"))
+
+    assert config["model"] == "gpt-5"
+    assert "enabled_providers" not in config
+    assert "provider" not in config
+
+
+def test_mcp_entry_omits_headers_without_a_run_token(tmp_path: Path) -> None:
+    """No per-run MCP token → no ``headers`` key at all on the remote MCP entry."""
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+    config = json.loads(oc.build_security_config(ctx, None))
+
+    entry = config["mcp"][MERGECRAFT_MCP_NAME]
+    assert entry["type"] == "remote"
+    assert entry["timeout"] == 300_000
+    assert "headers" not in entry
+
+
+def test_mcp_entry_carries_the_bearer_header_when_a_token_is_issued(tmp_path: Path) -> None:
+    """A per-run token becomes the MCP ``Authorization`` header."""
+    from dataclasses import replace
+
+    ctx = replace(
+        make_agent_run_context(tmp_path, resolved_model=None),
+        mcp_auth_token="run-token",
+    )
+    config = json.loads(oc.build_security_config(ctx, None))
+
+    assert config["mcp"][MERGECRAFT_MCP_NAME]["headers"] == {"Authorization": "Bearer run-token"}
+
+
+def _render_result(agent_block: dict[str, Any]) -> Any:
+    from mergecraft.agents.harness_render import HarnessRenderResult
+
+    return HarnessRenderResult(
+        harness="opencode",
+        payload={"agent": agent_block},
+        selected_agent_ids=(),
+    )
+
+
+def test_build_agent_overrides_merge_into_an_existing_build_agent(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Gateway generation knobs extend the rendered ``build`` agent, not replace it."""
+    monkeypatch.setattr(
+        "mergecraft.agents.harness_render.render_for_run",
+        lambda ctx, harness, **kwargs: _render_result(
+            {"build": {"prompt": "keep me"}, "other": {"x": 1}}
+        ),
+    )
+    monkeypatch.setattr(
+        oc,
+        "_provider_config_for_model",
+        lambda _model: _config(extra_options={"temperature": 0.25, "top_p": 0.8}),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model="gw/model-a")
+
+    config = json.loads(oc.build_security_config(ctx, "gw/model-a"))
+
+    assert config["agent"]["build"] == {
+        "prompt": "keep me",
+        "temperature": 0.25,
+        "top_p": 0.8,
+    }
+    assert config["agent"]["other"] == {"x": 1}
+
+
+def test_build_agent_overrides_create_the_build_agent_when_absent(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """No rendered ``build`` agent → the overrides become the whole entry."""
+    monkeypatch.setattr(
+        "mergecraft.agents.harness_render.render_for_run",
+        lambda ctx, harness, **kwargs: _render_result({}),
+    )
+    monkeypatch.setattr(
+        oc,
+        "_provider_config_for_model",
+        lambda _model: _config(extra_options={"temperature": 0.25}),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model="gw/model-a")
+
+    config = json.loads(oc.build_security_config(ctx, "gw/model-a"))
+
+    assert config["agent"]["build"] == {"temperature": 0.25}
+
+
+def test_non_mapping_render_payload_degrades_to_an_empty_agent_block(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A string payload (the claude/gemini projection shape) is not an agent block."""
+    from mergecraft.agents.harness_render import HarnessRenderResult
+
+    monkeypatch.setattr(
+        "mergecraft.agents.harness_render.render_for_run",
+        lambda ctx, harness, **kwargs: HarnessRenderResult(
+            harness="opencode", payload="not-a-mapping", selected_agent_ids=()
+        ),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    config = json.loads(oc.build_security_config(ctx, None))
+
+    assert config["agent"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _install — CLI absent
+# ---------------------------------------------------------------------------
+
+
+async def test_install_raises_with_an_actionable_message_when_cli_is_absent(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A missing binary names the package the operator has to install."""
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: None)
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        await oc._install(None)
+
+    assert "opencode-ai" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# _ServerHandle.close — teardown branches
+# ---------------------------------------------------------------------------
+
+
+class _FakeServeProc:
+    """``Popen`` look-alike for the ``opencode serve`` boot + teardown paths."""
+
+    def __init__(
+        self,
+        *,
+        stdout_lines: list[bytes] | None = None,
+        stderr: bytes = b"",
+        poll_values: list[int | None] | None = None,
+        wait_raises: bool = False,
+    ) -> None:
+        self._lines = list(stdout_lines or [])
+        self.stdout: Any = self
+        self.stderr: Any = _FakeBytesStream(stderr)
+        self._poll_values = list(poll_values or [])
+        self._wait_raises = wait_raises
+        self.pid = 777_001
+        self.wait_calls = 0
+        self.kill_calls = 0
+
+    def readline(self) -> bytes:
+        return self._lines.pop(0) if self._lines else b""
+
+    def poll(self) -> int | None:
+        return self._poll_values.pop(0) if self._poll_values else None
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        self.wait_calls += 1
+        if self._wait_raises:
+            raise subprocess.TimeoutExpired(cmd="opencode", timeout=5)
+        return 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+
+class _FakeBytesStream:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakeClock:
+    """Deterministic stand-in for the ``time`` module inside opencode."""
+
+    def __init__(self) -> None:
+        self._now = 0.0
+
+    def time(self) -> float:
+        self._now += 1.0
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self._now += max(seconds, 1.0)
+
+
+@pytest.fixture
+def killed_pids(monkeypatch: MonkeyPatch) -> list[int]:
+    """Capture ``kill_process_group`` targets instead of signalling real pids."""
+    killed: list[int] = []
+    monkeypatch.setattr(oc, "kill_process_group", lambda pid: killed.append(pid))
+    monkeypatch.setattr(oc, "register_process_group", lambda _pid: None)
+    monkeypatch.setattr(oc, "unregister_process_group", lambda _pid: None)
+    return killed
+
+
+def test_server_handle_close_is_idempotent(killed_pids: list[int]) -> None:
+    """A second ``close()`` must not signal the process group again."""
+    proc = _FakeServeProc(poll_values=[None])
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)  # type: ignore[arg-type]
+
+    handle.close()
+    handle.close()
+
+    assert killed_pids == [proc.pid]
+    assert proc.wait_calls == 1
+
+
+def test_server_handle_close_skips_the_kill_for_an_already_exited_process(
+    killed_pids: list[int],
+) -> None:
+    """An exited serve process is only unregistered, never signalled."""
+    proc = _FakeServeProc(poll_values=[0])
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)  # type: ignore[arg-type]
+
+    handle.close()
+
+    assert killed_pids == []
+    assert proc.wait_calls == 0
+
+
+def test_server_handle_close_hard_kills_a_process_that_ignores_the_group_signal(
+    killed_pids: list[int],
+) -> None:
+    """A serve process still alive after the grace wait gets ``kill()``."""
+    proc = _FakeServeProc(poll_values=[None], wait_raises=True)
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)  # type: ignore[arg-type]
+
+    handle.close()
+
+    assert killed_pids == [proc.pid]
+    assert proc.kill_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# _boot_opencode_server — the two failure modes and the URL parse
+# ---------------------------------------------------------------------------
+
+
+def _patch_popen(monkeypatch: MonkeyPatch, proc: _FakeServeProc) -> list[list[str]]:
+    captured: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **kwargs: object) -> _FakeServeProc:
+        captured.append(list(cmd))
+        return proc
+
+    monkeypatch.setattr(oc.subprocess, "Popen", _fake_popen)
+    return captured
+
+
+def test_boot_reports_the_child_stderr_when_serve_exits_early(
+    monkeypatch: MonkeyPatch, killed_pids: list[int]
+) -> None:
+    """The EACCES-class failure is surfaced verbatim so the operator can act."""
+    proc = _FakeServeProc(
+        poll_values=[1],
+        stderr=b"EACCES: permission denied, mkdir '/github/home/.local'",
+    )
+    _patch_popen(monkeypatch, proc)
+    monkeypatch.setattr(oc, "time", _FakeClock())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        oc._boot_opencode_server(cli="opencode", env={}, cwd=".")
+
+    assert "opencode serve exited early" in str(excinfo.value)
+    assert "EACCES: permission denied" in str(excinfo.value)
+    # The child already exited — no signal is sent to a dead group.
+    assert killed_pids == []
+
+
+def test_boot_kills_the_group_when_no_listening_url_is_printed(
+    monkeypatch: MonkeyPatch, killed_pids: list[int]
+) -> None:
+    """A serve process that never announces a URL is torn down, not leaked."""
+    proc = _FakeServeProc(stdout_lines=[b"starting up\n", b"still starting\n"])
+    _patch_popen(monkeypatch, proc)
+    monkeypatch.setattr(oc, "time", _FakeClock())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        oc._boot_opencode_server(cli="opencode", env={}, cwd=".")
+
+    assert "did not print a listening URL" in str(excinfo.value)
+    assert killed_pids == [proc.pid]
+
+
+def test_boot_returns_a_handle_on_the_announced_url_without_a_trailing_slash(
+    monkeypatch: MonkeyPatch, killed_pids: list[int]
+) -> None:
+    """The first URL printed becomes the base url, normalised."""
+    proc = _FakeServeProc(
+        stdout_lines=[b"boot\n", b"opencode server listening on http://127.0.0.1:41235/\n"]
+    )
+    captured = _patch_popen(monkeypatch, proc)
+    monkeypatch.setattr(oc, "time", _FakeClock())
+
+    handle = oc._boot_opencode_server(cli="/usr/bin/opencode", env={}, cwd=".")
+
+    assert handle.base_url == "http://127.0.0.1:41235"
+    assert killed_pids == []
+    assert captured[0][-4:] == ["--port", "0", "--hostname", "127.0.0.1"]
+
+
+# ---------------------------------------------------------------------------
+# _prompt_session_http — HTTP fallback and error shapes
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    def __init__(self, *, status_code: int, body: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._body = body
+        self.text = text
+        self.content = b"{}" if body is not None else b""
+
+    def json(self) -> Any:
+        return self._body
+
+
+class _RoutedClient:
+    """AsyncClient stub that answers by URL suffix."""
+
+    routes: dict[str, _StubResponse] = {}  # noqa: RUF012
+    calls: list[str] = []  # noqa: RUF012
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    async def __aenter__(self) -> _RoutedClient:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs: object) -> _StubResponse:
+        del kwargs
+        type(self).calls.append(url)
+        for suffix, response in type(self).routes.items():
+            if url.endswith(suffix):
+                return response
+        msg = f"unrouted url: {url}"
+        raise AssertionError(msg)
+
+
+def _route(monkeypatch: MonkeyPatch, routes: dict[str, _StubResponse]) -> type[_RoutedClient]:
+    client = type("_Client", (_RoutedClient,), {"routes": routes, "calls": []})
+    monkeypatch.setattr(httpx, "AsyncClient", client)
+    monkeypatch.setattr(oc, "instrument_httpx", lambda _client, tracer=None: None)
+    return client
+
+
+async def test_prompt_falls_back_to_the_legacy_prompt_endpoint_on_a_4xx(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A 404 from ``/message`` retries ``/prompt`` — the older API shape."""
+    client = _route(
+        monkeypatch,
+        {
+            "/message": _StubResponse(status_code=404, text="not found"),
+            "/prompt": _StubResponse(status_code=200, body={"text": "fallback answer"}),
+        },
+    )
+
+    result = await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1", session_id="s1", text="hi", model=None
+    )
+
+    assert result.success is True
+    assert result.output == "fallback answer"
+    assert [url.rsplit("/", 1)[-1] for url in client.calls] == ["message", "prompt"]
+
+
+async def test_prompt_failure_reports_the_status_code_and_a_truncated_body(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Both endpoints failing produce a diagnosable error, not a success."""
+    _route(
+        monkeypatch,
+        {
+            "/message": _StubResponse(status_code=500, text="x" * 900),
+            "/prompt": _StubResponse(status_code=500, text="x" * 900),
+        },
+    )
+
+    result = await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1", session_id="s1", text="hi", model=None
+    )
+
+    assert result.success is False
+    assert result.error is not None
+    assert result.error.startswith("opencode prompt failed (500): ")
+    assert result.error.count("x") == 500
+
+
+async def test_non_object_response_body_yields_no_output(monkeypatch: MonkeyPatch) -> None:
+    """A JSON array is not a session payload — output is ``None``, not ``"[]"``."""
+    _route(monkeypatch, {"/message": _StubResponse(status_code=200, body=["unexpected"])})
+
+    result = await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1", session_id="s1", text="hi", model=None
+    )
+
+    assert result.success is True
+    assert result.output is None
+    assert result.usage is None
+
+
+async def test_non_mapping_info_field_reports_no_usage(monkeypatch: MonkeyPatch) -> None:
+    """A malformed ``info`` must degrade to "no usage", never crash the attempt."""
+    _route(
+        monkeypatch,
+        {"/message": _StubResponse(status_code=200, body={"text": "answer", "info": ["bad"]})},
+    )
+
+    result = await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1", session_id="s1", text="hi", model=None
+    )
+
+    assert result.success is True
+    assert result.output == "answer"
+    assert result.usage is None
+
+
+async def test_cost_only_usage_is_still_reported(monkeypatch: MonkeyPatch) -> None:
+    """A response with cost but no token counts is a usage record."""
+    _route(
+        monkeypatch,
+        {
+            "/message": _StubResponse(
+                status_code=200, body={"text": "answer", "info": {"costUsd": 0.125}}
+            )
+        },
+    )
+
+    result = await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1", session_id="s1", text="hi", model=None
+    )
+
+    assert result.usage is not None
+    assert result.usage.agent == "opencode"
+    assert result.usage.cost_usd == pytest.approx(0.125)
+    assert result.usage.input_tokens == 0
+
+
+async def test_model_is_forwarded_in_the_prompt_payload(monkeypatch: MonkeyPatch) -> None:
+    """The resolved provider/model pair rides on the session request body."""
+    sent: list[dict[str, Any]] = []
+
+    class _Recorder(_RoutedClient):
+        routes = {"/message": _StubResponse(status_code=200, body={"text": "ok"})}  # noqa: RUF012
+        calls: list[str] = []  # noqa: RUF012
+
+        async def post(self, url: str, **kwargs: object) -> _StubResponse:
+            payload = kwargs.get("json")
+            if isinstance(payload, dict):
+                sent.append(payload)
+            return await super().post(url, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Recorder)
+    monkeypatch.setattr(oc, "instrument_httpx", lambda _client, tracer=None: None)
+
+    await oc._prompt_session_http(
+        base_url="http://127.0.0.1:1",
+        session_id="s1",
+        text="hi",
+        model={"providerID": "nous", "modelID": "deepseek-v4"},
+    )
+
+    assert sent[0]["model"] == {"providerID": "nous", "modelID": "deepseek-v4"}
+    assert sent[0]["parts"] == [{"type": "text", "text": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# _run_opencode_cli_streaming — spawn failure, timeout, non-zero exit
+# ---------------------------------------------------------------------------
+
+
+class _FakeCliProc:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout: list[str] = stdout.splitlines(keepends=True)
+        self.stderr: Any = _FakeTextStream(stderr)
+        self.returncode = returncode
+        self.pid = 777_002
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self.returncode
+
+
+class _FakeTextStream:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+def _spawn(process: _FakeCliProc) -> Any:
+    def _fake(cmd: list[str], **kwargs: object) -> _FakeCliProc:
+        del cmd, kwargs
+        return process
+
+    return _fake
+
+
+def test_cli_streaming_returns_a_failed_result_when_the_binary_is_missing(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A spawn failure is a failed ``AgentResult``, never a raised exception."""
+
+    def _boom(cmd: list[str], **kwargs: object) -> Any:
+        del cmd, kwargs
+        msg = "no such file: opencode"
+        raise FileNotFoundError(msg)
+
+    monkeypatch.setattr(oc, "spawn_agent_cli", _boom)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is False
+    assert result.error == "no such file: opencode"
+
+
+def test_cli_streaming_reports_a_timeout_as_a_clean_failed_result(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``TimeoutExpired`` becomes a named failure rather than a traceback."""
+    monkeypatch.setattr(oc, "spawn_agent_cli", _spawn(_FakeCliProc()))
+
+    def _timeout(process: Any, *, timeout: float | None) -> int:
+        del process, timeout
+        raise subprocess.TimeoutExpired(cmd="opencode", timeout=1)
+
+    monkeypatch.setattr(oc, "wait_or_kill_process_group", _timeout)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is False
+    assert result.error == "opencode run timed out"
+
+
+def test_cli_streaming_marks_rate_limited_failures_retryable(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """An overload message on stderr sets ``metadata['retryable']`` for the chain."""
+    monkeypatch.setattr(
+        oc,
+        "spawn_agent_cli",
+        _spawn(_FakeCliProc(stderr="provider overloaded, retry later\n", returncode=1)),
+    )
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is False
+    assert result.metadata == {"retryable": True}
+    assert result.error == "provider overloaded, retry later"
+
+
+def test_cli_streaming_falls_back_to_a_generic_message_with_empty_stderr(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """No stderr at all → the generic "opencode failed" marker."""
+    monkeypatch.setattr(oc, "spawn_agent_cli", _spawn(_FakeCliProc(stderr="", returncode=2)))
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is False
+    assert result.error == "opencode failed"
+    assert result.metadata == {}
+
+
+def test_cli_streaming_names_the_exit_code_for_whitespace_only_stderr(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Whitespace-only stderr strips to empty, so the exit code carries the signal."""
+    monkeypatch.setattr(oc, "spawn_agent_cli", _spawn(_FakeCliProc(stderr="  \n ", returncode=3)))
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is False
+    assert result.error == "opencode exited 3"
+
+
+def test_cli_streaming_success_with_no_events_reports_none_output(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """An empty stream on a clean exit is ``output=None``, not ``""``."""
+    monkeypatch.setattr(oc, "spawn_agent_cli", _spawn(_FakeCliProc(stdout="\n\n", returncode=0)))
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = oc._run_opencode_cli_streaming(cmd=["opencode"], ctx=ctx, env={})
+
+    assert result.success is True
+    assert result.output is None
+
+
+# ---------------------------------------------------------------------------
+# _run_cli_fallback — argv assembly
+# ---------------------------------------------------------------------------
+
+
+async def test_cli_fallback_prepends_the_system_prompt_and_passes_the_model(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """The fallback argv carries the joined prompt and the resolved model flag."""
+    from dataclasses import replace
+
+    from mergecraft.agents.shared import AgentResult, ResolvedInstructions
+
+    captured: dict[str, Any] = {}
+
+    def _fake_streaming(*, cmd: list[str], ctx: Any, env: dict[str, str]) -> AgentResult:
+        captured["cmd"] = cmd
+        return AgentResult(success=True, output="ok")
+
+    monkeypatch.setattr(oc, "_run_opencode_cli_streaming", _fake_streaming)
+    ctx = replace(
+        make_agent_run_context(tmp_path, resolved_model="nous/deepseek-v4"),
+        instructions=ResolvedInstructions(system="SYSTEM", user="USER"),
+    )
+
+    result = await oc._run_cli_fallback(cli="/usr/bin/opencode", ctx=ctx, env={})
+
+    cmd = captured["cmd"]
+    assert cmd[:4] == ["/usr/bin/opencode", "run", "--format", "json"]
+    assert cmd[4] == "SYSTEM\n\nUSER"
+    assert cmd[cmd.index("--model") + 1] == "nous/deepseek-v4"
+    assert result.output == "ok"
+
+
+async def test_cli_fallback_omits_the_model_flag_when_none_is_resolved(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """No resolved model → no ``--model`` flag and the user prompt stands alone."""
+    from mergecraft.agents.shared import AgentResult
+
+    captured: dict[str, Any] = {}
+
+    def _fake_streaming(*, cmd: list[str], ctx: Any, env: dict[str, str]) -> AgentResult:
+        captured["cmd"] = cmd
+        return AgentResult(success=True)
+
+    monkeypatch.setattr(oc, "_run_opencode_cli_streaming", _fake_streaming)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    await oc._run_cli_fallback(cli="opencode", ctx=ctx, env={})
+
+    assert "--model" not in captured["cmd"]
+    assert captured["cmd"][-1] == "review this diff"
+
+
+# ---------------------------------------------------------------------------
+# _run — install failure, serve fallback, session bootstrap failures
+# ---------------------------------------------------------------------------
+
+
+async def test_run_reports_a_missing_cli_without_touching_the_server(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``_run`` short-circuits on a missing binary before writing any config."""
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: None)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "opencode CLI not found" in result.error
+    assert not (tmp_path / "opencode.json").exists()
+
+
+async def test_run_falls_back_to_the_cli_when_serve_cannot_boot(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A serve boot failure degrades to ``opencode run`` instead of failing the review."""
+    from mergecraft.agents.shared import AgentResult
+
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+
+    def _boom(**kwargs: object) -> Any:
+        del kwargs
+        msg = "opencode serve did not print a listening URL"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(oc, "_boot_opencode_server", _boom)
+
+    async def _fallback(*, cli: str, ctx: Any, env: dict[str, str]) -> AgentResult:
+        return AgentResult(success=True, output="cli fallback output")
+
+    monkeypatch.setattr(oc, "_run_cli_fallback", _fallback)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert result.success is True
+    assert result.output == "cli fallback output"
+    # The config file is still written before the boot attempt.
+    assert (tmp_path / "opencode.json").is_file()
+
+
+async def test_run_reports_a_session_creation_failure(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A 4xx from ``POST /session`` aborts the run with the server's body."""
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    proc = _FakeServeProc()
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
+    monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
+    monkeypatch.setattr(oc, "kill_process_group", lambda _pid: None)
+    monkeypatch.setattr(oc, "unregister_process_group", lambda _pid: None)
+    _route(monkeypatch, {"/session": _StubResponse(status_code=503, text="server busy")})
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert result.success is False
+    assert result.error == "failed to create opencode session: server busy"
+
+
+async def test_run_rejects_a_session_response_without_an_id(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A 200 with no usable id is a failure — the run cannot be addressed."""
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    proc = _FakeServeProc()
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
+    monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
+    monkeypatch.setattr(oc, "kill_process_group", lambda _pid: None)
+    monkeypatch.setattr(oc, "unregister_process_group", lambda _pid: None)
+    _route(monkeypatch, {"/session": _StubResponse(status_code=200, body={"title": "mergecraft"})})
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert result.success is False
+    assert result.error == "opencode session missing id"
+
+
+async def test_run_converts_a_provider_timeout_into_a_clean_failed_attempt(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``ProviderTimeoutError`` is a controlled domain error, not a raised traceback."""
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    proc = _FakeServeProc()
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
+    monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
+    monkeypatch.setattr(oc, "kill_process_group", lambda _pid: None)
+    monkeypatch.setattr(oc, "unregister_process_group", lambda _pid: None)
+    _route(
+        monkeypatch,
+        {
+            "/session": _StubResponse(status_code=200, body={"id": "sess-1"}),
+            "/message": _StubResponse(status_code=200, body={"text": "hi"}),
+        },
+    )
+
+    async def _timeout(*args: object, **kwargs: object) -> Any:
+        msg = "opencode provider request timed out: read timeout"
+        raise oc.ProviderTimeoutError(msg)
+
+    monkeypatch.setattr(oc, "run_post_run_retry_loop", _timeout)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert result.success is False
+    assert result.error == "opencode provider request timed out: read timeout"
+    # The serve handle is always torn down, timeout or not.
+    assert proc.wait_calls == 1
+
+
+async def test_run_exports_the_bedrock_flag_only_for_a_matching_model(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``BEDROCK_MODEL_ID`` gates the BYOK flag on an exact model match."""
+    from mergecraft.agents.shared import AgentResult
+
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setenv("BEDROCK_MODEL_ID", "anthropic.claude-x")
+    captured: list[dict[str, str]] = []
+
+    def _boom(**kwargs: object) -> Any:
+        del kwargs
+        msg = "no serve"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(oc, "_boot_opencode_server", _boom)
+
+    async def _fallback(*, cli: str, ctx: Any, env: dict[str, str]) -> AgentResult:
+        captured.append(env)
+        return AgentResult(success=True)
+
+    monkeypatch.setattr(oc, "_run_cli_fallback", _fallback)
+
+    await oc._run(make_agent_run_context(tmp_path, resolved_model="anthropic.claude-x"))
+    assert captured[-1].get("CLAUDE_CODE_USE_BEDROCK") == "1"
+
+    await oc._run(make_agent_run_context(tmp_path, resolved_model="anthropic.claude-y"))
+    assert "CLAUDE_CODE_USE_BEDROCK" not in captured[-1]

--- a/tests/analyzers/test_cov_antislop_matcher_paths.py
+++ b/tests/analyzers/test_cov_antislop_matcher_paths.py
@@ -1,0 +1,567 @@
+"""Negative and boundary paths for the anti-slop rule matcher (#431, rules from #393).
+
+``tests/analyzers/test_antislop.py`` proves each rule fires on its positive
+fixture and stays quiet on its false-positive fixture. This file drives the
+decisions *between* those two poles: source that nearly matches a rule and must
+not be reported, rule definitions that are malformed or aimed at the wrong
+language, and the guards that keep a mid-edit file from crashing the analyzer.
+
+Every rule here lands findings on real pull requests, so a wrongly-taken branch
+is a false positive in somebody's review.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from mergecraft.analyzers.antislop.matcher import _snippet, apply_rules
+from mergecraft.analyzers.antislop.policy import AntislopRule, load_native_rules
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.antislop.policy import MatchKind
+
+_RULES = load_native_rules()
+
+
+def _findings(source: str, *, rel_path: str = "src/sample.py") -> list[tuple[str, int, str]]:
+    """Run the shipped rule set and return ``(rule_id, start_line, snippet)`` rows."""
+    return sorted(
+        (match.rule.rule_id, match.start_line, match.snippet)
+        for match in apply_rules(rel_path=rel_path, source=source, rules=_RULES)
+    )
+
+
+def _rule_ids(source: str, *, rel_path: str = "src/sample.py") -> list[str]:
+    return [rule_id for rule_id, _line, _snippet in _findings(source, rel_path=rel_path)]
+
+
+def _custom_rule(
+    *,
+    kind: str,
+    languages: set[str],
+    pattern: str | None = None,
+    rule_id: str = "antislop/custom",
+) -> AntislopRule:
+    """Build a rule directly, bypassing the YAML loader's validation."""
+    return AntislopRule(
+        rule_id=rule_id,
+        source_path="custom.yaml",
+        severity="minor",
+        confidence="likely",
+        category="Maintainability & Code Quality",
+        message="custom",
+        remediation="",
+        languages=frozenset(languages),
+        match_kind=cast("MatchKind", kind),
+        pattern=pattern,
+        compiled_pattern=re.compile(pattern) if pattern is not None else None,
+    )
+
+
+# --- language selection -------------------------------------------------------
+
+
+def test_unsupported_extension_is_never_scanned() -> None:
+    """A non-source path returns no matches even when its text is full of slop.
+
+    Markdown and config files routinely contain ``# Step 1:`` prose. Scanning
+    them would put a finding on every documentation change.
+    """
+    source = "# Step 1: install\n# ==========\n# TODO: implement the rest\n"
+
+    assert apply_rules(rel_path="docs/guide.md", source=source, rules=_RULES) == []
+    assert _rule_ids(source) == [
+        "antislop/placeholder-comment",
+        "antislop/section-divider-spam",
+        "antislop/step-comment",
+    ]
+
+
+def test_python_only_rules_do_not_fire_on_javascript() -> None:
+    """``.js`` resolves to javascript, so a python-only rule is gated out.
+
+    ``antislop/wrong-language-idiom`` flags ``.push`` in Python. In JavaScript
+    ``.push`` is the correct API — firing there would flag idiomatic code.
+    """
+    source = "const items = [];\nitems.push(1);\n"
+
+    assert _rule_ids(source, rel_path="src/app.js") == []
+    assert _rule_ids(source, rel_path="src/app.mjs") == []
+    assert _rule_ids("items = []\nitems.push(1)\n") == ["antislop/wrong-language-idiom"]
+
+
+def test_typescript_suffixes_resolve_to_typescript_not_javascript() -> None:
+    """``.ts``/``.tsx`` get the typescript label, ``.js``/``.jsx`` do not.
+
+    A rule declaring ``languages: [typescript]`` must fire on TypeScript alone.
+    Collapsing both to one label would silently widen every such rule.
+    """
+    rule = _custom_rule(kind="line_regex", languages={"typescript"}, pattern=r"marker")
+    source = "const marker = 1;\n"
+
+    def fired(rel_path: str) -> bool:
+        return bool(apply_rules(rel_path=rel_path, source=source, rules=(rule,)))
+
+    assert fired("src/app.ts") is True
+    assert fired("src/app.tsx") is True
+    assert fired("src/app.js") is False
+    assert fired("src/app.jsx") is False
+    assert fired("src/app.cjs") is False
+
+
+# --- malformed / mis-aimed rule definitions -----------------------------------
+
+
+@pytest.mark.parametrize("kind", ["comment_regex", "line_regex"])
+def test_regex_rule_without_a_compiled_pattern_matches_nothing(kind: str) -> None:
+    """A pattern-less regex rule is inert instead of raising.
+
+    ``compiled_pattern`` is ``None`` whenever a rule file omits ``match.pattern``.
+    Without the guard the matcher would call ``.search`` on ``None`` and take the
+    whole analyzer down for every file in the diff.
+    """
+    rule = _custom_rule(kind=kind, languages={"python"}, pattern=None)
+    source = "# TODO: implement this\nvalue = 1\n"
+
+    assert apply_rules(rel_path="src/sample.py", source=source, rules=(rule,)) == []
+
+
+def test_python_only_match_kind_declared_for_typescript_is_inert() -> None:
+    """A tree-sitter Python kind aimed at TypeScript yields nothing, not a crash.
+
+    The Python matchers parse with ``tree_sitter_python``. A rules author who
+    declares ``kind: python_pass_through_wrapper`` for ``[typescript]`` must get
+    silence, not Python-parsed nonsense over a TypeScript file.
+    """
+    rule = _custom_rule(kind="python_pass_through_wrapper", languages={"typescript"})
+    source = "function wrap(a) {\n  return helper(a);\n}\n"
+
+    assert apply_rules(rel_path="src/app.ts", source=source, rules=(rule,)) == []
+
+
+def test_unknown_match_kind_produces_no_matches() -> None:
+    """An unrecognised match kind is skipped rather than misrouted.
+
+    The YAML loader rejects unknown kinds, so this is the second line of defence
+    for a rule constructed in code: the matcher must not fall through into some
+    other kind's handler.
+    """
+    rule = _custom_rule(kind="python_future_kind", languages={"python"})
+    source = "def pending(value: int) -> int:\n    pass\n"
+
+    assert apply_rules(rel_path="src/sample.py", source=source, rules=(rule,)) == []
+
+
+def test_one_finding_per_rule_and_line_even_with_two_matches_on_it() -> None:
+    """Matches are deduplicated on ``(rule_id, start_line)``.
+
+    ``import os, sys`` binds two unused names on one line. The matcher reports
+    that line once, so a single-line import list cannot inflate the review with
+    duplicate comments anchored to the same line.
+    """
+    source = "import os, sys\n\n\ndef run() -> str:\n    return 'ok'\n"
+
+    assert _findings(source) == [("antislop/phantom-import", 1, "import os is unused")]
+
+
+# --- comment rules: the near-miss cases ---------------------------------------
+
+
+def test_comment_rules_only_inspect_whole_line_comments() -> None:
+    """A narrator comment trailing a statement is not reported.
+
+    ``_extract_line_comment`` requires the stripped line to *start* with the
+    comment prefix. Relaxing that would make every ``value = x  # ...`` line a
+    candidate, including comment text inside string literals.
+    """
+    assert _rule_ids("x = 1  # This function does things\n") == []
+    assert _rule_ids("# This function does things\n") == ["antislop/narrator-comment"]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("# This is a fine remark\n", []),
+        ("# This function does things\n", ["antislop/narrator-comment"]),
+        ("# Steps 1 and 2 are combined\n", []),
+        ("# Step 1: do the thing\n", ["antislop/step-comment"]),
+        ("# == two is not a divider\n", []),
+        ("# === three is\n", ["antislop/section-divider-spam"]),
+        ("# TODO: implement the parser\n", ["antislop/placeholder-comment"]),
+        ("# TODO: the parser is slow under load\n", []),
+    ],
+)
+def test_comment_rule_boundaries(source: str, expected: list[str]) -> None:
+    """Each comment rule fires on its trigger and stays quiet one step short of it.
+
+    The near-miss half of every pair is prose a human would legitimately write:
+    a "This is" sentence, a plural "Steps", a two-character divider, and a TODO
+    that records a known problem instead of unfinished work.
+    """
+    assert _rule_ids(source) == expected
+
+
+# --- line rules: quoted literals and word boundaries --------------------------
+
+
+def test_line_rules_ignore_text_inside_string_literals() -> None:
+    """Prose that quotes a suppression comment is not a suppression.
+
+    Rule files, docs strings, and error messages talk about ``# noqa``. Matching
+    the raw line would flag the code that *documents* lint evasion.
+    """
+    assert _rule_ids('msg = "add a # noqa: E501 comment"\n') == []
+    assert _rule_ids("value = compute()  # noqa: E501\n") == ["antislop/lint-evasion"]
+
+
+def test_line_rule_snippet_quotes_the_original_line_not_the_stripped_one() -> None:
+    """The reported snippet comes from the source line, literals intact.
+
+    Matching runs against a literal-stripped copy; reporting must not, or the
+    review comment would quote text that is nowhere in the file.
+    """
+    findings = _findings('value = "keep me"  # noqa: E501\n')
+
+    assert len(findings) == 1
+    _rule_id, _line, snippet = findings[0]
+    assert "keep me" in snippet
+    assert "noqa" in snippet
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("def f(x: anything) -> None:\n    return None\n", []),
+        ("def f(x: Any) -> None:\n    return None\n", ["antislop/type-evasion"]),
+        ("pushed = compute()\n", []),
+        ("items.pushall()\n", []),
+        ("items.push(1)\n", ["antislop/wrong-language-idiom"]),
+        ("length = len(items)\n", []),
+        ("items.length\n", ["antislop/wrong-language-idiom"]),
+    ],
+)
+def test_line_rule_word_boundaries(source: str, expected: list[str]) -> None:
+    """Word-boundary anchors keep identifiers containing a keyword out of scope.
+
+    ``anything`` is not ``any``, ``pushed`` is not ``.push``, and ``pushall`` is
+    a method whose name merely starts with the JavaScript one.
+    """
+    assert _rule_ids(source) == expected
+
+
+# --- placeholder implementation ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_snippet"),
+    [
+        ("    pass\n", "function body is only pass"),
+        ("    ...\n", "function body is only ..."),
+        ("    raise NotImplementedError\n", "raise NotImplementedError"),
+        ("    # keep this\n    pass\n", "function body is only pass"),
+    ],
+)
+def test_placeholder_bodies_are_reported_with_their_shape(body: str, expected_snippet: str) -> None:
+    """Each placeholder body form is reported, and comments do not hide one.
+
+    Comment nodes are filtered before the single-statement check, so adding a
+    comment above ``pass`` must not launder a stub past the rule.
+    """
+    findings = _findings(f"def pending(value: int) -> int:\n{body}")
+
+    assert findings == [("antislop/placeholder-implementation", 1, expected_snippet)]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        '    """Documented, deliberately empty."""\n',
+        "    raise ValueError('bad input')\n",
+        "    return value\n",
+        '    """Doc."""\n    return value\n',
+    ],
+)
+def test_real_function_bodies_are_not_placeholders(body: str) -> None:
+    """Bodies that do something — or that raise a *real* error — are left alone.
+
+    A docstring-only function is a deliberate no-op, ``raise ValueError`` is
+    working code, and any multi-statement body is past the stub stage. Flagging
+    these would fire on ordinary functions in every opted-in repository.
+    """
+    assert "antislop/placeholder-implementation" not in _rule_ids(
+        f"def handler(value: int) -> int:\n{body}"
+    )
+
+
+def test_function_without_a_parsable_body_does_not_crash_the_matcher() -> None:
+    """A truncated definition yields no finding instead of an exception.
+
+    Analyzers run on whatever the diff contains, including a file that does not
+    parse cleanly. ``child_by_field_name("body")`` returns ``None`` there.
+    """
+    assert _rule_ids("def f():\n") == []
+
+
+# --- pass-through wrapper ------------------------------------------------------
+
+
+def test_pass_through_wrapper_reports_a_forwarding_helper() -> None:
+    """A wrapper forwarding its exact parameter list is reported once."""
+    source = "def helper(value: int) -> int:\n    return value * 2\n\n\ndef wrapper(value: int) -> int:\n    return helper(value)\n"
+
+    assert ("antislop/pass-through-wrapper", 5, "return helper(value)") in _findings(source)
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    [
+        ("def wrap():\n    return helper()\n", "no parameters to forward"),
+        ("def wrap(a, b):\n    return helper(b, a)\n", "arguments reordered"),
+        ("def wrap(a):\n    return helper(value=a)\n", "forwarded by keyword"),
+        ("def wrap(a):\n    return a\n", "returns a value, not a call"),
+        ("def wrap(a):\n    return wrap(a)\n", "recursive call, not a wrapper"),
+        ("def wrap(a):\n    log(a)\n    return helper(a)\n", "adds behaviour"),
+    ],
+)
+def test_pass_through_wrapper_near_misses_are_not_reported(source: str, reason: str) -> None:
+    """Only an exact positional forward counts as a pass-through wrapper.
+
+    Reordering, appending, or keyword-binding arguments is adaptation, and a
+    self-recursive call is not a wrapper at all — each of these is real logic
+    that the rule must not claim adds nothing.
+    """
+    assert "antislop/pass-through-wrapper" not in _rule_ids(source), reason
+
+
+def test_pass_through_wrapper_reads_annotated_and_defaulted_parameters() -> None:
+    """Parameter names are recovered from typed and defaulted parameters.
+
+    ``_python_parameter_names`` has to reach into ``typed_parameter`` and
+    ``default_parameter`` nodes; missing them would leave the name list short and
+    silently disable the rule for annotated code — which is most of this repo.
+    """
+    source = "def wrap(a: int, b: int = 2) -> int:\n    return helper(a, b)\n"
+
+    assert _findings(source) == [("antislop/pass-through-wrapper", 1, "return helper(a, b)")]
+
+
+# --- phantom import ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_name"),
+    [
+        ("import os\n\n\ndef run() -> str:\n    return 'ok'\n", "os"),
+        ("import a.b as c\n\n\ndef run() -> str:\n    return 'ok'\n", "c"),
+        ("from pkg import alpha as a\n\n\ndef run() -> str:\n    return 'ok'\n", "a"),
+        ("from pkg import (alpha, beta)\n\n\ndef run() -> str:\n    return 'ok'\n", "alpha"),
+    ],
+)
+def test_unused_import_is_reported_under_the_name_it_binds(source: str, expected_name: str) -> None:
+    """The finding names the binding, not the module path.
+
+    ``import a.b as c`` binds ``c``; reporting ``a`` or ``a.b`` would send the
+    author looking for a name that is not in the file.
+    """
+    assert _findings(source) == [
+        ("antislop/phantom-import", 1, f"import {expected_name} is unused")
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import os\n\n\ndef run() -> str:\n    return os.sep\n",
+        "import a.b as c\n\n\ndef run() -> object:\n    return c.thing()\n",
+        "from pkg import alpha as a\n\n\ndef run() -> object:\n    return a()\n",
+        "from pkg import (alpha, beta)\n\n\ndef run() -> object:\n    return alpha(beta)\n",
+    ],
+)
+def test_used_imports_are_never_phantom(source: str) -> None:
+    """Every binding form is recognised as used when the body references it.
+
+    A false positive here fires on a correct import in an ordinary file, which
+    is the worst outcome for an opt-in style analyzer.
+    """
+    assert "antislop/phantom-import" not in _rule_ids(source)
+
+
+def test_type_checking_only_imports_are_exempt_in_every_import_form() -> None:
+    """Names imported under ``if TYPE_CHECKING`` count as used in annotations.
+
+    The repo's own style puts annotation-only imports in that block. Each import
+    spelling has its own branch in ``_collect_import_names``; a missed one turns
+    the house style into a finding on every module that uses it.
+    """
+    source = (
+        "from __future__ import annotations\n"
+        "\n"
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    import httpx\n"
+        "    import collections.abc as abc\n"
+        "    from pathlib import Path\n"
+        "    from decimal import Decimal as Dec\n"
+        "\n"
+        "\n"
+        "def fetch(client: httpx.Client, path: Path, amount: Dec, items: abc.Sequence) -> str:\n"
+        "    return f'{client}{path}{amount}{items}'\n"
+    )
+
+    assert _rule_ids(source) == []
+
+
+def test_type_checking_exempts_only_the_names_inside_the_block() -> None:
+    """A runtime import stays reportable next to a TYPE_CHECKING block.
+
+    The exemption set must not be applied wholesale to the file, or one
+    ``if TYPE_CHECKING`` block would disable the rule for the whole module.
+    """
+    source = (
+        "from typing import TYPE_CHECKING\n"
+        "\n"
+        "import unused_runtime\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    from pathlib import Path\n"
+        "\n"
+        "\n"
+        "def fetch(path: Path) -> str:\n"
+        "    return f'{path}!'\n"
+    )
+
+    assert _findings(source) == [("antislop/phantom-import", 3, "import unused_runtime is unused")]
+
+
+# --- snippet rendering ---------------------------------------------------------
+
+
+def test_snippet_windows_around_the_match_and_collapses_whitespace() -> None:
+    """A snippet is a bounded window around the match, not the whole line.
+
+    Snippets are posted verbatim into PR comments, so an unbounded one leaks the
+    rest of a long line into review output.
+    """
+    text = "left" * 20 + "  MATCH  " + "right" * 20
+    windowed = _snippet(text, re.compile("MATCH"))
+
+    assert "MATCH" in windowed
+    assert len(windowed) <= 120
+    assert "  " not in windowed
+    assert len(windowed) < len(text)
+
+
+def test_snippet_falls_back_to_the_truncated_text_when_the_pattern_misses() -> None:
+    """When the pattern cannot be re-found, the snippet is still bounded.
+
+    The display text is not always the text that was matched (line rules search a
+    literal-stripped copy). The fallback must stay capped at the same limit
+    rather than returning the entire line — or nothing.
+    """
+    text = "x" * 400
+
+    assert _snippet(text, re.compile("never-here")) == "x" * 120
+
+
+# --- known defects -------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason=(
+        "_call_positional_argument_names silently drops positional arguments that are "
+        'not identifiers or attributes, so `return request("GET", url)` is read as '
+        "forwarding exactly `(url,)` and the wrapper is reported as adding nothing. "
+        "Binding a constant argument is real behaviour; this fires on ordinary adapter "
+        "functions. Keyword arguments already abort the check (`return ()`) — literal "
+        "positionals must too."
+    ),
+    strict=True,
+)
+def test_wrapper_that_binds_a_literal_argument_is_not_a_pass_through() -> None:
+    """A wrapper supplying an extra constant argument adds behaviour."""
+    source = "def fetch(url: str) -> object:\n    return request('GET', url)\n"
+
+    assert "antislop/pass-through-wrapper" not in _rule_ids(source)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "_node_text slices the source string with tree-sitter BYTE offsets, so any "
+        "non-ASCII character earlier in the file shifts every later node's text. Here "
+        "the binding name for `import os` is read as 's\\n', which no body reference "
+        "can match, and a used import is reported as phantom. mergeCraft's own sources "
+        "are full of em dashes, so this fires on ordinary files."
+    ),
+    strict=True,
+)
+def test_non_ascii_above_an_import_must_not_make_a_used_import_phantom() -> None:
+    """A used import stays used when the file contains a non-ASCII character."""
+    source = "# café — notes\nimport os\n\n\ndef run() -> str:\n    return os.sep\n"
+
+    assert "antislop/phantom-import" not in _rule_ids(source)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "_node_text byte/char mismatch again: the reported snippet is a shifted slice "
+        "of the source ('ise NotImplementedError'), so the review comment quotes text "
+        "that does not exist in the file."
+    ),
+    strict=True,
+)
+def test_snippet_after_non_ascii_quotes_real_source_text() -> None:
+    """The placeholder snippet must be a substring of the file it came from."""
+    source = "# — notes\ndef pending(value: int) -> int:\n    raise NotImplementedError\n"
+
+    findings = _findings(source)
+    assert findings == [("antislop/placeholder-implementation", 2, "raise NotImplementedError")]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "antislop/empty-error-handler never fires on Python. tree-sitter-python's "
+        "except_clause exposes its suite as an unnamed child, so "
+        "child_by_field_name('body') is always None and the whole matcher body is "
+        "dead. The rule declares languages [python, javascript, typescript] and ships "
+        "a positive Python fixture; test_positive_fixture_fires_rule passes only "
+        "because the .ts fixture matches."
+    ),
+    strict=True,
+)
+def test_python_except_block_that_only_passes_is_reported() -> None:
+    """``except OSError: pass`` swallows the failure and must be reported."""
+    source = (
+        "def load() -> str:\n"
+        "    try:\n"
+        "        return open('data.txt', encoding='utf-8').read()\n"
+        "    except OSError:\n"
+        "        pass\n"
+        "    return 'fallback'\n"
+    )
+
+    assert "antislop/empty-error-handler" in _rule_ids(source)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "antislop/error-obscuring-catch never fires on Python — same dead "
+        "child_by_field_name('body') lookup on except_clause as empty-error-handler. "
+        "Its positive Python fixture is likewise carried by the .ts sibling."
+    ),
+    strict=True,
+)
+def test_python_except_block_returning_none_is_reported() -> None:
+    """``except KeyError: return None`` hides the failure and must be reported."""
+    source = (
+        "def lookup(key: str) -> str | None:\n"
+        "    try:\n"
+        "        return _fetch(key)\n"
+        "    except KeyError:\n"
+        "        return None\n"
+    )
+
+    assert "antislop/error-obscuring-catch" in _rule_ids(source)

--- a/tests/analyzers/test_cov_provision_paths.py
+++ b/tests/analyzers/test_cov_provision_paths.py
@@ -1,0 +1,711 @@
+"""Refusal, recovery, and extraction paths in managed-binary provisioning (#431).
+
+``tests/analyzers/test_provision.py`` covers the pinned happy path and
+``tests/analyzers/test_provision_cache_integrity.py`` covers receipt verification
+after a self-updating tool rewrites its binary. What neither drives is the set of
+decisions that *refuse* work: an unpinned or redirected download URL, an archive
+member that escapes its extraction directory, a cache entry that cannot be
+purged, and the second cache check taken after another worker won the lock.
+
+No test here reaches the network. ``_download_pinned_url`` is replaced with a
+local write, and the two tests that exercise the downloader itself replace
+``httpx.stream`` and the egress guards with in-memory fakes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import ipaddress
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.analyzers import provision
+from mergecraft.analyzers.manifest import AnalyzerManifest
+from mergecraft.security.egress import GuardedUrl, SsrfBlockedError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_PAYLOAD = b"#!/bin/sh\necho pinned-tool 1.0.0\n"
+_PAYLOAD_SHA = hashlib.sha256(_PAYLOAD).hexdigest()
+_PLATFORM = "linux-amd64"
+_URL = "https://example.invalid/faketool"
+
+
+def _manifest(*, url: str = _URL, sha256: str = _PAYLOAD_SHA, platform: str = _PLATFORM) -> Any:
+    """Managed manifest whose pinned artifact is the fake binary."""
+    return AnalyzerManifest.model_validate(
+        {
+            "id": "faketool",
+            "category": "ci",
+            "languages": [],
+            "detect": {"files": ["**/*"]},
+            "command": ["faketool", "{files}"],
+            "scope": "diff",
+            "parser": "sarif",
+            "supports_fix": False,
+            "default_enabled": "auto",
+            "version": "1.0.0",
+            "runtime": "managed",
+            "timeout_s": 60,
+            "trust": "untrusted",
+            "severity_map": {"error": "Major", "warning": "Minor", "note": "Trivial"},
+            "provenance": {platform: {"url": url, "sha256": sha256}},
+            "network_allowlist": [],
+        }
+    )
+
+
+@pytest.fixture
+def fake_download(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace the pinned download with a local write; return the call log."""
+    calls: list[str] = []
+
+    def _fake(url: str, dest: Path) -> None:
+        calls.append(url)
+        dest.write_bytes(_PAYLOAD)
+
+    monkeypatch.setattr(provision, "_download_pinned_url", _fake)
+    return calls
+
+
+def _provision(cache_dir: Path, manifest: Any = None) -> Any:
+    return provision.provision_managed_binary(
+        manifest=manifest if manifest is not None else _manifest(),
+        platform=_PLATFORM,
+        cache_dir=cache_dir,
+    )
+
+
+# --- refusals before anything is fetched ---------------------------------------
+
+
+def test_platform_without_provenance_is_refused_by_name() -> None:
+    """A platform the manifest never pinned cannot be provisioned.
+
+    Falling back to another platform's pin would install a binary for the wrong
+    architecture and still report it as pinned.
+    """
+    with pytest.raises(provision.ProvisionError) as exc_info:
+        provision.provision_managed_binary(
+            manifest=_manifest(),
+            platform="darwin-arm64",
+            cache_dir=Path("/nonexistent-cache"),
+        )
+
+    message = str(exc_info.value)
+    assert "darwin-arm64" in message
+    assert "faketool" in message
+
+
+def test_blank_sha256_pin_is_refused(tmp_path: Path, fake_download: list[str]) -> None:
+    """A whitespace-only pin is treated as no pin at all.
+
+    ``expected_sha256`` is stripped before use; without the emptiness check the
+    cache key would be the empty string and ``_verify_sha256`` would compare
+    against nothing, accepting any downloaded bytes.
+    """
+    with pytest.raises(provision.ProvisionError, match=r"non-empty sha256"):
+        provision.provision_managed_binary(
+            manifest=_manifest(),
+            platform=_PLATFORM,
+            cache_dir=tmp_path / "cache",
+            expected_sha256="   ",
+        )
+
+    assert fake_download == []
+
+
+def test_download_os_error_is_reported_as_a_provision_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A filesystem failure while downloading surfaces as ``ProvisionError``.
+
+    ``provision_managed_binary`` is the boundary the analyzer pipeline catches;
+    a bare ``OSError`` escaping it would abort the whole run instead of marking
+    one tool skipped.
+    """
+
+    def _explode(url: str, dest: Path) -> None:
+        _ = (url, dest)
+        msg = "No space left on device"
+        raise OSError(msg)
+
+    monkeypatch.setattr(provision, "_download_pinned_url", _explode)
+
+    with pytest.raises(provision.ProvisionError, match=r"download failed for faketool"):
+        _provision(tmp_path / "cache")
+
+
+# --- receipts ------------------------------------------------------------------
+
+
+def test_receipt_is_absent_for_a_directory_that_has_none(tmp_path: Path) -> None:
+    """Reading a receipt from a directory without one returns ``None``, not an error."""
+    assert provision.read_provision_receipt(tmp_path) is None
+
+
+def test_receipt_content_is_normalised_and_validated(tmp_path: Path) -> None:
+    """Only a bare 64-char hex digest counts as a receipt.
+
+    The receipt decides whether a cached binary is executed. Accepting truncated
+    or non-hex content would let a corrupt sidecar authorise an unverified file;
+    accepting a partial match would let ``deadbeef…`` plus trailing junk through.
+    """
+    receipt = tmp_path / provision.RECEIPT_NAME
+
+    receipt.write_text(f"{_PAYLOAD_SHA.upper()}\n", encoding="utf-8")
+    assert provision.read_provision_receipt(tmp_path) == _PAYLOAD_SHA
+
+    receipt.write_text("not-a-digest\n", encoding="utf-8")
+    assert provision.read_provision_receipt(tmp_path) is None
+
+    receipt.write_text(f"{_PAYLOAD_SHA} trailing\n", encoding="utf-8")
+    assert provision.read_provision_receipt(tmp_path) is None
+
+    receipt.write_text(f"{_PAYLOAD_SHA[:-1]}\n", encoding="utf-8")
+    assert provision.read_provision_receipt(tmp_path) is None
+
+
+def test_corrupt_receipt_forces_reprovisioning(tmp_path: Path, fake_download: list[str]) -> None:
+    """An unreadable receipt is a cache miss, not a cache hit.
+
+    A half-written sidecar (interrupted run, truncated volume) must send the
+    caller back to the pin rather than serving a binary nothing vouches for.
+    """
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    (first.resolved_path.parent / provision.RECEIPT_NAME).write_text("garbage", encoding="utf-8")
+
+    second = _provision(cache_dir)
+
+    assert second.source == "download"
+    assert second.sha256 == _PAYLOAD_SHA
+    assert fake_download == [_URL, _URL]
+
+
+# --- cache purge ---------------------------------------------------------------
+
+
+def test_purge_removes_directories_a_self_updating_tool_left_behind(
+    tmp_path: Path, fake_download: list[str]
+) -> None:
+    """Re-provisioning drops sibling directories, not just the binary.
+
+    TruffleHog's updater unpacks into a sibling directory. Leaving it in place
+    would let stale updater state survive the purge and re-enter the next run.
+    """
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    cache_root = first.resolved_path.parent
+    stale_dir = cache_root / "updater-state"
+    stale_dir.mkdir()
+    (stale_dir / "manifest.json").write_text("stale", encoding="utf-8")
+    first.resolved_path.write_bytes(b"#!/bin/sh\necho attacker 9.9.9\n")
+
+    second = _provision(cache_dir)
+
+    assert second.source == "download"
+    assert not stale_dir.exists()
+    assert second.resolved_path.read_bytes() == _PAYLOAD
+
+
+def test_undeletable_cache_entry_is_refused_rather_than_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_download: list[str]
+) -> None:
+    """A purge that cannot complete raises instead of falling through.
+
+    If the untrusted entry cannot be removed, provisioning must not continue and
+    overwrite around it — the run would end up executing whatever survived.
+    """
+    cache_dir = tmp_path / "cache"
+    first = _provision(cache_dir)
+    stale_dir = first.resolved_path.parent / "updater-state"
+    stale_dir.mkdir()
+    first.resolved_path.write_bytes(b"#!/bin/sh\necho attacker 9.9.9\n")
+
+    def _refuse(path: Any) -> None:
+        _ = path
+        msg = "Permission denied"
+        raise OSError(msg)
+
+    monkeypatch.setattr(provision.shutil, "rmtree", _refuse)
+
+    with pytest.raises(provision.ProvisionError, match=r"failed to discard untrusted cache entry"):
+        _provision(cache_dir)
+
+    assert len(fake_download) == 1, "no second download after the purge failed"
+
+
+# --- lock contention -----------------------------------------------------------
+
+
+def test_entry_provisioned_while_waiting_for_the_lock_is_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_download: list[str]
+) -> None:
+    """The in-lock re-check serves the winner's binary instead of downloading again.
+
+    Two workers can both miss the cache and queue on the lock. Without the second
+    check the loser re-downloads and ``os.replace``s the file the winner may be
+    executing. Here the lock helper stands in for the winning worker: it installs
+    a verified entry before the caller's critical section begins.
+    """
+    cache_dir = tmp_path / "cache"
+    cache_root = cache_dir / "faketool" / _PLATFORM / _PAYLOAD_SHA
+
+    @contextlib.contextmanager
+    def _lock_that_loses_the_race(root: Path) -> Iterator[None]:
+        root.mkdir(parents=True, exist_ok=True)
+        binary = root / "faketool"
+        binary.write_bytes(_PAYLOAD)
+        provision._write_provision_receipt(root, _PAYLOAD_SHA)
+        yield
+
+    monkeypatch.setattr(provision, "_cache_provision_lock", _lock_that_loses_the_race)
+
+    result = _provision(cache_dir)
+
+    assert result.source == "cache"
+    assert result.sha256 == _PAYLOAD_SHA
+    assert result.resolved_path == cache_root / "faketool"
+    assert fake_download == [], "the loser of the lock race must not re-download"
+
+
+# --- pinned download URL handling ----------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for the streamed ``httpx`` response."""
+
+    def __init__(self, *, status_code: int, headers: dict[str, str], body: bytes) -> None:
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            msg = f"HTTP {self.status_code}"
+            raise httpx.HTTPError(msg)
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        yield self._body
+
+
+@pytest.fixture
+def scripted_http(monkeypatch: pytest.MonkeyPatch) -> dict[str, _FakeResponse]:
+    """Serve scripted responses by URL and neutralise DNS/egress pinning."""
+    responses: dict[str, _FakeResponse] = {}
+    localhost = ipaddress.ip_address("93.184.216.34")
+
+    def _guard(url: str) -> GuardedUrl:
+        from urllib.parse import urlparse
+
+        return GuardedUrl(url=url, host=urlparse(url).hostname or "", addresses=(localhost,))
+
+    @contextlib.contextmanager
+    def _pin(host: str, addresses: Any) -> Iterator[None]:
+        _ = (host, addresses)
+        yield
+
+    @contextlib.contextmanager
+    def _stream(method: str, url: str, **kwargs: Any) -> Iterator[_FakeResponse]:
+        _ = (method, kwargs)
+        assert url in responses, f"unscripted request to {url}"
+        yield responses[url]
+
+    monkeypatch.setattr(provision, "inspect_external_url", _guard)
+    monkeypatch.setattr(provision, "pin_host_resolution", _pin)
+    monkeypatch.setattr(provision.httpx, "stream", _stream)
+    return responses
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["http://example.invalid/faketool", "file:///etc/passwd", "https:///faketool"],
+)
+def test_non_https_or_hostless_download_url_is_refused(tmp_path: Path, url: str) -> None:
+    """Only ``https://host/...`` is downloadable, and nothing is written.
+
+    A plaintext or hostless URL defeats the pin: the bytes can be substituted in
+    transit or read off the local filesystem.
+    """
+    dest = tmp_path / "artifact"
+
+    with pytest.raises(provision.ProvisionError, match=r"unpinned or non-https"):
+        provision._download_pinned_url(url, dest)
+
+    assert not dest.exists()
+
+
+def test_ssrf_blocked_url_is_reported_as_a_provision_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An SSRF verdict becomes a provisioning refusal with its reason intact.
+
+    The egress guard's message names *why* the host was rejected; wrapping must
+    not lose it, and ``SsrfBlockedError`` (a ``PermissionError``) must not escape
+    to callers that only handle ``ProvisionError``.
+    """
+
+    def _blocked(url: str) -> GuardedUrl:
+        _ = url
+        msg = "host resolves to a link-local address"
+        raise SsrfBlockedError(msg)
+
+    monkeypatch.setattr(provision, "inspect_external_url", _blocked)
+
+    with pytest.raises(provision.ProvisionError, match=r"link-local"):
+        provision._download_pinned_url("https://metadata.invalid/x", tmp_path / "artifact")
+
+
+def test_redirect_to_an_allowed_release_host_is_followed(
+    tmp_path: Path, scripted_http: dict[str, _FakeResponse]
+) -> None:
+    """GitHub's release redirect to its asset CDN is followed and the body kept.
+
+    Release downloads always 302 to ``objects.githubusercontent.com``; refusing
+    that hop would make every managed analyzer unprovisionable.
+    """
+    asset = "https://objects.githubusercontent.com/faketool"
+    scripted_http["https://github.invalid/faketool"] = _FakeResponse(
+        status_code=302, headers={"location": asset}, body=b""
+    )
+    scripted_http[asset] = _FakeResponse(status_code=200, headers={}, body=_PAYLOAD)
+    dest = tmp_path / "artifact"
+
+    provision._download_pinned_url("https://github.invalid/faketool", dest)
+
+    assert dest.read_bytes() == _PAYLOAD
+
+
+def test_redirect_without_a_location_header_is_refused(
+    tmp_path: Path, scripted_http: dict[str, _FakeResponse]
+) -> None:
+    """A 302 with no ``Location`` cannot be followed and must not silently pass.
+
+    Treating it as success would leave an empty file that then fails the sha
+    check with a confusing "mismatch" instead of the real cause.
+    """
+    scripted_http[_URL] = _FakeResponse(status_code=302, headers={}, body=b"")
+
+    with pytest.raises(provision.ProvisionError, match=r"missing Location"):
+        provision._download_pinned_url(_URL, tmp_path / "artifact")
+
+
+def test_redirect_off_the_allowlist_is_refused_naming_the_original_url(
+    tmp_path: Path, scripted_http: dict[str, _FakeResponse]
+) -> None:
+    """A redirect to an unrelated host is rejected, and the error names the pin.
+
+    This is the hop an attacker controls once a release host is compromised or a
+    URL is typo-squatted; the allowlist is what keeps the download on the CDN the
+    pin was computed against.
+    """
+    scripted_http[_URL] = _FakeResponse(
+        status_code=302, headers={"location": "https://evil.invalid/payload"}, body=b""
+    )
+    dest = tmp_path / "artifact"
+
+    with pytest.raises(provision.ProvisionError) as exc_info:
+        provision._download_pinned_url(_URL, dest)
+
+    message = str(exc_info.value)
+    assert _URL in message
+    assert "https://evil.invalid/payload" in message
+    assert not dest.exists()
+
+
+def test_redirect_chain_is_bounded(tmp_path: Path, scripted_http: dict[str, _FakeResponse]) -> None:
+    """A self-referential redirect terminates instead of looping forever.
+
+    ``_download_pinned_url`` allows eight hops; a redirect to the same URL would
+    otherwise hang the analyzer run rather than fail it.
+    """
+    scripted_http[_URL] = _FakeResponse(status_code=307, headers={"location": _URL}, body=b"")
+
+    with pytest.raises(provision.ProvisionError, match=r"too many redirects"):
+        provision._download_pinned_url(_URL, tmp_path / "artifact")
+
+
+def test_http_error_during_download_is_wrapped_with_the_url(
+    tmp_path: Path, scripted_http: dict[str, _FakeResponse]
+) -> None:
+    """A failing status becomes a ``ProvisionError`` naming the URL that failed."""
+    scripted_http[_URL] = _FakeResponse(status_code=503, headers={}, body=b"")
+
+    with pytest.raises(provision.ProvisionError, match=r"download failed for"):
+        provision._download_pinned_url(_URL, tmp_path / "artifact")
+
+
+# --- archive extraction ---------------------------------------------------------
+
+
+def _tar_bytes(members: dict[str, bytes], *, mode: str) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode=mode) as tar:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(data))
+    return buffer.getvalue()
+
+
+def _zip_bytes(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    return buffer.getvalue()
+
+
+def _archive_for(artifact_name: str) -> bytes:
+    """Build a one-binary archive in the format implied by ``artifact_name``."""
+    if artifact_name.endswith((".tar.gz", ".tgz")):
+        return _tar_bytes({"bin/faketool": _PAYLOAD}, mode="w:gz")
+    if artifact_name.endswith((".tar.xz", ".txz")):
+        return _tar_bytes({"bin/faketool": _PAYLOAD}, mode="w:xz")
+    return _zip_bytes({"bin/": b"", "bin/faketool": _PAYLOAD})
+
+
+@pytest.mark.parametrize(
+    "artifact_name",
+    ["faketool.tar.gz", "faketool.tgz", "faketool.tar.xz", "faketool.txz", "faketool.zip"],
+)
+def test_pinned_archive_is_unpacked_and_the_named_binary_installed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_name: str,
+) -> None:
+    """Each supported archive format yields the manifest's binary, executable.
+
+    The pin covers the *archive*, so the sha check runs on the download and the
+    extracted file is what gets its own receipt. A format that fell through to
+    the raw-file branch would install the compressed bytes as the executable.
+    """
+    archive = _archive_for(artifact_name)
+    url = f"https://example.invalid/{artifact_name}"
+
+    def _fake(download_url: str, dest: Path) -> None:
+        _ = download_url
+        dest.write_bytes(archive)
+
+    monkeypatch.setattr(provision, "_download_pinned_url", _fake)
+    manifest = _manifest(url=url, sha256=hashlib.sha256(archive).hexdigest())
+
+    result = _provision(tmp_path / "cache", manifest)
+
+    assert result.source == "download"
+    assert result.resolved_path.read_bytes() == _PAYLOAD
+    assert result.sha256 == _PAYLOAD_SHA
+    assert result.resolved_path.stat().st_mode & 0o111
+
+
+def test_zip_member_escaping_the_extraction_directory_is_refused(tmp_path: Path) -> None:
+    """A ``../`` member is rejected before anything is written outside the dir.
+
+    Zip-slip: the archive is attacker-influenced the moment a release host is
+    compromised, and extraction runs with the review job's privileges.
+    """
+    archive = tmp_path / "evil.zip"
+    archive.write_bytes(_zip_bytes({"../escaped": _PAYLOAD}))
+    dest_dir = tmp_path / "extract"
+    dest_dir.mkdir()
+
+    with pytest.raises(provision.ProvisionError, match=r"unsafe archive member path"):
+        provision._extract_executable(archive, dest_dir, "faketool")
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_archive_without_the_named_binary_falls_back_to_its_only_file(tmp_path: Path) -> None:
+    """A release that renames the binary still resolves to the file it shipped.
+
+    Upstream archives often carry ``faketool-linux-amd64``. Failing here would
+    make the analyzer unavailable even though the pinned bytes are present.
+    """
+    archive = tmp_path / "faketool.zip"
+    archive.write_bytes(_zip_bytes({"faketool-linux-amd64": _PAYLOAD}))
+    dest_dir = tmp_path / "extract"
+    dest_dir.mkdir()
+
+    extracted = provision._extract_executable(archive, dest_dir, "faketool")
+
+    assert extracted.name == "faketool-linux-amd64"
+    assert extracted.read_bytes() == _PAYLOAD
+
+
+def test_empty_archive_is_refused(tmp_path: Path) -> None:
+    """An archive with no files is an error, not an empty install."""
+    archive = tmp_path / "faketool.zip"
+    archive.write_bytes(_zip_bytes({}))
+    dest_dir = tmp_path / "extract"
+    dest_dir.mkdir()
+
+    with pytest.raises(provision.ProvisionError, match=r"no executable found in archive"):
+        provision._extract_executable(archive, dest_dir, "faketool")
+
+
+def test_non_archive_artifact_is_installed_verbatim(tmp_path: Path) -> None:
+    """A bare binary download is copied under the manifest's command name."""
+    artifact = tmp_path / "faketool"
+    artifact.write_bytes(_PAYLOAD)
+    dest_dir = tmp_path / "staging"
+    dest_dir.mkdir()
+
+    staged = provision._extract_executable(artifact, dest_dir, "faketool")
+
+    assert staged == dest_dir / "faketool"
+    assert staged.read_bytes() == _PAYLOAD
+
+
+# --- lockfile resolution --------------------------------------------------------
+
+
+def test_lock_entries_for_other_tools_are_ignored(tmp_path: Path, fake_download: list[str]) -> None:
+    """A lock recording another tool does not satisfy this manifest.
+
+    ``read_lock`` returns every entry in the file. Matching on anything but the
+    tool id would resolve ``faketool`` to whatever sha the neighbouring entry
+    happens to carry.
+    """
+    from mergecraft.analyzers.lockfile import LockEntry, read_lock, write_lock
+
+    lock_path = tmp_path / ".mergecraft" / "analyzers.lock"
+    write_lock(
+        lock_path,
+        [
+            LockEntry(
+                tool_id="othertool",
+                version="9.9.9",
+                mode="managed",
+                source="cache",
+                sha256="0" * 64,
+            )
+        ],
+    )
+
+    result = provision.resolve_with_lock(
+        manifest=_manifest(),
+        lock_path=lock_path,
+        cache_dir=tmp_path / "cache",
+        platform=_PLATFORM,
+    )
+
+    assert result.source == "download"
+    assert result.sha256 == _PAYLOAD_SHA
+    assert fake_download == [_URL]
+    assert {entry.tool_id for entry in read_lock(lock_path)} == {"othertool", "faketool"}
+
+
+def test_locked_tool_without_provenance_for_the_platform_is_refused(tmp_path: Path) -> None:
+    """A lock entry cannot stand in for a missing platform pin.
+
+    The lock records a sha but no URL. Serving from it when the manifest has no
+    provenance for this platform would mean trusting a digest with nothing to
+    fetch or re-verify it against.
+    """
+    from mergecraft.analyzers.lockfile import LockEntry, write_lock
+
+    lock_path = tmp_path / ".mergecraft" / "analyzers.lock"
+    write_lock(
+        lock_path,
+        [
+            LockEntry(
+                tool_id="faketool",
+                version="1.0.0",
+                mode="managed",
+                source="cache",
+                sha256=_PAYLOAD_SHA,
+            )
+        ],
+    )
+
+    with pytest.raises(provision.ProvisionError, match=r"no provenance for platform"):
+        provision.resolve_with_lock(
+            manifest=_manifest(),
+            lock_path=lock_path,
+            cache_dir=tmp_path / "cache",
+            platform="darwin-arm64",
+        )
+
+
+# --- baked image resolution ------------------------------------------------------
+
+
+def test_baked_binary_is_ignored_outside_the_full_analyzers_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``MERGECRAFT_ANALYZERS=full`` nothing on the host is trusted.
+
+    Resolving a same-named binary from the developer's ``PATH`` would run an
+    unpinned tool in place of the managed one.
+    """
+    baked = tmp_path / "analyzers"
+    baked.mkdir()
+    (baked / "faketool").write_bytes(_PAYLOAD)
+    monkeypatch.setattr(provision, "BAKED_ANALYZER_ROOT", baked)
+    monkeypatch.delenv("MERGECRAFT_ANALYZERS", raising=False)
+
+    assert provision.resolve_baked_binary(_manifest()) is None
+
+    monkeypatch.setenv("MERGECRAFT_ANALYZERS", "minimal")
+    assert provision.resolve_baked_binary(_manifest()) is None
+
+
+def test_baked_binary_is_used_in_the_full_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In the full image the baked path wins, case- and space-insensitively."""
+    baked = tmp_path / "analyzers"
+    baked.mkdir()
+    (baked / "faketool").write_bytes(_PAYLOAD)
+    monkeypatch.setattr(provision, "BAKED_ANALYZER_ROOT", baked)
+    monkeypatch.setenv("MERGECRAFT_ANALYZERS", "  FULL ")
+
+    assert provision.resolve_baked_binary(_manifest()) == baked / "faketool"
+
+
+def test_full_image_falls_back_to_path_then_gives_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the baked path is empty, ``PATH`` is consulted, then ``None`` is returned.
+
+    The fallback is what lets an apt/pip-installed analyzer serve the full image;
+    returning a path when nothing was found would send an unrunnable command to
+    the sandbox.
+    """
+    monkeypatch.setattr(provision, "BAKED_ANALYZER_ROOT", tmp_path / "empty")
+    monkeypatch.setenv("MERGECRAFT_ANALYZERS", "full")
+
+    on_path = tmp_path / "bin" / "faketool"
+    on_path.parent.mkdir()
+    on_path.write_bytes(_PAYLOAD)
+    monkeypatch.setattr(provision.shutil, "which", lambda name: str(on_path))
+    assert provision.resolve_baked_binary(_manifest()) == on_path
+
+    monkeypatch.setattr(provision.shutil, "which", lambda name: None)
+    assert provision.resolve_baked_binary(_manifest()) is None
+
+
+def test_platform_key_matches_the_provenance_key_format() -> None:
+    """The host platform key is the one manifests pin provenance under.
+
+    It is also a cache-path component, so a drifting format would silently
+    re-download every analyzer on every run.
+    """
+    from mergecraft.analyzers.execution import provision_platform_key
+
+    key = provision.platform_key()
+
+    assert key == provision_platform_key()
+    assert key.split("-")[0] in {"linux", "darwin", "windows"}
+    assert key.split("-")[1] in {"amd64", "arm64"}

--- a/tests/cli/test_cov_analyzers_cmd_paths.py
+++ b/tests/cli/test_cov_analyzers_cmd_paths.py
@@ -1,0 +1,568 @@
+"""Decision-path coverage for ``mergecraft analyzers`` (issue #431).
+
+Drives the arms of ``cli/analyzers_cmd.py`` the existing suite never reaches:
+the ``git diff`` probe's failure modes, the "no changed files" guards on
+``detect`` / ``run`` / ``export``, the ``--sarif`` vs ``--output`` mutual
+requirement, skipped-adapter bails, the optional ``explain`` rows, and every
+branch of ``lock``'s platform derivation, reuse/refresh, and per-tool skips.
+
+No test here runs a real analyzer, shells out to ``git``, or writes into the
+checkout: ``run_adapter``/``resolve_with_lock``/``write_analyzers_doc`` are
+stubbed and every path is under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mergecraft.analyzers.adapters import AdapterRunResult
+from mergecraft.analyzers.finding import make_finding
+from mergecraft.analyzers.lockfile import LockEntry
+from mergecraft.cli import analyzers_cmd
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_CONFIGURATION_EXIT_CODE
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# Rich wraps at the terminal width; pin it wide so table rows stay on one line.
+_WIDE = {"COLUMNS": "200", "TERM": "dumb"}
+
+
+def _plain(result: Any) -> str:
+    return _ANSI.sub("", result.stdout + result.stderr)
+
+
+def _row(text: str, analyzer_id: str) -> list[str]:
+    """Return the rendered table row cells whose first cell is ``analyzer_id``."""
+    for line in text.splitlines():
+        cells = [cell.strip() for cell in line.split("\u2502")]
+        if len(cells) > 1 and cells[1] == analyzer_id:
+            return cells[1:-1]
+    pytest.fail(f"no table row for {analyzer_id!r} in:\n{text}")
+
+
+def _finding(path: str, line: int | None, message: str) -> Any:
+    return make_finding(
+        tool="ruff",
+        rule_id="E501",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message=message,
+        path=path,
+        start_line=line,
+        end_line=line,
+        source="analyzer",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _git_changed_files — every way the probe can come back empty
+# ---------------------------------------------------------------------------
+
+
+def test_git_probe_returns_nothing_when_git_is_not_installed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("git: no such file")
+
+    monkeypatch.setattr(analyzers_cmd.subprocess, "run", _boom)
+    assert analyzers_cmd._git_changed_files(tmp_path) == []
+
+
+def test_git_probe_returns_nothing_on_a_non_zero_exit(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """``git diff`` outside a repository exits 128 — its stdout must be ignored."""
+    completed = subprocess.CompletedProcess(
+        args=["git"], returncode=128, stdout="fatal: not a git repository\n", stderr=""
+    )
+    monkeypatch.setattr(analyzers_cmd.subprocess, "run", lambda *a, **k: completed)
+    assert analyzers_cmd._git_changed_files(tmp_path) == []
+
+
+def test_git_probe_strips_blank_lines_and_whitespace(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=["git"], returncode=0, stdout="src/a.py\n\n  src/b.py  \n\n", stderr=""
+    )
+    monkeypatch.setattr(analyzers_cmd.subprocess, "run", lambda *a, **k: completed)
+    assert analyzers_cmd._git_changed_files(tmp_path) == ["src/a.py", "src/b.py"]
+
+
+# ---------------------------------------------------------------------------
+# analyzers list
+# ---------------------------------------------------------------------------
+
+
+def test_list_marks_an_analyzer_that_would_enable_for_the_changed_files(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(analyzers_cmd, "_git_changed_files", lambda _dir: ["a.py"])
+    result = runner.invoke(app, ["analyzers", "list", "--cwd", str(tmp_path)], env=_WIDE)
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert _row(text, "bandit") == ["bandit", "security", "auto", "yes"]
+    # An analyzer whose detect globs do not match must stay on the "no" side.
+    assert _row(text, "actionlint") == ["actionlint", "ci", "auto", "no"]
+
+
+def test_list_falls_back_to_the_whole_tree_when_git_reports_no_changes(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """The ``or ["."]`` fallback: nothing matches, so every row says "no"."""
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(analyzers_cmd, "_git_changed_files", lambda _dir: [])
+    result = runner.invoke(app, ["analyzers", "list", "--cwd", str(tmp_path)], env=_WIDE)
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert _row(text, "bandit") == ["bandit", "security", "auto", "no"]
+
+
+# ---------------------------------------------------------------------------
+# analyzers detect
+# ---------------------------------------------------------------------------
+
+
+def test_detect_bails_when_there_is_nothing_to_analyze(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(analyzers_cmd, "_git_changed_files", lambda _dir: [])
+    result = runner.invoke(app, ["analyzers", "detect", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "pass --file or run inside a git repo" in _plain(result)
+
+
+def test_detect_prints_id_category_and_runtime_for_explicit_files(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["analyzers", "detect", "--cwd", str(tmp_path), "--file", "a.py"],
+        env=_WIDE,
+    )
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert "bandit (security, repo-native)" in text
+    assert "actionlint" not in text
+
+
+# ---------------------------------------------------------------------------
+# analyzers run
+# ---------------------------------------------------------------------------
+
+
+def _stub_adapter(monkeypatch: MonkeyPatch, result: AdapterRunResult) -> dict[str, Any]:
+    seen: dict[str, Any] = {}
+
+    def _run(**kwargs: Any) -> AdapterRunResult:
+        seen.update(kwargs)
+        return result
+
+    monkeypatch.setattr(analyzers_cmd, "run_adapter", _run)
+    return seen
+
+
+def test_run_bails_without_changed_files(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(analyzers_cmd, "_git_changed_files", lambda _dir: [])
+    result = runner.invoke(app, ["analyzers", "run", "ruff", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "no changed files" in _plain(result)
+
+
+def test_run_surfaces_the_adapters_skip_reason(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    _stub_adapter(
+        monkeypatch,
+        AdapterRunResult(findings=[], skipped=True, skip_reason="ruff not installed"),
+    )
+    result = runner.invoke(
+        app, ["analyzers", "run", "ruff", "--cwd", str(tmp_path), "-f", "a.py"], env=_WIDE
+    )
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "ruff not installed" in _plain(result)
+
+
+def test_run_falls_back_to_a_generic_message_when_the_skip_has_no_reason(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _stub_adapter(monkeypatch, AdapterRunResult(findings=[], skipped=True, skip_reason=None))
+    result = runner.invoke(
+        app, ["analyzers", "run", "ruff", "--cwd", str(tmp_path), "-f", "a.py"], env=_WIDE
+    )
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "skipped ruff" in _plain(result)
+
+
+def test_run_prints_the_version_note_and_anchors_findings(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    seen = _stub_adapter(
+        monkeypatch,
+        AdapterRunResult(
+            findings=[
+                _finding("src/a.py", 12, "line too long"),
+                _finding("src/b.py", None, "file"),
+            ],
+            version_note="ruff 0.15.22 (repo-provided)",
+        ),
+    )
+    result = runner.invoke(
+        app, ["analyzers", "run", "ruff", "--cwd", str(tmp_path), "-f", "src/a.py"], env=_WIDE
+    )
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert "findings: 2" in text
+    assert "ruff 0.15.22 (repo-provided)" in text
+    assert "src/a.py:12 [Minor] line too long" in text
+    # No start line → the anchor is the bare path, with no trailing colon.
+    assert "src/b.py [Minor] file" in text
+    assert seen["changed_files"] == ["src/a.py"]
+    assert seen["tier"] == "trusted"
+
+
+def test_run_prints_at_most_twenty_findings(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    findings = [_finding("src/a.py", n, f"issue {n}") for n in range(1, 26)]
+    _stub_adapter(monkeypatch, AdapterRunResult(findings=findings, version_note=None))
+    result = runner.invoke(
+        app, ["analyzers", "run", "ruff", "--cwd", str(tmp_path), "-f", "src/a.py"], env=_WIDE
+    )
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert "findings: 25" in text
+    assert "issue 20" in text
+    assert "issue 21" not in text
+
+
+# ---------------------------------------------------------------------------
+# analyzers explain
+# ---------------------------------------------------------------------------
+
+
+def test_explain_rejects_an_unknown_analyzer_id() -> None:
+    result = runner.invoke(app, ["analyzers", "explain", "not-a-tool"], env=_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "unknown analyzer id: 'not-a-tool'" in _plain(result)
+
+
+def test_explain_prints_the_optional_rows_only_when_the_manifest_sets_them() -> None:
+    ruff = _plain(runner.invoke(app, ["analyzers", "explain", "ruff"], env=_WIDE))
+    assert "id: ruff" in ruff
+    assert "parser: ruff_json" in ruff
+    assert "runtime: repo-native" in ruff
+    assert "trust: trusted" in ruff
+    assert "exclusive_group: python-lint" in ruff
+    assert "declared_unavailable:" not in ruff
+
+    fortitude = _plain(runner.invoke(app, ["analyzers", "explain", "fortitude"], env=_WIDE))
+    assert "declared_unavailable: manifest-only" in fortitude
+    assert "exclusive_group:" not in fortitude
+
+    actionlint = _plain(runner.invoke(app, ["analyzers", "explain", "actionlint"], env=_WIDE))
+    # No languages declared → the em-dash placeholder, not an empty line.
+    assert "languages: —" in actionlint
+    assert "exclusive_group:" not in actionlint
+    assert "declared_unavailable:" not in actionlint
+
+
+# ---------------------------------------------------------------------------
+# analyzers export
+# ---------------------------------------------------------------------------
+
+
+def test_export_requires_one_of_sarif_or_output(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["analyzers", "export", "ruff", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "pass --sarif or --output" in _plain(result)
+
+
+def test_export_bails_without_changed_files(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(analyzers_cmd, "_git_changed_files", lambda _dir: [])
+    result = runner.invoke(
+        app, ["analyzers", "export", "ruff", "--cwd", str(tmp_path), "--sarif"], env=_WIDE
+    )
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "no changed files" in _plain(result)
+
+
+def test_export_bails_when_the_adapter_skipped(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    _stub_adapter(
+        monkeypatch, AdapterRunResult(findings=[], skipped=True, skip_reason="no python files")
+    )
+    result = runner.invoke(
+        app,
+        ["analyzers", "export", "ruff", "--cwd", str(tmp_path), "--sarif", "-f", "a.py"],
+        env=_WIDE,
+    )
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "no python files" in _plain(result)
+
+
+def test_export_sarif_goes_to_stdout_when_no_output_path_is_given(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _stub_adapter(monkeypatch, AdapterRunResult(findings=[_finding("src/a.py", 3, "bad")]))
+    result = runner.invoke(
+        app,
+        ["analyzers", "export", "ruff", "--cwd", str(tmp_path), "--sarif", "-f", "src/a.py"],
+        env=_WIDE,
+    )
+    assert result.exit_code == 0, _plain(result)
+    document = json.loads(result.stdout)
+    assert document["version"] == "2.1.0"
+    result_row = document["runs"][0]["results"][0]
+    assert result_row["ruleId"] == "E501"
+    assert result_row["message"]["text"] == "bad"
+
+
+def test_export_output_path_writes_the_file_and_keeps_stdout_clean(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--output`` alone satisfies the guard, and the payload lands on disk."""
+    _stub_adapter(monkeypatch, AdapterRunResult(findings=[_finding("src/a.py", 3, "bad")]))
+    out = tmp_path / "out.sarif"
+    result = runner.invoke(
+        app,
+        [
+            "analyzers",
+            "export",
+            "ruff",
+            "--cwd",
+            str(tmp_path),
+            "-o",
+            str(out),
+            "-f",
+            "src/a.py",
+        ],
+        env=_WIDE,
+    )
+    assert result.exit_code == 0, _plain(result)
+    assert f"wrote {out}" in _plain(result)
+    payload = out.read_text(encoding="utf-8")
+    assert payload.endswith("\n")
+    assert json.loads(payload)["runs"][0]["results"][0]["message"]["text"] == "bad"
+    assert "2.1.0" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# analyzers lock
+# ---------------------------------------------------------------------------
+
+
+class _FakeManifest:
+    """Minimal stand-in exposing only the fields ``lock_cmd`` reads."""
+
+    def __init__(
+        self,
+        analyzer_id: str,
+        *,
+        runtime: str,
+        provenance: dict[str, str] | None = None,
+        declared_unavailable: str | None = None,
+        version: str = "1.0.0",
+    ) -> None:
+        self.id = analyzer_id
+        self.runtime = runtime
+        self.provenance = provenance or {}
+        self.declared_unavailable = declared_unavailable
+        self.version = version
+
+
+def _stub_lock_world(
+    monkeypatch: MonkeyPatch,
+    *,
+    catalog: list[_FakeManifest],
+    existing: list[LockEntry] | None = None,
+    resolve: Any = None,
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def _write(path: Path, entries: list[Any], *, merge: bool = False) -> None:
+        captured["path"] = path
+        captured["entries"] = entries
+        captured["merge"] = merge
+
+    monkeypatch.setattr(analyzers_cmd, "load_catalog", lambda: list(catalog))
+    monkeypatch.setattr(analyzers_cmd, "read_lock", lambda _path: list(existing or []))
+    monkeypatch.setattr(analyzers_cmd, "write_lock", _write)
+    if resolve is not None:
+        monkeypatch.setattr(analyzers_cmd, "resolve_with_lock", resolve)
+    return captured
+
+
+class _Resolved:
+    def __init__(self, source: str, sha256: str) -> None:
+        self.source = source
+        self.sha256 = sha256
+
+
+def test_lock_skips_repo_native_and_declared_unavailable_tools(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    captured = _stub_lock_world(
+        monkeypatch,
+        catalog=[
+            _FakeManifest("ruff", runtime="repo-native"),
+            _FakeManifest("fortitude", runtime="managed", declared_unavailable="not bundled"),
+            _FakeManifest("infer", runtime="container", version="2.3"),
+        ],
+    )
+    result = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    entries = captured["entries"]
+    assert [entry.tool_id for entry in entries] == ["infer"]
+    assert entries[0].mode == "container"
+    assert entries[0].source == "container:infer:2.3"
+    assert entries[0].sha256 == "container"
+    assert captured["path"] == tmp_path / ".mergecraft" / "analyzers.lock"
+    assert captured["merge"] is True
+    assert "lockfile updated" in text
+    assert "(1 tools)" in text
+
+
+def test_lock_reuses_an_existing_entry_unless_refresh_is_passed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    pinned = LockEntry(
+        tool_id="semgrep", version="0.0.1", mode="managed", source="old-url", sha256="old-sha"
+    )
+    catalog = [
+        _FakeManifest(
+            "semgrep", runtime="managed", provenance={"linux-amd64": "url"}, version="9.9"
+        )
+    ]
+    resolved = _Resolved("new-url", "new-sha")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(analyzers_cmd, "load_catalog", lambda: list(catalog))
+
+    captured = _stub_lock_world(
+        monkeypatch,
+        catalog=catalog,
+        existing=[pinned],
+        resolve=lambda **_kwargs: resolved,
+    )
+    import platform as platform_mod
+
+    monkeypatch.setattr(platform_mod, "machine", lambda: "x86_64")
+
+    reused = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    assert reused.exit_code == 0, _plain(reused)
+    assert captured["entries"] == [pinned]
+
+    refreshed = runner.invoke(
+        app, ["analyzers", "lock", "--cwd", str(tmp_path), "--refresh"], env=_WIDE
+    )
+    assert refreshed.exit_code == 0, _plain(refreshed)
+    entry = captured["entries"][0]
+    assert (entry.tool_id, entry.version, entry.source, entry.sha256) == (
+        "semgrep",
+        "9.9",
+        "new-url",
+        "new-sha",
+    )
+    assert captured["merge"] is False
+
+
+def test_lock_skips_a_tool_with_no_provenance_for_this_platform(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """The derived platform key gates provenance — only the matching tool locks."""
+    import platform as platform_mod
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "aarch64")
+    captured = _stub_lock_world(
+        monkeypatch,
+        catalog=[
+            _FakeManifest("arm-only", runtime="managed", provenance={"linux-arm64": "u"}),
+            _FakeManifest("amd-only", runtime="managed", provenance={"linux-amd64": "u"}),
+        ],
+        resolve=lambda **_kwargs: _Resolved("u", "sha"),
+    )
+    result = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == 0, _plain(result)
+    assert [entry.tool_id for entry in captured["entries"]] == ["arm-only"]
+
+
+def test_lock_derives_the_darwin_platform_key_from_the_machine_arch(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    import platform as platform_mod
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "x86_64")
+    captured = _stub_lock_world(
+        monkeypatch,
+        catalog=[
+            _FakeManifest("mac-intel", runtime="managed", provenance={"darwin-amd64": "u"}),
+            _FakeManifest("mac-arm", runtime="managed", provenance={"darwin-arm64": "u"}),
+        ],
+        resolve=lambda **_kwargs: _Resolved("u", "sha"),
+    )
+    result = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == 0, _plain(result)
+    assert [entry.tool_id for entry in captured["entries"]] == ["mac-intel"]
+
+    monkeypatch.setattr(platform_mod, "machine", lambda: "ARM64")
+    result = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    assert result.exit_code == 0, _plain(result)
+    assert [entry.tool_id for entry in captured["entries"]] == ["mac-arm"]
+
+
+def test_lock_warns_and_continues_when_provisioning_one_tool_fails(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    import platform as platform_mod
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "x86_64")
+
+    def _resolve(*, manifest: Any, **_kwargs: Any) -> _Resolved:
+        if manifest.id == "broken":
+            msg = "checksum mismatch"
+            raise RuntimeError(msg)
+        return _Resolved("good-url", "good-sha")
+
+    captured = _stub_lock_world(
+        monkeypatch,
+        catalog=[
+            _FakeManifest("broken", runtime="managed", provenance={"linux-amd64": "u"}),
+            _FakeManifest("healthy", runtime="managed", provenance={"linux-amd64": "u"}),
+        ],
+        resolve=_resolve,
+    )
+    result = runner.invoke(app, ["analyzers", "lock", "--cwd", str(tmp_path)], env=_WIDE)
+    text = _plain(result)
+    assert result.exit_code == 0, text
+    assert "skip broken: checksum mismatch" in text
+    assert [entry.tool_id for entry in captured["entries"]] == ["healthy"]
+
+
+# ---------------------------------------------------------------------------
+# analyzers docs
+# ---------------------------------------------------------------------------
+
+
+def test_docs_reports_the_path_the_generator_wrote(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    generated = tmp_path / "ANALYZERS.md"
+    monkeypatch.setattr(analyzers_cmd, "write_analyzers_doc", lambda: generated)
+    result = runner.invoke(app, ["analyzers", "docs"], env=_WIDE)
+    assert result.exit_code == 0, _plain(result)
+    assert f"wrote {generated}" in _plain(result)

--- a/tests/cli/test_cov_auth_cmd_paths.py
+++ b/tests/cli/test_cov_auth_cmd_paths.py
@@ -1,0 +1,794 @@
+"""Decision-path coverage for ``mergecraft auth`` (issue #431).
+
+Drives the arms of ``cli/auth_cmd.py`` the existing suite never reaches: the
+``gh``/``git`` probe failures, ``--scope`` normalisation including its reject
+path, the partial-failure matrix in ``_persist_credential``, ``.env`` quoting
+and permission handling, the multi-line credential flattener, every status
+class of every provider validator, and the cancel / warn / bail arms of the
+interactive commands.
+
+Every HTTP call goes through ``httpx.MockTransport`` — no test in this file
+reaches a real provider, a real ``gh``, a real ``git``, or a real ``.env``.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+import typer
+from dotenv import dotenv_values
+from typer.testing import CliRunner
+
+from mergecraft.cli import auth_cmd
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_CONFIGURATION_EXIT_CODE, CLI_USAGE_EXIT_CODE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from _pytest.capture import CaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+_ENV_WIDE = {"COLUMNS": "200", "TERM": "dumb"}
+
+
+def _mock_httpx(
+    monkeypatch: MonkeyPatch, handler: Callable[[httpx.Request], httpx.Response]
+) -> None:
+    """Route every ``httpx.Client`` the auth module builds through ``handler``."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs.setdefault("transport", transport)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(auth_cmd.httpx, "Client", _factory)
+
+
+def _status(code: int) -> Callable[[httpx.Request], httpx.Response]:
+    return lambda _request: httpx.Response(code, json={})
+
+
+def _raiser(exc: Exception) -> Callable[..., Any]:
+    """A stand-in callable that raises ``exc`` no matter how it is called."""
+
+    def _handler(*_args: Any, **_kwargs: Any) -> Any:
+        raise exc
+
+    return _handler
+
+
+def _local_env(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
+    env_path = tmp_path / ".env"
+    monkeypatch.setenv("MERGECRAFT_ENV", str(env_path))
+    return env_path
+
+
+# ---------------------------------------------------------------------------
+# gh / git probes
+# ---------------------------------------------------------------------------
+
+
+def test_gh_token_probe_bails_when_the_cli_is_missing(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        auth_cmd.subprocess, "check_output", _raiser(FileNotFoundError("gh")), raising=True
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._get_gh_token()
+    assert excinfo.value.exit_code == CLI_CONFIGURATION_EXIT_CODE
+
+
+def test_gh_token_probe_bails_on_an_empty_token(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(auth_cmd.subprocess, "check_output", lambda *a, **k: "  \n")
+    with pytest.raises(typer.Exit):
+        auth_cmd._get_gh_token()
+    assert "empty token" in capsys.readouterr().err
+
+
+def test_gh_token_probe_returns_the_stripped_token(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_cmd.subprocess, "check_output", lambda *a, **k: "ghp_abc\n")
+    assert auth_cmd._get_gh_token() == "ghp_abc"
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    [
+        ("git@github.com:acme/widgets.git", ("acme", "widgets")),
+        ("https://github.com/acme/widgets/", ("acme", "widgets")),
+        ("ssh://git@github.com:22/acme/deep.repo", ("acme", "deep.repo")),
+    ],
+)
+def test_git_remote_parser_accepts_the_supported_url_shapes(
+    monkeypatch: MonkeyPatch, remote: str, expected: tuple[str, str]
+) -> None:
+    monkeypatch.setattr(auth_cmd.subprocess, "check_output", lambda *a, **k: remote + "\n")
+    assert auth_cmd._parse_git_remote() == expected
+
+
+def test_git_remote_parser_bails_on_a_non_github_remote(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        auth_cmd.subprocess, "check_output", lambda *a, **k: "https://gitlab.com/acme/widgets.git\n"
+    )
+    with pytest.raises(typer.Exit):
+        auth_cmd._parse_git_remote()
+    assert "could not parse github owner/repo" in capsys.readouterr().err
+
+
+def test_git_remote_parser_bails_when_there_is_no_origin(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        auth_cmd.subprocess,
+        "check_output",
+        _raiser(subprocess.CalledProcessError(2, ["git"])),
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._parse_git_remote()
+    assert excinfo.value.exit_code == CLI_CONFIGURATION_EXIT_CODE
+
+
+def test_set_gh_secret_reports_failure_instead_of_raising(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        auth_cmd.subprocess,
+        "run",
+        _raiser(subprocess.CalledProcessError(1, ["gh"])),
+    )
+    assert auth_cmd._set_gh_secret(name="X", value="v", repo_slug="acme/widgets") is False
+
+
+def test_set_gh_secret_passes_the_value_on_stdin(monkeypatch: MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _run(cmd: list[str], **kwargs: Any) -> Any:
+        seen["cmd"] = cmd
+        seen["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(auth_cmd.subprocess, "run", _run)
+    assert auth_cmd._set_gh_secret(name="X", value="v", repo_slug="acme/widgets") is True
+    assert seen["cmd"] == ["gh", "secret", "set", "X", "--repo", "acme/widgets"]
+    assert seen["input"] == "v"
+
+
+# ---------------------------------------------------------------------------
+# scope normalisation and target resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("local", "local"),
+        (" LOCAL ", "local"),
+        ("github", "github"),
+        ("gh", "github"),
+        ("action", "github"),
+        ("both", "both"),
+        ("all", "both"),
+    ],
+)
+def test_scope_synonyms_normalise_to_the_three_canonical_values(raw: str, expected: str) -> None:
+    assert auth_cmd._normalise_scope(raw) == expected
+
+
+def test_unknown_scope_is_a_usage_error_naming_the_valid_values(
+    capsys: CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._normalise_scope("remote")
+    assert excinfo.value.exit_code == CLI_USAGE_EXIT_CODE
+    assert "expected one of: local, github, both" in capsys.readouterr().err
+
+
+def test_local_scope_never_touches_gh_or_git(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_cmd, "_get_gh_token", _raiser(AssertionError("gh probed")))
+    monkeypatch.setattr(auth_cmd, "_parse_git_remote", _raiser(AssertionError("git probed")))
+    target = auth_cmd._resolve_auth_target("local")
+    assert target == auth_cmd.AuthTarget(local=True, github=None)
+
+
+def test_github_and_both_scopes_resolve_the_repo_slug(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_cmd, "_get_gh_token", lambda: "ghp_abc")
+    monkeypatch.setattr(auth_cmd, "_parse_git_remote", lambda: ("acme", "widgets"))
+    github_only = auth_cmd._resolve_auth_target("github")
+    assert github_only.local is False
+    assert github_only.github == auth_cmd.GitHubSecretTarget(repo_slug="acme/widgets")
+    assert auth_cmd._resolve_auth_target("both").local is True
+
+
+# ---------------------------------------------------------------------------
+# .env writing
+# ---------------------------------------------------------------------------
+
+
+def test_env_path_prefers_the_override_then_the_repo_root(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / "custom.env"))
+    assert auth_cmd._local_env_path() == (tmp_path / "custom.env").resolve()
+    monkeypatch.delenv("MERGECRAFT_ENV")
+    monkeypatch.setattr(auth_cmd, "git_repo_root", lambda: tmp_path)
+    assert auth_cmd._local_env_path() == tmp_path / ".env"
+
+
+def test_env_path_bails_outside_a_repository(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    monkeypatch.setattr(auth_cmd, "git_repo_root", lambda: None)
+    with pytest.raises(typer.Exit):
+        auth_cmd._local_env_path()
+    assert "could not locate the repository root" in capsys.readouterr().err
+
+
+def test_env_writer_quotes_only_values_that_need_it(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    assert auth_cmd._write_env_value(env_path, "NOUS_API_KEY", "nk-abc_123") is True
+    assert auth_cmd._write_env_value(env_path, "CODEX_AUTH_JSON", '{"a": "b"}') is True
+    raw = env_path.read_text(encoding="utf-8")
+    assert "NOUS_API_KEY=nk-abc_123" in raw
+    assert 'CODEX_AUTH_JSON=\'{"a": "b"}\'' in raw
+    assert dotenv_values(env_path)["CODEX_AUTH_JSON"] == '{"a": "b"}'
+
+
+def test_env_writer_reports_failure_rather_than_raising(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(auth_cmd, "_dotenv_set_key", _raiser(OSError("read-only fs")))
+    assert auth_cmd._write_env_value(tmp_path / ".env", "K", "v") is False
+
+
+def test_env_writer_still_succeeds_when_the_file_cannot_be_narrowed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed ``chmod`` is a warning — refusing to save the credential is worse."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXISTING=1\n", encoding="utf-8")
+
+    def _chmod(_self: Path, _mode: int) -> None:
+        raise OSError("chmod not permitted")
+
+    monkeypatch.setattr(Path, "chmod", _chmod)
+    assert auth_cmd._write_env_value(env_path, "NOUS_API_KEY", "nk-abc") is True
+    assert dotenv_values(env_path)["NOUS_API_KEY"] == "nk-abc"
+
+
+def test_env_writer_narrows_permissions_on_an_existing_world_readable_file(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXISTING=1\n", encoding="utf-8")
+    env_path.chmod(0o644)
+    assert auth_cmd._write_env_value(env_path, "NOUS_API_KEY", "nk-abc") is True
+    assert env_path.stat().st_mode & 0o777 == 0o600
+
+
+# ---------------------------------------------------------------------------
+# _single_line_credential
+# ---------------------------------------------------------------------------
+
+
+def test_single_line_credential_passes_a_one_line_value_through_untouched() -> None:
+    assert auth_cmd._single_line_credential(name="K", value="sk-abc") == "sk-abc"
+
+
+def test_single_line_credential_compacts_pretty_printed_json() -> None:
+    pretty = json.dumps({"tokens": {"access_token": "a"}}, indent=2)
+    compacted = auth_cmd._single_line_credential(name="CODEX_AUTH_JSON", value=pretty)
+    assert "\n" not in compacted
+    assert json.loads(compacted) == json.loads(pretty)
+
+
+def test_single_line_credential_refuses_a_multi_line_non_json_value(
+    capsys: CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit):
+        auth_cmd._single_line_credential(name="CODEX_AUTH_JSON", value="line one\nline two")
+    err = capsys.readouterr().err
+    assert "spans multiple lines and is not JSON" in err
+    assert "--scope github" in err
+
+
+# ---------------------------------------------------------------------------
+# _persist_credential — the partial-failure matrix
+# ---------------------------------------------------------------------------
+
+
+def test_local_only_success_writes_env_and_never_calls_gh(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd, "_set_gh_secret", _raiser(AssertionError("gh called")))
+    auth_cmd._persist_credential(
+        target=auth_cmd.AuthTarget(local=True, github=None), name="NOUS_API_KEY", value="nk-1"
+    )
+    assert dotenv_values(env_path)["NOUS_API_KEY"] == "nk-1"
+    assert "wrote NOUS_API_KEY" in capsys.readouterr().err
+
+
+def test_local_only_failure_bails_because_nothing_was_written(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd, "_write_env_value", lambda *a, **k: False)
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._persist_credential(
+            target=auth_cmd.AuthTarget(local=True, github=None), name="NOUS_API_KEY", value="nk-1"
+        )
+    assert excinfo.value.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "could not update" in err
+    assert "nothing was written" in err
+
+
+def test_github_only_failure_bails_with_the_manual_secrets_url(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(auth_cmd, "_set_gh_secret", lambda **_k: False)
+    target = auth_cmd.AuthTarget(
+        local=False, github=auth_cmd.GitHubSecretTarget(repo_slug="acme/widgets")
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._persist_credential(target=target, name="NOUS_API_KEY", value="nk-1")
+    assert excinfo.value.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "https://github.com/acme/widgets/settings/secrets/actions" in capsys.readouterr().err
+
+
+def test_both_scope_tolerates_a_failed_secret_when_the_local_write_landed(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    """Partial success: the operator still got a usable local credential."""
+    env_path = _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd, "_set_gh_secret", lambda **_k: False)
+    target = auth_cmd.AuthTarget(
+        local=True, github=auth_cmd.GitHubSecretTarget(repo_slug="acme/widgets")
+    )
+    auth_cmd._persist_credential(target=target, name="NOUS_API_KEY", value="nk-1")
+    assert dotenv_values(env_path)["NOUS_API_KEY"] == "nk-1"
+    assert "gh secret set failed" in capsys.readouterr().err
+
+
+def test_both_scope_bails_only_when_neither_half_lands(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd, "_write_env_value", lambda *a, **k: False)
+    monkeypatch.setattr(auth_cmd, "_set_gh_secret", lambda **_k: False)
+    target = auth_cmd.AuthTarget(
+        local=True, github=auth_cmd.GitHubSecretTarget(repo_slug="acme/widgets")
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        auth_cmd._persist_credential(target=target, name="NOUS_API_KEY", value="nk-1")
+    assert excinfo.value.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "both local and github scopes failed" in capsys.readouterr().err
+
+
+def test_local_entries_override_the_secret_pair_for_the_env_write(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """``auth logfire`` writes two env vars behind one Actions secret."""
+    env_path = _local_env(monkeypatch, tmp_path)
+    sent: dict[str, Any] = {}
+    monkeypatch.setattr(
+        auth_cmd, "_set_gh_secret", lambda **kwargs: bool(sent.update(kwargs) or True)
+    )
+    target = auth_cmd.AuthTarget(
+        local=True, github=auth_cmd.GitHubSecretTarget(repo_slug="acme/widgets")
+    )
+    auth_cmd._persist_credential(
+        target=target,
+        name="LOGFIRE_TOKEN",
+        value="pylf_v1_eu_abc",
+        local_entries={
+            "MERGECRAFT_LOGFIRE_TOKEN": "pylf_v1_eu_abc",
+            "MERGECRAFT_TRACING_PROJECT": "mergecraft",
+        },
+    )
+    values = dotenv_values(env_path)
+    assert values["MERGECRAFT_LOGFIRE_TOKEN"] == "pylf_v1_eu_abc"
+    assert values["MERGECRAFT_TRACING_PROJECT"] == "mergecraft"
+    assert "LOGFIRE_TOKEN" not in values
+    assert sent == {"name": "LOGFIRE_TOKEN", "value": "pylf_v1_eu_abc", "repo_slug": "acme/widgets"}
+
+
+# ---------------------------------------------------------------------------
+# provider validators
+# ---------------------------------------------------------------------------
+
+_VALIDATORS: list[tuple[str, str]] = [
+    ("_validate_gemini_api_key", "gemini"),
+    ("_validate_cursor_api_key", "cursor"),
+    ("_validate_nous_api_key", "nous"),
+    ("_validate_minimax_api_key", "minimax"),
+]
+
+
+@pytest.mark.parametrize(("attr", "_label"), _VALIDATORS)
+def test_validators_accept_200_reject_401_403_and_save_anyway_on_5xx(
+    monkeypatch: MonkeyPatch, attr: str, _label: str
+) -> None:
+    validate = getattr(auth_cmd, attr)
+    for code, expected in ((200, True), (401, False), (403, False), (503, True)):
+        _mock_httpx(monkeypatch, _status(code))
+        assert validate("key-under-test") is expected, f"{attr} on HTTP {code}"
+
+
+@pytest.mark.parametrize(("attr", "_label"), _VALIDATORS)
+def test_validators_save_anyway_when_the_probe_cannot_reach_the_provider(
+    monkeypatch: MonkeyPatch, attr: str, _label: str
+) -> None:
+    _mock_httpx(monkeypatch, _raiser(httpx.ConnectError("dns failure")))
+    assert getattr(auth_cmd, attr)("key-under-test") is True
+
+
+def test_openai_compatible_validator_probes_the_models_endpoint_with_a_bearer(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200, json={})
+
+    _mock_httpx(monkeypatch, _handler)
+    assert (
+        auth_cmd._validate_openai_compatible_key(
+            api_key="th-key", base_url="https://gw.invalid/v1/", label="tokenhub"
+        )
+        is True
+    )
+    assert seen["url"].startswith("https://gw.invalid/v1/models")
+    assert seen["auth"] == "Bearer th-key"
+
+
+def test_openai_compatible_validator_rejects_401_and_tolerates_network_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _mock_httpx(monkeypatch, _status(401))
+    assert (
+        auth_cmd._validate_openai_compatible_key(
+            api_key="bad", base_url="https://gw.invalid/v1", label="tokenhub"
+        )
+        is False
+    )
+    _mock_httpx(monkeypatch, _raiser(httpx.ReadTimeout("slow")))
+    assert (
+        auth_cmd._validate_openai_compatible_key(
+            api_key="bad", base_url="https://gw.invalid/v1", label="tokenhub"
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# logfire probe selection + validation
+# ---------------------------------------------------------------------------
+
+
+def test_logfire_probe_picks_the_regional_host_for_a_write_token() -> None:
+    assert auth_cmd._resolve_logfire_probe("pylf_v1_eu_abc") == (
+        "https://logfire-eu.pydantic.dev/v1/info",
+        "write-token",
+    )
+    assert auth_cmd._resolve_logfire_probe("pylf_v2_us_abc") == (
+        "https://logfire-us.pydantic.dev/v1/info",
+        "write-token",
+    )
+
+
+def test_logfire_probe_falls_back_to_the_management_api() -> None:
+    """An unknown region and a non-write-token shape both probe the API key path."""
+    assert auth_cmd._resolve_logfire_probe("pylf_v1_zz_abc") == (
+        auth_cmd.LOGFIRE_API_PROBE_URL,
+        "api-key",
+    )
+    assert auth_cmd._resolve_logfire_probe("lf_api_key_abc") == (
+        auth_cmd.LOGFIRE_API_PROBE_URL,
+        "api-key",
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [(200, True), (401, False), (403, False), (302, False), (307, False), (500, True)],
+)
+def test_logfire_token_validation_rejects_redirects_as_well_as_401(
+    monkeypatch: MonkeyPatch, code: int, expected: bool
+) -> None:
+    _mock_httpx(monkeypatch, _status(code))
+    assert auth_cmd._validate_logfire_token("pylf_v1_eu_abc") is expected
+
+
+def test_logfire_token_validation_saves_anyway_when_offline(monkeypatch: MonkeyPatch) -> None:
+    _mock_httpx(monkeypatch, _raiser(httpx.ConnectError("offline")))
+    assert auth_cmd._validate_logfire_token("pylf_v1_eu_abc") is True
+
+
+def test_logfire_extra_probe_reports_absence_without_raising(monkeypatch: MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "logfire":
+            msg = "no module named logfire"
+            raise ImportError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    assert auth_cmd._logfire_extra_installed() is False
+
+
+# ---------------------------------------------------------------------------
+# interactive command arms
+# ---------------------------------------------------------------------------
+
+
+def _stub_getpass(monkeypatch: MonkeyPatch, value: str | BaseException) -> None:
+    """Replace the interactive prompt with a fixed answer — or a raised signal."""
+
+    def _prompt(_label: str = "") -> str:
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    monkeypatch.setattr(getpass, "getpass", _prompt)
+
+
+def test_empty_input_cancels_cleanly_without_writing_anything(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "   ")
+    result = runner.invoke(app, ["auth", "claude", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "canceled." in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_a_keyboard_interrupt_at_the_prompt_cancels_cleanly(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, KeyboardInterrupt())
+    result = runner.invoke(app, ["auth", "gemini", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "canceled." in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_claude_warns_about_an_unexpected_prefix_but_still_saves(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "ghp_not_an_oauth_token")
+    result = runner.invoke(app, ["auth", "claude", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "doesn't look like a claude setup-token" in result.stdout + result.stderr
+    assert dotenv_values(env_path)["CLAUDE_CODE_OAUTH_TOKEN"] == "ghp_not_an_oauth_token"
+
+
+def test_a_rejected_provider_key_bails_before_writing_the_env(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "bad-key")
+    _mock_httpx(monkeypatch, _status(401))
+    result = runner.invoke(app, ["auth", "gemini", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "Gemini API key validation failed" in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_codex_bails_when_the_cli_is_not_on_path(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd.shutil, "which", lambda _name: None)
+    result = runner.invoke(app, ["auth", "codex", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "codex CLI not found on PATH" in result.stdout + result.stderr
+
+
+def test_codex_bails_when_the_login_writes_no_auth_json(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd.shutil, "which", lambda _name: "/usr/bin/codex")
+    monkeypatch.setattr(
+        auth_cmd.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0)
+    )
+    result = runner.invoke(app, ["auth", "codex", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "no auth.json was written" in result.stdout + result.stderr
+
+
+def test_codex_bails_when_the_login_command_fails(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    _local_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auth_cmd.shutil, "which", lambda _name: "/usr/bin/codex")
+    monkeypatch.setattr(
+        auth_cmd.subprocess, "run", _raiser(subprocess.CalledProcessError(7, ["codex"]))
+    )
+    result = runner.invoke(app, ["auth", "codex", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "codex login failed (exit 7)" in result.stdout + result.stderr
+
+
+def test_nous_success_names_the_model_slug_to_configure(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "nk-good")
+    _mock_httpx(monkeypatch, _status(200))
+    result = runner.invoke(app, ["auth", "nous", "--scope", "local"], env=_ENV_WIDE)
+    combined = result.stdout + result.stderr
+    assert result.exit_code == 0, combined
+    assert dotenv_values(env_path)["NOUS_API_KEY"] == "nk-good"
+    assert "nous/deepseek/deepseek-v4-flash" in combined
+
+
+def test_tokenhub_rejects_a_bad_key_and_keeps_the_env_untouched(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "th-bad")
+    _mock_httpx(monkeypatch, _status(403))
+    result = runner.invoke(app, ["auth", "tokenhub", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "TokenHub API key validation failed" in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_minimax_rejects_a_bad_key_and_names_the_custom_provider_secret(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "mm-good")
+    _mock_httpx(monkeypatch, _status(200))
+    result = runner.invoke(app, ["auth", "minimax", "--scope", "local"], env=_ENV_WIDE)
+    combined = result.stdout + result.stderr
+    assert result.exit_code == 0, combined
+    assert dotenv_values(env_path)["MERGECRAFT_CUSTOM_PROVIDER_API_KEY"] == "mm-good"
+    assert "minimax/MiniMax-M3" in combined
+
+
+def test_an_invalid_scope_stops_the_command_before_the_prompt(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, AssertionError("prompted despite a bad scope"))
+    result = runner.invoke(app, ["auth", "cursor", "--scope", "remote"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE
+    assert "expected one of: local, github, both" in result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# auth logfire
+# ---------------------------------------------------------------------------
+
+
+def test_logfire_cancels_when_the_project_label_is_left_blank(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "pylf_v1_eu_token")
+    _mock_httpx(monkeypatch, _status(200))
+    result = runner.invoke(app, ["auth", "logfire", "--scope", "local"], input="\n", env=_ENV_WIDE)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "canceled." in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_logfire_rejects_a_project_label_containing_whitespace(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "pylf_v1_eu_token")
+    _mock_httpx(monkeypatch, _status(200))
+    result = runner.invoke(
+        app, ["auth", "logfire", "--scope", "local"], input="my project\n", env=_ENV_WIDE
+    )
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "must not contain whitespace" in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_logfire_bails_on_a_rejected_token_before_asking_for_a_project(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "pylf_v1_eu_token")
+    _mock_httpx(monkeypatch, _status(302))
+    result = runner.invoke(app, ["auth", "logfire", "--scope", "local"], env=_ENV_WIDE)
+    assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
+    assert "Logfire token validation failed" in result.stdout + result.stderr
+    assert not env_path.exists()
+
+
+def test_logfire_warns_when_the_tracing_extra_is_missing_but_still_saves(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "pylf_v1_eu_token")
+    _mock_httpx(monkeypatch, _status(200))
+    monkeypatch.setattr(auth_cmd, "_logfire_extra_installed", lambda: False)
+    result = runner.invoke(
+        app, ["auth", "logfire", "--scope", "local"], input="mergecraft\n", env=_ENV_WIDE
+    )
+    combined = result.stdout + result.stderr
+    assert result.exit_code == 0, combined
+    assert "the [tracing] extra is not installed" in combined
+    values = dotenv_values(env_path)
+    assert values["MERGECRAFT_LOGFIRE_TOKEN"] == "pylf_v1_eu_token"
+    assert values["MERGECRAFT_TRACING_PROJECT"] == "mergecraft"
+
+
+def test_logfire_skips_the_extra_warning_when_the_package_is_present(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    _local_env(monkeypatch, tmp_path)
+    _stub_getpass(monkeypatch, "pylf_v1_eu_token")
+    _mock_httpx(monkeypatch, _status(200))
+    monkeypatch.setattr(auth_cmd, "_logfire_extra_installed", lambda: True)
+    result = runner.invoke(
+        app, ["auth", "logfire", "--scope", "local"], input="mergecraft\n", env=_ENV_WIDE
+    )
+    combined = result.stdout + result.stderr
+    assert result.exit_code == 0, combined
+    assert "extra is not installed" not in combined
+    assert "mergecraft config tracing" in combined
+
+
+# ---------------------------------------------------------------------------
+# Found defect (#431 investigation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason=(
+        "auth_cmd._persist_credential computes wrote_local = all([...]) across every "
+        "local entry, so a multi-entry write (auth logfire's MERGECRAFT_LOGFIRE_TOKEN + "
+        "MERGECRAFT_TRACING_PROJECT) where one entry lands and one fails reports "
+        "wrote_local=False. With --scope local that reaches the "
+        "'nothing was written' bail (cli/auth_cmd.py, target.github is None branch) "
+        "and exits 30 — contradicting the code's own comment that 'every entry is "
+        "attempted so a partial failure still leaves the entries that could be "
+        "written', and telling the operator to redo a write that partly succeeded. "
+        "It should report the partial write, not claim nothing landed."
+    ),
+    strict=True,
+)
+def test_partial_local_write_must_not_claim_that_nothing_was_written(
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    env_path = _local_env(monkeypatch, tmp_path)
+    real_write = auth_cmd._write_env_value
+
+    def _write(path: Path, key: str, value: str) -> bool:
+        if key == "MERGECRAFT_LOGFIRE_TOKEN":
+            return False
+        return real_write(path, key, value)
+
+    monkeypatch.setattr(auth_cmd, "_write_env_value", _write)
+    auth_cmd._persist_credential(
+        target=auth_cmd.AuthTarget(local=True, github=None),
+        name="LOGFIRE_TOKEN",
+        value="pylf_v1_eu_abc",
+        local_entries={
+            "MERGECRAFT_LOGFIRE_TOKEN": "pylf_v1_eu_abc",
+            "MERGECRAFT_TRACING_PROJECT": "mergecraft",
+        },
+    )
+    # The entry that did land is on disk, so "nothing was written" is false.
+    assert dotenv_values(env_path)["MERGECRAFT_TRACING_PROJECT"] == "mergecraft"
+    assert "nothing was written" not in capsys.readouterr().err

--- a/tests/scm/test_cov_protocol_paths.py
+++ b/tests/scm/test_cov_protocol_paths.py
@@ -1,0 +1,244 @@
+"""Decision-path coverage for ``mergecraft.scm.protocol`` (#431).
+
+The happy path — a complete, all-async adapter — is already pinned by
+``tests/scm/test_protocol.py`` and ``tests/scm/test_second_adapter.py``. What was
+never exercised is the *other* way out of each decision in ``validate_provider``
+and its helpers: an operation that is absent, not callable, or declared with the
+wrong async-ness, and a declared operation set that no longer covers the GitHub
+surface. Those are the branches that decide whether a broken adapter is allowed
+to reach a review run.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from mergecraft.scm.protocol import (
+    ScmProvider,
+    mcp_generic_tool_names,
+    protocol_operation_names,
+    protocol_supports_github_operations,
+    validate_provider,
+)
+
+
+def _async_stub(name: str) -> Any:
+    """Build an ``async def`` method that records nothing and returns its name."""
+
+    async def method(self: object, *args: Any, **kwargs: Any) -> str:
+        _ = (self, args, kwargs)
+        return name
+
+    method.__name__ = name
+    return method
+
+
+def _sync_stub(name: str) -> Any:
+    """Build a plain ``def`` method — the wrong shape for an async operation."""
+
+    def method(self: object, *args: Any, **kwargs: Any) -> str:
+        _ = (self, args, kwargs)
+        return name
+
+    method.__name__ = name
+    return method
+
+
+def _complete_provider_namespace() -> dict[str, Any]:
+    return {name: _async_stub(name) for name in protocol_operation_names()}
+
+
+def _make_provider(namespace: dict[str, Any]) -> object:
+    return type("_GeneratedProvider", (), namespace)()
+
+
+def test_complete_async_provider_reports_no_missing_operations() -> None:
+    """A provider with every operation as ``async def`` validates clean."""
+    report = validate_provider(_make_provider(_complete_provider_namespace()))
+
+    assert report.complete is True
+    assert report.missing == ()
+
+
+def test_absent_operations_are_named_in_the_report() -> None:
+    """A provider missing operations names exactly those, sorted, and is incomplete."""
+    namespace = _complete_provider_namespace()
+    del namespace["graphql"]
+    del namespace["create_review"]
+
+    report = validate_provider(_make_provider(namespace))
+
+    assert report.complete is False
+    assert report.missing == ("create_review", "graphql")
+
+
+def test_non_callable_attribute_counts_as_a_missing_operation() -> None:
+    """An attribute that shadows an operation with data is not an implementation."""
+    namespace = _complete_provider_namespace()
+    namespace["get_pull"] = {"number": 7}
+
+    report = validate_provider(_make_provider(namespace))
+
+    assert report.complete is False
+    assert report.missing == ("get_pull",)
+
+
+def test_sync_definition_of_an_async_operation_is_reported_as_expected_async() -> None:
+    """A sync ``def`` where the protocol declares ``async def`` is rejected.
+
+    Call sites ``await`` these operations. A sync implementation returns a plain
+    value that ``await`` then chokes on at run time, so validation must catch it.
+    """
+    namespace = _complete_provider_namespace()
+    namespace["list_pull_files"] = _sync_stub("list_pull_files")
+
+    report = validate_provider(_make_provider(namespace))
+
+    assert report.complete is False
+    assert report.missing == ("list_pull_files (expected async)",)
+
+
+def test_async_definition_of_a_sync_operation_is_reported_as_expected_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync side of the async-ness check fires for a non-async declared op.
+
+    Every operation on ``ScmProvider`` is async today, so this branch is only
+    reachable once the operation set names something the protocol does not
+    declare as a coroutine. Pinning it now means the day a sync helper joins the
+    set, an ``async def`` implementation of it is still reported — rather than
+    silently accepted because the check only ever ran in one direction.
+    """
+    extended = frozenset({*protocol_operation_names(), "repo_root"})
+    monkeypatch.setattr("mergecraft.scm.protocol._PROTOCOL_OPERATIONS", extended)
+
+    namespace = _complete_provider_namespace()
+    namespace["repo_root"] = _async_stub("repo_root")
+
+    report = validate_provider(_make_provider(namespace))
+
+    assert report.complete is False
+    assert report.missing == ("repo_root (expected sync)",)
+
+
+def test_a_declared_operation_absent_from_the_protocol_is_not_treated_as_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Names in the operation set but not on ``ScmProvider`` default to sync.
+
+    ``_async_protocol_operations`` reads async-ness off ``ScmProvider`` itself.
+    A name with no protocol member must be skipped rather than assumed async;
+    otherwise a sync helper added to the set would be demanded as a coroutine
+    from every adapter.
+    """
+    extended = frozenset({*protocol_operation_names(), "repo_root"})
+    monkeypatch.setattr("mergecraft.scm.protocol._PROTOCOL_OPERATIONS", extended)
+
+    namespace = _complete_provider_namespace()
+    namespace["repo_root"] = _sync_stub("repo_root")
+
+    report = validate_provider(_make_provider(namespace))
+
+    assert report.complete is True
+    assert report.missing == ()
+
+
+def test_github_surface_coverage_is_reported_true_for_the_shipped_protocol() -> None:
+    """The declared operation set covers the whole GitHub REST + MCP surface."""
+    assert protocol_supports_github_operations() is True
+
+
+@pytest.mark.parametrize(
+    ("dropped", "label"),
+    [("download_workflow_run_logs", "rest"), ("resolve_review_thread", "mcp-write")],
+)
+def test_github_surface_coverage_is_false_when_an_operation_is_dropped(
+    monkeypatch: pytest.MonkeyPatch, dropped: str, label: str
+) -> None:
+    """Dropping either half of the surface flips the guard to False.
+
+    ``protocol_supports_github_operations`` ANDs a REST check with an MCP check.
+    One case per operand proves neither side is dead: a REST-only regression and
+    an MCP-write-only regression are both caught.
+    """
+    reduced = frozenset(protocol_operation_names() - {dropped})
+    monkeypatch.setattr("mergecraft.scm.protocol._PROTOCOL_OPERATIONS", reduced)
+
+    assert protocol_supports_github_operations() is False, label
+
+
+def test_generic_mcp_tools_are_never_declared_as_protocol_operations() -> None:
+    """Generic-tool names must stay out of the operation set.
+
+    ``mcp_generic_tool_names`` lists MCP tools implemented with generic REST /
+    GraphQL calls. ``GitLabScmAdapter`` grows one stub method per name in
+    ``protocol_operation_names()``; adding a generic tool there would give every
+    adapter a namesake method that nothing implements or dispatches to.
+    """
+    generic = mcp_generic_tool_names()
+
+    assert generic == frozenset(
+        {"get_issue_events", "get_check_suite_logs", "get_review_comments", "checkout_pr"}
+    )
+    assert generic & protocol_operation_names() == frozenset()
+
+
+async def test_every_protocol_operation_is_an_inert_declaration() -> None:
+    """``ScmProvider`` declares operations; it must never implement one.
+
+    D10 is "declare, don't fake": a provider that cannot do something raises
+    ``UnsupportedScmCapability`` rather than fabricating a GitHub-shaped result.
+    That only holds while the protocol bodies stay empty — a concrete default on
+    ``ScmProvider`` (a GitHub-flavoured fallback, a hollow ``{}``) would be
+    inherited by any adapter subclassing it and would fake success instead.
+    """
+    inert = type("_InertProvider", (ScmProvider,), {})()
+
+    assert inert.capabilities is None
+    assert await inert.aclose() is None
+
+    for name in sorted(protocol_operation_names()):
+        operation = getattr(inert, name)
+        bound = inspect.signature(operation)
+        args = [
+            "x"
+            for parameter in bound.parameters.values()
+            if parameter.default is inspect.Parameter.empty
+            and parameter.kind
+            in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
+        ]
+        kwargs = {
+            parameter.name: "x"
+            for parameter in bound.parameters.values()
+            if parameter.default is inspect.Parameter.empty
+            and parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        assert await operation(*args, **kwargs) is None, f"{name} carries an implementation"
+
+
+async def test_adapters_do_not_inherit_the_protocol_stubs() -> None:
+    """Shipped adapters implement ``ScmProvider`` structurally, never by inheritance.
+
+    ``validate_provider`` cannot tell an inherited empty stub from a real method,
+    so a subclassing adapter would pass validation while returning ``None`` from
+    every unimplemented operation. ``GitLabScmAdapter`` avoids that by raising
+    ``UnsupportedScmCapability`` from generated stubs instead.
+    """
+    from mergecraft.scm.errors import UnsupportedScmCapability
+    from mergecraft.scm.github import GitHubScmAdapter
+    from mergecraft.scm.gitlab import GitLabScmAdapter
+
+    inert = type("_InertProvider", (ScmProvider,), {})()
+    assert validate_provider(inert).complete is True, (
+        "inherited stubs validate as complete — adapters must not subclass ScmProvider"
+    )
+
+    assert ScmProvider not in GitLabScmAdapter.__mro__
+    assert ScmProvider not in GitHubScmAdapter.__mro__
+
+    adapter = GitLabScmAdapter(token="test-token", base_url="https://gitlab.example/api/v4")
+    with pytest.raises(UnsupportedScmCapability):
+        await adapter.get_pull("acme", "demo", 7)

--- a/tests/utils/test_cov_agent_resolve_paths.py
+++ b/tests/utils/test_cov_agent_resolve_paths.py
@@ -1,0 +1,809 @@
+"""Decision-path coverage for ``mergecraft.utils.agent_resolve`` (issue #431).
+
+Every test here drives a *second* way out of a decision that production code
+only ever takes one way in the existing suite: the credential matrix per
+provider, the binary-availability fallbacks, chain construction under
+``pin``/``head``/``modelFallbacks``, the residency filter, the
+``allow_fallback=false`` policy, skip-reason classification, harness
+validation, and the fail-loud arms of ``resolve_runtime_agent``.
+
+Nothing here touches the network: every provider probe in this module is a
+pure environment read, and the only external lookups (``shutil.which``,
+``Path.exists``) are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.shared import AgentResult
+from mergecraft.config.settings import RepoSettings
+from mergecraft.models import BEDROCK_MODEL_ID_ENV, VERTEX_MODEL_ID_ENV
+from mergecraft.utils import agent_resolve as ar
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+# Every env var any credential probe in ``agent_resolve`` reads. Cleared for
+# each test so a developer machine's real credentials cannot make a
+# "missing credential" arm silently pass.
+_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "VERTEX_SERVICE_ACCOUNT_JSON",
+    "CODEX_AUTH_JSON",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "CURSOR_API_KEY",
+    "NOUS_API_KEY",
+    "TOKENHUB_API_KEY",
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+    "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL",
+    BEDROCK_MODEL_ID_ENV,
+    VERTEX_MODEL_ID_ENV,
+    "MERGECRAFT_MODEL",
+    "MERGECRAFT_AGENT",
+    "MERGECRAFT_TEMP_DIR",
+)
+
+CODEX_SUBSCRIPTION_JSON = json.dumps({"tokens": {"access_token": "codex-access"}})
+
+
+@pytest.fixture(autouse=True)
+def _clean_provider_env(monkeypatch: MonkeyPatch) -> None:
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# has_credentials_for_slug — one arm per provider, both answers
+# ---------------------------------------------------------------------------
+
+
+def test_has_credentials_rejects_a_slug_with_no_provider_prefix() -> None:
+    """A slug without ``provider/`` cannot be parsed — treated as no credentials."""
+    assert ar.has_credentials_for_slug("gpt-5") is False
+
+
+def test_anthropic_credentials_accept_either_oauth_token_or_api_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    assert ar.has_credentials_for_slug("anthropic/claude-sonnet") is False
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-x")
+    assert ar.has_credentials_for_slug("anthropic/claude-sonnet") is True
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+    assert ar.has_credentials_for_slug("anthropic/claude-sonnet") is True
+
+
+def test_whitespace_only_credential_does_not_count_as_configured(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``_has_env`` strips — a blank secret is the "unset in CI" shape."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    assert ar.has_credentials_for_slug("anthropic/claude-sonnet") is False
+
+
+def test_openai_credentials_prefer_subscription_json_then_api_key(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    assert ar.has_credentials_for_slug("openai/gpt") is False
+    monkeypatch.setenv("CODEX_AUTH_JSON", "not-json")
+    assert ar.has_credentials_for_slug("openai/gpt") is False
+    monkeypatch.setenv("CODEX_AUTH_JSON", CODEX_SUBSCRIPTION_JSON)
+    assert ar.has_credentials_for_slug("openai/gpt") is True
+    monkeypatch.delenv("CODEX_AUTH_JSON")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert ar.has_credentials_for_slug("openai/gpt") is True
+
+
+def test_google_and_cursor_credentials(monkeypatch: MonkeyPatch) -> None:
+    assert ar.has_credentials_for_slug("google/gemini-3-pro") is False
+    assert ar.has_credentials_for_slug("cursor/composer") is False
+    monkeypatch.setenv("GOOGLE_GENERATIVE_AI_API_KEY", "g-key")
+    monkeypatch.setenv("CURSOR_API_KEY", "c-key")
+    assert ar.has_credentials_for_slug("google/gemini-3-pro") is True
+    assert ar.has_credentials_for_slug("cursor/composer") is True
+
+
+def test_bedrock_needs_both_aws_auth_and_a_pinned_model_id(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Either half alone is a misconfiguration, not a usable Bedrock setup."""
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "aws-bearer")
+    assert ar.has_credentials_for_slug("bedrock/byok") is False
+    monkeypatch.setenv(BEDROCK_MODEL_ID_ENV, "anthropic.claude-3-5-sonnet")
+    assert ar.has_credentials_for_slug("bedrock/byok") is True
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK")
+    assert ar.has_credentials_for_slug("bedrock/byok") is False
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA")
+    assert ar.has_credentials_for_slug("bedrock/byok") is False
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    assert ar.has_credentials_for_slug("bedrock/byok") is True
+
+
+def test_vertex_needs_both_service_account_and_a_pinned_model_id(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VERTEX_SERVICE_ACCOUNT_JSON", "{}")
+    assert ar.has_credentials_for_slug("vertex/byok") is False
+    monkeypatch.setenv(VERTEX_MODEL_ID_ENV, "claude-sonnet-4")
+    assert ar.has_credentials_for_slug("vertex/byok") is True
+
+
+def test_gateway_providers_read_their_preset_key_and_the_custom_alias(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``nous``/``tokenhub``/``minimax`` all route through the gateway helper."""
+    assert ar.has_credentials_for_slug("nous/deepseek-v4") is False
+    assert ar.has_credentials_for_slug("tokenhub/hy3") is False
+    assert ar.has_credentials_for_slug("minimax/MiniMax-M3") is False
+
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    assert ar.has_credentials_for_slug("nous/deepseek-v4") is True
+    assert ar.has_credentials_for_slug("tokenhub/hy3") is False
+
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", "custom-key")
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", "https://example.invalid/v1")
+    assert ar.has_credentials_for_slug("minimax/MiniMax-M3") is True
+    assert ar.has_credentials_for_slug("tokenhub/hy3") is True
+
+
+def test_unknown_provider_prefix_has_no_credentials(monkeypatch: MonkeyPatch) -> None:
+    """A parseable but uncatalogued prefix falls off the end of the matrix."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert ar.has_credentials_for_slug("acme/private-1") is False
+
+
+# ---------------------------------------------------------------------------
+# _agent_binary_available / is_runnable_model_slug
+# ---------------------------------------------------------------------------
+
+
+def test_binary_gate_short_circuits_for_env_driven_harness_providers(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``nous``/``minimax`` map to ``None`` — no CLI on PATH is required."""
+    monkeypatch.setattr(ar.shutil, "which", lambda _name: None)
+    assert ar._agent_binary_available("nous/deepseek-v4") is True
+    assert ar._agent_binary_available("minimax/MiniMax-M3") is True
+    # An unmapped provider still needs no binary (``binary_by_provider`` miss).
+    assert ar._agent_binary_available("acme/private-1") is True
+
+
+def test_binary_gate_rejects_an_unparseable_slug() -> None:
+    assert ar._agent_binary_available("claude-sonnet") is False
+
+
+def test_binary_gate_falls_back_to_the_node_modules_bin_when_path_misses(
+    monkeypatch: MonkeyPatch, tmp_path: Any
+) -> None:
+    """No ``claude`` on PATH still runs when the vendored binary exists."""
+    monkeypatch.setattr(ar.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("MERGECRAFT_TEMP_DIR", str(tmp_path))
+    assert ar._agent_binary_available("anthropic/claude-sonnet") is False
+
+    vendored = tmp_path / "node_modules" / ".bin" / "claude"
+    vendored.parent.mkdir(parents=True)
+    vendored.write_text("#!/bin/sh\n", encoding="utf-8")
+    assert ar._agent_binary_available("anthropic/claude-sonnet") is True
+    assert ar._local_agent_binary("claude") == vendored
+
+
+def test_binary_gate_accepts_a_binary_found_on_path(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(ar.shutil, "which", lambda name: f"/usr/bin/{name}")
+    assert ar._agent_binary_available("openai/gpt") is True
+
+
+def test_is_runnable_requires_credentials_before_the_binary_gate(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The binary gate is never consulted when credentials are missing."""
+    calls: list[str] = []
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda slug: calls.append(slug) or True)
+    assert ar.is_runnable_model_slug("google/gemini-3-pro") is False
+    assert calls == []
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    assert ar.is_runnable_model_slug("google/gemini-3-pro") is True
+    assert calls == ["google/gemini-3-pro"]
+
+
+# ---------------------------------------------------------------------------
+# configured slugs / env promotion / effective resolution
+# ---------------------------------------------------------------------------
+
+
+def test_effective_model_slugs_promotes_the_env_override_and_dedupes(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings = RepoSettings.model_validate({"models": ["openai/gpt", "google/gemini-3-pro"]})
+    assert ar.effective_model_slugs(settings) == ["openai/gpt", "google/gemini-3-pro"]
+    monkeypatch.setenv("MERGECRAFT_MODEL", "google/gemini-3-pro")
+    assert ar.effective_model_slugs(settings) == ["google/gemini-3-pro", "openai/gpt"]
+
+
+def test_effective_model_slugs_falls_back_to_single_model_then_empty() -> None:
+    assert ar.effective_model_slugs(RepoSettings.model_validate({"model": "openai/gpt"})) == [
+        "openai/gpt"
+    ]
+    assert ar.effective_model_slugs(RepoSettings.model_validate({})) == []
+
+
+def test_resolve_effective_model_slug_prefers_env_then_credentialled_then_first(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings = RepoSettings.model_validate({"models": ["openai/gpt", "google/gemini-3-pro"]})
+    # No credentials anywhere → first configured entry regardless.
+    assert ar.resolve_effective_model_slug(settings) == "openai/gpt"
+    # Credentials for the second entry only → that entry wins.
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    assert ar.resolve_effective_model_slug(settings) == "google/gemini-3-pro"
+    # Env override beats config outright.
+    monkeypatch.setenv("MERGECRAFT_MODEL", "cursor/composer")
+    assert ar.resolve_effective_model_slug(settings) == "cursor/composer"
+
+
+def test_resolve_effective_model_slug_falls_through_to_the_alias_catalog() -> None:
+    """No ``models:`` list — ``model:`` resolves through ``resolve_model``."""
+    settings = RepoSettings.model_validate({"model": "acme/private-1"})
+    assert ar.resolve_effective_model_slug(settings) == "acme/private-1"
+    assert ar.resolve_effective_model_slug(RepoSettings.model_validate({})) is None
+
+
+# ---------------------------------------------------------------------------
+# chain construction
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_fallback_tail_walks_the_alias_chain() -> None:
+    assert ar._catalog_fallback_tail("openai/gpt-codex")[0] == "openai/gpt"
+    assert ar._catalog_fallback_tail("acme/private-1") == []
+
+
+def test_catalog_fallback_tail_stops_on_a_cycle(monkeypatch: MonkeyPatch) -> None:
+    """A self-referential alias table must terminate, not spin to the depth cap."""
+    from mergecraft.models import ModelAlias
+
+    a = ModelAlias(
+        slug="loop/a", provider="loop", display_name="A", resolve="loop-a", fallback="loop/b"
+    )
+    b = ModelAlias(
+        slug="loop/b", provider="loop", display_name="B", resolve="loop-b", fallback="loop/a"
+    )
+    monkeypatch.setattr(ar, "MODEL_ALIASES", [a, b])
+    assert ar._catalog_fallback_tail("loop/a") == ["loop/b", "loop/a"]
+
+
+def test_single_model_chain_appends_the_catalog_fallback_tail() -> None:
+    """One configured slug and no ``modelFallbacks`` → catalog tail is expanded."""
+    settings = RepoSettings.model_validate({"model": "openai/gpt-codex"})
+    assert ar.effective_model_chain(settings) == ["openai/gpt-codex", "openai/gpt"]
+
+
+def test_explicit_chain_suppresses_the_catalog_tail() -> None:
+    """Two configured slugs mean the operator owns the chain — no catalog tail."""
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-codex", "google/gemini-3-pro"]})
+    assert ar.effective_model_chain(settings) == ["openai/gpt-codex", "google/gemini-3-pro"]
+
+
+def test_explicit_chain_expands_configured_model_fallbacks() -> None:
+    settings = RepoSettings.model_validate(
+        {
+            "models": ["openai/gpt-codex"],
+            "modelFallbacks": {"openai/gpt-codex": ["cursor/composer", "cursor/composer"]},
+        }
+    )
+    assert ar.effective_model_chain(settings) == ["openai/gpt-codex", "cursor/composer"]
+
+
+def test_env_override_is_prepended_and_expanded_against_model_fallbacks(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings = RepoSettings.model_validate(
+        {
+            "models": ["openai/gpt-codex"],
+            "modelFallbacks": {"google/gemini-3-pro": ["cursor/composer"]},
+        }
+    )
+    monkeypatch.setenv("MERGECRAFT_MODEL", "google/gemini-3-pro")
+    assert ar.effective_model_chain(settings) == [
+        "google/gemini-3-pro",
+        "cursor/composer",
+        "openai/gpt-codex",
+    ]
+
+
+def test_head_moves_to_the_front_without_duplicating_a_configured_entry() -> None:
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-codex", "google/gemini-3-pro"]})
+    assert ar.effective_model_chain(settings, head="google/gemini-3-pro") == [
+        "google/gemini-3-pro",
+        "openai/gpt-codex",
+    ]
+
+
+def test_pin_collapses_to_the_head_or_the_first_configured_entry() -> None:
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-codex", "google/gemini-3-pro"]})
+    assert ar.effective_model_chain(settings, head="cursor/composer", pin=True) == [
+        "cursor/composer"
+    ]
+    assert ar.effective_model_chain(settings, pin=True) == ["openai/gpt-codex"]
+    assert ar.effective_model_chain(RepoSettings.model_validate({}), pin=True) == []
+
+
+def _bind_allowed_regions(monkeypatch: MonkeyPatch, *, permitted: set[str]) -> None:
+    """Pretend an ``enterprise.allowedRegions`` block is bound, permitting ``permitted``."""
+    from mergecraft.enterprise import runtime as ent
+
+    class _Settings:
+        allowed_regions = ("eu",)
+
+    def _enforce(slug: str, **_kwargs: Any) -> None:
+        if slug not in permitted:
+            msg = f"{slug} outside allowedRegions"
+            raise PermissionError(msg)
+
+    monkeypatch.setattr(ent, "current_enterprise_settings", lambda: _Settings())
+    monkeypatch.setattr(ent, "enforce_routed_model_residency", _enforce)
+
+
+def test_residency_filter_drops_disallowed_chain_entries(monkeypatch: MonkeyPatch) -> None:
+    _bind_allowed_regions(monkeypatch, permitted={"google/gemini-3-pro"})
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-codex", "google/gemini-3-pro"]})
+    assert ar.effective_model_chain(settings) == ["google/gemini-3-pro"]
+
+
+def test_residency_filter_raises_when_no_entry_survives(monkeypatch: MonkeyPatch) -> None:
+    _bind_allowed_regions(monkeypatch, permitted=set())
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-codex", "google/gemini-3-pro"]})
+    with pytest.raises(PermissionError, match=r"enterprise\.allowedRegions"):
+        ar.effective_model_chain(settings)
+
+
+# ---------------------------------------------------------------------------
+# pick_runnable_slug_from_chain
+# ---------------------------------------------------------------------------
+
+
+def test_empty_chain_names_the_config_keys_the_operator_must_set() -> None:
+    with pytest.raises(RuntimeError, match=r"set models: or model: in \.mergecraft/config\.yaml"):
+        ar.pick_runnable_slug_from_chain([])
+
+
+def test_chain_skips_entries_without_credentials_or_binary(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "c-key")
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    # Cursor has credentials but no binary; Gemini has both.
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda slug: not slug.startswith("cursor/"))
+    chain = ["openai/gpt", "cursor/composer", "google/gemini-3-pro"]
+    assert ar.pick_runnable_slug_from_chain(chain) == "google/gemini-3-pro"
+
+
+def test_chain_with_no_runnable_entry_says_to_configure_credentials(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda _slug: True)
+    with pytest.raises(RuntimeError, match="no runnable model slug in chain"):
+        ar.pick_runnable_slug_from_chain(["openai/gpt", "google/gemini-3-pro"])
+
+
+def test_allow_fallback_false_rejects_a_primary_missing_credentials() -> None:
+    with pytest.raises(ar.ModelFallbackPolicyError, match="missing credentials"):
+        ar.pick_runnable_slug_from_chain(
+            ["openai/gpt", "google/gemini-3-pro"], allow_fallback=False
+        )
+
+
+def test_allow_fallback_false_rejects_a_primary_missing_its_binary(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda _slug: False)
+    with pytest.raises(ar.ModelFallbackPolicyError, match="agent binary missing"):
+        ar.pick_runnable_slug_from_chain(
+            ["openai/gpt", "google/gemini-3-pro"], allow_fallback=False
+        )
+
+
+def test_allow_fallback_false_returns_the_primary_and_never_the_backup(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda _slug: True)
+    assert (
+        ar.pick_runnable_slug_from_chain(
+            ["openai/gpt", "google/gemini-3-pro"], allow_fallback=False
+        )
+        == "openai/gpt"
+    )
+
+
+def test_select_runnable_model_slug_honours_allow_fallback_from_settings(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setattr(ar, "_agent_binary_available", lambda _slug: True)
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt", "google/gemini-3-pro"], "allowFallback": False}
+    )
+    with pytest.raises(ar.ModelFallbackPolicyError):
+        ar.select_runnable_model_slug(settings=settings)
+
+    permissive = RepoSettings.model_validate(
+        {"models": ["openai/gpt", "google/gemini-3-pro"], "allowFallback": True}
+    )
+    assert ar.select_runnable_model_slug(settings=permissive) == "google/gemini-3-pro"
+
+
+# ---------------------------------------------------------------------------
+# result classification
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_failure_reason_reads_error_text_then_metadata() -> None:
+    timeout_by_text = AgentResult(success=False, error="provider TIMEOUT after 300s")
+    assert ar._retryable_failure_reason(timeout_by_text) is ar.FallbackReason.timeout
+
+    crash_by_meta = AgentResult(success=False, error="boom", metadata={"crash": True})
+    assert ar._retryable_failure_reason(crash_by_meta) is ar.FallbackReason.crash
+
+    generic = AgentResult(success=False, error=None)
+    assert ar._retryable_failure_reason(generic) is ar.FallbackReason.provider_error
+
+
+def test_is_retryable_failure_requires_the_literal_true_flag() -> None:
+    assert (
+        ar._is_retryable_failure(AgentResult(success=False, metadata={"retryable": True})) is True
+    )
+    assert (
+        ar._is_retryable_failure(AgentResult(success=False, metadata={"retryable": "yes"})) is False
+    )
+    assert ar._is_retryable_failure(AgentResult(success=False)) is False
+
+
+def test_classify_skip_reason_covers_stale_malformed_and_missing_verdict() -> None:
+    stale = AgentResult(
+        success=True, terminal_submission_received=True, diagnostics={"attempt_id": 0}
+    )
+    assert ar._classify_skip_reason(stale, 1) is ar.FallbackReason.stale_attempt
+
+    usable = AgentResult(
+        success=True, terminal_submission_received=True, diagnostics={"attempt_id": 1}
+    )
+    assert ar._classify_skip_reason(usable, 1) is None
+
+    failed = AgentResult(success=False, error="connection reset")
+    assert ar._classify_skip_reason(failed, 0) is ar.FallbackReason.provider_error
+
+    malformed = AgentResult(success=True, diagnostics={"malformed_submission": True})
+    assert ar._classify_skip_reason(malformed, 0) is ar.FallbackReason.malformed_submission
+
+    silent = AgentResult(success=True)
+    assert ar._classify_skip_reason(silent, 0) is ar.FallbackReason.no_terminal_verdict
+
+
+def _tool_state(**kwargs: Any) -> Any:
+    from mergecraft.mcp.tool_state import ToolState
+
+    return ToolState(repos={}, primary_repo_key="main", **kwargs)
+
+
+def test_incomplete_review_success_ignores_scripted_calls_without_tool_state() -> None:
+    result = AgentResult(success=True)
+    assert ar._is_incomplete_review_success(result, None) is False
+    assert ar._is_incomplete_review_success(AgentResult(success=False), _tool_state()) is False
+
+
+def test_incomplete_review_success_is_false_outside_review_modes() -> None:
+    state = _tool_state(selected_mode="Plan")
+    assert ar._is_incomplete_review_success(AgentResult(success=True), state) is False
+
+
+def test_incremental_review_with_a_final_summary_is_complete() -> None:
+    state = _tool_state(selected_mode="IncrementalReview", final_summary_written=True)
+    assert ar._is_incomplete_review_success(AgentResult(success=True), state) is False
+
+
+def test_review_without_any_submission_is_incomplete() -> None:
+    state = _tool_state(selected_mode="Review")
+    assert ar._is_incomplete_review_success(AgentResult(success=True), state) is True
+
+
+def test_prepare_chain_attempt_clears_a_prior_terminal_submission() -> None:
+    state = _tool_state(selected_mode="Review")
+    state.terminal_submission = object()  # type: ignore[assignment]  # — opaque sentinel; only cleared
+    state.terminal_submission_conflict = True
+    ar._prepare_chain_attempt(state, 2)
+    assert state.terminal_submission is None
+    assert state.terminal_submission_conflict is False
+    assert (state.attempt_id, state.fallback_index) == (2, 2)
+    # ``None`` tool state is a no-op rather than an AttributeError.
+    ar._prepare_chain_attempt(None, 3)
+
+
+def test_attach_model_evidence_stamps_fallback_fields() -> None:
+    stamped = ar._attach_model_evidence(
+        AgentResult(success=True, metadata={"keep": 1}),
+        requested_model="openai/gpt-codex",
+        executed_model="google/gemini-3-pro",
+        fallback_index=1,
+        fallback_reason=ar.FallbackReason.timeout,
+    )
+    assert stamped.metadata == {
+        "keep": 1,
+        "requested_model": "openai/gpt-codex",
+        "executed_model": "google/gemini-3-pro",
+        "provider": "google",
+        "fallback_index": 1,
+        "fallback_occurred": True,
+        "fallback_reason": ar.FallbackReason.timeout,
+    }
+
+
+def test_attach_model_evidence_omits_the_reason_when_nothing_was_skipped() -> None:
+    stamped = ar._attach_model_evidence(
+        AgentResult(success=True),
+        requested_model="openai/gpt",
+        executed_model="openai/gpt",
+        fallback_index=0,
+    )
+    assert "fallback_reason" not in stamped.metadata
+    assert stamped.metadata["fallback_occurred"] is False
+
+
+def test_promote_model_evidence_keeps_existing_values_for_blank_inputs() -> None:
+    state = _tool_state()
+    state.requested_model = "openai/gpt"
+    state.model = "openai/gpt"
+    ar.promote_model_evidence(state, requested_model=None, executed_model="", fallback_index=2)
+    assert state.requested_model == "openai/gpt"
+    assert state.model == "openai/gpt"
+    assert state.fallback_index == 2
+    assert state.fallback_occurred is True
+
+
+def test_empty_chain_result_is_a_flagged_failure() -> None:
+    result = ar._empty_chain_result()
+    assert result.success is False
+    assert result.error == "no model chain configured"
+    assert result.metadata["empty_chain"] is True
+
+
+# ---------------------------------------------------------------------------
+# harness resolution
+# ---------------------------------------------------------------------------
+
+
+def test_agent_mode_for_slug_maps_each_native_provider_and_defaults_to_opencode() -> None:
+    assert ar._agent_mode_for_slug("anthropic/claude-sonnet") == "claude"
+    assert ar._agent_mode_for_slug("openai/gpt") == "codex"
+    assert ar._agent_mode_for_slug("google/gemini-3-pro") == "gemini"
+    assert ar._agent_mode_for_slug("cursor/composer") == "cursor"
+    assert ar._agent_mode_for_slug("nous/deepseek-v4") == "opencode"
+    assert ar._agent_provider_for_slug("no-slash-here") == "unknown"
+
+
+def test_resolve_harness_infers_when_unset_and_validates_when_set() -> None:
+    inferred = RepoSettings.model_validate({})
+    assert ar.resolve_harness(inferred, "openai/gpt") == "codex"
+
+    explicit = RepoSettings.model_validate({"harness": "opencode"})
+    assert ar.resolve_harness(explicit, "openai/gpt") == "opencode"
+    # Uncatalogued prefixes route through OpenCode too.
+    assert ar.resolve_harness(explicit, "acme/private-1") == "opencode"
+
+
+def test_opencode_refuses_a_catalogued_provider_it_does_not_serve() -> None:
+    explicit = RepoSettings.model_validate({"harness": "opencode"})
+    with pytest.raises(ar.ModelFallbackPolicyError, match="incompatible"):
+        ar.resolve_harness(explicit, "google/gemini-3-pro")
+
+
+def test_native_harness_refuses_a_foreign_provider() -> None:
+    explicit = RepoSettings.model_validate({"harness": "claude"})
+    assert ar.resolve_harness(explicit, "anthropic/claude-sonnet") == "claude"
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"provider 'openai'"):
+        ar.resolve_harness(explicit, "openai/gpt")
+
+
+def test_attempt_harness_label_prefers_the_explicit_override() -> None:
+    explicit = RepoSettings.model_validate({"harness": "opencode"})
+    # A tail slug the harness could not actually run still stamps the override
+    # rather than re-validating.
+    assert ar._attempt_harness_label(explicit, "google/gemini-3-pro") == "opencode"
+    assert ar._attempt_harness_label(None, "google/gemini-3-pro") == "gemini"
+    assert ar._attempt_harness_label(RepoSettings.model_validate({}), "openai/gpt") == "codex"
+
+
+# ---------------------------------------------------------------------------
+# cost attrs
+# ---------------------------------------------------------------------------
+
+
+class _Usage:
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def test_cost_attrs_emit_both_mergecraft_and_genai_names() -> None:
+    attrs = ar._cost_attrs_from_usage(
+        _Usage(
+            input_tokens=10,
+            output_tokens=4,
+            cache_read_tokens=2,
+            cache_write_tokens=1,
+            cost_usd=0.5,
+        )
+    )
+    assert attrs["cost.tokens_in"] == 10
+    assert attrs["cost.tokens_out"] == 4
+    assert attrs["cost.cache_read"] == 2
+    assert attrs["cost.cache_write"] == 1
+    assert attrs["cost.usd"] == 0.5
+    assert attrs["gen_ai.usage.input_tokens"] == 10
+    assert attrs["gen_ai.usage.cache_creation_input_tokens"] == 1
+    assert attrs["gen_ai.usage.cost_usd"] == 0.5
+
+
+def test_cost_attrs_drop_missing_and_non_numeric_fields() -> None:
+    assert ar._cost_attrs_from_usage(_Usage()) == {}
+    attrs = ar._cost_attrs_from_usage(_Usage(input_tokens="12", cost_usd=None))
+    assert attrs == {}
+
+
+# ---------------------------------------------------------------------------
+# _slug_runnable
+# ---------------------------------------------------------------------------
+
+
+def test_slug_runnable_accepts_custom_prefixes_but_not_uncredentialled_natives() -> None:
+    assert ar._slug_runnable("openai/gpt") is False
+    assert ar._slug_runnable("acme/private-1") is True
+    assert ar._slug_runnable("no-slash") is False
+
+
+def test_slug_runnable_accepts_a_native_slug_once_credentials_exist(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert ar._slug_runnable("openai/gpt") is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_model / _resolve_slug
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_alias_requires_the_pinned_model_id(monkeypatch: MonkeyPatch) -> None:
+    with pytest.raises(ValueError, match=BEDROCK_MODEL_ID_ENV):
+        ar.resolve_model(slug="bedrock/byok")
+    monkeypatch.setenv(BEDROCK_MODEL_ID_ENV, "anthropic.claude-3-5-sonnet-v2")
+    assert ar.resolve_model(slug="bedrock/byok") == "anthropic.claude-3-5-sonnet-v2"
+
+
+def test_vertex_alias_requires_the_pinned_model_id(monkeypatch: MonkeyPatch) -> None:
+    with pytest.raises(ValueError, match=VERTEX_MODEL_ID_ENV):
+        ar.resolve_model(slug="vertex/byok")
+    monkeypatch.setenv(VERTEX_MODEL_ID_ENV, "claude-sonnet-4@20250514")
+    assert ar.resolve_model(slug="vertex/byok") == "claude-sonnet-4@20250514"
+
+
+def test_resolve_model_env_override_wins_unless_explicitly_ignored(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_MODEL", "acme/private-1")
+    assert ar.resolve_model(slug="openai/gpt") == "acme/private-1"
+    assert ar.resolve_model(slug="acme/other-1", respect_env_override=False) == "acme/other-1"
+
+
+def test_resolve_model_passes_through_a_raw_specifier_but_drops_a_bare_name() -> None:
+    assert ar.resolve_model(slug="acme/private-1") == "acme/private-1"
+    assert ar.resolve_model(slug="gpt-4o-latest") is None
+    assert ar.resolve_model(slug="   ") is None
+    assert ar.resolve_model() is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_runtime_agent
+# ---------------------------------------------------------------------------
+
+
+def test_env_agent_override_wins_and_an_unknown_one_falls_through(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_AGENT", "gemini")
+    assert ar.resolve_runtime_agent(model="openai/gpt").name == "gemini"
+    monkeypatch.setenv("MERGECRAFT_AGENT", "not-an-agent")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert ar.resolve_runtime_agent(model="openai/gpt").name == "codex"
+
+
+def test_explicit_harness_setting_overrides_provider_inference(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    settings = RepoSettings.model_validate({"harness": "opencode"})
+    assert ar.resolve_runtime_agent(model="openai/gpt", settings=settings).name == "opencode"
+    # No model to validate against — the configured harness is returned as-is.
+    assert ar.resolve_runtime_agent(model=None, settings=settings).name == "opencode"
+
+
+def test_bedrock_routing_splits_anthropic_ids_from_the_rest(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "aws-bearer")
+    monkeypatch.setenv(BEDROCK_MODEL_ID_ENV, "anthropic.claude-3-5-sonnet")
+    assert ar.resolve_runtime_agent(model="anthropic.claude-3-5-sonnet").name == "claude"
+    monkeypatch.setenv(BEDROCK_MODEL_ID_ENV, "meta.llama3-70b")
+    assert ar.resolve_runtime_agent(model="meta.llama3-70b").name == "opencode"
+
+
+def test_vertex_routing_splits_claude_ids_from_the_rest(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "sa.json")
+    monkeypatch.setenv(VERTEX_MODEL_ID_ENV, "claude-sonnet-4")
+    assert ar.resolve_runtime_agent(model="claude-sonnet-4").name == "claude"
+    monkeypatch.setenv(VERTEX_MODEL_ID_ENV, "gemini-3-pro")
+    assert ar.resolve_runtime_agent(model="gemini-3-pro").name == "opencode"
+
+
+def test_openai_without_a_credential_fails_loud_naming_both_env_vars() -> None:
+    with pytest.raises(ValueError, match="CODEX_AUTH_JSON, OPENAI_API_KEY"):
+        ar.resolve_runtime_agent(model="openai/gpt")
+
+
+def test_google_and_cursor_fail_loud_without_credentials() -> None:
+    with pytest.raises(ValueError, match="GEMINI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY"):
+        ar.resolve_runtime_agent(model="google/gemini-3-pro")
+    with pytest.raises(ValueError, match="CURSOR_API_KEY"):
+        ar.resolve_runtime_agent(model="cursor/composer")
+
+
+def test_credentialled_native_providers_resolve_to_their_agent(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setenv("CURSOR_API_KEY", "c-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    monkeypatch.setenv("CODEX_AUTH_JSON", CODEX_SUBSCRIPTION_JSON)
+    assert ar.resolve_runtime_agent(model="google/gemini-3-pro").name == "gemini"
+    assert ar.resolve_runtime_agent(model="cursor/composer").name == "cursor"
+    assert ar.resolve_runtime_agent(model="anthropic/claude-sonnet").name == "claude"
+    assert ar.resolve_runtime_agent(model="openai/gpt").name == "codex"
+
+
+def test_anthropic_without_credentials_falls_through_to_opencode() -> None:
+    """Anthropic is the one native provider with no fail-loud arm."""
+    assert ar.resolve_runtime_agent(model="anthropic/claude-sonnet").name == "opencode"
+
+
+def test_gateway_providers_fail_loud_with_their_own_auth_command() -> None:
+    with pytest.raises(ValueError, match="mergecraft auth nous"):
+        ar.resolve_runtime_agent(model="nous/deepseek-v4")
+    with pytest.raises(ValueError, match="mergecraft auth tokenhub"):
+        ar.resolve_runtime_agent(model="tokenhub/hy3")
+    with pytest.raises(ValueError, match="mergecraft auth minimax"):
+        ar.resolve_runtime_agent(model="minimax/MiniMax-M3")
+
+
+def test_gateway_providers_resolve_to_opencode_once_credentialled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", "custom-key")
+    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", "https://example.invalid/v1")
+    assert ar.resolve_runtime_agent(model="nous/deepseek-v4").name == "opencode"
+    assert ar.resolve_runtime_agent(model="tokenhub/hy3").name == "opencode"
+    assert ar.resolve_runtime_agent(model="minimax/MiniMax-M3").name == "opencode"
+
+
+def test_unknown_provider_and_no_model_both_land_on_opencode() -> None:
+    assert ar.resolve_runtime_agent(model="acme/private-1").name == "opencode"
+    assert ar.resolve_runtime_agent(model=None).name == "opencode"


### PR DESCRIPTION
## What?

Raises the coverage gate from a failing 79.58% to 82.11% so the release pipeline can pass, with headroom for the next merge.

Seven defects found while writing those tests are pinned as expected failures and filed separately. They are not fixed here.

## Why?

The gate failed after three same-day merges that each passed on their own branch. The release pipeline has been parked on that number since the alpha tag build.

The number that matters is branch-adjusted coverage, not line coverage. Line coverage was already above the floor; the shortfall was decisions that only ever resolved one way. Tests that only import a module would not have moved it.

## Note

Seven tests xfail on purpose. They pin defects that must not be mixed into this branch:

- #434 two antislop rules never fire on Python
- #435 antislop mixes byte and character offsets, so unused-import and snippet text drift after any non-ASCII character
- #436 Gemini and Codex spans always report zero tokens
- #437 `auth --scope local` can claim nothing was written after a partial write
- #438 pass-through-wrapper fires on wrappers that bind a literal

`fail_under` is unchanged: 82.11% sits inside the floor-plus-5 ratchet margin.

A single failure under `tests/mcp` during a full parallel run is #421, not this branch.

## Test plan

- [x] `make coverage-gate` — 82.11% within `[80.00%, 85.00%]`
- [x] `make ci-static`
- [x] ruff clean on the new tests (pre-commit on this commit)

## Related PR(s)/Issue(s)

Closes #431
Related #434 #435 #436 #437 #438
See also #432
