### PR TITLE
ci: bump the review pin and measure it against the branch tip

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -476,11 +476,14 @@ jobs:
         # pull_request_target is resolved from `main`, so #231 cannot consume this
         # pin until it lands there; pin the product-fix commit now so a follow-up
         # bump PR is not required after merge. 0592d72 survives merge intact.
-        # 2026-08-23 (eighth bump, PR #442): re-bumped to cfa36704 for OpenCode
-        # HTTP timeout (25m) + recallPass config unblock. pull_request_target resolves
-        # this workflow and action pin from the repo default branch (main), not
-        # the PR head — self-review PRs cannot bump the pin until after merge.
-        uses: alexhawat/mergeCraft@cfa36704cf6c58a6abe895e539a377c4599fa4bd # wave/rc-review-convergence (PR #442)
+        # 2026-08-23 (ninth bump, PR #457): re-bumped to 5b9ded9f so the reviewer
+        # runs the provider-failover fixes it is meant to exercise — retryable
+        # provider timeouts, drained opencode serve pipes, quota classification,
+        # and a single retryability decision path (#444, #445, #446, #447, #449).
+        # pull_request_target resolves this workflow and action pin from the repo
+        # default branch (main), not the PR head — self-review PRs cannot bump the
+        # pin until after merge.
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: 25m
@@ -578,11 +581,14 @@ jobs:
         # the fetch), then to 0592d72 (#231: skipped Python install under `shell:
         # disabled` must not fail prep) — see the matching comment on the Nous step
         # above for why.
-        # 2026-08-23 (eighth bump, PR #442): re-bumped to cfa36704 for OpenCode
-        # HTTP timeout (25m) + recallPass config unblock. pull_request_target resolves
-        # this workflow and action pin from the repo default branch (main), not
-        # the PR head — self-review PRs cannot bump the pin until after merge.
-        uses: alexhawat/mergeCraft@cfa36704cf6c58a6abe895e539a377c4599fa4bd # wave/rc-review-convergence (PR #442)
+        # 2026-08-23 (ninth bump, PR #457): re-bumped to 5b9ded9f so the reviewer
+        # runs the provider-failover fixes it is meant to exercise — retryable
+        # provider timeouts, drained opencode serve pipes, quota classification,
+        # and a single retryability decision path (#444, #445, #446, #447, #449).
+        # pull_request_target resolves this workflow and action pin from the repo
+        # default branch (main), not the PR head — self-review PRs cannot bump the
+        # pin until after merge.
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `make action-pin-check` also measures the pin against the default branch's own tip, not just against the
+  other branch's pin. Comparing pins to each other passes when both are equally stale, which is what happened
+  after #457 merged: both branches pinned the same SHA and the check reported OK while the reviewer ran none
+  of the fixes that had just landed. Lag is counted over `src/mergecraft/` only, since docs and test commits
+  do not change what the reviewer executes (#450)
 - `make action-pin-check` guards the self-review Action pin against drift. Because
   `.github/workflows/mergecraft.yml` runs on `pull_request_target`, GitHub resolves its `uses:` pin from the
   **default branch**, so a fix merged to `pre-0.0.1` does not reach the reviewer until it reaches `main` —

--- a/scripts/check_action_pin_freshness.py
+++ b/scripts/check_action_pin_freshness.py
@@ -21,6 +21,14 @@ Two checks:
    be an ancestor of this branch's pin and within ``MAX_DRIFT`` commits of it.
    Skips with a notice when the ref is not fetched, so a local ``make lint``
    in a shallow or offline checkout does not fail on it.
+3. **Staleness** (needs the default-branch ref). The pin must not lag the
+   default branch's own tip by more than ``MAX_PRODUCT_LAG`` commits touching
+   ``src/mergecraft/``. Check 2 compares the two branches' pins only to each
+   other, so it passes when *both* are equally stale: after PR #457 merged,
+   both branches pinned the same SHA and the check reported OK while the
+   reviewer ran none of the fixes that had just landed. Measuring against the
+   default branch's tip rather than HEAD keeps this stable, since unmerged
+   feature commits are not something a pin could reference yet.
 
 Module: scripts.check_action_pin_freshness
 Depends: os, re, subprocess, sys, pathlib
@@ -49,6 +57,16 @@ DEFAULT_BRANCH = os.environ.get("MERGECRAFT_DEFAULT_BRANCH", "main")
 # merges behind still runs substantially current code, while hundreds of
 # commits behind is how #450 went unnoticed. Override for a tighter policy.
 MAX_DRIFT = int(os.environ.get("MERGECRAFT_MAX_ACTION_PIN_DRIFT", "100"))
+
+# Product-code commits the pin may lag the default branch's tip by. Counted
+# over ``src/mergecraft/`` only: docs, tests and workflow commits do not change
+# what the reviewer executes, so counting them would fire for reasons an
+# operator cannot act on. Small, because each one is a behaviour difference
+# between the reviewer and the branch it is reviewing.
+MAX_PRODUCT_LAG = int(os.environ.get("MERGECRAFT_MAX_ACTION_PIN_PRODUCT_LAG", "5"))
+
+# The tree whose changes alter reviewer behaviour.
+PRODUCT_PATH = "src/mergecraft/"
 
 
 def _pins_in(text: str) -> list[tuple[int, str]]:
@@ -140,6 +158,32 @@ def _check_freshness(rel_path: str, head_sha: str) -> list[str]:
     ]
 
 
+def _check_staleness(rel_path: str, head_sha: str) -> list[str]:
+    """Compare the pin against the default branch's tip, not against another pin."""
+    ref = f"origin/{DEFAULT_BRANCH}"
+    if _git("rev-parse", "--verify", "--quiet", ref) is None:
+        ref = DEFAULT_BRANCH
+        if _git("rev-parse", "--verify", "--quiet", ref) is None:
+            return []
+    if _git("cat-file", "-e", f"{head_sha}^{{commit}}") is None:
+        return []
+    if _git("merge-base", "--is-ancestor", head_sha, ref) is None:
+        # The pin is not on the default branch's history: either it is ahead
+        # (bumped here, not yet promoted) or it points somewhere unrelated.
+        # Neither is staleness, and check 2 already covers divergence.
+        return []
+    lag_raw = _git("rev-list", "--count", f"{head_sha}..{ref}", "--", PRODUCT_PATH)
+    lag = int(lag_raw) if lag_raw and lag_raw.isdigit() else 0
+    if lag <= MAX_PRODUCT_LAG:
+        return []
+    return [
+        f"{rel_path}: pin {head_sha[:12]} lags {DEFAULT_BRANCH} by {lag} commits touching "
+        f"{PRODUCT_PATH} (max {MAX_PRODUCT_LAG}). The reviewer is not running the product "
+        f"code on {DEFAULT_BRANCH}, so anything merged since the pin is absent from every "
+        f"review. Bump the pin."
+    ]
+
+
 def main() -> int:
     """Report Action-pin drift; return 1 when a check fails."""
     if not WORKFLOW_DIR.is_dir():
@@ -157,6 +201,7 @@ def main() -> int:
         rel_path = path.relative_to(REPO).as_posix()
         failures.extend(_check_self_consistency(rel_path, pins))
         failures.extend(_check_freshness(rel_path, pins[0][1]))
+        failures.extend(_check_staleness(rel_path, pins[0][1]))
 
     if failures:
         print("action-pin-check FAILED:", file=sys.stderr)

--- a/tests/pins/test_action_pin_freshness.py
+++ b/tests/pins/test_action_pin_freshness.py
@@ -161,3 +161,98 @@ def test_the_live_workflow_pins_are_self_consistent() -> None:
     pins = module._pins_in(text)
     assert pins, "expected mergecraft.yml to pin the action by SHA"
     assert module._check_self_consistency(_WORKFLOW, pins) == []
