### PR TITLE
fix(ci): label the Nous review step with the model it runs

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -418,7 +418,7 @@ jobs:
           echo "baseline mergecraft-approval check-run: ${id:-none}"
           echo "id=${id}" >> "${GITHUB_OUTPUT}"
 
-      - name: mergeCraft PR review (Nous DeepSeek V4 Flash)
+      - name: mergeCraft PR review (Nous Tencent HY3)
         if: env.HAS_NOUS == 'true'
         id: mergecraft_nous
         continue-on-error: true


### PR DESCRIPTION
One line. The Nous review step's `model:` moved to `nous/tencent/hy3` in #471,
but its `name:` was left as "Nous DeepSeek V4 Flash", so every job log, step
header, and check line has been reporting a model that is not running.

```diff
-      - name: mergeCraft PR review (Nous DeepSeek V4 Flash)
+      - name: mergeCraft PR review (Nous Tencent HY3)
```

That mislabel is not only cosmetic — it actively misled a debugging session on
#443: the step header said DeepSeek, which read as the hy3 switch having been
reverted or fallen back, when hy3 had in fact run and produced the review.

Label only. No input, model, pin, or fallback-step change, and no `${{ }}` added
to any comment or description text.

## Still stale, deliberately not touched here

The workflow header still describes DeepSeek as the primary provider, in prose
that predates the model switch:

| Line | Text |
|---|---|
| 21 | "Provider priority: DeepSeek V4 Flash via the Nous Portal is primary" |
| 34 | "DeepSeek V4 Flash runs through the Nous Portal OpenAI-compatible endpoint" |
| 46–47 | "so `nous/deepseek/deepseek-v4-flash` registers provider `nous` serving …" |
| 53 | "NOUS_API_KEY — Nous Portal API key — primary (DeepSeek V4 Flash)" |
| 295 | "Nous/DeepSeek primary; Codex fallback when …" |

Lines 46–47 are still *correct as an example* of how the provider prefix is
parsed; the others are now wrong. Left out to keep this reviewable as the
one-line fix it is — happy to follow up.

Refs #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMVYZFZnJWKZXfujiMGdRu
