### PR TITLE
review: honour the named model and decide offline reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mergeCraft's consumer workflow approval gate now runs in a separate job that
   `needs:` the review-attempts job, so Codex fallback can post `mergecraft-approval`
   before the fail-closed gate samples check-runs (#433)
+- An explicit `--model` now beats `MERGECRAFT_MODEL`. `resolve_model()` read the env override first and
+  returned before it ever looked at the flag, so a review asked for one model and ran another with no line
+  saying the request was dropped — inverting the repo's own `ConfigLayer` order (CLI > env > YAML > default)
+  and the flag's help text. The named model also heads the subagent chains the harness renders, so it
+  reaches the whole run rather than just the top-level dispatch, and `config explain model` now reports the
+  YAML layer as the config file alone instead of the env value promoted to its front (#468)
+- Offline reviews (`--base`/`--head`, `--diff`, `--cwd`) can record a terminal verdict. Review scope was
+  only ever established by `checkout_pr`, which an offline run has no PR for, so `submit_review_verdict` was
+  refused on every attempt and a completed review — analyzer findings and all — was never decided. The
+  materialized diff now establishes scope on the offline path. The post-run retry loop also stops when a
+  resume leaves the identical issue set, instead of replaying a precondition that cannot change between
+  attempts (#470)
 - Retryability now has one decision path. `_is_retryable_failure` gated on `metadata["retryable"]` alone
   while `_retryable_failure_reason` inferred the same property from the error text, and only the
   metadata-blind one decided — so a driver that omitted the flag was silently read as "permanent" and its

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -228,6 +228,10 @@ preserved as the first entry):
 ```
 
 `MERGECRAFT_MODEL` (env var) follows the same rule: it joins as the head.
+When a model is named explicitly — the Action `with: model:` input or the
+CLI `--model` flag — that one heads the chain and `MERGECRAFT_MODEL`
+follows it, matching the CLI > env > YAML > default precedence that
+`mergecraft config explain model` reports.
 
 #### Escape hatch — `model_pin: enabled`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2560,6 +2560,10 @@ preserved as the first entry):
 ```
 
 `MERGECRAFT_MODEL` (env var) follows the same rule: it joins as the head.
+When a model is named explicitly — the Action `with: model:` input or the
+CLI `--model` flag — that one heads the chain and `MERGECRAFT_MODEL`
+follows it, matching the CLI > env > YAML > default precedence that
+`mergecraft config explain model` reports.
 
 #### Escape hatch — `model_pin: enabled`
 

--- a/src/mergecraft/agents/harness_render.py
+++ b/src/mergecraft/agents/harness_render.py
@@ -406,6 +406,24 @@ def default_subagent_selection(
     return tuple(roster)
 
 
+def _requested_model_head(ctx: AgentRunContext) -> str | None:
+    """Return the model slug the operator named for this run, if any.
+
+    The CLI ``--model`` flag and the Action ``with: model:`` input both land
+    on the run payload, which is a ``ResolvedPayload`` on the offline path
+    and a plain mapping on the Action path. An explicitly named model is the
+    CLI precedence layer, so it heads the subagent chains rather than being
+    displaced by ``MERGECRAFT_MODEL`` (issue #468).
+    """
+    payload = getattr(ctx, "payload", None)
+    if payload is None:
+        return None
+    raw = payload.get("model") if isinstance(payload, dict) else getattr(payload, "model", None)
+    if not isinstance(raw, str):
+        return None
+    return raw.strip() or None
+
+
 def render_for_run(
     ctx: AgentRunContext,
     harness: HarnessName,
@@ -417,7 +435,9 @@ def render_for_run(
 
     root = _repo_root_from_ctx(ctx) or Path(ctx.tmpdir)
     settings = load_repo_settings(root=root)
-    registry = load_registry(settings=settings, repo_root=root)
+    registry = load_registry(
+        settings=settings, repo_root=root, model_head=_requested_model_head(ctx)
+    )
     roster = (
         tuple(selected)
         if selected is not None

--- a/src/mergecraft/agents/post_run.py
+++ b/src/mergecraft/agents/post_run.py
@@ -243,6 +243,16 @@ async def finalize_agent_result(ctx: AgentRunContext, result: AgentResult) -> Ag
     )
 
 
+def _post_run_issue_signature(issues: PostRunIssues) -> tuple[Any, ...]:
+    """Identity of an issue set, for detecting a retry that changed nothing."""
+    return (
+        issues.stop_hook.exit_code if issues.stop_hook else None,
+        issues.dirty_tree,
+        issues.summary_stale.file_path if issues.summary_stale else None,
+        issues.unsubmitted_review,
+    )
+
+
 async def run_post_run_retry_loop(
     ctx: AgentRunContext,
     *,
@@ -252,14 +262,31 @@ async def run_post_run_retry_loop(
     """Resume the agent up to MAX_POST_RUN_RETRIES while hard/soft gates fail.
 
     ``resume`` is an async callable ``(prompt: str) -> AgentResult``.
+
+    A resume that leaves the issue set byte-identical made no progress, so
+    the loop stops there rather than replaying the same nudge against the
+    same unchangeable state — a deterministic precondition failure cannot
+    resolve itself across attempts, and retrying it only burns wall clock
+    (issue #470).
     """
     result = initial
     usage = result.usage
     skip_summary = False
+    previous_signature: tuple[Any, ...] | None = None
     for attempt in range(MAX_POST_RUN_RETRIES):
         issues = await collect_post_run_issues(ctx, skip_summary_stale=skip_summary)
         if not has_post_run_issues(issues):
             break
+        signature = _post_run_issue_signature(issues)
+        if signature == previous_signature:
+            logger.warning(
+                "post-run retry abandoned after {}/{} — the last resume left the same "
+                "unresolved issues, so a further attempt cannot change them",
+                attempt,
+                MAX_POST_RUN_RETRIES,
+            )
+            break
+        previous_signature = signature
         if issues.summary_stale and not (
             issues.stop_hook or issues.dirty_tree or issues.unsubmitted_review
         ):

--- a/src/mergecraft/agents/registry.py
+++ b/src/mergecraft/agents/registry.py
@@ -162,8 +162,13 @@ def _parse_role(value: str) -> AgentRole | None:
         return None
 
 
-def _default_model_chain(settings: RepoSettings, *, role: AgentRole) -> list[str]:
-    run_chain = effective_model_chain(settings)
+def _default_model_chain(
+    settings: RepoSettings,
+    *,
+    role: AgentRole,
+    model_head: str | None = None,
+) -> list[str]:
+    run_chain = effective_model_chain(settings, head=model_head or None)
     if not run_chain:
         run_chain = [AUTO_EFFICIENT]
     if role is AgentRole.verifier:
@@ -221,12 +226,17 @@ def _default_output_schema(role: AgentRole) -> str | None:
     return None
 
 
-def _build_default_binding(settings: RepoSettings, role: AgentRole) -> AgentBinding:
+def _build_default_binding(
+    settings: RepoSettings,
+    role: AgentRole,
+    *,
+    model_head: str | None = None,
+) -> AgentBinding:
     return AgentBinding(
         agent_id=_default_agent_id(role),
         role=role,
         lens=None,
-        model_chain=tuple(_default_model_chain(settings, role=role)),
+        model_chain=tuple(_default_model_chain(settings, role=role, model_head=model_head)),
         prompt_id=_default_prompt_id(role),
         prompt_version=_DEFAULT_PROMPT_VERSION,
         tool_classes=_default_tool_classes(role),
@@ -367,12 +377,20 @@ def load_registry(
     *,
     settings: RepoSettings,
     repo_root: Path | None = None,
+    model_head: str | None = None,
 ) -> Registry:
-    """Load defaults merged with ``settings.agents`` overrides."""
+    """Load defaults merged with ``settings.agents`` overrides.
+
+    ``model_head`` is the model the operator named for this run (the CLI
+    ``--model`` flag, or the Action ``with: model:`` input). It becomes the
+    head of every default binding's chain so an explicit request outranks
+    ``MERGECRAFT_MODEL`` and ``.mergecraft/config.yaml`` for subagents too
+    (issue #468). Per-agent ``model_chain`` overrides still win.
+    """
     del repo_root  # reserved for future repo-local agent manifests
     bindings: dict[str, AgentBinding] = {}
     for role in AgentRole:
-        bindings[role.value] = _build_default_binding(settings, role)
+        bindings[role.value] = _build_default_binding(settings, role, model_head=model_head)
 
     bindings.update(
         __import__(
@@ -397,7 +415,9 @@ def load_registry(
             base = bindings[lens_keys[override.lens]]
         else:
             base_role = declared_role or key_role or AgentRole.reviewer
-            base = bindings.get(base_role.value) or _build_default_binding(settings, base_role)
+            base = bindings.get(base_role.value) or _build_default_binding(
+                settings, base_role, model_head=model_head
+            )
         merged = _apply_override(base, override, agent_key=agent_key, settings=settings)
         if merged.lens is not None and merged.lens in lens_keys:
             stale_key = lens_keys[merged.lens]

--- a/src/mergecraft/cli/config_precedence.py
+++ b/src/mergecraft/cli/config_precedence.py
@@ -17,7 +17,7 @@ import yaml
 
 from mergecraft.cli.tracing_precedence import resolve_tracing_settings
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL, default_settings, load_repo_settings
-from mergecraft.utils.agent_resolve import effective_model_slugs, resolve_effective_model_slug
+from mergecraft.utils.agent_resolve import configured_model_slugs, resolve_effective_model_slug
 
 _TRUE_VALUES = {"true", "1", "yes", "on"}
 _FALSE_VALUES = {"false", "0", "no", "off"}
@@ -81,7 +81,10 @@ def _resolve_model_layers(*, cwd: Path, cli_model: str | None = None) -> dict[Co
     if env_model:
         layers[ConfigLayer.ENV] = env_model.strip()
     settings = load_repo_settings(root=cwd, load_learnings_files=False)
-    yaml_slugs = effective_model_slugs(settings)
+    # The YAML layer is what the config file says on its own —
+    # ``effective_model_slugs`` promotes ``MERGECRAFT_MODEL`` to the front,
+    # which would report the env value under the YAML layer.
+    yaml_slugs = configured_model_slugs(settings)
     if yaml_slugs:
         layers[ConfigLayer.YAML] = yaml_slugs[0]
     layers[ConfigLayer.DEFAULT] = resolve_effective_model_slug(settings)

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -276,7 +276,10 @@ def run(
         None,
         "--model",
         "-m",
-        help="Model slug override (otherwise .mergecraft/config.yaml / MERGECRAFT_MODEL).",
+        help=(
+            "Model slug override — wins over MERGECRAFT_MODEL, which wins over "
+            ".mergecraft/config.yaml."
+        ),
         rich_help_panel=_PANEL_AGENT,
     ),
     output: Path | None = typer.Option(

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -119,18 +119,42 @@ def _current_review_phase(tool_state: ToolState) -> ReviewPhase:
     return ReviewPhase(tool_state.review_phase)
 
 
+def establish_offline_review_scope(tool_state: ToolState, *, diff_path: str) -> None:
+    """Advance an offline run past ``INIT`` once its diff scope is materialized.
+
+    ``checkout_pr`` is how the Action path establishes review scope, but an
+    offline run (``--base``/``--head``, ``--diff``, ``--cwd``) has no PR to
+    check out — its scope comes from the materialized diff. Without this
+    transition the run stays in ``INIT`` and every terminal tool is refused
+    by :func:`ensure_review_scope_for_terminal`, so an offline review could
+    never record a verdict (issue #470).
+    """
+    primary_repo_state(tool_state).diff_path = diff_path
+    tool_state.review_phase = ReviewPhase.ESTABLISH_SCOPE.value
+    stamp_review_phase_on_active_span(ReviewPhase.ESTABLISH_SCOPE)
+
+
 def ensure_review_scope_for_terminal(tool_state: ToolState, tool_name: str) -> None:
-    """Raise when a Review-mode terminal tool runs before ``checkout_pr`` (D10)."""
+    """Raise when a Review-mode terminal tool runs before review scope exists (D10).
+
+    Scope is established by ``checkout_pr`` on the Action path and by
+    :func:`establish_offline_review_scope` on the offline path; a run that
+    already carries a materialized diff satisfies the precondition either
+    way, so the message names both routes rather than only the PR one.
+    """
     mode = tool_state.selected_mode
     if mode not in _REVIEW_MODES or _current_review_phase(tool_state) != ReviewPhase.INIT:
+        return
+    if primary_repo_state(tool_state).diff_path:
         return
     if mode == "IncrementalReview":
         primary = primary_repo_state(tool_state)
         if primary.incremental_changed_paths:
             return
     msg = (
-        f"{tool_name} requires checkout_pr to establish review scope "
-        "before the terminal verdict can be recorded"
+        f"{tool_name} requires review scope before the terminal verdict can be "
+        "recorded — run checkout_pr, or start the run against a diff "
+        "(--base/--head, --diff, --cwd)"
     )
     raise ValueError(msg)
 
@@ -731,6 +755,7 @@ __all__ = [
     "after_terminal_submission_recorded",
     "build_validation_state",
     "ensure_review_scope_for_terminal",
+    "establish_offline_review_scope",
     "record_validated_terminal_submission",
     "recorded_submission_payload",
     "revalidate_recorded_submission",

--- a/src/mergecraft/review/offline_agent.py
+++ b/src/mergecraft/review/offline_agent.py
@@ -21,7 +21,8 @@ from mergecraft.config.settings import (
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.endpoints import mcp_role_url
 from mergecraft.mcp.server import start_mcp_http_server
-from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.mcp.verdict import establish_offline_review_scope
 from mergecraft.modes import compute_modes
 from mergecraft.review.offline_result import (
     OfflineReviewResult,
@@ -84,7 +85,10 @@ async def run_offline_agent_review(
         tool_state = init_tool_state(owner="local", name=cwd.name, dir=str(cwd))
         tool_state.on_finding = on_finding
         tool_state.trust_tier = resolved_tier
-        primary_repo_state(tool_state).diff_path = str(materialization.path)
+        # Offline runs have no PR to check out; the materialized diff is the
+        # review scope, and establishing it here is what lets the terminal
+        # verdict tools run at all (issue #470).
+        establish_offline_review_scope(tool_state, diff_path=str(materialization.path))
         settings = load_repo_settings(root=cwd, load_learnings_files=False)
         settings, drops = apply_trust_tier_to_repo_settings(
             settings,

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -194,6 +194,16 @@ def is_runnable_model_slug(slug: str) -> bool:
     return _agent_binary_available(slug)
 
 
+def configured_model_slugs(settings: RepoSettings) -> list[str]:
+    """Return the slugs configured in ``.mergecraft/config.yaml``, env excluded.
+
+    The YAML precedence layer on its own — :func:`effective_model_slugs`
+    promotes ``MERGECRAFT_MODEL`` to the front, which conflates the env layer
+    with the YAML one for callers that report layers separately.
+    """
+    return _configured_model_slugs(settings)
+
+
 def _configured_model_slugs(settings: RepoSettings) -> list[str]:
     if settings.models:
         return list(settings.models)
@@ -1263,14 +1273,21 @@ def _resolve_slug(slug: str) -> str | None:
 
 
 def resolve_model(*, slug: str | None = None, respect_env_override: bool = True) -> str | None:
-    """Resolve the effective model string for this run."""
-    if respect_env_override:
-        env_model = os.environ.get("MERGECRAFT_MODEL", "").strip()
-        if env_model:
-            _enforce_resolved_model_residency(env_model)
-            return _resolve_slug(env_model) or env_model
+    """Resolve the effective model string for this run.
 
+    Precedence matches :class:`mergecraft.cli.config_precedence.ConfigLayer`:
+    an explicit ``slug`` (the CLI layer) outranks ``MERGECRAFT_MODEL`` (the
+    env layer). ``respect_env_override=False`` drops the env layer entirely
+    for callers that have already applied their own precedence (the Action
+    chain in :mod:`mergecraft.main` resolves a winning slug up front).
+
+    An explicit slug is never discarded silently — when it is dropped in
+    favour of the env override, or when it resolves to nothing, that is
+    reported.
+    """
     cleaned = (slug or "").strip()
+    env_model = os.environ.get("MERGECRAFT_MODEL", "").strip() if respect_env_override else ""
+
     if cleaned:
         _enforce_resolved_model_residency(cleaned)
         resolved = _resolve_slug(cleaned)
@@ -1283,6 +1300,11 @@ def resolve_model(*, slug: str | None = None, respect_env_override: bool = True)
             )
             return cleaned
         logger.warning('» unknown model slug "{}" — agent will auto-select', cleaned)
+        return None
+
+    if env_model:
+        _enforce_resolved_model_residency(env_model)
+        return _resolve_slug(env_model) or env_model
     return None
 
 
@@ -1388,6 +1410,7 @@ def resolve_runtime_agent(
 __all__ = [
     "FallbackReason",
     "ModelFallbackPolicyError",
+    "configured_model_slugs",
     "effective_model_chain",
     "effective_model_slugs",
     "has_credentials_for_slug",

--- a/tests/agents/test_agent_registry.py
+++ b/tests/agents/test_agent_registry.py
@@ -478,3 +478,58 @@ agents:
     verifier = _resolve_role(registry, "verifier")
     assert reviewer.agent_id == "mergecraft-reviewer"
     assert verifier.agent_id == "senior-reviewer"
+
+
+def test_model_head_outranks_the_env_override_in_default_chains(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """#468: an explicitly named model heads every default binding's chain.
+
+    ``MERGECRAFT_MODEL`` is the env layer and ``model_head`` is the CLI layer
+    (``--model`` / the Action ``with: model:`` input), so the named model must
+    lead — otherwise subagents run a model the operator did not ask for while
+    the flag is silently discarded.
+    """
+    from mergecraft.agents.registry import load_registry
+
+    monkeypatch.setenv("MERGECRAFT_MODEL", "acme/env-model")
+    settings = load_repo_settings(root=tmp_path)
+
+    without_head = load_registry(settings=settings, repo_root=tmp_path)
+    assert _resolve_role(without_head, "reviewer").model_chain[0] == "acme/env-model"
+
+    with_head = load_registry(settings=settings, repo_root=tmp_path, model_head="acme/cli-model")
+    for role in ("reviewer", "recall", "orchestrator"):
+        chain = _resolve_role(with_head, role).model_chain
+        assert chain[0] == "acme/cli-model", f"{role} chain must start with the CLI model: {chain}"
+        assert "acme/env-model" in chain, f"{role} must keep the env model as a fallback: {chain}"
+
+
+def test_requested_model_head_reads_both_run_payload_shapes(tmp_path: Path) -> None:
+    """#468: the model the operator named reaches the harness registry.
+
+    The run payload is a ``ResolvedPayload`` offline and a plain mapping on
+    the Action path; both carry the named model, and both must yield it as
+    the chain head so subagents do not fall back to ``MERGECRAFT_MODEL``.
+    """
+    from mergecraft.agents.harness_render import _requested_model_head
+    from mergecraft.agents.shared import AgentRunContext
+
+    def _ctx(payload: object) -> AgentRunContext:
+        return AgentRunContext(
+            payload=payload,
+            mcp_server_url="",
+            tmpdir=str(tmp_path),
+            subagent_denied_tools=(),
+            instructions=None,
+            tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        )
+
+    resolved = ResolvedPayload(
+        event=PayloadEvent(trigger="unknown", title="offline diff-review"),
+        model="acme/cli-model",
+    )
+    assert _requested_model_head(_ctx(resolved)) == "acme/cli-model"
+    assert _requested_model_head(_ctx({"model": "acme/cli-model"})) == "acme/cli-model"
+    assert _requested_model_head(_ctx({"model": "   "})) is None
+    assert _requested_model_head(_ctx({})) is None

--- a/tests/cli/test_config_surface.py
+++ b/tests/cli/test_config_surface.py
@@ -128,3 +128,34 @@ def test_config_validate_runs_before_expensive_execution(
     output = _plain(result.stdout + result.stderr)
     assert result.exit_code != 0, output
     assert not agent_called["value"], "agent must not run when config validation fails"
+
+
+def test_config_explain_model_reports_cli_over_env_and_yaml(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """#468: ``model`` resolves CLI > env > YAML, and each layer is reported as itself."""
+    from mergecraft.cli.config_precedence import ConfigLayer, explain_setting
+
+    _write_config(tmp_path, "models:\n  - anthropic/claude-sonnet\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGECRAFT_MODEL", "openai/gpt-5.3-codex")
+
+    explained = explain_setting("model", cwd=tmp_path, cli_model="nous/tencent/hy3")
+    assert explained["winner"] == ConfigLayer.CLI.value
+    assert explained["value"] == "nous/tencent/hy3"
+
+    layers = explained["layers"]
+    assert layers[ConfigLayer.CLI.value] == "nous/tencent/hy3"
+    assert layers[ConfigLayer.ENV.value] == "openai/gpt-5.3-codex"
+    # The YAML layer is the config file on its own — not the env value
+    # promoted to the front of the effective list.
+    assert layers[ConfigLayer.YAML.value] == "anthropic/claude-sonnet"
+
+    without_cli = explain_setting("model", cwd=tmp_path)
+    assert without_cli["winner"] == ConfigLayer.ENV.value
+    assert without_cli["value"] == "openai/gpt-5.3-codex"
+
+    monkeypatch.delenv("MERGECRAFT_MODEL")
+    yaml_only = explain_setting("model", cwd=tmp_path)
+    assert yaml_only["winner"] == ConfigLayer.YAML.value
+    assert yaml_only["value"] == "anthropic/claude-sonnet"

--- a/tests/review/test_phase_guards.py
+++ b/tests/review/test_phase_guards.py
@@ -241,3 +241,43 @@ async def test_phase_reaches_the_trace(tmp_path: Path, monkeypatch: pytest.Monke
         f"review.phase missing from span attrs after checkout_pr; events="
         f"{[getattr(e, 'attrs', None) for e in sink.events]!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_offline_scope_lets_the_terminal_verdict_be_recorded(tmp_path: Path) -> None:
+    """#470: an offline run has no PR, so its diff is what establishes scope."""
+    from mergecraft.mcp.tool_state import primary_repo_state
+    from mergecraft.mcp.verdict import (
+        ReviewPhase,
+        establish_offline_review_scope,
+        submit_review_verdict_tool,
+    )
+
+    ctx = _ctx(tmp_path)
+    diff_path = tmp_path / "review.diff"
+    diff_path.write_text("diff --git a/a.py b/a.py\n", encoding="utf-8")
+
+    establish_offline_review_scope(ctx.tool_state, diff_path=str(diff_path))
+
+    assert ctx.tool_state.review_phase == ReviewPhase.ESTABLISH_SCOPE.value
+    assert primary_repo_state(ctx.tool_state).diff_path == str(diff_path)
+
+    result = await submit_review_verdict_tool(ctx).execute(_valid_payload())
+    assert result.is_error is not True, _error_text(result)
+    assert ctx.tool_state.terminal_submission is not None
+
+
+def test_scope_gate_accepts_a_materialized_diff_without_a_phase_transition(
+    tmp_path: Path,
+) -> None:
+    """The gate's requirement is scope, not ``checkout_pr`` specifically (#470)."""
+    from mergecraft.mcp.tool_state import primary_repo_state
+    from mergecraft.mcp.verdict import ensure_review_scope_for_terminal
+
+    ctx = _ctx(tmp_path)
+    assert ctx.tool_state.review_phase == "INIT"
+    with pytest.raises(ValueError, match="review scope"):
+        ensure_review_scope_for_terminal(ctx.tool_state, "submit_review_verdict")
+
+    primary_repo_state(ctx.tool_state).diff_path = str(tmp_path / "review.diff")
+    ensure_review_scope_for_terminal(ctx.tool_state, "submit_review_verdict")

--- a/tests/review/test_post_run_terminal_gate.py
+++ b/tests/review/test_post_run_terminal_gate.py
@@ -17,7 +17,9 @@ from mergecraft.agents.shared import (
     MAX_POST_RUN_RETRIES,
     AgentResult,
     AgentRunContext,
+    PostRunIssues,
     ResolvedInstructions,
+    StopHookFailure,
 )
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.tool_state import ReviewRecord, TerminalSubmission, init_tool_state
@@ -166,7 +168,10 @@ async def test_retry_exhaustion_yields_inconclusive_not_passed(
         initial=AgentResult(success=True, output="done", terminal_submission_received=False),
         resume=resume,
     )
-    assert len(prompts) == MAX_POST_RUN_RETRIES
+    # #470: a resume that leaves the identical issue set made no progress, so
+    # the loop stops instead of replaying the same nudge to exhaustion.
+    assert len(prompts) == 1
+    assert len(prompts) < MAX_POST_RUN_RETRIES
     assert final.terminal_submission_received is False
 
     outcome, reason = _classify(final, mode="Review")
@@ -175,3 +180,43 @@ async def test_retry_exhaustion_yields_inconclusive_not_passed(
     assert outcome is not RunOutcome.failed
     assert reason == _MISSING_VERDICT_REASON
     assert run_succeeded_for_outcome(outcome) is False
+
+
+@pytest.mark.asyncio
+async def test_retry_loop_keeps_going_while_the_issue_set_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#470's early exit is a no-progress guard, not a retry-budget cut.
+
+    A resume that resolves one issue and leaves another still earns the next
+    attempt — only an unchanged issue set ends the loop early.
+    """
+    monkeypatch.setattr("mergecraft.agents.post_run.get_git_status", lambda: "")
+
+    tool_ctx = _tool_ctx(tmp_path)
+    tool_ctx.tool_state.selected_mode = "Review"
+    tool_ctx.tool_state.had_progress_comment = False
+
+    stop_hook_failures = [StopHookFailure(exit_code=2, output="first"), None]
+    prompts: list[str] = []
+
+    async def collect(ctx: AgentRunContext, *, skip_summary_stale: bool = False) -> PostRunIssues:
+        del ctx, skip_summary_stale
+        failure = stop_hook_failures.pop(0) if stop_hook_failures else None
+        return PostRunIssues(stop_hook=failure, unsubmitted_review="Review")
+
+    monkeypatch.setattr("mergecraft.agents.post_run.collect_post_run_issues", collect)
+
+    async def resume(prompt: str) -> AgentResult:
+        prompts.append(prompt)
+        return AgentResult(success=True, output="ack", terminal_submission_received=False)
+
+    await run_post_run_retry_loop(
+        _run_ctx(tool_ctx),
+        initial=AgentResult(success=True, output="done", terminal_submission_received=False),
+        resume=resume,
+    )
+
+    # Attempt 1 (stop hook + unsubmitted) → attempt 2 (unsubmitted only, a
+    # changed set) → attempt 3 collects the same set as attempt 2 and stops.
+    assert len(prompts) == 2

--- a/tests/utils/test_cov_agent_resolve_paths.py
+++ b/tests/utils/test_cov_agent_resolve_paths.py
@@ -697,12 +697,30 @@ def test_vertex_alias_requires_the_pinned_model_id(monkeypatch: MonkeyPatch) -> 
     assert ar.resolve_model(slug="vertex/byok") == "claude-sonnet-4@20250514"
 
 
-def test_resolve_model_env_override_wins_unless_explicitly_ignored(
+def test_resolve_model_explicit_slug_outranks_the_env_override(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """CLI beats ENV, matching ``ConfigLayer`` (issue #468)."""
+    monkeypatch.setenv("MERGECRAFT_MODEL", "acme/private-1")
+    assert ar.resolve_model(slug="acme/other-1") == "acme/other-1"
+    assert ar.resolve_model(slug="acme/other-1", respect_env_override=False) == "acme/other-1"
+
+
+def test_resolve_model_falls_back_to_the_env_override_without_a_slug(
     monkeypatch: MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("MERGECRAFT_MODEL", "acme/private-1")
-    assert ar.resolve_model(slug="openai/gpt") == "acme/private-1"
-    assert ar.resolve_model(slug="acme/other-1", respect_env_override=False) == "acme/other-1"
+    assert ar.resolve_model() == "acme/private-1"
+    assert ar.resolve_model(slug="  ") == "acme/private-1"
+    assert ar.resolve_model(respect_env_override=False) is None
+
+
+def test_resolve_model_reports_an_unknown_explicit_slug_instead_of_using_env(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An explicit request is never silently swapped for the env value."""
+    monkeypatch.setenv("MERGECRAFT_MODEL", "acme/private-1")
+    assert ar.resolve_model(slug="gpt-4o-latest") is None
 
 
 def test_resolve_model_passes_through_a_raw_specifier_but_drops_a_bare_name() -> None:


### PR DESCRIPTION
## What?

Two review-blocking defects, both of which let a run finish while quietly doing something other than what was asked.

- An explicit `--model` is honoured. It previously lost to `MERGECRAFT_MODEL` with no line reporting the flag was dropped, so a review ran on a model nobody asked for. The named model now also heads the subagent chains, so it reaches the whole run.
- An offline review reaches a terminal verdict. Runs started from `--base`/`--head`, `--diff` or `--cwd` could never record one, so findings were produced and then thrown away.

## Why?

Asking for a model and silently getting another one costs a full review: 10 to 25 minutes, real money on a metered provider, and no signal until someone reads the chain line and recognises it as wrong. The precedence was also backwards from what the repo documents in `ConfigLayer` and from what the flag's own help text promises, and `config explain model` reported an order the code did not implement.

Offline reviews were worse: 135 analyzer findings, 155 in the packet, and no verdict for any of it. Terminal scope was only ever established by `checkout_pr`, which an offline run has no PR for. The agent tried anyway, guessed a PR number, hit a dirty tree, reached for `git stash`, and was refused by the read-only allowlist. The packet still recorded a verdict from the trajectory auditor, so the run looked decided while the review's own verdict was never taken.

## Note

Two existing tests pinned the old behaviour and were updated rather than deleted: one asserted that the env override wins over an explicit slug, and one asserted the post-run loop always spends all three retries. The retry loop now stops early when a resume leaves the identical issue set, which is a no-progress guard, not a smaller retry budget.

Out of scope, deliberately: #469 (`get_pull_request` failing on an empty bearer token offline) and the question of whether GitHub tools should be exposed at all when there is no PR and no token.

## Test plan

- `make ci-static`, `make security`, `make test` on a clean tree, all green
- Drove a real offline review over the live MCP server before and after: the reported rejection reproduces before, `recorded: true` after
- `mergecraft config explain model` with a flag, an env var and a config file set, confirming `cli` wins and each layer reports itself

## Related PR(s)/Issue(s)

Closes #468
Closes #470