+
+
+def _staleness_with(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    product_lag: str | None,
+    is_ancestor: str | None = "",
+    pin_known: str | None = "",
+    ref_exists: str | None = "",
+) -> list[str]:
+    """Drive ``_check_staleness`` with git responses stubbed."""
+
+    def fake_git(*args: str) -> Any:
+        if args[0] == "rev-parse":
+            return ref_exists
+        if args[0] == "cat-file":
+            return pin_known
+        if args[0] == "merge-base":
+            return is_ancestor
+        if args[0] == "rev-list":
+            return product_lag
+        return ""
+
+    monkeypatch.setattr(module, "_git", fake_git)
+    return module._check_staleness(_WORKFLOW, _SHA_OLD)
+
+
+def test_a_pin_far_behind_the_default_tip_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load()
+    monkeypatch.setattr(module, "MAX_PRODUCT_LAG", 5)
+    failures = _staleness_with(module, monkeypatch, product_lag="8")
+    assert len(failures) == 1
+    assert "lags main by 8 commits" in failures[0]
+
+
+def test_a_pin_within_the_product_lag_bound_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load()
+    monkeypatch.setattr(module, "MAX_PRODUCT_LAG", 5)
+    assert _staleness_with(module, monkeypatch, product_lag="2") == []
+
+
+def test_docs_and_test_commits_do_not_count_as_lag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rev-list is scoped to the product tree, so a docs-only gap is zero.
+
+    Counting every commit would make this fire for changes that cannot alter
+    what the reviewer does, which an operator has no way to act on.
+    """
+    module = _load()
+    monkeypatch.setattr(module, "MAX_PRODUCT_LAG", 0)
+    assert _staleness_with(module, monkeypatch, product_lag="0") == []
+
+
+def test_a_pin_ahead_of_the_default_branch_is_not_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bumped here but not yet promoted is the healthy state, not a failure."""
+    module = _load()
+    assert _staleness_with(module, monkeypatch, product_lag="9", is_ancestor=None) == []
+
+
+def test_staleness_skips_when_the_default_ref_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load()
+    assert _staleness_with(module, monkeypatch, product_lag="9", ref_exists=None) == []
+
+
+def test_matching_pins_that_both_lag_the_tip_are_still_caught(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the gap this check exists to close.
+
+    After PR #457 merged, main and pre-0.0.1 pinned the same SHA, so the
+    pin-to-pin freshness check reported OK while the reviewer ran none of the
+    fixes that had just landed. Equal pins must not imply a current reviewer.
+    """
+    module = _load()
+    monkeypatch.setattr(module, "MAX_DRIFT", 100)
+    monkeypatch.setattr(module, "MAX_PRODUCT_LAG", 5)
+
+    # Freshness sees both branches on the same pin and is satisfied.
+    monkeypatch.setattr(module, "_default_branch_workflow", lambda _: _workflow_text(_SHA_OLD))
+    monkeypatch.setattr(module, "_git", lambda *_a: "")
+    assert module._check_freshness(_WORKFLOW, _SHA_OLD) == []
+
+    # Staleness measures against the branch tip and catches it.
+    failures = _staleness_with(module, monkeypatch, product_lag="8")
+    assert len(failures) == 1


### PR DESCRIPTION
## What?

The reviewer now runs the provider-failover work that merged in #457, and the drift check can tell when it does not.

- The self-review Action pin moves from cfa36704 to 5b9ded9f.
- `make action-pin-check` gains a staleness check that measures the pin against the default branch's own tip.

## Why?

Merging #457 put retryable provider timeouts, drained opencode serve pipes, quota classification, and a single retryability decision path into the repository. It did not put them into the thing doing the reviewing, because the pin still named a commit from before them. Every review since has run the old behaviour.

The check added for #450 was supposed to catch exactly this and did not. It compared the default branch's pin against this branch's pin, which says nothing when both are equally stale. After #457 merged the two branches agreed on a SHA that predated every fix in it, so the check reported OK while the reviewer was eight product commits behind. Equal pins were treated as a current reviewer, and they are not the same thing.

Staleness measures the pin against the default branch's tip instead. Lag counts only commits touching the product tree, because docs and test commits cannot change what the reviewer does and counting them would fire for reasons nobody can act on. Measuring against the default tip rather than the current branch keeps it quiet on feature branches, whose commits no pin could reference yet. A pin ahead of the default branch is the healthy bumped-not-yet-promoted state and is not reported.

## Note

Promoting this to main is what makes the bump take effect: `pull_request_target` resolves the workflow and its pin from the default branch. Until then the reviewer keeps running cfa36704.

The staleness check is deliberately silent right now, because the new pin is ahead of main rather than behind it. Against the pre-bump state it reports what it should, on real history:

```
pin cfa36704cf6c lags pre-0.0.1 by 8 commits touching src/mergecraft/ (max 5).
The reviewer is not running the product code on pre-0.0.1, so anything merged
since the pin is absent from every review. Bump the pin.
```

## Test plan

- `make lint`, `make typecheck` clean.
- `make test`: 6095 passed, 43 skipped, 22 xfailed.
- Six new tests, verified as real pins by disabling the staleness check and confirming all six fail. One is a direct regression for the gap: matching pins on both branches must still be caught when both lag the tip.

## Related PR(s)/Issue(s)

Refs #450
