### PR TITLE
fix(ci): drop --depth=1 so the pin staleness guard can measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,13 @@ jobs:
       - name: Action pin freshness (advisory)
         if: matrix.python == '3.14'
         run: |
-          git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || true
+          # No --depth here. A depth-limited fetch marks origin/main as a
+          # shallow boundary, so rev-list stops at the graft and the staleness
+          # check under-reports the product lag (measured on this repo: 5
+          # commits -> 1), silently defanging the guard in the only job that
+          # runs it. The checkout above is fetch-depth: 0, so the objects are
+          # already local and a full fetch is near-free.
+          git fetch --no-tags origin main:refs/remotes/origin/main || true
           if out="$(make action-pin-check 2>&1)"; then
             echo "$out"
           else

--- a/tests/pins/test_action_pin_freshness.py
+++ b/tests/pins/test_action_pin_freshness.py
@@ -18,7 +18,7 @@ import importlib.util
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, cast
 
-from tests.ci.workflow_support import REPO_ROOT
+from tests.ci.workflow_support import REPO_ROOT, job, load_workflow
 
 if TYPE_CHECKING:
     import pytest
@@ -163,6 +163,29 @@ def test_the_live_workflow_pins_are_self_consistent() -> None:
     pins = module._pins_in(text)
     assert pins, "expected mergecraft.yml to pin the action by SHA"
     assert module._check_self_consistency(_WORKFLOW, pins) == []
+
+
+def test_the_pin_check_ci_step_does_not_shallow_fetch_the_default_branch() -> None:
+    """A depth-limited fetch silently defangs the staleness guard.
+
+    ``--depth=1`` marks ``origin/main`` as a shallow boundary, so
+    ``_check_staleness``'s ``rev-list --count <pin>..origin/main`` stops at the
+    graft and under-reports the product lag — measured on this repo, 5 commits
+    read as 1. The guard exists for the #450 case freshness cannot see (both
+    branches pinning the same stale SHA), so a silent under-count is the one
+    failure that makes it useless while still reporting OK. The ``static`` job
+    checks out ``fetch-depth: 0``, so a full fetch costs nothing here.
+    """
+    static = job(load_workflow("ci.yml"), "static")
+    steps = [s for s in static["steps"] if "pin freshness" in str(s.get("name", "")).lower()]
+    assert len(steps) == 1, f"expected one pin-freshness step, got {len(steps)}"
+    run = steps[0]["run"]
+
+    fetches = [line.strip() for line in run.splitlines() if line.strip().startswith("git fetch")]
+    assert fetches, f"pin-freshness step no longer fetches the default branch:\n{run}"
+    for line in fetches:
+        assert "--depth" not in line, f"depth-limited fetch defeats the staleness guard: {line}"
+        assert "--shallow-since" not in line, f"shallow fetch defeats the staleness guard: {line}"
 
 
 def _staleness_with(


### PR DESCRIPTION
Addresses the unresolved mergeCraft review thread on #463
(`.github/workflows/ci.yml:97`). The finding is correct; I reproduced it.

## The bug

The pin-freshness step fetched the default branch with `--depth=1`. That marks
`origin/main` as a **shallow boundary** — git writes a graft point and history
walks stop there. So `_check_staleness`'s core measurement,

```
rev-list --count <pin>..origin/main -- src/mergecraft/
```

counts only as far as the graft, and `merge-base --is-ancestor` cannot resolve
ancestry past it either.

Reproduced against this repo (clone, fetch both ways, same pin):

| fetch | `is-shallow-repository` | product lag |
|---|---|---|
| `--no-tags` | `false` | **5** |
| `--no-tags --depth=1` | `true` | **1** |

The guard then takes its "not stale" return-`[]` branch and prints OK. So the
check **reported success while measuring nothing**, in the only CI job that runs
it. That is precisely the #450 failure mode the staleness check was added to
catch — a skew growing silently because nothing is looking — which makes this
worse than having no guard.

## The fix

Drop the flag. This costs nothing: the `static` job checks out with
`fetch-depth: 0`, so main's objects are **already local**. The fetch only moves
the ref — it is not re-downloading history. `--depth=1` was not buying speed,
it was discarding visibility the job already had.

## Regression test

`test_the_pin_check_ci_step_does_not_shallow_fetch_the_default_branch` asserts
the step's `git fetch` carries no `--depth` or `--shallow-since`. A comment
alone would not survive the next edit to this step.

Verified it actually catches the regression: **red** with `--depth=1` restored,
**green** with the fix. (A test that passes both ways would be worthless here.)

## No CHANGELOG entry

The staleness guard is itself an `[Unreleased]` **Added** entry from this same
cycle, so no released version ever had this bug. Per Keep a Changelog, a fix for
something that never shipped belongs in the feature's own entry, not a separate
**Fixed** line — and that entry's wording is still accurate.

## Verification

| Target | Result |
|---|---|
| `make lint` | pass — `All checks passed!`, 1095 files formatted, `type-ignore-check OK` |
| `make typecheck` | pass — `Success: no issues found in 456 source files` |
| `make test` | pass — `6096 passed, 43 skipped, 22 xfailed in 172.63s` |
| `make action-pin-check` | pass — `action-pin-check OK: 1 workflow(s) pin this action` |

Refs #463, #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMVYZFZnJWKZXfujiMGdRu
