### PR TITLE
fix: clear PR #463 review findings and move self-review to hy3

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -489,7 +489,12 @@ jobs:
           timeout: 25m
           # Provider prefix `nous/` selects the opencode harness and names the
           # provider registered from the MERGECRAFT_CUSTOM_PROVIDER_* env vars.
-          model: nous/deepseek/deepseek-v4-flash
+          # 2026-08-23: moved off deepseek-v4-flash, which repeatedly failed to
+          # reach a terminal verdict or ran out the 25m ceiling (runs
+          # 32649874241, 32647074137). hy3 completed a full local review of the
+          # same diff and calls tools correctly. Both models are served by the
+          # same Nous Portal key, so no secret changes are needed.
+          model: nous/tencent/hy3
           push: disabled
           shell: disabled
           status_checks: enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `make action-pin-check` also measures the pin against the default branch's own tip, not just against the
-  other branch's pin. Comparing pins to each other passes when both are equally stale, which is what happened
-  after #457 merged: both branches pinned the same SHA and the check reported OK while the reviewer ran none
-  of the fixes that had just landed. Lag is counted over `src/mergecraft/` only, since docs and test commits
-  do not change what the reviewer executes (#450)
-- `make action-pin-check` guards the self-review Action pin against drift. Because
-  `.github/workflows/mergecraft.yml` runs on `pull_request_target`, GitHub resolves its `uses:` pin from the
-  **default branch**, so a fix merged to `pre-0.0.1` does not reach the reviewer until it reaches `main` —
-  a skew that reached 687 commits undetected and made PR #443 time out on a ceiling already fixed on the
-  branch. The check also rejects a one-sided bump that leaves the review and fallback steps on different
-  SHAs. Advisory in CI: a stale pin is a property of the default branch, not of the PR under review (#450)
+- `make action-pin-check` also measures the pin against the default branch's own
+  tip, not just against the other branch's pin. Comparing pins to each other
+  passes when both are equally stale, which is what happened after #457 merged:
+  both branches pinned the same SHA and the check reported OK while the reviewer
+  ran none of the fixes that had just landed. Lag is counted over
+  `src/mergecraft/` only, since docs and test commits do not change what the
+  reviewer executes (#450)
+- `make action-pin-check` guards the self-review Action pin against drift.
+  Because `.github/workflows/mergecraft.yml` runs on `pull_request_target`,
+  GitHub resolves its `uses:` pin from the **default branch**, so a fix merged
+  to `pre-0.0.1` does not reach the reviewer until it reaches `main` — a skew
+  that reached 687 commits undetected and made PR #443 time out on a ceiling
+  already fixed on the branch. The check also rejects a one-sided bump that
+  leaves the review and fallback steps on different SHAs. Advisory in CI: a
+  stale pin is a property of the default branch, not of the PR under review
+  (#450)
 - First-pass recall metric (`mergecraft eval convergence`, `make eval-convergence`) with multi-round bank cases and a paired regression gate that holds first-pass recall flat while the DG1 precision corpus stays at or above its floor
 - Open-PR finding ledger in the sticky progress comment — `mergecraft findings ledger --pr N` inspects inline, deferred, withdrawn, and unpublished fingerprints without filing GitHub issues (D4, D5)
 - Optional recall pass (`review.recallPass`, default off) dispatches `mergecraft-recall` after aggregation; novel findings always publish in the deferred lane (D1, D7)

--- a/scripts/check_action_pin_freshness.py
+++ b/scripts/check_action_pin_freshness.py
@@ -6,13 +6,13 @@ GitHub resolves its definition — and therefore its ``uses:`` pin — from the
 repository **default branch**, never from the PR base. A fix merged to
 ``pre-0.0.1`` does not reach the reviewer until it reaches ``main``.
 
-Nothing detected that skew, and it reached 691 commits: PR #443 timed out on a
+Nothing detected that skew, and it reached 687 commits: PR #443 timed out on a
 600s ceiling that had already been fixed on ``pre-0.0.1``, because the run used
 ``main``'s older pin. The failure mode is quiet — the branch holds the fix, the
 branch's own workflow pins the fixed SHA, and CI still exercises the old code
 (#450).
 
-Two checks:
+Three checks:
 
 1. **Self-consistency** (offline, always runs). Every ``uses:`` pin of this
    action inside a workflow file must be the same SHA. The workflow header

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -10,6 +10,7 @@ out, and every numeric/model guard that currently only ever sees valid input.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from typing import TYPE_CHECKING, Any
 
@@ -18,7 +19,11 @@ import pytest
 from tests.agents.conftest import make_agent_run_context
 
 from mergecraft.agents import opencode as oc
-from mergecraft.agents.openai_compatible_gateways import ProviderConfig
+from mergecraft.agents.openai_compatible_gateways import (
+    CUSTOM_PROVIDER_API_KEY_ENV,
+    CUSTOM_PROVIDER_BASE_URL_ENV,
+    ProviderConfig,
+)
 from mergecraft.tracing.genai import ModelParams
 from mergecraft.types import MERGECRAFT_MCP_NAME
 
@@ -34,8 +39,8 @@ _BASE_URL = "https://gateway.example.com/v1"
 def _clear_gateway_env(monkeypatch: MonkeyPatch) -> None:
     """Keep operator gateway env out of every case in this module."""
     for name in (
-        oc.CUSTOM_PROVIDER_BASE_URL_ENV,
-        oc.CUSTOM_PROVIDER_API_KEY_ENV,
+        CUSTOM_PROVIDER_BASE_URL_ENV,
+        CUSTOM_PROVIDER_API_KEY_ENV,
         "NOUS_API_KEY",
         "NOUS_BASE_URL",
         "TOKENHUB_API_KEY",
@@ -409,7 +414,7 @@ async def test_install_raises_with_an_actionable_message_when_cli_is_absent(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """A missing binary names the package the operator has to install."""
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
 
     with pytest.raises(FileNotFoundError) as excinfo:
         await oc._install(None)
@@ -541,7 +546,7 @@ def _patch_popen(monkeypatch: MonkeyPatch, proc: _FakeServeProc) -> list[list[st
         captured.append(list(cmd))
         return proc
 
-    monkeypatch.setattr(oc.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
     return captured
 
 
@@ -959,7 +964,7 @@ async def test_run_reports_a_missing_cli_without_touching_the_server(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """``_run`` short-circuits on a missing binary before writing any config."""
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
     ctx = make_agent_run_context(tmp_path, resolved_model=None)
 
     result = await oc._run(ctx)
@@ -976,7 +981,7 @@ async def test_run_falls_back_to_the_cli_when_serve_cannot_boot(
     """A serve boot failure degrades to ``opencode run`` instead of failing the review."""
     from mergecraft.agents.shared import AgentResult
 
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
 
     def _boom(**kwargs: object) -> Any:
         del kwargs
@@ -1003,7 +1008,7 @@ async def test_run_reports_a_session_creation_failure(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """A 4xx from ``POST /session`` aborts the run with the server's body."""
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
     proc = _FakeServeProc()
     handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
     monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
@@ -1022,7 +1027,7 @@ async def test_run_rejects_a_session_response_without_an_id(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """A 200 with no usable id is a failure — the run cannot be addressed."""
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
     proc = _FakeServeProc()
     handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
     monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
@@ -1041,7 +1046,7 @@ async def test_run_converts_a_provider_timeout_into_a_clean_failed_attempt(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """``ProviderTimeoutError`` is a controlled domain error, not a raised traceback."""
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
     proc = _FakeServeProc()
     handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
     monkeypatch.setattr(oc, "_boot_opencode_server", lambda **kwargs: handle)
@@ -1084,7 +1089,7 @@ async def test_run_converts_an_initial_prompt_timeout_into_a_failed_attempt(
     ``ProviderTimeoutError`` escaped ``_run`` → ``run_once`` →
     ``run_with_model_chain`` and killed the run with no fallback.
     """
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
     proc = _FakeServeProc()
     handle = oc._ServerHandle(base_url="http://127.0.0.1:5", proc=proc)  # type: ignore[arg-type]
     handle._recent.append("serve: upstream stalled")
@@ -1159,7 +1164,7 @@ async def test_run_exports_the_bedrock_flag_only_for_a_matching_model(
     """``BEDROCK_MODEL_ID`` gates the BYOK flag on an exact model match."""
     from mergecraft.agents.shared import AgentResult
 
-    monkeypatch.setattr(oc.shutil, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/opencode")
     monkeypatch.setenv("BEDROCK_MODEL_ID", "anthropic.claude-x")
     captured: list[dict[str, str]] = []
 

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -116,6 +116,7 @@ async def test_opencode_retries_at_most_once(monkeypatch: pytest.MonkeyPatch) ->
     meta = result.metadata or {}
     assert meta["executed_model"] == attempts[-1]
     assert slug == attempts[-1]
+    assert settings.models is not None
     assert attempts[-1] != settings.models[-1]
 
 

--- a/tests/pins/test_action_pin_freshness.py
+++ b/tests/pins/test_action_pin_freshness.py
@@ -5,16 +5,18 @@ resolves its ``uses:`` pin from the default branch. When that pin lags, the
 reviewer executes old code while the branch under review holds the fix — the
 skew that made PR #443 time out on an already-fixed 600s ceiling.
 
-Covers the two guards in ``scripts/check_action_pin_freshness.py``: pins inside
-one workflow file must agree, and the default branch's pin must stay within
-``MAX_DRIFT`` commits of this branch's.
+Covers the three guards in ``scripts/check_action_pin_freshness.py``: pins
+inside one workflow file must agree, the default branch's pin must stay within
+``MAX_DRIFT`` commits of this branch's, and the pin must not lag the default
+branch's own tip by more than ``MAX_PRODUCT_LAG`` commits touching
+``src/mergecraft/``.
 """
 
 from __future__ import annotations
 
 import importlib.util
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from tests.ci.workflow_support import REPO_ROOT
 
@@ -91,7 +93,7 @@ def _freshness_with(
         return ""
 
     monkeypatch.setattr(module, "_git", fake_git)
-    return module._check_freshness(_WORKFLOW, _SHA_NEW)
+    return cast("list[str]", module._check_freshness(_WORKFLOW, _SHA_NEW))
 
 
 def test_identical_pins_are_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -186,7 +188,7 @@ def _staleness_with(
         return ""
 
     monkeypatch.setattr(module, "_git", fake_git)
-    return module._check_staleness(_WORKFLOW, _SHA_OLD)
+    return cast("list[str]", module._check_staleness(_WORKFLOW, _SHA_OLD))
 
 
 def test_a_pin_far_behind_the_default_tip_is_stale(


### PR DESCRIPTION
Fixes the actionable review findings from PR #463 and switches this repo's own
self-review model. Also closes the docstring half of #462.

## Fixed

**mypy in tests** — `make typecheck` scopes mypy to `src/mergecraft`, so none of
these reached the repo gate.

| File | Error | Fix |
|---|---|---|
| `tests/pins/test_action_pin_freshness.py` | `no-any-return` | The guard script is loaded via `importlib` and typed `ModuleType`, so its attributes are `Any`. Cast the `_check_freshness` / `_check_staleness` results to `list[str]`. |
| `tests/integration/test_provider_failures.py` | `index` | `settings.models` is `list[str] | None`; narrow with an explicit assert before indexing. |
| `tests/agents/test_cov_opencode_paths.py` | `attr-defined` | `oc.shutil`, `oc.subprocess` and the two `CUSTOM_PROVIDER_*_ENV` constants are re-exports, which strict mypy rejects under `no_implicit_reexport`. Import them from their real homes instead of reaching through the module under test. |

The findings named one site each, but the same three root causes produced **15**
errors across those files — all 15 are fixed. Behaviour is unchanged: `oc.shutil`
*is* the `shutil` module object, so patching it directly is the same operation.

**Docs (#462)** — `scripts/check_action_pin_freshness.py`:

- The docstring cited **691** commits of drift where the CHANGELOG, the CI
  comment and the tests all say **687**. 687 is the real pin-to-pin distance
  (`git rev-list --count 0592d72..cfa3670` → `687`), so the docstring was the
  outlier.
- The same docstring opened "Two checks:" and then listed three. Now "Three
  checks:", with the test module's matching "the two guards" wording updated to
  name the staleness guard it already covers (`test_a_pin_far_behind_the_default_tip_is_stale`
  and friends).

**markdownlint MD013** — rewrapped only the two action-pin bullets this branch's
history added (`982ab84`, `6efa36d`) to the 80-column default. Whitespace only,
verified word-for-word identical; unrelated entries are untouched.

## Deliberately not fixed

**bandit B101 across `tests/`** — `assert` is how pytest works. **B404/B603/B607**
in `scripts/check_action_pin_freshness.py` and `tests/agents/test_opencode_serve_drain.py`
— both legitimately use `subprocess`, and the drain test needs a real child
process to exercise an OS pipe. No suppression added: the repo has no
per-finding bandit-noqa pattern for these, and inventing one would be worse than
the noise.

**zizmor `artipacked` on `.github/workflows/ci.yml:29`** — deferred. Reasoning:

1. It is pre-existing and not introduced here. No workflow in this repo sets
   `persist-credentials: false` — there are **21** `actions/checkout` call sites
   across 9 workflows, and only `mergecraft.yml` sets the input at all
   (explicitly `true`, deliberately). Only line 29 was flagged because
   markdownlint/zizmor run `scope: diff`.
2. Fixing one of 21 sites buys ~no security while implying the workflow is
   hardened. The flagged job only runs `make lockcheck` and uploads no
   artifacts, which is the leak `artipacked` actually describes.
3. The `static` job in the same file (checkout at line 77) runs
   `git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main` to feed
   `make action-pin-check`. That fetch relies on the credential checkout
   persists. Flipping it there risks silently breaking the very drift check this
   branch's history added — the exact quiet-failure mode #450 was about.

The right shape is a dedicated hardening PR that does all 21 sites and verifies
each job that shells out to `git`. Happy to open it if you want it.

## Not a defect

`tests/ci/workflow_support.py:34` (`call-overload`) shows up when mypy is pointed
at the pin test, since it is imported transitively. It is **pre-existing**
(confirmed by stashing this branch's changes), in a file this PR does not touch,
and was not in the findings — left alone.

## Self-review model → `nous/tencent/hy3`

`deepseek-v4-flash` repeatedly failed to reach a terminal verdict or ran out the
25m ceiling (runs `32649874241`, `32647074137`). `hy3` completed a full local
review of the same diff and calls tools correctly. Both are served by the same
Nous Portal key, so no secret changes. Only the primary Nous step moves — the
Codex fallback and the action pin (`5b9ded9f`) are unchanged.

## Verification

| Target | Result |
|---|---|
| `make lint` | pass — `All checks passed!`, 1095 files formatted, `type-ignore-check OK` |
| `make typecheck` | pass — `Success: no issues found in 456 source files` |
| `make test` | pass — `6095 passed, 43 skipped, 22 xfailed in 177.54s` |
| `make action-pin-check` | pass — `action-pin-check OK: 1 workflow(s) pin this action` |
| `mypy` on each touched file | clean (only the pre-existing `workflow_support.py` error noted above) |

Refs #462, #463, #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMVYZFZnJWKZXfujiMGdRu
