### PR TITLE
findings/cli: short IDs, hunk output, durable reviews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 #     `.github/workflows/mergecraft.yml`); this file is only the local mirror.
 #
 # === Reviewer cascade (matches .github/workflows/mergecraft.yml) ===
-#   - NOUS_API_KEY              — primary (DeepSeek V4 Flash via Nous Portal)
+#   - NOUS_API_KEY              — primary (Tencent HY3 via Nous Portal, nous/tencent/hy3)
 #   - CODEX_AUTH_JSON / OPENAI_API_KEY — fallback when NOUS_API_KEY is absent
 #     or the Nous review posts no mergecraft-approval verdict
 #   - ANTHROPIC_API_KEY         — not used by the workflow (the workflow
@@ -31,7 +31,7 @@
 # BYOK; mergeCraft never stores these values.
 # ---------------------------------------------------------------------------
 
-# Nous Portal — primary reviewer in the workflow (DeepSeek V4 Flash).
+# Nous Portal — primary reviewer in the workflow (Tencent HY3, nous/tencent/hy3).
 # Get one at https://portal.nousresearch.com. Locally / in the Action,
 # `NOUS_API_KEY` alone is enough for `nous/…` models (opencode harness).
 # The workflow may still pass MERGECRAFT_CUSTOM_PROVIDER_* on the Nous step.

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -146,6 +146,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Single per-attempt review budget (D8 / #465). Nous + Codex steps and the
+  # review job timeout-minutes derive from this — do not shorten per-attempt for
+  # retry headroom.
+  MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES: "25"
+
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
   # so concurrent reviews do not cancel each other (GitHub Nov 2025 policy).
@@ -293,7 +299,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # > 2× MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES + checkout/setup slack (D8).
+    timeout-minutes: 65
     env:
       IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
       # Nous/DeepSeek primary; Codex fallback when Nous auth is absent or the
@@ -490,7 +497,7 @@ jobs:
         uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
-          timeout: 25m
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
           # Provider prefix `nous/` selects the opencode harness and names the
           # provider registered from the MERGECRAFT_CUSTOM_PROVIDER_* env vars.
           # 2026-08-23: moved off deepseek-v4-flash, which repeatedly failed to
@@ -602,9 +609,9 @@ jobs:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
           # first, the action never posts its `mergecraft` completion check and the
-          # only diagnostic is lost. Leaving 5 min of headroom lets it exit
-          # cleanly and report failure instead.
-          timeout: 25m
+          # only diagnostic is lost. Job timeout-minutes is composed from the same
+          # per-attempt budget (D8) so both attempts can finish before the ceiling.
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
           model: openai/gpt-codex
           push: disabled
           shell: disabled

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -20,7 +20,7 @@
 # `needs:` the review-attempts job so Codex fallback can finish before the gate
 # samples check-runs (#433).
 #
-# Provider priority: DeepSeek V4 Flash via the Nous Portal is primary; OpenAI
+# Provider priority: Tencent HY3 via the Nous Portal is primary; OpenAI
 # (Codex) is the one-shot fallback when Nous is absent or its review posts no
 # verdict. Claude is not used.
 #
@@ -33,11 +33,10 @@
 # the rest of the session. Fixed upstream in alexhawat/mergeCraft#78 (the
 # endpoint now returns 202 with no body for notification-only POSTs).
 #
-# DeepSeek V4 Flash runs through the Nous Portal OpenAI-compatible endpoint — the
-# same model sevn.bot's own runtime uses (DEFAULT_NOUS_INFERENCE_BASE_URL /
-# NOUS_PORTAL_DEEPSEEK_V4_FLASH_MODEL_ID in src/sevn/config/defaults.py). It
-# reaches mergeCraft's `opencode` harness, not the Codex one: mergeCraft routes
-# any model whose provider isn't anthropic/openai/google/cursor to opencode
+# Tencent HY3 (`nous/tencent/hy3`) runs through the Nous Portal OpenAI-compatible
+# endpoint via MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + NOUS_API_KEY. It reaches
+# mergeCraft's `opencode` harness, not the Codex one: mergeCraft routes any model
+# whose provider isn't anthropic/openai/google/cursor to opencode
 # (src/mergecraft/utils/agent_resolve.py resolve_runtime_agent()), and the Codex
 # harness cannot stand in because Codex 0.146 dropped `wire_api = "chat"`
 # ("no longer supported; set wire_api = \"responses\"") while Nous Portal serves
@@ -45,14 +44,14 @@
 # alexhawat/mergeCraft#79 (closes #57 and #71): the image now installs
 # `opencode-ai`, and the harness registers a custom OpenAI-compatible provider
 # from MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + MERGECRAFT_CUSTOM_PROVIDER_API_KEY.
-# The provider id comes from the model prefix, so `nous/deepseek/deepseek-v4-flash`
-# registers provider `nous` serving `deepseek/deepseek-v4-flash`.
+# The provider id comes from the model prefix, so `nous/tencent/hy3` registers
+# provider `nous` serving `tencent/hy3`.
 #
 # mergeCraft reads the native GITHUB_EVENT_PATH, so the workflow just passes a
 # prompt — no ~mergecraft JSON payload needed.
 #
 # Auth (same-repo only — forks skip):
-# - NOUS_API_KEY — Nous Portal API key — primary (DeepSeek V4 Flash)
+# - NOUS_API_KEY — Nous Portal API key — primary (Tencent HY3 via nous/tencent/hy3)
 # - CODEX_AUTH_JSON — ChatGPT/Codex subscription (`mergecraft auth codex`) — fallback
 # - OPENAI_API_KEY — OpenAI API key (same Codex harness as CODEX_AUTH_JSON)
 # The job skips gracefully when none are set (e.g. fork PRs). Without

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN cd /opt/agent-clis \
 
 WORKDIR /opt/mergecraft
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md hatch_build.py ./
 COPY src/mergecraft ./src/mergecraft
 
 RUN uv sync --frozen --no-dev \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,6 +102,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire unwire-workflow` | Remove Logfire tracing wiring from the consumer workflow. |
 | `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow. |
+| `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |
 | `mergecraft xrepo explain` | Explain a cross-repo finding, or report producer/consumer contract breakage. |

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -211,6 +211,7 @@ recommended-model column here.
 | `bedrock/byok` | `bedrock` | — |
 | `vertex/byok` | `vertex` | — |
 | `nous/deepseek/deepseek-v4-flash` | `nous` | preferred |
+| `nous/tencent/hy3` | `nous` | preferred |
 | `tokenhub/hy3` | `tokenhub` | preferred |
 | `tokenhub/deepseek-v4-flash` | `tokenhub` | — |
 | `tokenhub/deepseek-v4-pro` | `tokenhub` | — |

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -269,6 +269,48 @@ CLI (`src/mergecraft/cli/app.py`):
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CF | all tests in `tests/cli/test_update_version_cmd.py` |
+| CF | ✅ reconciled 2026-08-24 — 13/13 CF cases pass without `--runxfail` |
+
+## CG #465 — review timeout budget composition → CG RED
+
+Source: D8, issue #465. One declared per-attempt budget; job
+``timeout-minutes`` must exceed the sum of sequential review attempts plus
+checkout/setup slack. Do **not** shorten per-attempt timeouts to make room for
+Codex fallback — retries do not accumulate progress.
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Single declared attempt budget env | `tests/ci/test_mergecraft_workflow_timeout_budget.py::test_workflow_declares_single_review_attempt_timeout_budget` | unit |
+| Nous + Codex steps derive ``with.timeout`` | `…::test_mergecraft_review_steps_reference_declared_attempt_timeout` | integration |
+| Job budget > 2× attempt + slack | `…::test_review_job_timeout_composes_from_attempt_budget` | functional |
+| Full budget per attempt (not shortened) | `…::test_per_attempt_timeout_not_shortened_below_declared_budget` | edge |
+
+### Pinned public contract (implementation wave CG)
+
+Workflow (``.github/workflows/mergecraft.yml`` only — lane C scope):
+
+- ``env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES`` — single declared per-attempt
+  budget (whole minutes)
+- Both ``alexhawat/mergeCraft`` review steps use
+  ``timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m`` (or
+  equivalent env wiring — no independent ``25m`` literals)
+- ``review`` job ``timeout-minutes`` strictly greater than
+  ``2 × attempt + CHECKOUT_AND_SETUP_SLACK`` (10 minutes per
+  ``tests/ci/support_review_timeout_budget.py``)
+
+Helpers under ``tests/ci/support_review_timeout_budget.py`` encode the
+composition rule for pytest; implementation may mirror the same constants in
+workflow comments.
+
+Observability (D8): promote enough agent logs that a 25m stall is diagnosable —
+**out of lane C YAML scope**; tracked separately from these workflow-timeout
+tests.
+
+## xfail reconciliation (CG)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CG | all tests in `tests/ci/test_mergecraft_workflow_timeout_budget.py` |
 
 ## Verification commands
 
@@ -286,7 +328,8 @@ uv run pytest --collect-only -q \
   tests/cli/test_durable_review_by_id_cmd.py \
   tests/evals/test_lens_routing_capability.py \
   tests/evals/test_lens_capability_json.py \
-  tests/cli/test_update_version_cmd.py
+  tests/cli/test_update_version_cmd.py \
+  tests/ci/test_mergecraft_workflow_timeout_budget.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
@@ -298,5 +341,6 @@ uv run pytest -q \
   tests/cli/test_durable_review_by_id_cmd.py \
   tests/evals/test_lens_routing_capability.py \
   tests/evals/test_lens_capability_json.py \
-  tests/cli/test_update_version_cmd.py
+  tests/cli/test_update_version_cmd.py \
+  tests/ci/test_mergecraft_workflow_timeout_budget.py
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -311,6 +311,41 @@ tests.
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CG | all tests in `tests/ci/test_mergecraft_workflow_timeout_budget.py` |
+| CG | ✅ reconciled 2026-08-24 — 4/4 CG cases pass without `--runxfail` |
+
+## CI #487 — init gitignore for audit.jsonl → CI RED
+
+Source: D10, issue #487. Explicit ignore for ``.mergecraft/audit.jsonl`` in the
+``init`` gitignore scaffold so enterprise audit JSONL never appears as untracked
+local state. Lane C owns ``cli/init_cmd.py`` scaffold — not the mergeCraft repo
+``/.mergecraft/*`` negation pattern.
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Explicit gitignore line scaffolded | `tests/cli/test_init_audit_jsonl_gitignore.py::test_init_scaffolds_explicit_audit_jsonl_gitignore_line` | functional |
+| Append when .gitignore preexists | `…::test_init_appends_audit_jsonl_when_gitignore_preexists` | edge |
+| ``git check-ignore`` accepts path | `…::test_audit_jsonl_is_gitignored_after_init` | E2E |
+| Not listed as untracked | `…::test_audit_jsonl_not_listed_as_untracked_after_init` | E2E |
+| No duplicate line on re-init | `…::test_init_does_not_duplicate_audit_jsonl_gitignore_line` | edge |
+| Gitignore line pin | `…::test_support_pins_audit_jsonl_gitignore_line` | unit |
+
+### Pinned public contract (implementation wave CI)
+
+``src/mergecraft/cli/init_cmd.py``:
+
+- ``AUDIT_JSONL_GITIGNORE_LINE`` — ``".mergecraft/audit.jsonl"`` (matches
+  ``mergecraft.enterprise.audit.DEFAULT_AUDIT_REL``)
+- ``init`` creates or updates ``.gitignore`` with that explicit line (append when
+  missing; do not duplicate on ``--force`` re-run)
+
+Helpers under ``tests/cli/support_init_audit_jsonl.py`` encode the path and git
+checks for pytest.
+
+## xfail reconciliation (CI)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CI | all xfail tests in `tests/cli/test_init_audit_jsonl_gitignore.py` except `test_support_pins_audit_jsonl_gitignore_line` |
 
 ## Verification commands
 
@@ -329,7 +364,8 @@ uv run pytest --collect-only -q \
   tests/evals/test_lens_routing_capability.py \
   tests/evals/test_lens_capability_json.py \
   tests/cli/test_update_version_cmd.py \
-  tests/ci/test_mergecraft_workflow_timeout_budget.py
+  tests/ci/test_mergecraft_workflow_timeout_budget.py \
+  tests/cli/test_init_audit_jsonl_gitignore.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
@@ -342,5 +378,6 @@ uv run pytest -q \
   tests/evals/test_lens_routing_capability.py \
   tests/evals/test_lens_capability_json.py \
   tests/cli/test_update_version_cmd.py \
-  tests/ci/test_mergecraft_workflow_timeout_budget.py
+  tests/ci/test_mergecraft_workflow_timeout_budget.py \
+  tests/cli/test_init_audit_jsonl_gitignore.py
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -127,6 +127,58 @@ Declared in `tests/findings/support_round_trip.py::NAMED_FORMAT_HACKS`:
 - `HUNK_FILE_LEVEL_DROP` / `HUNK_FILE_LEVEL_FIRST_CHANGED_LINE`
 - `SARIF_SEVERITY_TO_LEVEL` / `SARIF_FILE_LEVEL_NO_REGION`
 
+## CD #453 — durable completed review by id → CD RED
+
+Source: D4, issue #453. No `mergecraft/renderers/` package. No `mergecraft session *`.
+Durable review composes `ReviewSnapshot` + run manifest + findings + evidence packets;
+existing `explain` / `findings` / `replay` resolve by stored review id without re-running.
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Persist stable review id | `tests/review/test_durable_review_completed.py::test_persist_completed_review_writes_stable_review_id` | unit |
+| D4 composition on disk (snapshot + manifest + findings) | `…::test_persist_stores_snapshot_manifest_and_findings` | integration |
+| Unknown review id is a miss | `…::test_load_returns_none_for_unknown_review_id` | error |
+| Corrupt stored record is a miss | `…::test_load_returns_none_for_corrupt_completed_record` | error |
+| List stored review ids | `…::test_list_completed_review_ids_returns_persisted_ids` | functional |
+| Storage under `.mergecraft/reviews/<id>` | `…::test_completed_review_dir_lives_under_mergecraft_reviews` | unit |
+| `CompletedReview` model round-trip | `…::test_completed_review_model_round_trips_required_fields` | unit |
+| Review persists id on success | `tests/cli/test_durable_review_by_id_cmd.py::test_review_persists_completed_review_id_on_success` | E2E |
+| `findings <review-id>` without rerun | `…::test_findings_by_review_id_returns_stored_findings_without_rerun` | E2E |
+| `explain <review-id> MC-…` resolves packet | `…::test_explain_with_review_id_and_short_finding_id_resolves_packet` | E2E |
+| `explain MC-… --review-id` resolves packet | `…::test_explain_short_id_with_review_context_flag_resolves_packet` | E2E |
+| `replay <review-id>` from stored traces | `…::test_replay_by_review_id_uses_stored_artifacts_without_rerun` | E2E |
+| Unknown review id fail-closed | `…::test_unknown_review_id_is_fail_closed_for_findings` | E2E / error |
+| Lookup never invokes review agent | `…::test_findings_lookup_does_not_invoke_review_agent` | functional |
+
+### Pinned public API (implementation wave CD)
+
+New module `src/mergecraft/review/completed.py`:
+
+- `COMPLETED_REVIEW_SCHEMA_VERSION` — `"1.0.0"`
+- `CompletedReview` — frozen record with `review_id`, `snapshot`, `manifest`, `findings`, `trace_session_id`
+- `completed_review_dir(review_id, *, repo_root) -> Path`
+- `persist_completed_review(review, *, repo_root, evidence_packets=None, trace_events=None) -> Path`
+- `load_completed_review(review_id, *, repo_root) -> CompletedReview | None`
+- `list_completed_review_ids(*, repo_root) -> list[str]`
+
+On-disk layout under `<repo>/.mergecraft/reviews/<review_id>/`:
+
+- `snapshot.json`, `manifest.json`, `findings.json`, `completed.json`
+- evidence packets + `trace.jsonl` co-located for `explain` / `replay`
+
+CLI extensions (compose existing verbs — no `session` namespace):
+
+- `mergecraft review` JSON output includes `review_id` and persists on success
+- `mergecraft findings <review-id> [--repo-root PATH]`
+- `mergecraft explain <review-id> <MC-…>` and `mergecraft explain <MC-…> --review-id <id>`
+- `mergecraft replay <review-id> [--repo-root PATH]`
+
+## xfail reconciliation (CD)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CD | all tests in `tests/review/test_durable_review_completed.py`, `tests/cli/test_durable_review_by_id_cmd.py` |
+
 ## Verification commands
 
 ```bash
@@ -138,12 +190,16 @@ uv run pytest --collect-only -q \
   tests/cli/test_explain_short_id_cmd.py \
   tests/findings/test_hunk_export.py \
   tests/cli/test_diff_review_hunk_output.py \
-  tests/findings/test_finding_output_round_trip.py
+  tests/findings/test_finding_output_round_trip.py \
+  tests/review/test_durable_review_completed.py \
+  tests/cli/test_durable_review_by_id_cmd.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
   tests/cli/test_explain_short_id_cmd.py \
   tests/findings/test_hunk_export.py \
   tests/cli/test_diff_review_hunk_output.py \
-  tests/findings/test_finding_output_round_trip.py
+  tests/findings/test_finding_output_round_trip.py \
+  tests/review/test_durable_review_completed.py \
+  tests/cli/test_durable_review_by_id_cmd.py
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -178,6 +178,44 @@ CLI extensions (compose existing verbs — no `session` namespace):
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CD | all tests in `tests/review/test_durable_review_completed.py`, `tests/cli/test_durable_review_by_id_cmd.py` |
+| CD | ✅ reconciled 2026-08-24 — 14/14 CD cases pass without `--runxfail` |
+
+## CE #455 — per-lens routing capability numbers → CE RED
+
+Source: D6, issue #455. Additive eval metrics only — do not rebuild the eval
+harness. Output must be diffable across commits (sorted JSON + content digest).
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Per-lens TP/FP/FN → precision/recall | `tests/evals/test_lens_routing_capability.py::test_score_lens_routing_reports_per_lens_precision_and_recall` | unit |
+| Macro averages over participating lenses | `…::test_score_lens_routing_macro_averages_participating_lenses_only` | unit |
+| Expected-but-never-selected → recall only | `…::test_lens_never_selected_has_no_precision_but_can_have_recall` | edge |
+| Spurious selection → precision only | `…::test_lens_selected_but_never_expected_has_no_recall` | edge |
+| Empty corpus honest-zero macros | `…::test_empty_corpus_yields_honest_zero_macro_metrics` | edge |
+| Mismatched case ids rejected | `…::test_score_lens_routing_rejects_mismatched_case_ids` | error |
+| Schema version pinned | `…::test_lens_routing_capability_report_pins_schema_version` | unit |
+| Canonical sorted JSON | `tests/evals/test_lens_capability_json.py::test_render_lens_capability_json_is_canonical_and_sorted` | functional |
+| Stable content digest | `…::test_lens_capability_digest_is_stable_for_identical_reports` | functional |
+| Digest ignores dict order | `…::test_lens_capability_digest_ignores_dict_insertion_order` | edge |
+
+### Pinned public API (implementation wave CE)
+
+New module `src/mergecraft/evals/lens_capability.py`:
+
+- `LENS_CAPABILITY_SCHEMA_VERSION` — `"1.0.0"`
+- `LensRoutingCaseLabel` — `case_id`, `expected_lens_ids`
+- `LensRoutingCaseOutcome` — `case_id`, `selected_lens_ids`
+- `PerLensRoutingMetrics` — `lens_id`, `precision`, `recall`, `true_positives`, `false_positives`, `false_negatives`
+- `LensRoutingCapabilityReport` — `schema_version`, `cases`, `by_lens`, `macro_precision`, `macro_recall`, `macro_f1`
+- `score_lens_routing(labels, outcomes) -> LensRoutingCapabilityReport`
+- `render_lens_capability_json(report) -> str` — compact JSON, `sort_keys=True`
+- `lens_capability_digest(report) -> str` — SHA-256 over canonical JSON
+
+## xfail reconciliation (CE)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CE | all tests in `tests/evals/test_lens_routing_capability.py`, `tests/evals/test_lens_capability_json.py` |
 
 ## Verification commands
 
@@ -192,7 +230,9 @@ uv run pytest --collect-only -q \
   tests/cli/test_diff_review_hunk_output.py \
   tests/findings/test_finding_output_round_trip.py \
   tests/review/test_durable_review_completed.py \
-  tests/cli/test_durable_review_by_id_cmd.py
+  tests/cli/test_durable_review_by_id_cmd.py \
+  tests/evals/test_lens_routing_capability.py \
+  tests/evals/test_lens_capability_json.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
@@ -201,5 +241,7 @@ uv run pytest -q \
   tests/cli/test_diff_review_hunk_output.py \
   tests/findings/test_finding_output_round_trip.py \
   tests/review/test_durable_review_completed.py \
-  tests/cli/test_durable_review_by_id_cmd.py
+  tests/cli/test_durable_review_by_id_cmd.py \
+  tests/evals/test_lens_routing_capability.py \
+  tests/evals/test_lens_capability_json.py
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -41,6 +41,51 @@ All symbols expected in `src/mergecraft/analyzers/finding.py`:
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CA | all tests in `tests/analyzers/test_finding_short_id.py`, `tests/findings/test_finding_short_id_outputs.py`, `tests/cli/test_explain_short_id_cmd.py` except `test_explain_unknown_short_id_is_an_error` |
+| CA | ✅ reconciled 2026-08-24 — all 16 collected CA cases pass without `--runxfail` |
+
+## CB #451 — Hunk exporter → CB RED
+
+Source: D3, issue #451, `.ignorelocal/waves/hunk-spike-451-notes.md`.
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Payload envelope `{"comments":[...]}` | `tests/findings/test_hunk_export.py::test_export_hunk_comments_returns_comments_envelope` | unit |
+| Field map (`filePath`, `newLine`, `summary`, `rationale`, `author`) | `…::test_export_hunk_comment_maps_finding_fields_to_golden_shape` | unit |
+| Never `hunkNumber` / `hunk` / `oldLine` fallback | `…::test_export_hunk_comment_never_emits_hunk_number_fallback` | unit / error |
+| Default drop file-level (`start_line is None`) | `…::test_export_hunk_drops_file_level_findings_by_default` | unit |
+| Opt-in `first-changed-line` + `[file-level]` prefix | `…::test_export_hunk_first_changed_line_maps_file_level_with_prefix` | unit / edge |
+| Empty findings → `{"comments":[]}` | `…::test_export_hunk_empty_findings_returns_empty_comments` | edge |
+| Author constant `mergeCraft` | `…::test_export_hunk_author_constant_is_mergecraft` | unit |
+| Invalid `file_findings` rejected | `…::test_export_hunk_rejects_invalid_file_findings_mode` | error |
+| Dropped count helper | `…::test_export_hunk_dropped_file_level_count_helper` | unit |
+| Counted warning message copy | `…::test_export_hunk_file_level_warning_message_is_counted` | unit |
+| Stdout-only JSON for piping | `tests/cli/test_diff_review_hunk_output.py::test_hunk_output_format_writes_json_to_stdout` | E2E |
+| No `--output` required | `…::test_hunk_output_format_does_not_require_output_path` | E2E |
+| Dropped file-level warning on stderr | `…::test_hunk_output_format_warns_about_dropped_file_level_on_stderr` | E2E |
+| Structured findings wired (`json_path`) | `…::test_hunk_output_format_requests_structured_findings_from_run_offline` | integration |
+| `--hunk-file-findings first-changed-line` | `…::test_hunk_file_findings_first_changed_line_flag` | E2E |
+| Help documents `hunk` format | `…::test_review_help_lists_hunk_output_format` | functional |
+
+### Pinned public API (implementation wave CB)
+
+New module `src/mergecraft/findings/hunk_export.py`:
+
+- `HUNK_COMMENT_AUTHOR` — `"mergeCraft"`
+- `export_hunk_comments(findings, *, file_findings="drop", first_changed_lines=None) -> dict[str, Any]`
+- `count_dropped_file_level_findings(findings) -> int`
+- `format_file_level_drop_warning(count: int) -> str`
+
+CLI (`src/mergecraft/cli/diff_review_cmd.py`):
+
+- Extend `OutputFormat` with `"hunk"`
+- `--hunk-file-findings {drop,first-changed-line}` (default `drop`)
+- Hunk branch writes JSON to **stdout**; dropped-file-level warnings on **stderr**
+
+## xfail reconciliation (CB)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CB | all tests in `tests/findings/test_hunk_export.py`, `tests/cli/test_diff_review_hunk_output.py` |
 
 ## Verification commands
 
@@ -50,10 +95,12 @@ make typecheck
 uv run pytest --collect-only -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
-  tests/cli/test_explain_short_id_cmd.py
+  tests/cli/test_explain_short_id_cmd.py \
+  tests/findings/test_hunk_export.py \
+  tests/cli/test_diff_review_hunk_output.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
   tests/cli/test_explain_short_id_cmd.py
-# expect XFAIL until CA implementation lands
+# CA passes; CB cases remain XFAIL until implementation lands
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -1,0 +1,59 @@
+# Open issues sweep 2026-08-24 lane C — CA #452 test plan
+
+Maps **CA RED** contracts for #452 (stable short finding id) to the test suite.
+Source plan: `.ignorelocal/waves/open-issues-sweep-2026-08-24-c-findings-cli-wave-plan.md`.
+
+## D2 — short id derived from fingerprint → CA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Prefix is `MC-` | `tests/analyzers/test_finding_short_id.py::test_finding_short_id_prefix_is_mc` | unit |
+| Same fingerprint → same short id | `…::test_finding_short_id_is_deterministic_for_same_fingerprint` | unit |
+| Default truncation matches issue example (`MC-a83f91`) | `…::test_finding_short_id_uses_fingerprint_prefix` | unit |
+| Different fingerprints → different ids | `…::test_finding_short_id_differs_for_different_fingerprints` | unit |
+| Unsafe fingerprint rejected | `…::test_finding_short_id_rejects_unsafe_fingerprint[*]` | unit / error |
+| Truncation collision disambiguated in batch | `…::test_resolve_finding_short_ids_disambiguates_truncation_collisions` | unit |
+| Collision resolution is stable | `…::test_resolve_finding_short_ids_is_stable_for_repeated_calls` | unit |
+| Markdown output includes short id | `tests/findings/test_finding_short_id_outputs.py::test_render_finding_markdown_includes_short_id` | integration |
+| JSON record includes short id | `…::test_finding_json_record_includes_short_id_field` | integration |
+| Agent JSONL record includes short id | `…::test_finding_agent_jsonl_record_includes_short_id_field` | integration |
+| PR comment body includes short id | `…::test_render_finding_pr_comment_includes_short_id` | integration |
+| Same `MC-…` across all surfaces | `…::test_all_output_surfaces_share_the_same_short_id` | functional |
+| `mergecraft explain MC-…` resolves packet | `tests/cli/test_explain_short_id_cmd.py::test_explain_accepts_short_finding_id` | E2E |
+| Unknown short id is an error | `…::test_explain_unknown_short_id_is_an_error` (no xfail — already fail-closed) | E2E / error |
+
+## Pinned public API (implementation wave CA)
+
+All symbols expected in `src/mergecraft/analyzers/finding.py`:
+
+- `FINDING_SHORT_ID_PREFIX` — `"MC-"`
+- `finding_short_id(fingerprint: str) -> str`
+- `resolve_finding_short_ids(fingerprints: Sequence[str]) -> dict[str, str]`
+- `render_finding_markdown(finding, *, short_id: str) -> str`
+- `finding_json_record(finding, *, short_id: str) -> dict[str, Any]`
+- `finding_agent_jsonl_record(finding, *, short_id: str) -> dict[str, Any]`
+- `render_finding_pr_comment(finding, *, short_id: str) -> str`
+
+`lookup_finding_packet` / `mergecraft explain` must accept the short id form.
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CA | all tests in `tests/analyzers/test_finding_short_id.py`, `tests/findings/test_finding_short_id_outputs.py`, `tests/cli/test_explain_short_id_cmd.py` except `test_explain_unknown_short_id_is_an_error` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q \
+  tests/analyzers/test_finding_short_id.py \
+  tests/findings/test_finding_short_id_outputs.py \
+  tests/cli/test_explain_short_id_cmd.py
+uv run pytest -q \
+  tests/analyzers/test_finding_short_id.py \
+  tests/findings/test_finding_short_id_outputs.py \
+  tests/cli/test_explain_short_id_cmd.py
+# expect XFAIL until CA implementation lands
+```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -216,6 +216,59 @@ New module `src/mergecraft/evals/lens_capability.py`:
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CE | all tests in `tests/evals/test_lens_routing_capability.py`, `tests/evals/test_lens_capability_json.py` |
+| CE | ✅ reconciled 2026-08-24 — 10/10 CE cases pass without `--runxfail` |
+
+## CF #473 — `mergecraft update` + commit in `--version` → CF RED
+
+Source: D7, issue #473. ``update`` shells to ``uv tool install --reinstall``;
+default ref ``main``; ``--branch`` accepts branch/tag/SHA. Version text shows
+``0.1.0a1 (abc1234)`` when commit known; omit parens when unknown. JSON ``commit``
+field is additive on ``version --format json``.
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| ``update --help`` documents uv reinstall | `tests/cli/test_update_version_cmd.py::test_update_help_documents_uv_reinstall` | functional |
+| Default update uses ``main`` ref | `…::test_update_default_shells_to_uv_tool_install_on_main` | E2E |
+| ``--branch`` accepts branch/tag/SHA | `…::test_update_branch_option_accepts_branch_tag_or_sha[*]` | E2E / edge |
+| Version helper with known commit | `…::test_format_version_display_includes_short_commit_when_known` | unit |
+| Version helper without commit | `…::test_format_version_display_omits_paren_commit_when_unknown` | unit |
+| ``--version`` with commit | `…::test_version_flag_includes_commit_when_known` | E2E |
+| ``version`` with commit | `…::test_version_command_includes_commit_when_known` | E2E |
+| ``--version`` without commit parens | `…::test_version_flag_omits_paren_commit_when_unknown` | edge |
+| JSON ``commit`` field additive | `…::test_version_json_includes_additive_commit_field` | functional |
+| JSON ``commit`` null when unknown | `…::test_version_json_commit_null_when_unknown` | edge |
+| ``uv`` failure propagates | `…::test_update_run_uses_check_true` | error |
+
+### Pinned public API (implementation wave CF)
+
+New module `src/mergecraft/cli/update_cmd.py`:
+
+- `DEFAULT_UPDATE_REF` — `"main"`
+- `MERGECRAFT_GIT_ORIGIN` — `"https://github.com/alexhawat/mergeCraft"`
+- `build_uv_install_argv(ref: str) -> list[str]` — argv for ``uv tool install --reinstall …``
+- `run(*, branch: str | None = None) -> None` — Typer command entry
+
+`src/mergecraft/__init__.py`:
+
+- `__commit__` — optional full build commit SHA (``None`` when unknown)
+
+Version helpers (module TBD — likely `mergecraft.version` or `cli/app.py`):
+
+- `format_version_display(version: str, commit: str | None) -> str`
+- `version_json_payload(version: str, commit: str | None) -> dict[str, Any]` — includes
+  ``schema_version``, ``version``, additive ``commit`` (short SHA or ``None``)
+
+CLI (`src/mergecraft/cli/app.py`):
+
+- `app.add_typer(update_cmd.app, name="update")` or `app.command("update")`
+- Root ``--version`` and ``version`` use ``format_version_display``
+- ``version --format json`` emits ``version_json_payload``
+
+## xfail reconciliation (CF)
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| CF | all tests in `tests/cli/test_update_version_cmd.py` |
 
 ## Verification commands
 
@@ -232,7 +285,8 @@ uv run pytest --collect-only -q \
   tests/review/test_durable_review_completed.py \
   tests/cli/test_durable_review_by_id_cmd.py \
   tests/evals/test_lens_routing_capability.py \
-  tests/evals/test_lens_capability_json.py
+  tests/evals/test_lens_capability_json.py \
+  tests/cli/test_update_version_cmd.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
@@ -243,5 +297,6 @@ uv run pytest -q \
   tests/review/test_durable_review_completed.py \
   tests/cli/test_durable_review_by_id_cmd.py \
   tests/evals/test_lens_routing_capability.py \
-  tests/evals/test_lens_capability_json.py
+  tests/evals/test_lens_capability_json.py \
+  tests/cli/test_update_version_cmd.py
 ```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-c-findings-cli.md
@@ -86,6 +86,46 @@ CLI (`src/mergecraft/cli/diff_review_cmd.py`):
 | Wave greens | Remove xfail from |
 | --- | --- |
 | CB | all tests in `tests/findings/test_hunk_export.py`, `tests/cli/test_diff_review_hunk_output.py` |
+| CB | ✅ reconciled 2026-08-24 — fixed duplicate-kwarg helpers in `tests/cli/test_diff_review_hunk_output.py`; 16/16 CB cases pass without `--runxfail` |
+
+## CC #454 — Finding round-trip conformance → CC
+
+Source: D5, issue #454 (after #451).
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| JSON record round-trips every corpus case | `tests/findings/test_finding_output_round_trip.py::test_json_record_round_trips_finding` | integration |
+| Agent JSONL matches JSON projection | `…::test_agent_jsonl_record_matches_json_record` | integration |
+| Markdown preserves core semantics | `…::test_markdown_render_preserves_core_semantics` | integration |
+| PR comment preserves core semantics | `…::test_pr_comment_render_preserves_core_semantics` | integration |
+| SARIF preserves message/rule/path/region | `…::test_sarif_export_preserves_core_semantics` | integration |
+| Hunk default drop for file-level | `…::test_hunk_default_export_respects_file_level_drop` | unit / edge |
+| Hunk first-changed-line named hack | `…::test_hunk_first_changed_line_exports_file_level_with_named_hack` | unit |
+| Hunk never invents location fallbacks | `…::test_hunk_export_never_invents_location_fallbacks` | unit / error |
+| Named hacks documented (D5) | `…::test_named_format_hacks_are_documented` | functional |
+| Same short id across all surfaces | `…::test_all_formats_share_short_id_for_one_finding` | functional |
+| JSON restore rejects `short_id` field | `…::test_json_round_trip_rejects_export_only_fields_on_restore` | error |
+
+### Corpus (`tests/findings/support_round_trip.py`)
+
+| Case id | Exercises |
+| --- | --- |
+| `line_anchored_minimal` | baseline line-anchored finding |
+| `file_level` | `start_line is None` |
+| `multi_line_range` | `start_line != end_line` with evidence |
+| `empty_evidence` | `evidence=[]` |
+| `no_remediation` | `remediation is None` |
+| `full_metadata` | optional fields populated |
+| `unicode_message` | non-ASCII path and message |
+
+### Named format hacks (D5)
+
+Declared in `tests/findings/support_round_trip.py::NAMED_FORMAT_HACKS`:
+
+- `JSON_ADDS_SHORT_ID` / `AGENT_JSONL_ADDS_SHORT_ID`
+- `MARKDOWN_ONE_WAY_RENDER` / `PR_COMMENT_ONE_WAY_RENDER`
+- `HUNK_FILE_LEVEL_DROP` / `HUNK_FILE_LEVEL_FIRST_CHANGED_LINE`
+- `SARIF_SEVERITY_TO_LEVEL` / `SARIF_FILE_LEVEL_NO_REGION`
 
 ## Verification commands
 
@@ -97,10 +137,13 @@ uv run pytest --collect-only -q \
   tests/findings/test_finding_short_id_outputs.py \
   tests/cli/test_explain_short_id_cmd.py \
   tests/findings/test_hunk_export.py \
-  tests/cli/test_diff_review_hunk_output.py
+  tests/cli/test_diff_review_hunk_output.py \
+  tests/findings/test_finding_output_round_trip.py
 uv run pytest -q \
   tests/analyzers/test_finding_short_id.py \
   tests/findings/test_finding_short_id_outputs.py \
-  tests/cli/test_explain_short_id_cmd.py
-# CA passes; CB cases remain XFAIL until implementation lands
+  tests/cli/test_explain_short_id_cmd.py \
+  tests/findings/test_hunk_export.py \
+  tests/cli/test_diff_review_hunk_output.py \
+  tests/findings/test_finding_output_round_trip.py
 ```

--- a/examples/workflows/mergecraft.yml
+++ b/examples/workflows/mergecraft.yml
@@ -63,6 +63,6 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/deepseek/deepseek-v4-flash
+          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/tencent/hy3
           # TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}   # + model: tokenhub/hy3
           # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}       # + model: google/gemini-*

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,56 @@
+"""Hatch build hook — stamp git HEAD into ``_build_metadata.py`` for wheels/sdists."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+_METADATA_TEMPLATE = '''"""Build-time metadata for installed distributions.
+
+The hatch ``build-commit`` hook overwrites this file in wheel/sdist artifacts
+only; the source tree keeps ``None`` until a build stamps the git SHA.
+"""
+
+from __future__ import annotations
+
+__commit__: str | None = {commit!r}
+'''
+
+
+class BuildCommitHook(BuildHookInterface):
+    """Stamp ``mergecraft._build_metadata.__commit__`` from ``git rev-parse HEAD``."""
+
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        commit = self._git_head_commit()
+        if commit is None:
+            return
+
+        out_dir = Path(self.directory) / "stamped_build_metadata"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / "_build_metadata.py"
+        out_path.write_text(_METADATA_TEMPLATE.format(commit=commit), encoding="utf-8")
+
+        force_include = build_data.setdefault("force_include", {})
+        if self.target_name == "sdist":
+            dest = "src/mergecraft/_build_metadata.py"
+        else:
+            dest = "mergecraft/_build_metadata.py"
+        force_include[str(out_path)] = dest
+
+    def _git_head_commit(self) -> str | None:
+        try:
+            output = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                cwd=self.root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        commit = output.strip()
+        return commit or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ artifacts = [
     "src/mergecraft/skills/**/*.md",
     "src/mergecraft/policy/packs/**/*.yaml",
     "src/mergecraft/evals/cases/**/*.json",
+    "src/mergecraft/evals/fixtures/**/*.json",
     "src/mergecraft/data/**/*.yaml",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
 [project]
 name = "merge-craft"
 version = "0.1.0a1"
@@ -90,7 +93,7 @@ artifacts = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/mergecraft", "tests", "README.md", "pyproject.toml"]
+include = ["src/mergecraft", "tests", "README.md", "pyproject.toml", "hatch_build.py"]
 
 [tool.ruff]
 target-version = "py311"

--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -32,6 +32,9 @@ git worktree add "$worktree" "$base_ref"
   # `make coverage-gate` died with "Failed to spawn: pytest" before measuring
   # anything. Sync the extra explicitly.
   "${UV:-uv}" sync --extra dev
+  # Repo-native analyzer tests (#427) require tools/node_modules/.bin; bootstrap
+  # only runs on the PR checkout, not this detached base worktree.
+  make setup-local-analyzers
   make coverage-gate
   cp coverage.json "${GITHUB_WORKSPACE}/coverage-base.json"
 )

--- a/scripts/example_workflows/minimal.yml.tpl
+++ b/scripts/example_workflows/minimal.yml.tpl
@@ -63,6 +63,6 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/deepseek/deepseek-v4-flash
+          # NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}           # + model: nous/tencent/hy3
           # TOKENHUB_API_KEY: ${{ secrets.TOKENHUB_API_KEY }}   # + model: tokenhub/hy3
           # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}       # + model: google/gemini-*

--- a/src/mergecraft/__init__.py
+++ b/src/mergecraft/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _distribution_version
+from typing import Any
 
 # Read from the installed distribution rather than restating the number here.
 # A literal drifted once already: `pyproject.toml` moved to the alpha while this
@@ -16,4 +17,40 @@ try:
 except PackageNotFoundError:  # pragma: no cover — source tree with nothing installed
     __version__ = "0.0.0+unknown"
 
-__all__ = ["__version__"]
+# Optional full build commit SHA baked in at release time; ``None`` when unknown.
+__commit__: str | None = None
+
+
+def short_commit(commit: str | None) -> str | None:
+    """Return the seven-character short SHA prefix, or ``None`` when unknown."""
+    if commit is None:
+        return None
+    trimmed = commit.strip()
+    if not trimmed:
+        return None
+    return trimmed[:7]
+
+
+def format_version_display(version: str, commit: str | None) -> str:
+    """Render ``<version> (<short-sha>)`` when commit is known; else ``version`` alone."""
+    short = short_commit(commit)
+    if short is None:
+        return version
+    return f"{version} ({short})"
+
+
+def version_json_payload(version: str, commit: str | None) -> dict[str, Any]:
+    """Machine-readable version document (``schema_version`` added by the CLI envelope)."""
+    return {
+        "version": version,
+        "commit": short_commit(commit),
+    }
+
+
+__all__ = [
+    "__commit__",
+    "__version__",
+    "format_version_display",
+    "short_commit",
+    "version_json_payload",
+]

--- a/src/mergecraft/__init__.py
+++ b/src/mergecraft/__init__.py
@@ -16,8 +16,10 @@ try:
 except PackageNotFoundError:  # pragma: no cover — source tree with nothing installed
     __version__ = "0.0.0+unknown"
 
+from mergecraft.build_metadata import resolve_build_commit
+
 # Optional full build commit SHA baked in at release time; ``None`` when unknown.
-__commit__: str | None = None
+__commit__: str | None = resolve_build_commit()
 
 from mergecraft.version_info import (
     format_version_display,

--- a/src/mergecraft/__init__.py
+++ b/src/mergecraft/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _distribution_version
-from typing import Any
 
 # Read from the installed distribution rather than restating the number here.
 # A literal drifted once already: `pyproject.toml` moved to the alpha while this
@@ -20,32 +19,11 @@ except PackageNotFoundError:  # pragma: no cover — source tree with nothing in
 # Optional full build commit SHA baked in at release time; ``None`` when unknown.
 __commit__: str | None = None
 
-
-def short_commit(commit: str | None) -> str | None:
-    """Return the seven-character short SHA prefix, or ``None`` when unknown."""
-    if commit is None:
-        return None
-    trimmed = commit.strip()
-    if not trimmed:
-        return None
-    return trimmed[:7]
-
-
-def format_version_display(version: str, commit: str | None) -> str:
-    """Render ``<version> (<short-sha>)`` when commit is known; else ``version`` alone."""
-    short = short_commit(commit)
-    if short is None:
-        return version
-    return f"{version} ({short})"
-
-
-def version_json_payload(version: str, commit: str | None) -> dict[str, Any]:
-    """Machine-readable version document (``schema_version`` added by the CLI envelope)."""
-    return {
-        "version": version,
-        "commit": short_commit(commit),
-    }
-
+from mergecraft.version_info import (
+    format_version_display,
+    short_commit,
+    version_json_payload,
+)
 
 __all__ = [
     "__commit__",

--- a/src/mergecraft/__init__.py
+++ b/src/mergecraft/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _distribution_version
+from typing import Any
 
 # Read from the installed distribution rather than restating the number here.
 # A literal drifted once already: `pyproject.toml` moved to the alpha while this
@@ -15,11 +16,6 @@ try:
     __version__ = _distribution_version("merge-craft")
 except PackageNotFoundError:  # pragma: no cover — source tree with nothing installed
     __version__ = "0.0.0+unknown"
-
-from mergecraft.build_metadata import resolve_build_commit
-
-# Optional full build commit SHA baked in at release time; ``None`` when unknown.
-__commit__: str | None = resolve_build_commit()
 
 from mergecraft.version_info import (
     format_version_display,
@@ -34,3 +30,13 @@ __all__ = [
     "short_commit",
     "version_json_payload",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy ``__commit__`` — avoid subprocess/git work on ``import mergecraft``."""
+    if name == "__commit__":
+        from mergecraft.build_metadata import resolve_build_commit
+
+        return resolve_build_commit()
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/mergecraft/_build_metadata.py
+++ b/src/mergecraft/_build_metadata.py
@@ -1,0 +1,9 @@
+"""Build-time metadata for installed distributions.
+
+The hatch ``build-commit`` hook overwrites this file in wheel/sdist artifacts
+only; the source tree keeps ``None`` until a build stamps the git SHA.
+"""
+
+from __future__ import annotations
+
+__commit__: str | None = None

--- a/src/mergecraft/analyzers/budget.py
+++ b/src/mergecraft/analyzers/budget.py
@@ -33,6 +33,7 @@ class FindingPlacement:
     mechanical_section: str | None = None
     deferred: list[Finding] = field(default_factory=list)
     deferred_section: str | None = None
+    short_ids: dict[str, str] = field(default_factory=dict)
 
 
 def default_inline_budget() -> int:
@@ -69,6 +70,32 @@ def _sort_key(item: Finding | dict[str, Any]) -> tuple[int, int, str, int]:
     else:
         line = int(item.get("line", item.get("start_line", 0)))
     return (_source_rank(item), _severity_rank(item), path, line)
+
+
+def _fingerprint_from_inline_item(item: Finding | dict[str, Any]) -> str | None:
+    if isinstance(item, Finding):
+        return item.fingerprint
+    supplied = str(item.get("fingerprint", "") or "").strip()
+    if supplied:
+        return supplied
+    path = str(item.get("path", ""))
+    message = str(item.get("message", item.get("body", "")))
+    return _overflow_fingerprint(item, path=path, message=message)
+
+
+def _placement_fingerprints(
+    inline: list[Any],
+    mechanical: list[Finding],
+    deferred: list[Finding],
+) -> list[str]:
+    fingerprints: list[str] = []
+    for item in inline:
+        fingerprint = _fingerprint_from_inline_item(item)
+        if fingerprint:
+            fingerprints.append(fingerprint)
+    fingerprints.extend(row.fingerprint for row in mechanical)
+    fingerprints.extend(row.fingerprint for row in deferred)
+    return fingerprints
 
 
 def _overflow_fingerprint(item: dict[str, Any], *, path: str, message: str) -> str:
@@ -212,18 +239,15 @@ def place_findings(
         elif not _is_body_only_finding(item):
             deferred.append(agent_dict_to_finding(item))
 
+    short_ids = resolve_finding_short_ids(_placement_fingerprints(inline, mechanical, deferred))
+
     return FindingPlacement(
         inline=inline,
         mechanical=mechanical,
-        mechanical_section=_render_mechanical_section(
-            mechanical,
-            short_ids=resolve_finding_short_ids([row.fingerprint for row in mechanical]),
-        ),
+        mechanical_section=_render_mechanical_section(mechanical, short_ids=short_ids),
         deferred=deferred,
-        deferred_section=render_deferred_section(
-            deferred,
-            short_ids=resolve_finding_short_ids([row.fingerprint for row in deferred]),
-        ),
+        deferred_section=render_deferred_section(deferred, short_ids=short_ids),
+        short_ids=short_ids,
     )
 
 
@@ -238,19 +262,33 @@ def finding_to_deferred_row(finding: Finding) -> dict[str, Any]:
     }
 
 
-def render_deferred_section_from_rows(rows: list[dict[str, Any]]) -> str | None:
+def render_deferred_section_from_rows(
+    rows: list[dict[str, Any]],
+    *,
+    short_ids: dict[str, str] | None = None,
+    all_fingerprints: list[str] | None = None,
+) -> str | None:
     """Render the deferred HTML section from serialized analyzer-run rows."""
     findings = [agent_dict_to_finding(row) for row in rows if isinstance(row, dict)]
     if not findings:
         return None
-    short_ids = resolve_finding_short_ids([row.fingerprint for row in findings])
-    return render_deferred_section(findings, short_ids=short_ids)
+    resolved_short_ids = short_ids
+    if resolved_short_ids is None:
+        fingerprint_batch = all_fingerprints or [row.fingerprint for row in findings]
+        resolved_short_ids = resolve_finding_short_ids(fingerprint_batch)
+    return render_deferred_section(findings, short_ids=resolved_short_ids)
 
 
 def sync_deferred_section(analyzer_run: AnalyzerRunState) -> None:
     """Re-render ``deferred_section`` from ``deferred_findings`` rows."""
+    all_fingerprints = [
+        str(row.get("fingerprint", ""))
+        for row in analyzer_run.findings
+        if isinstance(row, dict) and row.get("fingerprint")
+    ]
     analyzer_run.deferred_section = render_deferred_section_from_rows(
-        analyzer_run.deferred_findings
+        analyzer_run.deferred_findings,
+        all_fingerprints=all_fingerprints,
     )
 
 

--- a/src/mergecraft/analyzers/budget.py
+++ b/src/mergecraft/analyzers/budget.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.finding import Finding, resolve_finding_short_ids
 
 if TYPE_CHECKING:
     from mergecraft.mcp.tool_state import AnalyzerRunState
@@ -93,7 +93,11 @@ def _finding_anchor(finding: Finding) -> str:
     return f"{finding.path}:{finding.start_line}"
 
 
-def _render_mechanical_section(mechanical: list[Finding]) -> str | None:
+def _render_mechanical_section(
+    mechanical: list[Finding],
+    *,
+    short_ids: dict[str, str] | None = None,
+) -> str | None:
     if not mechanical:
         return None
     by_tool: dict[str, list[Finding]] = {}
@@ -108,11 +112,19 @@ def _render_mechanical_section(mechanical: list[Finding]) -> str | None:
         lines.append(f"| {tool} | {count} |")
     lines.append("")
     for finding in mechanical:
-        lines.append(f"- **{finding.tool}** `{finding.rule_id}` — {_finding_anchor(finding)}")
+        short_id = short_ids.get(finding.fingerprint) if short_ids else None
+        prefix = f"**{short_id}** " if short_id else ""
+        lines.append(
+            f"- {prefix}**{finding.tool}** `{finding.rule_id}` — {_finding_anchor(finding)}"
+        )
     return "\n".join(lines)
 
 
-def render_deferred_section(deferred: list[Finding]) -> str | None:
+def render_deferred_section(
+    deferred: list[Finding],
+    *,
+    short_ids: dict[str, str] | None = None,
+) -> str | None:
     if not deferred:
         return None
     lines = [
@@ -122,7 +134,11 @@ def render_deferred_section(deferred: list[Finding]) -> str | None:
         "",
     ]
     for finding in deferred:
-        lines.append(f"**{finding.severity}** `{_finding_anchor(finding)}` — {finding.message}")
+        short_id = short_ids.get(finding.fingerprint) if short_ids else None
+        prefix = f"**{short_id}** " if short_id else ""
+        lines.append(
+            f"{prefix}**{finding.severity}** `{_finding_anchor(finding)}` — {finding.message}"
+        )
         lines.append("")
     lines.append("</details>")
     return "\n".join(lines)
@@ -199,9 +215,15 @@ def place_findings(
     return FindingPlacement(
         inline=inline,
         mechanical=mechanical,
-        mechanical_section=_render_mechanical_section(mechanical),
+        mechanical_section=_render_mechanical_section(
+            mechanical,
+            short_ids=resolve_finding_short_ids([row.fingerprint for row in mechanical]),
+        ),
         deferred=deferred,
-        deferred_section=render_deferred_section(deferred),
+        deferred_section=render_deferred_section(
+            deferred,
+            short_ids=resolve_finding_short_ids([row.fingerprint for row in deferred]),
+        ),
     )
 
 

--- a/src/mergecraft/analyzers/budget.py
+++ b/src/mergecraft/analyzers/budget.py
@@ -241,7 +241,10 @@ def finding_to_deferred_row(finding: Finding) -> dict[str, Any]:
 def render_deferred_section_from_rows(rows: list[dict[str, Any]]) -> str | None:
     """Render the deferred HTML section from serialized analyzer-run rows."""
     findings = [agent_dict_to_finding(row) for row in rows if isinstance(row, dict)]
-    return render_deferred_section(findings)
+    if not findings:
+        return None
+    short_ids = resolve_finding_short_ids([row.fingerprint for row in findings])
+    return render_deferred_section(findings, short_ids=short_ids)
 
 
 def sync_deferred_section(analyzer_run: AnalyzerRunState) -> None:

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -1,8 +1,15 @@
-"""Normalized analyzer finding schema (D2)."""
+"""Normalized analyzer finding schema (D2).
+
+Short finding ids (issue #452) use prefix ``MC-`` and the leading hex of
+``Finding.fingerprint``. Single-fingerprint ids truncate to six hex chars
+(``MC-a83f91``). ``resolve_finding_short_ids`` extends truncation within a
+batch when two fingerprints would otherwise share the same six-char prefix.
+"""
 
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
@@ -16,11 +23,16 @@ from mergecraft.review_taxonomy import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 STRUCTURED_OUTPUT_REQUIRED_MSG = (
     "output_schema was provided but agent did not call set_output — structured output is required"
 )
+
+FINDING_SHORT_ID_PREFIX = "MC-"
+_FINDING_SHORT_ID_DEFAULT_HEX_LEN = 6
+_FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
 
 IntroducedByPr = Literal["true", "false", "unknown"]
 
@@ -180,14 +192,110 @@ def write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None
     json_path.write_text(f"{payload}\n", encoding="utf-8")
 
 
+def _validate_fingerprint_for_short_id(fingerprint: str) -> str:
+    """Reject empty, traversal, and other unsafe fingerprint values."""
+    if not isinstance(fingerprint, str):
+        msg = "fingerprint must be a string"
+        raise TypeError(msg)
+    if not fingerprint or fingerprint in {".", ".."}:
+        msg = f"unsafe fingerprint value: {fingerprint!r}"
+        raise ValueError(msg)
+    if "/" in fingerprint or "\\" in fingerprint:
+        msg = f"unsafe fingerprint value: {fingerprint!r}"
+        raise ValueError(msg)
+    if len(fingerprint) < _FINDING_SHORT_ID_DEFAULT_HEX_LEN:
+        msg = (
+            f"fingerprint must be at least {_FINDING_SHORT_ID_DEFAULT_HEX_LEN} "
+            f"characters, got {len(fingerprint)}"
+        )
+        raise ValueError(msg)
+    if not _FINGERPRINT_HEX_RE.fullmatch(fingerprint):
+        msg = f"fingerprint must be lowercase hex, got {fingerprint!r}"
+        raise ValueError(msg)
+    return fingerprint
+
+
+def finding_short_id(fingerprint: str) -> str:
+    """Return the default short id for one fingerprint (six hex chars after ``MC-``)."""
+    validated = _validate_fingerprint_for_short_id(fingerprint)
+    return f"{FINDING_SHORT_ID_PREFIX}{validated[:_FINDING_SHORT_ID_DEFAULT_HEX_LEN]}"
+
+
+def resolve_finding_short_ids(fingerprints: Sequence[str]) -> dict[str, str]:
+    """Assign stable short ids, extending truncation when six-char prefixes collide."""
+    unique = list(dict.fromkeys(_validate_fingerprint_for_short_id(fp) for fp in fingerprints))
+    assigned: dict[str, str] = {}
+    used_ids: set[str] = set()
+    for fingerprint in sorted(unique):
+        hex_len = _FINDING_SHORT_ID_DEFAULT_HEX_LEN
+        while hex_len <= len(fingerprint):
+            candidate = f"{FINDING_SHORT_ID_PREFIX}{fingerprint[:hex_len]}"
+            if candidate not in used_ids:
+                assigned[fingerprint] = candidate
+                used_ids.add(candidate)
+                break
+            hex_len += 1
+        else:
+            candidate = f"{FINDING_SHORT_ID_PREFIX}{fingerprint}"
+            assigned[fingerprint] = candidate
+            used_ids.add(candidate)
+    return {fp: assigned[_validate_fingerprint_for_short_id(fp)] for fp in fingerprints}
+
+
+def render_finding_markdown(finding: Finding, *, short_id: str) -> str:
+    """Render one finding as a markdown section that quotes ``short_id``."""
+    if finding.start_line is not None:
+        location = f"{finding.path}:{finding.start_line}"
+    else:
+        location = finding.path
+    lines = [
+        f"## [{short_id}] {location}",
+        "",
+        f"**{finding.severity}** · `{finding.tool}/{finding.rule_id}`",
+        "",
+        finding.message,
+        "",
+        f"`{short_id}` · fingerprint `{finding.fingerprint}`",
+    ]
+    return "\n".join(lines)
+
+
+def finding_json_record(finding: Finding, *, short_id: str) -> dict[str, Any]:
+    """Serialize a finding for structured JSON export with a stable short id."""
+    record = finding.model_dump()
+    record["short_id"] = short_id
+    return record
+
+
+def finding_agent_jsonl_record(finding: Finding, *, short_id: str) -> dict[str, Any]:
+    """Serialize a finding for agent JSONL events with a stable short id."""
+    return finding_json_record(finding, short_id=short_id)
+
+
+def render_finding_pr_comment(finding: Finding, *, short_id: str) -> str:
+    """Render a PR inline comment body that surfaces ``short_id`` for quoting."""
+    if finding.start_line is not None:
+        location = f"{finding.path}:{finding.start_line}"
+    else:
+        location = finding.path
+    return f"**{short_id}** ({location})\n\n{finding.message}"
+
+
 __all__ = [
+    "FINDING_SHORT_ID_PREFIX",
     "STRUCTURED_OUTPUT_REQUIRED_MSG",
     "Finding",
     "FindingValidationError",
     "FindingsPayload",
     "IntroducedByPr",
+    "finding_agent_jsonl_record",
+    "finding_json_record",
+    "finding_short_id",
     "findings_output_schema",
     "make_finding",
     "parse_findings_payload",
+    "render_finding_markdown",
+    "render_finding_pr_comment",
+    "resolve_finding_short_ids",
     "write_findings_json",
 ]

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -223,10 +223,13 @@ def finding_short_id(fingerprint: str) -> str:
 
 def resolve_finding_short_ids(fingerprints: Sequence[str]) -> dict[str, str]:
     """Assign stable short ids, extending truncation when six-char prefixes collide."""
-    unique = list(dict.fromkeys(_validate_fingerprint_for_short_id(fp) for fp in fingerprints))
+    validated_by_input: dict[str, str] = {}
+    for fp in fingerprints:
+        validated_by_input[fp] = _validate_fingerprint_for_short_id(fp)
+    unique = sorted(dict.fromkeys(validated_by_input.values()))
     assigned: dict[str, str] = {}
     used_ids: set[str] = set()
-    for fingerprint in sorted(unique):
+    for fingerprint in unique:
         hex_len = _FINDING_SHORT_ID_DEFAULT_HEX_LEN
         while hex_len <= len(fingerprint):
             candidate = f"{FINDING_SHORT_ID_PREFIX}{fingerprint[:hex_len]}"
@@ -239,15 +242,19 @@ def resolve_finding_short_ids(fingerprints: Sequence[str]) -> dict[str, str]:
             candidate = f"{FINDING_SHORT_ID_PREFIX}{fingerprint}"
             assigned[fingerprint] = candidate
             used_ids.add(candidate)
-    return {fp: assigned[_validate_fingerprint_for_short_id(fp)] for fp in fingerprints}
+    return {fp: assigned[validated_by_input[fp]] for fp in fingerprints}
+
+
+def _finding_location(finding: Finding) -> str:
+    """Return ``path:line`` when line-anchored, else ``path`` alone."""
+    if finding.start_line is not None:
+        return f"{finding.path}:{finding.start_line}"
+    return finding.path
 
 
 def render_finding_markdown(finding: Finding, *, short_id: str) -> str:
     """Render one finding as a markdown section that quotes ``short_id``."""
-    if finding.start_line is not None:
-        location = f"{finding.path}:{finding.start_line}"
-    else:
-        location = finding.path
+    location = _finding_location(finding)
     lines = [
         f"## [{short_id}] {location}",
         "",
@@ -267,17 +274,9 @@ def finding_json_record(finding: Finding, *, short_id: str) -> dict[str, Any]:
     return record
 
 
-def finding_agent_jsonl_record(finding: Finding, *, short_id: str) -> dict[str, Any]:
-    """Serialize a finding for agent JSONL events with a stable short id."""
-    return finding_json_record(finding, short_id=short_id)
-
-
 def render_finding_pr_comment(finding: Finding, *, short_id: str) -> str:
     """Render a PR inline comment body that surfaces ``short_id`` for quoting."""
-    if finding.start_line is not None:
-        location = f"{finding.path}:{finding.start_line}"
-    else:
-        location = finding.path
+    location = _finding_location(finding)
     return f"**{short_id}** ({location})\n\n{finding.message}"
 
 
@@ -288,7 +287,6 @@ __all__ = [
     "FindingValidationError",
     "FindingsPayload",
     "IntroducedByPr",
-    "finding_agent_jsonl_record",
     "finding_json_record",
     "finding_short_id",
     "findings_output_schema",

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -185,10 +185,18 @@ def parse_findings_payload(raw: str) -> list[dict[str, Any]]:
     return [finding.model_dump() for finding in payload.findings]
 
 
+def finding_record_without_short_id(record: dict[str, Any]) -> dict[str, Any]:
+    """Strip export-only fields before validating a stored or exported finding row."""
+    return {key: value for key, value in record.items() if key != "short_id"}
+
+
 def write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None:
-    """Write validated findings to a pretty-printed JSON file."""
+    """Write validated findings to a pretty-printed JSON file with stable short ids."""
+    models = [Finding.model_validate(finding_record_without_short_id(row)) for row in findings]
+    short_ids = resolve_finding_short_ids([row.fingerprint for row in models])
+    records = [finding_json_record(row, short_id=short_ids[row.fingerprint]) for row in models]
     json_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps({"findings": findings}, indent=2, ensure_ascii=False)
+    payload = json.dumps({"findings": records}, indent=2, ensure_ascii=False)
     json_path.write_text(f"{payload}\n", encoding="utf-8")
 
 
@@ -288,6 +296,7 @@ __all__ = [
     "FindingsPayload",
     "IntroducedByPr",
     "finding_json_record",
+    "finding_record_without_short_id",
     "finding_short_id",
     "findings_output_schema",
     "make_finding",

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -155,6 +155,23 @@ class FindingsPayload(BaseModel):
     findings: list[Finding]
 
 
+class FindingExportRecord(Finding):
+    """Wire record for JSON/JSONL export — ``Finding`` fields plus stable ``short_id``."""
+
+    short_id: str
+
+
+class FindingsExportPayload(BaseModel):
+    """Validated envelope for exported findings files and CLI JSON outputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    findings: list[FindingExportRecord]
+
+
+FINDINGS_EXPORT_SCHEMA_VERSION = "1.0.0"
+
+
 def findings_output_schema() -> dict[str, Any]:
     """JSON Schema for structured findings output derived from ``Finding``."""
     item_schema = Finding.model_json_schema()
@@ -173,6 +190,36 @@ def findings_output_schema() -> dict[str, Any]:
         },
         "required": ["findings"],
     }
+
+
+def findings_export_schema() -> dict[str, Any]:
+    """JSON Schema for exported findings (``Finding`` fields plus ``short_id``)."""
+    item_schema = FindingExportRecord.model_json_schema()
+    properties = item_schema.get("properties")
+    if isinstance(properties, dict):
+        properties["category"] = {"type": "string", "enum": list(FINDING_CATEGORIES)}
+        properties["severity"] = {"type": "string", "enum": list(FINDING_SEVERITIES)}
+        properties["confidence"] = {"type": "string", "enum": list(FINDING_CONFIDENCES)}
+    return {
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": item_schema,
+            }
+        },
+        "required": ["findings"],
+    }
+
+
+def validate_findings_export(payload: dict[str, Any]) -> list[FindingExportRecord]:
+    """Validate an exported findings payload and return typed export records."""
+    try:
+        envelope = FindingsExportPayload.model_validate(payload)
+    except ValidationError as exc:
+        msg = f"exported findings do not conform to export schema: {exc}"
+        raise ValueError(msg) from exc
+    return envelope.findings
 
 
 def parse_findings_payload(raw: str) -> list[dict[str, Any]]:
@@ -195,9 +242,11 @@ def write_findings_json(json_path: Path, findings: list[dict[str, Any]]) -> None
     models = [Finding.model_validate(finding_record_without_short_id(row)) for row in findings]
     short_ids = resolve_finding_short_ids([row.fingerprint for row in models])
     records = [finding_json_record(row, short_id=short_ids[row.fingerprint]) for row in models]
+    payload = {"findings": records}
+    validate_findings_export(payload)
     json_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps({"findings": records}, indent=2, ensure_ascii=False)
-    json_path.write_text(f"{payload}\n", encoding="utf-8")
+    encoded = json.dumps(payload, indent=2, ensure_ascii=False)
+    json_path.write_text(f"{encoded}\n", encoding="utf-8")
 
 
 def _validate_fingerprint_for_short_id(fingerprint: str) -> str:
@@ -277,9 +326,8 @@ def render_finding_markdown(finding: Finding, *, short_id: str) -> str:
 
 def finding_json_record(finding: Finding, *, short_id: str) -> dict[str, Any]:
     """Serialize a finding for structured JSON export with a stable short id."""
-    record = finding.model_dump()
-    record["short_id"] = short_id
-    return record
+    record = FindingExportRecord(short_id=short_id, **finding.model_dump())
+    return record.model_dump()
 
 
 def render_finding_pr_comment(finding: Finding, *, short_id: str) -> str:
@@ -289,20 +337,25 @@ def render_finding_pr_comment(finding: Finding, *, short_id: str) -> str:
 
 
 __all__ = [
+    "FINDINGS_EXPORT_SCHEMA_VERSION",
     "FINDING_SHORT_ID_PREFIX",
     "STRUCTURED_OUTPUT_REQUIRED_MSG",
     "Finding",
+    "FindingExportRecord",
     "FindingValidationError",
+    "FindingsExportPayload",
     "FindingsPayload",
     "IntroducedByPr",
     "finding_json_record",
     "finding_record_without_short_id",
     "finding_short_id",
+    "findings_export_schema",
     "findings_output_schema",
     "make_finding",
     "parse_findings_payload",
     "render_finding_markdown",
     "render_finding_pr_comment",
     "resolve_finding_short_ids",
+    "validate_findings_export",
     "write_findings_json",
 ]

--- a/src/mergecraft/analyzers/pipeline.py
+++ b/src/mergecraft/analyzers/pipeline.py
@@ -19,7 +19,7 @@ from mergecraft.analyzers.budget import (
     sync_deferred_section,
 )
 from mergecraft.analyzers.cluster import cluster_findings
-from mergecraft.analyzers.finding import Finding, resolve_finding_short_ids
+from mergecraft.analyzers.finding import Finding
 from mergecraft.analyzers.lockfile import lock_digest
 from mergecraft.analyzers.registry import detect_enabled
 from mergecraft.analyzers.review_gate import filter_for_review
@@ -393,8 +393,7 @@ def run_analyzer_pipeline(
         placement = place_findings(clustered, inline_budget=budget)
 
         serialized = [_serialize_finding(f) for f in clustered]
-        inline_findings = [item for item in placement.inline if isinstance(item, Finding)]
-        inline_short_ids = resolve_finding_short_ids([row.fingerprint for row in inline_findings])
+        inline_short_ids = placement.short_ids
         inline_payload: list[dict[str, Any]] = []
         for item in placement.inline:
             if isinstance(item, Finding):

--- a/src/mergecraft/analyzers/pipeline.py
+++ b/src/mergecraft/analyzers/pipeline.py
@@ -19,7 +19,7 @@ from mergecraft.analyzers.budget import (
     sync_deferred_section,
 )
 from mergecraft.analyzers.cluster import cluster_findings
-from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.finding import Finding, resolve_finding_short_ids
 from mergecraft.analyzers.lockfile import lock_digest
 from mergecraft.analyzers.registry import detect_enabled
 from mergecraft.analyzers.review_gate import filter_for_review
@@ -393,12 +393,17 @@ def run_analyzer_pipeline(
         placement = place_findings(clustered, inline_budget=budget)
 
         serialized = [_serialize_finding(f) for f in clustered]
+        inline_findings = [item for item in placement.inline if isinstance(item, Finding)]
+        inline_short_ids = resolve_finding_short_ids([row.fingerprint for row in inline_findings])
         inline_payload: list[dict[str, Any]] = []
         for item in placement.inline:
             if isinstance(item, Finding):
                 payload: dict[str, Any] = {
                     "finding": _serialize_finding(item),
-                    "inlineBody": format_analyzer_inline_body(item),
+                    "inlineBody": format_analyzer_inline_body(
+                        item,
+                        short_id=inline_short_ids[item.fingerprint],
+                    ),
                     "path": item.path,
                 }
                 if item.start_line is not None:

--- a/src/mergecraft/build_metadata.py
+++ b/src/mergecraft/build_metadata.py
@@ -1,0 +1,48 @@
+"""Resolve the installed build commit SHA for version display."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+from mergecraft._build_metadata import __commit__ as _baked_commit
+
+
+@lru_cache(maxsize=1)
+def resolve_build_commit() -> str | None:
+    """Return the full git SHA baked at build time, or from a source checkout."""
+    env_commit = os.environ.get("MERGECRAFT_BUILD_COMMIT", "").strip()
+    if env_commit:
+        return env_commit
+    if _baked_commit:
+        return _baked_commit
+    return _git_head_commit(_package_root())
+
+
+def _package_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _git_head_commit(root: Path) -> str | None:
+    for candidate in (root, *root.parents):
+        if (candidate / ".git").exists():
+            root = candidate
+            break
+    else:
+        return None
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    commit = output.strip()
+    return commit or None
+
+
+__all__ = ["resolve_build_commit"]

--- a/src/mergecraft/cli/agent_protocol.py
+++ b/src/mergecraft/cli/agent_protocol.py
@@ -136,23 +136,30 @@ def notify_findings(
     rows: Sequence[dict[str, Any]],
     *,
     seen: set[str] | None = None,
+    streamed_short_ids: dict[str, str] | None = None,
     refresh: bool = False,
 ) -> set[str]:
     """Call ``on_finding`` once per novel row. Returns the updated seen set.
 
-    When ``refresh`` is true, rows that carry a ``short_id`` are re-emitted even
-    when their fingerprint was already streamed without batch-resolved ids.
+    When ``refresh`` is true, rows whose batch-resolved ``short_id`` differs from
+    the provisional id already streamed are re-emitted once; unchanged ids are not
+    duplicated.
     """
     emitted = seen if seen is not None else set()
+    short_ids = streamed_short_ids if streamed_short_ids is not None else {}
     if on_finding is None:
         return emitted
     for row in rows:
         key = finding_event_key(row)
+        short_id = row.get("short_id")
         if key in emitted:
-            if refresh and row.get("short_id"):
+            if refresh and isinstance(short_id, str) and short_ids.get(key) != short_id:
                 on_finding(row)
+                short_ids[key] = short_id
             continue
         emitted.add(key)
+        if isinstance(short_id, str):
+            short_ids[key] = short_id
         on_finding(row)
     return emitted
 

--- a/src/mergecraft/cli/agent_protocol.py
+++ b/src/mergecraft/cli/agent_protocol.py
@@ -136,14 +136,21 @@ def notify_findings(
     rows: Sequence[dict[str, Any]],
     *,
     seen: set[str] | None = None,
+    refresh: bool = False,
 ) -> set[str]:
-    """Call ``on_finding`` once per novel row. Returns the updated seen set."""
+    """Call ``on_finding`` once per novel row. Returns the updated seen set.
+
+    When ``refresh`` is true, rows that carry a ``short_id`` are re-emitted even
+    when their fingerprint was already streamed without batch-resolved ids.
+    """
     emitted = seen if seen is not None else set()
     if on_finding is None:
         return emitted
     for row in rows:
         key = finding_event_key(row)
         if key in emitted:
+            if refresh and row.get("short_id"):
+                on_finding(row)
             continue
         emitted.add(key)
         on_finding(row)

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import typer
 from dotenv import load_dotenv
 
-from mergecraft import __version__
+import mergecraft
+from mergecraft import __version__, format_version_display, version_json_payload
 from mergecraft.cli import (
     agents_cmd,
     analyzers_cmd,
@@ -45,6 +46,7 @@ from mergecraft.cli import (
     support_bundle_cmd,
     tracing_cmd,
     tracing_logfire_cmd,
+    update_cmd,
     watch_cmd,
     xrepo_cmd,
 )
@@ -55,6 +57,7 @@ from mergecraft.cli.global_surface import (
     ColorMode,
     OutputFormat,
     apply_global_cli_options,
+    emit_cli_json,
     validate_log_level_option,
 )
 from mergecraft.cli.typer_group import MergecraftTyperGroup
@@ -101,6 +104,7 @@ app.add_typer(analyzers_cmd.app, name="analyzers")
 app.command("init")(init_cmd.run)
 app.command("watch")(watch_cmd.run)
 app.command("doctor")(doctor_cmd.run)
+app.command("update")(update_cmd.run)
 app.command("capabilities")(capabilities_cmd.run)
 app.command("describe")(describe_cmd.run)
 app.command("explain")(explain_cmd.run)
@@ -182,7 +186,7 @@ def _root(
         color=color,
     )
     if version:
-        typer.echo(__version__)
+        typer.echo(format_version_display(__version__, mergecraft.__commit__))
         raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
@@ -190,9 +194,19 @@ def _root(
 
 
 @app.command("version")
-def version_cmd() -> None:
+def version_cmd(
+    format: OutputFormat | None = typer.Option(
+        None,
+        "--format",
+        help="Output format. Defaults to text.",
+        case_sensitive=False,
+    ),
+) -> None:
     """Show the mergeCraft package version."""
-    typer.echo(__version__)
+    if format == "json":
+        emit_cli_json(version_json_payload(__version__, mergecraft.__commit__))
+        return
+    typer.echo(format_version_display(__version__, mergecraft.__commit__))
 
 
 def _local_env_path() -> Path:

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -13,7 +13,7 @@ from typing import Any, NoReturn
 import typer
 from loguru import logger
 
-from mergecraft.analyzers.finding import Finding, finding_short_id, write_findings_json
+from mergecraft.analyzers.finding import Finding, finding_short_id
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
@@ -174,6 +174,7 @@ def _agent_finding_record(finding: dict[str, Any]) -> dict[str, Any]:
 def _persist_completed_cli_review(
     *,
     review_id: str,
+    trace_session_id: str,
     snapshot: ReviewSnapshot,
     cwd: Path,
     model: str | None,
@@ -183,7 +184,6 @@ def _persist_completed_cli_review(
 ) -> None:
     from mergecraft.evidence.run_manifest import build_run_manifest
 
-    safe_review_id = _safe_review_id_for_persist(review_id)
     manifest = build_run_manifest(
         cwd=cwd,
         model=model or "(unresolved)",
@@ -192,18 +192,18 @@ def _persist_completed_cli_review(
     )
     findings_records = finding_json_records(findings)
     review = CompletedReview(
-        review_id=safe_review_id,
+        review_id=review_id,
         snapshot=snapshot,
         manifest=manifest,
         findings=findings_records,
-        trace_session_id=review_id,
+        trace_session_id=trace_session_id,
     )
     evidence_packets = collect_evidence_packets_for_persist(
         findings,
         repo_root=cwd,
         evidence_packet_path=evidence_packet_path,
     )
-    trace_events = collect_trace_events_for_review(review_id, repo_root=cwd)
+    trace_events = collect_trace_events_for_review(trace_session_id, repo_root=cwd)
     try:
         persist_completed_review(
             review,
@@ -694,15 +694,10 @@ def run(
         findings = parse_offline_review_findings(result)
         exit_code = cli_exit_code_for_review(outcome, findings)
 
-        if result.success and json_output is not None and findings:
-            write_findings_json(
-                json_output,
-                [row.model_dump(mode="json") for row in findings],
-            )
-
         if result.success and not dry_run:
             _persist_completed_cli_review(
-                review_id=review_id,
+                review_id=persist_review_id,
+                trace_session_id=review_id,
                 snapshot=snapshot,
                 cwd=root,
                 model=model,

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -13,7 +13,7 @@ from typing import Any, NoReturn
 import typer
 from loguru import logger
 
-from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.finding import Finding, finding_short_id, write_findings_json
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
@@ -156,9 +156,14 @@ def _safe_review_id_for_persist(review_id: str) -> str:
 
 
 def _agent_finding_record(finding: dict[str, Any]) -> dict[str, Any]:
-    """Normalize a streamed finding without attaching a per-row short id."""
-    if finding.get("fingerprint"):
-        return finding
+    """Normalize a streamed finding with a provisional short id when possible."""
+    fingerprint = finding.get("fingerprint")
+    if fingerprint:
+        record = dict(finding)
+        if "short_id" not in record:
+            with contextlib.suppress(ValueError, TypeError):
+                record["short_id"] = finding_short_id(str(fingerprint))
+        return record
     try:
         model = Finding.model_validate(finding)
     except ValueError:
@@ -244,11 +249,13 @@ def _finish_agent_protocol(
     exit_code: int,
     findings: Sequence[Finding],
     seen: set[str],
+    streamed_short_ids: dict[str, str],
 ) -> None:
     notify_findings(
         stream.finding,
         finding_json_records(findings),
         seen=seen,
+        streamed_short_ids=streamed_short_ids,
         refresh=True,
     )
     stream.verdict(outcome.value, exit_code)
@@ -612,6 +619,7 @@ def run(
 
     stream: AgentProtocolStream | None = None
     seen: set[str] = set()
+    streamed_short_ids: dict[str, str] = {}
     phases_emitted = False
     if agent_mode:
         agent_stream = _start_agent_protocol()
@@ -627,7 +635,12 @@ def run(
     def _on_finding(finding: dict[str, Any]) -> None:
         if stream is None:
             return
-        notify_findings(stream.finding, [_agent_finding_record(finding)], seen=seen)
+        notify_findings(
+            stream.finding,
+            [_agent_finding_record(finding)],
+            seen=seen,
+            streamed_short_ids=streamed_short_ids,
+        )
 
     read_cache = use_cache or resume
 
@@ -681,6 +694,12 @@ def run(
         findings = parse_offline_review_findings(result)
         exit_code = cli_exit_code_for_review(outcome, findings)
 
+        if result.success and json_output is not None and findings:
+            write_findings_json(
+                json_output,
+                [row.model_dump(mode="json") for row in findings],
+            )
+
         if result.success and not dry_run:
             _persist_completed_cli_review(
                 review_id=review_id,
@@ -702,6 +721,7 @@ def run(
                     exit_code=exit_code,
                     findings=findings,
                     seen=seen,
+                    streamed_short_ids=streamed_short_ids,
                 )
             _exit_with_message(result.error or "diff-review failed", exit_code)
 
@@ -712,6 +732,7 @@ def run(
                 exit_code=exit_code,
                 findings=findings,
                 seen=seen,
+                streamed_short_ids=streamed_short_ids,
             )
             raise typer.Exit(exit_code)
 

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -181,6 +181,7 @@ def _persist_completed_cli_review(
     prompt: str | None,
     findings: Sequence[Finding],
     evidence_packet_path: str | None = None,
+    trace_dir: Path | None = None,
 ) -> None:
     from mergecraft.evidence.run_manifest import build_run_manifest
 
@@ -203,7 +204,11 @@ def _persist_completed_cli_review(
         repo_root=cwd,
         evidence_packet_path=evidence_packet_path,
     )
-    trace_events = collect_trace_events_for_review(trace_session_id, repo_root=cwd)
+    trace_events = collect_trace_events_for_review(
+        trace_session_id,
+        repo_root=cwd,
+        trace_dir=trace_dir,
+    )
     try:
         persist_completed_review(
             review,
@@ -704,6 +709,7 @@ def run(
                 prompt=prompt,
                 findings=findings,
                 evidence_packet_path=result.evidence_packet_path,
+                trace_dir=trace_dir,
             )
 
         if not result.success:

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import tempfile
+import uuid
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import Any, NoReturn
 
 import typer
 from loguru import logger
 
-from mergecraft.analyzers.finding import finding_json_record, finding_short_id
+from mergecraft.analyzers.finding import Finding
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
@@ -35,13 +36,11 @@ from mergecraft.review.completed_artifacts import (
     collect_trace_events_for_review,
 )
 from mergecraft.review.engine import ReviewEngine
+from mergecraft.review.finding_lookup import is_safe_path_stem
 from mergecraft.review.snapshot import ReviewSnapshot, ReviewStageName, canonical_review_snapshot
 from mergecraft.types import ShellPermission  # noqa: TC001
 from mergecraft.utils.log import configure_logging
 from mergecraft.utils.source_resolve import SourceResolverSpec
-
-if TYPE_CHECKING:
-    from mergecraft.analyzers.finding import Finding
 
 _PANEL_SOURCE = "Source"
 _PANEL_DIFF = "Diff selection"
@@ -145,18 +144,26 @@ def _resolve_outcome(result: OfflineReviewResult) -> RunOutcome:
     return RunOutcome.passed if result.success else RunOutcome.failed
 
 
-def _agent_finding_record(finding: dict[str, Any]) -> dict[str, Any]:
-    """Attach a short id when ``finding`` carries a fingerprint."""
-    fingerprint = finding.get("fingerprint")
-    if not isinstance(fingerprint, str) or not fingerprint:
-        return finding
-    from mergecraft.analyzers.finding import Finding
+def _safe_review_id_for_persist(review_id: str) -> str:
+    """Return a path-safe review id for durable storage."""
+    if is_safe_path_stem(review_id):
+        return review_id
+    logger.warning(
+        "ignoring unsafe {} for durable review storage; using generated id",
+        review_id,
+    )
+    return uuid.uuid4().hex
 
+
+def _agent_finding_record(finding: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a streamed finding without attaching a per-row short id."""
+    if finding.get("fingerprint"):
+        return finding
     try:
         model = Finding.model_validate(finding)
     except ValueError:
         return finding
-    return finding_json_record(model, short_id=finding_short_id(fingerprint))
+    return model.model_dump(mode="json")
 
 
 def _persist_completed_cli_review(
@@ -171,6 +178,7 @@ def _persist_completed_cli_review(
 ) -> None:
     from mergecraft.evidence.run_manifest import build_run_manifest
 
+    safe_review_id = _safe_review_id_for_persist(review_id)
     manifest = build_run_manifest(
         cwd=cwd,
         model=model or "(unresolved)",
@@ -179,7 +187,7 @@ def _persist_completed_cli_review(
     )
     findings_records = finding_json_records(findings)
     review = CompletedReview(
-        review_id=review_id,
+        review_id=safe_review_id,
         snapshot=snapshot,
         manifest=manifest,
         findings=findings_records,
@@ -191,12 +199,15 @@ def _persist_completed_cli_review(
         evidence_packet_path=evidence_packet_path,
     )
     trace_events = collect_trace_events_for_review(review_id, repo_root=cwd)
-    persist_completed_review(
-        review,
-        repo_root=cwd,
-        evidence_packets=evidence_packets,
-        trace_events=trace_events,
-    )
+    try:
+        persist_completed_review(
+            review,
+            repo_root=cwd,
+            evidence_packets=evidence_packets,
+            trace_events=trace_events,
+        )
+    except ValueError as exc:
+        logger.warning("skipped durable review persistence: {}", exc)
 
 
 def cleanup_review_subprocesses() -> None:
@@ -238,6 +249,7 @@ def _finish_agent_protocol(
         stream.finding,
         finding_json_records(findings),
         seen=seen,
+        refresh=True,
     )
     stream.verdict(outcome.value, exit_code)
     stream.run_finished(exit_code)
@@ -589,6 +601,7 @@ def run(
     from mergecraft.tracing.review_context import resolve_review_id
 
     review_id = resolve_review_id()
+    persist_review_id = _safe_review_id_for_persist(review_id)
     json_stdout = (
         effective_output_format == "json"
         and json_output is None
@@ -706,7 +719,7 @@ def run(
             effective_output_format=effective_output_format,
             result=result,
             findings=findings,
-            review_id=review_id,
+            review_id=persist_review_id,
             output=output,
             json_output=json_output,
             json_stdout=json_stdout,
@@ -714,7 +727,12 @@ def run(
             exit_code=exit_code,
         )
 
-        if json_output is not None and result.success and not dry_run:
+        if (
+            json_output is not None
+            and result.success
+            and not dry_run
+            and effective_output_format != "json"
+        ):
             console.print(f"[green]wrote[/green] {json_output}")
 
         raise typer.Exit(exit_code)

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -211,7 +211,7 @@ def _persist_completed_cli_review(
             evidence_packets=evidence_packets,
             trace_events=trace_events,
         )
-    except ValueError as exc:
+    except (OSError, ValueError) as exc:
         logger.warning("skipped durable review persistence: {}", exc)
 
 

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -4,33 +4,36 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
 from loguru import logger
 
-from mergecraft.analyzers.sarif import export_sarif
+from mergecraft.analyzers.finding import finding_json_record, finding_short_id
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
-from mergecraft.cli.global_surface import emit_cli_json, get_cli_globals
-from mergecraft.config.settings import parse_cli_trust_override
-from mergecraft.findings.hunk_export import (
-    count_dropped_file_level_findings,
-    export_hunk_comments,
-    first_changed_lines_from_diff,
-    format_file_level_drop_warning,
+from mergecraft.cli.global_surface import get_cli_globals
+from mergecraft.cli.review_output import (
+    HunkFileFindings,
+    OutputFormat,
+    dispatch_review_output,
+    finding_json_records,
 )
+from mergecraft.config.settings import parse_cli_trust_override
 from mergecraft.offline_review import (
     OfflineReviewResult,
     parse_offline_review_findings,
     run_offline_diff_review,
 )
 from mergecraft.review.completed import CompletedReview, persist_completed_review
+from mergecraft.review.completed_artifacts import (
+    collect_evidence_packets_for_persist,
+    collect_trace_events_for_review,
+)
 from mergecraft.review.engine import ReviewEngine
 from mergecraft.review.snapshot import ReviewSnapshot, ReviewStageName, canonical_review_snapshot
 from mergecraft.types import ShellPermission  # noqa: TC001
@@ -39,10 +42,6 @@ from mergecraft.utils.source_resolve import SourceResolverSpec
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
-
-
-OutputFormat = Literal["text", "json", "jsonl", "sarif", "hunk"]
-HunkFileFindings = Literal["drop", "first-changed-line"]
 
 _PANEL_SOURCE = "Source"
 _PANEL_DIFF = "Diff selection"
@@ -146,11 +145,18 @@ def _resolve_outcome(result: OfflineReviewResult) -> RunOutcome:
     return RunOutcome.passed if result.success else RunOutcome.failed
 
 
-def _write_jsonl_findings(path: Path, findings: Sequence[Finding]) -> None:
-    lines: list[str] = []
-    for row in findings:
-        lines.append(json.dumps({"finding": row.model_dump()}, ensure_ascii=False))
-    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+def _agent_finding_record(finding: dict[str, Any]) -> dict[str, Any]:
+    """Attach a short id when ``finding`` carries a fingerprint."""
+    fingerprint = finding.get("fingerprint")
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return finding
+    from mergecraft.analyzers.finding import Finding
+
+    try:
+        model = Finding.model_validate(finding)
+    except ValueError:
+        return finding
+    return finding_json_record(model, short_id=finding_short_id(fingerprint))
 
 
 def _persist_completed_cli_review(
@@ -161,6 +167,7 @@ def _persist_completed_cli_review(
     model: str | None,
     prompt: str | None,
     findings: Sequence[Finding],
+    evidence_packet_path: str | None = None,
 ) -> None:
     from mergecraft.evidence.run_manifest import build_run_manifest
 
@@ -170,29 +177,25 @@ def _persist_completed_cli_review(
         agent_id="mergecraft",
         prompt_text=prompt or "",
     )
+    findings_records = finding_json_records(findings)
     review = CompletedReview(
         review_id=review_id,
         snapshot=snapshot,
         manifest=manifest,
-        findings=[row.model_dump(mode="json") for row in findings],
+        findings=findings_records,
         trace_session_id=review_id,
     )
-    persist_completed_review(review, repo_root=cwd)
-
-
-def _emit_review_json_stdout(
-    *,
-    review_id: str,
-    findings: Sequence[Finding],
-    output_text: str | None,
-) -> None:
-    emit_cli_json(
-        {
-            "review_id": review_id,
-            "count": len(findings),
-            "findings": [row.model_dump(mode="json") for row in findings],
-            "output": output_text,
-        }
+    evidence_packets = collect_evidence_packets_for_persist(
+        findings,
+        repo_root=cwd,
+        evidence_packet_path=evidence_packet_path,
+    )
+    trace_events = collect_trace_events_for_review(review_id, repo_root=cwd)
+    persist_completed_review(
+        review,
+        repo_root=cwd,
+        evidence_packets=evidence_packets,
+        trace_events=trace_events,
     )
 
 
@@ -233,7 +236,7 @@ def _finish_agent_protocol(
 ) -> None:
     notify_findings(
         stream.finding,
-        [row.model_dump() for row in findings],
+        finding_json_records(findings),
         seen=seen,
     )
     stream.verdict(outcome.value, exit_code)
@@ -611,7 +614,7 @@ def run(
     def _on_finding(finding: dict[str, Any]) -> None:
         if stream is None:
             return
-        notify_findings(stream.finding, [finding], seen=seen)
+        notify_findings(stream.finding, [_agent_finding_record(finding)], seen=seen)
 
     read_cache = use_cache or resume
 
@@ -673,6 +676,7 @@ def run(
                 model=model,
                 prompt=prompt,
                 findings=findings,
+                evidence_packet_path=result.evidence_packet_path,
             )
 
         if not result.success:
@@ -698,55 +702,17 @@ def run(
             )
             raise typer.Exit(exit_code)
 
-        text = result.output or ""
-
-        if effective_output_format == "text":
-            if output is not None:
-                output.write_text(text, encoding="utf-8")
-                console.print(f"[green]wrote[/green] {output}")
-            elif json_output is None:
-                console.print(text)
-        elif effective_output_format == "json":
-            target = json_output or output
-            if target is not None and target.is_file():
-                console.print(f"[green]wrote[/green] {target}")
-            if json_stdout:
-                _emit_review_json_stdout(
-                    review_id=review_id,
-                    findings=findings,
-                    output_text=text or None,
-                )
-        elif effective_output_format == "jsonl":
-            target = output
-            if target is None:
-                _exit_with_message("--output is required for --output-format jsonl", exit_code)
-            _write_jsonl_findings(target, findings)
-            console.print(f"[green]wrote[/green] {target}")
-        elif effective_output_format == "sarif":
-            target = output
-            if target is None:
-                _exit_with_message("--output is required for --output-format sarif", exit_code)
-            document = export_sarif(findings)
-            target.write_text(json.dumps(document, indent=2), encoding="utf-8")
-            console.print(f"[green]wrote[/green] {target}")
-        elif effective_output_format == "hunk":
-            first_changed_lines: dict[str, int] | None = None
-            if hunk_file_findings == "first-changed-line" and result.diff_path:
-                diff_path = Path(result.diff_path)
-                if diff_path.is_file():
-                    first_changed_lines = first_changed_lines_from_diff(
-                        diff_path.read_text(encoding="utf-8")
-                    )
-            if hunk_file_findings == "drop":
-                dropped = count_dropped_file_level_findings(findings)
-                if dropped:
-                    console.print(format_file_level_drop_warning(dropped))
-            payload = export_hunk_comments(
-                findings,
-                file_findings=hunk_file_findings,
-                first_changed_lines=first_changed_lines,
-            )
-            typer.echo(json.dumps(payload, ensure_ascii=False))
+        dispatch_review_output(
+            effective_output_format=effective_output_format,
+            result=result,
+            findings=findings,
+            review_id=review_id,
+            output=output,
+            json_output=json_output,
+            json_stdout=json_stdout,
+            hunk_file_findings=hunk_file_findings,
+            exit_code=exit_code,
+        )
 
         if json_output is not None and result.success and not dry_run:
             console.print(f"[green]wrote[/green] {json_output}")

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -17,7 +17,7 @@ from mergecraft.analyzers.sarif import export_sarif
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
-from mergecraft.cli.global_surface import get_cli_globals
+from mergecraft.cli.global_surface import emit_cli_json, get_cli_globals
 from mergecraft.config.settings import parse_cli_trust_override
 from mergecraft.findings.hunk_export import (
     count_dropped_file_level_findings,
@@ -30,6 +30,7 @@ from mergecraft.offline_review import (
     parse_offline_review_findings,
     run_offline_diff_review,
 )
+from mergecraft.review.completed import CompletedReview, persist_completed_review
 from mergecraft.review.engine import ReviewEngine
 from mergecraft.review.snapshot import ReviewSnapshot, ReviewStageName, canonical_review_snapshot
 from mergecraft.types import ShellPermission  # noqa: TC001
@@ -150,6 +151,49 @@ def _write_jsonl_findings(path: Path, findings: Sequence[Finding]) -> None:
     for row in findings:
         lines.append(json.dumps({"finding": row.model_dump()}, ensure_ascii=False))
     path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def _persist_completed_cli_review(
+    *,
+    review_id: str,
+    snapshot: ReviewSnapshot,
+    cwd: Path,
+    model: str | None,
+    prompt: str | None,
+    findings: Sequence[Finding],
+) -> None:
+    from mergecraft.evidence.run_manifest import build_run_manifest
+
+    manifest = build_run_manifest(
+        cwd=cwd,
+        model=model or "(unresolved)",
+        agent_id="mergecraft",
+        prompt_text=prompt or "",
+    )
+    review = CompletedReview(
+        review_id=review_id,
+        snapshot=snapshot,
+        manifest=manifest,
+        findings=[row.model_dump(mode="json") for row in findings],
+        trace_session_id=review_id,
+    )
+    persist_completed_review(review, repo_root=cwd)
+
+
+def _emit_review_json_stdout(
+    *,
+    review_id: str,
+    findings: Sequence[Finding],
+    output_text: str | None,
+) -> None:
+    emit_cli_json(
+        {
+            "review_id": review_id,
+            "count": len(findings),
+            "findings": [row.model_dump(mode="json") for row in findings],
+            "output": output_text,
+        }
+    )
 
 
 def cleanup_review_subprocesses() -> None:
@@ -476,6 +520,7 @@ def run(
         and json_output is None
         and output is None
         and not agent_mode
+        and get_cli_globals(ctx).format != "json"
     ):
         _exit_with_message(
             "--output is required for --output-format json (or use --json PATH)",
@@ -538,6 +583,16 @@ def run(
         replay_key=str(diff) if diff is not None else None,
     )
     engine: ReviewEngine[OfflineReviewResult] = ReviewEngine(snapshot=snapshot)
+    from mergecraft.tracing.review_context import resolve_review_id
+
+    review_id = resolve_review_id()
+    json_stdout = (
+        effective_output_format == "json"
+        and json_output is None
+        and output is None
+        and not agent_mode
+        and get_cli_globals(ctx).format == "json"
+    )
 
     stream: AgentProtocolStream | None = None
     seen: set[str] = set()
@@ -610,6 +665,16 @@ def run(
         findings = parse_offline_review_findings(result)
         exit_code = cli_exit_code_for_review(outcome, findings)
 
+        if result.success and not dry_run:
+            _persist_completed_cli_review(
+                review_id=review_id,
+                snapshot=snapshot,
+                cwd=root,
+                model=model,
+                prompt=prompt,
+                findings=findings,
+            )
+
         if not result.success:
             if result.output and not agent_mode:
                 console.print(result.output)
@@ -645,6 +710,12 @@ def run(
             target = json_output or output
             if target is not None and target.is_file():
                 console.print(f"[green]wrote[/green] {target}")
+            if json_stdout:
+                _emit_review_json_stdout(
+                    review_id=review_id,
+                    findings=findings,
+                    output_text=text or None,
+                )
         elif effective_output_format == "jsonl":
             target = output
             if target is None:

--- a/src/mergecraft/cli/diff_review_cmd.py
+++ b/src/mergecraft/cli/diff_review_cmd.py
@@ -19,6 +19,12 @@ from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import RunOutcome, cli_exit_code_for_review
 from mergecraft.cli.global_surface import get_cli_globals
 from mergecraft.config.settings import parse_cli_trust_override
+from mergecraft.findings.hunk_export import (
+    count_dropped_file_level_findings,
+    export_hunk_comments,
+    first_changed_lines_from_diff,
+    format_file_level_drop_warning,
+)
 from mergecraft.offline_review import (
     OfflineReviewResult,
     parse_offline_review_findings,
@@ -34,7 +40,8 @@ if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
 
 
-OutputFormat = Literal["text", "json", "jsonl", "sarif"]
+OutputFormat = Literal["text", "json", "jsonl", "sarif", "hunk"]
+HunkFileFindings = Literal["drop", "first-changed-line"]
 
 _PANEL_SOURCE = "Source"
 _PANEL_DIFF = "Diff selection"
@@ -104,6 +111,7 @@ Examples — output:
   mergecraft review --json findings.json
   mergecraft review --output-format sarif --output report.sarif.json
   mergecraft review --output-format jsonl --output stream.jsonl
+  mergecraft review --output-format hunk
   mergecraft review --agent
   mergecraft review 2> review.md              # human text lives on stderr (D14)
 
@@ -299,11 +307,21 @@ def run(
         None,
         "--output-format",
         help=(
-            "Review payload format: text (default), json, jsonl, or sarif. "
+            "Review payload format: text (default), json, jsonl, sarif, or hunk. "
             "Root --format json selects json when this flag is omitted; "
             "explicit --output-format text always renders human markdown on stderr. "
             "Default text mode writes human-readable review text to stderr (D14); "
-            "redirect with 2> to capture it."
+            "redirect with 2> to capture it. "
+            "hunk writes Hunk comment JSON to stdout (stdout-only; no --output)."
+        ),
+        rich_help_panel=_PANEL_OUTPUT,
+    ),
+    hunk_file_findings: HunkFileFindings = typer.Option(
+        "drop",
+        "--hunk-file-findings",
+        help=(
+            "For --output-format hunk: drop file-level findings (default) or "
+            "anchor them on the first changed line per file (first-changed-line)."
         ),
         rich_help_panel=_PANEL_OUTPUT,
     ),
@@ -640,6 +658,24 @@ def run(
             document = export_sarif(findings)
             target.write_text(json.dumps(document, indent=2), encoding="utf-8")
             console.print(f"[green]wrote[/green] {target}")
+        elif effective_output_format == "hunk":
+            first_changed_lines: dict[str, int] | None = None
+            if hunk_file_findings == "first-changed-line" and result.diff_path:
+                diff_path = Path(result.diff_path)
+                if diff_path.is_file():
+                    first_changed_lines = first_changed_lines_from_diff(
+                        diff_path.read_text(encoding="utf-8")
+                    )
+            if hunk_file_findings == "drop":
+                dropped = count_dropped_file_level_findings(findings)
+                if dropped:
+                    console.print(format_file_level_drop_warning(dropped))
+            payload = export_hunk_comments(
+                findings,
+                file_findings=hunk_file_findings,
+                first_changed_lines=first_changed_lines,
+            )
+            typer.echo(json.dumps(payload, ensure_ascii=False))
 
         if json_output is not None and result.success and not dry_run:
             console.print(f"[green]wrote[/green] {json_output}")

--- a/src/mergecraft/cli/eval_cmd.py
+++ b/src/mergecraft/cli/eval_cmd.py
@@ -485,6 +485,12 @@ def replay_bank_cmd(
     console.print(f"  regression: {result.metrics.cases_regression}")
     console.print(f"  blocked   : {result.metrics.cases_blocked}")
     console.print(f"  pass rate : {result.metrics.decision_replay_pass_rate:.2%}")
+    if result.lens_routing_capability is not None:
+        lens_report = result.lens_routing_capability
+        console.print(
+            f"  lens macro: precision {lens_report.macro_precision:.2%}, "
+            f"recall {lens_report.macro_recall:.2%}"
+        )
     console.print(f"  corpus @  : {result.pins.corpus_commit[:12]}")
     console.print(f"  rubric    : {result.pins.rubric_version}")
     if gate:

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -5,6 +5,7 @@ Exports: ``run``
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -12,13 +13,23 @@ from typing import Any
 import typer
 from rich.table import Table
 
+from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX
 from mergecraft.analyzers.scope import changed_paths_from_scope, parse_diff_scope
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
 from mergecraft.cli.global_surface import OutputFormat, emit_cli_json, wants_json_output
 from mergecraft.evidence.audit import lookup_finding_packet
-from mergecraft.review.completed import lookup_finding_packet_in_review
+from mergecraft.review.completed import load_completed_review, lookup_finding_packet_in_review
+from mergecraft.review.finding_lookup import is_safe_path_stem
+
+_FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
+
+
+def _is_finding_id_token(token: str) -> bool:
+    if token.startswith(FINDING_SHORT_ID_PREFIX):
+        return True
+    return len(token) >= 6 and _FINGERPRINT_HEX_RE.fullmatch(token) is not None
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -91,7 +102,7 @@ def run(
     ctx: typer.Context,
     review_id_or_finding: str | None = typer.Argument(
         default=None,
-        help="Review id, finding id, or short id (MC-…) depending on invocation.",
+        help="Finding id or short id (MC-…). With two arguments: review id then finding id.",
     ),
     finding_id: str | None = typer.Argument(
         default=None,
@@ -116,10 +127,23 @@ def run(
     """Explain a stored finding or the current working-tree change."""
     root = repo_root.expanduser().resolve()
     resolved_review_id = review_id
-    resolved_finding_id = review_id_or_finding
+    resolved_finding_id: str | None = None
+
     if finding_id is not None:
         resolved_review_id = review_id_or_finding
         resolved_finding_id = finding_id
+    elif review_id_or_finding is not None:
+        token = review_id_or_finding
+        if _is_finding_id_token(token):
+            resolved_finding_id = token
+        elif is_safe_path_stem(token) and load_completed_review(token, repo_root=root) is not None:
+            cli_bail(
+                f"{token!r} is a stored review id — pass a finding id (MC-…) "
+                "or use: explain <review-id> <finding-id>",
+                code=CLI_USAGE_EXIT_CODE,
+            )
+        else:
+            resolved_finding_id = token
 
     if resolved_finding_id:
         packet: dict[str, Any] | None = None

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -18,6 +18,7 @@ from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
 from mergecraft.cli.global_surface import OutputFormat, emit_cli_json, wants_json_output
 from mergecraft.evidence.audit import lookup_finding_packet
+from mergecraft.review.completed import lookup_finding_packet_in_review
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -53,17 +54,25 @@ def _change_payload(repo_root: Path) -> dict[str, Any]:
     }
 
 
-def _finding_payload(finding_id: str, packet: dict[str, Any]) -> dict[str, Any]:
+def _finding_payload(
+    finding_id: str,
+    packet: dict[str, Any],
+    *,
+    review_id: str | None = None,
+) -> dict[str, Any]:
     state = packet.get("state", "unverified")
     kinds = packet.get("kinds", [])
     kinds_text = ", ".join(str(item) for item in kinds) if isinstance(kinds, list) else "none"
-    return {
+    payload: dict[str, Any] = {
         "verb": "explain",
         "finding_id": finding_id,
         "paths": [],
         "summary": f"Finding {finding_id} is {state} (kinds: {kinds_text}).",
         "packet": packet,
     }
+    if review_id is not None:
+        payload["review_id"] = review_id
+    return payload
 
 
 def _render_table(payload: dict[str, Any]) -> Table:
@@ -80,14 +89,23 @@ def _render_table(payload: dict[str, Any]) -> Table:
 
 def run(
     ctx: typer.Context,
+    review_id_or_finding: str | None = typer.Argument(
+        default=None,
+        help="Review id, finding id, or short id (MC-…) depending on invocation.",
+    ),
     finding_id: str | None = typer.Argument(
         default=None,
-        help="Optional finding id to explain. Without it, explain the working-tree diff.",
+        help="Short finding id when the first argument is a stored review id.",
     ),
     repo_root: Path = typer.Option(
         Path("."),
         "--repo-root",
         help="Repository root to read (output-only; nothing is written).",
+    ),
+    review_id: str | None = typer.Option(
+        None,
+        "--review-id",
+        help="Stored review id when explaining a short finding id.",
     ),
     format: OutputFormat | None = typer.Option(
         None,
@@ -97,11 +115,29 @@ def run(
 ) -> None:
     """Explain a stored finding or the current working-tree change."""
     root = repo_root.expanduser().resolve()
-    if finding_id:
-        packet = lookup_finding_packet(finding_id, repo_root=root)
+    resolved_review_id = review_id
+    resolved_finding_id = review_id_or_finding
+    if finding_id is not None:
+        resolved_review_id = review_id_or_finding
+        resolved_finding_id = finding_id
+
+    if resolved_finding_id:
+        packet: dict[str, Any] | None = None
+        if resolved_review_id:
+            packet = lookup_finding_packet_in_review(
+                resolved_review_id,
+                resolved_finding_id,
+                repo_root=root,
+            )
         if packet is None:
-            cli_bail(f"unknown finding id {finding_id}", code=CLI_USAGE_EXIT_CODE)
-        payload = _finding_payload(finding_id, packet)
+            packet = lookup_finding_packet(resolved_finding_id, repo_root=root)
+        if packet is None:
+            cli_bail(f"unknown finding id {resolved_finding_id}", code=CLI_USAGE_EXIT_CODE)
+        payload = _finding_payload(
+            resolved_finding_id,
+            packet,
+            review_id=resolved_review_id,
+        )
     else:
         payload = _change_payload(root)
     use_json = format == "json" or (format is None and wants_json_output(ctx, json_flag=False))

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -20,7 +20,10 @@ from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
 from mergecraft.cli.global_surface import OutputFormat, emit_cli_json, wants_json_output
 from mergecraft.evidence.audit import lookup_finding_packet
-from mergecraft.review.completed import load_completed_review, lookup_finding_packet_in_review
+from mergecraft.review.completed import (
+    completed_review_exists,
+    lookup_finding_packet_in_review,
+)
 from mergecraft.review.finding_lookup import is_safe_path_stem
 
 _FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
@@ -136,7 +139,7 @@ def run(
         token = review_id_or_finding
         if _is_finding_id_token(token):
             resolved_finding_id = token
-        elif is_safe_path_stem(token) and load_completed_review(token, repo_root=root) is not None:
+        elif is_safe_path_stem(token) and completed_review_exists(token, repo_root=root):
             cli_bail(
                 f"{token!r} is a stored review id — pass a finding id (MC-…) "
                 "or use: explain <review-id> <finding-id>",
@@ -153,10 +156,12 @@ def run(
                 resolved_finding_id,
                 repo_root=root,
             )
-        if packet is None:
+            if packet is None:
+                cli_bail(f"unknown finding id {resolved_finding_id}", code=CLI_USAGE_EXIT_CODE)
+        else:
             packet = lookup_finding_packet(resolved_finding_id, repo_root=root)
-        if packet is None:
-            cli_bail(f"unknown finding id {resolved_finding_id}", code=CLI_USAGE_EXIT_CODE)
+            if packet is None:
+                cli_bail(f"unknown finding id {resolved_finding_id}", code=CLI_USAGE_EXIT_CODE)
         payload = _finding_payload(
             resolved_finding_id,
             packet,

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -5,7 +5,6 @@ Exports: ``run``
 
 from __future__ import annotations
 
-import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -13,7 +12,6 @@ from typing import Any
 import typer
 from rich.table import Table
 
-from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX
 from mergecraft.analyzers.scope import changed_paths_from_scope, parse_diff_scope
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
@@ -24,14 +22,6 @@ from mergecraft.review.completed import (
     completed_review_exists,
     lookup_finding_packet_in_review,
 )
-
-_FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
-
-
-def _is_finding_id_token(token: str) -> bool:
-    if token.startswith(FINDING_SHORT_ID_PREFIX):
-        return True
-    return len(token) >= 6 and _FINGERPRINT_HEX_RE.fullmatch(token) is not None
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -142,10 +132,7 @@ def run(
                 "or use: explain <review-id> <finding-id>",
                 code=CLI_USAGE_EXIT_CODE,
             )
-        elif _is_finding_id_token(token):
-            resolved_finding_id = token
-        else:
-            resolved_finding_id = token
+        resolved_finding_id = token
 
     if resolved_finding_id:
         packet: dict[str, Any] | None = None

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -16,7 +16,7 @@ from mergecraft.analyzers.scope import changed_paths_from_scope, parse_diff_scop
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
-from mergecraft.cli.global_surface import emit_cli_json, wants_json_output
+from mergecraft.cli.global_surface import OutputFormat, emit_cli_json, wants_json_output
 from mergecraft.evidence.audit import lookup_finding_packet
 
 
@@ -89,6 +89,11 @@ def run(
         "--repo-root",
         help="Repository root to read (output-only; nothing is written).",
     ),
+    format: OutputFormat | None = typer.Option(
+        None,
+        "--format",
+        help="Output format. Defaults to the root ``--format`` when omitted.",
+    ),
 ) -> None:
     """Explain a stored finding or the current working-tree change."""
     root = repo_root.expanduser().resolve()
@@ -99,7 +104,8 @@ def run(
         payload = _finding_payload(finding_id, packet)
     else:
         payload = _change_payload(root)
-    if wants_json_output(ctx, json_flag=False):
+    use_json = format == "json" or (format is None and wants_json_output(ctx, json_flag=False))
+    if use_json:
         emit_cli_json(payload)
         return
     console.print(_render_table(payload))

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -24,7 +24,6 @@ from mergecraft.review.completed import (
     completed_review_exists,
     lookup_finding_packet_in_review,
 )
-from mergecraft.review.finding_lookup import is_safe_path_stem
 
 _FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
 
@@ -137,14 +136,14 @@ def run(
         resolved_finding_id = finding_id
     elif review_id_or_finding is not None:
         token = review_id_or_finding
-        if _is_finding_id_token(token):
-            resolved_finding_id = token
-        elif is_safe_path_stem(token) and completed_review_exists(token, repo_root=root):
+        if completed_review_exists(token, repo_root=root):
             cli_bail(
                 f"{token!r} is a stored review id — pass a finding id (MC-…) "
                 "or use: explain <review-id> <finding-id>",
                 code=CLI_USAGE_EXIT_CODE,
             )
+        elif _is_finding_id_token(token):
+            resolved_finding_id = token
         else:
             resolved_finding_id = token
 

--- a/src/mergecraft/cli/findings_cmd.py
+++ b/src/mergecraft/cli/findings_cmd.py
@@ -10,19 +10,24 @@ before it is trusted with an automation trigger.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 
 if TYPE_CHECKING:
+    from click import Command, Context
+
     from mergecraft.findings.lifecycle import LifecycleRecord
 
 from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import (
     CLI_CONFIGURATION_EXIT_CODE,
     CLI_USAGE_EXIT_CODE,
 )
 from mergecraft.cli.global_surface import emit_cli_json, get_cli_globals, wants_json_output
+from mergecraft.cli.typer_group import MergecraftTyperGroup
 from mergecraft.findings.ledger import (
     LEDGER_SCHEMA_VERSION,
     FindingLedger,
@@ -41,16 +46,104 @@ from mergecraft.findings.sweep import (
     plan_carryover,
 )
 from mergecraft.findings.threads import fetch_review_threads
+from mergecraft.review.completed import load_completed_review
 from mergecraft.scm.github import GitHubScmAdapter
 from mergecraft.utils.github import GitHubClient, parse_repo_context
 from mergecraft.utils.token import get_job_token
 
+
+class _FindingsTyperGroup(MergecraftTyperGroup):
+    """Route unknown subcommands to durable review lookup (#453)."""
+
+    def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+        ctx.meta["durable_review_id"] = cmd_name
+        return super().get_command(ctx, "_by_review_id")
+
+
 app = typer.Typer(
     help="Inspect and carry forward review findings a merge would otherwise bury.",
     no_args_is_help=True,
+    cls=_FindingsTyperGroup,
 )
 
 _REPO_HELP = "Repository as owner/name. Defaults to $GITHUB_REPOSITORY."
+_REPO_ROOT_HELP = "Repository root for durable review lookup (read-only)."
+
+
+def _render_durable_findings_markdown(
+    *,
+    review_id: str,
+    findings: list[dict[str, Any]],
+) -> str:
+    if not findings:
+        return f"No findings stored for review {review_id}."
+    lines = [f"# Stored findings — {review_id}", ""]
+    for finding in findings:
+        path = str(finding.get("path") or "(no file)")
+        lines.append(f"## {path}")
+        lines.append("")
+        fingerprint = finding.get("fingerprint")
+        if fingerprint:
+            lines.append(f"`{fingerprint}`")
+            lines.append("")
+        message = finding.get("message")
+        if message:
+            lines.append(str(message))
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+@app.command("_by_review_id", hidden=True)
+def _by_review_id(
+    ctx: typer.Context,
+    repo_root: Annotated[
+        Path,
+        typer.Option("--repo-root", help=_REPO_ROOT_HELP),
+    ] = Path("."),
+    output_format: Annotated[
+        str | None,
+        typer.Option(
+            "--output-format",
+            help=(
+                "Stored-findings payload format: json or markdown (default: markdown). "
+                "Root --format json emits JSON when this flag is omitted."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Read persisted findings for a completed review id (D4)."""
+    review_id = str(ctx.meta.get("durable_review_id") or "")
+    if not review_id:
+        cli_bail("review id is required", code=CLI_USAGE_EXIT_CODE)
+    if output_format is not None and output_format not in {"json", "markdown"}:
+        console.print("[red]--output-format must be 'json' or 'markdown'[/red]")
+        raise typer.Exit(CLI_USAGE_EXIT_CODE)
+    emit_json = (
+        output_format == "json"
+        if output_format is not None
+        else get_cli_globals(ctx).format == "json"
+    )
+    root = repo_root.expanduser().resolve()
+    loaded = load_completed_review(review_id, repo_root=root)
+    if loaded is None:
+        cli_bail(f"unknown review id {review_id}", code=CLI_USAGE_EXIT_CODE)
+    if emit_json:
+        emit_cli_json(
+            {
+                "review_id": loaded.review_id,
+                "count": len(loaded.findings),
+                "findings": loaded.findings,
+            }
+        )
+        return
+    typer.echo(
+        _render_durable_findings_markdown(review_id=loaded.review_id, findings=loaded.findings)
+    )
+
+
 _RESOLVED_HELP = "Include threads the author already resolved."
 _ANSWERED_HELP = (
     "Include threads a human replied to (skipped by default: a reply means "

--- a/src/mergecraft/cli/findings_cmd.py
+++ b/src/mergecraft/cli/findings_cmd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
@@ -67,6 +68,16 @@ def _looks_like_review_id(token: str) -> bool:
     return len(token) >= 4 and _REVIEW_ID_PATTERN.fullmatch(token) is not None
 
 
+def _looks_like_subcommand_typo(cmd_name: str) -> bool:
+    """Return whether ``cmd_name`` is likely a misspelling of a reserved subcommand."""
+    for reserved in _FINDINGS_SUBCOMMANDS:
+        if len(cmd_name) >= 3 and reserved.startswith(cmd_name):
+            return True
+        if SequenceMatcher(None, cmd_name, reserved).ratio() >= 0.75:
+            return True
+    return False
+
+
 class _FindingsTyperGroup(MergecraftTyperGroup):
     """Route unknown subcommands to durable review lookup (#453)."""
 
@@ -75,6 +86,8 @@ class _FindingsTyperGroup(MergecraftTyperGroup):
         if command is not None:
             return command
         if cmd_name in _FINDINGS_SUBCOMMANDS:
+            return None
+        if _looks_like_subcommand_typo(cmd_name):
             return None
         if not _looks_like_review_id(cmd_name):
             return None

--- a/src/mergecraft/cli/findings_cmd.py
+++ b/src/mergecraft/cli/findings_cmd.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 from mergecraft.analyzers.finding import (
     Finding,
+    finding_record_without_short_id,
     finding_short_id,
     render_finding_markdown,
     resolve_finding_short_ids,
@@ -118,7 +119,7 @@ def _render_durable_findings_markdown(
     lines = [f"# Stored findings — {review_id}", ""]
     for row in findings:
         try:
-            finding = Finding.model_validate(row)
+            finding = Finding.model_validate(finding_record_without_short_id(row))
         except ValueError:
             path = str(row.get("path") or "(no file)")
             lines.append(f"## {path}")

--- a/src/mergecraft/cli/findings_cmd.py
+++ b/src/mergecraft/cli/findings_cmd.py
@@ -10,8 +10,9 @@ before it is trusted with an automation trigger.
 from __future__ import annotations
 
 import asyncio
+import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import typer
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
     from mergecraft.findings.lifecycle import LifecycleRecord
 
+from mergecraft.analyzers.finding import Finding, render_finding_markdown, resolve_finding_short_ids
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import (
@@ -51,6 +53,14 @@ from mergecraft.scm.github import GitHubScmAdapter
 from mergecraft.utils.github import GitHubClient, parse_repo_context
 from mergecraft.utils.token import get_job_token
 
+_FINDINGS_SUBCOMMANDS = frozenset({"export", "carryover", "ledger"})
+_REVIEW_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+FindingsOutputFormat = Literal["json", "markdown"]
+
+
+def _looks_like_review_id(token: str) -> bool:
+    return len(token) >= 4 and _REVIEW_ID_PATTERN.fullmatch(token) is not None
+
 
 class _FindingsTyperGroup(MergecraftTyperGroup):
     """Route unknown subcommands to durable review lookup (#453)."""
@@ -59,6 +69,10 @@ class _FindingsTyperGroup(MergecraftTyperGroup):
         command = super().get_command(ctx, cmd_name)
         if command is not None:
             return command
+        if cmd_name in _FINDINGS_SUBCOMMANDS:
+            return None
+        if not _looks_like_review_id(cmd_name):
+            return None
         ctx.meta["durable_review_id"] = cmd_name
         return super().get_command(ctx, "_by_review_id")
 
@@ -80,19 +94,25 @@ def _render_durable_findings_markdown(
 ) -> str:
     if not findings:
         return f"No findings stored for review {review_id}."
+    short_ids = resolve_finding_short_ids(
+        [str(row.get("fingerprint", "")) for row in findings if row.get("fingerprint")]
+    )
     lines = [f"# Stored findings — {review_id}", ""]
-    for finding in findings:
-        path = str(finding.get("path") or "(no file)")
-        lines.append(f"## {path}")
+    for row in findings:
+        try:
+            finding = Finding.model_validate(row)
+        except ValueError:
+            path = str(row.get("path") or "(no file)")
+            lines.append(f"## {path}")
+            lines.append("")
+            message = row.get("message")
+            if message:
+                lines.append(str(message))
+                lines.append("")
+            continue
+        short_id = short_ids.get(finding.fingerprint, finding.fingerprint[:6])
+        lines.append(render_finding_markdown(finding, short_id=short_id))
         lines.append("")
-        fingerprint = finding.get("fingerprint")
-        if fingerprint:
-            lines.append(f"`{fingerprint}`")
-            lines.append("")
-        message = finding.get("message")
-        if message:
-            lines.append(str(message))
-            lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -104,7 +124,7 @@ def _by_review_id(
         typer.Option("--repo-root", help=_REPO_ROOT_HELP),
     ] = Path("."),
     output_format: Annotated[
-        str | None,
+        FindingsOutputFormat | None,
         typer.Option(
             "--output-format",
             help=(
@@ -245,7 +265,7 @@ def ledger(
     pr: Annotated[int, typer.Option("--pr", help="Pull request number.")],
     repo: Annotated[str | None, typer.Option("--repo", help=_REPO_HELP)] = None,
     output_format: Annotated[
-        str | None,
+        FindingsOutputFormat | None,
         typer.Option(
             "--output-format",
             help=(
@@ -295,7 +315,7 @@ def export(
     pr: Annotated[int, typer.Option("--pr", help="Pull request number.")],
     repo: Annotated[str | None, typer.Option("--repo", help=_REPO_HELP)] = None,
     output_format: Annotated[
-        str | None,
+        FindingsOutputFormat | None,
         typer.Option(
             "--output-format",
             help=(

--- a/src/mergecraft/cli/findings_cmd.py
+++ b/src/mergecraft/cli/findings_cmd.py
@@ -21,7 +21,12 @@ if TYPE_CHECKING:
 
     from mergecraft.findings.lifecycle import LifecycleRecord
 
-from mergecraft.analyzers.finding import Finding, render_finding_markdown, resolve_finding_short_ids
+from mergecraft.analyzers.finding import (
+    Finding,
+    finding_short_id,
+    render_finding_markdown,
+    resolve_finding_short_ids,
+)
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import (
@@ -110,7 +115,7 @@ def _render_durable_findings_markdown(
                 lines.append(str(message))
                 lines.append("")
             continue
-        short_id = short_ids.get(finding.fingerprint, finding.fingerprint[:6])
+        short_id = short_ids.get(finding.fingerprint, finding_short_id(finding.fingerprint))
         lines.append(render_finding_markdown(finding, short_id=short_id))
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/src/mergecraft/cli/init_cmd.py
+++ b/src/mergecraft/cli/init_cmd.py
@@ -12,6 +12,7 @@ from loguru import logger
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
 from mergecraft.pins import action_pin_minimal
+from mergecraft.review.completed import COMPLETED_REVIEWS_GITIGNORE_LINE
 
 DEFAULT_CONFIG: dict[str, object] = {
     "models": ["anthropic/claude-sonnet"],
@@ -80,9 +81,12 @@ def _audit_jsonl_gitignore_line() -> str:
     return DEFAULT_AUDIT_REL.as_posix()
 
 
-def _ensure_audit_jsonl_gitignore(root: Path) -> None:
-    """Ensure consumer ``.gitignore`` ignores enterprise audit JSONL (D10 / #487)."""
-    line = _audit_jsonl_gitignore_line()
+def _reviews_gitignore_line() -> str:
+    return COMPLETED_REVIEWS_GITIGNORE_LINE
+
+
+def _ensure_gitignore_line(root: Path, line: str) -> None:
+    """Ensure consumer ``.gitignore`` contains ``line`` once."""
     gitignore_path = root / ".gitignore"
     if gitignore_path.is_file():
         text = gitignore_path.read_text(encoding="utf-8")
@@ -93,6 +97,16 @@ def _ensure_audit_jsonl_gitignore(root: Path) -> None:
     else:
         gitignore_path.write_text(f"{line}\n", encoding="utf-8")
     console.print(f"wrote [green]{gitignore_path.relative_to(root)}[/green]")
+
+
+def _ensure_audit_jsonl_gitignore(root: Path) -> None:
+    """Ensure consumer ``.gitignore`` ignores enterprise audit JSONL (D10 / #487)."""
+    _ensure_gitignore_line(root, _audit_jsonl_gitignore_line())
+
+
+def _ensure_reviews_gitignore(root: Path) -> None:
+    """Ensure consumer ``.gitignore`` ignores durable local review artifacts."""
+    _ensure_gitignore_line(root, _reviews_gitignore_line())
 
 
 def _parse_git_remote() -> tuple[str, str] | None:
@@ -156,6 +170,7 @@ def run(
         console.print(f"wrote [green]{learnings.relative_to(root)}[/green]")
 
     _ensure_audit_jsonl_gitignore(root)
+    _ensure_reviews_gitignore(root)
 
     console.print("\n[bold]next steps[/bold]")
     console.print(

--- a/src/mergecraft/cli/init_cmd.py
+++ b/src/mergecraft/cli/init_cmd.py
@@ -10,6 +10,7 @@ import yaml
 from loguru import logger
 
 from mergecraft.cli.consoles import err_console as console
+from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
 from mergecraft.pins import action_pin_minimal
 
 DEFAULT_CONFIG: dict[str, object] = {
@@ -75,6 +76,25 @@ jobs:
 """
 
 
+def _audit_jsonl_gitignore_line() -> str:
+    return DEFAULT_AUDIT_REL.as_posix()
+
+
+def _ensure_audit_jsonl_gitignore(root: Path) -> None:
+    """Ensure consumer ``.gitignore`` ignores enterprise audit JSONL (D10 / #487)."""
+    line = _audit_jsonl_gitignore_line()
+    gitignore_path = root / ".gitignore"
+    if gitignore_path.is_file():
+        text = gitignore_path.read_text(encoding="utf-8")
+        if line in text:
+            return
+        suffix = "" if not text or text.endswith("\n") else "\n"
+        gitignore_path.write_text(f"{text}{suffix}{line}\n", encoding="utf-8")
+    else:
+        gitignore_path.write_text(f"{line}\n", encoding="utf-8")
+    console.print(f"wrote [green]{gitignore_path.relative_to(root)}[/green]")
+
+
 def _parse_git_remote() -> tuple[str, str] | None:
     try:
         url = subprocess.check_output(
@@ -134,6 +154,8 @@ def run(
             encoding="utf-8",
         )
         console.print(f"wrote [green]{learnings.relative_to(root)}[/green]")
+
+    _ensure_audit_jsonl_gitignore(root)
 
     console.print("\n[bold]next steps[/bold]")
     console.print(

--- a/src/mergecraft/cli/replay_cmd.py
+++ b/src/mergecraft/cli/replay_cmd.py
@@ -22,7 +22,10 @@ from mergecraft.cli.trace_jsonl import (
     load_trace_jsonl_events,
     session_ids_in_trace_order,
 )
-from mergecraft.review.completed import load_completed_review_trace_events
+from mergecraft.review.completed import (
+    completed_review_exists,
+    load_completed_review_trace_events,
+)
 
 
 def _payload(*, run_id: str | None, events: list[dict[str, Any]]) -> dict[str, Any]:
@@ -73,6 +76,11 @@ def run(
     if run_id:
         events = load_completed_review_trace_events(run_id, repo_root=root)
         if not events:
+            if completed_review_exists(run_id, repo_root=root):
+                cli_bail(
+                    f"review {run_id} has no stored trace.jsonl",
+                    code=CLI_USAGE_EXIT_CODE,
+                )
             cli_bail(f"unknown review run id {run_id}", code=CLI_USAGE_EXIT_CODE)
     else:
         target = trace_dir if trace_dir is not None else default_trace_dir()

--- a/src/mergecraft/cli/replay_cmd.py
+++ b/src/mergecraft/cli/replay_cmd.py
@@ -18,6 +18,7 @@ from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
 from mergecraft.cli.global_surface import emit_cli_json, wants_json_output
 from mergecraft.cli.trace_jsonl import load_trace_jsonl_events, session_ids_in_trace_order
+from mergecraft.review.completed import load_completed_review_trace_events
 
 
 def _payload(*, run_id: str | None, events: list[dict[str, Any]]) -> dict[str, Any]:
@@ -51,6 +52,11 @@ def run(
         default=None,
         help="Optional stored review run id to replay. Defaults to the latest traced run.",
     ),
+    repo_root: Path = typer.Option(
+        Path("."),
+        "--repo-root",
+        help="Repository root for durable review replay (read-only).",
+    ),
     trace_dir: Path | None = typer.Option(
         None,
         "--trace-dir",
@@ -58,8 +64,13 @@ def run(
     ),
 ) -> None:
     """Replay a stored review run from local traces (read-only)."""
-    target = trace_dir if trace_dir is not None else trace_jsonl.default_trace_dir()
-    events = load_trace_jsonl_events(target)
+    root = repo_root.expanduser().resolve()
+    events: list[dict[str, Any]] = []
+    if run_id:
+        events = load_completed_review_trace_events(run_id, repo_root=root)
+    if not events:
+        target = trace_dir if trace_dir is not None else trace_jsonl.default_trace_dir()
+        events = load_trace_jsonl_events(target)
     payload = _payload(run_id=run_id, events=events)
     if wants_json_output(ctx, json_flag=False):
         emit_cli_json(payload)

--- a/src/mergecraft/cli/replay_cmd.py
+++ b/src/mergecraft/cli/replay_cmd.py
@@ -13,11 +13,15 @@ from typing import Any
 import typer
 from rich.table import Table
 
-from mergecraft.cli import trace_jsonl
 from mergecraft.cli.consoles import err_console as console
-from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
 from mergecraft.cli.global_surface import emit_cli_json, wants_json_output
-from mergecraft.cli.trace_jsonl import load_trace_jsonl_events, session_ids_in_trace_order
+from mergecraft.cli.trace_jsonl import (
+    default_trace_dir,
+    load_trace_jsonl_events,
+    session_ids_in_trace_order,
+)
 from mergecraft.review.completed import load_completed_review_trace_events
 
 
@@ -68,8 +72,10 @@ def run(
     events: list[dict[str, Any]] = []
     if run_id:
         events = load_completed_review_trace_events(run_id, repo_root=root)
-    if not events:
-        target = trace_dir if trace_dir is not None else trace_jsonl.default_trace_dir()
+        if not events:
+            cli_bail(f"unknown review run id {run_id}", code=CLI_USAGE_EXIT_CODE)
+    else:
+        target = trace_dir if trace_dir is not None else default_trace_dir()
         events = load_trace_jsonl_events(target)
     payload = _payload(run_id=run_id, events=events)
     if wants_json_output(ctx, json_flag=False):

--- a/src/mergecraft/cli/review_output.py
+++ b/src/mergecraft/cli/review_output.py
@@ -17,6 +17,7 @@ import typer
 from mergecraft.analyzers.finding import (
     finding_json_record,
     resolve_finding_short_ids,
+    write_findings_json,
 )
 from mergecraft.analyzers.sarif import export_sarif
 from mergecraft.cli.consoles import err_console as console
@@ -98,6 +99,11 @@ def dispatch_review_output(
                 output_text=text or None,
             )
         target = json_output or output
+        if target is not None and findings:
+            write_findings_json(
+                target,
+                [row.model_dump(mode="json") for row in findings],
+            )
         if target is not None and target.is_file():
             console.print(f"[green]wrote[/green] {target}")
         return

--- a/src/mergecraft/cli/review_output.py
+++ b/src/mergecraft/cli/review_output.py
@@ -17,6 +17,7 @@ import typer
 from mergecraft.analyzers.finding import (
     finding_json_record,
     resolve_finding_short_ids,
+    validate_findings_export,
     write_findings_json,
 )
 from mergecraft.analyzers.sarif import export_sarif
@@ -58,11 +59,13 @@ def emit_review_json_stdout(
     output_text: str | None,
 ) -> None:
     """Emit the review JSON envelope on stdout (root ``--format json``)."""
+    records = finding_json_records(findings)
+    validate_findings_export({"findings": records})
     emit_cli_json(
         {
             "review_id": review_id,
             "count": len(findings),
-            "findings": finding_json_records(findings),
+            "findings": records,
             "output": output_text,
         }
     )

--- a/src/mergecraft/cli/review_output.py
+++ b/src/mergecraft/cli/review_output.py
@@ -1,0 +1,149 @@
+"""Review output dispatch for ``mergecraft review`` (Thermos F8 / F16).
+
+Hunk export writes a **raw** ``{"comments":[...]}`` JSON object to stdout for
+pipe-friendly tooling — not the CLI ``emit_cli_json`` envelope used by
+``--format json`` on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+import typer
+
+from mergecraft.analyzers.finding import (
+    finding_json_record,
+    resolve_finding_short_ids,
+)
+from mergecraft.analyzers.sarif import export_sarif
+from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.global_surface import emit_cli_json
+from mergecraft.findings.hunk_export import (
+    count_dropped_file_level_findings,
+    export_hunk_comments,
+    first_changed_lines_from_diff,
+    format_file_level_drop_warning,
+)
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
+    from mergecraft.offline_review import OfflineReviewResult
+
+OutputFormat = Literal["text", "json", "jsonl", "sarif", "hunk"]
+HunkFileFindings = Literal["drop", "first-changed-line"]
+
+
+def finding_json_records(findings: Sequence[Finding]) -> list[dict[str, Any]]:
+    """Serialize findings for structured export with stable short ids."""
+    short_ids = resolve_finding_short_ids([row.fingerprint for row in findings])
+    return [finding_json_record(row, short_id=short_ids[row.fingerprint]) for row in findings]
+
+
+def write_jsonl_findings(path: Path, findings: Sequence[Finding]) -> None:
+    """Write one JSON object per line with short-id finding records."""
+    lines = [
+        json.dumps({"finding": row}, ensure_ascii=False) for row in finding_json_records(findings)
+    ]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def emit_review_json_stdout(
+    *,
+    review_id: str,
+    findings: Sequence[Finding],
+    output_text: str | None,
+) -> None:
+    """Emit the review JSON envelope on stdout (root ``--format json``)."""
+    emit_cli_json(
+        {
+            "review_id": review_id,
+            "count": len(findings),
+            "findings": finding_json_records(findings),
+            "output": output_text,
+        }
+    )
+
+
+def dispatch_review_output(
+    *,
+    effective_output_format: OutputFormat,
+    result: OfflineReviewResult,
+    findings: Sequence[Finding],
+    review_id: str,
+    output: Path | None,
+    json_output: Path | None,
+    json_stdout: bool,
+    hunk_file_findings: HunkFileFindings,
+    exit_code: int,
+) -> None:
+    """Write review artifacts after a successful run (stdout/stderr/files)."""
+    text = result.output or ""
+
+    if effective_output_format == "text":
+        if output is not None:
+            output.write_text(text, encoding="utf-8")
+            console.print(f"[green]wrote[/green] {output}")
+        elif json_output is None:
+            console.print(text)
+        return
+
+    if effective_output_format == "json":
+        target = json_output or output
+        if target is not None and target.is_file():
+            console.print(f"[green]wrote[/green] {target}")
+        if json_stdout:
+            emit_review_json_stdout(
+                review_id=review_id,
+                findings=findings,
+                output_text=text or None,
+            )
+        return
+
+    if effective_output_format == "jsonl":
+        target = output
+        if target is None:
+            console.print("[red]--output is required for --output-format jsonl[/red]")
+            raise typer.Exit(exit_code)
+        write_jsonl_findings(target, findings)
+        console.print(f"[green]wrote[/green] {target}")
+        return
+
+    if effective_output_format == "sarif":
+        target = output
+        if target is None:
+            console.print("[red]--output is required for --output-format sarif[/red]")
+            raise typer.Exit(exit_code)
+        document = export_sarif(list(findings))
+        target.write_text(json.dumps(document, indent=2), encoding="utf-8")
+        console.print(f"[green]wrote[/green] {target}")
+        return
+
+    if effective_output_format == "hunk":
+        first_changed_lines: dict[str, int] | None = None
+        if hunk_file_findings == "first-changed-line" and result.diff_path:
+            diff_path = Path(result.diff_path)
+            if diff_path.is_file():
+                first_changed_lines = first_changed_lines_from_diff(
+                    diff_path.read_text(encoding="utf-8")
+                )
+        if hunk_file_findings == "drop":
+            dropped = count_dropped_file_level_findings(findings)
+            if dropped:
+                console.print(format_file_level_drop_warning(dropped))
+        payload = export_hunk_comments(
+            findings,
+            file_findings=hunk_file_findings,
+            first_changed_lines=first_changed_lines,
+        )
+        typer.echo(json.dumps(payload, ensure_ascii=False))
+
+
+__all__ = [
+    "dispatch_review_output",
+    "emit_review_json_stdout",
+    "finding_json_records",
+    "write_jsonl_findings",
+]

--- a/src/mergecraft/cli/review_output.py
+++ b/src/mergecraft/cli/review_output.py
@@ -86,6 +86,12 @@ def dispatch_review_output(
     """Write review artifacts after a successful run (stdout/stderr/files)."""
     text = result.output or ""
 
+    if json_output is not None and findings and effective_output_format != "json":
+        write_findings_json(
+            json_output,
+            [row.model_dump(mode="json") for row in findings],
+        )
+
     if effective_output_format == "text":
         if output is not None:
             output.write_text(text, encoding="utf-8")

--- a/src/mergecraft/cli/review_output.py
+++ b/src/mergecraft/cli/review_output.py
@@ -1,4 +1,4 @@
-"""Review output dispatch for ``mergecraft review`` (Thermos F8 / F16).
+"""Review output dispatch for ``mergecraft review``.
 
 Hunk export writes a **raw** ``{"comments":[...]}`` JSON object to stdout for
 pipe-friendly tooling — not the CLI ``emit_cli_json`` envelope used by
@@ -91,15 +91,15 @@ def dispatch_review_output(
         return
 
     if effective_output_format == "json":
-        target = json_output or output
-        if target is not None and target.is_file():
-            console.print(f"[green]wrote[/green] {target}")
         if json_stdout:
             emit_review_json_stdout(
                 review_id=review_id,
                 findings=findings,
                 output_text=text or None,
             )
+        target = json_output or output
+        if target is not None and target.is_file():
+            console.print(f"[green]wrote[/green] {target}")
         return
 
     if effective_output_format == "jsonl":

--- a/src/mergecraft/cli/trace_jsonl.py
+++ b/src/mergecraft/cli/trace_jsonl.py
@@ -2,62 +2,10 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Any
-
-from mergecraft.tracing.sinks import read_jsonl_events
-
-
-def default_trace_dir() -> Path:
-    """Resolve ``MERGECRAFT_TRACE_DIR`` or the default ``.mergecraft/traces`` path."""
-    env_dir = os.environ.get("MERGECRAFT_TRACE_DIR")
-    if env_dir:
-        return Path(env_dir)
-    return Path(".mergecraft/traces")
-
-
-def load_trace_jsonl_events(trace_dir: Path) -> list[dict[str, Any]]:
-    """Parse every ``*.jsonl`` file under ``trace_dir`` via the tracing sink reader."""
-    if not trace_dir.is_dir():
-        return []
-    matched: list[dict[str, Any]] = []
-    for jsonl_path in sorted(trace_dir.glob("*.jsonl")):
-        try:
-            events = read_jsonl_events(jsonl_path)
-        except OSError:
-            continue
-        for event in events:
-            if isinstance(event, dict):
-                matched.append(event)
-    return matched
-
-
-def session_ids_in_trace_order(events: list[dict[str, Any]]) -> list[str]:
-    """Return unique ``session_id`` values ordered by earliest trace timestamp.
-
-    UUID4 (and operator-supplied) ids are not chronological; lexicographic sort
-    would pick the wrong default for ``replay`` / ``run inspect`` / ``run diff``.
-    """
-    first_index: dict[str, int] = {}
-    min_ts: dict[str, int] = {}
-    for idx, event in enumerate(events):
-        raw = event.get("session_id")
-        if raw is None or raw == "":
-            continue
-        session_id = str(raw)
-        if session_id not in first_index:
-            first_index[session_id] = idx
-        ts = event.get("ts_start_ns")
-        if isinstance(ts, int) and (session_id not in min_ts or ts < min_ts[session_id]):
-            min_ts[session_id] = ts
-
-    def _sort_key(session_id: str) -> tuple[int, int, int]:
-        if session_id in min_ts:
-            return (0, min_ts[session_id], first_index[session_id])
-        return (1, first_index[session_id], 0)
-
-    return sorted(first_index, key=_sort_key)
-
+from mergecraft.tracing.trace_jsonl import (
+    default_trace_dir,
+    load_trace_jsonl_events,
+    session_ids_in_trace_order,
+)
 
 __all__ = ["default_trace_dir", "load_trace_jsonl_events", "session_ids_in_trace_order"]

--- a/src/mergecraft/cli/update_cmd.py
+++ b/src/mergecraft/cli/update_cmd.py
@@ -9,6 +9,7 @@ import typer
 from mergecraft.cli.errors import cli_bail
 
 DEFAULT_UPDATE_REF = "main"
+"""Default ``uv tool install`` git ref — tracks ``main`` on mergeCraft (branch tip at install time)."""
 MERGECRAFT_GIT_ORIGIN = "https://github.com/alexhawat/mergeCraft"
 MERGECRAFT_UV_INSTALL_PACKAGE = "merge-craft"
 

--- a/src/mergecraft/cli/update_cmd.py
+++ b/src/mergecraft/cli/update_cmd.py
@@ -1,0 +1,51 @@
+"""``mergecraft update`` — reinstall the CLI via ``uv tool install --reinstall`` (#473)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+from mergecraft.cli.errors import cli_bail
+
+DEFAULT_UPDATE_REF = "main"
+MERGECRAFT_GIT_ORIGIN = "https://github.com/alexhawat/mergeCraft"
+MERGECRAFT_UV_INSTALL_PACKAGE = "merge-craft"
+
+
+def uv_install_spec(ref: str) -> str:
+    """Return the ``uv tool install`` git spec for ``ref`` (branch, tag, or SHA)."""
+    return f"{MERGECRAFT_UV_INSTALL_PACKAGE} @ git+{MERGECRAFT_GIT_ORIGIN}@{ref}"
+
+
+def build_uv_install_argv(ref: str) -> list[str]:
+    """Build argv for ``uv tool install --reinstall`` at ``ref``."""
+    return ["uv", "tool", "install", "--reinstall", uv_install_spec(ref)]
+
+
+def run(
+    branch: str | None = typer.Option(
+        None,
+        "--branch",
+        help="Git ref to install (branch, tag, or commit SHA). Defaults to main.",
+    ),
+) -> None:
+    """Reinstall mergecraft from GitHub using ``uv tool install --reinstall``."""
+    ref = branch or DEFAULT_UPDATE_REF
+    argv = build_uv_install_argv(ref)
+    try:
+        subprocess.run(argv, check=True)
+    except OSError as exc:
+        cli_bail(f"failed to run uv: {exc}")
+    except subprocess.CalledProcessError as exc:
+        cli_bail(f"uv tool install failed (exit {exc.returncode})")
+
+
+__all__ = [
+    "DEFAULT_UPDATE_REF",
+    "MERGECRAFT_GIT_ORIGIN",
+    "MERGECRAFT_UV_INSTALL_PACKAGE",
+    "build_uv_install_argv",
+    "run",
+    "uv_install_spec",
+]

--- a/src/mergecraft/evals/benchmark.py
+++ b/src/mergecraft/evals/benchmark.py
@@ -27,6 +27,10 @@ from mergecraft.agents.verifier import (
     pinned_judge_model,
 )
 from mergecraft.evals.convergence import ConvergenceCaseResult, ConvergenceMetrics, ConvergenceRound
+from mergecraft.evals.lens_capability import (
+    LensRoutingCapabilityReport,  # noqa: TC001 — Pydantic field type
+)
+from mergecraft.evals.lens_capability_benchmark import score_routing_baseline_capability
 from mergecraft.evals.scoring import DEFAULT_LINE_SLACK, AggregateScoreReport
 from mergecraft.evals.store import (
     CASE_STATUS_BLOCKED,
@@ -284,6 +288,8 @@ class BenchmarkResultSet(BaseModel):
     # `mergecraft eval convergence` runs (W4). Older result sets without
     # this key still validate (D3).
     convergence: ConvergenceMetrics | None = None
+    # CE #455: per-lens routing precision/recall from the frozen AP5 baseline.
+    lens_routing_capability: LensRoutingCapabilityReport | None = None
     skipped_reason: str | None = None
 
     @property
@@ -609,7 +615,12 @@ def run_structural_replay(
         line_slack=DEFAULT_LINE_SLACK,
     )
 
-    return BenchmarkResultSet(pins=pins, metrics=metrics, case_results=rows)
+    return BenchmarkResultSet(
+        pins=pins,
+        metrics=metrics,
+        case_results=rows,
+        lens_routing_capability=score_routing_baseline_capability(),
+    )
 
 
 def write_result_set(

--- a/src/mergecraft/evals/fixtures/ap5_routing_recall_baseline.json
+++ b/src/mergecraft/evals/fixtures/ap5_routing_recall_baseline.json
@@ -1,0 +1,86 @@
+{
+  "description": "AP5 routing recall baseline — expected lens selections for eval-shaped diffs",
+  "min_recall": 1.0,
+  "cases": [
+    {
+      "id": "docs-only-trivial",
+      "changed_paths": ["docs/guide.md"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 1,
+        "lines_deleted": 1
+      },
+      "expected_lens_ids": []
+    },
+    {
+      "id": "billing-one-liner",
+      "changed_paths": ["src/billing/tax_rate.py"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 1,
+        "lines_deleted": 1,
+        "diff": "@@ -1 +1 @@\n-OLD_RATE = 0.05\n+OLD_RATE = 0.06"
+      },
+      "expected_lens_ids": ["security", "correctness", "data-integrity"]
+    },
+    {
+      "id": "schema-migration",
+      "changed_paths": ["migrations/20260816_add_status.sql"],
+      "diff_stats": {
+        "files_changed": 1,
+        "diff": "ALTER TABLE invoices ADD COLUMN status text;"
+      },
+      "expected_lens_ids": ["schema-migration", "data-integrity"]
+    },
+    {
+      "id": "security-sql-injection",
+      "changed_paths": ["src/mergecraft/ci/db.py"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 5,
+        "diff": "query = f\"SELECT * FROM runs WHERE id = {run_id}\""
+      },
+      "expected_lens_ids": ["security", "correctness"]
+    },
+    {
+      "id": "dependency-manifest",
+      "changed_paths": ["pyproject.toml"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 2,
+        "lines_deleted": 1
+      },
+      "expected_lens_ids": ["dependency-build", "integration"]
+    },
+    {
+      "id": "public-api-surface",
+      "changed_paths": ["src/mergecraft/api/public.py"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 20,
+        "lines_deleted": 3
+      },
+      "expected_lens_ids": ["api-compatibility", "impact", "integration"]
+    },
+    {
+      "id": "concurrency-change",
+      "changed_paths": ["src/mergecraft/worker/pool.py"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 15,
+        "diff": "asyncio.gather"
+      },
+      "expected_lens_ids": ["concurrency", "correctness"]
+    },
+    {
+      "id": "cross-repo-config",
+      "changed_paths": [".mergecraft/config.yaml"],
+      "diff_stats": {
+        "files_changed": 1,
+        "lines_added": 4,
+        "diff": "xrepo:\n  mode: explicit"
+      },
+      "expected_lens_ids": ["cross-repo", "policy"]
+    }
+  ]
+}

--- a/src/mergecraft/evals/lens_capability.py
+++ b/src/mergecraft/evals/lens_capability.py
@@ -93,6 +93,11 @@ def _f1(precision: float | None, recall: float | None) -> float:
 
 
 def _macro_average(values: list[float | None]) -> float:
+    """Macro-average metric values over participating lenses only.
+
+    ``None`` precision/recall (lens never selected or never expected) counts as
+    0.0 so macro totals stay finite and match the CE routing capability tests.
+    """
     if not values:
         return 0.0
     total = sum(0.0 if value is None else value for value in values)

--- a/src/mergecraft/evals/lens_capability.py
+++ b/src/mergecraft/evals/lens_capability.py
@@ -1,0 +1,188 @@
+"""Per-lens routing precision/recall capability metrics (#455, CE).
+
+Additive eval metrics for labeled routing cases: compare expected lens sets
+against observed selections and emit a diffable JSON report. Does not rebuild
+the eval harness — scores labeled diffs only.
+
+Exports:
+    LENS_CAPABILITY_SCHEMA_VERSION: Stable schema version string.
+    LensRoutingCaseLabel: Ground-truth lenses for one labeled case.
+    LensRoutingCaseOutcome: Observed lens selection for one case.
+    PerLensRoutingMetrics: TP/FP/FN and precision/recall for one lens.
+    LensRoutingCapabilityReport: Corpus-wide routing capability report.
+    score_lens_routing: Score labels against outcomes.
+    render_lens_capability_json: Canonical compact JSON for stable diffs.
+    lens_capability_digest: SHA-256 digest over canonical JSON.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+LENS_CAPABILITY_SCHEMA_VERSION: Final[str] = "1.0.0"
+
+
+class LensRoutingCaseLabel(BaseModel):
+    """Ground-truth lenses that should fire for one labeled routing case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    expected_lens_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class LensRoutingCaseOutcome(BaseModel):
+    """Observed lens selection for one routing case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    selected_lens_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class PerLensRoutingMetrics(BaseModel):
+    """Per-lens routing precision/recall rolled up across labeled cases."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lens_id: str
+    true_positives: int = 0
+    false_positives: int = 0
+    false_negatives: int = 0
+    precision: float | None = None
+    recall: float | None = None
+
+
+class LensRoutingCapabilityReport(BaseModel):
+    """Corpus-wide per-lens routing capability numbers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = LENS_CAPABILITY_SCHEMA_VERSION
+    cases: int = 0
+    by_lens: dict[str, PerLensRoutingMetrics] = Field(default_factory=dict)
+    macro_precision: float = 0.0
+    macro_recall: float = 0.0
+    macro_f1: float = 0.0
+
+
+def _precision(tp: int, fp: int) -> float | None:
+    denom = tp + fp
+    if denom == 0:
+        return None
+    return tp / denom
+
+
+def _recall(tp: int, fn: int) -> float | None:
+    denom = tp + fn
+    if denom == 0:
+        return None
+    return tp / denom
+
+
+def _f1(precision: float | None, recall: float | None) -> float:
+    if precision is None or recall is None:
+        return 0.0
+    if precision == 0.0 and recall == 0.0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _macro_average(values: list[float | None]) -> float:
+    if not values:
+        return 0.0
+    total = sum(0.0 if value is None else value for value in values)
+    return total / len(values)
+
+
+def score_lens_routing(
+    labels: list[LensRoutingCaseLabel],
+    outcomes: list[LensRoutingCaseOutcome],
+) -> LensRoutingCapabilityReport:
+    """Score labeled routing cases against observed lens selections."""
+    label_ids = {label.case_id for label in labels}
+    outcome_ids = {outcome.case_id for outcome in outcomes}
+    if label_ids != outcome_ids:
+        raise ValueError(
+            f"case ids must align one-to-one: labels={sorted(label_ids)} outcomes={sorted(outcome_ids)}"
+        )
+
+    label_by_id = {label.case_id: label for label in labels}
+    outcome_by_id = {outcome.case_id: outcome for outcome in outcomes}
+
+    true_positives: dict[str, int] = {}
+    false_positives: dict[str, int] = {}
+    false_negatives: dict[str, int] = {}
+
+    for case_id in sorted(label_ids):
+        expected = set(label_by_id[case_id].expected_lens_ids)
+        selected = set(outcome_by_id[case_id].selected_lens_ids)
+        participating = expected | selected
+
+        for lens_id in participating:
+            if lens_id in expected and lens_id in selected:
+                true_positives[lens_id] = true_positives.get(lens_id, 0) + 1
+            elif lens_id in selected:
+                false_positives[lens_id] = false_positives.get(lens_id, 0) + 1
+            else:
+                false_negatives[lens_id] = false_negatives.get(lens_id, 0) + 1
+
+    by_lens: dict[str, PerLensRoutingMetrics] = {}
+    macro_precisions: list[float | None] = []
+    macro_recalls: list[float | None] = []
+    macro_f1s: list[float] = []
+
+    for lens_id in sorted(true_positives.keys() | false_positives.keys() | false_negatives.keys()):
+        tp = true_positives.get(lens_id, 0)
+        fp = false_positives.get(lens_id, 0)
+        fn = false_negatives.get(lens_id, 0)
+        precision = _precision(tp, fp)
+        recall = _recall(tp, fn)
+        metrics = PerLensRoutingMetrics(
+            lens_id=lens_id,
+            true_positives=tp,
+            false_positives=fp,
+            false_negatives=fn,
+            precision=precision,
+            recall=recall,
+        )
+        by_lens[lens_id] = metrics
+        macro_precisions.append(precision)
+        macro_recalls.append(recall)
+        macro_f1s.append(_f1(precision, recall))
+
+    return LensRoutingCapabilityReport(
+        cases=len(label_ids),
+        by_lens=by_lens,
+        macro_precision=_macro_average(macro_precisions),
+        macro_recall=_macro_average(macro_recalls),
+        macro_f1=sum(macro_f1s) / len(macro_f1s) if macro_f1s else 0.0,
+    )
+
+
+def render_lens_capability_json(report: LensRoutingCapabilityReport) -> str:
+    """Render a routing capability report as canonical compact JSON."""
+    payload = report.model_dump(mode="json")
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def lens_capability_digest(report: LensRoutingCapabilityReport) -> str:
+    """Return a SHA-256 digest over the canonical JSON representation."""
+    canonical = render_lens_capability_json(report)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "LENS_CAPABILITY_SCHEMA_VERSION",
+    "LensRoutingCapabilityReport",
+    "LensRoutingCaseLabel",
+    "LensRoutingCaseOutcome",
+    "PerLensRoutingMetrics",
+    "lens_capability_digest",
+    "render_lens_capability_json",
+    "score_lens_routing",
+]

--- a/src/mergecraft/evals/lens_capability_benchmark.py
+++ b/src/mergecraft/evals/lens_capability_benchmark.py
@@ -1,0 +1,80 @@
+"""Lens routing capability scoring for eval benchmark result sets (#455, CE)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final
+
+from mergecraft.classify.change_classifier import classify_change
+from mergecraft.classify.generated_files import ChangeSet  # noqa: TC001 — TypedDict wire shape
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.evals.lens_capability import (
+    LensRoutingCapabilityReport,
+    LensRoutingCaseLabel,
+    LensRoutingCaseOutcome,
+    score_lens_routing,
+)
+from mergecraft.review.lens_routing import load_routing_registry, route_lenses
+
+_RECALL_BASELINE_REL: Final[Path] = Path("tests/_fixtures/ap5_routing_recall_baseline.json")
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+
+
+def _resolved_recall_baseline_path() -> Path:
+    if _RECALL_BASELINE_REL.is_file():
+        return _RECALL_BASELINE_REL
+    checkout = _REPO_ROOT / _RECALL_BASELINE_REL
+    if checkout.is_file():
+        return checkout
+    msg = f"routing recall baseline fixture missing: {_RECALL_BASELINE_REL}"
+    raise FileNotFoundError(msg)
+
+
+def score_routing_baseline_capability(
+    *,
+    repo_root: Path | None = None,
+) -> LensRoutingCapabilityReport:
+    """Score the frozen AP5 routing baseline without live provider calls."""
+    baseline_path = _resolved_recall_baseline_path()
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    cases_raw = baseline["cases"]
+    if not isinstance(cases_raw, list):
+        msg = "routing recall baseline cases must be a list"
+        raise TypeError(msg)
+
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    settings = load_repo_settings(root=root)
+    registry = load_routing_registry(settings=settings, repo_root=root)
+
+    labels: list[LensRoutingCaseLabel] = []
+    outcomes: list[LensRoutingCaseOutcome] = []
+    for case in cases_raw:
+        if not isinstance(case, dict):
+            msg = "routing recall baseline case must be an object"
+            raise TypeError(msg)
+        case_id = str(case["id"])
+        expected_raw = case.get("expected_lens_ids", [])
+        if not isinstance(expected_raw, list):
+            msg = f"expected_lens_ids must be a list for case {case_id}"
+            raise TypeError(msg)
+        expected = tuple(str(item) for item in expected_raw)
+        labels.append(LensRoutingCaseLabel(case_id=case_id, expected_lens_ids=expected))
+
+        change: ChangeSet = {
+            "changed_paths": case["changed_paths"],
+            "diff_stats": case["diff_stats"],
+        }
+        classification = classify_change(change)
+        decision = route_lenses(classification, registry=registry)
+        outcomes.append(
+            LensRoutingCaseOutcome(
+                case_id=case_id,
+                selected_lens_ids=tuple(decision.selected_lens_ids),
+            )
+        )
+
+    return score_lens_routing(labels, outcomes)
+
+
+__all__ = ["score_routing_baseline_capability"]

--- a/src/mergecraft/evals/lens_capability_benchmark.py
+++ b/src/mergecraft/evals/lens_capability_benchmark.py
@@ -17,17 +17,19 @@ from mergecraft.evals.lens_capability import (
 )
 from mergecraft.review.lens_routing import load_routing_registry, route_lenses
 
-_RECALL_BASELINE_REL: Final[Path] = Path("tests/_fixtures/ap5_routing_recall_baseline.json")
-_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+_RECALL_BASELINE_NAME: Final[str] = "ap5_routing_recall_baseline.json"
+_EVALS_DIR: Final[Path] = Path(__file__).resolve().parent
+_REPO_ROOT: Final[Path] = _EVALS_DIR.parents[2]
 
 
 def _resolved_recall_baseline_path() -> Path:
-    if _RECALL_BASELINE_REL.is_file():
-        return _RECALL_BASELINE_REL
-    checkout = _REPO_ROOT / _RECALL_BASELINE_REL
+    shipped = _EVALS_DIR / "fixtures" / _RECALL_BASELINE_NAME
+    if shipped.is_file():
+        return shipped
+    checkout = _REPO_ROOT / "evals" / "fixtures" / _RECALL_BASELINE_NAME
     if checkout.is_file():
         return checkout
-    msg = f"routing recall baseline fixture missing: {_RECALL_BASELINE_REL}"
+    msg = f"routing recall baseline fixture missing: {_RECALL_BASELINE_NAME}"
     raise FileNotFoundError(msg)
 
 

--- a/src/mergecraft/evidence/audit.py
+++ b/src/mergecraft/evidence/audit.py
@@ -31,10 +31,16 @@ import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from fnmatch import fnmatch
-from pathlib import Path
-from typing import Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
-from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+from mergecraft.review.finding_lookup import (
+    is_safe_path_stem,
+    load_json_packets_in_dir,
+    lookup_packet_by_finding_id,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 VerifierState = Literal[
     "proven",
@@ -358,43 +364,13 @@ def apply_verifier_outcome(
     return VerifierStateOutcome(state=safe, reason="verifier did not name a state")
 
 
-def _is_safe_packet_stem(finding_id: str) -> bool:
-    """Reject empty, ``..``, and any separator so ids cannot escape evidence_dir."""
-    if not finding_id or finding_id in {".", ".."}:
-        return False
-    if "/" in finding_id or "\\" in finding_id:
-        return False
-    return Path(finding_id).parts == (finding_id,)
-
-
 def _lookup_short_finding_packet(short_id: str, *, repo_root: Path) -> dict[str, Any] | None:
     """Resolve ``MC-…`` ids against stored evidence packets."""
-    if not short_id.startswith(FINDING_SHORT_ID_PREFIX):
-        return None
-    suffix = short_id[len(FINDING_SHORT_ID_PREFIX) :]
-    if not suffix or not all(char in "0123456789abcdef" for char in suffix):
-        return None
     evidence_dir = repo_root / ".mergecraft" / "evidence"
-    if not evidence_dir.is_dir():
+    packets_by_fingerprint = load_json_packets_in_dir(evidence_dir)
+    if not packets_by_fingerprint:
         return None
-    fingerprints: list[str] = []
-    packets_by_fingerprint: dict[str, dict[str, Any]] = {}
-    for path in sorted(evidence_dir.glob("*.json")):
-        stem = path.stem
-        if not _is_safe_packet_stem(stem):
-            continue
-        loaded = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(loaded, dict):
-            continue
-        fingerprints.append(stem)
-        packets_by_fingerprint[stem] = loaded
-    if not fingerprints:
-        return None
-    mapping = resolve_finding_short_ids(fingerprints)
-    for fingerprint, mapped_id in mapping.items():
-        if mapped_id == short_id:
-            return packets_by_fingerprint[fingerprint]
-    return None
+    return lookup_packet_by_finding_id(short_id, packets_by_fingerprint)
 
 
 def lookup_finding_packet(finding_id: str, *, repo_root: Path) -> dict[str, Any] | None:
@@ -407,9 +383,11 @@ def lookup_finding_packet(finding_id: str, *, repo_root: Path) -> dict[str, Any]
     Returns:
         Packet mapping, or None when the finding is unknown.
     """
+    from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX
+
     if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
         return _lookup_short_finding_packet(finding_id, repo_root=repo_root)
-    if not _is_safe_packet_stem(finding_id):
+    if not is_safe_path_stem(finding_id):
         return None
     evidence_dir = repo_root / ".mergecraft" / "evidence"
     try:
@@ -422,25 +400,14 @@ def lookup_finding_packet(finding_id: str, *, repo_root: Path) -> dict[str, Any]
     except OSError:
         resolved = None
     if resolved is not None and resolved.is_file() and resolved.is_relative_to(evidence_root):
-        loaded = json.loads(resolved.read_text(encoding="utf-8"))
+        try:
+            loaded = json.loads(resolved.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded = None
         if isinstance(loaded, dict):
             return loaded
-    if not evidence_dir.is_dir():
-        return None
-    for path in sorted(evidence_dir.glob("*.json")):
-        loaded = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(loaded, dict):
-            continue
-        if str(loaded.get("finding_id", "")) == finding_id:
-            return loaded
-        findings = loaded.get("findings")
-        if isinstance(findings, list):
-            for item in findings:
-                if not isinstance(item, dict):
-                    continue
-                if str(item.get("fingerprint", "")) == finding_id:
-                    return loaded
-    return None
+    packets_by_fingerprint = load_json_packets_in_dir(evidence_dir)
+    return lookup_packet_by_finding_id(finding_id, packets_by_fingerprint)
 
 
 __all__ = [

--- a/src/mergecraft/evidence/audit.py
+++ b/src/mergecraft/evidence/audit.py
@@ -34,6 +34,8 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Final, Literal
 
+from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+
 VerifierState = Literal[
     "proven",
     "strongly-supported",
@@ -365,6 +367,36 @@ def _is_safe_packet_stem(finding_id: str) -> bool:
     return Path(finding_id).parts == (finding_id,)
 
 
+def _lookup_short_finding_packet(short_id: str, *, repo_root: Path) -> dict[str, Any] | None:
+    """Resolve ``MC-…`` ids against stored evidence packets."""
+    if not short_id.startswith(FINDING_SHORT_ID_PREFIX):
+        return None
+    suffix = short_id[len(FINDING_SHORT_ID_PREFIX) :]
+    if not suffix or not all(char in "0123456789abcdef" for char in suffix):
+        return None
+    evidence_dir = repo_root / ".mergecraft" / "evidence"
+    if not evidence_dir.is_dir():
+        return None
+    fingerprints: list[str] = []
+    packets_by_fingerprint: dict[str, dict[str, Any]] = {}
+    for path in sorted(evidence_dir.glob("*.json")):
+        stem = path.stem
+        if not _is_safe_packet_stem(stem):
+            continue
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            continue
+        fingerprints.append(stem)
+        packets_by_fingerprint[stem] = loaded
+    if not fingerprints:
+        return None
+    mapping = resolve_finding_short_ids(fingerprints)
+    for fingerprint, mapped_id in mapping.items():
+        if mapped_id == short_id:
+            return packets_by_fingerprint[fingerprint]
+    return None
+
+
 def lookup_finding_packet(finding_id: str, *, repo_root: Path) -> dict[str, Any] | None:
     """Load a stored evidence packet for ``finding_id``, or None if missing.
 
@@ -375,6 +407,8 @@ def lookup_finding_packet(finding_id: str, *, repo_root: Path) -> dict[str, Any]
     Returns:
         Packet mapping, or None when the finding is unknown.
     """
+    if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
+        return _lookup_short_finding_packet(finding_id, repo_root=repo_root)
     if not _is_safe_packet_stem(finding_id):
         return None
     evidence_dir = repo_root / ".mergecraft" / "evidence"

--- a/src/mergecraft/evidence/minimal_packet.py
+++ b/src/mergecraft/evidence/minimal_packet.py
@@ -1,0 +1,17 @@
+"""Minimal evidence-packet stubs for findings without on-disk packets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def minimal_evidence_packet(fingerprint: str) -> dict[str, Any]:
+    """Return the default unverified stub keyed by ``finding_id``."""
+    return {
+        "finding_id": fingerprint,
+        "state": "unverified",
+        "kinds": [],
+    }
+
+
+__all__ = ["minimal_evidence_packet"]

--- a/src/mergecraft/findings/hunk_export.py
+++ b/src/mergecraft/findings/hunk_export.py
@@ -1,0 +1,111 @@
+"""Pure Hunk comment exporter for ``--output-format hunk`` (issue #451, D3).
+
+Maps normalized findings to the stdin JSON envelope Hunk expects
+(``{"comments":[...]}``) without subprocess, HTTP, or a Hunk dependency.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from mergecraft.analyzers.scope import parse_diff_scope
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from mergecraft.analyzers.finding import Finding
+
+HUNK_COMMENT_AUTHOR = "mergeCraft"
+
+FileFindingsMode = Literal["drop", "first-changed-line"]
+_VALID_FILE_FINDINGS: frozenset[str] = frozenset({"drop", "first-changed-line"})
+
+
+def count_dropped_file_level_findings(findings: Sequence[Finding]) -> int:
+    """Return how many findings lack a line anchor (``start_line is None``)."""
+    return sum(1 for finding in findings if finding.start_line is None)
+
+
+def format_file_level_drop_warning(count: int) -> str:
+    """Human stderr copy when file-level findings are omitted from export."""
+    noun = "finding" if count == 1 else "findings"
+    return f"{count} file-level {noun} not exportable"
+
+
+def first_changed_lines_from_diff(diff_text: str) -> dict[str, int]:
+    """Map each changed path to the first new-file line number in ``diff_text``."""
+    scope = parse_diff_scope(diff_text)
+    return {
+        path: min(start for start, _ in ranges)
+        for path, ranges in scope.hunk_ranges.items()
+        if ranges
+    }
+
+
+def _format_hunk_summary(finding: Finding, *, file_level: bool = False) -> str:
+    prefix = "[file-level] " if file_level else ""
+    return f"{prefix}{finding.rule_id} [{finding.severity}/{finding.confidence}]"
+
+
+def _format_hunk_rationale(finding: Finding) -> str:
+    parts: list[str] = [finding.message]
+    if finding.remediation:
+        parts.append(finding.remediation)
+    parts.extend(finding.evidence)
+    return "\n\n".join(parts)
+
+
+def export_hunk_comments(
+    findings: Sequence[Finding],
+    *,
+    file_findings: str = "drop",
+    first_changed_lines: Mapping[str, int] | None = None,
+) -> dict[str, Any]:
+    """Convert findings to the Hunk ``comment apply --stdin`` payload."""
+    if file_findings not in _VALID_FILE_FINDINGS:
+        msg = (
+            f"file_findings must be one of {sorted(_VALID_FILE_FINDINGS)!r}, got {file_findings!r}"
+        )
+        raise ValueError(msg)
+
+    comments: list[dict[str, Any]] = []
+    for finding in findings:
+        if finding.start_line is None:
+            if file_findings == "drop":
+                continue
+            if first_changed_lines is None:
+                continue
+            new_line = first_changed_lines.get(finding.path)
+            if new_line is None:
+                continue
+            comments.append(
+                {
+                    "filePath": finding.path,
+                    "newLine": new_line,
+                    "summary": _format_hunk_summary(finding, file_level=True),
+                    "rationale": _format_hunk_rationale(finding),
+                    "author": HUNK_COMMENT_AUTHOR,
+                }
+            )
+            continue
+
+        comments.append(
+            {
+                "filePath": finding.path,
+                "newLine": finding.start_line,
+                "summary": _format_hunk_summary(finding),
+                "rationale": _format_hunk_rationale(finding),
+                "author": HUNK_COMMENT_AUTHOR,
+            }
+        )
+
+    return {"comments": comments}
+
+
+__all__ = [
+    "HUNK_COMMENT_AUTHOR",
+    "count_dropped_file_level_findings",
+    "export_hunk_comments",
+    "first_changed_lines_from_diff",
+    "format_file_level_drop_warning",
+]

--- a/src/mergecraft/findings/hunk_export.py
+++ b/src/mergecraft/findings/hunk_export.py
@@ -58,7 +58,7 @@ def _format_hunk_rationale(finding: Finding) -> str:
 def export_hunk_comments(
     findings: Sequence[Finding],
     *,
-    file_findings: str = "drop",
+    file_findings: FileFindingsMode = "drop",
     first_changed_lines: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Convert findings to the Hunk ``comment apply --stdin`` payload."""

--- a/src/mergecraft/findings/hunk_export.py
+++ b/src/mergecraft/findings/hunk_export.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from mergecraft.analyzers.finding import resolve_finding_short_ids
 from mergecraft.analyzers.scope import parse_diff_scope
 
 if TYPE_CHECKING:
@@ -42,9 +43,15 @@ def first_changed_lines_from_diff(diff_text: str) -> dict[str, int]:
     }
 
 
-def _format_hunk_summary(finding: Finding, *, file_level: bool = False) -> str:
+def _format_hunk_summary(
+    finding: Finding,
+    *,
+    short_id: str | None = None,
+    file_level: bool = False,
+) -> str:
     prefix = "[file-level] " if file_level else ""
-    return f"{prefix}{finding.rule_id} [{finding.severity}/{finding.confidence}]"
+    id_prefix = f"{short_id} " if short_id else ""
+    return f"{prefix}{id_prefix}{finding.rule_id} [{finding.severity}/{finding.confidence}]"
 
 
 def _format_hunk_rationale(finding: Finding) -> str:
@@ -69,7 +76,9 @@ def export_hunk_comments(
         raise ValueError(msg)
 
     comments: list[dict[str, Any]] = []
+    short_ids = resolve_finding_short_ids([finding.fingerprint for finding in findings])
     for finding in findings:
+        short_id = short_ids[finding.fingerprint]
         if finding.start_line is None:
             if file_findings == "drop":
                 continue
@@ -82,7 +91,11 @@ def export_hunk_comments(
                 {
                     "filePath": finding.path,
                     "newLine": new_line,
-                    "summary": _format_hunk_summary(finding, file_level=True),
+                    "summary": _format_hunk_summary(
+                        finding,
+                        short_id=short_id,
+                        file_level=True,
+                    ),
                     "rationale": _format_hunk_rationale(finding),
                     "author": HUNK_COMMENT_AUTHOR,
                 }
@@ -93,7 +106,7 @@ def export_hunk_comments(
             {
                 "filePath": finding.path,
                 "newLine": finding.start_line,
-                "summary": _format_hunk_summary(finding),
+                "summary": _format_hunk_summary(finding, short_id=short_id),
                 "rationale": _format_hunk_rationale(finding),
                 "author": HUNK_COMMENT_AUTHOR,
             }

--- a/src/mergecraft/mcp/deferred_publish.py
+++ b/src/mergecraft/mcp/deferred_publish.py
@@ -9,6 +9,7 @@ from mergecraft.review_taxonomy import FINDING_MARKER_PREFIX, finding_fingerprin
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
+    from mergecraft.mcp.tool_state import AnalyzerRunState
 
 
 def deferred_findings_for_publish(ctx: ToolContext) -> list[dict[str, Any]]:
@@ -74,6 +75,58 @@ def inject_deferred_fix_all_brief(body: str, findings: list[dict[str, Any]]) -> 
     return f"{body[:idx].rstrip()}\n\n{block}\n\n{body[idx:]}"
 
 
+def _analyzer_inline_fingerprints(analyzer_run: AnalyzerRunState) -> set[str]:
+    fingerprints: set[str] = set()
+    for row in analyzer_run.inline:
+        if not isinstance(row, dict):
+            continue
+        finding = row.get("finding")
+        if isinstance(finding, dict):
+            fp = str(finding.get("fingerprint", "")).strip()
+            if fp:
+                fingerprints.add(fp)
+    return fingerprints
+
+
+def refresh_analyzer_sections_for_publish(
+    analyzer_run: AnalyzerRunState,
+    *,
+    short_ids: dict[str, str],
+    inline_comment_fingerprints: set[str] | None = None,
+) -> None:
+    """Re-render body-appended analyzer sections with publish-time short ids."""
+    from mergecraft.analyzers.budget import (
+        _render_mechanical_section,
+        render_deferred_section_from_rows,
+    )
+    from mergecraft.analyzers.finding import Finding, FindingValidationError
+
+    exclude_fps = _analyzer_inline_fingerprints(analyzer_run)
+    if inline_comment_fingerprints:
+        exclude_fps |= inline_comment_fingerprints
+    mechanical: list[Finding] = []
+    for row in analyzer_run.findings:
+        if not isinstance(row, dict):
+            continue
+        try:
+            finding = Finding.model_validate(row)
+        except (FindingValidationError, ValueError):
+            continue
+        if finding.fingerprint not in exclude_fps:
+            mechanical.append(finding)
+
+    if analyzer_run.mechanical_section is not None:
+        analyzer_run.mechanical_section = _render_mechanical_section(
+            mechanical,
+            short_ids=short_ids,
+        )
+    if analyzer_run.deferred_section is not None:
+        analyzer_run.deferred_section = render_deferred_section_from_rows(
+            analyzer_run.deferred_findings,
+            short_ids=short_ids,
+        )
+
+
 def merge_analyzer_sections_into_review_body(ctx: ToolContext, body: str) -> str:
     analyzer_run = ctx.tool_state.analyzer_run
     if analyzer_run is None:
@@ -95,6 +148,7 @@ __all__ = [
     "deferred_findings_for_publish",
     "inject_deferred_fix_all_brief",
     "merge_analyzer_sections_into_review_body",
+    "refresh_analyzer_sections_for_publish",
     "section_present",
     "stamp_deferred_section",
 ]

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -17,7 +17,10 @@ from mergecraft.mcp.convergence_runtime import (
     recall_publish_sets,
     strip_recall_inline_comments,
 )
-from mergecraft.mcp.deferred_publish import merge_analyzer_sections_into_review_body
+from mergecraft.mcp.deferred_publish import (
+    merge_analyzer_sections_into_review_body,
+    refresh_analyzer_sections_for_publish,
+)
 from mergecraft.mcp.review_comments import fetch_review_threads, resolve_review_thread
 from mergecraft.mcp.shared import ToolClass, execute, tool
 from mergecraft.mcp.tool_state import ApprovalRecord, ReviewRecord, primary_repo_state
@@ -97,6 +100,28 @@ def _comment_fingerprint(comment: dict[str, Any]) -> str:
 
 def _comment_fingerprints(comments: list[dict[str, Any]]) -> list[str]:
     return [_comment_fingerprint(comment) for comment in comments]
+
+
+def _analyzer_publish_fingerprints(ctx: ToolContext) -> list[str]:
+    """Return analyzer-run finding fingerprints merged into the review body."""
+    analyzer_run = ctx.tool_state.analyzer_run
+    if analyzer_run is None:
+        return []
+    fingerprints: list[str] = []
+    for row in analyzer_run.findings:
+        if isinstance(row, dict):
+            fp = str(row.get("fingerprint", "")).strip()
+            if fp:
+                fingerprints.append(fp)
+    return fingerprints
+
+
+def _publish_fingerprint_batch(
+    comments: list[dict[str, Any]],
+    ctx: ToolContext,
+) -> list[str]:
+    """Collect inline and body-appended fingerprints for one publish batch."""
+    return _comment_fingerprints(comments) + _analyzer_publish_fingerprints(ctx)
 
 
 def _body_has_short_id_line(body: str) -> bool:
@@ -336,6 +361,15 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
     repo_root = Path(primary.dir or Path.cwd())
     review_settings = load_repo_settings(root=repo_root, load_learnings_files=False).review
 
+    publish_short_ids = resolve_finding_short_ids(_publish_fingerprint_batch(comments, ctx))
+    analyzer_run = ctx.tool_state.analyzer_run
+    if analyzer_run is not None:
+        refresh_analyzer_sections_for_publish(
+            analyzer_run,
+            short_ids=publish_short_ids,
+            inline_comment_fingerprints=set(_comment_fingerprints(comments)),
+        )
+
     payload: dict[str, Any] = {"event": event}
     if body:
         await ensure_learnings_review_delta(ctx.tool_state)
@@ -365,7 +399,6 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
             incremental_diff_text = Path(incremental_path).read_text(encoding="utf-8")
 
     collateral_map = collateral_by_fingerprint(ctx)
-    inline_short_ids = resolve_finding_short_ids(_comment_fingerprints(comments))
 
     inline: list[dict[str, Any]] = []
     for c in comments:
@@ -379,7 +412,7 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
         )
         comment_body = str(c.get("body") or "")
         raw_fingerprint = _comment_fingerprint(c)
-        short_id = inline_short_ids.get(raw_fingerprint)
+        short_id = publish_short_ids.get(raw_fingerprint)
         prepared_body = prepare_inline_comment_for_publish(
             ctx,
             path=path,

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -110,12 +110,26 @@ def _body_has_short_id_line(body: str) -> bool:
 
 
 def _prepend_short_id(body: str, short_id: str) -> str:
-    if _body_has_short_id_line(body):
-        return body
+    """Stamp or refresh the publication short-id line with batch-resolved ``short_id``."""
     marker = f"**{short_id}**"
-    if body.strip():
-        return f"{marker}\n\n{body}"
-    return marker
+    if not body.strip():
+        return marker
+    if _body_has_short_id_line(body):
+        content = _body_without_short_id_line(body)
+        if content.strip():
+            return f"{marker}\n\n{content}"
+        return marker
+    title_match = re.match(
+        rf"^\*\*{re.escape(FINDING_SHORT_ID_PREFIX)}[0-9a-f]{{6,}}\*\*(\s*\([^)]+\))\s*\n?",
+        body.lstrip(),
+    )
+    if title_match:
+        rest = body.lstrip()[title_match.end() :].lstrip()
+        first_line = f"{marker}{title_match.group(1)}"
+        if rest:
+            return f"{first_line}\n\n{rest}"
+        return first_line
+    return f"{marker}\n\n{body}"
 
 
 _FRESH_PR_TRIGGERS: frozenset[str] = frozenset(

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -46,13 +46,17 @@ if TYPE_CHECKING:
 def format_analyzer_inline_body(
     finding: Finding,
     *,
+    short_id: str | None = None,
     effort: str = "Quick win",
     verification_note: str | None = None,
 ) -> str:
     """Format an analyzer-sourced inline comment with tool citation and confidence (W7.6)."""
     tag = f"_{finding.category}_ | _{finding.severity}_ | _{effort}_ | _{finding.confidence}_"
     citation = f"`{finding.tool}` `{finding.rule_id}`"
-    lines = [tag, "", f"{finding.message}", "", f"Source: {citation}."]
+    lines: list[str] = []
+    if short_id:
+        lines.append(f"**{short_id}**")
+    lines.extend([tag, "", f"{finding.message}", "", f"Source: {citation}."])
     if verification_note:
         lines.extend(["", verification_note.strip()])
     return "\n".join(lines)

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from loguru import logger
 
+from mergecraft.analyzers.finding import resolve_finding_short_ids
 from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.convergence_runtime import (
     collateral_by_fingerprint,
@@ -65,6 +66,28 @@ def format_analyzer_inline_body(
 def enrich_analyzer_comment_body(body: str) -> str:
     """Return review comment bodies unchanged (formatting is upstream)."""
     return body
+
+
+def _comment_fingerprints(comments: list[dict[str, Any]]) -> list[str]:
+    fingerprints: list[str] = []
+    for comment in comments:
+        path = str(comment.get("path", ""))
+        body = str(comment.get("body") or "")
+        fingerprint = str(comment.get("fingerprint") or "") or finding_fingerprint(
+            path=path,
+            body=body,
+        )
+        fingerprints.append(fingerprint)
+    return fingerprints
+
+
+def _prepend_short_id(body: str, short_id: str) -> str:
+    marker = f"**{short_id}**"
+    if marker in body:
+        return body
+    if body.strip():
+        return f"{marker}\n\n{body}"
+    return marker
 
 
 _FRESH_PR_TRIGGERS: frozenset[str] = frozenset(
@@ -300,6 +323,7 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
             incremental_diff_text = Path(incremental_path).read_text(encoding="utf-8")
 
     collateral_map = collateral_by_fingerprint(ctx)
+    inline_short_ids = resolve_finding_short_ids(_comment_fingerprints(comments))
 
     inline: list[dict[str, Any]] = []
     for c in comments:
@@ -316,6 +340,7 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
             path=path,
             body=comment_body,
         )
+        short_id = inline_short_ids.get(raw_fingerprint)
         prepared_body = prepare_inline_comment_for_publish(
             ctx,
             path=path,
@@ -338,7 +363,13 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
                 if item["body"]
                 else f"```suggestion\n{suggestion}\n```"
             )
-        item["body"] = stamp_finding_fingerprint(path=item["path"], body=item["body"])
+        item["body"] = stamp_finding_fingerprint(
+            path=item["path"],
+            body=item["body"],
+            fingerprint=raw_fingerprint,
+        )
+        if short_id:
+            item["body"] = _prepend_short_id(item["body"], short_id)
         if "line" in c:
             item["line"] = int(c["line"])
         if "side" in c:

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 import httpx
 from loguru import logger
 
-from mergecraft.analyzers.finding import resolve_finding_short_ids
+from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
 from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.convergence_runtime import (
     collateral_by_fingerprint,
@@ -68,23 +69,50 @@ def enrich_analyzer_comment_body(body: str) -> str:
     return body
 
 
+_SHORT_ID_LINE_RE = re.compile(
+    rf"^\*\*{re.escape(FINDING_SHORT_ID_PREFIX)}[0-9a-f]{{6,}}\*\*\s*\n?",
+    re.MULTILINE,
+)
+
+
+def _body_without_short_id_line(body: str) -> str:
+    """Strip a leading publication short-id line before content fingerprinting."""
+    return _SHORT_ID_LINE_RE.sub("", body, count=1).lstrip()
+
+
+def _comment_fingerprint(comment: dict[str, Any]) -> str:
+    """Return the stable fingerprint for one inline comment row."""
+    explicit = str(comment.get("fingerprint") or "").strip()
+    if explicit:
+        return explicit
+    finding = comment.get("finding")
+    if isinstance(finding, dict):
+        nested = str(finding.get("fingerprint") or "").strip()
+        if nested:
+            return nested
+    path = str(comment.get("path", ""))
+    body = str(comment.get("body") or "")
+    return finding_fingerprint(path=path, body=_body_without_short_id_line(body))
+
+
 def _comment_fingerprints(comments: list[dict[str, Any]]) -> list[str]:
-    fingerprints: list[str] = []
-    for comment in comments:
-        path = str(comment.get("path", ""))
-        body = str(comment.get("body") or "")
-        fingerprint = str(comment.get("fingerprint") or "") or finding_fingerprint(
-            path=path,
-            body=body,
+    return [_comment_fingerprint(comment) for comment in comments]
+
+
+def _body_has_short_id_line(body: str) -> bool:
+    first_line = body.lstrip().split("\n", 1)[0]
+    return bool(
+        re.fullmatch(
+            rf"\*\*{re.escape(FINDING_SHORT_ID_PREFIX)}[0-9a-f]{{6,}}\*\*",
+            first_line,
         )
-        fingerprints.append(fingerprint)
-    return fingerprints
+    )
 
 
 def _prepend_short_id(body: str, short_id: str) -> str:
-    marker = f"**{short_id}**"
-    if marker in body:
+    if _body_has_short_id_line(body):
         return body
+    marker = f"**{short_id}**"
     if body.strip():
         return f"{marker}\n\n{body}"
     return marker
@@ -336,10 +364,7 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
             else None
         )
         comment_body = str(c.get("body") or "")
-        raw_fingerprint = str(c.get("fingerprint") or "") or finding_fingerprint(
-            path=path,
-            body=comment_body,
-        )
+        raw_fingerprint = _comment_fingerprint(c)
         short_id = inline_short_ids.get(raw_fingerprint)
         prepared_body = prepare_inline_comment_for_publish(
             ctx,

--- a/src/mergecraft/models.py
+++ b/src/mergecraft/models.py
@@ -428,6 +428,15 @@ PROVIDERS: dict[str, ProviderConfig] = {
                     resolve="nous/deepseek/deepseek-v4-flash",
                     preferred=True,
                 ),
+                "tencent/hy3": ModelDef(
+                    display_name="Tencent HY3 (Nous Portal)",
+                    description=(
+                        "Tencent Hunyuan HY3 via the Nous Portal OpenAI-compatible endpoint. "
+                        "Pass as nous/tencent/hy3 for the portal model id."
+                    ),
+                    resolve="nous/tencent/hy3",
+                    preferred=True,
+                ),
             },
         )
     ),

--- a/src/mergecraft/review/completed.py
+++ b/src/mergecraft/review/completed.py
@@ -14,30 +14,24 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from mergecraft.analyzers.finding import Finding
+from mergecraft.review.finding_lookup import (
+    is_safe_path_stem,
+    load_json_packets_in_dir,
+    lookup_packet_by_finding_id,
+)
 from mergecraft.review.snapshot import ReviewSnapshot
 
 COMPLETED_REVIEW_SCHEMA_VERSION = "1.0.0"
 _REVIEWS_SUBDIR = ".mergecraft/reviews"
-
-
-def _is_safe_review_id(review_id: str) -> bool:
-    if not review_id or review_id in {".", ".."}:
-        return False
-    if "/" in review_id or "\\" in review_id:
-        return False
-    return Path(review_id).parts == (review_id,)
-
-
-def _is_safe_packet_stem(finding_id: str) -> bool:
-    if not finding_id or finding_id in {".", ".."}:
-        return False
-    if "/" in finding_id or "\\" in finding_id:
-        return False
-    return Path(finding_id).parts == (finding_id,)
+_REVIEW_ARTIFACT_SKIP = frozenset(
+    {"snapshot.json", "manifest.json", "findings.json", "completed.json"}
+)
 
 
 def completed_review_dir(review_id: str, *, repo_root: Path) -> Path:
@@ -64,7 +58,7 @@ def persist_completed_review(
     trace_events: list[dict[str, Any]] | None = None,
 ) -> Path:
     """Persist ``review`` and optional evidence/trace artifacts; return the directory."""
-    if not _is_safe_review_id(review.review_id):
+    if not is_safe_path_stem(review.review_id):
         msg = f"unsafe review id {review.review_id!r}"
         raise ValueError(msg)
     root = completed_review_dir(review.review_id, repo_root=repo_root)
@@ -91,7 +85,7 @@ def persist_completed_review(
         encoding="utf-8",
     )
     for fingerprint, packet in (evidence_packets or {}).items():
-        if not _is_safe_packet_stem(fingerprint):
+        if not is_safe_path_stem(fingerprint):
             continue
         (root / f"{fingerprint}.json").write_text(
             json.dumps(packet, ensure_ascii=False, indent=2),
@@ -108,9 +102,26 @@ def _read_json_file(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _validate_loaded_findings(raw_findings: list[Any]) -> list[dict[str, Any]] | None:
+    validated: list[dict[str, Any]] = []
+    for row in raw_findings:
+        if not isinstance(row, dict):
+            return None
+        short_id = row.get("short_id")
+        payload = {key: value for key, value in row.items() if key != "short_id"}
+        try:
+            record = Finding.model_validate(payload).model_dump(mode="json")
+        except ValueError:
+            return None
+        if isinstance(short_id, str):
+            record["short_id"] = short_id
+        validated.append(record)
+    return validated
+
+
 def load_completed_review(review_id: str, *, repo_root: Path) -> CompletedReview | None:
     """Load a stored review, or ``None`` when missing or corrupt."""
-    if not _is_safe_review_id(review_id):
+    if not is_safe_path_stem(review_id):
         return None
     root = completed_review_dir(review_id, repo_root=repo_root)
     completed_path = root / "completed.json"
@@ -132,8 +143,14 @@ def load_completed_review(review_id: str, *, repo_root: Path) -> CompletedReview
             return None
         if not isinstance(findings_payload, dict):
             return None
+        schema_version = completed_payload.get("schema_version")
+        if schema_version != COMPLETED_REVIEW_SCHEMA_VERSION:
+            return None
         raw_findings = findings_payload.get("findings")
         if not isinstance(raw_findings, list):
+            return None
+        findings = _validate_loaded_findings(raw_findings)
+        if findings is None:
             return None
         snapshot = ReviewSnapshot.model_validate(snapshot_payload)
         trace_session_id = completed_payload.get("trace_session_id")
@@ -141,7 +158,7 @@ def load_completed_review(review_id: str, *, repo_root: Path) -> CompletedReview
             review_id=str(completed_payload.get("review_id", review_id)),
             snapshot=snapshot,
             manifest=manifest_payload,
-            findings=[row for row in raw_findings if isinstance(row, dict)],
+            findings=findings,
             trace_session_id=str(trace_session_id) if trace_session_id else None,
         )
     except (OSError, json.JSONDecodeError, ValueError):
@@ -158,7 +175,7 @@ def list_completed_review_ids(*, repo_root: Path) -> list[str]:
         if not child.is_dir():
             continue
         review_id = child.name
-        if not _is_safe_review_id(review_id):
+        if not is_safe_path_stem(review_id):
             continue
         if (child / "completed.json").is_file():
             ids.append(review_id)
@@ -166,17 +183,16 @@ def list_completed_review_ids(*, repo_root: Path) -> list[str]:
 
 
 def _packets_in_review_dir(review_dir: Path) -> dict[str, dict[str, Any]]:
-    packets: dict[str, dict[str, Any]] = {}
-    for path in sorted(review_dir.glob("*.json")):
-        if path.name in {"snapshot.json", "manifest.json", "findings.json", "completed.json"}:
-            continue
-        stem = path.stem
-        if not _is_safe_packet_stem(stem):
-            continue
-        loaded = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(loaded, dict):
-            packets[stem] = loaded
-    return packets
+    return load_json_packets_in_dir(review_dir, skip_names=_REVIEW_ARTIFACT_SKIP)
+
+
+def _fingerprints_from_findings(findings: list[dict[str, Any]]) -> list[str]:
+    fingerprints: list[str] = []
+    for row in findings:
+        fp = row.get("fingerprint")
+        if isinstance(fp, str) and fp:
+            fingerprints.append(fp)
+    return fingerprints
 
 
 def lookup_finding_packet_in_review(
@@ -186,32 +202,26 @@ def lookup_finding_packet_in_review(
     repo_root: Path,
 ) -> dict[str, Any] | None:
     """Resolve a finding id against one completed review's co-located evidence."""
-    if not _is_safe_review_id(review_id):
+    if not is_safe_path_stem(review_id):
         return None
     review_dir = completed_review_dir(review_id, repo_root=repo_root)
     if not review_dir.is_dir():
         return None
     packets_by_fingerprint = _packets_in_review_dir(review_dir)
-    if not packets_by_fingerprint:
-        return None
-    if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
-        suffix = finding_id[len(FINDING_SHORT_ID_PREFIX) :]
-        if not suffix or not all(char in "0123456789abcdef" for char in suffix):
-            return None
-        mapping = resolve_finding_short_ids(list(packets_by_fingerprint))
-        for fingerprint, mapped_id in mapping.items():
-            if mapped_id == finding_id:
-                return packets_by_fingerprint[fingerprint]
-        return None
-    if not _is_safe_packet_stem(finding_id):
-        return None
-    direct = packets_by_fingerprint.get(finding_id)
-    if direct is not None:
-        return direct
-    for packet in packets_by_fingerprint.values():
-        if str(packet.get("finding_id", "")) == finding_id:
+    if packets_by_fingerprint:
+        packet = lookup_packet_by_finding_id(finding_id, packets_by_fingerprint)
+        if packet is not None:
             return packet
-    return None
+    loaded = load_completed_review(review_id, repo_root=repo_root)
+    if loaded is None:
+        return None
+    fingerprints = _fingerprints_from_findings(loaded.findings)
+    if not fingerprints:
+        return None
+    fallback_packets = {
+        fp: {"finding_id": fp, "state": "unverified", "kinds": []} for fp in fingerprints
+    }
+    return lookup_packet_by_finding_id(finding_id, fallback_packets)
 
 
 def load_completed_review_trace_events(
@@ -220,7 +230,7 @@ def load_completed_review_trace_events(
     repo_root: Path,
 ) -> list[dict[str, Any]]:
     """Return trace rows stored beside a completed review."""
-    if not _is_safe_review_id(review_id):
+    if not is_safe_path_stem(review_id):
         return []
     trace_path = completed_review_dir(review_id, repo_root=repo_root) / "trace.jsonl"
     if not trace_path.is_file():
@@ -229,7 +239,10 @@ def load_completed_review_trace_events(
     for line in trace_path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
-        loaded = json.loads(line)
+        try:
+            loaded = json.loads(line)
+        except json.JSONDecodeError:
+            continue
         if isinstance(loaded, dict):
             events.append(loaded)
     return events

--- a/src/mergecraft/review/completed.py
+++ b/src/mergecraft/review/completed.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from mergecraft.analyzers.finding import Finding
+from mergecraft.evidence.minimal_packet import minimal_evidence_packet
 from mergecraft.review.finding_lookup import (
     is_safe_path_stem,
     load_json_packets_in_dir,
@@ -37,6 +38,13 @@ _REVIEW_ARTIFACT_SKIP = frozenset(
 def completed_review_dir(review_id: str, *, repo_root: Path) -> Path:
     """Return ``<repo>/.mergecraft/reviews/<review_id>``."""
     return repo_root / _REVIEWS_SUBDIR / review_id
+
+
+def completed_review_exists(review_id: str, *, repo_root: Path) -> bool:
+    """Return whether ``review_id`` has a readable ``completed.json`` marker."""
+    if not is_safe_path_stem(review_id):
+        return False
+    return (completed_review_dir(review_id, repo_root=repo_root) / "completed.json").is_file()
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,9 +226,7 @@ def lookup_finding_packet_in_review(
     fingerprints = _fingerprints_from_findings(loaded.findings)
     if not fingerprints:
         return None
-    fallback_packets = {
-        fp: {"finding_id": fp, "state": "unverified", "kinds": []} for fp in fingerprints
-    }
+    fallback_packets = {fp: minimal_evidence_packet(fp) for fp in fingerprints}
     return lookup_packet_by_finding_id(finding_id, fallback_packets)
 
 
@@ -252,6 +258,7 @@ __all__ = [
     "COMPLETED_REVIEW_SCHEMA_VERSION",
     "CompletedReview",
     "completed_review_dir",
+    "completed_review_exists",
     "list_completed_review_ids",
     "load_completed_review",
     "load_completed_review_trace_events",

--- a/src/mergecraft/review/completed.py
+++ b/src/mergecraft/review/completed.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pathlib import Path
 
-from mergecraft.analyzers.finding import Finding
+from mergecraft.analyzers.finding import Finding, finding_record_without_short_id
 from mergecraft.evidence.minimal_packet import minimal_evidence_packet
 from mergecraft.review.finding_lookup import (
     is_safe_path_stem,
@@ -30,6 +30,7 @@ from mergecraft.review.snapshot import ReviewSnapshot
 
 COMPLETED_REVIEW_SCHEMA_VERSION = "1.0.0"
 _REVIEWS_SUBDIR = ".mergecraft/reviews"
+COMPLETED_REVIEWS_GITIGNORE_LINE = f"{_REVIEWS_SUBDIR}/"
 _REVIEW_ARTIFACT_SKIP = frozenset(
     {"snapshot.json", "manifest.json", "findings.json", "completed.json"}
 )
@@ -116,7 +117,7 @@ def _validate_loaded_findings(raw_findings: list[Any]) -> list[dict[str, Any]] |
         if not isinstance(row, dict):
             return None
         short_id = row.get("short_id")
-        payload = {key: value for key, value in row.items() if key != "short_id"}
+        payload = finding_record_without_short_id(row)
         try:
             record = Finding.model_validate(payload).model_dump(mode="json")
         except ValueError:
@@ -255,6 +256,7 @@ def load_completed_review_trace_events(
 
 
 __all__ = [
+    "COMPLETED_REVIEWS_GITIGNORE_LINE",
     "COMPLETED_REVIEW_SCHEMA_VERSION",
     "CompletedReview",
     "completed_review_dir",

--- a/src/mergecraft/review/completed.py
+++ b/src/mergecraft/review/completed.py
@@ -1,0 +1,247 @@
+"""Durable completed-review storage for CLI follow-up commands (#453 / D4).
+
+Exports:
+    COMPLETED_REVIEW_SCHEMA_VERSION: Schema version for ``completed.json``.
+    CompletedReview: Snapshot + manifest + findings for one finished review.
+    completed_review_dir: On-disk directory for a stored review id.
+    persist_completed_review: Write a completed review and related artifacts.
+    load_completed_review: Reload a stored review, or ``None`` on miss/corrupt.
+    list_completed_review_ids: Enumerate stored review ids under a repo root.
+    lookup_finding_packet_in_review: Evidence packet lookup scoped to one review.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+from mergecraft.review.snapshot import ReviewSnapshot
+
+COMPLETED_REVIEW_SCHEMA_VERSION = "1.0.0"
+_REVIEWS_SUBDIR = ".mergecraft/reviews"
+
+
+def _is_safe_review_id(review_id: str) -> bool:
+    if not review_id or review_id in {".", ".."}:
+        return False
+    if "/" in review_id or "\\" in review_id:
+        return False
+    return Path(review_id).parts == (review_id,)
+
+
+def _is_safe_packet_stem(finding_id: str) -> bool:
+    if not finding_id or finding_id in {".", ".."}:
+        return False
+    if "/" in finding_id or "\\" in finding_id:
+        return False
+    return Path(finding_id).parts == (finding_id,)
+
+
+def completed_review_dir(review_id: str, *, repo_root: Path) -> Path:
+    """Return ``<repo>/.mergecraft/reviews/<review_id>``."""
+    return repo_root / _REVIEWS_SUBDIR / review_id
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedReview:
+    """One finished review composed for durable lookup (D4)."""
+
+    review_id: str
+    snapshot: ReviewSnapshot
+    manifest: dict[str, Any]
+    findings: list[dict[str, Any]]
+    trace_session_id: str | None = None
+
+
+def persist_completed_review(
+    review: CompletedReview,
+    *,
+    repo_root: Path,
+    evidence_packets: dict[str, dict[str, Any]] | None = None,
+    trace_events: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Persist ``review`` and optional evidence/trace artifacts; return the directory."""
+    if not _is_safe_review_id(review.review_id):
+        msg = f"unsafe review id {review.review_id!r}"
+        raise ValueError(msg)
+    root = completed_review_dir(review.review_id, repo_root=repo_root)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "snapshot.json").write_text(
+        json.dumps(review.snapshot.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(review.manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (root / "findings.json").write_text(
+        json.dumps({"findings": review.findings}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    completed_marker = {
+        "schema_version": COMPLETED_REVIEW_SCHEMA_VERSION,
+        "review_id": review.review_id,
+        "trace_session_id": review.trace_session_id or review.review_id,
+    }
+    (root / "completed.json").write_text(
+        json.dumps(completed_marker, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    for fingerprint, packet in (evidence_packets or {}).items():
+        if not _is_safe_packet_stem(fingerprint):
+            continue
+        (root / f"{fingerprint}.json").write_text(
+            json.dumps(packet, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    events = trace_events or []
+    if events:
+        lines = [json.dumps(event, ensure_ascii=False) for event in events]
+        (root / "trace.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return root
+
+
+def _read_json_file(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_completed_review(review_id: str, *, repo_root: Path) -> CompletedReview | None:
+    """Load a stored review, or ``None`` when missing or corrupt."""
+    if not _is_safe_review_id(review_id):
+        return None
+    root = completed_review_dir(review_id, repo_root=repo_root)
+    completed_path = root / "completed.json"
+    snapshot_path = root / "snapshot.json"
+    manifest_path = root / "manifest.json"
+    findings_path = root / "findings.json"
+    if not all(
+        path.is_file() for path in (completed_path, snapshot_path, manifest_path, findings_path)
+    ):
+        return None
+    try:
+        completed_payload = _read_json_file(completed_path)
+        snapshot_payload = _read_json_file(snapshot_path)
+        manifest_payload = _read_json_file(manifest_path)
+        findings_payload = _read_json_file(findings_path)
+        if not isinstance(completed_payload, dict):
+            return None
+        if not isinstance(manifest_payload, dict):
+            return None
+        if not isinstance(findings_payload, dict):
+            return None
+        raw_findings = findings_payload.get("findings")
+        if not isinstance(raw_findings, list):
+            return None
+        snapshot = ReviewSnapshot.model_validate(snapshot_payload)
+        trace_session_id = completed_payload.get("trace_session_id")
+        return CompletedReview(
+            review_id=str(completed_payload.get("review_id", review_id)),
+            snapshot=snapshot,
+            manifest=manifest_payload,
+            findings=[row for row in raw_findings if isinstance(row, dict)],
+            trace_session_id=str(trace_session_id) if trace_session_id else None,
+        )
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def list_completed_review_ids(*, repo_root: Path) -> list[str]:
+    """Return review ids with a readable ``completed.json`` marker."""
+    reviews_root = repo_root / _REVIEWS_SUBDIR
+    if not reviews_root.is_dir():
+        return []
+    ids: list[str] = []
+    for child in sorted(reviews_root.iterdir()):
+        if not child.is_dir():
+            continue
+        review_id = child.name
+        if not _is_safe_review_id(review_id):
+            continue
+        if (child / "completed.json").is_file():
+            ids.append(review_id)
+    return ids
+
+
+def _packets_in_review_dir(review_dir: Path) -> dict[str, dict[str, Any]]:
+    packets: dict[str, dict[str, Any]] = {}
+    for path in sorted(review_dir.glob("*.json")):
+        if path.name in {"snapshot.json", "manifest.json", "findings.json", "completed.json"}:
+            continue
+        stem = path.stem
+        if not _is_safe_packet_stem(stem):
+            continue
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            packets[stem] = loaded
+    return packets
+
+
+def lookup_finding_packet_in_review(
+    review_id: str,
+    finding_id: str,
+    *,
+    repo_root: Path,
+) -> dict[str, Any] | None:
+    """Resolve a finding id against one completed review's co-located evidence."""
+    if not _is_safe_review_id(review_id):
+        return None
+    review_dir = completed_review_dir(review_id, repo_root=repo_root)
+    if not review_dir.is_dir():
+        return None
+    packets_by_fingerprint = _packets_in_review_dir(review_dir)
+    if not packets_by_fingerprint:
+        return None
+    if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
+        suffix = finding_id[len(FINDING_SHORT_ID_PREFIX) :]
+        if not suffix or not all(char in "0123456789abcdef" for char in suffix):
+            return None
+        mapping = resolve_finding_short_ids(list(packets_by_fingerprint))
+        for fingerprint, mapped_id in mapping.items():
+            if mapped_id == finding_id:
+                return packets_by_fingerprint[fingerprint]
+        return None
+    if not _is_safe_packet_stem(finding_id):
+        return None
+    direct = packets_by_fingerprint.get(finding_id)
+    if direct is not None:
+        return direct
+    for packet in packets_by_fingerprint.values():
+        if str(packet.get("finding_id", "")) == finding_id:
+            return packet
+    return None
+
+
+def load_completed_review_trace_events(
+    review_id: str,
+    *,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    """Return trace rows stored beside a completed review."""
+    if not _is_safe_review_id(review_id):
+        return []
+    trace_path = completed_review_dir(review_id, repo_root=repo_root) / "trace.jsonl"
+    if not trace_path.is_file():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in trace_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        loaded = json.loads(line)
+        if isinstance(loaded, dict):
+            events.append(loaded)
+    return events
+
+
+__all__ = [
+    "COMPLETED_REVIEW_SCHEMA_VERSION",
+    "CompletedReview",
+    "completed_review_dir",
+    "list_completed_review_ids",
+    "load_completed_review",
+    "load_completed_review_trace_events",
+    "lookup_finding_packet_in_review",
+    "persist_completed_review",
+]

--- a/src/mergecraft/review/completed_artifacts.py
+++ b/src/mergecraft/review/completed_artifacts.py
@@ -1,32 +1,17 @@
-"""Collect durable-review artifacts after a CLI review completes (Thermos F1)."""
+"""Collect durable-review artifacts after a CLI review completes (#453)."""
 
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mergecraft.cli.trace_jsonl import load_trace_jsonl_events
-from mergecraft.review.finding_lookup import is_safe_path_stem, load_json_packets_in_dir
+from mergecraft.evidence.minimal_packet import minimal_evidence_packet
+from mergecraft.review.finding_lookup import is_safe_path_stem
+from mergecraft.tracing.trace_jsonl import default_trace_dir, load_trace_jsonl_events
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
-def _trace_dir_for_repo(repo_root: Path) -> Path:
-    env_dir = os.environ.get("MERGECRAFT_TRACE_DIR")
-    if env_dir:
-        return Path(env_dir)
-    return repo_root / ".mergecraft" / "traces"
-
-
-def _minimal_evidence_packet(fingerprint: str) -> dict[str, Any]:
-    return {
-        "finding_id": fingerprint,
-        "state": "unverified",
-        "kinds": [],
-    }
 
 
 def collect_evidence_packets_for_persist(
@@ -35,12 +20,21 @@ def collect_evidence_packets_for_persist(
     repo_root: Path,
     evidence_packet_path: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Merge per-fingerprint packets from disk with minimal stubs for each finding."""
+    """Load packets for current findings only; stub any fingerprint still missing."""
     packets: dict[str, dict[str, Any]] = {}
     evidence_dir = repo_root / ".mergecraft" / "evidence"
-    packets.update(
-        load_json_packets_in_dir(evidence_dir, skip_names=frozenset()),
-    )
+    for finding in findings:
+        fingerprint = finding.fingerprint
+        if not is_safe_path_stem(fingerprint):
+            continue
+        path = evidence_dir / f"{fingerprint}.json"
+        if path.is_file():
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                loaded = None
+            if isinstance(loaded, dict):
+                packets[fingerprint] = loaded
     if evidence_packet_path:
         path = Path(evidence_packet_path)
         if path.is_file() and is_safe_path_stem(path.stem):
@@ -53,7 +47,7 @@ def collect_evidence_packets_for_persist(
     for finding in findings:
         fingerprint = finding.fingerprint
         if fingerprint not in packets:
-            packets[fingerprint] = _minimal_evidence_packet(fingerprint)
+            packets[fingerprint] = minimal_evidence_packet(fingerprint)
     return packets
 
 
@@ -63,8 +57,10 @@ def collect_trace_events_for_review(
     repo_root: Path,
 ) -> list[dict[str, Any]]:
     """Return trace rows for ``review_id`` from the repo trace directory."""
-    events = load_trace_jsonl_events(_trace_dir_for_repo(repo_root))
-    return [event for event in events if str(event.get("session_id", "")) == review_id]
+    return load_trace_jsonl_events(
+        default_trace_dir(repo_root=repo_root),
+        session_id=review_id,
+    )
 
 
 __all__ = [

--- a/src/mergecraft/review/completed_artifacts.py
+++ b/src/mergecraft/review/completed_artifacts.py
@@ -1,0 +1,73 @@
+"""Collect durable-review artifacts after a CLI review completes (Thermos F1)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.cli.trace_jsonl import load_trace_jsonl_events
+from mergecraft.review.finding_lookup import is_safe_path_stem, load_json_packets_in_dir
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _trace_dir_for_repo(repo_root: Path) -> Path:
+    env_dir = os.environ.get("MERGECRAFT_TRACE_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return repo_root / ".mergecraft" / "traces"
+
+
+def _minimal_evidence_packet(fingerprint: str) -> dict[str, Any]:
+    return {
+        "finding_id": fingerprint,
+        "state": "unverified",
+        "kinds": [],
+    }
+
+
+def collect_evidence_packets_for_persist(
+    findings: Sequence[Any],
+    *,
+    repo_root: Path,
+    evidence_packet_path: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Merge per-fingerprint packets from disk with minimal stubs for each finding."""
+    packets: dict[str, dict[str, Any]] = {}
+    evidence_dir = repo_root / ".mergecraft" / "evidence"
+    packets.update(
+        load_json_packets_in_dir(evidence_dir, skip_names=frozenset()),
+    )
+    if evidence_packet_path:
+        path = Path(evidence_packet_path)
+        if path.is_file() and is_safe_path_stem(path.stem):
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    packets[path.stem] = loaded
+            except (OSError, json.JSONDecodeError):
+                pass
+    for finding in findings:
+        fingerprint = finding.fingerprint
+        if fingerprint not in packets:
+            packets[fingerprint] = _minimal_evidence_packet(fingerprint)
+    return packets
+
+
+def collect_trace_events_for_review(
+    review_id: str,
+    *,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    """Return trace rows for ``review_id`` from the repo trace directory."""
+    events = load_trace_jsonl_events(_trace_dir_for_repo(repo_root))
+    return [event for event in events if str(event.get("session_id", "")) == review_id]
+
+
+__all__ = [
+    "collect_evidence_packets_for_persist",
+    "collect_trace_events_for_review",
+]

--- a/src/mergecraft/review/completed_artifacts.py
+++ b/src/mergecraft/review/completed_artifacts.py
@@ -55,12 +55,11 @@ def collect_trace_events_for_review(
     review_id: str,
     *,
     repo_root: Path,
+    trace_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
-    """Return trace rows for ``review_id`` from the repo trace directory."""
-    return load_trace_jsonl_events(
-        default_trace_dir(repo_root=repo_root),
-        session_id=review_id,
-    )
+    """Return trace rows for ``review_id`` from the configured trace directory."""
+    target = trace_dir if trace_dir is not None else default_trace_dir(repo_root=repo_root)
+    return load_trace_jsonl_events(target, session_id=review_id)
 
 
 __all__ = [

--- a/src/mergecraft/review/finding_lookup.py
+++ b/src/mergecraft/review/finding_lookup.py
@@ -1,0 +1,99 @@
+"""Shared finding-id safety checks and evidence-packet lookup (#453 / Thermos F3).
+
+Exports:
+    is_safe_path_stem: Reject traversal and separator characters in file stems.
+    load_json_packets_in_dir: Load ``*.json`` packets keyed by stem.
+    lookup_packet_by_finding_id: Resolve a finding or short id against a packet map.
+    fingerprint_for_short_id: Map ``MC-…`` back to a fingerprint in a batch.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+
+
+def is_safe_path_stem(stem: str) -> bool:
+    """Reject empty, ``..``, and separator characters so stems cannot escape a directory."""
+    if not stem or stem in {".", ".."}:
+        return False
+    if "/" in stem or "\\" in stem:
+        return False
+    return Path(stem).parts == (stem,)
+
+
+def load_json_packets_in_dir(
+    directory: Path,
+    *,
+    skip_names: frozenset[str] = frozenset(),
+) -> dict[str, dict[str, Any]]:
+    """Load ``*.json`` files in ``directory`` keyed by stem; skip corrupt files."""
+    if not directory.is_dir():
+        return {}
+    packets: dict[str, dict[str, Any]] = {}
+    for path in sorted(directory.glob("*.json")):
+        if path.name in skip_names:
+            continue
+        stem = path.stem
+        if not is_safe_path_stem(stem):
+            continue
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(loaded, dict):
+            packets[stem] = loaded
+    return packets
+
+
+@lru_cache(maxsize=128)
+def _short_id_index(fingerprints_tuple: tuple[str, ...]) -> dict[str, str]:
+    """Memoized short-id → fingerprint map for one fingerprint batch."""
+    mapping = resolve_finding_short_ids(fingerprints_tuple)
+    return {short_id: fingerprint for fingerprint, short_id in mapping.items()}
+
+
+def fingerprint_for_short_id(short_id: str, fingerprints: tuple[str, ...]) -> str | None:
+    """Return the fingerprint for ``MC-…`` when it maps uniquely in ``fingerprints``."""
+    if not short_id.startswith(FINDING_SHORT_ID_PREFIX):
+        return None
+    suffix = short_id[len(FINDING_SHORT_ID_PREFIX) :]
+    if not suffix or not all(char in "0123456789abcdef" for char in suffix):
+        return None
+    return _short_id_index(tuple(sorted(fingerprints))).get(short_id)
+
+
+def lookup_packet_by_finding_id(
+    finding_id: str,
+    packets_by_fingerprint: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Resolve a fingerprint or ``MC-…`` id against an in-memory packet map."""
+    if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
+        fingerprint = fingerprint_for_short_id(
+            finding_id,
+            tuple(packets_by_fingerprint),
+        )
+        if fingerprint is None:
+            return None
+        return packets_by_fingerprint.get(fingerprint)
+    if not is_safe_path_stem(finding_id):
+        return None
+    direct = packets_by_fingerprint.get(finding_id)
+    if direct is not None:
+        return direct
+    for packet in packets_by_fingerprint.values():
+        if str(packet.get("finding_id", "")) == finding_id:
+            return packet
+    return None
+
+
+__all__ = [
+    "fingerprint_for_short_id",
+    "is_safe_path_stem",
+    "load_json_packets_in_dir",
+    "lookup_packet_by_finding_id",
+]

--- a/src/mergecraft/review/finding_lookup.py
+++ b/src/mergecraft/review/finding_lookup.py
@@ -10,6 +10,7 @@ Exports:
 from __future__ import annotations
 
 import json
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
+
+_FINGERPRINT_HEX_RE = re.compile(r"^[0-9a-f]+$")
+_MIN_FINGERPRINT_HEX_LEN = 6
 
 
 def is_safe_path_stem(stem: str) -> bool:
@@ -53,6 +57,15 @@ def load_json_packets_in_dir(
     return packets
 
 
+def _is_hex_fingerprint(value: str) -> bool:
+    """Return whether ``value`` is a lowercase hex fingerprint suitable for short ids."""
+    if not value or "/" in value or "\\" in value:
+        return False
+    if len(value) < _MIN_FINGERPRINT_HEX_LEN:
+        return False
+    return _FINGERPRINT_HEX_RE.fullmatch(value) is not None
+
+
 def _nested_packet_candidates(packet: dict[str, Any]) -> Iterable[dict[str, Any]]:
     """Yield per-finding packets nested inside an aggregate evidence packet."""
     for key in ("packets", "evidence", "finding_packets"):
@@ -76,18 +89,18 @@ def _fingerprints_in_packet_map(
     seen: set[str] = set()
     ordered: list[str] = []
     for stem, packet in packets_by_fingerprint.items():
-        if stem and stem not in seen:
+        if stem and _is_hex_fingerprint(stem) and stem not in seen:
             seen.add(stem)
             ordered.append(stem)
         nested_id = str(packet.get("finding_id", "")).strip()
-        if nested_id and nested_id not in seen:
+        if nested_id and _is_hex_fingerprint(nested_id) and nested_id not in seen:
             seen.add(nested_id)
             ordered.append(nested_id)
         for nested in _nested_packet_candidates(packet):
             fingerprint = str(nested.get("fingerprint", "")).strip()
             if not fingerprint:
                 fingerprint = str(nested.get("finding_id", "")).strip()
-            if fingerprint and fingerprint not in seen:
+            if fingerprint and _is_hex_fingerprint(fingerprint) and fingerprint not in seen:
                 seen.add(fingerprint)
                 ordered.append(fingerprint)
     return tuple(ordered)
@@ -96,7 +109,10 @@ def _fingerprints_in_packet_map(
 @lru_cache(maxsize=128)
 def _short_id_index(fingerprints_tuple: tuple[str, ...]) -> dict[str, str]:
     """Memoized short-id → fingerprint map for one fingerprint batch."""
-    mapping = resolve_finding_short_ids(fingerprints_tuple)
+    valid = tuple(fp for fp in fingerprints_tuple if _is_hex_fingerprint(fp))
+    if not valid:
+        return {}
+    mapping = resolve_finding_short_ids(valid)
     return {short_id: fingerprint for fingerprint, short_id in mapping.items()}
 
 

--- a/src/mergecraft/review/finding_lookup.py
+++ b/src/mergecraft/review/finding_lookup.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 from mergecraft.analyzers.finding import FINDING_SHORT_ID_PREFIX, resolve_finding_short_ids
 
@@ -50,6 +53,46 @@ def load_json_packets_in_dir(
     return packets
 
 
+def _nested_packet_candidates(packet: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield per-finding packets nested inside an aggregate evidence packet."""
+    for key in ("packets", "evidence", "finding_packets"):
+        nested = packet.get(key)
+        if not isinstance(nested, dict):
+            continue
+        for value in nested.values():
+            if isinstance(value, dict):
+                yield value
+    findings = packet.get("findings")
+    if isinstance(findings, list):
+        for row in findings:
+            if isinstance(row, dict):
+                yield row
+
+
+def _fingerprints_in_packet_map(
+    packets_by_fingerprint: dict[str, dict[str, Any]],
+) -> tuple[str, ...]:
+    """Collect fingerprint ids from packet keys and nested aggregate rows."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for stem, packet in packets_by_fingerprint.items():
+        if stem and stem not in seen:
+            seen.add(stem)
+            ordered.append(stem)
+        nested_id = str(packet.get("finding_id", "")).strip()
+        if nested_id and nested_id not in seen:
+            seen.add(nested_id)
+            ordered.append(nested_id)
+        for nested in _nested_packet_candidates(packet):
+            fingerprint = str(nested.get("fingerprint", "")).strip()
+            if not fingerprint:
+                fingerprint = str(nested.get("finding_id", "")).strip()
+            if fingerprint and fingerprint not in seen:
+                seen.add(fingerprint)
+                ordered.append(fingerprint)
+    return tuple(ordered)
+
+
 @lru_cache(maxsize=128)
 def _short_id_index(fingerprints_tuple: tuple[str, ...]) -> dict[str, str]:
     """Memoized short-id → fingerprint map for one fingerprint batch."""
@@ -72,14 +115,15 @@ def lookup_packet_by_finding_id(
     packets_by_fingerprint: dict[str, dict[str, Any]],
 ) -> dict[str, Any] | None:
     """Resolve a fingerprint or ``MC-…`` id against an in-memory packet map."""
+    fingerprint_batch = _fingerprints_in_packet_map(packets_by_fingerprint)
     if finding_id.startswith(FINDING_SHORT_ID_PREFIX):
-        fingerprint = fingerprint_for_short_id(
-            finding_id,
-            tuple(packets_by_fingerprint),
-        )
+        fingerprint = fingerprint_for_short_id(finding_id, fingerprint_batch)
         if fingerprint is None:
             return None
-        return packets_by_fingerprint.get(fingerprint)
+        direct = packets_by_fingerprint.get(fingerprint)
+        if direct is not None:
+            return direct
+        finding_id = fingerprint
     if not is_safe_path_stem(finding_id):
         return None
     direct = packets_by_fingerprint.get(finding_id)
@@ -88,6 +132,11 @@ def lookup_packet_by_finding_id(
     for packet in packets_by_fingerprint.values():
         if str(packet.get("finding_id", "")) == finding_id:
             return packet
+        for nested in _nested_packet_candidates(packet):
+            nested_id = str(nested.get("finding_id", "")).strip()
+            nested_fp = str(nested.get("fingerprint", "")).strip()
+            if finding_id in {nested_id, nested_fp}:
+                return nested
     return None
 
 

--- a/src/mergecraft/review/finding_lookup.py
+++ b/src/mergecraft/review/finding_lookup.py
@@ -1,4 +1,4 @@
-"""Shared finding-id safety checks and evidence-packet lookup (#453 / Thermos F3).
+"""Shared finding-id safety checks and evidence-packet lookup (#453).
 
 Exports:
     is_safe_path_stem: Reject traversal and separator characters in file stems.

--- a/src/mergecraft/review_taxonomy.py
+++ b/src/mergecraft/review_taxonomy.py
@@ -69,11 +69,12 @@ def finding_fingerprint(*, path: str, body: str) -> str:
     return hashlib.sha256(f"{path}\n{normalized}".encode()).hexdigest()[:24]
 
 
-def stamp_finding_fingerprint(*, path: str, body: str) -> str:
+def stamp_finding_fingerprint(*, path: str, body: str, fingerprint: str | None = None) -> str:
     """Append the dedup marker to ``body``, unless it already carries one."""
     if _MARKER_RE.search(body):
         return body
-    marker = f"{FINDING_MARKER_PREFIX}{finding_fingerprint(path=path, body=body)} -->"
+    resolved = fingerprint or finding_fingerprint(path=path, body=body)
+    marker = f"{FINDING_MARKER_PREFIX}{resolved} -->"
     return f"{body}\n\n{marker}" if body else marker
 
 

--- a/src/mergecraft/tracing/trace_jsonl.py
+++ b/src/mergecraft/tracing/trace_jsonl.py
@@ -1,0 +1,68 @@
+"""Shared JSONL trace loading for CLI replay/inspect and durable review artifacts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from mergecraft.tracing.sinks import read_jsonl_events
+
+
+def default_trace_dir(*, repo_root: Path | None = None) -> Path:
+    """Resolve ``MERGECRAFT_TRACE_DIR`` or the default ``.mergecraft/traces`` path."""
+    env_dir = os.environ.get("MERGECRAFT_TRACE_DIR")
+    if env_dir:
+        return Path(env_dir)
+    if repo_root is not None:
+        return repo_root / ".mergecraft" / "traces"
+    return Path(".mergecraft/traces")
+
+
+def load_trace_jsonl_events(
+    trace_dir: Path,
+    *,
+    session_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Parse ``*.jsonl`` files under ``trace_dir``, optionally filtering by session."""
+    if not trace_dir.is_dir():
+        return []
+    matched: list[dict[str, Any]] = []
+    for jsonl_path in sorted(trace_dir.glob("*.jsonl")):
+        try:
+            events = read_jsonl_events(jsonl_path)
+        except OSError:
+            continue
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            if session_id is not None and str(event.get("session_id", "")) != session_id:
+                continue
+            matched.append(event)
+    return matched
+
+
+def session_ids_in_trace_order(events: list[dict[str, Any]]) -> list[str]:
+    """Return unique ``session_id`` values ordered by earliest trace timestamp."""
+    first_index: dict[str, int] = {}
+    min_ts: dict[str, int] = {}
+    for idx, event in enumerate(events):
+        raw = event.get("session_id")
+        if raw is None or raw == "":
+            continue
+        session = str(raw)
+        if session not in first_index:
+            first_index[session] = idx
+        ts = event.get("ts_start_ns")
+        if isinstance(ts, int) and (session not in min_ts or ts < min_ts[session]):
+            min_ts[session] = ts
+
+    def _sort_key(session: str) -> tuple[int, int, int]:
+        if session in min_ts:
+            return (0, min_ts[session], first_index[session])
+        return (1, first_index[session], 0)
+
+    return sorted(first_index, key=_sort_key)
+
+
+__all__ = ["default_trace_dir", "load_trace_jsonl_events", "session_ids_in_trace_order"]

--- a/src/mergecraft/version_info.py
+++ b/src/mergecraft/version_info.py
@@ -1,4 +1,4 @@
-"""Version display helpers for CLI and telemetry (#473 / Thermos F17)."""
+"""Version display helpers for CLI and telemetry (#473)."""
 
 from __future__ import annotations
 

--- a/src/mergecraft/version_info.py
+++ b/src/mergecraft/version_info.py
@@ -1,0 +1,38 @@
+"""Version display helpers for CLI and telemetry (#473 / Thermos F17)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def short_commit(commit: str | None) -> str | None:
+    """Return the seven-character short SHA prefix, or ``None`` when unknown."""
+    if commit is None:
+        return None
+    trimmed = commit.strip()
+    if not trimmed:
+        return None
+    return trimmed[:7]
+
+
+def format_version_display(version: str, commit: str | None) -> str:
+    """Render ``<version> (<short-sha>)`` when commit is known; else ``version`` alone."""
+    short = short_commit(commit)
+    if short is None:
+        return version
+    return f"{version} ({short})"
+
+
+def version_json_payload(version: str, commit: str | None) -> dict[str, Any]:
+    """Machine-readable version document (``schema_version`` added by the CLI envelope)."""
+    return {
+        "version": version,
+        "commit": short_commit(commit),
+    }
+
+
+__all__ = [
+    "format_version_display",
+    "short_commit",
+    "version_json_payload",
+]

--- a/tests/analyzers/support_short_id.py
+++ b/tests/analyzers/support_short_id.py
@@ -1,0 +1,67 @@
+"""Shared lazy-import helpers for CA #452 short finding id RED tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from tests.analyzers.support import import_module
+
+_FINDING_MOD = "mergecraft.analyzers.finding"
+
+
+def finding_module() -> Any:
+    """Return the ``mergecraft.analyzers.finding`` module."""
+    return import_module(_FINDING_MOD)
+
+
+def require_attr(name: str) -> Any:
+    """Return ``finding`` module attribute ``name`` or fail the RED test."""
+    mod = finding_module()
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_FINDING_MOD}.{name} is not implemented"
+    return value
+
+
+def require_callable(name: str) -> Callable[..., Any]:
+    """Return a callable exported from ``finding`` or fail the RED test."""
+    value = require_attr(name)
+    assert callable(value), f"{_FINDING_MOD}.{name} must be callable"
+    return value
+
+
+def sample_finding(*, fingerprint: str | None = None) -> Any:
+    """Build a taxonomy-valid finding for output-surface tests."""
+    kwargs: dict[str, Any] = {
+        "tool": "ruff",
+        "rule_id": "F401",
+        "category": "Maintainability & Code Quality",
+        "severity": "Minor",
+        "confidence": "likely",
+        "message": "unused import os",
+        "path": "src/demo.py",
+        "start_line": 3,
+        "end_line": 3,
+        "source": "analyzer",
+    }
+    if fingerprint is not None:
+        kwargs["fingerprint"] = fingerprint
+    return finding_module().make_finding(**kwargs)
+
+
+def collision_fingerprints() -> tuple[str, str]:
+    """Two distinct 24-char fingerprints that share the same 6-char truncation."""
+    prefix = "a83f91"
+    return (
+        f"{prefix}{'0' * 18}",
+        f"{prefix}{'1' * 18}",
+    )
+
+
+__all__ = [
+    "collision_fingerprints",
+    "finding_module",
+    "require_attr",
+    "require_callable",
+    "sample_finding",
+]

--- a/tests/analyzers/test_budget.py
+++ b/tests/analyzers/test_budget.py
@@ -50,6 +50,23 @@ def test_mechanical_section_includes_short_ids() -> None:
     assert short_id in placement.mechanical_section
 
 
+def test_sync_deferred_section_includes_short_ids() -> None:
+    """Live markdown regen keeps batch-resolved short ids on deferred overflow rows."""
+    from mergecraft.mcp.tool_state import AnalyzerRunState
+
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    budget = import_module("mergecraft.analyzers.budget")
+    finding = _finding("Major", path="src/deferred.py", line=9)
+    run_state = AnalyzerRunState(
+        ran=True,
+        deferred_findings=[budget.finding_to_deferred_row(finding)],
+    )
+    budget.sync_deferred_section(run_state)
+    assert run_state.deferred_section is not None
+    short_id = finding_mod.finding_short_id(finding.fingerprint)
+    assert short_id in run_state.deferred_section
+
+
 def test_trivial_severity_never_inline() -> None:
     budget = import_module("mergecraft.analyzers.budget")
     trivial = _finding(BODY_ONLY_SEVERITY)

--- a/tests/analyzers/test_budget.py
+++ b/tests/analyzers/test_budget.py
@@ -38,6 +38,18 @@ def test_overflow_lands_in_mechanical_section() -> None:
     assert "### 🔧 Mechanical findings" in placement.mechanical_section
 
 
+def test_mechanical_section_includes_short_ids() -> None:
+    """Production markdown surfaces batch-resolved short ids for overflow findings."""
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    budget = import_module("mergecraft.analyzers.budget")
+    findings = [_finding("Major", path=f"src/f{i}.py", line=i) for i in range(1, INLINE_BUDGET + 2)]
+    placement = budget.place_findings(findings, inline_budget=0)
+    assert placement.mechanical_section is not None
+    overflow = findings[0]
+    short_id = finding_mod.finding_short_id(overflow.fingerprint)
+    assert short_id in placement.mechanical_section
+
+
 def test_trivial_severity_never_inline() -> None:
     budget = import_module("mergecraft.analyzers.budget")
     trivial = _finding(BODY_ONLY_SEVERITY)

--- a/tests/analyzers/test_budget.py
+++ b/tests/analyzers/test_budget.py
@@ -59,12 +59,61 @@ def test_sync_deferred_section_includes_short_ids() -> None:
     finding = _finding("Major", path="src/deferred.py", line=9)
     run_state = AnalyzerRunState(
         ran=True,
+        findings=[{"fingerprint": finding.fingerprint}],
         deferred_findings=[budget.finding_to_deferred_row(finding)],
     )
     budget.sync_deferred_section(run_state)
     assert run_state.deferred_section is not None
     short_id = finding_mod.finding_short_id(finding.fingerprint)
     assert short_id in run_state.deferred_section
+
+
+def test_cross_lane_short_ids_disambiguate_collisions() -> None:
+    """Inline and mechanical lanes share one batch-resolved ``MC-…`` mapping."""
+    from mergecraft.review.finding_lookup import fingerprint_for_short_id
+
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    budget = import_module("mergecraft.analyzers.budget")
+    from tests.analyzers.support_short_id import collision_fingerprints
+
+    fp1, fp2 = collision_fingerprints()
+    inline_finding = finding_mod.make_finding(
+        tool="actionlint",
+        rule_id="inline",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="likely",
+        message="inline collision",
+        path="src/inline.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        fingerprint=fp1,
+    )
+    mechanical_finding = finding_mod.make_finding(
+        tool="actionlint",
+        rule_id="overflow",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="likely",
+        message="mechanical collision",
+        path="src/mechanical.py",
+        start_line=2,
+        end_line=2,
+        source="analyzer",
+        fingerprint=fp2,
+    )
+    placement = budget.place_findings(
+        [inline_finding, mechanical_finding],
+        inline_budget=1,
+    )
+    expected_short_ids = finding_mod.resolve_finding_short_ids([fp1, fp2])
+    assert placement.short_ids == expected_short_ids
+    assert placement.short_ids[fp1] != placement.short_ids[fp2]
+    assert placement.mechanical_section is not None
+    assert f"**{placement.short_ids[fp2]}**" in placement.mechanical_section
+    displayed = placement.short_ids[fp2]
+    assert fingerprint_for_short_id(displayed, (fp1, fp2)) == fp2
 
 
 def test_trivial_severity_never_inline() -> None:

--- a/tests/analyzers/test_finding_short_id.py
+++ b/tests/analyzers/test_finding_short_id.py
@@ -1,0 +1,97 @@
+"""CA #452 RED — stable short finding id derived from ``Finding.fingerprint`` (D2).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-c-findings-cli-wave-plan.md``
+Implementation wave: **CA**. Pins prefix ``MC-``, deterministic derivation, and
+documented collision behaviour when truncated ids would clash.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.analyzers.support_short_id import (
+    collision_fingerprints,
+    require_attr,
+    require_callable,
+)
+
+_MC_ID_RE = re.compile(r"^MC-[0-9a-f]{6,}$")
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_short_id_prefix_is_mc() -> None:
+    """D2 — short ids use the ``MC-`` prefix."""
+    prefix = require_attr("FINDING_SHORT_ID_PREFIX")
+    finding_short_id = require_callable("finding_short_id")
+    fingerprint = "a83f91c2d4e5f6a7b8c9d0e1"
+    short_id = finding_short_id(fingerprint)
+    assert prefix == "MC-"
+    assert short_id.startswith("MC-")
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_short_id_is_deterministic_for_same_fingerprint() -> None:
+    """Happy — the same fingerprint always maps to the same short id."""
+    finding_short_id = require_callable("finding_short_id")
+    fingerprint = "deadbeefcafebabe01234567"
+    assert finding_short_id(fingerprint) == finding_short_id(fingerprint)
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_short_id_uses_fingerprint_prefix() -> None:
+    """Happy — default truncation uses the fingerprint's leading hex (issue example)."""
+    finding_short_id = require_callable("finding_short_id")
+    fingerprint = "a83f91c2d4e5f6a7b8c9d0e1"
+    assert finding_short_id(fingerprint) == "MC-a83f91"
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_short_id_differs_for_different_fingerprints() -> None:
+    """Edge — unrelated fingerprints should not share a short id by default."""
+    finding_short_id = require_callable("finding_short_id")
+    left = finding_short_id("111111111111111111111111")
+    right = finding_short_id("222222222222222222222222")
+    assert left != right
+
+
+@pytest.mark.parametrize(
+    ("fingerprint", "label"),
+    [
+        ("", "empty"),
+        (".", "dot"),
+        ("..", "dotdot"),
+        ("../escape", "path traversal"),
+    ],
+)
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_short_id_rejects_unsafe_fingerprint(
+    fingerprint: str,
+    label: str,
+) -> None:
+    """Error — unsafe fingerprint values are rejected at the helper boundary."""
+    finding_short_id = require_callable("finding_short_id")
+    with pytest.raises((ValueError, TypeError), match=r".+"):
+        finding_short_id(fingerprint)
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_resolve_finding_short_ids_disambiguates_truncation_collisions() -> None:
+    """D2 — batch assignment yields distinct ids when truncation would collide."""
+    resolve_finding_short_ids = require_callable("resolve_finding_short_ids")
+    fp1, fp2 = collision_fingerprints()
+    mapping = resolve_finding_short_ids([fp1, fp2])
+    assert mapping[fp1] != mapping[fp2]
+    assert _MC_ID_RE.match(mapping[fp1])
+    assert _MC_ID_RE.match(mapping[fp2])
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_resolve_finding_short_ids_is_stable_for_repeated_calls() -> None:
+    """Happy — collision resolution is deterministic across repeated batch calls."""
+    resolve_finding_short_ids = require_callable("resolve_finding_short_ids")
+    fingerprints = list(collision_fingerprints())
+    first = resolve_finding_short_ids(fingerprints)
+    second = resolve_finding_short_ids(fingerprints)
+    assert first == second

--- a/tests/analyzers/test_finding_short_id.py
+++ b/tests/analyzers/test_finding_short_id.py
@@ -20,7 +20,6 @@ from tests.analyzers.support_short_id import (
 _MC_ID_RE = re.compile(r"^MC-[0-9a-f]{6,}$")
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_short_id_prefix_is_mc() -> None:
     """D2 — short ids use the ``MC-`` prefix."""
     prefix = require_attr("FINDING_SHORT_ID_PREFIX")
@@ -31,7 +30,6 @@ def test_finding_short_id_prefix_is_mc() -> None:
     assert short_id.startswith("MC-")
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_short_id_is_deterministic_for_same_fingerprint() -> None:
     """Happy — the same fingerprint always maps to the same short id."""
     finding_short_id = require_callable("finding_short_id")
@@ -39,7 +37,6 @@ def test_finding_short_id_is_deterministic_for_same_fingerprint() -> None:
     assert finding_short_id(fingerprint) == finding_short_id(fingerprint)
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_short_id_uses_fingerprint_prefix() -> None:
     """Happy — default truncation uses the fingerprint's leading hex (issue example)."""
     finding_short_id = require_callable("finding_short_id")
@@ -47,7 +44,6 @@ def test_finding_short_id_uses_fingerprint_prefix() -> None:
     assert finding_short_id(fingerprint) == "MC-a83f91"
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_short_id_differs_for_different_fingerprints() -> None:
     """Edge — unrelated fingerprints should not share a short id by default."""
     finding_short_id = require_callable("finding_short_id")
@@ -65,7 +61,6 @@ def test_finding_short_id_differs_for_different_fingerprints() -> None:
         ("../escape", "path traversal"),
     ],
 )
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_short_id_rejects_unsafe_fingerprint(
     fingerprint: str,
     label: str,
@@ -76,7 +71,6 @@ def test_finding_short_id_rejects_unsafe_fingerprint(
         finding_short_id(fingerprint)
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_resolve_finding_short_ids_disambiguates_truncation_collisions() -> None:
     """D2 — batch assignment yields distinct ids when truncation would collide."""
     resolve_finding_short_ids = require_callable("resolve_finding_short_ids")
@@ -87,7 +81,6 @@ def test_resolve_finding_short_ids_disambiguates_truncation_collisions() -> None
     assert _MC_ID_RE.match(mapping[fp2])
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_resolve_finding_short_ids_is_stable_for_repeated_calls() -> None:
     """Happy — collision resolution is deterministic across repeated batch calls."""
     resolve_finding_short_ids = require_callable("resolve_finding_short_ids")

--- a/tests/ci/support_review_timeout_budget.py
+++ b/tests/ci/support_review_timeout_budget.py
@@ -1,0 +1,169 @@
+"""CG #465 — helpers for mergecraft.yml review timeout budget composition (D8).
+
+Pins one declared per-attempt budget and derived job ``timeout-minutes`` so
+Nous + Codex fallback can each run a full attempt without the job being killed
+first. Retries do not accumulate progress — per-attempt ceilings must not be
+shortened to "make room" for a second attempt.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from tests.ci.workflow_support import job, load_workflow, read_text
+
+_WORKFLOW = "mergecraft.yml"
+_WORKFLOW_PATH = f".github/workflows/{_WORKFLOW}"
+_REVIEW_JOB = "review"
+
+# Declared once in the workflow; both review steps and the job budget derive from it.
+DECLARED_ATTEMPT_TIMEOUT_ENV = "MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES"
+
+# Headroom for checkout, image pull, prompt composition, and gate polling — not
+# per-attempt review time. D8: job > sum(attempts) + checkout slack.
+CHECKOUT_AND_SETUP_SLACK_MINUTES = 10
+
+# Worst-case sequential path: primary Nous attempt then Codex fallback.
+MAX_SEQUENTIAL_REVIEW_ATTEMPTS = 2
+
+_MERGECRAFT_USES = re.compile(r"^\s+uses:\s+alexhawat/mergeCraft@", re.MULTILINE)
+_DURATION = re.compile(r"^(\d+)\s*([mhs])$", re.IGNORECASE)
+_ENV_REF = re.compile(
+    r"^\$\{\{\s*env\.([A-Z0-9_]+)\s*\}\}m?$",
+    re.IGNORECASE,
+)
+
+
+def review_job(doc: dict[str, Any] | None = None) -> dict[str, Any]:
+    return job(doc or load_workflow(_WORKFLOW), _REVIEW_JOB)
+
+
+def workflow_env(doc: dict[str, Any] | None = None) -> dict[str, Any]:
+    loaded = doc or load_workflow(_WORKFLOW)
+    env = loaded.get("env") or {}
+    assert isinstance(env, dict), "workflow env must be a mapping when present"
+    return env
+
+
+def review_job_env(doc: dict[str, Any] | None = None) -> dict[str, Any]:
+    env = review_job(doc).get("env") or {}
+    assert isinstance(env, dict), "review job env must be a mapping when present"
+    return env
+
+
+def declared_attempt_timeout_minutes(doc: dict[str, Any] | None = None) -> int:
+    """Return the single declared per-attempt budget in whole minutes."""
+    loaded = doc or load_workflow(_WORKFLOW)
+    for scope in (workflow_env(loaded), review_job_env(loaded)):
+        raw = scope.get(DECLARED_ATTEMPT_TIMEOUT_ENV)
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if not text.isdigit():
+            msg = f"{DECLARED_ATTEMPT_TIMEOUT_ENV} must be an integer minute count, got {raw!r}"
+            raise ValueError(msg)
+        minutes = int(text)
+        if minutes <= 0:
+            msg = f"{DECLARED_ATTEMPT_TIMEOUT_ENV} must be positive, got {minutes}"
+            raise ValueError(msg)
+        return minutes
+    msg = (
+        f"{_WORKFLOW} must declare {DECLARED_ATTEMPT_TIMEOUT_ENV} once at workflow "
+        "or review-job scope"
+    )
+    raise ValueError(msg)
+
+
+def parse_duration_minutes(value: str) -> int:
+    """Parse GitHub Action ``timeout`` inputs like ``25m`` into whole minutes."""
+    text = value.strip()
+    env_match = _ENV_REF.match(text)
+    if env_match:
+        env_name = env_match.group(1)
+        if env_name != DECLARED_ATTEMPT_TIMEOUT_ENV:
+            msg = f"unexpected env ref for attempt timeout: {env_name!r}"
+            raise ValueError(msg)
+        return declared_attempt_timeout_minutes()
+    match = _DURATION.fullmatch(text)
+    if not match:
+        msg = f"unparseable duration: {value!r}"
+        raise ValueError(msg)
+    amount = int(match.group(1))
+    unit = match.group(2).lower()
+    if unit == "m":
+        return amount
+    if unit == "h":
+        return amount * 60
+    if unit == "s":
+        return max(1, (amount + 59) // 60)
+    msg = f"unsupported duration unit in {value!r}"
+    raise ValueError(msg)
+
+
+def mergecraft_review_steps(doc: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Return mergeCraft action steps in the review job (Nous + Codex)."""
+    steps = review_job(doc).get("steps")
+    assert isinstance(steps, list), "review job steps must be a list"
+    found: list[dict[str, Any]] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        uses = step.get("uses")
+        if isinstance(uses, str) and uses.startswith("alexhawat/mergeCraft@"):
+            found.append(step)
+    return found
+
+
+def step_attempt_timeout_minutes(step: dict[str, Any]) -> int:
+    with_block = step.get("with") or {}
+    assert isinstance(with_block, dict), "mergeCraft step with: must be a mapping"
+    timeout = with_block.get("timeout")
+    assert isinstance(timeout, str), (
+        f"mergeCraft step {step.get('name')!r} must declare with.timeout"
+    )
+    return parse_duration_minutes(timeout)
+
+
+def review_job_timeout_minutes(doc: dict[str, Any] | None = None) -> int:
+    raw = review_job(doc).get("timeout-minutes")
+    assert isinstance(raw, int), "review job must declare timeout-minutes"
+    assert raw > 0, "review job timeout-minutes must be positive"
+    return raw
+
+
+def minimum_composed_job_minutes(
+    attempt_minutes: int,
+    *,
+    sequential_attempts: int = MAX_SEQUENTIAL_REVIEW_ATTEMPTS,
+    slack_minutes: int = CHECKOUT_AND_SETUP_SLACK_MINUTES,
+) -> int:
+    """Strict lower bound the job budget must exceed (D8 composition)."""
+    return sequential_attempts * attempt_minutes + slack_minutes
+
+
+def job_timeout_composes(
+    job_minutes: int,
+    attempt_minutes: int,
+    *,
+    sequential_attempts: int = MAX_SEQUENTIAL_REVIEW_ATTEMPTS,
+    slack_minutes: int = CHECKOUT_AND_SETUP_SLACK_MINUTES,
+) -> bool:
+    return job_minutes > minimum_composed_job_minutes(
+        attempt_minutes,
+        sequential_attempts=sequential_attempts,
+        slack_minutes=slack_minutes,
+    )
+
+
+def timeout_uses_declared_env_reference(value: str) -> bool:
+    """True when the step timeout is wired to the single declared env budget."""
+    return bool(_ENV_REF.match(value.strip()))
+
+
+def workflow_text() -> str:
+    return read_text(_WORKFLOW_PATH)
+
+
+def count_mergecraft_uses_in_workflow_text() -> int:
+    return len(_MERGECRAFT_USES.findall(workflow_text()))

--- a/tests/ci/test_mergecraft_workflow_timeout_budget.py
+++ b/tests/ci/test_mergecraft_workflow_timeout_budget.py
@@ -37,7 +37,6 @@ def workflow_doc() -> dict[str, object]:
     return load_workflow(_WORKFLOW)
 
 
-@pytest.mark.xfail(reason="green after CG", strict=False)
 def test_workflow_declares_single_review_attempt_timeout_budget(
     workflow_doc: dict[str, object],
 ) -> None:
@@ -50,7 +49,6 @@ def test_workflow_declares_single_review_attempt_timeout_budget(
     assert minutes >= 25, "declared attempt budget should not regress below the prior 25m ceiling"
 
 
-@pytest.mark.xfail(reason="green after CG", strict=False)
 def test_mergecraft_review_steps_reference_declared_attempt_timeout(
     workflow_doc: dict[str, object],
 ) -> None:
@@ -74,7 +72,6 @@ def test_mergecraft_review_steps_reference_declared_attempt_timeout(
         )
 
 
-@pytest.mark.xfail(reason="green after CG", strict=False)
 def test_review_job_timeout_composes_from_attempt_budget(
     workflow_doc: dict[str, object],
 ) -> None:
@@ -90,7 +87,6 @@ def test_review_job_timeout_composes_from_attempt_budget(
     )
 
 
-@pytest.mark.xfail(reason="green after CG", strict=False)
 def test_per_attempt_timeout_not_shortened_below_declared_budget(
     workflow_doc: dict[str, object],
 ) -> None:

--- a/tests/ci/test_mergecraft_workflow_timeout_budget.py
+++ b/tests/ci/test_mergecraft_workflow_timeout_budget.py
@@ -1,0 +1,107 @@
+"""CG #465 RED — review timeout budgets must compose from one number (D8).
+
+Issue #465: independent ``timeout-minutes: 60`` and two ``timeout: 25m``
+literals do not compose — a Nous attempt followed by Codex fallback can exceed
+the job ceiling and GitHub kills the job before the action posts diagnostics.
+
+D8 pins:
+- one declared per-attempt budget;
+- job ``timeout-minutes`` > sum of sequential attempts + checkout slack;
+- do **not** shorten per-attempt timeouts to make room for retry headroom.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.ci.support_review_timeout_budget import (
+    CHECKOUT_AND_SETUP_SLACK_MINUTES,
+    DECLARED_ATTEMPT_TIMEOUT_ENV,
+    MAX_SEQUENTIAL_REVIEW_ATTEMPTS,
+    declared_attempt_timeout_minutes,
+    job_timeout_composes,
+    mergecraft_review_steps,
+    minimum_composed_job_minutes,
+    review_job_timeout_minutes,
+    step_attempt_timeout_minutes,
+    timeout_uses_declared_env_reference,
+    workflow_env,
+)
+from tests.ci.workflow_support import load_workflow
+
+_WORKFLOW = "mergecraft.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow_doc() -> dict[str, object]:
+    return load_workflow(_WORKFLOW)
+
+
+@pytest.mark.xfail(reason="green after CG", strict=False)
+def test_workflow_declares_single_review_attempt_timeout_budget(
+    workflow_doc: dict[str, object],
+) -> None:
+    """Happy — one env var is the sole declared per-attempt budget."""
+    env = workflow_env(workflow_doc)
+    assert DECLARED_ATTEMPT_TIMEOUT_ENV in env, (
+        f"{_WORKFLOW} must declare {DECLARED_ATTEMPT_TIMEOUT_ENV} at workflow scope"
+    )
+    minutes = declared_attempt_timeout_minutes(workflow_doc)
+    assert minutes >= 25, "declared attempt budget should not regress below the prior 25m ceiling"
+
+
+@pytest.mark.xfail(reason="green after CG", strict=False)
+def test_mergecraft_review_steps_reference_declared_attempt_timeout(
+    workflow_doc: dict[str, object],
+) -> None:
+    """Integration — Nous and Codex steps derive ``with.timeout`` from the budget."""
+    steps = mergecraft_review_steps(workflow_doc)
+    assert len(steps) == MAX_SEQUENTIAL_REVIEW_ATTEMPTS, (
+        f"expected {MAX_SEQUENTIAL_REVIEW_ATTEMPTS} mergeCraft review steps, got {len(steps)}"
+    )
+    declared = declared_attempt_timeout_minutes(workflow_doc)
+    for step in steps:
+        with_block = step.get("with") or {}
+        assert isinstance(with_block, dict)
+        timeout = with_block.get("timeout")
+        assert isinstance(timeout, str), f"step {step.get('name')!r} missing with.timeout"
+        assert timeout_uses_declared_env_reference(timeout), (
+            f"step {step.get('name')!r} must reference env.{DECLARED_ATTEMPT_TIMEOUT_ENV}, "
+            f"not an independent literal ({timeout!r})"
+        )
+        assert step_attempt_timeout_minutes(step) == declared, (
+            "per-attempt timeout must equal the declared budget — do not shorten for retry headroom"
+        )
+
+
+@pytest.mark.xfail(reason="green after CG", strict=False)
+def test_review_job_timeout_composes_from_attempt_budget(
+    workflow_doc: dict[str, object],
+) -> None:
+    """Functional — job budget exceeds 2x attempt + checkout slack (D8)."""
+    attempt = declared_attempt_timeout_minutes(workflow_doc)
+    job_minutes = review_job_timeout_minutes(workflow_doc)
+    floor = minimum_composed_job_minutes(attempt)
+    assert job_timeout_composes(job_minutes, attempt), (
+        f"review job timeout-minutes={job_minutes} must be > "
+        f"{MAX_SEQUENTIAL_REVIEW_ATTEMPTS}×{attempt} + "
+        f"{CHECKOUT_AND_SETUP_SLACK_MINUTES} slack (>{floor}); "
+        "otherwise GitHub kills the job before Codex fallback can finish"
+    )
+
+
+@pytest.mark.xfail(reason="green after CG", strict=False)
+def test_per_attempt_timeout_not_shortened_below_declared_budget(
+    workflow_doc: dict[str, object],
+) -> None:
+    """Edge — retries do not accumulate progress; each attempt keeps the full budget."""
+    declared = declared_attempt_timeout_minutes(workflow_doc)
+    attempt_timeouts = [
+        step_attempt_timeout_minutes(step) for step in mergecraft_review_steps(workflow_doc)
+    ]
+    assert attempt_timeouts, "expected mergeCraft review steps"
+    assert all(minutes == declared for minutes in attempt_timeouts), (
+        "every review attempt must use the full declared budget — shortening per-attempt "
+        f"to make room for retry makes large reviews strictly worse (got {attempt_timeouts!r} "
+        f"vs declared {declared})"
+    )

--- a/tests/cli/support_init_audit_jsonl.py
+++ b/tests/cli/support_init_audit_jsonl.py
@@ -1,0 +1,56 @@
+"""CI #487 — helpers for ``init`` gitignore scaffold of ``.mergecraft/audit.jsonl`` (D10).
+
+Pins explicit ignore line in consumer ``.gitignore`` so enterprise audit JSONL
+never appears as untracked local state after a review run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
+
+# D10: explicit line — not a broad ``/.mergecraft/*`` blanket for consumer repos.
+AUDIT_JSONL_GITIGNORE_LINE = DEFAULT_AUDIT_REL.as_posix()
+
+
+def audit_jsonl_rel_path() -> str:
+    return DEFAULT_AUDIT_REL.as_posix()
+
+
+def audit_jsonl_path(repo_root: Path) -> Path:
+    return repo_root / DEFAULT_AUDIT_REL
+
+
+def gitignore_path(repo_root: Path) -> Path:
+    return repo_root / ".gitignore"
+
+
+def gitignore_contains_audit_jsonl(repo_root: Path) -> bool:
+    path = gitignore_path(repo_root)
+    if not path.is_file():
+        return False
+    return AUDIT_JSONL_GITIGNORE_LINE in path.read_text(encoding="utf-8")
+
+
+def git_check_ignores(repo_root: Path, rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", rel_path],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def git_status_porcelain(repo_root: Path, rel_path: str) -> str:
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--", rel_path],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        msg = result.stderr or result.stdout or "git status failed"
+        raise RuntimeError(msg)
+    return result.stdout.strip()

--- a/tests/cli/support_update_version.py
+++ b/tests/cli/support_update_version.py
@@ -1,0 +1,62 @@
+"""Shared fixtures for CF #473 ``update`` + commit in ``--version`` RED tests (D7)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.analyzers.support import import_module
+
+_UPDATE_CMD_MOD = "mergecraft.cli.update_cmd"
+_VERSION_MOD = "mergecraft"
+
+# D7 default git ref when ``--branch`` is omitted.
+DEFAULT_UPDATE_REF = "main"
+
+# README / AGENTS install spec shape (``uv tool install --reinstall`` target).
+MERGECRAFT_UV_INSTALL_PACKAGE = "merge-craft"
+MERGECRAFT_GIT_ORIGIN = "https://github.com/alexhawat/mergeCraft"
+
+
+def update_cmd_module() -> Any:
+    """Return the ``mergecraft.cli.update_cmd`` module."""
+    return import_module(_UPDATE_CMD_MOD)
+
+
+def require_update_attr(name: str) -> Any:
+    """Return a symbol from ``mergecraft.cli.update_cmd`` or fail the RED test."""
+    mod = update_cmd_module()
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_UPDATE_CMD_MOD}.{name} is not implemented"
+    return value
+
+
+def require_version_attr(name: str) -> Any:
+    """Return a symbol from ``mergecraft`` or fail the RED test."""
+    mod = import_module(_VERSION_MOD)
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_VERSION_MOD}.{name} is not implemented"
+    return value
+
+
+def require_version_callable(name: str) -> Any:
+    """Return a callable version helper or fail the RED test."""
+    value = require_version_attr(name)
+    assert callable(value), f"{_VERSION_MOD}.{name} must be callable"
+    return value
+
+
+def uv_install_spec(ref: str) -> str:
+    """Build the ``uv tool install`` git spec for ``ref`` (branch, tag, or SHA)."""
+    return f"{MERGECRAFT_UV_INSTALL_PACKAGE} @ git+{MERGECRAFT_GIT_ORIGIN}@{ref}"
+
+
+__all__ = [
+    "DEFAULT_UPDATE_REF",
+    "MERGECRAFT_GIT_ORIGIN",
+    "MERGECRAFT_UV_INSTALL_PACKAGE",
+    "require_update_attr",
+    "require_version_attr",
+    "require_version_callable",
+    "update_cmd_module",
+    "uv_install_spec",
+]

--- a/tests/cli/test_diff_review_hunk_output.py
+++ b/tests/cli/test_diff_review_hunk_output.py
@@ -1,0 +1,224 @@
+"""CB #451 RED — ``mergecraft review --output-format hunk`` (D3).
+
+Pins stdout-only Hunk JSON piping, structured-findings wiring, and stderr warnings
+for dropped file-level findings. No subprocess / Hunk dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+from tests.analyzers.support import import_module as import_analyzer_module
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.offline_review import OfflineReviewResult
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+_SAMPLE_PATCH = (
+    "diff --git a/demo.py b/demo.py\n"
+    "--- a/demo.py\n"
+    "+++ b/demo.py\n"
+    "@@ -0,0 +1,3 @@\n"
+    "+import os\n"
+    "+print(os.getcwd())\n"
+    "+# tail\n"
+)
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _line_finding_dict(**overrides: object) -> dict[str, object]:
+    finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import os",
+        path="demo.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        introduced_by_pr="unknown",
+        **overrides,
+    )
+    return finding.model_dump()
+
+
+def _file_level_finding_dict(**overrides: object) -> dict[str, object]:
+    return _line_finding_dict(start_line=None, end_line=None, path="README.md", **overrides)
+
+
+def _review_argv(tmp_path: Path, *extra: str) -> list[str]:
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    return ["review", "--diff", str(patch), "--cwd", str(tmp_path), *extra]
+
+
+def _install_fake_review(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    findings: list[dict[str, object]],
+) -> None:
+    async def fake_run_offline_diff_review(**kwargs: object) -> OfflineReviewResult:
+        materialization_path = kwargs.get("diff_file")
+        diff_path = str(materialization_path) if materialization_path else None
+        payload = json.dumps({"findings": findings})
+        json_path = kwargs.get("json_path")
+        if json_path is not None:
+            await asyncio.to_thread(Path(str(json_path)).write_text, payload, encoding="utf-8")
+        return OfflineReviewResult(
+            success=True,
+            output="# Review\n\nWith findings.",
+            structured_output=payload,
+            diff_path=diff_path,
+        )
+
+    monkeypatch.setattr(
+        "mergecraft.cli.diff_review_cmd.run_offline_diff_review",
+        fake_run_offline_diff_review,
+    )
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_hunk_output_format_writes_json_to_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3 — Hunk payload is emitted on stdout for shell piping."""
+    _install_fake_review(monkeypatch, findings=[_line_finding_dict()])
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--output-format", "hunk"),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    payload = json.loads(result.stdout)
+    assert isinstance(payload.get("comments"), list)
+    assert payload["comments"], combined
+    assert payload["comments"][0]["filePath"] == "demo.py"
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_hunk_output_format_does_not_require_output_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3 — unlike sarif/jsonl, hunk format is stdout-only (no ``--output`` requirement)."""
+    _install_fake_review(monkeypatch, findings=[_line_finding_dict()])
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--output-format", "hunk"),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    assert "--output is required" not in combined.lower()
+    assert json.loads(result.stdout)["comments"]
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_hunk_output_format_warns_about_dropped_file_level_on_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default drop mode surfaces a counted warning on stderr, not stdout."""
+    _install_fake_review(
+        monkeypatch,
+        findings=[_file_level_finding_dict(), _line_finding_dict()],
+    )
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--output-format", "hunk"),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    payload = json.loads(result.stdout)
+    assert len(payload["comments"]) == 1
+    stderr = _plain(result.stderr)
+    assert "file-level" in stderr.casefold()
+    assert "not exportable" in stderr.casefold()
+    assert re.search(r"\b1\b", stderr)
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_hunk_output_format_requests_structured_findings_from_run_offline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--output-format hunk`` threads ``json_path`` so agent findings are available."""
+    captured: dict[str, object] = {}
+
+    async def _capture_run(**kwargs: object) -> OfflineReviewResult:
+        captured["kwargs"] = kwargs
+        finding = _line_finding_dict()
+        payload = json.dumps({"findings": [finding]})
+        json_path = kwargs.get("json_path")
+        if json_path is not None:
+            await asyncio.to_thread(Path(str(json_path)).write_text, payload, encoding="utf-8")
+        return OfflineReviewResult(
+            success=True,
+            output="# Review\n\nWith findings.",
+            structured_output=payload,
+            diff_path=str(kwargs.get("diff_file")) if kwargs.get("diff_file") else None,
+        )
+
+    monkeypatch.setattr("mergecraft.cli.diff_review_cmd.run_offline_diff_review", _capture_run)
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--output-format", "hunk"),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    sent_json_path = captured["kwargs"].get("json_path")  # type: ignore[union-attr]
+    assert sent_json_path is not None, (
+        f"--output-format hunk must request structured findings; got json_path={sent_json_path!r}"
+    )
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_hunk_file_findings_first_changed_line_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in ``--hunk-file-findings first-changed-line`` exports file-level rows."""
+    _install_fake_review(monkeypatch, findings=[_file_level_finding_dict(path="demo.py")])
+    result = runner.invoke(
+        app,
+        _review_argv(
+            tmp_path,
+            "--output-format",
+            "hunk",
+            "--hunk-file-findings",
+            "first-changed-line",
+        ),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    comment = json.loads(result.stdout)["comments"][0]
+    assert comment["filePath"] == "demo.py"
+    assert comment["newLine"] == 1
+    assert str(comment["summary"]).startswith("[file-level]")
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_review_help_lists_hunk_output_format() -> None:
+    """CLI surface documents the hunk exporter."""
+    result = runner.invoke(app, ["review", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
+    assert result.exit_code == 0
+    help_text = _plain(result.stdout)
+    assert "hunk" in help_text.casefold()

--- a/tests/cli/test_diff_review_hunk_output.py
+++ b/tests/cli/test_diff_review_hunk_output.py
@@ -10,13 +10,16 @@ import asyncio
 import json
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
 from tests.analyzers.support import import_module as import_analyzer_module
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
 from mergecraft.offline_review import OfflineReviewResult
+
+if TYPE_CHECKING:
+    import pytest
 
 runner = CliRunner()
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -38,25 +41,32 @@ def _plain(text: str) -> str:
 
 def _line_finding_dict(**overrides: object) -> dict[str, object]:
     finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
-    finding = finding_mod.make_finding(
-        tool="ruff",
-        rule_id="F401",
-        category="Maintainability & Code Quality",
-        severity="Minor",
-        confidence="likely",
-        message="unused import os",
-        path="demo.py",
-        start_line=1,
-        end_line=1,
-        source="analyzer",
-        introduced_by_pr="unknown",
-        **overrides,
-    )
+    kwargs: dict[str, object] = {
+        "tool": "ruff",
+        "rule_id": "F401",
+        "category": "Maintainability & Code Quality",
+        "severity": "Minor",
+        "confidence": "likely",
+        "message": "unused import os",
+        "path": "demo.py",
+        "start_line": 1,
+        "end_line": 1,
+        "source": "analyzer",
+        "introduced_by_pr": "unknown",
+    }
+    kwargs.update(overrides)
+    finding = finding_mod.make_finding(**kwargs)
     return finding.model_dump()
 
 
 def _file_level_finding_dict(**overrides: object) -> dict[str, object]:
-    return _line_finding_dict(start_line=None, end_line=None, path="README.md", **overrides)
+    defaults: dict[str, object] = {
+        "start_line": None,
+        "end_line": None,
+        "path": "README.md",
+    }
+    defaults.update(overrides)
+    return _line_finding_dict(**defaults)
 
 
 def _review_argv(tmp_path: Path, *extra: str) -> list[str]:
@@ -90,7 +100,6 @@ def _install_fake_review(
     )
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_hunk_output_format_writes_json_to_stdout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -110,7 +119,6 @@ def test_hunk_output_format_writes_json_to_stdout(
     assert payload["comments"][0]["filePath"] == "demo.py"
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_hunk_output_format_does_not_require_output_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -128,7 +136,6 @@ def test_hunk_output_format_does_not_require_output_path(
     assert json.loads(result.stdout)["comments"]
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_hunk_output_format_warns_about_dropped_file_level_on_stderr(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -153,7 +160,6 @@ def test_hunk_output_format_warns_about_dropped_file_level_on_stderr(
     assert re.search(r"\b1\b", stderr)
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_hunk_output_format_requests_structured_findings_from_run_offline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -189,7 +195,6 @@ def test_hunk_output_format_requests_structured_findings_from_run_offline(
     )
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_hunk_file_findings_first_changed_line_flag(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -215,7 +220,6 @@ def test_hunk_file_findings_first_changed_line_flag(
     assert str(comment["summary"]).startswith("[file-level]")
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_review_help_lists_hunk_output_format() -> None:
     """CLI surface documents the hunk exporter."""
     result = runner.invoke(app, ["review", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -210,7 +210,10 @@ def test_cli_diff_review_json_validates_findings(
         assert isinstance(payload.get("findings"), list)
         finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
         for item in payload["findings"]:
-            finding_mod.Finding.model_validate(item)
+            short_id = item.get("short_id")
+            assert isinstance(short_id, str)
+            assert short_id.startswith("MC-")
+            finding_mod.Finding.model_validate(finding_mod.finding_record_without_short_id(item))
     else:
         assert result.exit_code != 0, combined
         assert not json_out.exists(), combined

--- a/tests/cli/test_diff_review_json.py
+++ b/tests/cli/test_diff_review_json.py
@@ -10,7 +10,7 @@ import pytest
 from tests.analyzers.support import import_module as import_analyzer_module
 from typer.testing import CliRunner
 
-from mergecraft.analyzers.finding import Finding, findings_output_schema
+from mergecraft.analyzers.finding import Finding, findings_export_schema, validate_findings_export
 from mergecraft.cli.app import app
 from mergecraft.offline_review import OfflineReviewResult, build_offline_review_prompt
 
@@ -50,8 +50,8 @@ def _step_four_block(prompt: str) -> str:
     return match.group(1)
 
 
-def test_findings_output_schema_is_valid_json_schema() -> None:
-    schema = findings_output_schema()
+def test_findings_export_schema_is_valid_json_schema() -> None:
+    schema = findings_export_schema()
 
     assert schema.get("type") == "object"
     properties = schema.get("properties")
@@ -65,12 +65,9 @@ def test_findings_output_schema_is_valid_json_schema() -> None:
 
     item_properties = items.get("properties")
     assert isinstance(item_properties, dict)
+    assert "short_id" in item_properties
     assert frozenset(item_properties) >= frozenset(Finding.model_json_schema()["properties"])
     assert schema.get("required") == ["findings"]
-
-    severity = item_properties.get("severity")
-    assert isinstance(severity, dict)
-    assert "enum" in severity
 
 
 def test_build_offline_review_prompt_requires_set_output_when_json_mode(
@@ -208,12 +205,10 @@ def test_cli_diff_review_json_validates_findings(
         assert json_out.is_file(), combined
         payload = json.loads(json_out.read_text(encoding="utf-8"))
         assert isinstance(payload.get("findings"), list)
-        finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
+        validate_findings_export(payload)
         for item in payload["findings"]:
-            short_id = item.get("short_id")
-            assert isinstance(short_id, str)
-            assert short_id.startswith("MC-")
-            finding_mod.Finding.model_validate(finding_mod.finding_record_without_short_id(item))
+            assert isinstance(item.get("short_id"), str)
+            assert item["short_id"].startswith("MC-")
     else:
         assert result.exit_code != 0, combined
         assert not json_out.exists(), combined

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -265,3 +265,78 @@ def test_findings_lookup_does_not_invoke_review_agent(
     combined = _plain(result.stdout + result.stderr)
     assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
     assert calls == []
+
+
+def test_explain_with_review_id_fails_closed_when_finding_missing_in_review(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Error — review-scoped explain does not fall back to global evidence."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["explain", review_id, "MC-deadbeef", "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "unknown finding id" in combined.casefold()
+
+
+def test_replay_unknown_review_id_fails_closed_without_global_fallback(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Error — explicit replay ids without co-located traces do not scan global traces."""
+    review_id = "review-missing-replay-453"
+    _guard_against_review_rerun(monkeypatch)
+    trace_calls: list[object] = []
+
+    def _boom(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        trace_calls.append((args, kwargs))
+        msg = "global trace fallback must not run for explicit review id"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("mergecraft.cli.replay_cmd.load_trace_jsonl_events", _boom)
+    result = runner.invoke(
+        app,
+        ["replay", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "unknown review run" in combined.casefold()
+    assert trace_calls == []
+
+
+def test_review_with_unsafe_review_id_still_succeeds_and_persists_safely(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — unsafe ``MERGECRAFT_REVIEW_ID`` values do not crash persistence."""
+    unsafe_review_id = "../escape"
+    _install_fake_review(monkeypatch)
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+        ],
+        env={**_DUMB_ENV, "MERGECRAFT_REVIEW_ID": unsafe_review_id},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    from tests.review.support_durable_review import require_callable
+
+    loaded_ids = require_callable("list_completed_review_ids")(repo_root=tmp_path)
+    assert loaded_ids
+    assert unsafe_review_id not in loaded_ids

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -444,3 +444,10 @@ def test_review_with_unsafe_review_id_still_succeeds_and_persists_safely(
     loaded_ids = require_callable("list_completed_review_ids")(repo_root=tmp_path)
     assert loaded_ids
     assert unsafe_review_id not in loaded_ids
+    assert len(loaded_ids) == 1
+    persisted_id = loaded_ids[0]
+    payload = json.loads(result.stdout)
+    assert payload.get("review_id") == persisted_id
+    loaded = require_callable("load_completed_review")(persisted_id, repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded.review_id == persisted_id

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -1,0 +1,270 @@
+"""CD #453 RED — ``findings`` / ``explain`` / ``replay`` by stored review id (D4).
+
+After a completed review, follow-up commands resolve from persisted artifacts
+without re-running the review agent. No ``mergecraft session *`` namespace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.review.support_durable_review import (
+    sample_fingerprint,
+    sample_review_id,
+    sample_short_finding_id,
+    seed_completed_review,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
+from mergecraft.offline_review import OfflineReviewResult
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+_SAMPLE_PATCH = (
+    "diff --git a/demo.py b/demo.py\n--- a/demo.py\n+++ b/demo.py\n@@ -0,0 +1 @@\n+print(1)\n"
+)
+
+pytestmark = pytest.mark.xfail(reason="green after CD", strict=False)
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _install_fake_review(monkeypatch: MonkeyPatch) -> None:
+    async def fake_run_offline_diff_review(**kwargs: object) -> OfflineReviewResult:
+        materialization_path = kwargs.get("diff_file")
+        diff_path = str(materialization_path) if materialization_path else None
+        payload = json.dumps(
+            {
+                "findings": [
+                    {
+                        "tool": "ruff",
+                        "rule_id": "F401",
+                        "category": "Maintainability & Code Quality",
+                        "severity": "Minor",
+                        "confidence": "likely",
+                        "message": "unused import os",
+                        "path": "demo.py",
+                        "start_line": 1,
+                        "end_line": 1,
+                        "source": "analyzer",
+                        "introduced_by_pr": "unknown",
+                        "fingerprint": sample_fingerprint(),
+                    }
+                ]
+            }
+        )
+        json_path = kwargs.get("json_path")
+        if json_path is not None:
+            await asyncio.to_thread(
+                Path(str(json_path)).write_text,
+                payload,
+                encoding="utf-8",
+            )
+        return OfflineReviewResult(
+            success=True,
+            output="# Review\n\nCompleted.",
+            structured_output=payload,
+            diff_path=diff_path,
+        )
+
+    monkeypatch.setattr(
+        "mergecraft.cli.diff_review_cmd.run_offline_diff_review",
+        fake_run_offline_diff_review,
+    )
+
+
+def _guard_against_review_rerun(monkeypatch: MonkeyPatch) -> None:
+    async def boom(**_kwargs: object) -> OfflineReviewResult:
+        msg = "review agent must not rerun for durable lookup"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "mergecraft.cli.diff_review_cmd.run_offline_diff_review",
+        boom,
+    )
+
+
+def test_review_persists_completed_review_id_on_success(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — a successful ``mergecraft review`` leaves a durable review id behind."""
+    review_id = sample_review_id()
+    monkeypatch.setenv("MERGECRAFT_REVIEW_ID", review_id)
+    _install_fake_review(monkeypatch)
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+        ],
+        env={**_DUMB_ENV, "MERGECRAFT_REVIEW_ID": review_id},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    payload = json.loads(result.stdout)
+    assert payload.get("review_id") == review_id
+    from tests.review.support_durable_review import require_callable
+
+    loaded = require_callable("load_completed_review")(review_id, repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded.review_id == review_id
+
+
+def test_findings_by_review_id_returns_stored_findings_without_rerun(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — ``mergecraft findings <review-id>`` reads persisted findings only."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["--format", "json", "findings", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    payload = json.loads(result.stdout)
+    assert payload.get("review_id") == review_id
+    findings = payload.get("findings")
+    assert isinstance(findings, list)
+    assert findings
+    assert findings[0]["fingerprint"] == sample_fingerprint()
+
+
+def test_explain_with_review_id_and_short_finding_id_resolves_packet(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — ``mergecraft explain <review-id> MC-…`` resolves in review context."""
+    review_id = sample_review_id()
+    short_id = sample_short_finding_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["explain", review_id, short_id, "--repo-root", str(tmp_path), "--format", "json"],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    payload = json.loads(result.stdout)
+    assert payload.get("review_id") == review_id
+    assert payload.get("finding_id") == short_id
+    packet = payload.get("packet")
+    assert isinstance(packet, dict)
+    assert packet.get("finding_id") == sample_fingerprint()
+
+
+def test_explain_short_id_with_review_context_flag_resolves_packet(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — ``mergecraft explain MC-… --review-id`` resolves without rerun."""
+    review_id = sample_review_id()
+    short_id = sample_short_finding_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "explain",
+            short_id,
+            "--review-id",
+            review_id,
+            "--repo-root",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    payload = json.loads(result.stdout)
+    assert payload.get("review_id") == review_id
+    assert payload.get("finding_id") == short_id
+
+
+def test_replay_by_review_id_uses_stored_artifacts_without_rerun(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — ``mergecraft replay <review-id>`` replays stored trace rows."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["--format", "json", "replay", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    payload = json.loads(result.stdout)
+    assert payload.get("run_id") == review_id
+    assert payload.get("replayed") is True
+    assert payload.get("event_count", 0) >= 1
+
+
+def test_unknown_review_id_is_fail_closed_for_findings(tmp_path: Path) -> None:
+    """Error — unknown review ids exit non-zero with a readable message."""
+    result = runner.invoke(
+        app,
+        ["findings", "review-missing-453", "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "unknown review" in combined.casefold()
+
+
+def test_findings_lookup_does_not_invoke_review_agent(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Functional — durable lookup never schedules ``run_offline_diff_review``."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    calls: list[dict[str, Any]] = []
+
+    async def recorder(**kwargs: object) -> OfflineReviewResult:
+        calls.append(dict(kwargs))
+        msg = "review agent must not rerun for durable lookup"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "mergecraft.cli.diff_review_cmd.run_offline_diff_review",
+        recorder,
+    )
+    result = runner.invoke(
+        app,
+        ["--format", "json", "findings", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    assert calls == []

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -415,6 +415,54 @@ def test_findings_subcommand_typo_surfaces_typer_error_not_unknown_review_id(
     assert "unknown review" not in combined.casefold()
 
 
+def test_review_persists_trace_from_custom_trace_dir_for_replay(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Regression — ``--trace-dir`` traces are persisted for ``replay <review-id>``."""
+    review_id = sample_review_id()
+    custom_trace_dir = tmp_path / "custom-traces"
+    custom_trace_dir.mkdir(parents=True)
+    trace_events = sample_trace_events(review_id=review_id)
+    (custom_trace_dir / "2026-08-24.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in trace_events) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MERGECRAFT_REVIEW_ID", review_id)
+    _install_fake_review(monkeypatch)
+    patch = tmp_path / "change.diff"
+    patch.write_text(_SAMPLE_PATCH, encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "review",
+            "--diff",
+            str(patch),
+            "--cwd",
+            str(tmp_path),
+            "--trace-dir",
+            str(custom_trace_dir),
+        ],
+        env={**_DUMB_ENV, "MERGECRAFT_REVIEW_ID": review_id},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    _guard_against_review_rerun(monkeypatch)
+    replay = runner.invoke(
+        app,
+        ["--format", "json", "replay", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    replay_combined = _plain(replay.stdout + replay.stderr)
+    assert replay.exit_code == CLI_SUCCESS_EXIT_CODE, replay_combined
+    payload = json.loads(replay.stdout)
+    assert payload.get("run_id") == review_id
+    assert payload.get("replayed") is True
+    assert payload.get("event_count", 0) >= 1
+
+
 def test_review_with_unsafe_review_id_still_succeeds_and_persists_safely(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -311,6 +311,60 @@ def test_replay_unknown_review_id_fails_closed_without_global_fallback(
     assert trace_calls == []
 
 
+def test_explain_single_arg_hex_review_id_steers_to_two_arg_form(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Error — a stored uuid hex review id alone steers to two-arg explain, not unknown finding."""
+    review_id = "b1c2d3e4f5a6789012345678abcdef90"
+    seed_completed_review(tmp_path, review_id=review_id)
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["explain", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "stored review id" in combined.casefold()
+    assert "explain <review-id> <finding-id>" in combined
+    assert "unknown finding id" not in combined.casefold()
+
+
+def test_replay_review_without_trace_distinguishes_from_unknown_review_id(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Error — replay names a stored review missing trace.jsonl with a distinct message."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id, trace_events=[])
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["replay", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "no stored trace.jsonl" in combined.casefold()
+    assert "unknown review run" not in combined.casefold()
+
+
+def test_findings_subcommand_typo_surfaces_typer_error_not_unknown_review_id(
+    tmp_path: Path,
+) -> None:
+    """Error — subcommand typos like ``expor`` fail as Typer usage, not durable lookup."""
+    result = runner.invoke(
+        app,
+        ["findings", "expor", "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_USAGE_EXIT_CODE, combined
+    assert "no such command" in combined.casefold()
+    assert "unknown review" not in combined.casefold()
+
+
 def test_review_with_unsafe_review_id_still_succeeds_and_persists_safely(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -13,9 +13,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from tests.review.support_durable_review import (
+    require_callable,
     sample_fingerprint,
+    sample_manifest,
     sample_review_id,
     sample_short_finding_id,
+    sample_snapshot,
+    sample_trace_events,
     seed_completed_review,
 )
 from typer.testing import CliRunner
@@ -127,6 +131,52 @@ def test_review_persists_completed_review_id_on_success(
     loaded = require_callable("load_completed_review")(review_id, repo_root=tmp_path)
     assert loaded is not None
     assert loaded.review_id == review_id
+
+
+def test_findings_by_review_id_markdown_includes_short_id_and_severity(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — stored rows with export-only short ids still render full markdown."""
+    from mergecraft.cli.review_output import finding_json_records
+
+    review_id = sample_review_id()
+    finding_mod = __import__("mergecraft.analyzers.finding", fromlist=["make_finding"])
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import os",
+        path="demo.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        introduced_by_pr="unknown",
+        fingerprint=sample_fingerprint(),
+    )
+    completed_cls = require_callable("CompletedReview")
+    persist = require_callable("persist_completed_review")
+    review = completed_cls(
+        review_id=review_id,
+        snapshot=sample_snapshot(),
+        manifest=sample_manifest(),
+        findings=finding_json_records([finding]),
+        trace_session_id=review_id,
+    )
+    persist(review, repo_root=tmp_path, trace_events=sample_trace_events(review_id=review_id))
+    _guard_against_review_rerun(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["findings", review_id, "--repo-root", str(tmp_path)],
+        env=_DUMB_ENV,
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, combined
+    assert sample_short_finding_id() in combined
+    assert "Minor" in combined
+    assert "F401" in combined
 
 
 def test_findings_by_review_id_returns_stored_findings_without_rerun(

--- a/tests/cli/test_durable_review_by_id_cmd.py
+++ b/tests/cli/test_durable_review_by_id_cmd.py
@@ -12,7 +12,6 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import pytest
 from tests.review.support_durable_review import (
     sample_fingerprint,
     sample_review_id,
@@ -35,8 +34,6 @@ _DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
 _SAMPLE_PATCH = (
     "diff --git a/demo.py b/demo.py\n--- a/demo.py\n+++ b/demo.py\n@@ -0,0 +1 @@\n+print(1)\n"
 )
-
-pytestmark = pytest.mark.xfail(reason="green after CD", strict=False)
 
 
 def _plain(text: str) -> str:

--- a/tests/cli/test_explain_short_id_cmd.py
+++ b/tests/cli/test_explain_short_id_cmd.py
@@ -1,0 +1,59 @@
+"""CA #452 RED — ``mergecraft explain MC-…`` resolves stored findings (D2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from tests.analyzers.support_short_id import require_callable
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+runner = CliRunner()
+
+
+def _write_evidence_packet(repo_root: Path, *, fingerprint: str) -> None:
+    evidence_dir = repo_root / ".mergecraft" / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    packet = {
+        "finding_id": fingerprint,
+        "state": "unverified",
+        "kinds": ["changed_lines"],
+    }
+    (evidence_dir / f"{fingerprint}.json").write_text(
+        json.dumps(packet),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_explain_accepts_short_finding_id(tmp_path: Path) -> None:
+    """Happy — ``mergecraft explain MC-…`` loads the stored evidence packet."""
+    finding_short_id = require_callable("finding_short_id")
+    fingerprint = "a83f91c2d4e5f6a7b8c9d0e1"
+    short_id = finding_short_id(fingerprint)
+    _write_evidence_packet(tmp_path, fingerprint=fingerprint)
+
+    result = runner.invoke(
+        app,
+        ["explain", short_id, "--repo-root", str(tmp_path), "--format", "json"],
+    )
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.output
+    payload = json.loads(result.stdout)
+    assert payload["finding_id"] == short_id
+    assert payload["packet"]["finding_id"] == fingerprint
+
+
+def test_explain_unknown_short_id_is_an_error(tmp_path: Path) -> None:
+    """Error — unknown ``MC-…`` ids exit non-zero with a readable message (fail-closed today)."""
+    result = runner.invoke(
+        app,
+        ["explain", "MC-deadbeef", "--repo-root", str(tmp_path)],
+    )
+    combined = result.stdout + result.stderr
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE
+    assert "unknown finding id" in combined.casefold()

--- a/tests/cli/test_explain_short_id_cmd.py
+++ b/tests/cli/test_explain_short_id_cmd.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from tests.analyzers.support_short_id import require_callable
 from typer.testing import CliRunner
 
@@ -29,7 +28,6 @@ def _write_evidence_packet(repo_root: Path, *, fingerprint: str) -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_explain_accepts_short_finding_id(tmp_path: Path) -> None:
     """Happy — ``mergecraft explain MC-…`` loads the stored evidence packet."""
     finding_short_id = require_callable("finding_short_id")

--- a/tests/cli/test_finding_stream_boundary.py
+++ b/tests/cli/test_finding_stream_boundary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from io import StringIO
 from types import SimpleNamespace
 from typing import Any
@@ -39,8 +40,8 @@ def test_diff_review_cmd_uses_notify_findings_once_policy() -> None:
     assert len(emitted) == 1
 
 
-def test_finish_agent_protocol_does_not_redeliver_already_seen_finding() -> None:
-    """Edge: finish-path notify shares ``seen`` so a live finding is not emitted twice."""
+def test_finish_agent_protocol_re_emits_batch_short_ids_for_seen_findings() -> None:
+    """Edge: finish-path notify refreshes streamed rows with batch-resolved short ids."""
     buf = StringIO()
     stream = AgentProtocolStream(stream=buf)
     finding = make_finding(
@@ -69,7 +70,10 @@ def test_finish_agent_protocol_does_not_redeliver_already_seen_finding() -> None
     finding_events = [
         line for line in events if '"event": "finding"' in line or '"event":"finding"' in line
     ]
-    assert len(finding_events) == 1
+    assert len(finding_events) == 2
+    final = json.loads(finding_events[-1])["finding"]
+    assert isinstance(final.get("short_id"), str)
+    assert final["short_id"].startswith("MC-")
 
 
 def test_mcp_set_output_notifies_on_finding_per_row_without_cli_import() -> None:

--- a/tests/cli/test_finding_stream_boundary.py
+++ b/tests/cli/test_finding_stream_boundary.py
@@ -10,7 +10,7 @@ from typing import Any
 import mergecraft.offline_review as offline_mod
 from mergecraft.analyzers.finding import make_finding
 from mergecraft.cli.agent_protocol import AgentProtocolStream, notify_findings
-from mergecraft.cli.diff_review_cmd import _finish_agent_protocol
+from mergecraft.cli.diff_review_cmd import _agent_finding_record, _finish_agent_protocol
 from mergecraft.mcp.output import _notify_set_output_findings
 from mergecraft.run_outcome import RunOutcome
 
@@ -40,8 +40,8 @@ def test_diff_review_cmd_uses_notify_findings_once_policy() -> None:
     assert len(emitted) == 1
 
 
-def test_finish_agent_protocol_re_emits_batch_short_ids_for_seen_findings() -> None:
-    """Edge: finish-path notify refreshes streamed rows with batch-resolved short ids."""
+def test_finish_agent_protocol_re_emits_only_when_batch_short_id_changes() -> None:
+    """Edge: finish-path refresh upgrades short ids without duplicating unchanged rows."""
     buf = StringIO()
     stream = AgentProtocolStream(stream=buf)
     finding = make_finding(
@@ -58,22 +58,90 @@ def test_finish_agent_protocol_re_emits_batch_short_ids_for_seen_findings() -> N
     )
     row = finding.model_dump()
     seen: set[str] = set()
-    notify_findings(stream.finding, [row], seen=seen)
+    streamed_short_ids: dict[str, str] = {}
+    notify_findings(
+        stream.finding,
+        [_agent_finding_record(row)],
+        seen=seen,
+        streamed_short_ids=streamed_short_ids,
+    )
     _finish_agent_protocol(
         stream,
         outcome=RunOutcome.passed,
         exit_code=0,
         findings=[finding],
         seen=seen,
+        streamed_short_ids=streamed_short_ids,
     )
     events = [line for line in buf.getvalue().splitlines() if line.strip()]
     finding_events = [
         line for line in events if '"event": "finding"' in line or '"event":"finding"' in line
     ]
-    assert len(finding_events) == 2
+    assert len(finding_events) == 1
+    payload = json.loads(finding_events[0])["finding"]
+    assert isinstance(payload.get("short_id"), str)
+    assert payload["short_id"].startswith("MC-")
+
+
+def test_finish_agent_protocol_refreshes_colliding_short_ids() -> None:
+    """Edge: batch collision resolution re-emits only rows whose short id changed."""
+    buf = StringIO()
+    stream = AgentProtocolStream(stream=buf)
+    fp1 = "a83f91c2d4e5f6a7b8c9d0e1f2a3b4c5"
+    fp2 = "a83f91d3e4f5a6b7c8d9e0f1a2b3c4d6"
+    findings = [
+        make_finding(
+            tool="mergecraft-agent",
+            rule_id="COLLIDE-1",
+            category="Maintainability & Code Quality",
+            severity="Minor",
+            confidence="likely",
+            message="first",
+            path="a.py",
+            start_line=1,
+            end_line=1,
+            source="agent",
+            fingerprint=fp1,
+        ),
+        make_finding(
+            tool="mergecraft-agent",
+            rule_id="COLLIDE-2",
+            category="Maintainability & Code Quality",
+            severity="Minor",
+            confidence="likely",
+            message="second",
+            path="b.py",
+            start_line=1,
+            end_line=1,
+            source="agent",
+            fingerprint=fp2,
+        ),
+    ]
+    seen: set[str] = set()
+    streamed_short_ids: dict[str, str] = {}
+    for finding in findings:
+        notify_findings(
+            stream.finding,
+            [_agent_finding_record(finding.model_dump())],
+            seen=seen,
+            streamed_short_ids=streamed_short_ids,
+        )
+    _finish_agent_protocol(
+        stream,
+        outcome=RunOutcome.passed,
+        exit_code=0,
+        findings=findings,
+        seen=seen,
+        streamed_short_ids=streamed_short_ids,
+    )
+    events = [line for line in buf.getvalue().splitlines() if line.strip()]
+    finding_events = [
+        line for line in events if '"event": "finding"' in line or '"event":"finding"' in line
+    ]
+    assert len(finding_events) == 3
     final = json.loads(finding_events[-1])["finding"]
-    assert isinstance(final.get("short_id"), str)
-    assert final["short_id"].startswith("MC-")
+    assert final["fingerprint"] == fp2
+    assert final["short_id"] == "MC-a83f91d"
 
 
 def test_mcp_set_output_notifies_on_finding_per_row_without_cli_import() -> None:

--- a/tests/cli/test_init_audit_jsonl_gitignore.py
+++ b/tests/cli/test_init_audit_jsonl_gitignore.py
@@ -11,7 +11,6 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
 from tests.cli.support_init_audit_jsonl import (
     AUDIT_JSONL_GITIGNORE_LINE,
     audit_jsonl_path,
@@ -54,7 +53,6 @@ def _init_git_repo(tmp_path: Path) -> None:
     )
 
 
-@pytest.mark.xfail(reason="green after CI", strict=False)
 def test_init_scaffolds_explicit_audit_jsonl_gitignore_line(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -70,7 +68,6 @@ def test_init_scaffolds_explicit_audit_jsonl_gitignore_line(
     )
 
 
-@pytest.mark.xfail(reason="green after CI", strict=False)
 def test_init_appends_audit_jsonl_when_gitignore_preexists(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -85,7 +82,6 @@ def test_init_appends_audit_jsonl_when_gitignore_preexists(
     assert AUDIT_JSONL_GITIGNORE_LINE in text
 
 
-@pytest.mark.xfail(reason="green after CI", strict=False)
 def test_audit_jsonl_is_gitignored_after_init(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Functional — ``git check-ignore`` accepts audit.jsonl after init."""
     _init_git_repo(tmp_path)
@@ -100,7 +96,6 @@ def test_audit_jsonl_is_gitignored_after_init(tmp_path: Path, monkeypatch: Monke
     )
 
 
-@pytest.mark.xfail(reason="green after CI", strict=False)
 def test_audit_jsonl_not_listed_as_untracked_after_init(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -118,7 +113,6 @@ def test_audit_jsonl_not_listed_as_untracked_after_init(
     )
 
 
-@pytest.mark.xfail(reason="green after CI", strict=False)
 def test_init_does_not_duplicate_audit_jsonl_gitignore_line(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:

--- a/tests/cli/test_init_audit_jsonl_gitignore.py
+++ b/tests/cli/test_init_audit_jsonl_gitignore.py
@@ -1,0 +1,140 @@
+"""CI #487 RED — ``mergecraft init`` must ignore ``.mergecraft/audit.jsonl`` (D10).
+
+Issue #487: without an explicit gitignore entry, enterprise audit JSONL shows up
+as untracked after review runs. D10 pins the line in the init scaffold — never
+rely on consumers inventing ``/.mergecraft/*`` negation rules.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.cli.support_init_audit_jsonl import (
+    AUDIT_JSONL_GITIGNORE_LINE,
+    audit_jsonl_path,
+    audit_jsonl_rel_path,
+    git_check_ignores,
+    git_status_porcelain,
+    gitignore_path,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+
+def _init_git_repo(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "init@test.local"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Init Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "README.md").write_text("init scaffold\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.xfail(reason="green after CI", strict=False)
+def test_init_scaffolds_explicit_audit_jsonl_gitignore_line(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Happy — init writes the explicit ``.mergecraft/audit.jsonl`` ignore line."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    assert gitignore_path(tmp_path).is_file(), "init must scaffold or update .gitignore"
+    text = gitignore_path(tmp_path).read_text(encoding="utf-8")
+    assert AUDIT_JSONL_GITIGNORE_LINE in text, (
+        f".gitignore must include explicit ignore for {AUDIT_JSONL_GITIGNORE_LINE!r} (D10)"
+    )
+
+
+@pytest.mark.xfail(reason="green after CI", strict=False)
+def test_init_appends_audit_jsonl_when_gitignore_preexists(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Edge — init appends the audit line when .gitignore exists without it."""
+    _init_git_repo(tmp_path)
+    gitignore_path(tmp_path).write_text("node_modules/\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    text = gitignore_path(tmp_path).read_text(encoding="utf-8")
+    assert "node_modules/" in text
+    assert AUDIT_JSONL_GITIGNORE_LINE in text
+
+
+@pytest.mark.xfail(reason="green after CI", strict=False)
+def test_audit_jsonl_is_gitignored_after_init(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Functional — ``git check-ignore`` accepts audit.jsonl after init."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    rel = audit_jsonl_rel_path()
+    audit_jsonl_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    audit_jsonl_path(tmp_path).write_text('{"event_type":"test"}\n', encoding="utf-8")
+    assert git_check_ignores(tmp_path, rel), (
+        f"{rel} must be ignored after init scaffold (D10 / #487)"
+    )
+
+
+@pytest.mark.xfail(reason="green after CI", strict=False)
+def test_audit_jsonl_not_listed_as_untracked_after_init(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Functional — audit.jsonl does not appear in ``git status`` as untracked."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    rel = audit_jsonl_rel_path()
+    audit_jsonl_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    audit_jsonl_path(tmp_path).write_text('{"event_type":"test"}\n', encoding="utf-8")
+    status = git_status_porcelain(tmp_path, rel)
+    assert status == "", (
+        f"{rel} must not show as untracked after init; got git status line {status!r}"
+    )
+
+
+@pytest.mark.xfail(reason="green after CI", strict=False)
+def test_init_does_not_duplicate_audit_jsonl_gitignore_line(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Edge — re-init with --force does not duplicate the audit.jsonl ignore line."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    first = runner.invoke(app, ["init", "--force"])
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(app, ["init", "--force"])
+    assert second.exit_code == 0, second.output
+    text = gitignore_path(tmp_path).read_text(encoding="utf-8")
+    assert text.count(AUDIT_JSONL_GITIGNORE_LINE) == 1, (
+        "init must not duplicate the audit.jsonl gitignore entry on re-run"
+    )
+
+
+def test_support_pins_audit_jsonl_gitignore_line() -> None:
+    """Contract pin — gitignore line matches enterprise audit default path."""
+    assert AUDIT_JSONL_GITIGNORE_LINE == ".mergecraft/audit.jsonl"

--- a/tests/cli/test_init_reviews_gitignore.py
+++ b/tests/cli/test_init_reviews_gitignore.py
@@ -1,0 +1,83 @@
+"""Init scaffold must ignore durable local review artifacts under ``.mergecraft/reviews/``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.cli.support_init_audit_jsonl import (
+    git_check_ignores,
+    git_status_porcelain,
+    gitignore_path,
+)
+from tests.cli.test_init_audit_jsonl_gitignore import _init_git_repo
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.review.completed import COMPLETED_REVIEWS_GITIGNORE_LINE
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+
+
+def reviews_rel_path() -> str:
+    return f"{COMPLETED_REVIEWS_GITIGNORE_LINE.rstrip('/')}/review-fixture/completed.json"
+
+
+def reviews_path(repo_root: Path) -> Path:
+    return repo_root / reviews_rel_path()
+
+
+def test_init_scaffolds_reviews_gitignore_line(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Happy — init writes the explicit ``.mergecraft/reviews/`` ignore line."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    text = gitignore_path(tmp_path).read_text(encoding="utf-8")
+    assert COMPLETED_REVIEWS_GITIGNORE_LINE in text
+
+
+def test_reviews_dir_is_gitignored_after_init(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Functional — ``git check-ignore`` accepts review artifacts after init."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    rel = reviews_rel_path()
+    reviews_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    reviews_path(tmp_path).write_text('{"schema_version":"1.0.0"}\n', encoding="utf-8")
+    assert git_check_ignores(tmp_path, rel)
+
+
+def test_reviews_dir_not_listed_as_untracked_after_init(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Functional — review artifacts do not appear in ``git status`` as untracked."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.output
+    rel = reviews_rel_path()
+    reviews_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    reviews_path(tmp_path).write_text('{"schema_version":"1.0.0"}\n', encoding="utf-8")
+    status = git_status_porcelain(tmp_path, rel)
+    assert status == ""
+
+
+def test_init_does_not_duplicate_reviews_gitignore_line(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Edge — re-init with --force does not duplicate the reviews ignore line."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    first = runner.invoke(app, ["init", "--force"])
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(app, ["init", "--force"])
+    assert second.exit_code == 0, second.output
+    text = gitignore_path(tmp_path).read_text(encoding="utf-8")
+    assert text.count(COMPLETED_REVIEWS_GITIGNORE_LINE) == 1

--- a/tests/cli/test_output_formats.py
+++ b/tests/cli/test_output_formats.py
@@ -125,6 +125,26 @@ def test_json_format_writes_output_path(tmp_path: Path, monkeypatch: pytest.Monk
     assert json_out.is_file(), combined
     payload = json.loads(json_out.read_text(encoding="utf-8"))
     assert payload["findings"][0]["rule_id"] == finding["rule_id"]
+    assert isinstance(payload["findings"][0].get("short_id"), str)
+    assert payload["findings"][0]["short_id"].startswith("MC-")
+
+
+def test_json_flag_writes_short_ids_to_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--json PATH`` writes batch-resolved short ids into the findings file."""
+    finding = _agent_finding_dict()
+    _install_fake_review(monkeypatch, findings=[finding])
+    json_out = tmp_path / "findings.json"
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--json", str(json_out)),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["findings"][0]["short_id"].startswith("MC-")
 
 
 def test_json_format_matches_existing_findings_schema(

--- a/tests/cli/test_output_formats.py
+++ b/tests/cli/test_output_formats.py
@@ -147,6 +147,32 @@ def test_json_flag_writes_short_ids_to_file(
     assert payload["findings"][0]["short_id"].startswith("MC-")
 
 
+def test_json_flag_writes_findings_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--json PATH`` with default text output writes the findings file exactly once."""
+    import mergecraft.cli.review_output as review_output_mod
+    from mergecraft.analyzers import finding as finding_mod
+
+    finding = _agent_finding_dict()
+    _install_fake_review(monkeypatch, findings=[finding])
+    writes: list[Path] = []
+    original = finding_mod.write_findings_json
+
+    def _recording_write(path: Path, rows: list[dict[str, object]]) -> None:
+        writes.append(path)
+        original(path, rows)
+
+    monkeypatch.setattr(review_output_mod, "write_findings_json", _recording_write)
+    json_out = tmp_path / "findings.json"
+    result = runner.invoke(
+        app,
+        _review_argv(tmp_path, "--json", str(json_out)),
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    combined = _plain(result.stdout + result.stderr)
+    assert result.exit_code == 10, combined
+    assert writes == [json_out]
+
+
 def test_json_format_matches_existing_findings_schema(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_update_version_cmd.py
+++ b/tests/cli/test_update_version_cmd.py
@@ -46,7 +46,6 @@ def _set_build_commit(monkeypatch: MonkeyPatch, commit: str | None) -> None:
     monkeypatch.setattr("mergecraft.__commit__", commit, raising=False)
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_update_help_documents_uv_reinstall() -> None:
     """Happy — ``update --help`` documents the self-update command."""
     result = runner.invoke(app, ["update", "--help"], env=_DUMB_ENV)
@@ -58,7 +57,6 @@ def test_update_help_documents_uv_reinstall() -> None:
     assert "reinstall" in lowered or "install" in lowered
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_update_default_shells_to_uv_tool_install_on_main(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -91,7 +89,6 @@ def test_update_default_shells_to_uv_tool_install_on_main(
         "e0a48d9f",
     ],
 )
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_update_branch_option_accepts_branch_tag_or_sha(
     monkeypatch: MonkeyPatch,
     ref: str,
@@ -111,7 +108,6 @@ def test_update_branch_option_accepts_branch_tag_or_sha(
     assert uv_install_spec(ref) in cmd
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_format_version_display_includes_short_commit_when_known() -> None:
     """Unit — version helper renders ``<version> (<short-sha>)`` when commit known."""
     format_display = require_version_callable("format_version_display")
@@ -119,7 +115,6 @@ def test_format_version_display_includes_short_commit_when_known() -> None:
     assert rendered == f"{__version__} ({_SHORT_COMMIT})"
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_format_version_display_omits_paren_commit_when_unknown() -> None:
     """Unit — version helper omits parentheses when build commit is unknown."""
     format_display = require_version_callable("format_version_display")
@@ -128,7 +123,6 @@ def test_format_version_display_omits_paren_commit_when_unknown() -> None:
     assert "(" not in rendered
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_version_flag_includes_commit_when_known(monkeypatch: MonkeyPatch) -> None:
     """Happy — ``mergecraft --version`` includes short commit when available."""
     _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
@@ -138,7 +132,6 @@ def test_version_flag_includes_commit_when_known(monkeypatch: MonkeyPatch) -> No
     assert output == f"{__version__} ({_SHORT_COMMIT})"
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_version_command_includes_commit_when_known(monkeypatch: MonkeyPatch) -> None:
     """Happy — ``mergecraft version`` includes short commit when available."""
     _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
@@ -158,7 +151,6 @@ def test_version_flag_omits_paren_commit_when_unknown(monkeypatch: MonkeyPatch) 
     assert "(" not in output
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_version_json_includes_additive_commit_field(monkeypatch: MonkeyPatch) -> None:
     """Functional — ``version --format json`` adds ``commit`` without breaking ``version``."""
     _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
@@ -174,7 +166,6 @@ def test_version_json_includes_additive_commit_field(monkeypatch: MonkeyPatch) -
     assert "schema_version" in payload
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_version_json_commit_null_when_unknown(monkeypatch: MonkeyPatch) -> None:
     """Edge — JSON ``commit`` is null (additive) when build commit is unknown."""
     _set_build_commit(monkeypatch, None)
@@ -189,7 +180,6 @@ def test_version_json_commit_null_when_unknown(monkeypatch: MonkeyPatch) -> None
     assert payload["commit"] is None
 
 
-@pytest.mark.xfail(reason="green after CF", strict=False)
 def test_update_run_uses_check_true(monkeypatch: MonkeyPatch) -> None:
     """Error — ``update`` propagates ``uv`` failures (``check=True`` contract)."""
 

--- a/tests/cli/test_update_version_cmd.py
+++ b/tests/cli/test_update_version_cmd.py
@@ -212,7 +212,7 @@ def test_resolve_build_commit_reads_git_head_from_checkout() -> None:
 
 
 def test_installed_wheel_reports_build_commit(tmp_path: Path) -> None:
-    """Functional — installed artifacts resolve commit from git or MERGECRAFT_BUILD_COMMIT."""
+    """Functional — installed wheel artifacts carry a build-time stamped commit."""
     repo_root = Path(__file__).resolve().parents[2]
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root, text=True).strip()
     dist_dir = tmp_path / "dist"
@@ -225,7 +225,29 @@ def test_installed_wheel_reports_build_commit(tmp_path: Path) -> None:
     subprocess.run([str(python), "-m", "pip", "install", str(wheels[-1])], check=True)
     output = subprocess.check_output(
         [str(python), "-c", "import mergecraft; print(mergecraft.__commit__ or '')"],
-        env={"MERGECRAFT_BUILD_COMMIT": head},
+        cwd=tmp_path,
         text=True,
     ).strip()
     assert output == head
+
+
+def test_mergecraft_commit_is_lazy() -> None:
+    """Unit — ``import mergecraft`` does not resolve ``__commit__`` until accessed."""
+    script = """
+import mergecraft.build_metadata as build_metadata
+
+calls = 0
+
+def _fake_resolve() -> str | None:
+    global calls
+    calls += 1
+    return None
+
+build_metadata.resolve_build_commit = _fake_resolve
+import mergecraft
+
+assert calls == 0
+assert mergecraft.__commit__ is None
+assert calls == 1
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/tests/cli/test_update_version_cmd.py
+++ b/tests/cli/test_update_version_cmd.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -192,3 +195,37 @@ def test_update_run_uses_check_true(monkeypatch: MonkeyPatch) -> None:
     assert result.exit_code != CLI_SUCCESS_EXIT_CODE
     combined = _plain(result.stdout + result.stderr).lower()
     assert "uv" in combined or "missing" in combined or "error" in combined
+
+
+def test_resolve_build_commit_reads_git_head_from_checkout() -> None:
+    """Unit — editable/source checkouts resolve ``__commit__`` from git HEAD."""
+    from mergecraft.build_metadata import resolve_build_commit
+
+    resolve_build_commit.cache_clear()
+    commit = resolve_build_commit()
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+    ).strip()
+    assert commit == head
+
+
+def test_installed_wheel_reports_build_commit(tmp_path: Path) -> None:
+    """Functional — installed artifacts resolve commit from git or MERGECRAFT_BUILD_COMMIT."""
+    repo_root = Path(__file__).resolve().parents[2]
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root, text=True).strip()
+    dist_dir = tmp_path / "dist"
+    env_dir = tmp_path / "venv"
+    subprocess.run(["uv", "build", "--out-dir", str(dist_dir)], cwd=repo_root, check=True)
+    wheels = sorted(dist_dir.glob("merge_craft-*.whl"))
+    assert wheels, "uv build must produce a wheel"
+    subprocess.run([sys.executable, "-m", "venv", str(env_dir)], check=True)
+    python = env_dir / "bin" / "python"
+    subprocess.run([str(python), "-m", "pip", "install", str(wheels[-1])], check=True)
+    output = subprocess.check_output(
+        [str(python), "-c", "import mergecraft; print(mergecraft.__commit__ or '')"],
+        env={"MERGECRAFT_BUILD_COMMIT": head},
+        text=True,
+    ).strip()
+    assert output == head

--- a/tests/cli/test_update_version_cmd.py
+++ b/tests/cli/test_update_version_cmd.py
@@ -1,0 +1,204 @@
+"""CF #473 RED — ``mergecraft update`` and commit in ``--version`` (D7).
+
+Pins:
+- ``update`` shells to ``uv tool install --reinstall``; default ref ``main``.
+- ``--branch`` accepts branch, tag, or SHA.
+- ``--version`` / ``version`` show ``0.1.0a1 (abc1234)`` when commit known;
+  omit parentheses when unknown.
+- JSON ``commit`` field is additive on ``version --format json``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.cli.support_update_version import (
+    DEFAULT_UPDATE_REF,
+    require_version_callable,
+    update_cmd_module,
+    uv_install_spec,
+)
+from typer.testing import CliRunner
+
+from mergecraft import __version__
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_SAMPLE_COMMIT = "abc1234567890abcdef1234567890abcdef123456"
+_SHORT_COMMIT = "abc1234"
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _set_build_commit(monkeypatch: MonkeyPatch, commit: str | None) -> None:
+    """Pin the installed build commit for version display helpers."""
+    monkeypatch.setattr("mergecraft.__commit__", commit, raising=False)
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_update_help_documents_uv_reinstall() -> None:
+    """Happy — ``update --help`` documents the self-update command."""
+    result = runner.invoke(app, ["update", "--help"], env=_DUMB_ENV)
+    output = _plain(result.stdout)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "update" in lowered
+    assert "uv" in lowered
+    assert "reinstall" in lowered or "install" in lowered
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_update_default_shells_to_uv_tool_install_on_main(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Happy — default ``update`` runs ``uv tool install --reinstall`` at ``main``."""
+    recorded: list[list[str]] = []
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> Any:
+        recorded.append(list(argv))
+        return None
+
+    monkeypatch.setattr(update_cmd_module().subprocess, "run", _fake_run)
+
+    result = runner.invoke(app, ["update"], env=_DUMB_ENV)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.output
+
+    assert recorded, "update must invoke subprocess.run"
+    cmd = recorded[0]
+    assert cmd[0] == "uv"
+    assert "tool" in cmd
+    assert "install" in cmd
+    assert "--reinstall" in cmd
+    assert uv_install_spec(DEFAULT_UPDATE_REF) in cmd
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "feature/cli-update",
+        "pre-0.0.1",
+        "e0a48d9f",
+    ],
+)
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_update_branch_option_accepts_branch_tag_or_sha(
+    monkeypatch: MonkeyPatch,
+    ref: str,
+) -> None:
+    """Edge — ``--branch`` accepts branch names, tags, and short SHAs."""
+    recorded: list[list[str]] = []
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> Any:
+        recorded.append(list(argv))
+        return None
+
+    monkeypatch.setattr(update_cmd_module().subprocess, "run", _fake_run)
+
+    result = runner.invoke(app, ["update", "--branch", ref], env=_DUMB_ENV)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.output
+    cmd = recorded[0]
+    assert uv_install_spec(ref) in cmd
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_format_version_display_includes_short_commit_when_known() -> None:
+    """Unit — version helper renders ``<version> (<short-sha>)`` when commit known."""
+    format_display = require_version_callable("format_version_display")
+    rendered = format_display(__version__, _SAMPLE_COMMIT)
+    assert rendered == f"{__version__} ({_SHORT_COMMIT})"
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_format_version_display_omits_paren_commit_when_unknown() -> None:
+    """Unit — version helper omits parentheses when build commit is unknown."""
+    format_display = require_version_callable("format_version_display")
+    rendered = format_display(__version__, None)
+    assert rendered == __version__
+    assert "(" not in rendered
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_version_flag_includes_commit_when_known(monkeypatch: MonkeyPatch) -> None:
+    """Happy — ``mergecraft --version`` includes short commit when available."""
+    _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
+    result = runner.invoke(app, ["--version"], env=_DUMB_ENV)
+    output = _plain(result.stdout).strip()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert output == f"{__version__} ({_SHORT_COMMIT})"
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_version_command_includes_commit_when_known(monkeypatch: MonkeyPatch) -> None:
+    """Happy — ``mergecraft version`` includes short commit when available."""
+    _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
+    result = runner.invoke(app, ["version"], env=_DUMB_ENV)
+    output = _plain(result.stdout).strip()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert output == f"{__version__} ({_SHORT_COMMIT})"
+
+
+def test_version_flag_omits_paren_commit_when_unknown(monkeypatch: MonkeyPatch) -> None:
+    """Edge — ``--version`` omits parentheses when build commit is unknown."""
+    _set_build_commit(monkeypatch, None)
+    result = runner.invoke(app, ["--version"], env=_DUMB_ENV)
+    output = _plain(result.stdout).strip()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert output == __version__
+    assert "(" not in output
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_version_json_includes_additive_commit_field(monkeypatch: MonkeyPatch) -> None:
+    """Functional — ``version --format json`` adds ``commit`` without breaking ``version``."""
+    _set_build_commit(monkeypatch, _SAMPLE_COMMIT)
+    result = runner.invoke(
+        app,
+        ["version", "--format", "json"],
+        env=_DUMB_ENV,
+    )
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.output
+    payload = json.loads(result.stdout)
+    assert payload["version"] == __version__
+    assert payload["commit"] == _SHORT_COMMIT
+    assert "schema_version" in payload
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_version_json_commit_null_when_unknown(monkeypatch: MonkeyPatch) -> None:
+    """Edge — JSON ``commit`` is null (additive) when build commit is unknown."""
+    _set_build_commit(monkeypatch, None)
+    result = runner.invoke(
+        app,
+        ["version", "--format", "json"],
+        env=_DUMB_ENV,
+    )
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.output
+    payload = json.loads(result.stdout)
+    assert payload["version"] == __version__
+    assert payload["commit"] is None
+
+
+@pytest.mark.xfail(reason="green after CF", strict=False)
+def test_update_run_uses_check_true(monkeypatch: MonkeyPatch) -> None:
+    """Error — ``update`` propagates ``uv`` failures (``check=True`` contract)."""
+
+    def _boom(argv: list[str], **kwargs: Any) -> None:
+        raise OSError("uv missing")
+
+    monkeypatch.setattr(update_cmd_module().subprocess, "run", _boom)
+
+    result = runner.invoke(app, ["update"], env=_DUMB_ENV)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE
+    combined = _plain(result.stdout + result.stderr).lower()
+    assert "uv" in combined or "missing" in combined or "error" in combined

--- a/tests/evals/support_lens_capability.py
+++ b/tests/evals/support_lens_capability.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for CE #455 per-lens routing capability RED tests (D6)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.analyzers.support import import_module
+
+_LENS_CAPABILITY_MOD = "mergecraft.evals.lens_capability"
+
+
+def lens_capability_module() -> Any:
+    """Return the ``mergecraft.evals.lens_capability`` module."""
+    return import_module(_LENS_CAPABILITY_MOD)
+
+
+def require_attr(name: str) -> Any:
+    """Return a symbol from ``mergecraft.evals.lens_capability`` or fail the RED test."""
+    mod = lens_capability_module()
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_LENS_CAPABILITY_MOD}.{name} is not implemented"
+    return value
+
+
+def require_callable(name: str) -> Any:
+    """Return a callable from ``mergecraft.evals.lens_capability`` or fail the RED test."""
+    value = require_attr(name)
+    assert callable(value), f"{_LENS_CAPABILITY_MOD}.{name} must be callable"
+    return value
+
+
+def routing_label(case_id: str, *expected_lens_ids: str) -> Any:
+    """Build one labeled routing case (ground-truth lenses that should fire)."""
+    label_cls = require_attr("LensRoutingCaseLabel")
+    return label_cls(case_id=case_id, expected_lens_ids=tuple(expected_lens_ids))
+
+
+def routing_outcome(case_id: str, *selected_lens_ids: str) -> Any:
+    """Build one observed routing outcome (lenses the router actually selected)."""
+    outcome_cls = require_attr("LensRoutingCaseOutcome")
+    return outcome_cls(case_id=case_id, selected_lens_ids=tuple(selected_lens_ids))
+
+
+__all__ = [
+    "lens_capability_module",
+    "require_attr",
+    "require_callable",
+    "routing_label",
+    "routing_outcome",
+]

--- a/tests/evals/test_lens_capability_json.py
+++ b/tests/evals/test_lens_capability_json.py
@@ -1,0 +1,72 @@
+"""CE #455 RED — stable JSON emission for per-lens capability numbers (D6).
+
+Output must be diffable across commits: sorted keys, fixed float formatting,
+and a content digest that ignores key order in the Python object graph.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from tests.evals.support_lens_capability import (
+    require_callable,
+    routing_label,
+    routing_outcome,
+)
+
+pytestmark = pytest.mark.xfail(reason="green after CE", strict=False)
+
+_GOLDEN_JSON = (
+    '{"by_lens":{"security":{"false_negatives":0,"false_positives":0,'
+    '"lens_id":"security","precision":1.0,"recall":1.0,"true_positives":1}},'
+    '"cases":1,"macro_f1":1.0,"macro_precision":1.0,"macro_recall":1.0,'
+    '"schema_version":"1.0.0"}'
+)
+
+
+def _sample_report() -> object:
+    score = require_callable("score_lens_routing")
+    return score(
+        [routing_label("case-a", "security")],
+        [routing_outcome("case-a", "security")],
+    )
+
+
+def test_render_lens_capability_json_is_canonical_and_sorted() -> None:
+    """Happy — JSON uses sorted keys and compact separators for stable diffs."""
+    render = require_callable("render_lens_capability_json")
+    payload = render(_sample_report())
+    assert payload == _GOLDEN_JSON
+    parsed = json.loads(payload)
+    assert list(parsed.keys()) == sorted(parsed.keys())
+    assert list(parsed["by_lens"].keys()) == ["security"]
+
+
+def test_lens_capability_digest_is_stable_for_identical_reports() -> None:
+    """Happy — identical routing scores produce identical digests."""
+    digest = require_callable("lens_capability_digest")
+    report = _sample_report()
+    first = digest(report)
+    second = digest(report)
+    assert first == second
+    assert len(first) == 64
+
+
+def test_lens_capability_digest_ignores_dict_insertion_order() -> None:
+    """Edge — digest is over canonical JSON, not Python dict iteration order."""
+    digest = require_callable("lens_capability_digest")
+    render = require_callable("render_lens_capability_json")
+    report = _sample_report()
+    from_payload = json.loads(render(report))
+    reordered = {
+        "macro_recall": from_payload["macro_recall"],
+        "schema_version": from_payload["schema_version"],
+        "by_lens": from_payload["by_lens"],
+        "cases": from_payload["cases"],
+        "macro_precision": from_payload["macro_precision"],
+        "macro_f1": from_payload["macro_f1"],
+    }
+    report_cls = type(report)
+    round_tripped = report_cls.model_validate(reordered)
+    assert digest(report) == digest(round_tripped)

--- a/tests/evals/test_lens_capability_json.py
+++ b/tests/evals/test_lens_capability_json.py
@@ -8,14 +8,11 @@ from __future__ import annotations
 
 import json
 
-import pytest
 from tests.evals.support_lens_capability import (
     require_callable,
     routing_label,
     routing_outcome,
 )
-
-pytestmark = pytest.mark.xfail(reason="green after CE", strict=False)
 
 _GOLDEN_JSON = (
     '{"by_lens":{"security":{"false_negatives":0,"false_positives":0,'

--- a/tests/evals/test_lens_routing_capability.py
+++ b/tests/evals/test_lens_routing_capability.py
@@ -1,0 +1,136 @@
+"""CE #455 RED — per-lens routing precision/recall capability numbers (D6).
+
+Pins additive eval metrics in ``mergecraft.evals.lens_capability`` so routing
+quality can be quoted from labeled diffs instead of asserted. Does not rebuild
+the eval harness — scores labeled expected-vs-selected lens sets and folds them
+into a diffable report.
+
+Implementation wave CE commits ``feat(evals): emit per-lens capability numbers``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from tests.evals.support_lens_capability import (
+    require_attr,
+    require_callable,
+    routing_label,
+    routing_outcome,
+)
+
+pytestmark = pytest.mark.xfail(reason="green after CE", strict=False)
+
+
+def test_score_lens_routing_reports_per_lens_precision_and_recall() -> None:
+    """Happy — per-lens TP/FP/FN roll up to precision and recall independently."""
+    score = require_callable("score_lens_routing")
+    report = score(
+        [
+            routing_label("auth-diff", "security", "correctness"),
+            routing_label("docs-only", "copy-vs-code"),
+        ],
+        [
+            routing_outcome("auth-diff", "security", "migration"),
+            routing_outcome("docs-only", "copy-vs-code"),
+        ],
+    )
+
+    by_lens = report.by_lens
+    assert by_lens["security"].true_positives == 1
+    assert by_lens["security"].false_positives == 0
+    assert by_lens["security"].false_negatives == 0
+    assert by_lens["security"].precision == pytest.approx(1.0)
+    assert by_lens["security"].recall == pytest.approx(1.0)
+
+    assert by_lens["migration"].true_positives == 0
+    assert by_lens["migration"].false_positives == 1
+    assert by_lens["migration"].precision == pytest.approx(0.0)
+
+    assert by_lens["correctness"].false_negatives == 1
+    assert by_lens["correctness"].recall == pytest.approx(0.0)
+
+    assert by_lens["copy-vs-code"].precision == pytest.approx(1.0)
+    assert by_lens["copy-vs-code"].recall == pytest.approx(1.0)
+
+
+def test_score_lens_routing_macro_averages_participating_lenses_only() -> None:
+    """Edge — macro precision/recall average lenses that fired or were expected."""
+    score = require_callable("score_lens_routing")
+    report = score(
+        [routing_label("case-a", "security")],
+        [routing_outcome("case-a", "security", "migration")],
+    )
+
+    # security: perfect; migration: precision 0; correctness never appeared.
+    assert report.macro_precision == pytest.approx(0.5)
+    assert report.macro_recall == pytest.approx(0.5)
+    assert report.macro_f1 == pytest.approx(0.5)
+    assert report.cases == 1
+    assert "correctness" not in report.by_lens
+
+
+def test_lens_never_selected_has_no_precision_but_can_have_recall() -> None:
+    """Edge — expected-but-never-selected lens reports recall, not a fake precision."""
+    score = require_callable("score_lens_routing")
+    report = score(
+        [routing_label("case-a", "security")],
+        [routing_outcome("case-a", "migration")],
+    )
+
+    security = report.by_lens["security"]
+    assert security.true_positives == 0
+    assert security.false_negatives == 1
+    assert security.recall == pytest.approx(0.0)
+    assert security.precision is None
+
+
+def test_lens_selected_but_never_expected_has_no_recall() -> None:
+    """Edge — spurious selection reports precision, not a fake recall."""
+    score = require_callable("score_lens_routing")
+    report = score(
+        [routing_label("case-a", "security")],
+        [routing_outcome("case-a", "security", "migration")],
+    )
+
+    migration = report.by_lens["migration"]
+    assert migration.true_positives == 0
+    assert migration.false_positives == 1
+    assert migration.precision == pytest.approx(0.0)
+    assert migration.recall is None
+
+
+def test_empty_corpus_yields_honest_zero_macro_metrics() -> None:
+    """Edge — zero labeled cases never fabricate NaN macro numbers."""
+    score = require_callable("score_lens_routing")
+    report = score([], [])
+
+    assert report.cases == 0
+    assert report.by_lens == {}
+    assert report.macro_precision == 0.0
+    assert report.macro_recall == 0.0
+    assert report.macro_f1 == 0.0
+    for value in (report.macro_precision, report.macro_recall, report.macro_f1):
+        assert not math.isnan(value)
+
+
+def test_score_lens_routing_rejects_mismatched_case_ids() -> None:
+    """Error — label/outcome case ids must align one-to-one."""
+    score = require_callable("score_lens_routing")
+    with pytest.raises(ValueError, match="case"):
+        score(
+            [routing_label("case-a", "security")],
+            [routing_outcome("case-b", "security")],
+        )
+
+
+def test_lens_routing_capability_report_pins_schema_version() -> None:
+    """Unit — report carries a stable schema version for diffable JSON."""
+    score = require_callable("score_lens_routing")
+    schema_version = require_attr("LENS_CAPABILITY_SCHEMA_VERSION")
+    report = score(
+        [routing_label("case-a", "security")],
+        [routing_outcome("case-a", "security")],
+    )
+    assert report.schema_version == schema_version

--- a/tests/evals/test_lens_routing_capability.py
+++ b/tests/evals/test_lens_routing_capability.py
@@ -135,6 +135,17 @@ def test_structural_replay_emits_lens_routing_capability() -> None:
     assert report.by_lens
 
 
+def test_routing_baseline_fixture_is_shipped_under_evals() -> None:
+    """Installed eval replay must not depend on ``tests/_fixtures``."""
+    from mergecraft.evals.lens_capability_benchmark import _resolved_recall_baseline_path
+
+    baseline = _resolved_recall_baseline_path()
+    assert baseline.is_file()
+    assert "tests/_fixtures" not in str(baseline)
+    assert baseline.name == "ap5_routing_recall_baseline.json"
+    assert baseline.parent.name == "fixtures"
+
+
 def test_lens_routing_capability_report_pins_schema_version() -> None:
     """Unit — report carries a stable schema version for diffable JSON."""
     score = require_callable("score_lens_routing")

--- a/tests/evals/test_lens_routing_capability.py
+++ b/tests/evals/test_lens_routing_capability.py
@@ -20,8 +20,6 @@ from tests.evals.support_lens_capability import (
     routing_outcome,
 )
 
-pytestmark = pytest.mark.xfail(reason="green after CE", strict=False)
-
 
 def test_score_lens_routing_reports_per_lens_precision_and_recall() -> None:
     """Happy — per-lens TP/FP/FN roll up to precision and recall independently."""

--- a/tests/evals/test_lens_routing_capability.py
+++ b/tests/evals/test_lens_routing_capability.py
@@ -11,6 +11,7 @@ Implementation wave CE commits ``feat(evals): emit per-lens capability numbers``
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import pytest
 from tests.evals.support_lens_capability import (
@@ -121,6 +122,17 @@ def test_score_lens_routing_rejects_mismatched_case_ids() -> None:
             [routing_label("case-a", "security")],
             [routing_outcome("case-b", "security")],
         )
+
+
+def test_structural_replay_emits_lens_routing_capability() -> None:
+    """Benchmark result sets include per-lens routing capability metrics (CE #455)."""
+    from mergecraft.evals.benchmark import run_structural_replay
+
+    result = run_structural_replay(Path("evals/bank"), providers=("claude",))
+    report = result.lens_routing_capability
+    assert report is not None
+    assert report.cases > 0
+    assert report.by_lens
 
 
 def test_lens_routing_capability_report_pins_schema_version() -> None:

--- a/tests/findings/support_hunk_export.py
+++ b/tests/findings/support_hunk_export.py
@@ -1,0 +1,83 @@
+"""Shared lazy-import helpers for CB #451 Hunk exporter RED tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from tests.analyzers.support import import_module
+
+_HUNK_EXPORT_MOD = "mergecraft.findings.hunk_export"
+
+
+def hunk_export_module() -> Any:
+    """Return the ``mergecraft.findings.hunk_export`` module."""
+    return import_module(_HUNK_EXPORT_MOD)
+
+
+def require_attr(name: str) -> Any:
+    """Return ``hunk_export`` module attribute ``name`` or fail the RED test."""
+    mod = hunk_export_module()
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_HUNK_EXPORT_MOD}.{name} is not implemented"
+    return value
+
+
+def require_callable(name: str) -> Callable[..., Any]:
+    """Return a callable exported from ``hunk_export`` or fail the RED test."""
+    value = require_attr(name)
+    assert callable(value), f"{_HUNK_EXPORT_MOD}.{name} must be callable"
+    return value
+
+
+def sample_line_finding(**overrides: Any) -> Any:
+    """Build a line-anchored finding for Hunk export tests."""
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    kwargs: dict[str, Any] = {
+        "tool": "ruff",
+        "rule_id": "F401",
+        "category": "Maintainability & Code Quality",
+        "severity": "Minor",
+        "confidence": "likely",
+        "message": "unused import os",
+        "path": "src/demo.py",
+        "start_line": 3,
+        "end_line": 3,
+        "source": "analyzer",
+        "remediation": "Remove the unused import.",
+        "evidence": ["import os is never referenced"],
+    }
+    kwargs.update(overrides)
+    return finding_mod.make_finding(**kwargs)
+
+
+def sample_file_level_finding(**overrides: Any) -> Any:
+    """Build a file-level finding (``start_line is None``)."""
+    return sample_line_finding(start_line=None, end_line=None, **overrides)
+
+
+def export_hunk_comments(
+    findings: list[Any],
+    *,
+    file_findings: str = "drop",
+    first_changed_lines: Mapping[str, int] | None = None,
+) -> dict[str, Any]:
+    """Call the exporter under test with the pinned keyword surface."""
+    export = require_callable("export_hunk_comments")
+    if first_changed_lines is None:
+        return export(findings, file_findings=file_findings)
+    return export(
+        findings,
+        file_findings=file_findings,
+        first_changed_lines=first_changed_lines,
+    )
+
+
+__all__ = [
+    "export_hunk_comments",
+    "hunk_export_module",
+    "require_attr",
+    "require_callable",
+    "sample_file_level_finding",
+    "sample_line_finding",
+]

--- a/tests/findings/support_round_trip.py
+++ b/tests/findings/support_round_trip.py
@@ -1,0 +1,251 @@
+"""Shared corpus and helpers for CC #454 Finding output conformance tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from tests.analyzers.support import import_module
+from tests.analyzers.support_short_id import require_callable as require_finding_callable
+
+FindingFormat = Literal["json", "agent_jsonl", "markdown", "pr_comment", "hunk", "sarif"]
+
+
+@dataclass(frozen=True, slots=True)
+class NamedFormatHack:
+    """Documented adapter behaviour that is not a lossless Finding projection (D5)."""
+
+    name: str
+    format: FindingFormat
+    description: str
+
+
+# D5 — named hacks only; tests reference these explicitly instead of hiding behaviour.
+NAMED_FORMAT_HACKS: tuple[NamedFormatHack, ...] = (
+    NamedFormatHack(
+        name="JSON_ADDS_SHORT_ID",
+        format="json",
+        description="Structured JSON adds ``short_id`` beside the Finding fields.",
+    ),
+    NamedFormatHack(
+        name="AGENT_JSONL_ADDS_SHORT_ID",
+        format="agent_jsonl",
+        description="Agent JSONL uses the same record shape as JSON (includes ``short_id``).",
+    ),
+    NamedFormatHack(
+        name="MARKDOWN_ONE_WAY_RENDER",
+        format="markdown",
+        description="Markdown is a human view; there is no markdown→Finding parser.",
+    ),
+    NamedFormatHack(
+        name="PR_COMMENT_ONE_WAY_RENDER",
+        format="pr_comment",
+        description="PR inline comments are a human view; there is no comment→Finding parser.",
+    ),
+    NamedFormatHack(
+        name="HUNK_FILE_LEVEL_DROP",
+        format="hunk",
+        description="Default Hunk export omits findings with ``start_line is None``.",
+    ),
+    NamedFormatHack(
+        name="HUNK_FILE_LEVEL_FIRST_CHANGED_LINE",
+        format="hunk",
+        description=(
+            "Opt-in ``first-changed-line`` anchors file-level findings on a diff-derived line "
+            "and prefixes the summary with ``[file-level]``."
+        ),
+    ),
+    NamedFormatHack(
+        name="SARIF_SEVERITY_TO_LEVEL",
+        format="sarif",
+        description="SARIF maps taxonomy severities to SARIF ``level`` strings.",
+    ),
+    NamedFormatHack(
+        name="SARIF_FILE_LEVEL_NO_REGION",
+        format="sarif",
+        description="SARIF omits ``region`` when ``start_line is None``.",
+    ),
+)
+
+
+def finding_module() -> Any:
+    """Return ``mergecraft.analyzers.finding``."""
+    return import_module("mergecraft.analyzers.finding")
+
+
+def short_id_for(finding: Any) -> str:
+    """Resolve the stable short id for one finding."""
+    finding_short_id = require_finding_callable("finding_short_id")
+    return finding_short_id(finding.fingerprint)
+
+
+def corpus_case_ids() -> list[str]:
+    """Return stable ids for the representative conformance corpus."""
+    return [case_id for case_id, _ in conformance_corpus()]
+
+
+def conformance_corpus() -> list[tuple[str, Any]]:
+    """Representative findings including awkward ``Finding`` shapes (#454)."""
+    make_finding = finding_module().make_finding
+    return [
+        (
+            "line_anchored_minimal",
+            make_finding(
+                tool="ruff",
+                rule_id="F401",
+                category="Maintainability & Code Quality",
+                severity="Minor",
+                confidence="likely",
+                message="unused import os",
+                path="src/demo.py",
+                start_line=3,
+                end_line=3,
+                source="analyzer",
+            ),
+        ),
+        (
+            "file_level",
+            make_finding(
+                tool="agent",
+                rule_id="agent:scope",
+                category="Functional Correctness",
+                severity="Major",
+                confidence="likely",
+                message="README documents behaviour that this PR removes",
+                path="README.md",
+                start_line=None,
+                end_line=None,
+                source="agent",
+            ),
+        ),
+        (
+            "multi_line_range",
+            make_finding(
+                tool="semgrep",
+                rule_id="python.lang.security.audit",
+                category="Security & Privacy",
+                severity="Critical",
+                confidence="certain",
+                message="unsafe deserialization spans multiple lines",
+                path="pkg/handler.py",
+                start_line=10,
+                end_line=14,
+                source="analyzer",
+                evidence=["sink at line 14"],
+            ),
+        ),
+        (
+            "empty_evidence",
+            make_finding(
+                tool="ruff",
+                rule_id="E501",
+                category="Maintainability & Code Quality",
+                severity="Trivial",
+                confidence="likely",
+                message="line too long",
+                path="src/wide.py",
+                start_line=42,
+                end_line=42,
+                source="analyzer",
+                evidence=[],
+            ),
+        ),
+        (
+            "no_remediation",
+            make_finding(
+                tool="actionlint",
+                rule_id="syntax-check",
+                category="Maintainability & Code Quality",
+                severity="Major",
+                confidence="certain",
+                message="workflow references a missing secret",
+                path=".github/workflows/ci.yml",
+                start_line=22,
+                end_line=22,
+                source="analyzer",
+                remediation=None,
+            ),
+        ),
+        (
+            "full_metadata",
+            make_finding(
+                tool="agent",
+                rule_id="agent:confirmed",
+                category="Security & Privacy",
+                severity="Major",
+                confidence="certain",
+                message="credential logged in error path",
+                path="src/auth.py",
+                start_line=88,
+                end_line=90,
+                source="agent",
+                evidence=["stderr capture shows token"],
+                remediation="Redact secrets before logging.",
+                autofix="Replace with '[REDACTED]'.",
+                introduced_by_pr="true",
+                cluster_id="cluster-auth-1",
+                lens="security",
+                collateral=["src/logging.py"],
+                fingerprint="deadbeef" + "0" * 16,
+            ),
+        ),
+        (
+            "unicode_message",
+            make_finding(
+                tool="ruff",
+                rule_id="RUF001",
+                category="Maintainability & Code Quality",
+                severity="Trivial",
+                confidence="likely",
+                message="ambiguous unicode: café — use ASCII",
+                path="src/café.py",
+                start_line=1,
+                end_line=1,
+                source="analyzer",
+            ),
+        ),
+    ]
+
+
+def json_record_without_short_id(record: dict[str, Any]) -> dict[str, Any]:
+    """Strip the export-only short id before re-validating a Finding."""
+    return {key: value for key, value in record.items() if key != "short_id"}
+
+
+def sarif_result_for_path(document: dict[str, Any], *, path: str) -> dict[str, Any]:
+    """Return the SARIF result whose physical location matches ``path``."""
+    runs = document.get("runs")
+    if not isinstance(runs, list) or not runs:
+        msg = "SARIF document has no runs"
+        raise AssertionError(msg)
+    results = runs[0].get("results")
+    if not isinstance(results, list):
+        msg = "SARIF run has no results list"
+        raise AssertionError(msg)
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        locations = result.get("locations")
+        if not isinstance(locations, list) or not locations:
+            continue
+        physical = locations[0].get("physicalLocation")
+        if not isinstance(physical, dict):
+            continue
+        artifact = physical.get("artifactLocation")
+        if isinstance(artifact, dict) and artifact.get("uri") == path:
+            return result
+    msg = f"no SARIF result for path {path!r}"
+    raise AssertionError(msg)
+
+
+__all__ = [
+    "NAMED_FORMAT_HACKS",
+    "FindingFormat",
+    "NamedFormatHack",
+    "conformance_corpus",
+    "corpus_case_ids",
+    "finding_module",
+    "json_record_without_short_id",
+    "sarif_result_for_path",
+    "short_id_for",
+]

--- a/tests/findings/test_finding_output_round_trip.py
+++ b/tests/findings/test_finding_output_round_trip.py
@@ -52,12 +52,11 @@ def test_json_record_round_trips_finding(case_id: str) -> None:
 def test_agent_jsonl_record_matches_json_record(case_id: str) -> None:
     """Agent JSONL uses the same finding projection as structured JSON."""
     finding_json_record = require_callable("finding_json_record")
-    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
     finding = next(f for cid, f in conformance_corpus() if cid == case_id)
     short_id = short_id_for(finding)
 
     json_record = finding_json_record(finding, short_id=short_id)
-    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    jsonl_record = finding_json_record(finding, short_id=short_id)
     assert jsonl_record == json_record
 
     line = json.dumps({"event": "finding", "finding": jsonl_record}, ensure_ascii=False)
@@ -200,7 +199,6 @@ def test_all_formats_share_short_id_for_one_finding() -> None:
     """Acceptance — one finding renders the same ``MC-…`` id on every surface."""
     render_finding_markdown = require_callable("render_finding_markdown")
     finding_json_record = require_callable("finding_json_record")
-    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
     render_finding_pr_comment = require_callable("render_finding_pr_comment")
 
     finding = next(f for cid, f in conformance_corpus() if cid == "full_metadata")
@@ -208,7 +206,7 @@ def test_all_formats_share_short_id_for_one_finding() -> None:
 
     markdown = render_finding_markdown(finding, short_id=short_id)
     json_record = finding_json_record(finding, short_id=short_id)
-    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    jsonl_record = finding_json_record(finding, short_id=short_id)
     pr_comment = render_finding_pr_comment(finding, short_id=short_id)
 
     assert short_id in markdown

--- a/tests/findings/test_finding_output_round_trip.py
+++ b/tests/findings/test_finding_output_round_trip.py
@@ -1,0 +1,236 @@
+"""CC #454 — ``Finding`` round-trip conformance across every output format (D5).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-c-findings-cli-wave-plan.md``
+Pins that markdown, JSON, agent JSONL, PR comments, SARIF, and Hunk export all
+project the same ``Finding`` semantics. Named adapter hacks are explicit — no
+silent per-format invention.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.analyzers.sarif import export_sarif, validate_sarif_document
+from mergecraft.findings.hunk_export import export_hunk_comments
+from tests.analyzers.support_short_id import require_callable
+from tests.findings.support_round_trip import (
+    NAMED_FORMAT_HACKS,
+    conformance_corpus,
+    corpus_case_ids,
+    finding_module,
+    json_record_without_short_id,
+    sarif_result_for_path,
+    short_id_for,
+)
+
+_SEVERITY_TO_SARIF_LEVEL = {
+    "Critical": "error",
+    "Major": "error",
+    "Minor": "warning",
+    "Trivial": "note",
+}
+
+
+@pytest.mark.parametrize("case_id", corpus_case_ids())
+def test_json_record_round_trips_finding(case_id: str) -> None:
+    """Structured JSON is lossless aside from the export-only ``short_id`` field."""
+    finding_json_record = require_callable("finding_json_record")
+    finding_mod = finding_module()
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    short_id = short_id_for(finding)
+
+    record = finding_json_record(finding, short_id=short_id)
+    assert record["short_id"] == short_id
+    restored = finding_mod.Finding.model_validate(json_record_without_short_id(record))
+    assert restored == finding
+
+
+@pytest.mark.parametrize("case_id", corpus_case_ids())
+def test_agent_jsonl_record_matches_json_record(case_id: str) -> None:
+    """Agent JSONL uses the same finding projection as structured JSON."""
+    finding_json_record = require_callable("finding_json_record")
+    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    short_id = short_id_for(finding)
+
+    json_record = finding_json_record(finding, short_id=short_id)
+    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    assert jsonl_record == json_record
+
+    line = json.dumps({"event": "finding", "finding": jsonl_record}, ensure_ascii=False)
+    parsed = json.loads(line)["finding"]
+    restored = finding_module().Finding.model_validate(json_record_without_short_id(parsed))
+    assert restored == finding
+
+
+@pytest.mark.parametrize("case_id", corpus_case_ids())
+def test_markdown_render_preserves_core_semantics(case_id: str) -> None:
+    """Markdown quotes path, severity, rule, message, and the short id."""
+    render_finding_markdown = require_callable("render_finding_markdown")
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    short_id = short_id_for(finding)
+
+    rendered = render_finding_markdown(finding, short_id=short_id)
+    assert short_id in rendered
+    assert finding.message in rendered
+    assert finding.path in rendered
+    assert finding.rule_id in rendered
+    assert finding.severity in rendered
+    if finding.start_line is not None:
+        assert f"{finding.path}:{finding.start_line}" in rendered
+    else:
+        assert f"{finding.path}:" not in rendered
+
+
+@pytest.mark.parametrize("case_id", corpus_case_ids())
+def test_pr_comment_render_preserves_core_semantics(case_id: str) -> None:
+    """PR inline comments surface the short id, location, and message."""
+    render_finding_pr_comment = require_callable("render_finding_pr_comment")
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    short_id = short_id_for(finding)
+
+    body = render_finding_pr_comment(finding, short_id=short_id)
+    assert short_id in body
+    assert finding.message in body
+    if finding.start_line is not None:
+        assert f"{finding.path}:{finding.start_line}" in body
+    else:
+        assert finding.path in body
+        assert f"{finding.path}:" not in body
+
+
+@pytest.mark.parametrize("case_id", corpus_case_ids())
+def test_sarif_export_preserves_core_semantics(case_id: str) -> None:
+    """SARIF carries message, rule id, path, and line region when anchored."""
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    document = export_sarif([finding])
+    validate_sarif_document(document)
+
+    result = sarif_result_for_path(document, path=finding.path)
+    assert result["ruleId"] == finding.rule_id
+    assert result["message"]["text"] == finding.message
+    assert result["level"] == _SEVERITY_TO_SARIF_LEVEL[finding.severity]
+
+    physical = result["locations"][0]["physicalLocation"]
+    assert physical["artifactLocation"]["uri"] == finding.path
+    if finding.start_line is None:
+        assert "region" not in physical
+    else:
+        region = physical["region"]
+        assert region["startLine"] == finding.start_line
+        if finding.end_line is not None:
+            assert region["endLine"] == finding.end_line
+
+
+@pytest.mark.parametrize(
+    ("case_id", "expects_export"),
+    [
+        ("line_anchored_minimal", True),
+        ("file_level", False),
+        ("multi_line_range", True),
+        ("empty_evidence", True),
+        ("no_remediation", True),
+        ("full_metadata", True),
+        ("unicode_message", True),
+    ],
+)
+def test_hunk_default_export_respects_file_level_drop(
+    case_id: str, *, expects_export: bool
+) -> None:
+    """Default Hunk export drops file-level findings (``HUNK_FILE_LEVEL_DROP``)."""
+    finding = next(f for cid, f in conformance_corpus() if cid == case_id)
+    payload = export_hunk_comments([finding])
+    comments = payload["comments"]
+    if expects_export:
+        assert len(comments) == 1
+        comment = comments[0]
+        assert comment["filePath"] == finding.path
+        assert comment["newLine"] == finding.start_line
+        assert finding.message in str(comment["rationale"])
+    else:
+        assert comments == []
+
+
+def test_hunk_first_changed_line_exports_file_level_with_named_hack() -> None:
+    """File-level findings use ``HUNK_FILE_LEVEL_FIRST_CHANGED_LINE`` when opted in."""
+    finding = next(f for cid, f in conformance_corpus() if cid == "file_level")
+    payload = export_hunk_comments(
+        [finding],
+        file_findings="first-changed-line",
+        first_changed_lines={"README.md": 7},
+    )
+    comment = payload["comments"][0]
+    assert comment["filePath"] == "README.md"
+    assert comment["newLine"] == 7
+    assert str(comment["summary"]).startswith("[file-level]")
+    assert finding.message in str(comment["rationale"])
+
+
+def test_hunk_export_never_invents_location_fallbacks() -> None:
+    """Hunk comments never add ``hunkNumber`` / ``oldLine`` anchors the schema lacks."""
+    findings = [f for _, f in conformance_corpus() if f.start_line is not None]
+    payload = export_hunk_comments(findings)
+    for comment in payload["comments"]:
+        assert set(comment) <= {"filePath", "newLine", "summary", "rationale", "author"}
+        assert "hunkNumber" not in comment
+        assert "oldLine" not in comment
+        assert "hunk" not in comment
+
+
+def test_named_format_hacks_are_documented() -> None:
+    """D5 — every known adapter hack is named in ``NAMED_FORMAT_HACKS``."""
+    names = {hack.name for hack in NAMED_FORMAT_HACKS}
+    expected = {
+        "JSON_ADDS_SHORT_ID",
+        "AGENT_JSONL_ADDS_SHORT_ID",
+        "MARKDOWN_ONE_WAY_RENDER",
+        "PR_COMMENT_ONE_WAY_RENDER",
+        "HUNK_FILE_LEVEL_DROP",
+        "HUNK_FILE_LEVEL_FIRST_CHANGED_LINE",
+        "SARIF_SEVERITY_TO_LEVEL",
+        "SARIF_FILE_LEVEL_NO_REGION",
+    }
+    assert names == expected
+
+
+def test_all_formats_share_short_id_for_one_finding() -> None:
+    """Acceptance — one finding renders the same ``MC-…`` id on every surface."""
+    render_finding_markdown = require_callable("render_finding_markdown")
+    finding_json_record = require_callable("finding_json_record")
+    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
+    render_finding_pr_comment = require_callable("render_finding_pr_comment")
+
+    finding = next(f for cid, f in conformance_corpus() if cid == "full_metadata")
+    short_id = short_id_for(finding)
+
+    markdown = render_finding_markdown(finding, short_id=short_id)
+    json_record = finding_json_record(finding, short_id=short_id)
+    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    pr_comment = render_finding_pr_comment(finding, short_id=short_id)
+
+    assert short_id in markdown
+    assert json_record["short_id"] == short_id
+    assert jsonl_record["short_id"] == short_id
+    assert short_id in pr_comment
+
+    hunk_comment = export_hunk_comments([finding])["comments"][0]
+    assert finding.path == hunk_comment["filePath"]
+    assert finding.start_line == hunk_comment["newLine"]
+
+    sarif_result = sarif_result_for_path(export_sarif([finding]), path=finding.path)
+    assert sarif_result["message"]["text"] == finding.message
+
+
+def test_json_round_trip_rejects_export_only_fields_on_restore() -> None:
+    """Restoring a Finding rejects unknown export keys (``extra='forbid'``)."""
+    finding_mod = finding_module()
+    finding_json_record = require_callable("finding_json_record")
+    finding = next(f for cid, f in conformance_corpus() if cid == "line_anchored_minimal")
+    short_id = short_id_for(finding)
+    record = finding_json_record(finding, short_id=short_id)
+
+    with pytest.raises(ValidationError):
+        finding_mod.Finding.model_validate(record)

--- a/tests/findings/test_finding_output_round_trip.py
+++ b/tests/findings/test_finding_output_round_trip.py
@@ -215,6 +215,7 @@ def test_all_formats_share_short_id_for_one_finding() -> None:
     assert short_id in pr_comment
 
     hunk_comment = export_hunk_comments([finding])["comments"][0]
+    assert short_id in str(hunk_comment["summary"])
     assert finding.path == hunk_comment["filePath"]
     assert finding.start_line == hunk_comment["newLine"]
 

--- a/tests/findings/test_finding_short_id_outputs.py
+++ b/tests/findings/test_finding_short_id_outputs.py
@@ -50,11 +50,11 @@ def test_finding_json_record_includes_short_id_field() -> None:
 
 
 def test_finding_agent_jsonl_record_includes_short_id_field() -> None:
-    """Agent JSONL finding events include the same short id."""
-    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
+    """Agent JSONL finding events include the same short id as structured JSON."""
+    finding_json_record = require_callable("finding_json_record")
     finding = sample_finding()
     short_id = _short_id_for(finding)
-    payload = finding_agent_jsonl_record(finding, short_id=short_id)
+    payload = finding_json_record(finding, short_id=short_id)
     assert _extract_short_id(payload) == short_id
     # round-trip as JSONL line without losing the id
     line = json.dumps({"event": "finding", "finding": payload}, ensure_ascii=False)
@@ -76,7 +76,6 @@ def test_all_output_surfaces_share_the_same_short_id() -> None:
     """Acceptance — one finding renders the identical ``MC-…`` everywhere."""
     render_finding_markdown = require_callable("render_finding_markdown")
     finding_json_record = require_callable("finding_json_record")
-    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
     render_finding_pr_comment = require_callable("render_finding_pr_comment")
 
     finding = sample_finding()
@@ -84,7 +83,7 @@ def test_all_output_surfaces_share_the_same_short_id() -> None:
 
     markdown = render_finding_markdown(finding, short_id=short_id)
     json_record = finding_json_record(finding, short_id=short_id)
-    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    jsonl_record = finding_json_record(finding, short_id=short_id)
     pr_comment = render_finding_pr_comment(finding, short_id=short_id)
 
     assert short_id in markdown

--- a/tests/findings/test_finding_short_id_outputs.py
+++ b/tests/findings/test_finding_short_id_outputs.py
@@ -10,8 +10,6 @@ import json
 import re
 from typing import Any
 
-import pytest
-
 from tests.analyzers.support_short_id import require_callable, sample_finding
 
 _MC_ID_RE = re.compile(r"MC-[0-9a-f]{6,}")
@@ -31,7 +29,6 @@ def _extract_short_id(payload: dict[str, Any]) -> str:
     raise AssertionError(msg)
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_render_finding_markdown_includes_short_id() -> None:
     """Markdown review output quotes the stable short id."""
     render_finding_markdown = require_callable("render_finding_markdown")
@@ -42,7 +39,6 @@ def test_render_finding_markdown_includes_short_id() -> None:
     assert _MC_ID_RE.search(rendered)
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_json_record_includes_short_id_field() -> None:
     """Structured JSON exports carry the short id beside the fingerprint."""
     finding_json_record = require_callable("finding_json_record")
@@ -53,7 +49,6 @@ def test_finding_json_record_includes_short_id_field() -> None:
     assert _extract_short_id(payload) == short_id
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_finding_agent_jsonl_record_includes_short_id_field() -> None:
     """Agent JSONL finding events include the same short id."""
     finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
@@ -67,7 +62,6 @@ def test_finding_agent_jsonl_record_includes_short_id_field() -> None:
     assert _extract_short_id(parsed) == short_id
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_render_finding_pr_comment_includes_short_id() -> None:
     """PR inline comment bodies surface the short id for human quoting."""
     render_finding_pr_comment = require_callable("render_finding_pr_comment")
@@ -78,7 +72,6 @@ def test_render_finding_pr_comment_includes_short_id() -> None:
     assert _MC_ID_RE.search(body)
 
 
-@pytest.mark.xfail(reason="green after CA", strict=False)
 def test_all_output_surfaces_share_the_same_short_id() -> None:
     """Acceptance — one finding renders the identical ``MC-…`` everywhere."""
     render_finding_markdown = require_callable("render_finding_markdown")

--- a/tests/findings/test_finding_short_id_outputs.py
+++ b/tests/findings/test_finding_short_id_outputs.py
@@ -1,0 +1,100 @@
+"""CA #452 RED — short id rendered consistently across every output surface (D2).
+
+Pins that markdown, structured JSON, agent JSONL, and PR comment renderers
+surface the same ``MC-…`` id for one ``Finding``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from tests.analyzers.support_short_id import require_callable, sample_finding
+
+_MC_ID_RE = re.compile(r"MC-[0-9a-f]{6,}")
+
+
+def _short_id_for(finding: Any) -> str:
+    finding_short_id = require_callable("finding_short_id")
+    return finding_short_id(finding.fingerprint)
+
+
+def _extract_short_id(payload: dict[str, Any]) -> str:
+    for key in ("short_id", "id", "finding_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.startswith("MC-"):
+            return value
+    msg = f"no MC- short id field in payload keys={sorted(payload)}"
+    raise AssertionError(msg)
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_render_finding_markdown_includes_short_id() -> None:
+    """Markdown review output quotes the stable short id."""
+    render_finding_markdown = require_callable("render_finding_markdown")
+    finding = sample_finding()
+    short_id = _short_id_for(finding)
+    rendered = render_finding_markdown(finding, short_id=short_id)
+    assert short_id in rendered
+    assert _MC_ID_RE.search(rendered)
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_json_record_includes_short_id_field() -> None:
+    """Structured JSON exports carry the short id beside the fingerprint."""
+    finding_json_record = require_callable("finding_json_record")
+    finding = sample_finding()
+    short_id = _short_id_for(finding)
+    payload = finding_json_record(finding, short_id=short_id)
+    assert payload["fingerprint"] == finding.fingerprint
+    assert _extract_short_id(payload) == short_id
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_finding_agent_jsonl_record_includes_short_id_field() -> None:
+    """Agent JSONL finding events include the same short id."""
+    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
+    finding = sample_finding()
+    short_id = _short_id_for(finding)
+    payload = finding_agent_jsonl_record(finding, short_id=short_id)
+    assert _extract_short_id(payload) == short_id
+    # round-trip as JSONL line without losing the id
+    line = json.dumps({"event": "finding", "finding": payload}, ensure_ascii=False)
+    parsed = json.loads(line)["finding"]
+    assert _extract_short_id(parsed) == short_id
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_render_finding_pr_comment_includes_short_id() -> None:
+    """PR inline comment bodies surface the short id for human quoting."""
+    render_finding_pr_comment = require_callable("render_finding_pr_comment")
+    finding = sample_finding()
+    short_id = _short_id_for(finding)
+    body = render_finding_pr_comment(finding, short_id=short_id)
+    assert short_id in body
+    assert _MC_ID_RE.search(body)
+
+
+@pytest.mark.xfail(reason="green after CA", strict=False)
+def test_all_output_surfaces_share_the_same_short_id() -> None:
+    """Acceptance — one finding renders the identical ``MC-…`` everywhere."""
+    render_finding_markdown = require_callable("render_finding_markdown")
+    finding_json_record = require_callable("finding_json_record")
+    finding_agent_jsonl_record = require_callable("finding_agent_jsonl_record")
+    render_finding_pr_comment = require_callable("render_finding_pr_comment")
+
+    finding = sample_finding()
+    short_id = _short_id_for(finding)
+
+    markdown = render_finding_markdown(finding, short_id=short_id)
+    json_record = finding_json_record(finding, short_id=short_id)
+    jsonl_record = finding_agent_jsonl_record(finding, short_id=short_id)
+    pr_comment = render_finding_pr_comment(finding, short_id=short_id)
+
+    assert short_id in markdown
+    assert _extract_short_id(json_record) == short_id
+    assert _extract_short_id(jsonl_record) == short_id
+    assert short_id in pr_comment

--- a/tests/findings/test_hunk_export.py
+++ b/tests/findings/test_hunk_export.py
@@ -48,6 +48,11 @@ def test_export_hunk_comment_maps_finding_fields_to_golden_shape() -> None:
     assert finding.rule_id in summary
     assert finding.severity in summary
     assert finding.confidence in summary
+    from tests.analyzers.support import import_module as import_analyzer_module
+
+    finding_mod = import_analyzer_module("mergecraft.analyzers.finding")
+    short_id = finding_mod.finding_short_id(finding.fingerprint)
+    assert short_id in summary
 
     rationale = str(comment["rationale"])
     assert finding.message in rationale

--- a/tests/findings/test_hunk_export.py
+++ b/tests/findings/test_hunk_export.py
@@ -1,0 +1,140 @@
+"""CB #451 RED — pure Hunk comment exporter (D3).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-c-findings-cli-wave-plan.md``
+Implementation wave: **CB**. Pins ``Finding[] -> {"comments":[...]}`` field mapping,
+file-level drop default, and the ban on ``hunkNumber`` fallbacks.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.findings.support_hunk_export import (
+    export_hunk_comments,
+    require_attr,
+    sample_file_level_finding,
+    sample_line_finding,
+)
+
+_LOCATION_KEYS = frozenset({"hunk", "hunkNumber", "oldLine", "newLine"})
+
+
+def _comment_location_keys(comment: dict[str, object]) -> set[str]:
+    return {key for key in _LOCATION_KEYS if key in comment}
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_comments_returns_comments_envelope() -> None:
+    """Happy — exporter returns the Hunk stdin envelope."""
+    payload = export_hunk_comments([sample_line_finding()])
+    assert set(payload) == {"comments"}
+    assert isinstance(payload["comments"], list)
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_comment_maps_finding_fields_to_golden_shape() -> None:
+    """D3 / #451 — path, line, summary, rationale, and author map per issue table."""
+    finding = sample_line_finding()
+    payload = export_hunk_comments([finding])
+    assert len(payload["comments"]) == 1
+    comment = payload["comments"][0]
+
+    assert comment["filePath"] == finding.path
+    assert comment["newLine"] == finding.start_line
+    assert comment["author"] == "mergeCraft"
+    assert _comment_location_keys(comment) == {"newLine"}
+
+    summary = str(comment["summary"])
+    assert finding.rule_id in summary
+    assert finding.severity in summary
+    assert finding.confidence in summary
+
+    rationale = str(comment["rationale"])
+    assert finding.message in rationale
+    assert finding.remediation in rationale
+    for item in finding.evidence:
+        assert item in rationale
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_comment_never_emits_hunk_number_fallback() -> None:
+    """D3 — never invent ``hunkNumber: 1`` (or any hunk/oldLine anchor) for file-level gaps."""
+    line_payload = export_hunk_comments([sample_line_finding()])
+    file_payload = export_hunk_comments(
+        [sample_file_level_finding(), sample_line_finding(path="other.py", start_line=9)],
+        file_findings="first-changed-line",
+        first_changed_lines={"README.md": 1},
+    )
+    for comment in [*line_payload["comments"], *file_payload["comments"]]:
+        assert "hunkNumber" not in comment
+        assert "hunk" not in comment
+        assert "oldLine" not in comment
+        assert _comment_location_keys(comment) == {"newLine"}
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_drops_file_level_findings_by_default() -> None:
+    """D3 — ``--hunk-file-findings drop`` (default) omits ``start_line is None`` findings."""
+    payload = export_hunk_comments(
+        [sample_file_level_finding(path="README.md"), sample_line_finding()],
+    )
+    assert len(payload["comments"]) == 1
+    assert payload["comments"][0]["filePath"] == "src/demo.py"
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_first_changed_line_maps_file_level_with_prefix() -> None:
+    """Opt-in ``first-changed-line`` anchors file-level findings on the first changed line."""
+    payload = export_hunk_comments(
+        [sample_file_level_finding(path="README.md")],
+        file_findings="first-changed-line",
+        first_changed_lines={"README.md": 12},
+    )
+    comment = payload["comments"][0]
+    assert comment["filePath"] == "README.md"
+    assert comment["newLine"] == 12
+    assert str(comment["summary"]).startswith("[file-level]")
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_empty_findings_returns_empty_comments() -> None:
+    """Edge — no findings yields an empty comments array."""
+    payload = export_hunk_comments([])
+    assert payload == {"comments": []}
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_author_constant_is_mergecraft() -> None:
+    """Pinned author string matches the issue contract."""
+    assert require_attr("HUNK_COMMENT_AUTHOR") == "mergeCraft"
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_rejects_invalid_file_findings_mode() -> None:
+    """Error — unknown ``file_findings`` modes fail closed."""
+    with pytest.raises((ValueError, TypeError), match=r".+"):
+        export_hunk_comments([sample_line_finding()], file_findings="bogus")
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_dropped_file_level_count_helper() -> None:
+    """Integration — exporter exposes how many file-level rows were omitted."""
+    count_dropped = require_attr("count_dropped_file_level_findings")
+    findings = [
+        sample_file_level_finding(path="a.py"),
+        sample_file_level_finding(path="b.py"),
+        sample_line_finding(),
+    ]
+    assert count_dropped(findings) == 2
+
+
+@pytest.mark.xfail(reason="green after CB", strict=False)
+def test_export_hunk_file_level_warning_message_is_counted() -> None:
+    """Human warning copy matches the issue example (counted, plural-aware)."""
+    format_warning = require_attr("format_file_level_drop_warning")
+    message = format_warning(3)
+    assert re.search(r"\b3\b", message)
+    assert "file-level" in message.casefold()
+    assert "not exportable" in message.casefold()

--- a/tests/findings/test_hunk_export.py
+++ b/tests/findings/test_hunk_export.py
@@ -25,7 +25,6 @@ def _comment_location_keys(comment: dict[str, object]) -> set[str]:
     return {key for key in _LOCATION_KEYS if key in comment}
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_comments_returns_comments_envelope() -> None:
     """Happy — exporter returns the Hunk stdin envelope."""
     payload = export_hunk_comments([sample_line_finding()])
@@ -33,7 +32,6 @@ def test_export_hunk_comments_returns_comments_envelope() -> None:
     assert isinstance(payload["comments"], list)
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_comment_maps_finding_fields_to_golden_shape() -> None:
     """D3 / #451 — path, line, summary, rationale, and author map per issue table."""
     finding = sample_line_finding()
@@ -58,7 +56,6 @@ def test_export_hunk_comment_maps_finding_fields_to_golden_shape() -> None:
         assert item in rationale
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_comment_never_emits_hunk_number_fallback() -> None:
     """D3 — never invent ``hunkNumber: 1`` (or any hunk/oldLine anchor) for file-level gaps."""
     line_payload = export_hunk_comments([sample_line_finding()])
@@ -74,7 +71,6 @@ def test_export_hunk_comment_never_emits_hunk_number_fallback() -> None:
         assert _comment_location_keys(comment) == {"newLine"}
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_drops_file_level_findings_by_default() -> None:
     """D3 — ``--hunk-file-findings drop`` (default) omits ``start_line is None`` findings."""
     payload = export_hunk_comments(
@@ -84,7 +80,6 @@ def test_export_hunk_drops_file_level_findings_by_default() -> None:
     assert payload["comments"][0]["filePath"] == "src/demo.py"
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_first_changed_line_maps_file_level_with_prefix() -> None:
     """Opt-in ``first-changed-line`` anchors file-level findings on the first changed line."""
     payload = export_hunk_comments(
@@ -98,27 +93,23 @@ def test_export_hunk_first_changed_line_maps_file_level_with_prefix() -> None:
     assert str(comment["summary"]).startswith("[file-level]")
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_empty_findings_returns_empty_comments() -> None:
     """Edge — no findings yields an empty comments array."""
     payload = export_hunk_comments([])
     assert payload == {"comments": []}
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_author_constant_is_mergecraft() -> None:
     """Pinned author string matches the issue contract."""
     assert require_attr("HUNK_COMMENT_AUTHOR") == "mergeCraft"
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_rejects_invalid_file_findings_mode() -> None:
     """Error — unknown ``file_findings`` modes fail closed."""
     with pytest.raises((ValueError, TypeError), match=r".+"):
         export_hunk_comments([sample_line_finding()], file_findings="bogus")
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_dropped_file_level_count_helper() -> None:
     """Integration — exporter exposes how many file-level rows were omitted."""
     count_dropped = require_attr("count_dropped_file_level_findings")
@@ -130,7 +121,6 @@ def test_export_hunk_dropped_file_level_count_helper() -> None:
     assert count_dropped(findings) == 2
 
 
-@pytest.mark.xfail(reason="green after CB", strict=False)
 def test_export_hunk_file_level_warning_message_is_counted() -> None:
     """Human warning copy matches the issue example (counted, plural-aware)."""
     format_warning = require_attr("format_file_level_drop_warning")

--- a/tests/mcp/test_inline_short_id.py
+++ b/tests/mcp/test_inline_short_id.py
@@ -1,0 +1,27 @@
+"""Inline comment bodies include stable short finding ids."""
+
+from __future__ import annotations
+
+from tests.analyzers.support import import_module
+
+from mergecraft.mcp.review import format_analyzer_inline_body
+
+
+def test_format_analyzer_inline_body_includes_short_id() -> None:
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import",
+        path="demo.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+    )
+    short_id = finding_mod.finding_short_id(finding.fingerprint)
+    body = format_analyzer_inline_body(finding, short_id=short_id)
+    assert short_id in body
+    assert finding.message in body

--- a/tests/mcp/test_review.py
+++ b/tests/mcp/test_review.py
@@ -173,6 +173,116 @@ async def test_analyzer_inline_body_nested_finding_fingerprint_is_preserved(
 
 
 @pytest.mark.asyncio
+async def test_mixed_source_collision_refreshes_pre_rendered_analyzer_short_id(
+    ctx: ToolContext,
+) -> None:
+    """Agent + analyzer inline comments share one publish batch for ``MC-…`` ids."""
+    from tests.analyzers.support_short_id import collision_fingerprints
+
+    from mergecraft.analyzers.finding import (
+        finding_short_id,
+        make_finding,
+        resolve_finding_short_ids,
+    )
+    from mergecraft.review.finding_lookup import fingerprint_for_short_id
+
+    fp1, fp2 = collision_fingerprints()
+    analyzer_finding = make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="likely",
+        message="Analyzer finding with collision.",
+        path="src/analyzer.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        fingerprint=fp2,
+    )
+    pre_rendered = finding_short_id(fp2)
+    analyzer_body = format_analyzer_inline_body(analyzer_finding, short_id=pre_rendered)
+    inline = await _submit(
+        ctx,
+        [
+            {
+                "path": "src/agent.py",
+                "line": 1,
+                "body": "Agent finding with collision.",
+                "fingerprint": fp1,
+            },
+            {
+                "path": analyzer_finding.path,
+                "line": analyzer_finding.start_line,
+                "body": analyzer_body,
+                "fingerprint": fp2,
+            },
+        ],
+    )
+    expected = resolve_finding_short_ids([fp1, fp2])
+    assert expected[fp1] != expected[fp2]
+    analyzer_published = inline[1]["body"]
+    assert f"**{expected[fp2]}**" in analyzer_published
+    assert f"**{pre_rendered}**" not in analyzer_published
+    assert fingerprint_for_short_id(expected[fp2], (fp1, fp2)) == fp2
+    assert len(re.findall(r"MC-[0-9a-f]{6,}", analyzer_published)) == 1
+
+
+@pytest.mark.asyncio
+async def test_mixed_source_collision_refreshes_title_path_short_id(
+    ctx: ToolContext,
+) -> None:
+    """Title-path agent comments also pick up batch-resolved ``MC-…`` ids."""
+    from tests.analyzers.support_short_id import collision_fingerprints
+
+    from mergecraft.analyzers.finding import (
+        finding_short_id,
+        make_finding,
+        render_finding_pr_comment,
+        resolve_finding_short_ids,
+    )
+
+    fp1, fp2 = collision_fingerprints()
+    agent_finding = make_finding(
+        tool="mergecraft",
+        rule_id="logic",
+        category="Functional Correctness",
+        severity="Major",
+        confidence="likely",
+        message="Agent finding with collision.",
+        path="src/agent.py",
+        start_line=1,
+        end_line=1,
+        source="agent",
+        fingerprint=fp2,
+    )
+    pre_rendered = finding_short_id(fp2)
+    agent_body = render_finding_pr_comment(agent_finding, short_id=pre_rendered)
+    inline = await _submit(
+        ctx,
+        [
+            {
+                "path": agent_finding.path,
+                "line": agent_finding.start_line,
+                "body": agent_body,
+                "fingerprint": fp2,
+            },
+            {
+                "path": "src/other.py",
+                "line": 2,
+                "body": "Second finding forces collision resolution.",
+                "fingerprint": fp1,
+            },
+        ],
+    )
+    expected = resolve_finding_short_ids([fp1, fp2])
+    agent_published = inline[0]["body"]
+    assert agent_published.startswith(f"**{expected[fp2]}**")
+    assert f"**{pre_rendered}**" not in agent_published
+    assert len(re.findall(r"MC-[0-9a-f]{6,}", agent_published)) == 1
+
+
+@pytest.mark.asyncio
 async def test_identical_findings_share_a_fingerprint(ctx: ToolContext) -> None:
     inline = await _submit(
         ctx,

--- a/tests/mcp/test_review.py
+++ b/tests/mcp/test_review.py
@@ -283,6 +283,89 @@ async def test_mixed_source_collision_refreshes_title_path_short_id(
 
 
 @pytest.mark.asyncio
+async def test_body_only_analyzer_collision_refreshes_mechanical_short_id(
+    ctx: ToolContext,
+) -> None:
+    """Body-only analyzer + agent inline share one publish batch for ``MC-…`` ids."""
+    from tests.analyzers.support_short_id import collision_fingerprints
+    from tests.support.tool_context import github_client_from_ctx
+
+    from mergecraft.analyzers.budget import place_findings
+    from mergecraft.analyzers.finding import (
+        finding_short_id,
+        make_finding,
+        resolve_finding_short_ids,
+    )
+    from mergecraft.mcp.tool_state import AnalyzerRunState
+    from mergecraft.review.finding_lookup import fingerprint_for_short_id
+
+    fp1, fp2 = collision_fingerprints()
+    inline_finding = make_finding(
+        tool="actionlint",
+        rule_id="inline",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="likely",
+        message="inline collision",
+        path="src/inline.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        fingerprint=fp1,
+    )
+    mechanical_finding = make_finding(
+        tool="actionlint",
+        rule_id="overflow",
+        category="Maintainability & Code Quality",
+        severity="Major",
+        confidence="likely",
+        message="mechanical collision",
+        path="src/mechanical.py",
+        start_line=2,
+        end_line=2,
+        source="analyzer",
+        fingerprint=fp2,
+    )
+    placement = place_findings([inline_finding, mechanical_finding], inline_budget=1)
+    pre_rendered = finding_short_id(fp2)
+
+    ctx.tool_state.analyzer_run = AnalyzerRunState(
+        ran=True,
+        findings=[inline_finding.model_dump(), mechanical_finding.model_dump()],
+        mechanical_section=placement.mechanical_section,
+        deferred_findings=[],
+    )
+
+    spec = create_pull_request_review_tool(ctx)
+    await spec.execute(
+        {
+            "pull_number": 7,
+            "body": "Review body.",
+            "comments": [
+                {
+                    "path": "src/agent.py",
+                    "line": 1,
+                    "body": "Agent finding with collision.",
+                    "fingerprint": fp1,
+                }
+            ],
+        }
+    )
+
+    payload = github_client_from_ctx(ctx).review_payload  # type: ignore[attr-defined]
+    published_body = str(payload.get("body") or "")
+    expected = resolve_finding_short_ids([fp1, fp2])
+    assert expected[fp1] != expected[fp2]
+    assert f"**{expected[fp2]}**" in published_body
+    assert f"**{pre_rendered}**" not in published_body
+    assert fingerprint_for_short_id(expected[fp2], (fp1, fp2)) == fp2
+
+    inline = list(payload.get("comments") or [])
+    assert f"**{expected[fp1]}**" in inline[0]["body"]
+    assert fingerprint_for_short_id(expected[fp1], (fp1, fp2)) == fp1
+
+
+@pytest.mark.asyncio
 async def test_identical_findings_share_a_fingerprint(ctx: ToolContext) -> None:
     inline = await _submit(
         ctx,

--- a/tests/mcp/test_review.py
+++ b/tests/mcp/test_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -14,7 +15,7 @@ from mergecraft.mcp.context import (
     ResolvedPayload,
     ToolContext,
 )
-from mergecraft.mcp.review import create_pull_request_review_tool
+from mergecraft.mcp.review import create_pull_request_review_tool, format_analyzer_inline_body
 from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
 from mergecraft.modes import compute_modes
 from mergecraft.review_taxonomy import (
@@ -92,6 +93,83 @@ async def test_inline_comments_include_batch_resolved_short_id(ctx: ToolContext)
     fingerprint = finding_fingerprint(path=path, body=body)
     short_id = finding_short_id(fingerprint)
     assert short_id in inline[0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_analyzer_inline_body_keeps_single_short_id_and_fingerprint(
+    ctx: ToolContext,
+) -> None:
+    """Analyzer inline bodies already stamped with ``MC-…`` must not double-prefix."""
+    from mergecraft.analyzers.finding import make_finding, resolve_finding_short_ids
+
+    finding = make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import",
+        path="src/demo.py",
+        start_line=3,
+        end_line=3,
+        source="analyzer",
+    )
+    short_ids = resolve_finding_short_ids([finding.fingerprint])
+    short_id = short_ids[finding.fingerprint]
+    body = format_analyzer_inline_body(finding, short_id=short_id)
+    inline = await _submit(
+        ctx,
+        [
+            {
+                "path": finding.path,
+                "line": finding.start_line,
+                "body": body,
+                "fingerprint": finding.fingerprint,
+            }
+        ],
+    )
+    published = inline[0]["body"]
+    assert published.count(f"**{short_id}**") == 1
+    assert f"{FINDING_MARKER_PREFIX}{finding.fingerprint} -->" in published
+    assert len(re.findall(r"MC-[0-9a-f]{6,}", published)) == 1
+
+
+@pytest.mark.asyncio
+async def test_analyzer_inline_body_nested_finding_fingerprint_is_preserved(
+    ctx: ToolContext,
+) -> None:
+    """Nested ``finding.fingerprint`` wins over body-derived hashing at publish."""
+    from mergecraft.analyzers.finding import make_finding, resolve_finding_short_ids
+
+    finding = make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import",
+        path="src/demo.py",
+        start_line=3,
+        end_line=3,
+        source="analyzer",
+    )
+    short_ids = resolve_finding_short_ids([finding.fingerprint])
+    short_id = short_ids[finding.fingerprint]
+    body = format_analyzer_inline_body(finding, short_id=short_id)
+    inline = await _submit(
+        ctx,
+        [
+            {
+                "path": finding.path,
+                "line": finding.start_line,
+                "body": body,
+                "finding": {"fingerprint": finding.fingerprint},
+            }
+        ],
+    )
+    published = inline[0]["body"]
+    assert published.count(f"**{short_id}**") == 1
+    assert f"{FINDING_MARKER_PREFIX}{finding.fingerprint} -->" in published
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_review.py
+++ b/tests/mcp/test_review.py
@@ -77,8 +77,21 @@ async def _submit(ctx: ToolContext, comments: list[dict[str, Any]]) -> list[dict
 async def test_inline_comments_are_fingerprinted(ctx: ToolContext) -> None:
     inline = await _submit(ctx, [{"path": "src/app.py", "line": 12, "body": "A finding."}])
     expected = finding_fingerprint(path="src/app.py", body="A finding.")
-    assert inline[0]["body"].startswith("A finding.")
+    assert "A finding." in inline[0]["body"]
     assert f"{FINDING_MARKER_PREFIX}{expected} -->" in inline[0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_inline_comments_include_batch_resolved_short_id(ctx: ToolContext) -> None:
+    """Production PR inline comments surface ``MC-…`` ids for human quoting."""
+    from mergecraft.analyzers.finding import finding_short_id
+
+    body = "Unchecked null before return."
+    path = "src/util.py"
+    inline = await _submit(ctx, [{"path": path, "line": 4, "body": body}])
+    fingerprint = finding_fingerprint(path=path, body=body)
+    short_id = finding_short_id(fingerprint)
+    assert short_id in inline[0]["body"]
 
 
 @pytest.mark.asyncio

--- a/tests/review/support_durable_review.py
+++ b/tests/review/support_durable_review.py
@@ -1,0 +1,190 @@
+"""Shared helpers for CD #453 durable completed-review RED tests (D4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.analyzers.support import import_module
+from tests.analyzers.support_short_id import require_callable as require_finding_callable
+
+_COMPLETED_MOD = "mergecraft.review.completed"
+_REVIEWS_SUBDIR = ".mergecraft/reviews"
+_ARTIFACT_NAMES = ("snapshot.json", "manifest.json", "findings.json")
+
+_SAMPLE_FINGERPRINT = "a83f91c2d4e5f6a7b8c9d0e1f2a3b4c5"
+_SAMPLE_REVIEW_ID = "review-cd-fixture-001"
+
+
+def completed_module() -> Any:
+    """Return the ``mergecraft.review.completed`` module."""
+    return import_module(_COMPLETED_MOD)
+
+
+def require_attr(name: str) -> Any:
+    """Return a symbol from ``mergecraft.review.completed`` or fail the RED test."""
+    mod = completed_module()
+    value = getattr(mod, name, None)
+    assert value is not None, f"{_COMPLETED_MOD}.{name} is not implemented"
+    return value
+
+
+def require_callable(name: str) -> Any:
+    """Return a callable from ``mergecraft.review.completed`` or fail the RED test."""
+    value = require_attr(name)
+    assert callable(value), f"{_COMPLETED_MOD}.{name} must be callable"
+    return value
+
+
+def sample_review_id() -> str:
+    """Stable review id used across CD CLI fixtures."""
+    return _SAMPLE_REVIEW_ID
+
+
+def sample_fingerprint() -> str:
+    """Fingerprint backing the sample short finding id."""
+    return _SAMPLE_FINGERPRINT
+
+
+def sample_short_finding_id() -> str:
+    """Return ``MC-…`` for the sample fingerprint (CA #452 helper)."""
+    finding_short_id = require_finding_callable("finding_short_id")
+    return finding_short_id(_SAMPLE_FINGERPRINT)
+
+
+def sample_finding_dict() -> dict[str, Any]:
+    """One structured finding dict for durable-review fixtures."""
+    finding_mod = import_module("mergecraft.analyzers.finding")
+    finding = finding_mod.make_finding(
+        tool="ruff",
+        rule_id="F401",
+        category="Maintainability & Code Quality",
+        severity="Minor",
+        confidence="likely",
+        message="unused import os",
+        path="demo.py",
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+        introduced_by_pr="unknown",
+        fingerprint=_SAMPLE_FINGERPRINT,
+    )
+    return finding.model_dump()
+
+
+def sample_snapshot() -> Any:
+    """Canonical CLI ``ReviewSnapshot`` for persistence tests."""
+    snapshot_mod = import_module("mergecraft.review.snapshot")
+    return snapshot_mod.canonical_review_snapshot(entry="cli", source="tests")
+
+
+def sample_manifest() -> dict[str, Any]:
+    """Minimal run manifest payload composed into a completed review (D4)."""
+    manifest_mod = import_module("mergecraft.evidence.run_manifest")
+    return manifest_mod.build_run_manifest(
+        cwd=Path("."),
+        model="claude-opus",
+        agent_id="mergecraft",
+        prompt_text="review prompt",
+    )
+
+
+def sample_trace_events(*, review_id: str) -> list[dict[str, Any]]:
+    """Trace rows replay should read without re-running the review agent."""
+    return [
+        {
+            "session_id": review_id,
+            "kind": "span",
+            "name": "review",
+            "ts_start_ns": 1_000,
+        },
+        {
+            "session_id": review_id,
+            "kind": "span",
+            "name": "publish",
+            "ts_start_ns": 2_000,
+        },
+    ]
+
+
+def sample_evidence_packet(*, fingerprint: str | None = None) -> dict[str, Any]:
+    """Evidence packet stored beside the completed review."""
+    fp = fingerprint or _SAMPLE_FINGERPRINT
+    return {
+        "finding_id": fp,
+        "state": "unverified",
+        "kinds": ["changed_lines"],
+    }
+
+
+def completed_review_dir(repo_root: Path, review_id: str) -> Path:
+    """Expected on-disk directory for one completed review."""
+    return repo_root / _REVIEWS_SUBDIR / review_id
+
+
+def build_completed_review(*, review_id: str | None = None) -> Any:
+    """Construct a ``CompletedReview`` record for store round-trips."""
+    completed_cls = require_attr("CompletedReview")
+    rid = review_id or _SAMPLE_REVIEW_ID
+    return completed_cls(
+        review_id=rid,
+        snapshot=sample_snapshot(),
+        manifest=sample_manifest(),
+        findings=[sample_finding_dict()],
+        trace_session_id=rid,
+    )
+
+
+def seed_completed_review(
+    repo_root: Path,
+    *,
+    review_id: str | None = None,
+    evidence_packets: dict[str, dict[str, Any]] | None = None,
+    trace_events: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Persist a completed review through the public store API (CD impl)."""
+    persist = require_callable("persist_completed_review")
+    rid = review_id or _SAMPLE_REVIEW_ID
+    packets = evidence_packets
+    if packets is None:
+        packets = {sample_fingerprint(): sample_evidence_packet()}
+    events = trace_events if trace_events is not None else sample_trace_events(review_id=rid)
+    review = build_completed_review(review_id=rid)
+    return persist(
+        review,
+        repo_root=repo_root,
+        evidence_packets=packets,
+        trace_events=events,
+    )
+
+
+def artifact_paths(repo_root: Path, review_id: str) -> dict[str, Path]:
+    """Map artifact names to their expected paths under ``.mergecraft/reviews``."""
+    root = completed_review_dir(repo_root, review_id)
+    return {name: root / name for name in _ARTIFACT_NAMES}
+
+
+def read_json(path: Path) -> Any:
+    """Read JSON from ``path`` for assertions."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "artifact_paths",
+    "build_completed_review",
+    "completed_module",
+    "completed_review_dir",
+    "read_json",
+    "require_attr",
+    "require_callable",
+    "sample_evidence_packet",
+    "sample_finding_dict",
+    "sample_fingerprint",
+    "sample_manifest",
+    "sample_review_id",
+    "sample_short_finding_id",
+    "sample_snapshot",
+    "sample_trace_events",
+    "seed_completed_review",
+]

--- a/tests/review/test_durable_review_completed.py
+++ b/tests/review/test_durable_review_completed.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from tests.review.support_durable_review import (
     artifact_paths,
     build_completed_review,
@@ -25,8 +23,6 @@ from tests.review.support_durable_review import (
     sample_snapshot,
     seed_completed_review,
 )
-
-pytestmark = pytest.mark.xfail(reason="green after CD", strict=False)
 
 
 def test_persist_completed_review_writes_stable_review_id(tmp_path: Path) -> None:

--- a/tests/review/test_durable_review_completed.py
+++ b/tests/review/test_durable_review_completed.py
@@ -1,0 +1,107 @@
+"""CD #453 RED — durable completed review store (D4).
+
+Pins persistence of ``ReviewSnapshot`` + run manifest + findings + evidence so
+``findings`` / ``explain`` / ``replay`` can resolve by review id without
+re-running the review agent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.review.support_durable_review import (
+    artifact_paths,
+    build_completed_review,
+    completed_review_dir,
+    read_json,
+    require_attr,
+    require_callable,
+    sample_fingerprint,
+    sample_manifest,
+    sample_review_id,
+    sample_snapshot,
+    seed_completed_review,
+)
+
+pytestmark = pytest.mark.xfail(reason="green after CD", strict=False)
+
+
+def test_persist_completed_review_writes_stable_review_id(tmp_path: Path) -> None:
+    """Happy — persisted review id is stable and reloadable."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    load = require_callable("load_completed_review")
+    loaded = load(review_id, repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded.review_id == review_id
+
+
+def test_persist_stores_snapshot_manifest_and_findings(tmp_path: Path) -> None:
+    """D4 — durable review composes snapshot + manifest + findings on disk."""
+    review_id = sample_review_id()
+    seed_completed_review(tmp_path, review_id=review_id)
+    paths = artifact_paths(tmp_path, review_id)
+    for path in paths.values():
+        assert path.is_file(), f"missing artifact {path.name}"
+    snapshot_payload = read_json(paths["snapshot.json"])
+    manifest_payload = read_json(paths["manifest.json"])
+    findings_payload = read_json(paths["findings.json"])
+    assert snapshot_payload["entry"] == "cli"
+    assert manifest_payload["agent_id"] == "mergecraft"
+    assert isinstance(findings_payload.get("findings"), list)
+    assert findings_payload["findings"][0]["fingerprint"] == sample_fingerprint()
+
+
+def test_load_returns_none_for_unknown_review_id(tmp_path: Path) -> None:
+    """Error — unknown review ids are a miss, not a crash."""
+    load = require_callable("load_completed_review")
+    assert load("review-does-not-exist", repo_root=tmp_path) is None
+
+
+def test_load_returns_none_for_corrupt_completed_record(tmp_path: Path) -> None:
+    """Error — corrupt JSON under ``.mergecraft/reviews`` is a miss."""
+    review_id = sample_review_id()
+    root = completed_review_dir(tmp_path, review_id)
+    root.mkdir(parents=True)
+    (root / "findings.json").write_text("{not-json", encoding="utf-8")
+    load = require_callable("load_completed_review")
+    assert load(review_id, repo_root=tmp_path) is None
+
+
+def test_list_completed_review_ids_returns_persisted_ids(tmp_path: Path) -> None:
+    """Happy — operators can enumerate stored completed reviews."""
+    first = "review-cd-alpha"
+    second = "review-cd-beta"
+    seed_completed_review(tmp_path, review_id=first)
+    seed_completed_review(tmp_path, review_id=second)
+    list_ids = require_callable("list_completed_review_ids")
+    assert sorted(list_ids(repo_root=tmp_path)) == sorted([first, second])
+
+
+def test_completed_review_dir_lives_under_mergecraft_reviews(tmp_path: Path) -> None:
+    """Unit — storage root is ``<repo>/.mergecraft/reviews/<review_id>``."""
+    review_id = sample_review_id()
+    path = seed_completed_review(tmp_path, review_id=review_id)
+    expected = completed_review_dir(tmp_path, review_id)
+    assert path == expected
+    assert expected.is_relative_to(tmp_path / ".mergecraft" / "reviews")
+
+
+def test_completed_review_model_round_trips_required_fields(tmp_path: Path) -> None:
+    """Unit — ``CompletedReview`` keeps snapshot, manifest, and findings together."""
+    completed_cls = require_attr("CompletedReview")
+    review = build_completed_review()
+    assert isinstance(review, completed_cls)
+    assert review.snapshot.entry == sample_snapshot().entry
+    assert review.manifest["agent_id"] == sample_manifest()["agent_id"]
+    assert review.findings[0]["fingerprint"] == sample_fingerprint()
+    schema_version = require_attr("COMPLETED_REVIEW_SCHEMA_VERSION")
+    persist = require_callable("persist_completed_review")
+    persist(review, repo_root=tmp_path)
+    marker = completed_review_dir(tmp_path, review.review_id) / "completed.json"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == schema_version
+    assert payload["review_id"] == review.review_id

--- a/tests/review/test_finding_lookup.py
+++ b/tests/review/test_finding_lookup.py
@@ -1,0 +1,32 @@
+"""Pins for shared finding-id lookup helpers (#453)."""
+
+from __future__ import annotations
+
+from mergecraft.review.finding_lookup import lookup_packet_by_finding_id
+
+
+def test_lookup_packet_by_finding_id_matches_nested_finding_id_field() -> None:
+    """Happy — lookup falls back to packet ``finding_id`` when stem keys differ."""
+    nested_id = "legacy-finding-alias-001"
+    packets = {
+        "other-stem": {
+            "finding_id": nested_id,
+            "state": "unverified",
+            "kinds": [],
+        }
+    }
+    packet = lookup_packet_by_finding_id(nested_id, packets)
+    assert packet is not None
+    assert packet["finding_id"] == nested_id
+
+
+def test_lookup_packet_by_finding_id_prefers_direct_fingerprint_key() -> None:
+    """Happy — direct fingerprint stem wins over nested ``finding_id`` scan."""
+    fingerprint = "bbbbbbbbbbbbbbbbbbbbbbbb"
+    packets = {
+        fingerprint: {"finding_id": fingerprint, "state": "proven", "kinds": ["test"]},
+        "other": {"finding_id": fingerprint, "state": "unverified", "kinds": []},
+    }
+    packet = lookup_packet_by_finding_id(fingerprint, packets)
+    assert packet is not None
+    assert packet["state"] == "proven"

--- a/tests/review/test_finding_lookup.py
+++ b/tests/review/test_finding_lookup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from mergecraft.analyzers.finding import finding_short_id
 from mergecraft.review.finding_lookup import lookup_packet_by_finding_id
 
 
@@ -48,6 +49,28 @@ def test_lookup_packet_by_finding_id_resolves_nested_aggregate_fingerprint() -> 
         }
     }
     packet = lookup_packet_by_finding_id(fingerprint, packets)
+    assert packet is not None
+    assert packet["finding_id"] == fingerprint
+    assert packet["state"] == "proven"
+
+
+def test_lookup_packet_by_finding_id_ignores_aggregate_stems_for_short_id_resolution() -> None:
+    """Regression — aggregate packet stems must not break ``MC-…`` short-id lookup."""
+    fingerprint = "a83f91c2d4e5f6a7b8c9d0e1f2a3b4c5"
+    aggregate_stem = "local-run-001-merge-evidence-packet"
+    packets = {
+        aggregate_stem: {
+            "schema_version": "1.8.0",
+            "packets": {
+                fingerprint: {
+                    "finding_id": fingerprint,
+                    "state": "proven",
+                    "kinds": ["analyzer_findings"],
+                }
+            },
+        }
+    }
+    packet = lookup_packet_by_finding_id(finding_short_id(fingerprint), packets)
     assert packet is not None
     assert packet["finding_id"] == fingerprint
     assert packet["state"] == "proven"

--- a/tests/review/test_finding_lookup.py
+++ b/tests/review/test_finding_lookup.py
@@ -30,3 +30,24 @@ def test_lookup_packet_by_finding_id_prefers_direct_fingerprint_key() -> None:
     packet = lookup_packet_by_finding_id(fingerprint, packets)
     assert packet is not None
     assert packet["state"] == "proven"
+
+
+def test_lookup_packet_by_finding_id_resolves_nested_aggregate_fingerprint() -> None:
+    """Happy — aggregate evidence packets expose per-finding rows under ``packets``."""
+    fingerprint = "cccccccccccccccccccccccc"
+    packets = {
+        "merge-run": {
+            "schema_version": "1.8.0",
+            "packets": {
+                fingerprint: {
+                    "finding_id": fingerprint,
+                    "state": "proven",
+                    "kinds": ["analyzer_findings"],
+                }
+            },
+        }
+    }
+    packet = lookup_packet_by_finding_id(fingerprint, packets)
+    assert packet is not None
+    assert packet["finding_id"] == fingerprint
+    assert packet["state"] == "proven"


### PR DESCRIPTION
## What?

Findings get stable short IDs across every output surface, a Hunk-friendly export format, and durable completed reviews you can replay or explain by ID. Evals report per-lens capability numbers. Operators can reinstall with `mergecraft update`, see the build commit in `--version`, and rely on workflow timeouts that scale from one budget number. Init scaffolds ignore rules for local audit logs, and self-review docs name HY3 instead of DeepSeek.

- Short finding IDs (`MC-…`) appear in markdown, JSON, JSONL, PR comments, and `mergecraft explain`.
- `--output-format hunk` exports findings for Hunk with `newLine` line endings.
- Completed reviews persist under `.mergecraft/reviews/` and resolve by review id for replay and explain.
- Eval runs emit per-lens capability metrics alongside aggregate scores.
- `mergecraft update` reinstalls from GitHub; `mergecraft version` includes the git commit when available.
- Consumer workflow timeout minutes derive child step limits from the top-level job budget.
- `mergecraft init` adds `.mergecraft/audit.jsonl` to the scaffolded gitignore.

## Why?

Operators and agents need to cite the same finding across tools without copying full fingerprints or hunting ephemeral review output. Hunk integration needs a dedicated export shape. Replaying or explaining a finished review should not depend on the original terminal session still being open.

Eval authors need lens-level pass rates, not only rolled-up scores. Installations drift from git tip without a one-command refresh, and version output without a commit hash makes bug reports ambiguous. Workflow timeouts that do not compose leave child steps with stale fixed limits when the job budget changes. Local audit logs should not show up as untracked noise after init, and self-review setup copy should match the HY3 default model.

## Test plan

- [x] `make ci` (full pre-merge gate on lane C worktree)
- [x] `make lint`
- [x] `make typecheck`
- [x] Targeted pytest for findings short id, hunk export, round-trip, durable review, explain/replay by id, update/version, init gitignore, lens capability, and workflow timeout budget modules

## Related PR(s)/Issue(s)

Closes #452
Closes #451
Closes #454
Closes #453
Closes #455
Closes #473
Closes #465
Closes #486
Closes #487
