### PR TITLE
agents: recover from provider stalls instead of losing the review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,22 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Static, typecheck, build tier
         run: make ci-static
+      # Reports self-review Action-pin drift (#450). Advisory on purpose: the
+      # stale pin lives on the default branch, so it is not a defect in the PR
+      # being checked, and failing here would block every unrelated change
+      # until someone bumps main. The annotation is what makes the skew
+      # visible instead of silent -- which is how it reached 687 commits.
+      - name: Action pin freshness (advisory)
+        if: matrix.python == '3.14'
+        run: |
+          git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || true
+          if out="$(make action-pin-check 2>&1)"; then
+            echo "$out"
+          else
+            echo "$out"
+            detail="$(printf '%s' "$out" | grep -m1 -- '  - ' | sed 's/^  - //')"
+            echo "::warning title=mergecraft action pin drift::${detail:-see log}"
+          fi
 
   security:
     name: Verify (security audit py${{ matrix.python }})

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -478,7 +478,7 @@ jobs:
         # bump PR is not required after merge. 0592d72 survives merge intact.
         # 2026-08-23 (eighth bump, PR #442): re-bumped to cfa36704 for OpenCode
         # HTTP timeout (25m) + recallPass config unblock. pull_request_target resolves
-        # this workflow and action pin from the repo default branch (pre-0.0.1), not
+        # this workflow and action pin from the repo default branch (main), not
         # the PR head — self-review PRs cannot bump the pin until after merge.
         uses: alexhawat/mergeCraft@cfa36704cf6c58a6abe895e539a377c4599fa4bd # wave/rc-review-convergence (PR #442)
         with:
@@ -580,7 +580,7 @@ jobs:
         # above for why.
         # 2026-08-23 (eighth bump, PR #442): re-bumped to cfa36704 for OpenCode
         # HTTP timeout (25m) + recallPass config unblock. pull_request_target resolves
-        # this workflow and action pin from the repo default branch (pre-0.0.1), not
+        # this workflow and action pin from the repo default branch (main), not
         # the PR head — self-review PRs cannot bump the pin until after merge.
         uses: alexhawat/mergeCraft@cfa36704cf6c58a6abe895e539a377c4599fa4bd # wave/rc-review-convergence (PR #442)
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opencode serve` output is now drained for the process lifetime. Boot read the child's stdout only until
+  the listening URL appeared and nothing read either pipe afterwards, so once the child filled the ~64KB
+  pipe buffer it blocked in `write()` and stopped answering HTTP — a hang with no output, indistinguishable
+  from an unresponsive provider. A bounded tail of that output is now attached to a provider-timeout error,
+  which previously stringified to nothing at all (#449)
 - A provider timeout no longer kills the review. `ProviderTimeoutError` on the opencode path returned an
   `AgentResult` with no `retryable` metadata, and the model chain gates on that flag alone, so the single
   most recoverable failure there is read as permanent and terminated the run at attempt 1 of 10 — leaving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `make action-pin-check` guards the self-review Action pin against drift. Because
+  `.github/workflows/mergecraft.yml` runs on `pull_request_target`, GitHub resolves its `uses:` pin from the
+  **default branch**, so a fix merged to `pre-0.0.1` does not reach the reviewer until it reaches `main` —
+  a skew that reached 687 commits undetected and made PR #443 time out on a ceiling already fixed on the
+  branch. The check also rejects a one-sided bump that leaves the review and fallback steps on different
+  SHAs. Advisory in CI: a stale pin is a property of the default branch, not of the PR under review (#450)
 - First-pass recall metric (`mergecraft eval convergence`, `make eval-convergence`) with multi-round bank cases and a paired regression gate that holds first-pass recall flat while the DG1 precision corpus stays at or above its floor
 - Open-PR finding ledger in the sticky progress comment — `mergecraft findings ledger --pr N` inspects inline, deferred, withdrawn, and unpublished fingerprints without filing GitHub issues (D4, D5)
 - Optional recall pass (`review.recallPass`, default off) dispatches `mergecraft-recall` after aggregation; novel findings always publish in the deferred lane (D1, D7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Provider quota exhaustion is now classified as retryable for failover. The CLI classifier matched only
+  rate-limit wording (`rate limit`, `too many requests`, `overloaded`, `429`), so Codex's "You've hit your
+  usage limit" matched nothing and read as permanent — the chain refused to try the next model even though
+  the next model was unaffected (#446)
 - `opencode serve` output is now drained for the process lifetime. Boot read the child's stdout only until
   the listening URL appeared and nothing read either pipe afterwards, so once the child filled the ~64KB
   pipe buffer it blocked in `write()` and stopped answering HTTP — a hang with no output, indistinguishable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retryability now has one decision path. `_is_retryable_failure` gated on `metadata["retryable"]` alone
+  while `_retryable_failure_reason` inferred the same property from the error text, and only the
+  metadata-blind one decided — so a driver that omitted the flag was silently read as "permanent" and its
+  failure terminated the run. An explicit flag still wins in both directions; an omitted one now falls back
+  to inference. A retryable failure at the chain tail is bounded to one in-place retry and then returns that
+  failure, instead of re-asking a refusing provider until the attempt cap raised and replaced the real error
+  with a cap message (#447)
 - Codex `error` and `turn.failed` events are no longer discarded. Codex reports fatal failures as structured
   events on stdout, and the stream handler had no branch for them, so the message was counted and dropped
   and the run reported whatever unrelated text stderr happened to hold — PR #443 surfaced "Reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Codex `error` and `turn.failed` events are no longer discarded. Codex reports fatal failures as structured
+  events on stdout, and the stream handler had no branch for them, so the message was counted and dropped
+  and the run reported whatever unrelated text stderr happened to hold — PR #443 surfaced "Reading
+  additional input from stdin..." for a quota exhaustion, in the job annotation, the merge evidence packet,
+  and the chain log. The provider's own message is now the run's error and feeds retry classification (#445)
 - Provider quota exhaustion is now classified as retryable for failover. The CLI classifier matched only
   rate-limit wording (`rate limit`, `too many requests`, `overloaded`, `429`), so Codex's "You've hit your
   usage limit" matched nothing and read as permanent — the chain refused to try the next model even though

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,14 +59,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the listening URL appeared and nothing read either pipe afterwards, so once the child filled the ~64KB
   pipe buffer it blocked in `write()` and stopped answering HTTP — a hang with no output, indistinguishable
   from an unresponsive provider. A bounded tail of that output is now attached to a provider-timeout error,
-  which previously stringified to nothing at all (#449)
+  which previously stringified to nothing at all — the tail is read under the same lock the drain threads
+  hold, so collecting it cannot raise `deque mutated during iteration` in place of the failure it explains
+  (#449)
 - A provider timeout no longer kills the review. `ProviderTimeoutError` on the opencode path returned an
   `AgentResult` with no `retryable` metadata, and the model chain gates on that flag alone, so the single
   most recoverable failure there is read as permanent and terminated the run at attempt 1 of 10 — leaving
   the PR with no review rather than a review from the next model in the chain. Gateway 429/5xx responses on
   the same path were mis-classified the same way. Two bounds keep the retries from multiplying: opencode
   gets the initial attempt plus exactly one retry, and the chain now honours a wall-clock deadline derived
-  from `RunBounds.run_timeout_s` instead of relying on the attempt cap alone (#444)
+  from `RunBounds.run_timeout_s` instead of relying on the attempt cap alone. Every prompt on that path is
+  covered, the initial review turn included — the likeliest one to time out, and the one whose timeout
+  previously escaped the harness and aborted the chain outright. When the allowance runs out at the chain
+  tail, the evidence packet now names the model that actually ran instead of the entry being skipped (#444)
 - `mergecraft --version` reported `0.1.0` while the project was at `0.1.0a1`: the number was restated as a literal in `mergecraft/__init__.py` alongside `pyproject.toml` and the two drifted. It is now read from the installed distribution. The value also keys the offline result cache and is stamped on telemetry and eval reproducibility pins, so the mismatch quietly mixed artefacts from different builds
 - Managed analyzers no longer report a clean scan as skipped: the adapter's fallback re-parse ran on the
   human-readable output string, which carries the `version_note` prose prefix, so any managed tool whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A provider timeout no longer kills the review. `ProviderTimeoutError` on the opencode path returned an
+  `AgentResult` with no `retryable` metadata, and the model chain gates on that flag alone, so the single
+  most recoverable failure there is read as permanent and terminated the run at attempt 1 of 10 — leaving
+  the PR with no review rather than a review from the next model in the chain. Gateway 429/5xx responses on
+  the same path were mis-classified the same way. Two bounds keep the retries from multiplying: opencode
+  gets the initial attempt plus exactly one retry, and the chain now honours a wall-clock deadline derived
+  from `RunBounds.run_timeout_s` instead of relying on the attempt cap alone (#444)
 - `mergecraft --version` reported `0.1.0` while the project was at `0.1.0a1`: the number was restated as a literal in `mergecraft/__init__.py` alongside `pyproject.toml` and the two drifted. It is now read from the installed distribution. The value also keys the offline result cache and is stamped on telemetry and eval reproducibility pins, so the mismatch quietly mixed artefacts from different builds
 - Managed analyzers no longer report a clean scan as skipped: the adapter's fallback re-parse ran on the
   human-readable output string, which carries the `version_note` prose prefix, so any managed tool whose

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PRE_COMMIT ?= $(UV) run pre-commit
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check reference-docs reference-docs-check bench-review eval-gate eval-replay eval-convergence \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check pins-check
+	lint-ruff-advisory hook-pins-check pins-check action-pin-check
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -63,6 +63,9 @@ action-yml-hygiene-check: ## Fail when an action.yml description embeds a litera
 
 hook-pins-check: ## Fail when .pre-commit-config.yaml hook revs drift from pyproject.toml pins
 	$(UV) run python scripts/check_hook_pins.py
+
+action-pin-check: ## Fail when the default branch's self-review Action pin drifts too far behind (#450)
+	$(UV) run python scripts/check_action_pin_freshness.py
 
 lint-ruff-advisory: ## Ruff advisory families (non-blocking CI; #146)
 	$(RUFF) check src tests scripts --select $(RUFF_ADVISORY_FAMILIES)

--- a/scripts/check_action_pin_freshness.py
+++ b/scripts/check_action_pin_freshness.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Guard: the self-review Action pin must not drift far behind this branch.
+
+``.github/workflows/mergecraft.yml`` triggers on ``pull_request_target``, so
+GitHub resolves its definition — and therefore its ``uses:`` pin — from the
+repository **default branch**, never from the PR base. A fix merged to
+``pre-0.0.1`` does not reach the reviewer until it reaches ``main``.
+
+Nothing detected that skew, and it reached 691 commits: PR #443 timed out on a
+600s ceiling that had already been fixed on ``pre-0.0.1``, because the run used
+``main``'s older pin. The failure mode is quiet — the branch holds the fix, the
+branch's own workflow pins the fixed SHA, and CI still exercises the old code
+(#450).
+
+Two checks:
+
+1. **Self-consistency** (offline, always runs). Every ``uses:`` pin of this
+   action inside a workflow file must be the same SHA. The workflow header
+   warns that a one-sided bump is a footgun; this makes it an error.
+2. **Freshness** (needs the default-branch ref). The default branch's pin must
+   be an ancestor of this branch's pin and within ``MAX_DRIFT`` commits of it.
+   Skips with a notice when the ref is not fetched, so a local ``make lint``
+   in a shallow or offline checkout does not fail on it.
+
+Module: scripts.check_action_pin_freshness
+Depends: os, re, subprocess, sys, pathlib
+
+Exports:
+    main — CLI entry; compares self-review Action pins for drift.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO / ".github" / "workflows"
+
+# The action pins itself here; a consumer's own pin is their business.
+_PIN_RE = re.compile(r"uses:\s*alexhawat/mergeCraft@(?P<sha>[0-9a-f]{40})")
+
+DEFAULT_BRANCH = os.environ.get("MERGECRAFT_DEFAULT_BRANCH", "main")
+
+# Chosen to catch a genuinely stale reviewer, not routine lag: a pin a few
+# merges behind still runs substantially current code, while hundreds of
+# commits behind is how #450 went unnoticed. Override for a tighter policy.
+MAX_DRIFT = int(os.environ.get("MERGECRAFT_MAX_ACTION_PIN_DRIFT", "100"))
+
+
+def _pins_in(text: str) -> list[tuple[int, str]]:
+    """Return ``(line_number, sha)`` for every self-referential Action pin."""
+    return [
+        (index, match.group("sha"))
+        for index, line in enumerate(text.splitlines(), start=1)
+        if (match := _PIN_RE.search(line))
+    ]
+
+
+def _git(*args: str) -> str | None:
+    """Run a read-only git command, returning ``None`` when it fails."""
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def _default_branch_workflow(rel_path: str) -> str | None:
+    """Return the workflow's text on the default branch, or ``None``."""
+    for ref in (f"origin/{DEFAULT_BRANCH}", DEFAULT_BRANCH):
+        if _git("rev-parse", "--verify", "--quiet", ref) is None:
+            continue
+        text = _git("show", f"{ref}:{rel_path}")
+        if text is not None:
+            return text
+    return None
+
+
+def _check_self_consistency(rel_path: str, pins: list[tuple[int, str]]) -> list[str]:
+    """Every pin inside one workflow file must name the same SHA."""
+    distinct = {sha for _, sha in pins}
+    if len(distinct) <= 1:
+        return []
+    locations = ", ".join(f"line {line}: {sha[:12]}" for line, sha in pins)
+    return [
+        f"{rel_path}: {len(distinct)} different Action pins in one file "
+        f"({locations}). A one-sided bump leaves the review and fallback steps "
+        f"on different code."
+    ]
+
+
+def _check_freshness(rel_path: str, head_sha: str) -> list[str]:
+    """Compare this branch's pin against the default branch's."""
+    base_text = _default_branch_workflow(rel_path)
+    if base_text is None:
+        print(
+            f"action-pin-check: skipped freshness for {rel_path} — "
+            f"'{DEFAULT_BRANCH}' is not available in this checkout",
+        )
+        return []
+    base_pins = _pins_in(base_text)
+    if not base_pins:
+        return []
+    base_sha = base_pins[0][1]
+    if base_sha == head_sha:
+        return []
+    if _git("cat-file", "-e", f"{base_sha}^{{commit}}") is None:
+        print(
+            f"action-pin-check: skipped freshness for {rel_path} — "
+            f"{DEFAULT_BRANCH} pin {base_sha[:12]} is not in this checkout",
+        )
+        return []
+    if _git("merge-base", "--is-ancestor", base_sha, head_sha) is None:
+        return [
+            f"{rel_path}: {DEFAULT_BRANCH} pins {base_sha[:12]}, which is not an "
+            f"ancestor of this branch's pin {head_sha[:12]}. The branches have "
+            f"diverged; reconcile them before merging."
+        ]
+    drift_raw = _git("rev-list", "--count", f"{base_sha}..{head_sha}")
+    drift = int(drift_raw) if drift_raw and drift_raw.isdigit() else 0
+    if drift <= MAX_DRIFT:
+        return []
+    return [
+        f"{rel_path}: {DEFAULT_BRANCH} pins {base_sha[:12]}, {drift} commits behind "
+        f"this branch's pin {head_sha[:12]} (max {MAX_DRIFT}). Because this workflow "
+        f"runs on pull_request_target, the reviewer executes the {DEFAULT_BRANCH} pin "
+        f"— every fix newer than it is absent from CI. Bump {DEFAULT_BRANCH}."
+    ]
+
+
+def main() -> int:
+    """Report Action-pin drift; return 1 when a check fails."""
+    if not WORKFLOW_DIR.is_dir():
+        print("action-pin-check: no .github/workflows directory; nothing to check")
+        return 0
+
+    failures: list[str] = []
+    checked = 0
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        pins = _pins_in(text)
+        if not pins:
+            continue
+        checked += 1
+        rel_path = path.relative_to(REPO).as_posix()
+        failures.extend(_check_self_consistency(rel_path, pins))
+        failures.extend(_check_freshness(rel_path, pins[0][1]))
+
+    if failures:
+        print("action-pin-check FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"action-pin-check OK: {checked} workflow(s) pin this action")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mergecraft/agents/_stream_consumer.py
+++ b/src/mergecraft/agents/_stream_consumer.py
@@ -94,6 +94,17 @@ class StreamSpanAccumulator:
     final_output: str | None = None
     parsed_event_count: int = 0
     malformed_event_count: int = 0
+    # First provider-reported fatal error seen on the stream. Providers report
+    # these on stdout as structured events, not on stderr, so without capturing
+    # them the run's only failure signal is whatever unrelated text the CLI
+    # happened to leave on stderr (#445).
+    stream_error: str | None = None
+
+    def set_stream_error(self, message: str | None) -> None:
+        """Record the first provider-reported fatal error on this stream."""
+        text = (message or "").strip()
+        if text and self.stream_error is None:
+            self.stream_error = text
 
     def absorb_usage(self, usage_payload: Mapping[str, Any] | None) -> None:
         """Fold one event's ``usage`` mapping into the accumulator totals."""

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -814,7 +814,10 @@ def _run_codex_streaming(
         usage = None
 
     if returncode != 0:
-        error = stderr_text.strip() or f"codex exited {returncode}"
+        # The provider's own event is the authoritative reason; stderr is the
+        # fallback, because it routinely carries benign CLI chatter (#445).
+        stream_error = accumulator.stream_error
+        error = stream_error or stderr_text.strip() or f"codex exited {returncode}"
         # bwrap fails on the very first exec, so this is the difference between
         # "the environment cannot run Codex" and "the reviewer errored" (#70).
         if is_user_namespace_failure(f"{stderr_text}\n{output or ''}"):
@@ -825,7 +828,12 @@ def _run_codex_streaming(
                 CODEX_SANDBOX_UNSANDBOXED,
             )
             error = f"{user_namespace_failure_hint()}\n\ncodex stderr:\n{error}"
-        retryable = is_retryable_cli_failure(returncode=returncode, stderr=stderr_text)
+        # Classify against the provider's message too — a stdout-only failure
+        # is invisible to a stderr-only classifier (#445, #446).
+        retryable = is_retryable_cli_failure(
+            returncode=returncode,
+            stderr=f"{stream_error or ''}\n{stderr_text}",
+        )
         return AgentResult(
             success=False,
             output=output or None,
@@ -914,6 +922,23 @@ def _codex_stream_event_handler(
                         "total_cost_usd": usage.cost_usd,
                     }
                 )
+            return
+
+        # Codex reports a fatal turn failure as a stdout event, never on
+        # stderr. With no branch here the message was counted and dropped, and
+        # the run surfaced whatever unrelated line stderr happened to hold —
+        # PR #443 reported "Reading additional input from stdin..." for a quota
+        # exhaustion (#445).
+        if event_type in {"error", "turn.failed"}:
+            payload = event.get("error")
+            message = (
+                payload.get("message")
+                if isinstance(payload, dict)
+                else (payload if isinstance(payload, str) else None)
+            )
+            if not message:
+                message = event.get("message")
+            accumulator.set_stream_error(str(message) if message else None)
             return
 
         if event_type == "thread.started":

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -9,7 +9,9 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -62,6 +64,8 @@ from mergecraft.utils.retry_policy import is_retryable_cli_failure
 from mergecraft.utils.secrets import build_agent_env
 
 if TYPE_CHECKING:
+    from typing import IO
+
     from mergecraft.tracing.content import ContentCapture
 
 # Re-exported for tests / callers that import these names from opencode.
@@ -83,6 +87,11 @@ _OPENCODE_LIMIT_SOURCE_KEYS: frozenset[str] = frozenset({"context_limit", "conte
 # (Nous inference hung ~10min in PR #442). Match the workflow action timeout
 # (25m) so httpx does not abort before the Action's own budget.
 _OPENCODE_PROVIDER_HTTP_TIMEOUT_DEFAULT_S: Final[float] = 1500.0
+
+# Ring-buffer depth for `opencode serve` output. Bounded because the buffer is
+# a diagnostic tail, not a log sink: enough to explain a stall, never enough to
+# grow without limit on a long run.
+_SERVER_LOG_TAIL_LINES: Final[int] = 50
 
 
 def _opencode_provider_http_timeout_s() -> float:
@@ -367,6 +376,46 @@ class _ServerHandle:
         self.base_url = base_url
         self.proc = proc
         self._closed = False
+        self._recent: deque[str] = deque(maxlen=_SERVER_LOG_TAIL_LINES)
+        self._drains: list[threading.Thread] = []
+
+    def start_draining(self) -> None:
+        """Consume the child's pipes for the rest of its life (#449).
+
+        Boot reads stdout only until the listening URL appears. Without a
+        reader after that, the child blocks in ``write()`` as soon as it fills
+        the ~64KB pipe buffer and stops answering HTTP — a hang with no output,
+        which is exactly what an unexplained provider timeout looks like.
+        """
+        for stream, label in ((self.proc.stdout, "out"), (self.proc.stderr, "err")):
+            if stream is None:
+                continue
+            thread = threading.Thread(
+                target=self._drain,
+                args=(stream, label),
+                name=f"opencode-serve-{label}",
+                daemon=True,
+            )
+            thread.start()
+            self._drains.append(thread)
+
+    def _drain(self, stream: IO[bytes], label: str) -> None:
+        try:
+            for raw in iter(stream.readline, b""):
+                text = raw.decode("utf-8", errors="replace").rstrip()
+                if not text:
+                    continue
+                # deque.append is atomic under the GIL, so the reader thread
+                # needs no lock against recent_output().
+                self._recent.append(text)
+                logger.debug("[opencode serve/{}] {}", label, text)
+        except (OSError, ValueError):
+            # Pipe closed under us during teardown — expected, not an error.
+            return
+
+    def recent_output(self) -> str:
+        """Return the buffered tail of server output, newest last."""
+        return "\n".join(self._recent)
 
     def close(self) -> None:
         if self._closed:
@@ -425,7 +474,9 @@ def _boot_opencode_server(*, cli: str, env: dict[str, str], cwd: str) -> _Server
         msg = "opencode serve did not print a listening URL"
         raise RuntimeError(msg)
     register_process_group(proc.pid)
-    return _ServerHandle(base_url=base_url, proc=proc)
+    handle = _ServerHandle(base_url=base_url, proc=proc)
+    handle.start_draining()
+    return handle
 
 
 def _parse_model(value: str | None) -> dict[str, str] | None:
@@ -675,9 +726,13 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
             # ``retryable`` is what lets the model chain advance (#444): the
             # chain gates on this flag alone, so omitting it reads as a
             # permanent failure and terminates the run at attempt 1.
+            # httpx.ReadTimeout stringifies to nothing, so without the server's
+            # own tail the operator gets a bare "timed out:" and no lead (#449).
+            tail = handle.recent_output()
+            detail = f"{exc}\n\nrecent opencode serve output:\n{tail}" if tail else str(exc)
             return AgentResult(
                 success=False,
-                error=str(exc),
+                error=detail,
                 metadata={"retryable": True},
             )
         return await finalize_agent_result(ctx, result)

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -377,6 +377,7 @@ class _ServerHandle:
         self.proc = proc
         self._closed = False
         self._recent: deque[str] = deque(maxlen=_SERVER_LOG_TAIL_LINES)
+        self._recent_lock = threading.Lock()
         self._drains: list[threading.Thread] = []
 
     def start_draining(self) -> None:
@@ -405,9 +406,15 @@ class _ServerHandle:
                 text = raw.decode("utf-8", errors="replace").rstrip()
                 if not text:
                     continue
-                # deque.append is atomic under the GIL, so the reader thread
-                # needs no lock against recent_output().
-                self._recent.append(text)
+                # ``deque.append`` is itself atomic, but that says nothing
+                # about *iteration*: joining the deque while a drain thread
+                # appends raises ``RuntimeError: deque mutated during
+                # iteration`` until the buffer reaches ``maxlen``. Since
+                # recent_output() is called from inside the timeout handler,
+                # that would replace the clean failed AgentResult with an
+                # exception — so both sides take this lock.
+                with self._recent_lock:
+                    self._recent.append(text)
                 logger.debug("[opencode serve/{}] {}", label, text)
         except (OSError, ValueError):
             # Pipe closed under us during teardown — expected, not an error.
@@ -415,7 +422,9 @@ class _ServerHandle:
 
     def recent_output(self) -> str:
         """Return the buffered tail of server output, newest last."""
-        return "\n".join(self._recent)
+        with self._recent_lock:
+            lines = list(self._recent)
+        return "\n".join(lines)
 
     def close(self) -> None:
         if self._closed:
@@ -699,15 +708,6 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         # cap must not be defeatable by environment control).
         capture_policy = resolve_capture_policy(ctx.tool_state.trust_tier)
 
-        initial = await _prompt_session(
-            base_url=handle.base_url,
-            session_id=session_id,
-            text=prompt,
-            model=model_obj,
-            resolved_model=model,
-            capture_policy=capture_policy,
-        )
-
         async def resume(followup: str) -> AgentResult:
             return await _prompt_session(
                 base_url=handle.base_url,
@@ -719,6 +719,19 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
             )
 
         try:
+            # The initial prompt carries the whole review and is by far the
+            # likeliest place to time out, so it must sit inside the same
+            # handler as the retry loop (#444). Left outside, a timeout here
+            # propagated out of ``run_once`` and aborted the chain with no
+            # fallback — the exact failure this branch exists to fix.
+            initial = await _prompt_session(
+                base_url=handle.base_url,
+                session_id=session_id,
+                text=prompt,
+                model=model_obj,
+                resolved_model=model,
+                capture_policy=capture_policy,
+            )
             result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
         except ProviderTimeoutError as exc:
             # Controlled domain error: surface as a clean failed attempt

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -544,9 +544,14 @@ async def _prompt_session_http(
             logger.warning("opencode provider request timed out: {}", exc)
             raise ProviderTimeoutError(f"opencode provider request timed out: {exc}") from exc
         if resp.status_code >= 400:
+            # 429 and 5xx are the gateway saying "not now", not "never" — mark
+            # them retryable so the chain moves to the next entry (#444). Other
+            # 4xx are request-shaped faults that the next model would repeat.
+            retryable = resp.status_code == 429 or resp.status_code >= 500
             return AgentResult(
                 success=False,
                 error=f"opencode prompt failed ({resp.status_code}): {resp.text[:500]}",
+                metadata={"retryable": True} if retryable else {},
             )
         data = resp.json() if resp.content else {}
 
@@ -667,7 +672,14 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         except ProviderTimeoutError as exc:
             # Controlled domain error: surface as a clean failed attempt
             # rather than letting a raw httpx traceback abort the review.
-            return AgentResult(success=False, error=str(exc))
+            # ``retryable`` is what lets the model chain advance (#444): the
+            # chain gates on this flag alone, so omitting it reads as a
+            # permanent failure and terminates the run at attempt 1.
+            return AgentResult(
+                success=False,
+                error=str(exc),
+                metadata={"retryable": True},
+            )
         return await finalize_agent_result(ctx, result)
     finally:
         handle.close()

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -719,6 +719,10 @@ async def run_with_model_chain(
         opencode_attempts = 0
         tail_retries = 0
         last_result: AgentResult | None = None
+        # The slug that actually produced ``last_result``. The loop variable
+        # ``slug`` can point at an entry being *skipped*, so evidence must be
+        # stamped from this instead.
+        last_executed_slug: str | None = None
 
         root_parent_id = _root.span_id if hasattr(_root, "span_id") else None
 
@@ -742,17 +746,20 @@ async def run_with_model_chain(
                     # the spent attempts already produced rather than raising a
                     # cap error that hides it. The allowance cannot be spent
                     # before an attempt has run, so ``last_result`` is set.
-                    if last_result is None:  # pragma: no cover - unreachable
-                        break
+                    if last_result is None or last_executed_slug is None:
+                        break  # pragma: no cover - allowance implies an attempt
+                    # ``slug`` here is the entry being skipped — it never ran.
+                    # Stamp the slug that actually produced ``last_result`` so
+                    # the evidence packet names the model that really failed.
                     spent = _attach_model_evidence(
                         last_result,
-                        requested_model=requested_model or slug,
-                        executed_model=slug,
+                        requested_model=requested_model or last_executed_slug,
+                        executed_model=last_executed_slug,
                         fallback_index=chain_index,
                         fallback_reason=last_skip_reason,
                     )
                     _root.set_status("error", last_result.error or "opencode retries exhausted")
-                    return slug, spent
+                    return last_executed_slug, spent
                 opencode_attempts += 1
             attempts += 1
             _prepare_chain_attempt(tool_state, chain_index)
@@ -789,6 +796,7 @@ async def run_with_model_chain(
             ) as attempt_span:
                 result = await run_once(slug)
                 last_result = result
+                last_executed_slug = slug
 
                 call_attrs: dict[str, Any] = {
                     "model.id": slug,

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -436,6 +436,14 @@ def select_runnable_model_slug(*, settings: RepoSettings) -> str:
 # wall clock on it and let the chain move on (#444).
 _OPENCODE_MAX_ATTEMPTS: int = 2
 
+# In-place retries at the chain tail, where there is no next entry to fail over
+# to. Re-issuing against the model that just refused has little value and no
+# backoff, so one retry is the whole allowance; past that the failure is the
+# run's answer. Widening what counts as retryable (#447) made this branch far
+# easier to reach, and unbounded it would spend the attempt cap re-asking a
+# provider that already said no.
+_MAX_TAIL_RETRIES: int = 1
+
 
 def _chain_deadline() -> float | None:
     """Monotonic wall-clock ceiling for the whole chain, or ``None`` when unset.
@@ -458,16 +466,49 @@ def _chain_deadline() -> float | None:
     return time.monotonic() + run_timeout_s
 
 
-def _is_retryable_failure(result: AgentResult) -> bool:
+def _inferred_retryable(result: AgentResult) -> bool:
+    """Best-effort retryability from the failure itself, ignoring metadata."""
+    from mergecraft.utils.retry_policy import is_retryable_cli_failure
+
     metadata = result.metadata or {}
-    retryable = metadata.get("retryable")
-    return retryable is True
+    if metadata.get("timeout") is True or metadata.get("crash") is True:
+        return True
+    error = result.error or ""
+    lowered = error.lower()
+    if "timeout" in lowered or "timed out" in lowered or "crash" in lowered:
+        return True
+    return is_retryable_cli_failure(returncode=None, stderr=error)
+
+
+def _is_retryable_failure(result: AgentResult) -> bool:
+    """Decide whether a failed attempt may advance the chain (#447).
+
+    Precedence, and the only decision path — ``_retryable_failure_reason``
+    labels a skip that this function has already decided:
+
+    1. An explicit ``metadata["retryable"]`` (``True`` or ``False``) wins. A
+       driver that states its intent is always believed.
+    2. Unset means *infer* from the failure.
+
+    Unset used to mean "permanent", which made a driver's omission silently
+    fatal rather than merely imprecise: #444 was exactly that shape — an
+    opencode timeout whose error text said "timed out", which
+    ``_retryable_failure_reason`` duly labelled ``FallbackReason.timeout``,
+    terminating the run at attempt 1 because the deciding classifier read only
+    the absent flag. Inference keeps a forgotten flag from costing a review.
+    """
+    metadata = result.metadata or {}
+    declared = metadata.get("retryable")
+    if isinstance(declared, bool):
+        return declared
+    return _inferred_retryable(result)
 
 
 def _retryable_failure_reason(result: AgentResult) -> FallbackReason:
+    """Label a failure for tracing. Never decides — see ``_is_retryable_failure``."""
     error = (result.error or "").lower()
     metadata = result.metadata or {}
-    if "timeout" in error or metadata.get("timeout") is True:
+    if "timeout" in error or "timed out" in error or metadata.get("timeout") is True:
         return FallbackReason.timeout
     if "crash" in error or metadata.get("crash") is True:
         return FallbackReason.crash
@@ -676,6 +717,7 @@ async def run_with_model_chain(
         last_skip_reason: FallbackReason | None = None
         deadline = _chain_deadline()
         opencode_attempts = 0
+        tail_retries = 0
         last_result: AgentResult | None = None
 
         root_parent_id = _root.span_id if hasattr(_root, "span_id") else None
@@ -837,15 +879,29 @@ async def run_with_model_chain(
                         chain_index + 1,
                     )
                 elif not result.success and _is_retryable_failure(result):
-                    attempt_span.set_status("retryable", result.error or "unknown error")
-                    terminal_status = "retryable"
-                    logger.warning(
-                        "» model chain slug={} failed (retryable): {} — retrying ({}/{})",
-                        slug,
-                        result.error or "unknown error",
-                        attempts,
-                        max_attempts,
-                    )
+                    if tail_retries >= _MAX_TAIL_RETRIES:
+                        # No fallback left and the retry is spent: this failure
+                        # is the answer. Returning it beats spending the attempt
+                        # cap and then raising, which hides the real error.
+                        attempt_span.set_status("error", result.error or "unknown error")
+                        terminal_status = "error"
+                        logger.warning(
+                            "» model chain slug={} failed (retryable) at the chain tail "
+                            "with its retry spent: {}",
+                            slug,
+                            result.error or "unknown error",
+                        )
+                    else:
+                        tail_retries += 1
+                        attempt_span.set_status("retryable", result.error or "unknown error")
+                        terminal_status = "retryable"
+                        logger.warning(
+                            "» model chain slug={} failed (retryable): {} — retrying ({}/{})",
+                            slug,
+                            result.error or "unknown error",
+                            attempts,
+                            max_attempts,
+                        )
                 else:
                     attempt_span.set_status("error", skip_reason.value)
                     terminal_status = "error"

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+import time
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -429,6 +430,34 @@ def select_runnable_model_slug(*, settings: RepoSettings) -> str:
     )
 
 
+# OpenCode attempts are the expensive ones: each retryable failure on that
+# harness can cost a full external-operation timeout before it returns. Allow
+# the initial attempt plus exactly one retry, then stop spending the run's
+# wall clock on it and let the chain move on (#444).
+_OPENCODE_MAX_ATTEMPTS: int = 2
+
+
+def _chain_deadline() -> float | None:
+    """Monotonic wall-clock ceiling for the whole chain, or ``None`` when unset.
+
+    Retryable failures are what make the chain useful, but a retryable
+    *timeout* costs a full external-operation budget each time it recurs, so an
+    attempt-count cap alone is not a bound: ten 1500s timeouts is a four-hour
+    run. This ceiling reuses the existing per-run ``run_timeout_s`` budget
+    rather than introducing a second notion of "too long" (#444).
+    """
+    from mergecraft.utils.run_bounds import resolve_run_bounds
+
+    try:
+        run_timeout_s = resolve_run_bounds().run_timeout_s
+    except Exception as exc:  # pragma: no cover - defensive: never block a run
+        logger.debug("chain deadline unavailable, continuing unbounded: {}", exc)
+        return None
+    if run_timeout_s <= 0:
+        return None
+    return time.monotonic() + run_timeout_s
+
+
 def _is_retryable_failure(result: AgentResult) -> bool:
     metadata = result.metadata or {}
     retryable = metadata.get("retryable")
@@ -645,6 +674,9 @@ async def run_with_model_chain(
         chain_index = 0
         attempts = 0
         last_skip_reason: FallbackReason | None = None
+        deadline = _chain_deadline()
+        opencode_attempts = 0
+        last_result: AgentResult | None = None
 
         root_parent_id = _root.span_id if hasattr(_root, "span_id") else None
 
@@ -652,6 +684,34 @@ async def run_with_model_chain(
 
         while attempts < max_attempts:
             slug = chain[chain_index]
+            if _agent_mode_for_slug(slug) == "opencode":
+                if opencode_attempts >= _OPENCODE_MAX_ATTEMPTS:
+                    logger.warning(
+                        "» model chain skipping slug={} (fallback_index={}): opencode "
+                        "retry allowance of {} attempts already spent",
+                        slug,
+                        chain_index,
+                        _OPENCODE_MAX_ATTEMPTS,
+                    )
+                    if chain_index < len(chain) - 1:
+                        chain_index += 1
+                        continue
+                    # Last entry and the allowance is gone: surface the failure
+                    # the spent attempts already produced rather than raising a
+                    # cap error that hides it. The allowance cannot be spent
+                    # before an attempt has run, so ``last_result`` is set.
+                    if last_result is None:  # pragma: no cover - unreachable
+                        break
+                    spent = _attach_model_evidence(
+                        last_result,
+                        requested_model=requested_model or slug,
+                        executed_model=slug,
+                        fallback_index=chain_index,
+                        fallback_reason=last_skip_reason,
+                    )
+                    _root.set_status("error", last_result.error or "opencode retries exhausted")
+                    return slug, spent
+                opencode_attempts += 1
             attempts += 1
             _prepare_chain_attempt(tool_state, chain_index)
             logger.info("» model chain attempt {}/{} slug={}", attempts, max_attempts, slug)
@@ -686,6 +746,7 @@ async def run_with_model_chain(
                 attrs_source=_snapshot_attrs(attempt_attrs),
             ) as attempt_span:
                 result = await run_once(slug)
+                last_result = result
 
                 call_attrs: dict[str, Any] = {
                     "model.id": slug,
@@ -834,6 +895,27 @@ async def run_with_model_chain(
                 return slug, stamped
 
             if chain_index < len(chain) - 1:
+                if deadline is not None and time.monotonic() >= deadline:
+                    # Budget spent. Stop advancing and surface the failure we
+                    # already have — a further attempt cannot finish inside the
+                    # run's own ceiling, and pretending otherwise just burns
+                    # the job's remaining wall clock (#444).
+                    logger.warning(
+                        "» model chain stopped at slug={} (fallback_index={}): run budget "
+                        "exhausted with {} chain entries unvisited",
+                        slug,
+                        chain_index,
+                        len(chain) - chain_index - 1,
+                    )
+                    exhausted = _attach_model_evidence(
+                        result,
+                        requested_model=requested_model or slug,
+                        executed_model=slug,
+                        fallback_index=chain_index,
+                        fallback_reason=last_skip_reason,
+                    )
+                    _root.set_status("error", "chain budget exhausted")
+                    return slug, exhausted
                 chain_index += 1
                 continue
 

--- a/src/mergecraft/utils/retry_policy.py
+++ b/src/mergecraft/utils/retry_policy.py
@@ -46,13 +46,31 @@ def is_safe_http_method(method: str) -> bool:
     return method.strip().upper() in SAFE_HTTP_METHODS
 
 
+# Provider prose for "not now". Two distinct classes, both retryable *for
+# failover* — the chain's job is to reach a different model, not to re-issue
+# against the one that just refused:
+#   - rate limiting / overload: transient, the same provider may work later
+#   - quota or credit exhaustion: not transient, but the next provider is
+#     unaffected. Codex says "You've hit your usage limit", which matches none
+#     of the rate-limit wording and so read as permanent (#446).
+_RETRYABLE_CLI_NEEDLES: Final[tuple[str, ...]] = (
+    "rate limit",
+    "rate_limit",
+    "too many requests",
+    "overloaded",
+    "429",
+    "usage limit",
+    "quota",
+    "insufficient_quota",
+)
+
+
 def is_retryable_cli_failure(*, returncode: int | None, stderr: str = "") -> bool:
-    """Classify CLI rate-limit / overload failures as retryable for the chain."""
+    """Classify CLI rate-limit / overload / quota failures as retryable."""
     if returncode is not None and returncode in RATE_LIMIT_EXIT_CODES:
         return True
     lowered = stderr.lower()
-    needles = ("rate limit", "rate_limit", "too many requests", "overloaded", "429")
-    return any(n in lowered for n in needles)
+    return any(needle in lowered for needle in _RETRYABLE_CLI_NEEDLES)
 
 
 class retry_transient_safe_methods(retry_base):

--- a/tests/agents/test_cov_codex_paths.py
+++ b/tests/agents/test_cov_codex_paths.py
@@ -952,3 +952,81 @@ def test_close_all_flushes_spans_left_open_by_a_truncated_stream() -> None:
 
     assert [attrs["tool.name"] for attrs in _events_of(sink, "tool.call")] == ["shell"]
     assert len(_events_of(sink, "llm.call")) == 1
+
+
+def test_error_event_message_is_captured_from_stdout() -> None:
+    """#445 — Codex reports fatal failures as stdout events, not on stderr.
+
+    The handler had no branch for them, so the message was counted into
+    ``parsed_event_count`` and dropped. PR #443 then reported an unrelated
+    stderr line ("Reading additional input from stdin...") as the run's error,
+    hiding a quota exhaustion.
+    """
+    handler, _close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+    quota = "You've hit your usage limit. Upgrade to Pro or try again at Aug 27th."
+
+    handler(accumulator, {"type": "error", "message": quota})
+
+    assert accumulator.stream_error == quota
+
+
+def test_turn_failed_nested_error_message_is_captured() -> None:
+    """``turn.failed`` nests the message under ``error``, unlike ``error``."""
+    handler, _close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+
+    handler(accumulator, {"type": "turn.failed", "error": {"message": "boom"}})
+
+    assert accumulator.stream_error == "boom"
+
+
+def test_the_first_stream_error_wins() -> None:
+    """A turn emits ``error`` then ``turn.failed`` for the same cause; the
+    run's reason should not be overwritten by the echo.
+    """
+    handler, _close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+
+    handler(accumulator, {"type": "error", "message": "first"})
+    handler(accumulator, {"type": "turn.failed", "error": {"message": "second"}})
+
+    assert accumulator.stream_error == "first"
+
+
+def test_a_captured_quota_error_classifies_as_retryable() -> None:
+    """The captured message must reach classification, not just the log.
+
+    Together with #444 this is what lets a quota wall fail over to the next
+    model instead of terminating the run.
+    """
+    from mergecraft.utils.retry_policy import is_retryable_cli_failure
+
+    handler, _close_all = codex_module._codex_stream_event_handler(
+        tracer=None,
+        model_id="gpt-5.3-codex",
+    )
+    accumulator = StreamSpanAccumulator(agent_name="codex")
+    handler(
+        accumulator,
+        {"type": "error", "message": "You've hit your usage limit."},
+    )
+
+    # The driver classifies against the stream error joined with stderr; stderr
+    # here is the benign chatter that used to be the only signal.
+    assert (
+        is_retryable_cli_failure(
+            returncode=1,
+            stderr=f"{accumulator.stream_error}\nReading additional input from stdin...",
+        )
+        is True
+    )

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -1074,6 +1074,85 @@ async def test_run_converts_a_provider_timeout_into_a_clean_failed_attempt(
     assert proc.wait_calls == 1
 
 
+async def test_run_converts_an_initial_prompt_timeout_into_a_failed_attempt(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A timeout on the FIRST prompt fails cleanly instead of propagating (#444).
+
+    The initial ``_prompt_session`` call carries the whole review, so it is the
+    likeliest place to time out. When it sat outside the handler, the raised
+    ``ProviderTimeoutError`` escaped ``_run`` → ``run_once`` →
+    ``run_with_model_chain`` and killed the run with no fallback.
+    """
+    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    proc = _FakeServeProc()
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
+    handle._recent.append("serve: upstream stalled")
+    monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
+    monkeypatch.setattr(oc, "kill_process_group", lambda _pid: None)
+    monkeypatch.setattr(oc, "unregister_process_group", lambda _pid: None)
+    _route(monkeypatch, {"/session": _StubResponse(status_code=200, body={"id": "sess-1"})})
+
+    calls: list[str] = []
+
+    async def _timeout(*args: object, **kwargs: object) -> Any:
+        calls.append("prompt")
+        msg = "opencode provider request timed out: read timeout"
+        raise oc.ProviderTimeoutError(msg)
+
+    monkeypatch.setattr(oc, "_prompt_session", _timeout)
+    ctx = make_agent_run_context(tmp_path, resolved_model=None)
+
+    result = await oc._run(ctx)
+
+    assert calls == ["prompt"]
+    assert result.success is False
+    assert (result.metadata or {}).get("retryable") is True
+    # #449 — the operator gets the server's own tail, not a bare "timed out:".
+    assert "serve: upstream stalled" in (result.error or "")
+    assert proc.wait_calls == 1
+
+
+def test_recent_output_and_the_drain_thread_share_one_lock() -> None:
+    """The tail buffer is lock-guarded on both sides.
+
+    ``deque.append`` being atomic says nothing about *iteration*: joining the
+    buffer while a drain thread appends can raise ``RuntimeError: deque mutated
+    during iteration`` before it reaches ``maxlen``. ``recent_output()`` runs
+    inside the ``ProviderTimeoutError`` handler, so that would replace the clean
+    failed result with an exception.
+    """
+    import threading
+
+    proc = _FakeServeProc()
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
+    lines = [b"serve: hello\n"]
+
+    class _OneLineStream:
+        def readline(self) -> bytes:
+            return lines.pop(0) if lines else b""
+
+    stream: Any = _OneLineStream()
+    reads: list[str] = []
+
+    with handle._recent_lock:
+        writer = threading.Thread(target=handle._drain, args=(stream, "out"), daemon=True)
+        reader = threading.Thread(target=lambda: reads.append(handle.recent_output()), daemon=True)
+        writer.start()
+        reader.start()
+        writer.join(timeout=0.2)
+        reader.join(timeout=0.2)
+        # Both sides must take the same lock, so both are still blocked here.
+        assert writer.is_alive()
+        assert reader.is_alive()
+
+    writer.join(timeout=2.0)
+    reader.join(timeout=2.0)
+    assert not writer.is_alive()
+    assert not reader.is_alive()
+    assert handle.recent_output() == "serve: hello"
+
+
 async def test_run_exports_the_bedrock_flag_only_for_a_matching_model(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -1066,6 +1066,10 @@ async def test_run_converts_a_provider_timeout_into_a_clean_failed_attempt(
 
     assert result.success is False
     assert result.error == "opencode provider request timed out: read timeout"
+    # #444 — the chain gates on this flag alone. Without it a provider timeout
+    # reads as permanent and terminates the run at attempt 1 instead of failing
+    # over. Supersedes plan 06 D11's claim that this path stays non-retryable.
+    assert (result.metadata or {}).get("retryable") is True
     # The serve handle is always torn down, timeout or not.
     assert proc.wait_calls == 1
 

--- a/tests/agents/test_opencode_serve_drain.py
+++ b/tests/agents/test_opencode_serve_drain.py
@@ -1,0 +1,114 @@
+"""`opencode serve` pipe draining (#449).
+
+Boot reads the child's stdout only until the listening URL appears. With no
+reader after that, the child blocks in ``write()`` once it fills the pipe
+buffer (~64KB on Linux) and stops answering HTTP — a hang with no output, which
+is indistinguishable from an unresponsive provider. PR #443 showed that shape:
+9m51s of silence, then a timeout whose exception stringified to nothing.
+
+These tests use a real subprocess because the defect is in OS pipe behaviour;
+a stubbed stream cannot exhibit it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+import mergecraft.agents.opencode as oc
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Comfortably past the 64KB pipe buffer: ~820KB.
+_FLOOD = (
+    "import sys\n"
+    "for _ in range(20000):\n"
+    "    print('x' * 40)\n"
+    "print('SENTINEL-DONE')\n"
+    "sys.stdout.flush()\n"
+)
+
+
+@pytest.fixture
+def reap() -> Iterator[list[subprocess.Popen[bytes]]]:
+    """Kill any process a test leaves blocked, so nothing outlives the run."""
+    spawned: list[subprocess.Popen[bytes]] = []
+    yield spawned
+    for proc in spawned:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None:
+                stream.close()
+
+
+def _spawn(reap: list[subprocess.Popen[bytes]]) -> subprocess.Popen[bytes]:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _FLOOD],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    reap.append(proc)
+    return proc
+
+
+def test_a_chatty_server_runs_to_completion_when_drained(
+    reap: list[subprocess.Popen[bytes]],
+) -> None:
+    """The fix: a drained child writes past the pipe buffer and finishes."""
+    proc = _spawn(reap)
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)
+    handle.start_draining()
+
+    assert proc.wait(timeout=30) == 0
+    for thread in handle._drains:
+        thread.join(timeout=5)
+    assert "SENTINEL-DONE" in handle.recent_output()
+
+
+def test_an_undrained_server_blocks_on_a_full_pipe(
+    reap: list[subprocess.Popen[bytes]],
+) -> None:
+    """Negative control — without draining the same child never finishes.
+
+    This is the #443 hang in miniature. If this test ever starts passing
+    without ``start_draining``, the buffer assumption changed and the guard
+    above is no longer proving anything.
+    """
+    proc = _spawn(reap)
+    oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)  # no start_draining()
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        proc.wait(timeout=5)
+    assert proc.poll() is None, "child should still be blocked writing to a full pipe"
+
+
+def test_recent_output_is_bounded(reap: list[subprocess.Popen[bytes]]) -> None:
+    """The tail is a diagnostic buffer, not an unbounded log sink."""
+    proc = _spawn(reap)
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=proc)
+    handle.start_draining()
+    proc.wait(timeout=30)
+    for thread in handle._drains:
+        thread.join(timeout=5)
+
+    lines = handle.recent_output().splitlines()
+    assert 0 < len(lines) <= oc._SERVER_LOG_TAIL_LINES
+
+
+def test_recent_output_is_empty_before_anything_is_drained() -> None:
+    """A handle with no draining started reports nothing, and does not raise."""
+
+    class _Fake:
+        stdout = None
+        stderr = None
+        pid = -1
+
+    handle = oc._ServerHandle(base_url="http://127.0.0.1:1", proc=_Fake())  # type: ignore[arg-type]
+    handle.start_draining()
+    assert handle.recent_output() == ""

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -142,3 +142,106 @@ async def test_chain_stops_advancing_once_the_run_budget_is_spent(
     _slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
     assert attempts == ["openai/gpt-5.3-codex"]
     assert result.success is False
+
+
+class TestRetryabilityHasOneDecisionPath:
+    """#447 — the deciding classifier must not ignore the failure itself.
+
+    ``_is_retryable_failure`` gated on ``metadata['retryable']`` alone while
+    ``_retryable_failure_reason`` inferred the same property from the error
+    text, and only the metadata-blind one decided. A driver that omitted the
+    flag therefore read as "permanent", which is how #444 cost a whole review.
+    """
+
+    def test_an_explicit_true_is_believed(self) -> None:
+        result = AgentResult(success=False, error="anything", metadata={"retryable": True})
+        assert _is_retryable_failure(result) is True
+
+    def test_an_explicit_false_overrides_retryable_looking_text(self) -> None:
+        """A driver that says "permanent" is believed even when the text says
+        otherwise — inference must never overrule a stated intent.
+        """
+        result = AgentResult(
+            success=False,
+            error="request timed out",
+            metadata={"retryable": False},
+        )
+        assert _is_retryable_failure(result) is False
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "opencode provider request timed out: ",
+            "codex CLI timed out",
+            "provider crash during turn",
+            "You've hit your usage limit.",
+            "429 rate limit exceeded",
+        ],
+        ids=["opencode-timeout", "cli-timeout", "crash", "quota", "rate-limit"],
+    )
+    def test_an_omitted_flag_falls_back_to_inference(self, error: str) -> None:
+        """The #444 shape: no metadata, but the error plainly says "recoverable"."""
+        assert _is_retryable_failure(AgentResult(success=False, error=error)) is True
+
+    def test_an_omitted_flag_on_an_ordinary_failure_stays_permanent(self) -> None:
+        """Inference must not turn every failure into a retry."""
+        result = AgentResult(success=False, error="SyntaxError: invalid syntax")
+        assert _is_retryable_failure(result) is False
+
+
+@pytest.mark.asyncio
+async def test_a_driver_that_forgets_the_flag_does_not_kill_the_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end #447: an omitted flag degrades to inference, not to a dead run."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        if slug.startswith("openai/"):
+            # No metadata at all — the omission this issue is about.
+            return AgentResult(success=False, error="provider request timed out")
+        return AgentResult(success=True, output="ok")
+
+    slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert attempts == ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]
+    assert slug == "google/gemini-3.1-pro-preview"
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_a_tail_failure_returns_rather_than_exhausting_the_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retryable failure with no fallback left gets one retry, then answers.
+
+    Widening retryability (#447) made this branch easy to reach. Unbounded, a
+    single-entry chain re-asked the same refusing provider until the attempt
+    cap tripped and then raised ``RuntimeError`` — spending the budget and
+    replacing the real error with a cap message.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate({"models": ["openai/gpt-5.3-codex"]})
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        return AgentResult(success=False, error="api quota exhausted")
+
+    # pin=True collapses the chain to its head; without it the configured
+    # fallback tail is appended and this exercises advance, not tail retry.
+    _slug, result = await run_with_model_chain(settings=settings, run_once=run_once, pin=True)
+    assert len(attempts) == 2, f"expected one retry, got {len(attempts)}"
+    assert result.success is False
+    assert result.error == "api quota exhausted"

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -78,8 +78,67 @@ def test_parse_failure_is_not_retryable() -> None:
     assert _is_retryable_failure(result) is False
 
 
-def test_opencode_http_timeout_is_not_marked_retryable() -> None:
-    """Pin — opencode timeout path remains non-retryable (D11)."""
-    from mergecraft.agents.opencode import ProviderTimeoutError
+@pytest.mark.asyncio
+async def test_opencode_retries_at_most_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenCode gets the initial attempt plus exactly one retry, then the chain
+    stops spending wall clock on that harness (#444).
+    """
+    monkeypatch.setenv("NOUS_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    settings = RepoSettings.model_validate(
+        {
+            "models": [
+                "nous/deepseek/deepseek-v4-flash",
+                "nous/deepseek/deepseek-v4-pro",
+                "nous/qwen/qwen3.8-max",
+            ]
+        }
+    )
+    attempts: list[str] = []
 
-    assert ProviderTimeoutError.__name__ == "ProviderTimeoutError"
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        return AgentResult(
+            success=False,
+            error="opencode provider request timed out: ",
+            metadata={"retryable": True},
+        )
+
+    slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert len(attempts) == 2, f"opencode ran {len(attempts)} times, expected 2: {attempts}"
+    assert result.success is False
+    assert slug
+
+
+@pytest.mark.asyncio
+async def test_chain_stops_advancing_once_the_run_budget_is_spent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exhausted run budget stops the chain instead of letting retryable
+    timeouts multiply into a multi-hour run (#444).
+    """
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
+    )
+    # Deadline already in the past: the first attempt still runs, the advance
+    # to the second entry must not.
+    monkeypatch.setattr(
+        "mergecraft.utils.agent_resolve._chain_deadline",
+        lambda: __import__("time").monotonic() - 1.0,
+    )
+    settings = RepoSettings.model_validate(
+        {"models": ["openai/gpt-5.3-codex", "google/gemini-3.1-pro-preview"]}
+    )
+    attempts: list[str] = []
+
+    async def run_once(slug: str) -> AgentResult:
+        attempts.append(slug)
+        return AgentResult(success=False, error="boom", metadata={"retryable": True})
+
+    _slug, result = await run_with_model_chain(settings=settings, run_once=run_once)
+    assert attempts == ["openai/gpt-5.3-codex"]
+    assert result.success is False

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -110,6 +110,13 @@ async def test_opencode_retries_at_most_once(monkeypatch: pytest.MonkeyPatch) ->
     assert len(attempts) == 2, f"opencode ran {len(attempts)} times, expected 2: {attempts}"
     assert result.success is False
     assert slug
+    # The evidence must name the slug that actually ran. The tail entry is only
+    # *skipped* once the allowance is spent, so stamping it would blame a model
+    # that never executed.
+    meta = result.metadata or {}
+    assert meta["executed_model"] == attempts[-1]
+    assert slug == attempts[-1]
+    assert attempts[-1] != settings.models[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/pins/test_action_pin_freshness.py
+++ b/tests/pins/test_action_pin_freshness.py
@@ -1,0 +1,163 @@
+"""Self-review Action pin drift guard (#450).
+
+``.github/workflows/mergecraft.yml`` runs on ``pull_request_target``, so GitHub
+resolves its ``uses:`` pin from the default branch. When that pin lags, the
+reviewer executes old code while the branch under review holds the fix — the
+skew that made PR #443 time out on an already-fixed 600s ceiling.
+
+Covers the two guards in ``scripts/check_action_pin_freshness.py``: pins inside
+one workflow file must agree, and the default branch's pin must stay within
+``MAX_DRIFT`` commits of this branch's.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+from tests.ci.workflow_support import REPO_ROOT
+
+if TYPE_CHECKING:
+    import pytest
+
+_SHA_OLD = "0592d72828797005fdc5af1da9e413b0a98bd8a0"
+_SHA_NEW = "cfa36704cf6c58a6abe895e539a377c4599fa4bd"
+_WORKFLOW = ".github/workflows/mergecraft.yml"
+
+
+def _load() -> ModuleType:
+    """Import the guard script by path — ``scripts/`` is not a package."""
+    path = REPO_ROOT / "scripts" / "check_action_pin_freshness.py"
+    spec = importlib.util.spec_from_file_location("check_action_pin_freshness", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _workflow_text(*shas: str) -> str:
+    lines = ["name: mergecraft", "jobs:"]
+    lines.extend(f"        uses: alexhawat/mergeCraft@{sha} # pin" for sha in shas)
+    return "\n".join(lines) + "\n"
+
+
+def test_pins_are_extracted_with_line_numbers() -> None:
+    module = _load()
+    pins = module._pins_in(_workflow_text(_SHA_NEW, _SHA_NEW))
+    assert [sha for _, sha in pins] == [_SHA_NEW, _SHA_NEW]
+    assert [line for line, _ in pins] == [3, 4]
+
+
+def test_a_one_sided_bump_is_an_error() -> None:
+    """The workflow header calls a one-sided bump a footgun; make it fail."""
+    module = _load()
+    pins = module._pins_in(_workflow_text(_SHA_NEW, _SHA_OLD))
+    failures = module._check_self_consistency(_WORKFLOW, pins)
+    assert len(failures) == 1
+    assert "2 different Action pins" in failures[0]
+
+
+def test_matching_pins_pass_self_consistency() -> None:
+    module = _load()
+    pins = module._pins_in(_workflow_text(_SHA_NEW, _SHA_NEW))
+    assert module._check_self_consistency(_WORKFLOW, pins) == []
+
+
+def _freshness_with(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_sha: str,
+    drift: str | None,
+    is_ancestor: str | None = "",
+    base_known: str | None = "",
+) -> list[str]:
+    """Drive ``_check_freshness`` with git responses stubbed."""
+    monkeypatch.setattr(
+        module,
+        "_default_branch_workflow",
+        lambda _: _workflow_text(base_sha),
+    )
+
+    def fake_git(*args: str) -> Any:
+        if args[0] == "cat-file":
+            return base_known
+        if args[0] == "merge-base":
+            return is_ancestor
+        if args[0] == "rev-list":
+            return drift
+        return ""
+
+    monkeypatch.setattr(module, "_git", fake_git)
+    return module._check_freshness(_WORKFLOW, _SHA_NEW)
+
+
+def test_identical_pins_are_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load()
+    assert _freshness_with(module, monkeypatch, base_sha=_SHA_NEW, drift="0") == []
+
+
+def test_drift_within_the_bound_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load()
+    monkeypatch.setattr(module, "MAX_DRIFT", 100)
+    assert _freshness_with(module, monkeypatch, base_sha=_SHA_OLD, drift="12") == []
+
+
+def test_excessive_drift_fails_and_names_the_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real #450 shape: hundreds of commits behind, silently."""
+    module = _load()
+    monkeypatch.setattr(module, "MAX_DRIFT", 100)
+    failures = _freshness_with(module, monkeypatch, base_sha=_SHA_OLD, drift="687")
+    assert len(failures) == 1
+    assert "687 commits behind" in failures[0]
+    assert "pull_request_target" in failures[0]
+
+
+def test_a_diverged_default_branch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load()
+    failures = _freshness_with(
+        module,
+        monkeypatch,
+        base_sha=_SHA_OLD,
+        drift="5",
+        is_ancestor=None,
+    )
+    assert len(failures) == 1
+    assert "not an ancestor" in failures[0]
+
+
+def test_an_unfetched_default_branch_skips_rather_than_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shallow or offline checkout must not fail the guard."""
+    module = _load()
+    monkeypatch.setattr(module, "_default_branch_workflow", lambda _: None)
+    assert module._check_freshness(_WORKFLOW, _SHA_NEW) == []
+
+
+def test_an_unknown_base_pin_skips_rather_than_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The base pin's commit may be absent from a partial clone."""
+    module = _load()
+    failures = _freshness_with(
+        module,
+        monkeypatch,
+        base_sha=_SHA_OLD,
+        drift="687",
+        base_known=None,
+    )
+    assert failures == []
+
+
+def test_the_live_workflow_pins_are_self_consistent() -> None:
+    """Guards the checked-in workflow itself, offline and without git."""
+    module = _load()
+    text = (REPO_ROOT / _WORKFLOW).read_text(encoding="utf-8")
+    pins = module._pins_in(text)
+    assert pins, "expected mergecraft.yml to pin the action by SHA"
+    assert module._check_self_consistency(_WORKFLOW, pins) == []

--- a/tests/utils/test_model_chain_resolve.py
+++ b/tests/utils/test_model_chain_resolve.py
@@ -131,7 +131,22 @@ async def test_model_chain_caps_attempts_at_max_depth(
         "Callable[..., Awaitable[tuple[str, AgentResult]]]",
         _import_chain_symbol("run_with_model_chain"),
     )
-    settings = _chain_settings(["openai/gpt-5.3-codex"])
+    # A chain longer than the attempt cap is what makes the cap reachable.
+    # A short chain no longer gets here: a retryable failure at the tail is
+    # bounded to one in-place retry and then returns that failure, because
+    # re-asking the model that just refused has no backoff and no new
+    # information (see test_a_tail_failure_returns_rather_than_exhausting_the_cap
+    # in tests/integration/test_provider_failures.py). The cap remains the
+    # backstop for a chain that keeps finding somewhere to advance to.
+    settings = _chain_settings(
+        [
+            "openai/gpt-5.3-codex",
+            "anthropic/claude-sonnet",
+            "google/gemini-3.1-pro-preview",
+            "openai/gpt-5.1",
+            "anthropic/claude-opus-4.5",
+        ]
+    )
     attempts: list[str] = []
 
     async def run_once(slug: str) -> AgentResult:
@@ -146,7 +161,7 @@ async def test_model_chain_caps_attempts_at_max_depth(
         await run_with_model_chain(
             settings=settings,
             run_once=run_once,
-            max_attempts=_MAX_FALLBACK_DEPTH,
+            max_attempts=3,
         )
-
-    assert len(attempts) == _MAX_FALLBACK_DEPTH
+    assert len(attempts) == 3, "the cap, not the chain length, must stop it"
+    assert len(attempts) < _MAX_FALLBACK_DEPTH, "cap must bind below the default depth"

--- a/tests/utils/test_retry_policy.py
+++ b/tests/utils/test_retry_policy.py
@@ -162,6 +162,38 @@ class TestRetryableCliFailure:
 
         assert is_retryable_cli_failure(returncode=1, stderr=stderr) is True
 
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "You've hit your usage limit. Upgrade to Pro or try again at Aug 27th.",
+            "insufficient_quota: you exceeded your current quota",
+            "Quota exceeded for this billing period",
+        ],
+        ids=["codex-usage-limit", "insufficient_quota", "quota-exceeded"],
+    )
+    def test_quota_exhaustion_is_retryable_for_failover(self, stderr: str) -> None:
+        """#446 — quota wording matches none of the rate-limit needles.
+
+        Retrying the same provider cannot succeed until the quota resets, but
+        the next entry in the chain is unaffected, so this must still advance
+        rather than terminate the run. The first case is the verbatim Codex
+        message that killed PR #443's review.
+        """
+        from mergecraft.utils.retry_policy import is_retryable_cli_failure
+
+        assert is_retryable_cli_failure(returncode=1, stderr=stderr) is True
+
+    def test_benign_cli_chatter_is_not_retryable(self) -> None:
+        """Guard the other direction: the stderr line PR #443 actually reported
+        is not a provider refusal and must not be read as one.
+        """
+        from mergecraft.utils.retry_policy import is_retryable_cli_failure
+
+        assert (
+            is_retryable_cli_failure(returncode=1, stderr="Reading additional input from stdin...")
+            is False
+        )
+
     def test_ordinary_failure_is_not_retryable(self) -> None:
         from mergecraft.utils.retry_policy import is_retryable_cli_failure
 


### PR DESCRIPTION
## What?

A provider that stalls, refuses, or runs out of credit now costs a fallback instead of the whole review.

- A provider timeout advances the model chain rather than terminating the run at the first attempt.
- Quota exhaustion counts as a reason to try the next model, not as a permanent failure.
- The reviewer subprocess no longer deadlocks once it fills its output pipe.
- A failure reports what the provider actually said, instead of whatever unrelated text the CLI left on stderr.
- Drift between the default branch's review pin and the branch under test is reported instead of silent.

## Why?

PR #443 got no review at all. The primary reviewer hung for ten minutes and the fallback died four seconds later, and between them the pull request ended with a failing gate and nothing to act on. Each step of that had its own cause, and any one of them alone would have been survivable.

- The subprocess stopped answering because nothing read its output after startup, so it blocked as soon as it filled the pipe buffer. Ten minutes of silence follow, then a timeout carrying no message.
- That timeout ended the run instead of falling back, because the chain decides retryability from a metadata flag alone and the driver never set one. Nine configured attempts went unused.
- The fallback hit a credit limit, whose wording matched none of the phrases the classifier recognises, so it also read as permanent.
- The reason never reached the log either. The provider reports fatal errors as events on stdout, and the handler had no branch for them, so the run reported a stray line about reading from stdin and the real cause appeared nowhere.

Retrying a timeout is only safe if it cannot multiply, since each one can cost a full request budget. OpenCode gets one retry, the chain honours a wall-clock deadline derived from the existing per-run budget, and a retryable failure with nowhere left to fall back to answers with itself rather than re-asking a provider that already refused.

## Note

Supersedes D11 in the review-harness plan, which read "leave ProviderTimeoutError non-retryable". That was a scoping note for a wave forbidden from touching src, not a design ruling, and the pin it cited only asserted that a class name equalled itself. It is rewritten in place with the reasoning and the real pins.

The pin-drift check is advisory in CI rather than blocking. A stale pin is a property of the default branch, not a defect in the pull request being checked, so failing there would block unrelated work. It currently reports the live drift and will keep doing so until the pin moves to a commit containing these fixes, which is the promotion after this one.

## Test plan

- `make lint`, `make typecheck`, `make pyright` clean.
- `make test`: 6087 passed, 43 skipped, 22 xfailed.
- New tests verified as real pins by reverting the product change and confirming they fail. The pipe-deadlock test drives a real subprocess and keeps a negative control asserting the same child still hangs undrained.

## Related PR(s)/Issue(s)

Closes #444
Closes #445
Closes #446
Closes #447
Closes #449
Refs #450
