### PR TITLE
cli: operator-managed provider and model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`success` / `failure` / `neutral`); schema version 1.9.0
 - `mergecraft-approval` posts `neutral` when the evidence packet was not
   assembled, instead of omitting the check
+- Custom provider slugs not in the operator registry now fail closed instead of silently routing to OpenCode; the built-in catalog allow-list was narrowed accordingly.
+- Seeded ``tokenhub``/``minimax`` registry rows no longer shadow legacy ``TOKENHUB_API_KEY`` / ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` credentials: ``resolve_runtime_agent`` honours the same legacy fallbacks as ``has_credentials_for_slug``, and ``provider migrate`` can index those keys.
 - Repo-native analyzers no longer fall back to an arbitrary PATH binary. When
   the checkout did not provide a tool, resolution fell through to
   `shutil.which`, so a system copy ran against the consumer's code at an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,8 +11,10 @@ Pass `--help` to any invocation below for its full flag set.
 <!-- BEGIN:cli-commands -->
 | Command | Description |
 |---------|-------------|
+| `mergecraft agents addbackupmodel` | Append a registered model to an agent's backup chain. |
 | `mergecraft agents list` | List agent bindings with model chain, prompt id, and tool count. |
 | `mergecraft agents set <role>` | Write a single agent binding override into `.mergecraft/config.yaml`. |
+| `mergecraft agents setmodel` | Replace the primary model for an agent role; backups are preserved (D8). |
 | `mergecraft agents show <role>` | Show resolved prompt text and MCP tool names for one role. |
 | `mergecraft analyzers detect` | Show analyzers that would run for changed paths in this repo. |
 | `mergecraft analyzers docs` | Regenerate `ANALYZERS.md` from manifests. |
@@ -77,6 +79,9 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft memory list` | List active memory entries for a repository. |
 | `mergecraft memory show` | Show one memory entry by id. |
 | `mergecraft memory validate` | Validate the repo memory document for structure, staleness, and conflicts. |
+| `mergecraft model add <model-id>` | Register a model on a provider in config (env override optional). |
+| `mergecraft model delete <provider> <model-id>` | Remove a model from a provider (model index gap is preserved). |
+| `mergecraft model list` | List models registered on each provider. |
 | `mergecraft models list` | List curated model slugs and whether credentials are detected locally. |
 | `mergecraft models set <slugs>` | Write an ordered `models:` list to `.mergecraft/config.yaml`. |
 | `mergecraft models show` | Show effective model order, env override, and the slug that would win now. |
@@ -90,6 +95,13 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft policy simulate` | Simulate a proposed rule against past PRs. |
 | `mergecraft policy test --fixtures FIXTURES` | Run should-trigger and should-not policy fixtures. |
 | `mergecraft profile recommend --risk RISK` | Print the review profile auto-selected from `--risk`. |
+| `mergecraft provider add --label LABEL` | Register a provider in config and allocate an indexed `.env` slot. |
+| `mergecraft provider auth` | Authenticate one registered provider into indexed `LLM_PROVIDER_*` secrets. |
+| `mergecraft provider delete <label>` | Remove a provider label from config (env index gap is preserved). |
+| `mergecraft provider edit <label>` | Update an existing provider entry in config. |
+| `mergecraft provider harnesses` | List supported agent harnesses (generated from code). |
+| `mergecraft provider list` | List registered provider labels. |
+| `mergecraft provider migrate` | Migrate legacy `*_API_KEY` env vars into indexed provider registry layout (D2 / #483). |
 | `mergecraft replay` | Replay a stored review run from local traces (read-only). |
 | `mergecraft requirements explain <requirement-id>` | Explain one requirement by id; unknown ids are an error. |
 | `mergecraft requirements inspect` | List ingested requirements and their states. |
@@ -105,6 +117,12 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |
+| `mergecraft workflow agents setmodel --agent AGENT` | Wire an agent's primary model into a mergeCraft workflow step. |
+| `mergecraft workflow list` | List provider/model wiring present in mergeCraft workflow steps. |
+| `mergecraft workflow model add <model>` | Wire a registered model into `with.model` on a mergeCraft workflow step. |
+| `mergecraft workflow model prioritize` | Promote one model ahead of another in the workflow fallback chain. |
+| `mergecraft workflow provider add --label LABEL` | Register a provider and wire indexed custom-provider env keys into the workflow. |
+| `mergecraft workflow provider harnesses` | List supported agent harnesses (generated from code). |
 | `mergecraft xrepo explain` | Explain a cross-repo finding, or report producer/consumer contract breakage. |
 <!-- END:cli-commands -->
 

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -547,4 +547,4 @@ uv run pytest -q tests/cli/test_workflow_cmd.py tests/cli/test_workflow_wf_yaml.
 
 ## BG RED evidence
 
-- BG test-author wave: pending — 26 collected, 26 xfails expected; lint+typecheck clean
+- BG test-author wave: `bdde388f` — 26 collected, 23 xfails + 3 xpass; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -314,4 +314,4 @@ uv run pytest -q tests/cli/test_agents_setmodel_cmd.py  # RED: xfails expected
 
 ## BD RED evidence
 
-- BD test-author wave: pending — 15 collected, 15 xfails expected
+- BD test-author wave: `6618dba3` — 15 collected, 15 xfails; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -384,3 +384,7 @@ Shared fixtures in `tests/cli/support_provider_registry.py`:
 uv run pytest --collect-only -q tests/agents/test_registry_provider_runtime.py tests/agents/test_registry_provider_presets_removed.py
 uv run pytest -q tests/agents/test_registry_provider_runtime.py tests/agents/test_registry_provider_presets_removed.py  # RED: xfails expected
 ```
+
+## BE RED evidence
+
+- BE test-author wave: `f8ca1c23` — 28 collected, 28 xfails; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -253,3 +253,65 @@ make typecheck
 uv run pytest --collect-only -q tests/cli/test_model_cmd.py
 uv run pytest -q tests/cli/test_model_cmd.py  # RED: xfails expected
 ```
+
+## BD #480 — ``agents setmodel`` / ``addbackupmodel``
+
+Maps **BD RED** contracts for #480 (`agents setmodel` / `addbackupmodel`) to the test suite.
+
+### D8 — primary-only replacement + backup append → BD
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| ``setmodel`` replaces primary only; backups preserved | `tests/cli/test_agents_setmodel_cmd.py::test_agents_setmodel_replaces_primary_preserves_backups` | E2E |
+| ``addbackupmodel`` appends one entry | `…::test_agents_addbackupmodel_appends_to_chain` | E2E |
+| Two ``addbackupmodel`` calls yield ordered distinct backups | `…::test_agents_addbackupmodel_twice_yields_two_distinct_backups_in_order` | E2E |
+| Duplicate backup (same provider+model) rejected | `…::test_agents_addbackupmodel_rejects_duplicate_backup` | error |
+| ``agents set --model`` no longer wipes backup chain | `…::test_agents_set_preserves_backup_chain_after_model_override` | E2E / regression |
+
+### Registry validation at write time → BD
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Unregistered provider exits non-zero; config unchanged | `…::test_agents_setmodel_unregistered_provider_fails_at_write_time` | error |
+| Unregistered model exits non-zero; config unchanged | `…::test_agents_setmodel_unregistered_model_fails_at_write_time` | error |
+| ``addbackupmodel`` unregistered pair fails at write time | `…::test_agents_addbackupmodel_unregistered_pair_fails_at_write_time` | error |
+
+### CLI verbs + UX → BD
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| ``setmodel`` / ``addbackupmodel`` registered on agents app | `…::test_agents_help_lists_setmodel_and_addbackupmodel_verbs` | functional |
+| Help documents ``--provider`` / ``--model`` / ``--all`` | `…::test_agents_setmodel_help_documents_flags` | functional |
+| Unknown agent role exits non-zero and lists valid roles | `…::test_agents_setmodel_rejects_unknown_role_lists_valid_roles`, `…::test_agents_addbackupmodel_rejects_unknown_role` | error |
+| Interactive pickers when flags omitted | `…::test_agents_setmodel_interactive_picker_when_flags_omitted` | E2E |
+| ``--all`` lists overwrite targets before applying | `…::test_agents_setmodel_all_lists_targets_before_overwrite` | E2E |
+| ``AgentBindingOverride`` validation before file write | `…::test_agents_setmodel_validates_binding_before_write` | error |
+
+### Pinned public API (implementation wave BD)
+
+Extend `src/mergecraft/cli/agents_cmd.py`:
+
+- Typer subcommands: `setmodel` (`setmodel_cmd`), `addbackupmodel` (`addbackupmodel_cmd`)
+- Registry validation helper (e.g. `validate_registered_model_slug(provider, model_id)`) — fails at write time
+- Fix `set_cmd` so `--model` replaces primary only (D8 bug fix)
+
+Shared fixtures in `tests/cli/support_provider_registry.py`:
+
+- `format_model_slug`, `write_agents_model_chain`, `agents_model_chain`, `import_agents_cmd`
+
+### xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BD | all `@BD_XFAIL` / `@pytest.mark.xfail(reason="green after BD impl")` in `tests/cli/test_agents_setmodel_cmd.py` |
+
+### BD verification commands
+
+```bash
+uv run pytest --collect-only -q tests/cli/test_agents_setmodel_cmd.py
+uv run pytest -q tests/cli/test_agents_setmodel_cmd.py  # RED: xfails expected
+```
+
+## BD RED evidence
+
+- BD test-author wave: pending — 15 collected, 15 xfails expected

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -103,3 +103,149 @@ uv run pytest -q tests/cli/test_provider_cmd.py tests/cli/test_provider_registry
 ## BA RED evidence
 
 - W1 test-author wave: `97b21581` — 35 collected, 34 xfails, 1 pass (`test_providers_catalog_has_fourteen_builtin_entries`)
+
+## BB #478 — unified ``provider auth`` → BB
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `provider auth` registered on Typer app | `tests/cli/test_provider_auth_registry.py::test_provider_auth_cmd_registered_on_provider_app`, `tests/cli/test_provider_auth_cmd.py::test_provider_help_lists_auth_verb` | functional |
+| Non-interactive `provider auth <label>` writes `LLM_PROVIDER_<N>_API_KEY` | `tests/cli/test_provider_auth_cmd.py::test_provider_auth_nous_writes_indexed_api_key` | E2E |
+| Unknown label exits non-zero | `…::test_provider_auth_unknown_label_exits_nonzero` | error |
+| Re-auth overwrites indexed key in place | `…::test_provider_auth_reauth_overwrites_indexed_key_in_place` | E2E |
+| Interactive picker when label omitted | `…::test_provider_auth_interactive_picker_selects_provider`, `…::test_provider_auth_picker_lists_registered_labels_and_urls` | E2E |
+| `--scope` flag documented | `…::test_provider_auth_help_documents_scope_flag` | functional |
+
+### D6 — ``auth logfire`` stays separate → BB
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `auth logfire` remains under `mergecraft auth` | `tests/cli/test_provider_auth_cmd.py::test_auth_logfire_remains_under_auth_namespace` | functional (green) |
+| `provider auth logfire` rejected | `…::test_provider_auth_logfire_is_rejected` | error |
+| Picker excludes logfire | `…::test_provider_auth_picker_excludes_logfire` | E2E |
+
+### D10 — auth kinds / cloud_chain → BB
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `api_key` / `oauth` / `device_code` indexed suffixes | `tests/cli/test_provider_auth_registry.py::test_indexed_credential_keys_for_auth_kind[*]` | unit |
+| `resolve_auth_strategy` dispatches per kind | `…::test_resolve_auth_strategy_returns_handler_per_kind[*]` | unit |
+| Bedrock `cloud_chain` writes AWS keys, not `_API_KEY` | `tests/cli/test_provider_auth_cmd.py::test_provider_auth_bedrock_cloud_chain_writes_indexed_aws_keys[*]`, `tests/cli/test_provider_auth_registry.py::test_cloud_chain_bedrock_keys_exclude_api_key_suffix` | E2E / unit |
+| Vertex path-based credentials | `tests/cli/test_provider_auth_cmd.py::test_provider_auth_vertex_writes_credentials_path_not_api_key` | E2E |
+| Multi-line JSON guard preserved | `…::test_provider_auth_vertex_refuses_multiline_json_for_local_scope` | error |
+| Seeded built-in `authKind` defaults | `tests/cli/test_provider_auth_registry.py::test_seeded_builtin_auth_kind_defaults[*]` | unit |
+
+### D7 — legacy shim → BB
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Legacy `auth <provider>` warns and delegates to indexed write | `tests/cli/test_provider_auth_cmd.py::test_legacy_auth_commands_warn_and_write_indexed_secret[*]` | E2E |
+| Warning emitted once per process | `…::test_legacy_auth_warning_emitted_once_per_process` | unit / E2E |
+
+### Pinned public API (implementation wave BB)
+
+Extend `src/mergecraft/cli/provider_cmd.py`:
+
+- Typer subcommand: `auth` (`provider_auth_cmd`)
+- `indexed_credential_keys(entry: Mapping[str, Any]) -> Sequence[str]`
+- `resolve_auth_strategy(auth_kind: str) -> AuthStrategy`
+- `_warn_legacy_auth_once(message: str) -> None` in `auth_cmd.py` (once-per-process guard)
+
+Extend `src/mergecraft/config/provider_registry.py`:
+
+- `default_auth_kind_for_label` — add `device_code` (`openai`), `oauth` (`anthropic`)
+
+### BB xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BB | all `@BB_XFAIL` tests in `tests/cli/test_provider_auth_cmd.py` and `tests/cli/test_provider_auth_registry.py` except `test_auth_logfire_remains_under_auth_namespace` |
+
+### BB verification commands
+
+```bash
+uv run pytest --collect-only -q tests/cli/test_provider_auth_cmd.py tests/cli/test_provider_auth_registry.py
+uv run pytest -q tests/cli/test_provider_auth_cmd.py tests/cli/test_provider_auth_registry.py  # RED: xfails expected
+```
+
+## BC #479 — model add/list/delete per provider
+
+Maps **BC RED** contracts for #479 (`model add/list/delete`) to the test suite.
+
+### D2 — config source of truth + optional env override → BC
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Models stored in `.mergecraft/config.yaml` under provider `models:` | `tests/cli/test_model_cmd.py::test_model_add_writes_model_to_config_without_provider_prefix` | E2E |
+| Config is source of truth; env not written by default | `…::test_model_add_does_not_write_env_by_default` | E2E |
+| `LLM_PROVIDER_<N>_MODEL_<M>` env override optional | `…::test_model_env_override_optional` | E2E / integration |
+
+### D3 — permanent model indices → BC
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `delete` leaves a model index gap | `tests/cli/test_model_cmd.py::test_model_delete_leaves_model_index_gap_and_never_reuses` | E2E |
+| New `add` allocates `max(existing modelIndex) + 1` | `…::test_model_add_allocates_max_plus_one_model_index_with_gaps`, `…::test_allocate_model_index_returns_max_plus_one` | E2E / unit |
+| Freed model indices are never reused | `…::test_model_delete_leaves_model_index_gap_and_never_reuses`, `…::test_allocate_model_index_never_reuses_gaps` | E2E / unit |
+
+### Model id shape → BC
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Model id stored without provider prefix | `tests/cli/test_model_cmd.py::test_model_add_writes_model_to_config_without_provider_prefix`, `…::test_stored_model_rows_use_id_without_provider_prefix_field` | E2E |
+| Prefixed CLI input normalizes to unprefixed storage | `…::test_stored_model_rows_use_id_without_provider_prefix_field` | E2E |
+
+### CLI verbs → BC
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `model add/list/delete` registered | `tests/cli/test_model_cmd.py::test_model_help_lists_registry_verbs` | functional |
+| `model list` surfaces registered models | `…::test_model_list_shows_registered_models` | E2E |
+| `model delete` removes model row | `…::test_model_delete_removes_model_from_config` | E2E |
+| Unknown `--provider` fails and names registered providers | `…::test_model_add_unknown_provider_fails_and_names_registered_providers`, `…::test_model_delete_unknown_provider_fails` | error |
+| Omitting `--provider` prompts registered providers | `…::test_model_add_without_provider_prompts_registered_providers` | functional |
+| Duplicate model on same provider rejected | `…::test_model_add_rejects_duplicate_model_on_same_provider` | error |
+
+### Pinned public API (implementation wave BC)
+
+New module `src/mergecraft/cli/model_cmd.py`:
+
+- Typer subcommands: `add`, `list`, `delete`
+- Interactive provider picker when `--provider` omitted
+
+New module `src/mergecraft/config/model_registry.py` (or extend `provider_registry`):
+
+- `allocate_model_index(entries: Sequence[Mapping[str, Any]]) -> int`
+
+Config schema (`ProviderRegistryEntry` additive):
+
+```yaml
+providers:
+  - label: nous
+  url: https://…
+  harness: opencode
+  envIndex: 1
+  models:
+    - id: deepseek/deepseek-v4-flash
+      modelIndex: 1
+```
+
+Optional `.env` override keys:
+
+```dotenv
+LLM_PROVIDER_1_MODEL_1=deepseek/deepseek-v4-flash
+```
+
+### xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BC | all `@pytest.mark.xfail(reason="green after BC impl")` in `tests/cli/test_model_cmd.py` |
+
+### BC RED verification
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/cli/test_model_cmd.py
+uv run pytest -q tests/cli/test_model_cmd.py  # RED: xfails expected
+```

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -388,3 +388,79 @@ uv run pytest -q tests/agents/test_registry_provider_runtime.py tests/agents/tes
 ## BE RED evidence
 
 - BE test-author wave: `f8ca1c23` — 28 collected, 28 xfails; lint+typecheck clean
+
+## BF #483 — config/secret split + ``provider migrate``
+
+Maps **BF RED** contracts for #483 (``provider migrate``, config/secret split enforcement,
+legacy shim precedence, Bedrock/Vertex ``cloud_chain`` migration) to the test suite.
+
+### D2 — config/secret split → BF
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Structure in ``.mergecraft/config.yaml`` (providers, harness, url, region) | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_apply_writes_provider_config_and_indexed_secrets`, `…::test_provider_migrate_config_yaml_never_contains_credential_values` | E2E |
+| Secrets in ``.env`` via indexed ``LLM_PROVIDER_<N>_*`` keys | `…::test_provider_migrate_apply_writes_provider_config_and_indexed_secrets`, `tests/cli/test_provider_migrate_registry.py::test_plan_migration_lists_target_indexed_key_names_only` | E2E / unit |
+| ``.env`` must not carry harness/url/modelChain structure | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_env_never_contains_harness_or_url_structure`, `tests/cli/test_provider_migrate_registry.py::test_validate_config_secret_split_flags_structure_in_env` | E2E / error |
+| ``config.yaml`` must not contain credential values | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_config_yaml_never_contains_credential_values`, `tests/cli/test_provider_migrate_registry.py::test_validate_config_secret_split_flags_credential_in_yaml` | E2E / error |
+
+### ``provider migrate`` dry-run / apply → BF
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Dry-run is default; writes nothing | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_default_is_dry_run_no_writes` | E2E |
+| Diff prints key **names** and sources, never secret values | `…::test_provider_migrate_dry_run_prints_key_names_not_secret_values[*]`, `…::test_provider_migrate_dry_run_shows_fingerprint_not_full_secret`, `tests/cli/test_provider_migrate_registry.py::test_migration_secret_fingerprint_redacts_full_value` | E2E / unit |
+| ``--apply`` writes config + indexed env keys | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_apply_writes_provider_config_and_indexed_secrets` | E2E |
+| Idempotent re-run is a no-op | `…::test_provider_migrate_apply_idempotent_second_run_is_noop`, `tests/cli/test_provider_migrate_registry.py::test_apply_provider_migration_is_idempotent` | E2E / unit |
+| Partial manual migration completes only missing pieces | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_apply_only_fills_missing_after_partial_manual` | E2E |
+| Deterministic index allocation across machines | `…::test_provider_migrate_deterministic_index_allocation` | E2E |
+| Ambiguous ``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` refuses / prompts | `…::test_provider_migrate_ambiguous_custom_base_url_refuses_or_prompts` | error |
+
+### D7 — legacy ``*_API_KEY`` shim → BF
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Registry ``LLM_PROVIDER_<N>_API_KEY`` wins over legacy env for same provider | `tests/cli/test_provider_migrate_cmd.py::test_legacy_env_registry_key_wins_with_single_deprecation_warning`, `tests/cli/test_provider_migrate_registry.py::test_registry_credential_precedence_over_legacy_env[*]` | unit / E2E |
+| Deprecation warning names ignored legacy var; once per process | `…::test_legacy_env_registry_key_wins_with_single_deprecation_warning` | unit |
+
+### D10 — Bedrock/Vertex ``cloud_chain`` multi-secret → BF
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Bedrock maps ``AWS_*`` secrets under one ``envIndex`` (not ``_API_KEY``) | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_bedrock_maps_multi_secret_under_one_index`, `tests/cli/test_provider_migrate_registry.py::test_cloud_chain_migration_bedrock_suffixes_under_one_index` | E2E / unit |
+| Shared ``AWS_*`` vars copied, never moved/deleted; diff says so | `tests/cli/test_provider_migrate_cmd.py::test_provider_migrate_bedrock_copies_aws_vars_leaves_originals_in_place` | E2E |
+| ``AWS_REGION`` / project / location land in config | `…::test_provider_migrate_bedrock_maps_multi_secret_under_one_index`, `…::test_provider_migrate_vertex_maps_credentials_under_one_index` | E2E |
+| Vertex credentials path under one index | `…::test_provider_migrate_vertex_maps_credentials_under_one_index`, `tests/cli/test_provider_migrate_registry.py::test_cloud_chain_migration_vertex_suffixes_under_one_index` | E2E / unit |
+
+### Pinned public API (implementation wave BF)
+
+Extend `src/mergecraft/cli/provider_cmd.py`:
+
+- Typer subcommand: `migrate` (`migrate_cmd`, dry-run default, `--apply`)
+- `plan_provider_migration(env_path, config_path) -> MigrationPlan`
+- `apply_provider_migration(plan, *, env_path, config_path) -> None`
+- `migration_secret_fingerprint(value: str) -> str`
+- `validate_config_secret_split(config_path, env_path) -> list[str]`
+- `resolve_indexed_credential(entry: Mapping[str, Any]) -> str | None` — registry key wins; legacy shim warns once (D7)
+
+Shared fixtures in `tests/cli/support_provider_registry.py`:
+
+- `BF_XFAIL`, `LEGACY_API_KEY_MIGRATIONS`, `write_env_pairs`, `stub_mergecraft_env`, `require_provider_migrate_symbols`
+
+### xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BF | all `@BF_XFAIL` / `@pytest.mark.xfail(reason="green after BF impl")` in `tests/cli/test_provider_migrate_cmd.py` and `tests/cli/test_provider_migrate_registry.py` |
+
+### BF verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/cli/test_provider_migrate_cmd.py tests/cli/test_provider_migrate_registry.py
+uv run pytest -q tests/cli/test_provider_migrate_cmd.py tests/cli/test_provider_migrate_registry.py  # RED: xfails expected
+```
+
+## BF RED evidence
+
+- BF test-author wave: `47b5ad2f` — 35 collected, 35 xfails; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -102,4 +102,4 @@ uv run pytest -q tests/cli/test_provider_cmd.py tests/cli/test_provider_registry
 
 ## BA RED evidence
 
-- W1 test-author wave: pending commit
+- W1 test-author wave: `97b21581` — 35 collected, 34 xfails, 1 pass (`test_providers_catalog_has_fourteen_builtin_entries`)

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -241,10 +241,14 @@ LLM_PROVIDER_1_MODEL_1=deepseek/deepseek-v4-flash
 | --- | --- |
 | BC | all `@pytest.mark.xfail(reason="green after BC impl")` in `tests/cli/test_model_cmd.py` |
 
+## BC RED evidence
+
+- BC test-author wave: `a97b2664` — 15 collected, 15 xfails; BC test files lint clean; `make typecheck` clean
+
 ### BC RED verification
 
 ```bash
-make lint
+uv run ruff check tests/cli/test_model_cmd.py tests/cli/support_provider_registry.py
 make typecheck
 uv run pytest --collect-only -q tests/cli/test_model_cmd.py
 uv run pytest -q tests/cli/test_model_cmd.py  # RED: xfails expected

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -1,0 +1,105 @@
+# Open issues sweep 2026-08-24 lane B — BA #477 test plan
+
+Maps **BA RED** contracts for #477 (`provider add/list/edit/delete`) to the test suite.
+Source plan: `.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md`.
+
+## D2 — config/secret split → BA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Structure in `.mergecraft/config.yaml` (`providers:` list) | `tests/cli/test_provider_cmd.py::test_provider_add_writes_config_and_env_indexed_secret` | E2E |
+| Secrets in `.env` via `envIndex` (`LLM_PROVIDER_<N>`) | `…::test_provider_add_writes_config_and_env_indexed_secret` | E2E |
+| `provider list` surfaces registered labels | `…::test_provider_list_shows_registered_labels` | E2E |
+
+## D3 — permanent indices → BA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `delete` leaves an index gap | `tests/cli/test_provider_cmd.py::test_provider_delete_leaves_index_gap_and_never_reuses` | E2E |
+| New `add` allocates `max(existing) + 1` | `…::test_provider_add_allocates_max_plus_one_even_with_gaps`, `tests/cli/test_provider_registry.py::test_allocate_env_index_returns_max_plus_one` | E2E / unit |
+| Freed indices are never reused | `…::test_provider_delete_leaves_index_gap_and_never_reuses`, `tests/cli/test_provider_registry.py::test_allocate_env_index_never_reuses_gaps` | E2E / unit |
+
+## D4 — harness required, built-in defaults → BA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Custom provider without `--harness` fails and names supported values | `tests/cli/test_provider_cmd.py::test_provider_add_without_harness_fails_for_custom_provider[*]` | E2E / error |
+| Unknown `--harness` fails | `…::test_provider_add_rejects_unknown_harness` | E2E / error |
+| Built-in defaults: `openai→codex`, `anthropic→claude`, `google→gemini`, `cursor→cursor` | `…::test_builtin_provider_add_resolves_harness_without_flag[*]`, `tests/cli/test_provider_registry.py::test_builtin_harness_defaults_match_agent_resolve_table[*]` | E2E / unit |
+| Incompatible (harness, provider) pair rejected via `_harness_supports_provider` | `tests/cli/test_provider_cmd.py::test_provider_add_rejects_incompatible_harness_provider_pair`, `tests/cli/test_provider_registry.py::test_harness_support_predicate_is_reused_not_duplicated` | E2E / unit |
+| `provider harnesses` lists harnesses from code | `tests/cli/test_provider_cmd.py::test_provider_harnesses_lists_supported_values_from_code`, `tests/cli/test_provider_registry.py::test_list_supported_harnesses_is_generated_from_code` | E2E / unit |
+| Unknown provider must not silently default to `opencode` | `tests/cli/test_provider_cmd.py::test_unknown_registry_provider_does_not_default_to_opencode` | unit / error |
+
+## CLI verbs → BA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `provider add/list/edit/delete/harnesses` registered | `tests/cli/test_provider_cmd.py::test_provider_help_lists_registry_verbs` | functional |
+| `provider edit` updates config | `…::test_provider_edit_updates_url_in_config` | E2E |
+| `provider delete` removes label | `…::test_provider_delete_removes_label_from_config` | E2E |
+| Duplicate label rejected | `…::test_provider_add_rejects_duplicate_label` | error |
+| Unknown label on edit/delete exits non-zero | `…::test_provider_edit_unknown_label_exits_nonzero`, `…::test_provider_delete_unknown_label_exits_nonzero` | error |
+| Absolute http(s) URL required | `…::test_provider_add_rejects_non_http_url[*]` | error |
+
+## Seeding — `PROVIDERS` is seed data only → BA
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Built-in catalog has 14 entries (seed source) | `tests/cli/test_provider_registry.py::test_providers_catalog_has_fourteen_builtin_entries` | unit (passes pre-impl) |
+| Seeding imports all 14 built-ins with metadata | `tests/cli/test_provider_cmd.py::test_provider_seed_imports_all_builtin_catalog_entries` | integration |
+| `PROVIDERS` not consulted at runtime after seeding | `…::test_provider_registry_does_not_read_providers_dict_at_runtime` | integration |
+| Deleted built-in stays deleted (no reconcile) | `…::test_deleted_builtin_provider_is_not_reseeded_on_next_load` | functional |
+
+## Pinned public API (implementation wave BA)
+
+New module `src/mergecraft/cli/provider_cmd.py`:
+
+- Typer subcommands: `add`, `list`, `edit`, `delete`, `harnesses`
+- `list_supported_harnesses() -> Sequence[tuple[str, str] | HarnessInfo]`
+- `seed_builtin_providers(config_path: Path) -> None`
+- `load_provider_registry(config_path: Path) -> ProviderRegistry`
+- `resolve_provider_harness(label: str, *, harness: str | None) -> str`
+
+New module `src/mergecraft/config/provider_registry.py`:
+
+- `BUILTIN_HARNESS_DEFAULTS: dict[str, str]`
+- `allocate_env_index(entries: Sequence[Mapping[str, Any]]) -> int`
+- `harness_supports_provider` — alias of `mergecraft.utils.agent_resolve._harness_supports_provider`
+- `list_supported_harnesses() -> Sequence[HarnessRow]`
+
+Config schema (`src/mergecraft/config/settings.py` additive):
+
+```yaml
+providers:
+  - label: nous
+    url: https://…
+    harness: opencode
+    envIndex: 1
+    authKind: api_key   # optional; cloud_chain for Bedrock/Vertex
+```
+
+`.env` indexed keys:
+
+```dotenv
+LLM_PROVIDER_1=nous
+LLM_PROVIDER_1_API_KEY=…
+```
+
+## xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BA | all `@_XFAIL` / module-xfail tests in `tests/cli/test_provider_cmd.py` and `tests/cli/test_provider_registry.py` except `test_providers_catalog_has_fourteen_builtin_entries` |
+
+## Verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/cli/test_provider_cmd.py tests/cli/test_provider_registry.py
+uv run pytest -q tests/cli/test_provider_cmd.py tests/cli/test_provider_registry.py  # RED: xfails expected
+```
+
+## BA RED evidence
+
+- W1 test-author wave: pending commit

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -463,4 +463,4 @@ uv run pytest -q tests/cli/test_provider_migrate_cmd.py tests/cli/test_provider_
 
 ## BF RED evidence
 
-- BF test-author wave: `47b5ad2f` — 35 collected, 35 xfails; lint+typecheck clean
+- BF test-author wave: `6aafe11c` — 35 collected, 35 xfails; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -464,3 +464,87 @@ uv run pytest -q tests/cli/test_provider_migrate_cmd.py tests/cli/test_provider_
 ## BF RED evidence
 
 - BF test-author wave: `6aafe11c` — 35 collected, 35 xfails; lint+typecheck clean
+
+## BG #484 — ``workflow`` CLI mutates Action ``with:``/``env:``
+
+Maps **BG RED** contracts for #484 (``workflow`` authoring namespace, surgical YAML
+mutation, ``--dry-run`` diff, byte-stable comments, hygiene gate, missing-secret
+reporting) to the test suite.
+
+### D9 — ``workflow`` namespace, authoring vs runtime → BG
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Root ``workflow`` Typer group (not ``gha``) | `tests/cli/test_workflow_cmd.py::test_workflow_namespace_registered_on_root_app`, `…::test_workflow_help_lists_provider_model_agents_and_list_verbs` | functional |
+| ``gha`` does not expose authoring verbs | `…::test_gha_namespace_does_not_expose_workflow_authoring_verbs` | functional |
+| Runs without ``GITHUB_*`` runner env | `…::test_workflow_runs_without_github_actions_env` | E2E |
+| Authoring failures are ordinary CLI errors (no ``::error::``) | `…::test_workflow_failure_is_ordinary_cli_error_not_action_annotation` | error |
+
+### Surgical ``with:``/``env:`` mutation → BG
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Owned ``with:`` key is ``model`` only | `tests/cli/test_workflow_wf_yaml.py::test_workflow_owned_key_constants_match_registry_contract`, `…::test_apply_model_wiring_updates_with_model_key` | unit |
+| Owned ``env:`` keys are indexed ``MERGECRAFT_CUSTOM_PROVIDER_{BASE_URL,API_KEY}_<N>`` | `…::test_apply_provider_env_wiring_writes_indexed_custom_provider_keys`, `tests/cli/test_workflow_cmd.py::test_workflow_provider_add_apply_writes_owned_env_keys` | unit / E2E |
+| Byte-stable comments and timeout literals (#486 / #465) | `…::test_apply_provider_env_wiring_preserves_surrounding_comments`, `tests/cli/test_workflow_cmd.py::test_workflow_provider_add_apply_writes_owned_env_keys` | unit / E2E |
+| Only owned keys move (line-diff guard) | `tests/cli/support_provider_registry.py::assert_only_owned_workflow_keys_changed`, workflow cmd/wf_yaml apply tests | unit / E2E |
+| Refuses when no ``uses: alexhawat/mergeCraft`` step | `tests/cli/test_workflow_wf_yaml.py::test_apply_provider_env_wiring_raises_when_no_mergecraft_step`, `tests/cli/test_workflow_cmd.py::test_workflow_mutate_refuses_when_no_mergecraft_step` | error |
+| PyYAML parse-verify after surgery | implied by mutator tests + idempotency | unit |
+| No ``ruamel.yaml`` | implementation constraint (extend `tracing_logfire_wf_yaml.py` pattern) | — |
+
+### ``--dry-run`` / ``--apply`` → BG
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Default dry-run prints diff, writes nothing | `tests/cli/test_workflow_cmd.py::test_workflow_provider_add_default_dry_run_shows_diff_without_writing` | E2E |
+| ``--apply`` writes workflow file | `…::test_workflow_provider_add_apply_writes_owned_env_keys`, `…::test_workflow_model_add_updates_with_model_key` | E2E |
+| Unified diff rendering | `tests/cli/test_workflow_wf_yaml.py::test_render_workflow_diff_emits_unified_diff` | unit |
+| Default ``--workflow`` is ``.github/workflows/mergecraft.yml`` | `tests/cli/test_workflow_cmd.py::test_workflow_default_path_targets_mergecraft_yml` | functional |
+
+### Registry parity + operator guidance → BG
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| ``workflow provider harnesses`` lists harnesses from code (#477) | `tests/cli/test_workflow_cmd.py::test_workflow_provider_harnesses_lists_supported_values_from_code` | E2E |
+| Unknown harness rejected | `…::test_workflow_provider_add_rejects_unknown_harness` | error |
+| Reports GitHub secrets still required | `…::test_workflow_provider_add_reports_missing_github_secrets` | E2E |
+| ``workflow model add`` / ``agents setmodel`` / ``model prioritize`` round-trip | `…::test_workflow_model_add_updates_with_model_key`, `…::test_workflow_agents_setmodel_updates_primary_step_model`, `…::test_workflow_model_prioritize_reorders_fallback_steps` | E2E |
+| ``workflow list`` surfaces workflow state | `…::test_workflow_list_shows_provider_model_state` | E2E |
+| ``scripts/check_action_yml_hygiene.py`` stays green | `…::test_workflow_mutated_repo_passes_action_yml_hygiene_check` | integration |
+
+### Pinned public API (implementation wave BG)
+
+New module `src/mergecraft/cli/workflow_cmd.py`:
+
+- Typer app registered as ``workflow`` (not under ``gha``)
+- Subcommands: ``list``, ``provider add`` / ``provider harnesses``, ``model add`` / ``model prioritize``, ``agents setmodel``
+- ``--dry-run`` default; ``--apply`` writes; ``--workflow`` path option
+
+New module `src/mergecraft/cli/workflow_wf_yaml.py` (extend `tracing_logfire_wf_yaml.py` helpers):
+
+- ``WORKFLOW_OWNED_WITH_KEYS``, ``WORKFLOW_OWNED_ENV_PREFIXES``
+- ``WorkflowYamlError``, ``WorkflowChange``
+- ``apply_provider_env_wiring``, ``apply_model_wiring``, ``render_workflow_diff``
+
+Shared fixtures in `tests/cli/support_provider_registry.py`:
+
+- ``BG_XFAIL``, workflow templates, ``scaffold_workflow_file``, ``require_workflow_*_symbols``, ``assert_only_owned_workflow_keys_changed``
+
+### xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BG | all `@BG_XFAIL` / `@pytest.mark.xfail(reason="green after BG impl")` in `tests/cli/test_workflow_cmd.py` and `tests/cli/test_workflow_wf_yaml.py` |
+
+### BG verification commands
+
+```bash
+make lint
+make typecheck
+uv run pytest --collect-only -q tests/cli/test_workflow_cmd.py tests/cli/test_workflow_wf_yaml.py
+uv run pytest -q tests/cli/test_workflow_cmd.py tests/cli/test_workflow_wf_yaml.py  # RED: xfails expected
+```
+
+## BG RED evidence
+
+- BG test-author wave: pending — 26 collected, 26 xfails expected; lint+typecheck clean

--- a/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-24-b-provider-registry.md
@@ -315,3 +315,72 @@ uv run pytest -q tests/cli/test_agents_setmodel_cmd.py  # RED: xfails expected
 ## BD RED evidence
 
 - BD test-author wave: `6618dba3` — 15 collected, 15 xfails; lint+typecheck clean
+
+## BE #481 — Nous as ordinary registry provider
+
+Maps **BE RED** contracts for #481 (drop presets, registry-only runtime, kill opencode
+fallback) to the test suite.
+
+### D4 — unknown provider is configuration_error → BE
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Unknown slug must not infer ``opencode`` via ``_agent_mode_for_slug`` | `tests/agents/test_registry_provider_runtime.py::test_agent_mode_for_unknown_provider_raises_configuration_error` | unit / error |
+| ``resolve_harness`` fails for unregistered provider | `…::test_resolve_harness_unknown_provider_raises_configuration_error` | unit / error |
+| ``resolve_runtime_agent`` must not silently return opencode | `…::test_resolve_runtime_agent_unknown_provider_not_opencode` | integration / error |
+| Error maps to ``RunOutcome.configuration_error`` | `…::test_classify_unknown_provider_error_maps_to_configuration_error` | integration |
+| ``_harness_supports_provider`` rejects unregistered custom label | `…::test_harness_supports_provider_rejects_unregistered_custom_provider` | unit |
+
+### Registry-only Nous (harness: opencode) → BE
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Nous slug resolves via registry ``harness: opencode`` | `…::test_nous_resolves_to_opencode_via_registry_harness` | integration |
+| Indexed ``LLM_PROVIDER_<N>_API_KEY`` is the credential source | `…::test_nous_credentials_from_indexed_registry_key_only` | unit |
+| Nous without registry row is configuration error | `…::test_nous_without_registry_entry_raises_configuration_error` | error |
+| Gateway endpoint uses registry URL, not preset default | `…::test_resolve_gateway_endpoint_uses_registry_url_not_preset` | integration |
+
+### Remove presets / special-casing → BE
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| ``GATEWAY_PRESETS`` excludes nous/tokenhub/minimax | `tests/agents/test_registry_provider_presets_removed.py::test_gateway_presets_exclude_nous_tokenhub_minimax` | unit |
+| Preset env/base-url constants removed | `…::test_named_gateway_env_constants_removed[*]` | unit |
+| ``_OPENCODE_NATIVE_PROVIDERS`` excludes preset labels | `…::test_opencode_native_providers_exclude_gateway_preset_labels` | unit |
+| ``_KNOWN_CATALOG_PROVIDERS`` excludes preset labels | `…::test_known_catalog_providers_exclude_gateway_preset_labels` | unit |
+| No hardcoded nous/tokenhub/minimax branches in ``agent_resolve`` | `…::test_agent_resolve_has_no_nous_tokenhub_minimax_branches` | structural |
+
+### Harness per registry row → BE
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Each harness value honoured from registry data | `tests/agents/test_registry_provider_runtime.py::test_registry_declared_harness_respected_at_runtime[*]` | integration |
+
+### D7 — legacy ``NOUS_API_KEY`` shim → BE
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| Legacy key works with one deprecation warning per process | `…::test_legacy_nous_api_key_emits_deprecation_warning_once` | unit |
+
+### Pinned owner modules (implementation wave BE)
+
+- `src/mergecraft/utils/agent_resolve.py` — kill bare ``return "opencode"``; registry lookup; remove preset branches
+- `src/mergecraft/models.py` — ``PROVIDERS`` seed-only (no runtime special-casing)
+- `src/mergecraft/agents/openai_compatible_gateways.py` — remove ``GATEWAY_PRESETS`` nous/tokenhub/minimax rows and named env constants
+
+Shared fixtures in `tests/cli/support_provider_registry.py`:
+
+- `bootstrap_nous_registry`, `write_registry_provider_row`, `write_indexed_provider_secret`, `clear_legacy_gateway_env`
+
+### xfail reconciliation
+
+| Wave greens | Remove xfail from |
+| --- | --- |
+| BE | all `@BE_XFAIL` / `@pytest.mark.xfail(reason="green after BE impl")` in `tests/agents/test_registry_provider_runtime.py` and `tests/agents/test_registry_provider_presets_removed.py` |
+
+### BE verification commands
+
+```bash
+uv run pytest --collect-only -q tests/agents/test_registry_provider_runtime.py tests/agents/test_registry_provider_presets_removed.py
+uv run pytest -q tests/agents/test_registry_provider_runtime.py tests/agents/test_registry_provider_presets_removed.py  # RED: xfails expected
+```

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -231,7 +231,7 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
         or (vertex_id and model == vertex_id)
     ):
         extras["CLAUDE_CODE_USE_VERTEX"] = "1"
-    return build_agent_env("claude", extras)
+    return build_agent_env("claude", extras, model=ctx.resolved_model)
 
 
 def _build_claude_streaming_usage(payload: dict[str, Any]) -> AgentUsage:

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -567,7 +567,7 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
     extra: dict[str, str] = {"CODEX_HOME": str(codex_home)}
     if ctx.mcp_auth_token:
         extra[_CODEX_MCP_TOKEN_ENV] = ctx.mcp_auth_token
-    env = build_agent_env("codex", extra)
+    env = build_agent_env("codex", extra, model=ctx.resolved_model)
     _setup_codex_auth(ctx, codex_home=codex_home)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process

--- a/src/mergecraft/agents/gemini.py
+++ b/src/mergecraft/agents/gemini.py
@@ -171,7 +171,7 @@ def _normalize_gemini_api_key(env: dict[str, str]) -> None:
 
 
 def _build_env(ctx: AgentRunContext) -> dict[str, str]:
-    env = build_agent_env("gemini", {"HOME": str(Path(ctx.tmpdir))})
+    env = build_agent_env("gemini", {"HOME": str(Path(ctx.tmpdir))}, model=ctx.resolved_model)
     _normalize_gemini_api_key(env)
     return env
 

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -1,17 +1,10 @@
-"""Known OpenAI-compatible gateways (Nous Portal, Tencent TokenHub).
+"""OpenAI-compatible gateway helpers for the opencode harness.
 
-These providers are reached through the opencode harness via
-``@ai-sdk/openai-compatible``. Callers may still set
-``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` + ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY``
-to override any preset; when those are absent, model prefixes ``nous/`` and
-``tokenhub/`` resolve from ``NOUS_API_KEY`` / ``TOKENHUB_API_KEY``.
-
-W3 (issue #71) extends the contract so a workflow can wire several
-OpenAI-compatible providers simultaneously — each addressed by an indexed
-``MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`` env-var pair (operator
-locked). The single-provider shape (and the named-preset paths) are
-preserved; the multi-provider resolver adds a dict-valued surface that both
-``agents/opencode.py`` and ``agents/codex.py`` consume.
+Operators configure providers through the registry (``.mergecraft/config.yaml``
+``providers:`` + indexed ``LLM_PROVIDER_<N>_API_KEY`` secrets). The singleton
+``MERGECRAFT_CUSTOM_PROVIDER_{BASE_URL,API_KEY}`` pair and indexed
+``MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`` env vars remain as
+generic OpenAI-compatible escape hatches for advanced deployments.
 """
 
 from __future__ import annotations
@@ -20,6 +13,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 from urllib.parse import urlparse
 
@@ -31,28 +25,10 @@ from pydantic.functional_validators import BeforeValidator
 if TYPE_CHECKING:
     from mergecraft.tracing.genai import ModelParams
 
-NOUS_API_KEY_ENV = "NOUS_API_KEY"
-NOUS_BASE_URL_ENV = "NOUS_BASE_URL"
-DEFAULT_NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
-
-TOKENHUB_API_KEY_ENV = "TOKENHUB_API_KEY"
-TOKENHUB_BASE_URL_ENV = "TOKENHUB_BASE_URL"
-DEFAULT_TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
-
 CUSTOM_PROVIDER_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
 CUSTOM_PROVIDER_API_KEY_ENV = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY"
 CUSTOM_PROVIDER_EXTRA_OPTIONS_ENV = "MERGECRAFT_CUSTOM_PROVIDER_EXTRA_OPTIONS"
 PROVIDER_EXTRA_OPTIONS_ENV = "MERGECRAFT_PROVIDER_EXTRA_OPTIONS"
-
-# W6 (#34): MiniMax is reachable through the existing custom-provider helper
-# (operator-locked D10 / option ii). The alias env vars re-use the D7
-# singleton names so the operator's mental model stays uniform with the
-# generic custom-provider surface; the default base URL pins the
-# OpenAI-compatible endpoint documented at
-# https://platform.minimax.io/docs/api-reference/text-openai-api.md.
-MINIMAX_API_KEY_ENV = CUSTOM_PROVIDER_API_KEY_ENV
-MINIMAX_BASE_URL_ENV = CUSTOM_PROVIDER_BASE_URL_ENV
-DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 
 # Indexed multi-provider convention (W3 / issue #71). Both halves must be
 # set per index; partial pairs are dropped. Discovery enumerates every
@@ -141,6 +117,21 @@ class ProviderConfig(BaseModel):
         return stripped
 
 
+@dataclass(frozen=True, slots=True)
+class GatewayPreset:
+    """One named OpenAI-compatible inference gateway (seed metadata only)."""
+
+    provider_id: str
+    api_key_env: str
+    base_url_env: str
+    default_base_url: str
+
+
+# Named gateway presets were removed in BE #481 — operators register providers
+# in config instead. The dict remains for typing/back-compat imports.
+GATEWAY_PRESETS: dict[str, GatewayPreset] = {}
+
+
 def require_capabilities(config: ProviderConfig, required: frozenset[str]) -> None:
     """Fail closed when ``config`` lacks a declared capability (D12).
 
@@ -156,38 +147,6 @@ def require_capabilities(config: ProviderConfig, required: frozenset[str]) -> No
         raise _ConfigurationError(msg)
 
 
-@dataclass(frozen=True, slots=True)
-class GatewayPreset:
-    """One named OpenAI-compatible inference gateway."""
-
-    provider_id: str
-    api_key_env: str
-    base_url_env: str
-    default_base_url: str
-
-
-GATEWAY_PRESETS: dict[str, GatewayPreset] = {
-    "nous": GatewayPreset(
-        provider_id="nous",
-        api_key_env=NOUS_API_KEY_ENV,
-        base_url_env=NOUS_BASE_URL_ENV,
-        default_base_url=DEFAULT_NOUS_BASE_URL,
-    ),
-    "tokenhub": GatewayPreset(
-        provider_id="tokenhub",
-        api_key_env=TOKENHUB_API_KEY_ENV,
-        base_url_env=TOKENHUB_BASE_URL_ENV,
-        default_base_url=DEFAULT_TOKENHUB_BASE_URL,
-    ),
-    "minimax": GatewayPreset(
-        provider_id="minimax",
-        api_key_env=MINIMAX_API_KEY_ENV,
-        base_url_env=MINIMAX_BASE_URL_ENV,
-        default_base_url=DEFAULT_MINIMAX_BASE_URL,
-    ),
-}
-
-
 def _has_env(name: str) -> bool:
     val = os.environ.get(name)
     return isinstance(val, str) and bool(val.strip())
@@ -199,22 +158,14 @@ def has_custom_provider_env() -> bool:
 
 
 def has_gateway_credentials(provider_id: str) -> bool:
-    """Return whether ``provider_id`` can authenticate from the environment.
-
-    For ``nous``, ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` is honoured as a
-    back-compat alias even when ``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL`` is
-    unset — the opencode harness contract re-passes ``NOUS_API_KEY`` as
-    ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` on the Nous step, so a workflow
-    that wires the alias alone should still resolve credentials (D4).
-    """
+    """Return whether ``provider_id`` can authenticate from generic custom env."""
     if has_custom_provider_env():
         return True
-    preset = GATEWAY_PRESETS.get(provider_id.lower())
-    if preset is None:
-        return False
-    if _has_env(preset.api_key_env):
-        return True
-    return bool(provider_id.lower() == "nous" and _has_env(CUSTOM_PROVIDER_API_KEY_ENV))
+    from mergecraft.config.runtime_provider_registry import has_registry_credentials
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    return has_registry_credentials(settings, provider_id.lower())
 
 
 def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
@@ -222,8 +173,8 @@ def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
 
     Preference order:
 
-    1. Explicit ``MERGECRAFT_CUSTOM_PROVIDER_*`` pair (any ``provider/model`` slug)
-    2. Named preset matching the model prefix (``nous/…``, ``tokenhub/…``)
+    1. Operator registry row for the model prefix
+    2. Explicit ``MERGECRAFT_CUSTOM_PROVIDER_*`` pair (any ``provider/model`` slug)
 
     Returns ``None`` when credentials or a usable model prefix are missing.
     """
@@ -237,19 +188,20 @@ def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
     if not model_id:
         return None
 
+    from mergecraft.config.runtime_provider_registry import resolve_registry_gateway_endpoint
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    registry_endpoint = resolve_registry_gateway_endpoint(model, settings=settings)
+    if registry_endpoint is not None:
+        return registry_endpoint
+
     custom_base = os.environ.get(CUSTOM_PROVIDER_BASE_URL_ENV, "").strip()
     custom_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()
     if custom_base and custom_key:
         return provider_id, custom_base, custom_key
 
-    preset = GATEWAY_PRESETS.get(provider_id)
-    if preset is None:
-        return None
-    api_key = os.environ.get(preset.api_key_env, "").strip()
-    if not api_key:
-        return None
-    base_url = os.environ.get(preset.base_url_env, "").strip() or preset.default_base_url
-    return provider_id, base_url, api_key
+    return None
 
 
 def _parse_extra_options_env(env_name: str) -> dict[str, Any]:
@@ -413,15 +365,29 @@ def _provider_config_for_model(model: str) -> ProviderConfig | None:
     if resolved is None:
         return None
     preset_provider_id, base_url, _api_key = resolved
-    preset = GATEWAY_PRESETS.get(preset_provider_id)
-    if preset is None:
-        return None
+    api_key_env = (
+        f"LLM_PROVIDER_{_registry_env_index_for_provider(preset_provider_id)}_API_KEY"
+        if _registry_env_index_for_provider(preset_provider_id) is not None
+        else CUSTOM_PROVIDER_API_KEY_ENV
+    )
     return ProviderConfig(
         provider_id=preset_provider_id,
         base_url=base_url,
-        api_key_env=preset.api_key_env,
+        api_key_env=api_key_env,
         extra_options=_extra_options_for_provider(preset_provider_id),
     )
+
+
+def _registry_env_index_for_provider(provider_id: str) -> int | None:
+    from mergecraft.config.runtime_provider_registry import lookup_registry_entry
+    from mergecraft.config.settings import load_repo_settings
+
+    entry = lookup_registry_entry(
+        load_repo_settings(root=Path.cwd(), load_learnings_files=False), provider_id
+    )
+    if entry is None:
+        return None
+    return entry.env_index
 
 
 def resolve_model_params_for_model(model: str | None) -> ModelParams | None:
@@ -441,17 +407,8 @@ __all__ = [
     "CAPABILITY_VALUES",
     "CUSTOM_PROVIDER_API_KEY_ENV",
     "CUSTOM_PROVIDER_BASE_URL_ENV",
-    "DEFAULT_MINIMAX_BASE_URL",
-    "DEFAULT_NOUS_BASE_URL",
-    "DEFAULT_TOKENHUB_BASE_URL",
     "GATEWAY_PRESETS",
-    "MINIMAX_API_KEY_ENV",
-    "MINIMAX_BASE_URL_ENV",
-    "NOUS_API_KEY_ENV",
-    "NOUS_BASE_URL_ENV",
     "SINGLETON_PROVIDER_ID",
-    "TOKENHUB_API_KEY_ENV",
-    "TOKENHUB_BASE_URL_ENV",
     "GatewayPreset",
     "ProviderConfig",
     "has_custom_provider_env",

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -37,6 +37,7 @@ PROVIDER_EXTRA_OPTIONS_ENV = "MERGECRAFT_PROVIDER_EXTRA_OPTIONS"
 # (no renumbering).
 INDEXED_CUSTOM_PROVIDER_BASE_URL_RE = re.compile(r"^MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_(\d+)$")
 INDEXED_CUSTOM_PROVIDER_API_KEY_RE = re.compile(r"^MERGECRAFT_CUSTOM_PROVIDER_API_KEY_(\d+)$")
+INDEXED_LLM_PROVIDER_API_KEY_RE = re.compile(r"^LLM_PROVIDER_(\d+)_API_KEY$")
 INDEXED_CUSTOM_PROVIDER_EXTRA_OPTIONS_FMT = "MERGECRAFT_CUSTOM_PROVIDER_EXTRA_OPTIONS_{n}"
 # Provider-id derivation rule (operator locked): ``"provider_" + str(N)`` for
 # indexed pairs; ``"default"`` for the singleton back-compat alias.
@@ -349,17 +350,28 @@ def _resolve_indexed_providers() -> dict[str, ProviderConfig]:
                 continue
             base_url, api_key = by_index.get(n, ("", ""))
             by_index[n] = (base_url, stripped)
+            continue
+        match = INDEXED_LLM_PROVIDER_API_KEY_RE.match(key)
+        if match is not None:
+            n = int(match.group(1))
+            stripped = value.strip()
+            if not stripped:
+                continue
+            base_url, api_key = by_index.get(n, ("", ""))
+            by_index[n] = (base_url, stripped)
     out: dict[str, ProviderConfig] = {}
     for n in sorted(by_index):
         base_url, api_key = by_index[n]
         if not base_url or not api_key:
             # Partial pair — drop silently.
             continue
-        provider_id = INDEXED_PROVIDER_ID_FMT.format(n=n)
+        from mergecraft.config.runtime_provider_registry import _provider_id_for_env_index
+
+        provider_id = _provider_id_for_env_index(n)
         out[provider_id] = _provider_config_from_env_pair(
             provider_id=provider_id,
             base_url=base_url,
-            api_key_env=f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}",
+            api_key_env=f"LLM_PROVIDER_{n}_API_KEY",
             extra_options_env=INDEXED_CUSTOM_PROVIDER_EXTRA_OPTIONS_FMT.format(n=n),
         )
     return out

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
@@ -131,6 +132,62 @@ class GatewayPreset:
 # in config instead. The dict remains for typing/back-compat imports.
 GATEWAY_PRESETS: dict[str, GatewayPreset] = {}
 
+# Deprecated compatibility window: legacy ``mergecraft auth tokenhub`` /
+# ``mergecraft auth minimax`` still write singleton env keys that must resolve
+# until operators migrate to the registry. Constants stay module-private (BE #481).
+_LEGACY_TOKENHUB_API_KEY_ENV = "TOKENHUB_API_KEY"
+_LEGACY_TOKENHUB_BASE_URL_ENV = "TOKENHUB_BASE_URL"
+_LEGACY_DEFAULT_TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+_LEGACY_DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+_LEGACY_GATEWAY_PRESETS: dict[str, GatewayPreset] = {
+    "tokenhub": GatewayPreset(
+        provider_id="tokenhub",
+        api_key_env=_LEGACY_TOKENHUB_API_KEY_ENV,
+        base_url_env=_LEGACY_TOKENHUB_BASE_URL_ENV,
+        default_base_url=_LEGACY_DEFAULT_TOKENHUB_BASE_URL,
+    ),
+    "minimax": GatewayPreset(
+        provider_id="minimax",
+        api_key_env=CUSTOM_PROVIDER_API_KEY_ENV,
+        base_url_env=CUSTOM_PROVIDER_BASE_URL_ENV,
+        default_base_url=_LEGACY_DEFAULT_MINIMAX_BASE_URL,
+    ),
+}
+
+_LEGACY_PRESET_WARNED: set[str] = set()
+
+
+def _warn_legacy_gateway_preset_once(provider_id: str) -> None:
+    if provider_id in _LEGACY_PRESET_WARNED:
+        return
+    _LEGACY_PRESET_WARNED.add(provider_id)
+    warnings.warn(
+        f"{provider_id} legacy env credentials are deprecated; use "
+        f"`mergecraft provider auth {provider_id}` to write indexed secrets.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _legacy_gateway_preset_credentials(provider_id: str) -> bool:
+    preset = _LEGACY_GATEWAY_PRESETS.get(provider_id.lower())
+    if preset is None:
+        return False
+    return _has_env(preset.api_key_env)
+
+
+def _resolve_legacy_gateway_preset(provider_id: str) -> tuple[str, str, str] | None:
+    preset = _LEGACY_GATEWAY_PRESETS.get(provider_id)
+    if preset is None:
+        return None
+    api_key = os.environ.get(preset.api_key_env, "").strip()
+    if not api_key:
+        return None
+    base_url = os.environ.get(preset.base_url_env, "").strip() or preset.default_base_url
+    _warn_legacy_gateway_preset_once(provider_id)
+    return provider_id, base_url, api_key
+
 
 def require_capabilities(config: ProviderConfig, required: frozenset[str]) -> None:
     """Fail closed when ``config`` lacks a declared capability (D12).
@@ -165,7 +222,9 @@ def has_gateway_credentials(provider_id: str) -> bool:
     from mergecraft.config.settings import load_repo_settings
 
     settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
-    return has_registry_credentials(settings, provider_id.lower())
+    if has_registry_credentials(settings, provider_id.lower()):
+        return True
+    return _legacy_gateway_preset_credentials(provider_id)
 
 
 def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
@@ -200,6 +259,10 @@ def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
     custom_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()
     if custom_base and custom_key:
         return provider_id, custom_base, custom_key
+
+    legacy_endpoint = _resolve_legacy_gateway_preset(provider_id)
+    if legacy_endpoint is not None:
+        return legacy_endpoint
 
     return None
 

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -248,13 +248,23 @@ def resolve_gateway_endpoint(model: str | None) -> tuple[str, str, str] | None:
     if not model_id:
         return None
 
-    from mergecraft.config.runtime_provider_registry import resolve_registry_gateway_endpoint
+    from mergecraft.config.runtime_provider_registry import (
+        resolve_legacy_nous_gateway_endpoint,
+        resolve_registry_gateway_endpoint,
+    )
     from mergecraft.config.settings import load_repo_settings
 
     settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
     registry_endpoint = resolve_registry_gateway_endpoint(model, settings=settings)
     if registry_endpoint is not None:
         return registry_endpoint
+
+    legacy_nous_endpoint = resolve_legacy_nous_gateway_endpoint(
+        provider_id,
+        settings=settings,
+    )
+    if legacy_nous_endpoint is not None:
+        return legacy_nous_endpoint
 
     custom_base = os.environ.get(CUSTOM_PROVIDER_BASE_URL_ENV, "").strip()
     custom_key = os.environ.get(CUSTOM_PROVIDER_API_KEY_ENV, "").strip()

--- a/src/mergecraft/agents/openai_compatible_gateways.py
+++ b/src/mergecraft/agents/openai_compatible_gateways.py
@@ -333,6 +333,21 @@ def _provider_config_from_env_pair(
     )
 
 
+def _indexed_api_key_env(n: int) -> str | None:
+    """Return the env-var name holding the API key for index *n*, if any.
+
+    ``LLM_PROVIDER_<N>_API_KEY`` wins when both indexed key surfaces are set;
+    otherwise fall back to ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY_<N>`` (D16).
+    """
+    llm_key = f"LLM_PROVIDER_{n}_API_KEY"
+    if os.environ.get(llm_key, "").strip():
+        return llm_key
+    workflow_key = f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}"
+    if os.environ.get(workflow_key, "").strip():
+        return workflow_key
+    return None
+
+
 def _resolve_indexed_providers() -> dict[str, ProviderConfig]:
     """Enumerate ``MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_<N>`` pairs.
 
@@ -341,38 +356,19 @@ def _resolve_indexed_providers() -> dict[str, ProviderConfig]:
     dropped, never half-emitted. The numeric ordering of indices is
     preserved — gaps are not renumbered.
     """
-    by_index: dict[int, tuple[str, str]] = {}
+    by_index: dict[int, str] = {}
     for key, value in os.environ.items():
         match = INDEXED_CUSTOM_PROVIDER_BASE_URL_RE.match(key)
         if match is not None:
             n = int(match.group(1))
             stripped = value.strip()
-            if not stripped:
-                continue
-            base_url, api_key = by_index.get(n, ("", ""))
-            by_index[n] = (stripped, api_key)
-            continue
-        match = INDEXED_CUSTOM_PROVIDER_API_KEY_RE.match(key)
-        if match is not None:
-            n = int(match.group(1))
-            stripped = value.strip()
-            if not stripped:
-                continue
-            base_url, api_key = by_index.get(n, ("", ""))
-            by_index[n] = (base_url, stripped)
-            continue
-        match = INDEXED_LLM_PROVIDER_API_KEY_RE.match(key)
-        if match is not None:
-            n = int(match.group(1))
-            stripped = value.strip()
-            if not stripped:
-                continue
-            base_url, api_key = by_index.get(n, ("", ""))
-            by_index[n] = (base_url, stripped)
+            if stripped:
+                by_index[n] = stripped
     out: dict[str, ProviderConfig] = {}
     for n in sorted(by_index):
-        base_url, api_key = by_index[n]
-        if not base_url or not api_key:
+        base_url = by_index[n]
+        api_key_env = _indexed_api_key_env(n)
+        if not base_url or api_key_env is None:
             # Partial pair — drop silently.
             continue
         from mergecraft.config.runtime_provider_registry import _provider_id_for_env_index
@@ -381,7 +377,7 @@ def _resolve_indexed_providers() -> dict[str, ProviderConfig]:
         out[provider_id] = _provider_config_from_env_pair(
             provider_id=provider_id,
             base_url=base_url,
-            api_key_env=f"LLM_PROVIDER_{n}_API_KEY",
+            api_key_env=api_key_env,
             extra_options_env=INDEXED_CUSTOM_PROVIDER_EXTRA_OPTIONS_FMT.format(n=n),
         )
     return out

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -250,7 +250,7 @@ def build_custom_provider(model: str | None) -> dict[str, object] | None:
        This preserves the W1.1 single-provider regression pin's emitted
        shape: a singleton + ``nous/...`` model still produces a
        ``provider.nous`` block, not a ``provider.default`` one.
-    2. **Registry rows**: indexed ``LLM_PROVIDER_<N>_*`` credentials plus optional
+    3. **Registry rows**: indexed ``LLM_PROVIDER_<N>_*`` credentials plus optional
        ``MERGECRAFT_CUSTOM_PROVIDER_*`` workflow env (GHA injects secrets there).
     """
     providers = resolve_gateway_endpoints()

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -250,8 +250,8 @@ def build_custom_provider(model: str | None) -> dict[str, object] | None:
        This preserves the W1.1 single-provider regression pin's emitted
        shape: a singleton + ``nous/...`` model still produces a
        ``provider.nous`` block, not a ``provider.default`` one.
-    3. **Named presets**: ``nous/*`` via ``NOUS_API_KEY``, ``tokenhub/*`` via
-       ``TOKENHUB_API_KEY`` (optional ``NOUS_BASE_URL`` / ``TOKENHUB_BASE_URL``).
+    2. **Registry rows**: indexed ``LLM_PROVIDER_<N>_*`` credentials plus optional
+       ``MERGECRAFT_CUSTOM_PROVIDER_*`` workflow env (GHA injects secrets there).
     """
     providers = resolve_gateway_endpoints()
     slash = model.find("/") if model else -1

--- a/src/mergecraft/cli/agents_cmd.py
+++ b/src/mergecraft/cli/agents_cmd.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import typer
-import yaml
 from rich.table import Table
 
 from mergecraft.agents.registry import (
@@ -16,7 +16,21 @@ from mergecraft.agents.registry import (
 )
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.model_cmd import (
+    _find_provider_index,
+    _model_id_from_row,
+    _model_rows,
+    _registered_labels,
+    _unknown_provider_message,
+)
+from mergecraft.cli.provider_cmd import (
+    _config_path,
+    _load_config_dict,
+    _provider_entries,
+    _write_config_dict,
+)
 from mergecraft.cli.target_dir import target_dir as resolve_target_dir
+from mergecraft.config.model_registry import normalize_model_id
 from mergecraft.config.settings import AgentBindingOverride, load_repo_settings
 from mergecraft.mcp.context import (
     PayloadEvent,
@@ -58,6 +72,152 @@ def _tool_ctx(target_dir: Path) -> ToolContext:
         xrepo=XrepoConfig(mode="explicit", read=[], write=[]),
         static_checks_enabled=True,
     )
+
+
+def _known_roles_message() -> str:
+    return ", ".join(item.value for item in AgentRole)
+
+
+def _validate_role_key(role: str) -> str:
+    role_key = role.strip().lower()
+    try:
+        AgentRole(role_key)
+    except ValueError:
+        cli_bail(f"unknown role: {role!r} (expected one of: {_known_roles_message()})")
+    return role_key
+
+
+def _model_chain_from_entry(entry: dict[str, Any]) -> list[str]:
+    chain = entry.get("modelChain")
+    if chain is None:
+        return []
+    if not isinstance(chain, list):
+        cli_bail("modelChain must be a list")
+    return [str(item) for item in chain]
+
+
+def _replace_primary_in_entry(entry: dict[str, Any], new_primary: str) -> None:
+    chain = _model_chain_from_entry(entry)
+    if chain:
+        entry["modelChain"] = [new_primary, *chain[1:]]
+    else:
+        entry["modelChain"] = [new_primary]
+
+
+def _append_backup_to_entry(entry: dict[str, Any], backup_slug: str) -> None:
+    chain = _model_chain_from_entry(entry)
+    if backup_slug in chain:
+        cli_bail(f"duplicate model {backup_slug!r} already in chain")
+    if not chain:
+        cli_bail("cannot add backup model — set a primary model first")
+    entry["modelChain"] = [*chain, backup_slug]
+
+
+def format_model_slug(provider_label: str, model_id: str) -> str:
+    """Return ``provider/model`` slug for agent ``modelChain`` entries (#480)."""
+    return f"{provider_label.strip().lower()}/{model_id}"
+
+
+def validate_registered_model_slug(
+    data: dict[str, Any],
+    provider_label: str,
+    model_id: str,
+) -> str:
+    """Validate *provider_label* / *model_id* against the operator registry (#480)."""
+    entries = _provider_entries(data)
+    labels = _registered_labels(entries)
+    provider_label = provider_label.strip()
+    provider_idx = _find_provider_index(entries, provider_label)
+    if provider_idx is None:
+        cli_bail(_unknown_provider_message(provider_label, labels))
+
+    entry = entries[provider_idx]
+    provider_name = str(entry.get("label", provider_label))
+    normalised_id = normalize_model_id(provider_name, model_id)
+    if not normalised_id:
+        cli_bail("model id must not be empty")
+
+    for row in _model_rows(entry):
+        if _model_id_from_row(row) == normalised_id:
+            return format_model_slug(provider_name, normalised_id)
+
+    msg = (
+        f"unregistered model {normalised_id!r} on provider {provider_name!r} — "
+        "run mergecraft model add first"
+    )
+    cli_bail(msg)
+    return ""  # unreachable — cli_bail exits
+
+
+def validate_agent_binding_override(entry: dict[str, Any]) -> AgentBindingOverride:
+    """Round-trip *entry* through Pydantic before persisting agent overrides."""
+    return AgentBindingOverride.model_validate(entry)
+
+
+def _load_agents_block(config_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not config_path.is_file():
+        cli_bail(f"no config at {config_path} — run mergecraft init first")
+    raw = _load_config_dict(config_path)
+    agents = raw.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        cli_bail("agents block must be a mapping")
+    return raw, agents
+
+
+def _agent_entry(agents: dict[str, Any], role_key: str) -> dict[str, Any]:
+    entry = agents.setdefault(role_key, {})
+    if not isinstance(entry, dict):
+        cli_bail(f"agents.{role_key} must be a mapping")
+    return entry
+
+
+def _prompt_agent_role() -> str:
+    choices = _known_roles_message()
+    return _validate_role_key(str(typer.prompt(f"agent role ({choices})")))
+
+
+def _prompt_provider(labels: list[str]) -> str:
+    choices = ", ".join(labels)
+    return str(typer.prompt(f"provider ({choices})"))
+
+
+def _prompt_model() -> str:
+    return str(typer.prompt("model id"))
+
+
+def _configured_agent_roles(agents: dict[str, Any]) -> list[str]:
+    roles: list[str] = []
+    for key in sorted(agents):
+        if not isinstance(agents.get(key), dict):
+            continue
+        try:
+            AgentRole(key)
+        except ValueError:
+            continue
+        roles.append(key)
+    return roles
+
+
+def _resolve_provider_model(
+    data: dict[str, Any],
+    *,
+    provider: str | None,
+    model: str | None,
+) -> str:
+    entries = _provider_entries(data)
+    labels = _registered_labels(entries)
+    if not labels:
+        cli_bail("no providers registered — run mergecraft provider add first")
+
+    provider_label = provider
+    if provider_label is None:
+        provider_label = _prompt_provider(labels)
+
+    model_id = model
+    if model_id is None:
+        model_id = _prompt_model()
+
+    return validate_registered_model_slug(data, provider_label, model_id)
 
 
 @app.command("list")
@@ -139,34 +299,92 @@ def set_cmd(
     if model is None:
         cli_bail("pass at least one override flag (e.g. --model)")
 
-    role_key = role.lower()
-    try:
-        AgentRole(role_key)
-    except ValueError:
-        known = ", ".join(item.value for item in AgentRole)
-        cli_bail(f"unknown role: {role!r} (expected one of: {known})")
-
+    role_key = _validate_role_key(role)
     target_dir = resolve_target_dir(cwd)
-    config_path = target_dir / ".mergecraft" / "config.yaml"
-    if not config_path.is_file():
-        cli_bail(f"no config at {config_path} — run mergecraft init first")
-
-    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict):
-        cli_bail(f"config must be a mapping: {config_path}")
-
-    agents = raw.setdefault("agents", {})
-    if not isinstance(agents, dict):
-        cli_bail("agents block must be a mapping")
-
-    entry = agents.setdefault(role_key, {})
-    if not isinstance(entry, dict):
-        cli_bail(f"agents.{role_key} must be a mapping")
+    config_path = _config_path(target_dir)
+    raw, agents = _load_agents_block(config_path)
+    entry = _agent_entry(agents, role_key)
 
     if model is not None:
-        entry["modelChain"] = [model]
+        _replace_primary_in_entry(entry, model)
 
-    # Validate the override round-trips through Pydantic before writing.
-    AgentBindingOverride.model_validate(entry)
-    config_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    validate_agent_binding_override(entry)
+    _write_config_dict(config_path, raw)
     console.print(f"[green]updated agents.{role_key} in {config_path}[/green]")
+
+
+@app.command("setmodel")
+def setmodel_cmd(
+    agent: str | None = typer.Option(None, "--agent", help="Agent role to update."),
+    provider: str | None = typer.Option(None, "--provider", help="Registered provider label."),
+    model: str | None = typer.Option(None, "--model", help="Registered model id."),
+    all_agents: bool = typer.Option(
+        False,
+        "--all",
+        help="Replace primary model on every configured agent role.",
+    ),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
+) -> None:
+    """Replace the primary model for an agent role; backups are preserved (D8)."""
+    if all_agents and agent is not None:
+        cli_bail("pass either --agent or --all, not both")
+
+    target_dir = resolve_target_dir(cwd)
+    config_path = _config_path(target_dir)
+    raw, agents = _load_agents_block(config_path)
+
+    slug = _resolve_provider_model(raw, provider=provider, model=model)
+
+    if all_agents:
+        role_keys = _configured_agent_roles(agents)
+        if not role_keys:
+            cli_bail("no configured agent roles — set agents.<role> in config first")
+        for role_key in role_keys:
+            console.print(f"updating primary model for agent [bold]{role_key}[/bold]")
+            entry = _agent_entry(agents, role_key)
+            _replace_primary_in_entry(entry, slug)
+            validate_agent_binding_override(entry)
+        _write_config_dict(config_path, raw)
+        console.print(f"[green]updated primary model for {len(role_keys)} agent role(s)[/green]")
+        return
+
+    role_key = _prompt_agent_role() if agent is None else _validate_role_key(agent)
+
+    entry = _agent_entry(agents, role_key)
+    _replace_primary_in_entry(entry, slug)
+    validate_agent_binding_override(entry)
+    _write_config_dict(config_path, raw)
+    console.print(f"[green]updated primary model for agents.{role_key}[/green]")
+
+
+@app.command("addbackupmodel")
+def addbackupmodel_cmd(
+    agent: str | None = typer.Option(None, "--agent", help="Agent role to update."),
+    provider: str | None = typer.Option(None, "--provider", help="Registered provider label."),
+    model: str | None = typer.Option(None, "--model", help="Registered model id."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Working directory."),
+) -> None:
+    """Append a registered model to an agent's backup chain."""
+    target_dir = resolve_target_dir(cwd)
+    config_path = _config_path(target_dir)
+    raw, agents = _load_agents_block(config_path)
+
+    slug = _resolve_provider_model(raw, provider=provider, model=model)
+
+    role_key = _prompt_agent_role() if agent is None else _validate_role_key(agent)
+
+    entry = _agent_entry(agents, role_key)
+    _append_backup_to_entry(entry, slug)
+    validate_agent_binding_override(entry)
+    _write_config_dict(config_path, raw)
+    console.print(f"[green]appended backup model to agents.{role_key}[/green]")
+
+
+__all__ = [
+    "addbackupmodel_cmd",
+    "app",
+    "format_model_slug",
+    "setmodel_cmd",
+    "validate_agent_binding_override",
+    "validate_registered_model_slug",
+]

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -40,6 +40,7 @@ from mergecraft.cli import (
     plan_cmd,
     policy_cmd,
     profile_cmd,
+    provider_cmd,
     replay_cmd,
     requirements_cmd,
     run_cmd,
@@ -99,6 +100,7 @@ app.add_typer(mcp_cmd.app, name="mcp")
 app.add_typer(cache_cmd.app, name="cache")
 app.add_typer(context_cmd.app, name="context")
 app.add_typer(auth_cmd.app, name="auth")
+app.add_typer(provider_cmd.app, name="provider")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")
 app.command("init")(init_cmd.run)

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -50,6 +50,7 @@ from mergecraft.cli import (
     tracing_logfire_cmd,
     update_cmd,
     watch_cmd,
+    workflow_cmd,
     xrepo_cmd,
 )
 from mergecraft.cli.exits import (
@@ -103,6 +104,7 @@ app.add_typer(context_cmd.app, name="context")
 app.add_typer(auth_cmd.app, name="auth")
 app.add_typer(provider_cmd.app, name="provider")
 app.add_typer(model_cmd.app, name="model")
+app.add_typer(workflow_cmd.app, name="workflow")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")
 app.command("init")(init_cmd.run)

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -35,6 +35,7 @@ from mergecraft.cli import (
     lens_cmd,
     mcp_cmd,
     memory_cmd,
+    model_cmd,
     models_cmd,
     pipeline_cmd,
     plan_cmd,
@@ -101,6 +102,7 @@ app.add_typer(cache_cmd.app, name="cache")
 app.add_typer(context_cmd.app, name="context")
 app.add_typer(auth_cmd.app, name="auth")
 app.add_typer(provider_cmd.app, name="provider")
+app.add_typer(model_cmd.app, name="model")
 app.add_typer(models_cmd.app, name="models")
 app.add_typer(analyzers_cmd.app, name="analyzers")
 app.command("init")(init_cmd.run)

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -8,7 +8,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,8 +30,6 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 _LEGACY_AUTH_WARNED = False
-# BB #478 — pytest ``monkeypatch.setattr(module, "shutil.which", ...)`` needs a flat name.
-setattr(sys.modules[__name__], "shutil.which", shutil.which)
 
 app = typer.Typer(
     help="Manage provider credentials for the current repository.", no_args_is_help=True
@@ -283,8 +280,7 @@ def auth_codex(scope: str = _SCOPE_OPTION) -> None:
     _legacy_auth_hint("codex")
     target = _resolve_auth_target(scope)
 
-    which = getattr(sys.modules[__name__], "shutil.which", shutil.which)
-    if not which("codex"):
+    if not shutil.which("codex"):
         cli_bail(
             "codex CLI not found on PATH.\n"
             "  install: npm i -g @openai/codex\n"

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +29,10 @@ from mergecraft.utils.workspace import git_repo_root
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+_LEGACY_AUTH_WARNED = False
+# BB #478 — pytest ``monkeypatch.setattr(module, "shutil.which", ...)`` needs a flat name.
+setattr(sys.modules[__name__], "shutil.which", shutil.which)
 
 app = typer.Typer(
     help="Manage provider credentials for the current repository.", no_args_is_help=True
@@ -275,9 +280,11 @@ def _persist_credential(
 @app.command("codex")
 def auth_codex(scope: str = _SCOPE_OPTION) -> None:
     """Mint a Codex subscription credential and save it as CODEX_AUTH_JSON."""
+    _legacy_auth_hint("codex")
     target = _resolve_auth_target(scope)
 
-    if not shutil.which("codex"):
+    which = getattr(sys.modules[__name__], "shutil.which", shutil.which)
+    if not which("codex"):
         cli_bail(
             "codex CLI not found on PATH.\n"
             "  install: npm i -g @openai/codex\n"
@@ -304,12 +311,16 @@ def auth_codex(scope: str = _SCOPE_OPTION) -> None:
         # anything to persist (#221).
         value = auth_path.read_text(encoding="utf-8")
 
+    if _legacy_auth_shim("codex", scope, {"API_KEY": value}):
+        return
+
     _persist_credential(target=target, name=CODEX_AUTH_SECRET, value=value)
 
 
 @app.command("claude")
 def auth_claude(scope: str = _SCOPE_OPTION) -> None:
     """Save a Claude Code OAuth token as CLAUDE_CODE_OAUTH_TOKEN."""
+    _legacy_auth_hint("claude")
     target = _resolve_auth_target(scope)
     console.print(
         "mint a token with [cyan]claude setup-token[/cyan], then paste it below "
@@ -328,6 +339,9 @@ def auth_claude(scope: str = _SCOPE_OPTION) -> None:
             f"[yellow]warning:[/yellow] that doesn't look like a claude setup-token "
             f"(expected {CLAUDE_OAUTH_TOKEN_PREFIX}…). saving it anyway."
         )
+
+    if _legacy_auth_shim("claude", scope, {"API_KEY": oauth_token}):
+        return
 
     _persist_credential(target=target, name=CLAUDE_OAUTH_SECRET, value=oauth_token)
 
@@ -355,6 +369,7 @@ def _validate_gemini_api_key(api_key: str) -> bool:
 @app.command("gemini")
 def auth_gemini(scope: str = _SCOPE_OPTION) -> None:
     """Save a Gemini API key as GEMINI_API_KEY."""
+    _legacy_auth_hint("gemini")
     target = _resolve_auth_target(scope)
     console.print(
         "create an API key at [cyan]https://aistudio.google.com/apikey[/cyan], then paste it below."
@@ -369,6 +384,9 @@ def auth_gemini(scope: str = _SCOPE_OPTION) -> None:
         raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
     if not _validate_gemini_api_key(api_key):
         cli_bail("Gemini API key validation failed (401/403). Check the key and retry.")
+
+    if _legacy_auth_shim("gemini", scope, {"API_KEY": api_key}):
+        return
 
     _persist_credential(target=target, name=GEMINI_API_SECRET, value=api_key)
 
@@ -403,6 +421,7 @@ def _validate_cursor_api_key(api_key: str) -> bool:
 @app.command("cursor")
 def auth_cursor(scope: str = _SCOPE_OPTION) -> None:
     """Save a Cursor API key as CURSOR_API_KEY."""
+    _legacy_auth_hint("cursor")
     target = _resolve_auth_target(scope)
     console.print(
         "create an API key in the Cursor dashboard, then paste it below "
@@ -418,6 +437,9 @@ def auth_cursor(scope: str = _SCOPE_OPTION) -> None:
         raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
     if not _validate_cursor_api_key(api_key):
         cli_bail("Cursor API key validation failed (401/403). Check the key and retry.")
+
+    if _legacy_auth_shim("cursor", scope, {"API_KEY": api_key}):
+        return
 
     _persist_credential(target=target, name=CURSOR_API_SECRET, value=api_key)
 
@@ -485,6 +507,7 @@ def _validate_nous_api_key(api_key: str) -> bool:
 @app.command("nous")
 def auth_nous(scope: str = _SCOPE_OPTION) -> None:
     """Save a Nous Portal API key as NOUS_API_KEY."""
+    _legacy_auth_hint("nous")
     target = _resolve_auth_target(scope)
     console.print(
         "create an API key at [cyan]https://portal.nousresearch.com[/cyan], then paste it below."
@@ -500,6 +523,9 @@ def auth_nous(scope: str = _SCOPE_OPTION) -> None:
     if not _validate_nous_api_key(api_key):
         cli_bail("Nous API key validation failed (401/403). Check the key and retry.")
 
+    if _legacy_auth_shim("nous", scope, {"API_KEY": api_key}):
+        return
+
     _persist_credential(target=target, name=NOUS_API_SECRET, value=api_key)
     console.print(
         "use model [cyan]nous/deepseek/deepseek-v4-flash[/cyan] "
@@ -510,6 +536,7 @@ def auth_nous(scope: str = _SCOPE_OPTION) -> None:
 @app.command("tokenhub")
 def auth_tokenhub(scope: str = _SCOPE_OPTION) -> None:
     """Save a Tencent TokenHub API key as TOKENHUB_API_KEY."""
+    _legacy_auth_hint("tokenhub")
     target = _resolve_auth_target(scope)
     console.print(
         "create an API key in the TokenHub console, then paste it below "
@@ -528,6 +555,9 @@ def auth_tokenhub(scope: str = _SCOPE_OPTION) -> None:
         api_key=api_key, base_url=DEFAULT_TOKENHUB, label="tokenhub"
     ):
         cli_bail("TokenHub API key validation failed (401/403). Check the key and retry.")
+
+    if _legacy_auth_shim("tokenhub", scope, {"API_KEY": api_key}):
+        return
 
     _persist_credential(target=target, name=TOKENHUB_API_SECRET, value=api_key)
     console.print(
@@ -752,6 +782,36 @@ def _normalise_scope(value: str) -> CredentialScope:
     raise AssertionError("unreachable")
 
 
+def _warn_legacy_auth_once(message: str) -> None:
+    """Emit the yellow-box deprecation line (shim calls this once per process)."""
+    console.print(f"[yellow]warning:[/yellow] {message}")
+
+
+def _legacy_deprecation_message(label: str) -> str:
+    return (
+        f"mergecraft auth {label} is deprecated — use "
+        f"mergecraft provider auth {label} (unified provider auth)."
+    )
+
+
+def _legacy_auth_hint(label: str) -> None:
+    """Print deprecation guidance; yellow warning box only once per process (D7)."""
+    global _LEGACY_AUTH_WARNED
+    message = _legacy_deprecation_message(label)
+    if not _LEGACY_AUTH_WARNED:
+        _warn_legacy_auth_once(message)
+        _LEGACY_AUTH_WARNED = True
+    else:
+        console.print(message, markup=False)
+
+
+def _legacy_auth_shim(label: str, scope: str, credential_map: Mapping[str, str]) -> bool:
+    """Try indexed provider auth; return whether delegation succeeded."""
+    from mergecraft.cli.provider_cmd import persist_legacy_indexed_auth
+
+    return persist_legacy_indexed_auth(label, scope, credential_map)
+
+
 @app.command("logfire")
 def auth_logfire(
     scope: str = typer.Option(
@@ -912,6 +972,7 @@ def auth_minimax(scope: str = _SCOPE_OPTION) -> None:
     operator may override, or rely on the preset's default
     ``https://api.minimax.io/v1``).
     """
+    _legacy_auth_hint("minimax")
     target = _resolve_auth_target(scope)
     console.print(
         "create an API key on the MiniMax platform "
@@ -927,6 +988,9 @@ def auth_minimax(scope: str = _SCOPE_OPTION) -> None:
         raise typer.Exit(CLI_SUCCESS_EXIT_CODE) from None
     if not _validate_minimax_api_key(api_key):
         cli_bail("MiniMax API key validation failed (401/403). Check the key and retry.")
+
+    if _legacy_auth_shim("minimax", scope, {"API_KEY": api_key}):
+        return
 
     _persist_credential(target=target, name=MINIMAX_API_SECRET, value=api_key)
     console.print(

--- a/src/mergecraft/cli/init_cmd.py
+++ b/src/mergecraft/cli/init_cmd.py
@@ -10,6 +10,7 @@ import yaml
 from loguru import logger
 
 from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.provider_cmd import seed_builtin_providers
 from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
 from mergecraft.pins import action_pin_minimal
 from mergecraft.review.completed import COMPLETED_REVIEWS_GITIGNORE_LINE
@@ -171,6 +172,9 @@ def run(
 
     _ensure_audit_jsonl_gitignore(root)
     _ensure_reviews_gitignore(root)
+
+    if config_path.is_file():
+        seed_builtin_providers(config_path)
 
     console.print("\n[bold]next steps[/bold]")
     console.print(

--- a/src/mergecraft/cli/model_cmd.py
+++ b/src/mergecraft/cli/model_cmd.py
@@ -1,0 +1,215 @@
+"""``mergecraft model`` — per-provider model registry (#479 / BC)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.provider_cmd import (
+    _config_path,
+    _env_path,
+    _load_config_dict,
+    _provider_entries,
+    _write_config_dict,
+    load_provider_registry,
+)
+from mergecraft.config.model_registry import (
+    allocate_model_index,
+    effective_model_id,
+    normalize_model_id,
+)
+
+app = typer.Typer(
+    help="Add, list, and delete models on registered LLM providers.",
+    no_args_is_help=True,
+)
+
+
+def _model_rows(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = entry.get("models")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        cli_bail("models must be a list on provider entry")
+    return [row for row in raw if isinstance(row, dict)]
+
+
+def _model_id_from_row(row: dict[str, Any]) -> str:
+    for key in ("id", "modelId", "model"):
+        value = row.get(key)
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def _model_index_from_row(row: dict[str, Any]) -> int | None:
+    raw = row.get("modelIndex")
+    if raw is None:
+        return None
+    return int(raw)
+
+
+def _find_provider_index(entries: list[dict[str, Any]], label: str) -> int | None:
+    lowered = label.strip().lower()
+    for idx, entry in enumerate(entries):
+        if str(entry.get("label", "")).lower() == lowered:
+            return idx
+    return None
+
+
+def _registered_labels(entries: list[dict[str, Any]]) -> list[str]:
+    return [str(entry["label"]) for entry in entries if entry.get("label")]
+
+
+def _unknown_provider_message(label: str, labels: list[str]) -> str:
+    registered = ", ".join(labels) if labels else "none"
+    return f"unknown provider {label!r} — not registered; registered providers: {registered}"
+
+
+def _prompt_provider(labels: list[str]) -> str:
+    choices = ", ".join(labels)
+    return str(typer.prompt(f"provider ({choices})"))
+
+
+@app.command("list")
+def list_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """List models registered on each provider."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    registry = load_provider_registry(config_path)
+    env_file = _env_path()
+
+    if not registry.labels():
+        console.print("no models registered")
+        return
+
+    any_model = False
+    for entry in registry.entries:
+        label = str(entry.get("label", ""))
+        env_index = entry.get("envIndex")
+        models = _model_rows(entry)
+        if not models:
+            continue
+        for row in models:
+            model_index = _model_index_from_row(row)
+            stored_id = _model_id_from_row(row)
+            if model_index is None or env_index is None:
+                display_id = stored_id
+            else:
+                display_id = effective_model_id(
+                    stored_id,
+                    env_path=env_file,
+                    env_index=int(env_index),
+                    model_index=model_index,
+                )
+            console.print(f"{label}  {display_id}")
+            any_model = True
+
+    if not any_model:
+        console.print("no models registered")
+
+
+@app.command("add")
+def add_cmd(
+    model_id: str = typer.Argument(..., help="Model id (provider prefix optional)."),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Registered provider label.",
+    ),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Register a model on a provider in config (env override optional)."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+    labels = _registered_labels(entries)
+
+    if not labels:
+        cli_bail("no providers registered — run mergecraft provider add first")
+
+    provider_label = provider
+    if provider_label is None:
+        provider_label = _prompt_provider(labels)
+
+    provider_label = provider_label.strip()
+    provider_idx = _find_provider_index(entries, provider_label)
+    if provider_idx is None:
+        cli_bail(_unknown_provider_message(provider_label, labels))
+
+    entry = dict(entries[provider_idx])
+    provider_name = str(entry.get("label", provider_label))
+    models = _model_rows(entry)
+    normalised_id = normalize_model_id(provider_name, model_id)
+
+    if not normalised_id:
+        cli_bail("model id must not be empty")
+
+    for row in models:
+        if _model_id_from_row(row) == normalised_id:
+            cli_bail(
+                f"duplicate model {normalised_id!r} already registered on provider {provider_name!r}"
+            )
+
+    model_index = allocate_model_index(models)
+    models.append({"id": normalised_id, "modelIndex": model_index})
+    entry["models"] = models
+    entries[provider_idx] = entry
+    data["providers"] = entries
+    _write_config_dict(config_path, data)
+    console.print(
+        f"registered model [green]{normalised_id}[/green] on provider "
+        f"[green]{provider_name}[/green] (modelIndex={model_index})"
+    )
+
+
+@app.command("delete")
+def delete_cmd(
+    provider: str = typer.Argument(..., help="Registered provider label."),
+    model_id: str = typer.Argument(..., help="Model id to remove."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Remove a model from a provider (model index gap is preserved)."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+    labels = _registered_labels(entries)
+
+    provider_idx = _find_provider_index(entries, provider)
+    if provider_idx is None:
+        cli_bail(_unknown_provider_message(provider, labels))
+
+    entry = dict(entries[provider_idx])
+    provider_name = str(entry.get("label", provider))
+    models = _model_rows(entry)
+    target_id = normalize_model_id(provider_name, model_id)
+
+    remaining: list[dict[str, Any]] = []
+    removed = False
+    for row in models:
+        if _model_id_from_row(row) == target_id:
+            removed = True
+            continue
+        remaining.append(row)
+
+    if not removed:
+        cli_bail(f"unknown model {target_id!r} on provider {provider_name!r}")
+
+    entry["models"] = remaining
+    entries[provider_idx] = entry
+    data["providers"] = entries
+    _write_config_dict(config_path, data)
+    console.print(
+        f"deleted model [green]{target_id}[/green] from provider [green]{provider_name}[/green]"
+    )
+
+
+__all__ = ["app"]

--- a/src/mergecraft/cli/model_cmd.py
+++ b/src/mergecraft/cli/model_cmd.py
@@ -83,7 +83,7 @@ def list_cmd(
     repo_root = cwd.resolve()
     config_path = _config_path(repo_root)
     registry = load_provider_registry(config_path)
-    env_file = _env_path()
+    env_file = _env_path(repo_root)
 
     if not registry.labels():
         console.print("no models registered")

--- a/src/mergecraft/cli/plan_cmd.py
+++ b/src/mergecraft/cli/plan_cmd.py
@@ -19,6 +19,7 @@ from mergecraft.config.settings import load_repo_settings
 from mergecraft.mcp.shared import REVIEWER_ALLOWED_TOOL_CLASSES
 from mergecraft.offline_review import build_offline_review_prompt
 from mergecraft.utils.agent_resolve import (
+    ModelFallbackPolicyError,
     effective_model_slugs,
     resolve_model,
     resolve_runtime_agent,
@@ -92,7 +93,7 @@ def build_plan_report(
     agent_label: str
     try:
         agent_label = resolve_runtime_agent(model=resolved_model, settings=settings).name
-    except ValueError:
+    except (ValueError, ModelFallbackPolicyError):
         if resolved_model and "/" in resolved_model:
             agent_label = resolved_model.partition("/")[0]
         else:

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -446,9 +446,10 @@ def _persist_indexed_credentials(
     scope: str,
     credential_map: Mapping[str, str],
 ) -> None:
-    """Write ``LLM_PROVIDER_<N>`` label plus indexed credential suffixes to ``.env``."""
+    """Write ``LLM_PROVIDER_<N>`` label plus indexed credential suffixes."""
     from mergecraft.cli.auth_cmd import (
         _resolve_auth_target,
+        _set_gh_secret,
         _single_line_credential,
         _write_env_value,
     )
@@ -456,22 +457,53 @@ def _persist_indexed_credentials(
     env_index = int(entry["envIndex"])
     label = str(entry["label"])
     target = _resolve_auth_target(scope)
-    if not target.local:
-        cli_bail("indexed provider auth requires --scope local or --scope both")
 
     env_path = _env_path()
     label_key = _indexed_label_key(env_index)
-    if not _write_env_value(env_path, label_key, label):
-        cli_bail(f"could not write {label_key} to {env_path}")
+    any_local_written = False
 
-    for suffix, raw_value in credential_map.items():
-        key = f"LLM_PROVIDER_{env_index}_{suffix}"
-        value = _single_line_credential(name=key, value=raw_value)
-        if not _write_env_value(env_path, key, value):
-            cli_bail(f"could not write {key} to {env_path}")
+    if target.local:
+        if not _write_env_value(env_path, label_key, label):
+            cli_bail(f"could not write {label_key} to {env_path}")
+        for suffix, raw_value in credential_map.items():
+            key = f"LLM_PROVIDER_{env_index}_{suffix}"
+            value = _single_line_credential(name=key, value=raw_value)
+            if not _write_env_value(env_path, key, value):
+                cli_bail(f"could not write {key} to {env_path}")
+        landed = ", ".join([label_key, *credential_map.keys()])
+        console.print(f"[green]wrote {landed}[/green] to {env_path}")
+        any_local_written = True
 
-    landed = ", ".join([label_key, *credential_map.keys()])
-    console.print(f"[green]wrote {landed}[/green] to {env_path}")
+    if target.github is not None:
+        wrote_any_github = False
+        for suffix, raw_value in credential_map.items():
+            key = f"LLM_PROVIDER_{env_index}_{suffix}"
+            console.print(f"saving [cyan]{key}[/cyan] via gh secret set...")
+            if _set_gh_secret(name=key, value=raw_value, repo_slug=target.github.repo_slug):
+                console.print(f"[green]saved {key}[/green] to GitHub Actions secrets")
+                wrote_any_github = True
+            elif not target.local:
+                secrets_url = (
+                    f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
+                )
+                cli_bail(f"could not set secret {key!r} — set it manually at:\n  {secrets_url}")
+            else:
+                secrets_url = (
+                    f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
+                )
+                console.print(
+                    f"[yellow]warning:[/yellow] gh secret set failed for {key!r} — "
+                    f"set it manually at:\n  {secrets_url}"
+                )
+        if not wrote_any_github and not any_local_written:
+            cli_bail(
+                "nothing was written — both local and github scopes failed. "
+                "retry with --scope local or --scope github to isolate the failure."
+            )
+        return
+
+    if not any_local_written:
+        cli_bail("nothing was written — could not save indexed credentials locally.")
 
 
 def _cancelable_getpass(prompt: str) -> str | None:
@@ -901,13 +933,13 @@ def plan_provider_migration(
                 region_value = env_map.get(region_key, "").strip()
                 if region_value:
                     entry["region"] = region_value
-                    entry[region_key] = region_value
                     break
         if label == "vertex":
             for config_key in VERTEX_LEGACY_CONFIG_KEYS:
                 config_value = env_map.get(config_key, "").strip()
-                if config_value:
-                    entry[config_key] = config_value
+                if config_value and config_key == "VERTEX_LOCATION":
+                    entry["region"] = config_value
+                    break
         providers_out.append(entry)
         label_to_entry[label] = entry
         next_index = _next_migration_index(tuple(label_to_entry.values()), next_index + 1)
@@ -1105,7 +1137,13 @@ def persist_legacy_indexed_auth(
     entry = registry.lookup(label)
     if entry is None:
         return False
-    run_provider_auth(entry, scope, credential_map=credential_map)
+    mapped = dict(credential_map)
+    if "API_KEY" in mapped and len(mapped) == 1:
+        auth_kind = _entry_auth_kind(entry)
+        suffix = AUTH_KIND_PRIMARY_SUFFIX.get(auth_kind, "API_KEY")
+        if suffix != "API_KEY":
+            mapped = {suffix: mapped["API_KEY"]}
+    run_provider_auth(entry, scope, credential_map=mapped)
     return True
 
 

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -72,9 +72,7 @@ VERTEX_LEGACY_CONFIG_KEYS: tuple[str, ...] = ("GOOGLE_CLOUD_PROJECT", "VERTEX_LO
 
 STRUCTURE_KEYS_IN_ENV: frozenset[str] = frozenset({"harness", "envIndex", "modelChain", "authKind"})
 
-ENV_STRUCTURE_KEYS_TO_REMOVE_ON_APPLY: frozenset[str] = frozenset(
-    {NOUS_BASE_URL_ENV, *VERTEX_LEGACY_CONFIG_KEYS, *BEDROCK_LEGACY_CONFIG_KEYS}
-)
+ENV_STRUCTURE_KEYS_TO_REMOVE_ON_APPLY: frozenset[str] = frozenset({NOUS_BASE_URL_ENV})
 
 CREDENTIAL_SUBSTRINGS_IN_CONFIG: tuple[str, ...] = (
     "api_key",
@@ -1057,10 +1055,8 @@ def apply_provider_migration(
             label = str(provider_entry.get("label", "")).lower()
             if label == "nous":
                 keys_to_remove.add(NOUS_BASE_URL_ENV)
-            if label == "vertex":
-                keys_to_remove.update(VERTEX_LEGACY_CONFIG_KEYS)
-            if label == "bedrock":
-                keys_to_remove.update(BEDROCK_LEGACY_CONFIG_KEYS)
+            if label == "vertex" and provider_entry.get("region"):
+                keys_to_remove.add("VERTEX_LOCATION")
         if keys_to_remove and env_path.is_file():
             lines = env_path.read_text(encoding="utf-8").splitlines()
             kept = [

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -7,8 +7,9 @@ import os
 import shutil
 import subprocess
 import tempfile
+import warnings
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,41 @@ BEDROCK_CLOUD_SUFFIXES: tuple[str, ...] = (
 )
 
 VERTEX_CLOUD_SUFFIXES: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+LEGACY_API_KEY_MIGRATIONS: dict[str, tuple[str, str]] = {
+    "OPENAI_API_KEY": ("openai", "API_KEY"),
+    "ANTHROPIC_API_KEY": ("anthropic", "API_KEY"),
+    "GEMINI_API_KEY": ("google", "API_KEY"),
+    "CURSOR_API_KEY": ("cursor", "API_KEY"),
+    "DEEPSEEK_API_KEY": ("deepseek", "API_KEY"),
+    "NOUS_API_KEY": ("nous", "API_KEY"),
+}
+
+LEGACY_LABEL_TO_API_KEY_ENV: dict[str, str] = {
+    label: legacy_key for legacy_key, (label, _suffix) in LEGACY_API_KEY_MIGRATIONS.items()
+}
+
+NOUS_BASE_URL_ENV = "NOUS_BASE_URL"
+CUSTOM_PROVIDER_BASE_URL_ENV = "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL"
+
+BEDROCK_LEGACY_CONFIG_KEYS: tuple[str, ...] = ("AWS_REGION", "AWS_DEFAULT_REGION")
+VERTEX_LEGACY_CONFIG_KEYS: tuple[str, ...] = ("GOOGLE_CLOUD_PROJECT", "VERTEX_LOCATION")
+
+STRUCTURE_KEYS_IN_ENV: frozenset[str] = frozenset({"harness", "envIndex", "modelChain", "authKind"})
+
+ENV_STRUCTURE_KEYS_TO_REMOVE_ON_APPLY: frozenset[str] = frozenset(
+    {NOUS_BASE_URL_ENV, *VERTEX_LEGACY_CONFIG_KEYS, *BEDROCK_LEGACY_CONFIG_KEYS}
+)
+
+CREDENTIAL_SUBSTRINGS_IN_CONFIG: tuple[str, ...] = (
+    "api_key",
+    "apiKey",
+    "secret",
+    "password",
+    "token",
+)
+
+_LEGACY_CREDENTIAL_WARNED_KEYS: set[str] = set()
 
 _PROVIDER_AUTH_SCOPE_OPTION: str = typer.Option(
     "github",
@@ -630,6 +666,434 @@ def run_provider_auth(
     strategy.run(entry, scope)
 
 
+@dataclass(frozen=True, slots=True)
+class MigrationPlan:
+    """Planned provider migration from legacy env vars (#483 / BF)."""
+
+    providers: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    env_writes: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _read_env_map(env_path: Path) -> dict[str, str]:
+    """Parse ``KEY=value`` lines from *env_path* (secrets stay file-local)."""
+    if not env_path.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for raw in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        out[key] = value
+    return out
+
+
+def migration_secret_fingerprint(value: str) -> str:
+    """Return a redacted fingerprint suitable for dry-run output (never the full secret)."""
+    stripped = value.strip()
+    if len(stripped) <= 4:
+        return "…"
+    return f"…{stripped[-4:]}"
+
+
+def validate_config_secret_split(
+    config_path: Path,
+    env_path: Path,
+) -> list[str]:
+    """Return violations when credentials leak into config or structure leaks into ``.env``."""
+    violations: list[str] = []
+    if config_path.is_file():
+        config_data = _load_config_dict(config_path)
+        for entry in _provider_entries(config_data):
+            for key, value in entry.items():
+                key_lower = str(key).lower()
+                if any(token.lower() in key_lower for token in CREDENTIAL_SUBSTRINGS_IN_CONFIG):
+                    violations.append(
+                        f"config provider {entry.get('label', '?')!r} contains credential field {key!r}"
+                    )
+                if isinstance(value, str) and value.strip():
+                    value_lower = value.lower()
+                    if any(token in value_lower for token in ("sk-", "apikey", "secret")):
+                        violations.append(
+                            f"config provider {entry.get('label', '?')!r} may contain a credential value"
+                        )
+
+    if env_path.is_file():
+        for raw in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key = line.split("=", 1)[0].strip()
+            key_lower = key.lower()
+            if key_lower in STRUCTURE_KEYS_IN_ENV:
+                violations.append(f".env contains structure key {key!r} (move to config.yaml)")
+            if any(token.lower() in key_lower for token in CREDENTIAL_SUBSTRINGS_IN_CONFIG):
+                if key.startswith("LLM_PROVIDER_"):
+                    continue
+                if key in LEGACY_API_KEY_MIGRATIONS:
+                    continue
+                if key in BEDROCK_CLOUD_SUFFIXES or key in VERTEX_CLOUD_SUFFIXES:
+                    continue
+    return violations
+
+
+def _indexed_label_from_env(env_map: Mapping[str, str], env_index: int) -> str | None:
+    raw = env_map.get(f"LLM_PROVIDER_{env_index}", "").strip()
+    return raw or None
+
+
+def _indexed_value(env_map: Mapping[str, str], env_index: int, suffix: str) -> str | None:
+    raw = env_map.get(f"LLM_PROVIDER_{env_index}_{suffix}", "").strip()
+    return raw or None
+
+
+def _warn_legacy_credential_once(legacy_key: str, indexed_key: str) -> None:
+    if legacy_key in _LEGACY_CREDENTIAL_WARNED_KEYS:
+        return
+    _LEGACY_CREDENTIAL_WARNED_KEYS.add(legacy_key)
+    message = (
+        f"{indexed_key} wins over legacy {legacy_key}; "
+        f"legacy {legacy_key} is ignored — prefer indexed registry keys."
+    )
+    warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+
+def resolve_indexed_credential(entry: Mapping[str, Any]) -> str | None:
+    """Resolve the primary API credential for *entry*; registry key wins over legacy (D7)."""
+    env_index = int(entry["envIndex"])
+    label = str(entry.get("label", "")).lower()
+    auth_kind = str(entry.get("authKind") or AUTH_KIND_API_KEY)
+
+    env_map = _read_env_map(_env_path())
+    legacy_key = LEGACY_LABEL_TO_API_KEY_ENV.get(label)
+    legacy_value = env_map.get(legacy_key, "").strip() if legacy_key else ""
+
+    if auth_kind == AUTH_KIND_CLOUD_CHAIN:
+        if label == "bedrock":
+            for suffix in BEDROCK_CLOUD_SUFFIXES:
+                value = _indexed_value(env_map, env_index, suffix)
+                if value:
+                    return value
+            return None
+        if label == "vertex":
+            return _indexed_value(env_map, env_index, VERTEX_CLOUD_SUFFIXES[0])
+        return None
+
+    api_key_value = _indexed_value(env_map, env_index, "API_KEY")
+    if api_key_value:
+        if legacy_value and legacy_value != api_key_value and legacy_key:
+            _warn_legacy_credential_once(legacy_key, f"LLM_PROVIDER_{env_index}_API_KEY")
+        return api_key_value
+
+    suffix = AUTH_KIND_PRIMARY_SUFFIX.get(auth_kind, "API_KEY")
+    if suffix != "API_KEY":
+        registry_value = _indexed_value(env_map, env_index, suffix)
+        if registry_value:
+            if legacy_value and legacy_value != registry_value and legacy_key:
+                _warn_legacy_credential_once(legacy_key, f"LLM_PROVIDER_{env_index}_{suffix}")
+            return registry_value
+
+    if legacy_value:
+        if legacy_key:
+            _warn_legacy_credential_once(legacy_key, f"LLM_PROVIDER_{env_index}_API_KEY")
+        return legacy_value
+
+    return None
+
+
+def _migration_provider_template(label: str, env_index: int) -> dict[str, Any]:
+    harness = default_harness_for_label(label) or "opencode"
+    entry: dict[str, Any] = {
+        "label": label,
+        "harness": harness,
+        "envIndex": env_index,
+    }
+    auth_kind = default_auth_kind_for_label(label)
+    if auth_kind is not None:
+        entry["authKind"] = auth_kind
+    url = _seed_url_for_label(label)
+    if url is not None:
+        entry["url"] = url
+    return entry
+
+
+def _next_migration_index(entries: Sequence[Mapping[str, Any]], planned: int) -> int:
+    indices = [
+        int(entry["envIndex"])
+        for entry in entries
+        if isinstance(entry, Mapping) and entry.get("envIndex") is not None
+    ]
+    if not indices:
+        return planned
+    return max(indices) + 1
+
+
+def plan_provider_migration(
+    env_path: Path,
+    config_path: Path,
+) -> MigrationPlan:
+    """Plan migration from legacy ``*_API_KEY`` env vars to indexed registry layout (#483)."""
+    env_map = _read_env_map(env_path)
+    config_data = _load_config_dict(config_path)
+    existing_entries = _provider_entries(config_data)
+    label_to_entry: dict[str, dict[str, Any]] = {}
+    for entry in existing_entries:
+        label = str(entry.get("label", "")).lower()
+        if label:
+            label_to_entry[label] = entry
+
+    providers_out: list[dict[str, Any]] = []
+    env_writes_out: list[dict[str, Any]] = []
+    notes_out: list[str] = []
+
+    if env_map.get(CUSTOM_PROVIDER_BASE_URL_ENV, "").strip():
+        notes_out.append(
+            f"ambiguous legacy {CUSTOM_PROVIDER_BASE_URL_ENV} — add a provider label with "
+            "mergecraft provider add before migrating custom endpoints"
+        )
+
+    next_index = allocate_env_index(existing_entries)
+    labels_to_add: list[str] = []
+
+    for legacy_key, (label, suffix) in LEGACY_API_KEY_MIGRATIONS.items():
+        legacy_value = env_map.get(legacy_key, "").strip()
+        if not legacy_value:
+            continue
+        if label in label_to_entry:
+            entry = label_to_entry[label]
+            env_index = int(entry["envIndex"])
+            if _indexed_value(env_map, env_index, suffix):
+                continue
+            target = f"LLM_PROVIDER_{env_index}_{suffix}"
+            env_writes_out.append(
+                {
+                    "source": legacy_key,
+                    "target": target,
+                    "provider": label,
+                }
+            )
+            continue
+        if label not in labels_to_add:
+            labels_to_add.append(label)
+
+    bedrock_present = any(env_map.get(key, "").strip() for key in BEDROCK_CLOUD_SUFFIXES)
+    if bedrock_present and "bedrock" not in label_to_entry and "bedrock" not in labels_to_add:
+        labels_to_add.append("bedrock")
+        notes_out.append("will copy AWS credentials to indexed keys and leave originals in place")
+
+    vertex_cred = env_map.get(VERTEX_CLOUD_SUFFIXES[0], "").strip()
+    if vertex_cred and "vertex" not in label_to_entry and "vertex" not in labels_to_add:
+        labels_to_add.append("vertex")
+
+    for label in labels_to_add:
+        entry = _migration_provider_template(label, next_index)
+        if label == "nous":
+            nous_url = env_map.get(NOUS_BASE_URL_ENV, "").strip()
+            if nous_url:
+                entry["url"] = nous_url
+        if label == "bedrock":
+            for region_key in BEDROCK_LEGACY_CONFIG_KEYS:
+                region_value = env_map.get(region_key, "").strip()
+                if region_value:
+                    entry["region"] = region_value
+                    entry[region_key] = region_value
+                    break
+        if label == "vertex":
+            for config_key in VERTEX_LEGACY_CONFIG_KEYS:
+                config_value = env_map.get(config_key, "").strip()
+                if config_value:
+                    entry[config_key] = config_value
+        providers_out.append(entry)
+        label_to_entry[label] = entry
+        next_index = _next_migration_index(tuple(label_to_entry.values()), next_index + 1)
+
+    for legacy_key, (label, suffix) in LEGACY_API_KEY_MIGRATIONS.items():
+        legacy_value = env_map.get(legacy_key, "").strip()
+        if not legacy_value:
+            continue
+        matched = label_to_entry.get(label)
+        if matched is None:
+            continue
+        env_index = int(matched["envIndex"])
+        if _indexed_value(env_map, env_index, suffix):
+            continue
+        target = f"LLM_PROVIDER_{env_index}_{suffix}"
+        if any(step.get("target") == target for step in env_writes_out):
+            continue
+        env_writes_out.append(
+            {
+                "source": legacy_key,
+                "target": target,
+                "provider": label,
+            }
+        )
+
+    if "bedrock" in label_to_entry:
+        bedrock_entry = label_to_entry["bedrock"]
+        env_index = int(bedrock_entry["envIndex"])
+        for suffix in BEDROCK_CLOUD_SUFFIXES:
+            source_value = env_map.get(suffix, "").strip()
+            if not source_value:
+                continue
+            target = f"LLM_PROVIDER_{env_index}_{suffix}"
+            if _indexed_value(env_map, env_index, suffix):
+                continue
+            if any(step.get("target") == target for step in env_writes_out):
+                continue
+            env_writes_out.append(
+                {
+                    "source": suffix,
+                    "target": target,
+                    "provider": "bedrock",
+                }
+            )
+
+    if "vertex" in label_to_entry:
+        vertex_entry = label_to_entry["vertex"]
+        env_index = int(vertex_entry["envIndex"])
+        for suffix in VERTEX_CLOUD_SUFFIXES:
+            source_value = env_map.get(suffix, "").strip()
+            if not source_value:
+                continue
+            target = f"LLM_PROVIDER_{env_index}_{suffix}"
+            if _indexed_value(env_map, env_index, suffix):
+                continue
+            if any(step.get("target") == target for step in env_writes_out):
+                continue
+            env_writes_out.append(
+                {
+                    "source": suffix,
+                    "target": target,
+                    "provider": "vertex",
+                }
+            )
+
+    return MigrationPlan(
+        providers=tuple(providers_out),
+        env_writes=tuple(env_writes_out),
+        notes=tuple(notes_out),
+    )
+
+
+def apply_provider_migration(
+    plan: MigrationPlan,
+    *,
+    env_path: Path,
+    config_path: Path,
+) -> None:
+    """Apply a migration plan to config and ``.env`` (#483)."""
+    from mergecraft.cli.auth_cmd import _write_env_value
+
+    if not plan.providers and not plan.env_writes:
+        return
+
+    config_data = _load_config_dict(config_path)
+    entries = _provider_entries(config_data)
+    if plan.providers:
+        entries.extend(plan.providers)
+        config_data["providers"] = entries
+        _write_config_dict(config_path, config_data)
+
+    env_map = _read_env_map(env_path)
+    for provider_entry in plan.providers:
+        env_index = int(provider_entry["envIndex"])
+        label = str(provider_entry["label"])
+        label_key = f"LLM_PROVIDER_{env_index}"
+        if not env_map.get(label_key, "").strip() and _write_env_value(env_path, label_key, label):
+            env_map[label_key] = label
+
+    for step in plan.env_writes:
+        source = str(step.get("source", ""))
+        target = str(step.get("target", ""))
+        if not source or not target:
+            continue
+        value = env_map.get(source, "").strip()
+        if not value:
+            continue
+        if not _write_env_value(env_path, target, value):
+            cli_bail(f"could not write {target} to {env_path}")
+        env_map[target] = value
+
+    if plan.providers:
+        keys_to_remove = set(ENV_STRUCTURE_KEYS_TO_REMOVE_ON_APPLY)
+        for provider_entry in plan.providers:
+            label = str(provider_entry.get("label", "")).lower()
+            if label == "nous":
+                keys_to_remove.add(NOUS_BASE_URL_ENV)
+            if label == "vertex":
+                keys_to_remove.update(VERTEX_LEGACY_CONFIG_KEYS)
+            if label == "bedrock":
+                keys_to_remove.update(BEDROCK_LEGACY_CONFIG_KEYS)
+        if keys_to_remove and env_path.is_file():
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+            kept = [
+                line
+                for line in lines
+                if not line.strip()
+                or line.strip().startswith("#")
+                or line.split("=", 1)[0].strip() not in keys_to_remove
+            ]
+            env_path.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+
+
+def _print_migration_plan(plan: MigrationPlan, env_path: Path) -> None:
+    env_map = _read_env_map(env_path)
+    for note in plan.notes:
+        console.print(note)
+    for provider_row in plan.providers:
+        label = str(provider_row.get("label", ""))
+        env_index = provider_row.get("envIndex")
+        harness = provider_row.get("harness")
+        console.print(
+            f"provider [cyan]{label}[/cyan] -> config (envIndex={env_index}, harness={harness})"
+        )
+    for step in plan.env_writes:
+        source = str(step.get("source", ""))
+        target = str(step.get("target", ""))
+        provider_label = str(step.get("provider", ""))
+        raw_value = env_map.get(source, "")
+        fingerprint = migration_secret_fingerprint(raw_value) if raw_value else "…"
+        console.print(f"{source} -> {target} ({provider_label}) fingerprint {fingerprint}")
+
+
+@app.command("migrate")
+def migrate_cmd(
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Write indexed keys and config (default is dry-run; never prints secret values).",
+    ),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Migrate legacy ``*_API_KEY`` env vars into indexed provider registry layout (D2 / #483)."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    env_path = _env_path()
+    plan = plan_provider_migration(env_path=env_path, config_path=config_path)
+
+    if not plan.providers and not plan.env_writes:
+        for note in plan.notes:
+            console.print(note)
+        if apply:
+            console.print("no changes — already migrated")
+        elif not plan.notes:
+            console.print("no migration planned")
+        return
+
+    if apply:
+        apply_provider_migration(plan, env_path=env_path, config_path=config_path)
+        console.print("[green]migration applied[/green]")
+        return
+
+    console.print("dry-run — no files written (pass --apply to migrate)")
+    _print_migration_plan(plan, env_path)
+
+
 def persist_legacy_indexed_auth(
     label: str,
     scope: str,
@@ -686,16 +1150,24 @@ __all__ = [
     "AUTH_KIND_DEVICE_CODE",
     "AUTH_KIND_OAUTH",
     "AUTH_KIND_PRIMARY_SUFFIX",
+    "LEGACY_API_KEY_MIGRATIONS",
     "AuthStrategy",
+    "MigrationPlan",
     "ProviderRegistry",
     "app",
+    "apply_provider_migration",
     "indexed_credential_keys",
     "list_supported_harnesses",
     "load_provider_registry",
+    "migrate_cmd",
+    "migration_secret_fingerprint",
     "persist_legacy_indexed_auth",
+    "plan_provider_migration",
     "provider_auth_cmd",
     "resolve_auth_strategy",
+    "resolve_indexed_credential",
     "resolve_provider_harness",
     "run_provider_auth",
     "seed_builtin_providers",
+    "validate_config_secret_split",
 ]

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -1,0 +1,327 @@
+"""``mergecraft provider`` — operator provider registry (#477 / BA)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+from mergecraft.agents.openai_compatible_gateways import GATEWAY_PRESETS
+from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.errors import cli_bail
+from mergecraft.config.provider_registry import (
+    BUILTIN_HARNESS_DEFAULTS,
+    allocate_env_index,
+    default_auth_kind_for_label,
+    default_harness_for_label,
+    harness_supports_provider,
+    list_supported_harnesses,
+    supported_harness_names,
+    validate_http_url,
+)
+from mergecraft.config.settings import _DEFAULT_CONFIG_REL
+from mergecraft.models import PROVIDERS
+
+app = typer.Typer(
+    help="Add, list, edit, and delete LLM providers in the operator registry.",
+    no_args_is_help=True,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRegistry:
+    """In-memory view of ``providers:`` from config (no ``PROVIDERS`` consult)."""
+
+    entries: tuple[dict[str, Any], ...]
+
+    def get(self, label: str) -> dict[str, Any] | None:
+        return self.lookup(label)
+
+    def lookup(self, label: str) -> dict[str, Any] | None:
+        lowered = label.strip().lower()
+        for entry in self.entries:
+            if str(entry.get("label", "")).lower() == lowered:
+                return entry
+        return None
+
+    def labels(self) -> list[str]:
+        return [str(entry["label"]) for entry in self.entries if entry.get("label")]
+
+
+def _config_path(cwd: Path) -> Path:
+    return (cwd / _DEFAULT_CONFIG_REL).resolve()
+
+
+def _env_path() -> Path:
+    configured = os.environ.get("MERGECRAFT_ENV")
+    if configured:
+        return Path(configured).resolve()
+    return Path.cwd() / ".env"
+
+
+def _load_config_dict(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        cli_bail(f"config must be a mapping: {path}")
+    return loaded
+
+
+def _write_config_dict(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def _provider_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = data.get("providers")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        cli_bail("providers must be a list in config")
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
+def _write_env_label(env_index: int, label: str) -> None:
+    from mergecraft.cli.auth_cmd import _write_env_value
+
+    key = f"LLM_PROVIDER_{env_index}"
+    _write_env_value(_env_path(), key, label)
+
+
+def _harness_help_suffix() -> str:
+    names = ", ".join(sorted(supported_harness_names()))
+    return f"supported harness values: {names}"
+
+
+def resolve_provider_harness(label: str, *, harness: str | None = None) -> str:
+    """Resolve harness for *label*; unknown labels never default to ``opencode`` (D4)."""
+    normalised = label.strip().lower()
+    if harness is not None:
+        harness_value = harness.strip().lower()
+        if harness_value not in supported_harness_names():
+            msg = f"unknown harness {harness!r}; {_harness_help_suffix()}"
+            raise ValueError(msg)
+        if not harness_supports_provider(harness_value, normalised):
+            msg = (
+                f"incompatible harness {harness_value!r} for provider {label!r}; "
+                f"{_harness_help_suffix()}"
+            )
+            raise ValueError(msg)
+        return harness_value
+
+    default = default_harness_for_label(normalised)
+    if default is not None:
+        return default
+
+    msg = f"provider {label!r} requires --harness; {_harness_help_suffix()}"
+    raise ValueError(msg)
+
+
+def load_provider_registry(config_path: Path) -> ProviderRegistry:
+    """Load registry entries from *config_path* only (``PROVIDERS`` is seed-only)."""
+    data = _load_config_dict(config_path)
+    return ProviderRegistry(entries=tuple(_provider_entries(data)))
+
+
+def _seed_url_for_label(label: str) -> str | None:
+    preset = GATEWAY_PRESETS.get(label)
+    if preset is not None:
+        return preset.default_base_url
+    return None
+
+
+def seed_builtin_providers(config_path: Path) -> None:
+    """Import built-in ``PROVIDERS`` catalog rows once (not a reconcile loop)."""
+    data = _load_config_dict(config_path)
+    if data.get("providersSeeded"):
+        return
+
+    entries = _provider_entries(data)
+    existing = {str(entry.get("label", "")).lower() for entry in entries}
+    next_index = allocate_env_index(entries)
+
+    for label in sorted(PROVIDERS.keys()):
+        if label.lower() in existing:
+            continue
+        harness = default_harness_for_label(label) or "opencode"
+        entry: dict[str, Any] = {
+            "label": label,
+            "harness": harness,
+            "envIndex": next_index,
+        }
+        auth_kind = default_auth_kind_for_label(label)
+        if auth_kind is not None:
+            entry["authKind"] = auth_kind
+        url = _seed_url_for_label(label)
+        if url is not None:
+            entry["url"] = url
+        entries.append(entry)
+        next_index += 1
+
+    data["providers"] = entries
+    data["providersSeeded"] = True
+    _write_config_dict(config_path, data)
+
+
+@app.command("harnesses")
+def harnesses_cmd() -> None:
+    """List supported agent harnesses (generated from code)."""
+    for row in list_supported_harnesses():
+        console.print(f"{row.name}  {row.description}")
+
+
+@app.command("list")
+def list_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """List registered provider labels."""
+    config_path = _config_path(cwd.resolve())
+    registry = load_provider_registry(config_path)
+    if not registry.labels():
+        console.print("no providers registered")
+        return
+    for label in registry.labels():
+        console.print(label)
+
+
+@app.command("add")
+def add_cmd(
+    label: str = typer.Option(..., "--label", help="Stable provider handle."),
+    url: str | None = typer.Option(None, "--url", help="OpenAI-compatible base URL."),
+    harness: str | None = typer.Option(None, "--harness", help="Agent harness for this provider."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Register a provider in config and allocate an indexed ``.env`` slot."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+
+    normalised_label = label.strip()
+    if not normalised_label:
+        cli_bail("label must not be empty")
+
+    if any(str(entry.get("label", "")).lower() == normalised_label.lower() for entry in entries):
+        cli_bail(f"duplicate provider label {normalised_label!r} already registered")
+
+    try:
+        resolved_harness = resolve_provider_harness(normalised_label, harness=harness)
+    except ValueError as exc:
+        cli_bail(str(exc))
+
+    is_builtin_default = normalised_label.lower() in BUILTIN_HARNESS_DEFAULTS
+    resolved_url: str | None = None
+    if url is not None:
+        try:
+            resolved_url = validate_http_url(url)
+        except ValueError as exc:
+            cli_bail(str(exc))
+    elif not is_builtin_default:
+        cli_bail(f"provider {normalised_label!r} requires --url (absolute http(s) URL)")
+
+    env_index = allocate_env_index(entries)
+    entry: dict[str, Any] = {
+        "label": normalised_label,
+        "harness": resolved_harness,
+        "envIndex": env_index,
+    }
+    if resolved_url is not None:
+        entry["url"] = resolved_url
+
+    entries.append(entry)
+    data["providers"] = entries
+    _write_config_dict(config_path, data)
+    _write_env_label(env_index, normalised_label)
+    console.print(
+        f"registered provider [green]{normalised_label}[/green] "
+        f"(envIndex={env_index}, harness={resolved_harness})"
+    )
+
+
+@app.command("edit")
+def edit_cmd(
+    label: str = typer.Argument(..., help="Provider label to update."),
+    url: str | None = typer.Option(None, "--url", help="New OpenAI-compatible base URL."),
+    harness: str | None = typer.Option(None, "--harness", help="New agent harness."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Update an existing provider entry in config."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+
+    match_index: int | None = None
+    for idx, entry in enumerate(entries):
+        if str(entry.get("label", "")).lower() == label.strip().lower():
+            match_index = idx
+            break
+    if match_index is None:
+        cli_bail(f"unknown provider label {label!r}")
+
+    updated = dict(entries[match_index])
+    if url is not None:
+        try:
+            updated["url"] = validate_http_url(url)
+        except ValueError as exc:
+            cli_bail(str(exc))
+    if harness is not None:
+        try:
+            updated["harness"] = resolve_provider_harness(
+                str(updated.get("label", label)),
+                harness=harness,
+            )
+        except ValueError as exc:
+            cli_bail(str(exc))
+
+    entries[match_index] = updated
+    data["providers"] = entries
+    _write_config_dict(config_path, data)
+    console.print(f"updated provider [green]{updated.get('label', label)}[/green]")
+
+
+@app.command("delete")
+def delete_cmd(
+    label: str = typer.Argument(..., help="Provider label to remove."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Remove a provider label from config (env index gap is preserved)."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+
+    remaining: list[dict[str, Any]] = []
+    removed = False
+    for entry in entries:
+        if str(entry.get("label", "")).lower() == label.strip().lower():
+            removed = True
+            continue
+        remaining.append(entry)
+
+    if not removed:
+        cli_bail(f"unknown provider label {label!r}")
+
+    data["providers"] = remaining
+    _write_config_dict(config_path, data)
+    console.print(f"deleted provider [green]{label}[/green]")
+
+
+__all__ = [
+    "ProviderRegistry",
+    "app",
+    "list_supported_harnesses",
+    "load_provider_registry",
+    "resolve_provider_harness",
+    "seed_builtin_providers",
+]

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -59,6 +59,8 @@ LEGACY_API_KEY_MIGRATIONS: dict[str, tuple[str, str]] = {
     "CURSOR_API_KEY": ("cursor", "API_KEY"),
     "DEEPSEEK_API_KEY": ("deepseek", "API_KEY"),
     "NOUS_API_KEY": ("nous", "API_KEY"),
+    "TOKENHUB_API_KEY": ("tokenhub", "API_KEY"),
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY": ("minimax", "API_KEY"),
 }
 
 LEGACY_LABEL_TO_API_KEY_ENV: dict[str, str] = {

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import getpass
 import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,6 +18,7 @@ import yaml
 from mergecraft.agents.openai_compatible_gateways import GATEWAY_PRESETS
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
 from mergecraft.config.provider_registry import (
     BUILTIN_HARNESS_DEFAULTS,
     allocate_env_index,
@@ -25,6 +31,34 @@ from mergecraft.config.provider_registry import (
 )
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL
 from mergecraft.models import PROVIDERS
+
+AUTH_KIND_API_KEY = "api_key"
+AUTH_KIND_OAUTH = "oauth"
+AUTH_KIND_DEVICE_CODE = "device_code"
+AUTH_KIND_CLOUD_CHAIN = "cloud_chain"
+
+AUTH_KIND_PRIMARY_SUFFIX: dict[str, str] = {
+    AUTH_KIND_API_KEY: "API_KEY",
+    AUTH_KIND_OAUTH: "CLAUDE_CODE_OAUTH_TOKEN",
+    AUTH_KIND_DEVICE_CODE: "CODEX_AUTH_JSON",
+}
+
+BEDROCK_CLOUD_SUFFIXES: tuple[str, ...] = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+)
+
+VERTEX_CLOUD_SUFFIXES: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+_PROVIDER_AUTH_SCOPE_OPTION: str = typer.Option(
+    "github",
+    "--scope",
+    "-s",
+    help=(
+        "Where to persist credentials: 'local' (.env only), 'github' "
+        "(gh secret set, the default), or 'both'."
+    ),
+)
 
 app = typer.Typer(
     help="Add, list, edit, and delete LLM providers in the operator registry.",
@@ -317,11 +351,352 @@ def delete_cmd(
     console.print(f"deleted provider [green]{label}[/green]")
 
 
+def indexed_credential_keys(entry: Mapping[str, Any]) -> Sequence[str]:
+    """Return indexed ``LLM_PROVIDER_<N>_<SUFFIX>`` keys for *entry* (#478)."""
+    env_index = int(entry["envIndex"])
+    auth_kind = str(entry.get("authKind") or AUTH_KIND_API_KEY)
+    label = str(entry.get("label", "")).lower()
+
+    if auth_kind == AUTH_KIND_CLOUD_CHAIN:
+        if label == "bedrock":
+            suffixes = BEDROCK_CLOUD_SUFFIXES
+        elif label == "vertex":
+            suffixes = VERTEX_CLOUD_SUFFIXES
+        else:
+            suffixes = BEDROCK_CLOUD_SUFFIXES
+    else:
+        suffix = AUTH_KIND_PRIMARY_SUFFIX.get(auth_kind, "API_KEY")
+        suffixes = (suffix,)
+
+    return [f"LLM_PROVIDER_{env_index}_{suffix}" for suffix in suffixes]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthStrategy:
+    """Dispatch target for one provider ``authKind`` (#478)."""
+
+    run: Callable[..., None]
+
+
+def _entry_auth_kind(entry: Mapping[str, Any]) -> str:
+    explicit = entry.get("authKind")
+    if explicit is not None:
+        return str(explicit)
+    label = str(entry.get("label", ""))
+    default = default_auth_kind_for_label(label)
+    return default or AUTH_KIND_API_KEY
+
+
+def resolve_auth_strategy(auth_kind: str) -> AuthStrategy:
+    """Return the credential collector for *auth_kind*."""
+    normalised = auth_kind.strip().lower()
+    handlers: dict[str, Callable[..., None]] = {
+        AUTH_KIND_API_KEY: _run_api_key_strategy,
+        AUTH_KIND_OAUTH: _run_oauth_strategy,
+        AUTH_KIND_DEVICE_CODE: _run_device_code_strategy,
+        AUTH_KIND_CLOUD_CHAIN: _run_cloud_chain_strategy,
+    }
+    handler = handlers.get(normalised)
+    if handler is None:
+        cli_bail(f"unknown auth kind {auth_kind!r}")
+    return AuthStrategy(run=handler)
+
+
+def _indexed_label_key(env_index: int) -> str:
+    return f"LLM_PROVIDER_{env_index}"
+
+
+def _persist_indexed_credentials(
+    entry: Mapping[str, Any],
+    scope: str,
+    credential_map: Mapping[str, str],
+) -> None:
+    """Write ``LLM_PROVIDER_<N>`` label plus indexed credential suffixes to ``.env``."""
+    from mergecraft.cli.auth_cmd import (
+        _resolve_auth_target,
+        _single_line_credential,
+        _write_env_value,
+    )
+
+    env_index = int(entry["envIndex"])
+    label = str(entry["label"])
+    target = _resolve_auth_target(scope)
+    if not target.local:
+        cli_bail("indexed provider auth requires --scope local or --scope both")
+
+    env_path = _env_path()
+    label_key = _indexed_label_key(env_index)
+    if not _write_env_value(env_path, label_key, label):
+        cli_bail(f"could not write {label_key} to {env_path}")
+
+    for suffix, raw_value in credential_map.items():
+        key = f"LLM_PROVIDER_{env_index}_{suffix}"
+        value = _single_line_credential(name=key, value=raw_value)
+        if not _write_env_value(env_path, key, value):
+            cli_bail(f"could not write {key} to {env_path}")
+
+    landed = ", ".join([label_key, *credential_map.keys()])
+    console.print(f"[green]wrote {landed}[/green] to {env_path}")
+
+
+def _cancelable_getpass(prompt: str) -> str | None:
+    try:
+        value = getpass.getpass(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        console.print("canceled.")
+        raise typer.Exit(CLI_SUCCESS_EXIT_CODE) from None
+    if not value:
+        console.print("canceled.")
+        raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
+    return value
+
+
+def _validate_api_key_for_label(label: str, api_key: str, url: str | None) -> bool:
+    from mergecraft.cli.auth_cmd import (
+        DEFAULT_TOKENHUB,
+        _validate_cursor_api_key,
+        _validate_gemini_api_key,
+        _validate_minimax_api_key,
+        _validate_nous_api_key,
+        _validate_openai_compatible_key,
+    )
+
+    lowered = label.lower()
+    if lowered in {"nous", "google", "gemini"}:
+        if lowered == "nous":
+            return _validate_nous_api_key(api_key)
+        return _validate_gemini_api_key(api_key)
+    if lowered == "cursor":
+        return _validate_cursor_api_key(api_key)
+    if lowered == "minimax":
+        return _validate_minimax_api_key(api_key)
+    if lowered == "tokenhub":
+        return _validate_openai_compatible_key(
+            api_key=api_key,
+            base_url=DEFAULT_TOKENHUB,
+            label="tokenhub",
+        )
+    if url:
+        return _validate_openai_compatible_key(api_key=api_key, base_url=url, label=label)
+    return True
+
+
+def _run_api_key_strategy(entry: Mapping[str, Any], scope: str) -> None:
+    label = str(entry["label"])
+    url = entry.get("url")
+    url_str = str(url) if url is not None else None
+    console.print(f"paste the API key for provider [cyan]{label}[/cyan] below.")
+    api_key = _cancelable_getpass(f"{label} API key (Enter to cancel): ")
+    if api_key is None:
+        return
+    if not _validate_api_key_for_label(label, api_key, url_str):
+        cli_bail(f"{label} API key validation failed (401/403). Check the key and retry.")
+    _persist_indexed_credentials(
+        entry,
+        scope,
+        {AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_API_KEY]: api_key},
+    )
+
+
+def _run_oauth_strategy(entry: Mapping[str, Any], scope: str) -> None:
+    from mergecraft.cli.auth_cmd import CLAUDE_OAUTH_TOKEN_PREFIX
+
+    console.print(
+        "mint a token with [cyan]claude setup-token[/cyan], then paste it below "
+        f"(expected prefix [cyan]{CLAUDE_OAUTH_TOKEN_PREFIX}…[/cyan])."
+    )
+    oauth_token = _cancelable_getpass("Claude Code OAuth token (Enter to cancel): ")
+    if oauth_token is None:
+        return
+    if not oauth_token.startswith(CLAUDE_OAUTH_TOKEN_PREFIX):
+        console.print(
+            f"[yellow]warning:[/yellow] that doesn't look like a claude setup-token "
+            f"(expected {CLAUDE_OAUTH_TOKEN_PREFIX}…). saving it anyway."
+        )
+    suffix = AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_OAUTH]
+    _persist_indexed_credentials(entry, scope, {suffix: oauth_token})
+
+
+def _run_device_code_strategy(entry: Mapping[str, Any], scope: str) -> None:
+    if not shutil.which("codex"):
+        cli_bail(
+            "codex CLI not found on PATH.\n"
+            "  install: npm i -g @openai/codex\n"
+            "  then:    mergecraft provider auth openai"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="mergecraft-codex-") as tmp:
+        env = {**os.environ, "CODEX_HOME": tmp}
+        console.print("running [cyan]codex login --device-auth[/cyan] (isolated CODEX_HOME)...")
+        try:
+            subprocess.run(
+                ["codex", "login", "--device-auth"],
+                env=env,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            cli_bail(f"codex login failed (exit {exc.returncode})")
+
+        auth_path = Path(tmp) / "auth.json"
+        if not auth_path.is_file():
+            cli_bail("no auth.json was written — enable device-code auth and retry")
+        value = auth_path.read_text(encoding="utf-8")
+
+    suffix = AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_DEVICE_CODE]
+    _persist_indexed_credentials(entry, scope, {suffix: value})
+
+
+def _run_cloud_chain_strategy(entry: Mapping[str, Any], scope: str) -> None:
+    label = str(entry.get("label", "")).lower()
+    if label == "bedrock":
+        credentials: dict[str, str] = {}
+        for suffix in BEDROCK_CLOUD_SUFFIXES:
+            prompt_label = suffix.replace("_", " ")
+            value = _cancelable_getpass(f"{prompt_label} (Enter to cancel): ")
+            if value is None:
+                return
+            credentials[suffix] = value
+        _persist_indexed_credentials(entry, scope, credentials)
+        return
+
+    if label == "vertex":
+        path_or_empty = typer.prompt(
+            "Path to service account JSON (Enter to paste inline)",
+            default="",
+            show_default=False,
+        ).strip()
+        if path_or_empty:
+            _persist_indexed_credentials(
+                entry,
+                scope,
+                {VERTEX_CLOUD_SUFFIXES[0]: path_or_empty},
+            )
+            return
+
+        pasted = _cancelable_getpass("Paste service account JSON (Enter to cancel): ")
+        if pasted is None:
+            return
+        if "\n" in pasted:
+            cli_bail(
+                "VERTEX_SERVICE_ACCOUNT_JSON spans multiple lines — refusing to write a "
+                "broken .env entry. Provide a path via GOOGLE_APPLICATION_CREDENTIALS, "
+                "use --scope github, or store base64 in a GitHub secret."
+            )
+        suffix = VERTEX_CLOUD_SUFFIXES[0]
+        _persist_indexed_credentials(entry, scope, {suffix: pasted})
+        return
+
+    cli_bail(f"cloud_chain auth is not configured for provider {label!r}")
+
+
+def _interactive_provider_picker(registry: ProviderRegistry) -> dict[str, Any]:
+    entries = [dict(entry) for entry in registry.entries if entry.get("label")]
+    if not entries:
+        cli_bail("no providers registered — run mergecraft provider add first")
+
+    console.print("select a provider to authenticate:")
+    for idx, entry in enumerate(entries, start=1):
+        label = str(entry.get("label", ""))
+        url = entry.get("url")
+        if url:
+            console.print(f"  {idx}. {label}  ({url})")
+        else:
+            console.print(f"  {idx}. {label}")
+
+    choice = typer.prompt("Selection (Enter to cancel)", default="", show_default=False).strip()
+    if not choice:
+        console.print("canceled.")
+        raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
+    try:
+        selected = int(choice)
+    except ValueError:
+        cli_bail(f"invalid selection {choice!r}")
+    if selected < 1 or selected > len(entries):
+        cli_bail(f"selection {selected} out of range (1-{len(entries)})")
+    return entries[selected - 1]
+
+
+def run_provider_auth(
+    entry: Mapping[str, Any],
+    scope: str,
+    *,
+    credential_map: Mapping[str, str] | None = None,
+) -> None:
+    """Execute unified provider auth for one registry row (#478)."""
+    if credential_map is not None:
+        _persist_indexed_credentials(entry, scope, credential_map)
+        return
+    auth_kind = _entry_auth_kind(entry)
+    strategy = resolve_auth_strategy(auth_kind)
+    strategy.run(entry, scope)
+
+
+def persist_legacy_indexed_auth(
+    label: str,
+    scope: str,
+    credential_map: Mapping[str, str],
+) -> bool:
+    """Write *credential_map* via the indexed provider path when *label* is registered."""
+    config_path = _config_path(Path.cwd())
+    registry = load_provider_registry(config_path)
+    entry = registry.lookup(label)
+    if entry is None:
+        return False
+    run_provider_auth(entry, scope, credential_map=credential_map)
+    return True
+
+
+@app.command("auth")
+def provider_auth_cmd(
+    label: str | None = typer.Argument(
+        None,
+        help="Provider label (interactive picker when omitted).",
+    ),
+    scope: str = _PROVIDER_AUTH_SCOPE_OPTION,
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Authenticate one registered provider into indexed ``LLM_PROVIDER_*`` secrets."""
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    registry = load_provider_registry(config_path)
+
+    if label is not None:
+        normalised = label.strip()
+        if not normalised:
+            cli_bail("provider label must not be empty", code=CLI_USAGE_EXIT_CODE)
+        if normalised.lower() == "logfire":
+            cli_bail(
+                "logfire is telemetry, not an LLM provider — use "
+                "[cyan]mergecraft auth logfire[/cyan] instead."
+            )
+        entry = registry.lookup(normalised)
+        if entry is None:
+            cli_bail(f"unknown provider label {normalised!r}")
+        console.print(f"authenticating provider [cyan]{entry.get('label', normalised)}[/cyan]")
+        run_provider_auth(entry, scope)
+        return
+
+    picked = _interactive_provider_picker(registry)
+    console.print(f"authenticating provider [cyan]{picked.get('label')}[/cyan]")
+    run_provider_auth(picked, scope)
+
+
 __all__ = [
+    "AUTH_KIND_API_KEY",
+    "AUTH_KIND_CLOUD_CHAIN",
+    "AUTH_KIND_DEVICE_CODE",
+    "AUTH_KIND_OAUTH",
+    "AUTH_KIND_PRIMARY_SUFFIX",
+    "AuthStrategy",
     "ProviderRegistry",
     "app",
+    "indexed_credential_keys",
     "list_supported_harnesses",
     "load_provider_registry",
+    "persist_legacy_indexed_auth",
+    "provider_auth_cmd",
+    "resolve_auth_strategy",
     "resolve_provider_harness",
+    "run_provider_auth",
     "seed_builtin_providers",
 ]

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -15,7 +15,6 @@ from typing import Any
 import typer
 import yaml
 
-from mergecraft.agents.openai_compatible_gateways import GATEWAY_PRESETS
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
@@ -29,6 +28,7 @@ from mergecraft.config.provider_registry import (
     supported_harness_names,
     validate_http_url,
 )
+from mergecraft.config.runtime_provider_registry import SEED_PROVIDER_URLS
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL
 from mergecraft.models import PROVIDERS
 
@@ -145,7 +145,9 @@ def resolve_provider_harness(label: str, *, harness: str | None = None) -> str:
         if harness_value not in supported_harness_names():
             msg = f"unknown harness {harness!r}; {_harness_help_suffix()}"
             raise ValueError(msg)
-        if not harness_supports_provider(harness_value, normalised):
+        if default_harness_for_label(normalised) is not None and not harness_supports_provider(
+            harness_value, normalised
+        ):
             msg = (
                 f"incompatible harness {harness_value!r} for provider {label!r}; "
                 f"{_harness_help_suffix()}"
@@ -168,10 +170,7 @@ def load_provider_registry(config_path: Path) -> ProviderRegistry:
 
 
 def _seed_url_for_label(label: str) -> str | None:
-    preset = GATEWAY_PRESETS.get(label)
-    if preset is not None:
-        return preset.default_base_url
-    return None
+    return SEED_PROVIDER_URLS.get(label)
 
 
 def seed_builtin_providers(config_path: Path) -> None:

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -32,6 +32,7 @@ from mergecraft.config.provider_registry import (
 from mergecraft.config.runtime_provider_registry import SEED_PROVIDER_URLS
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL
 from mergecraft.models import PROVIDERS
+from mergecraft.utils.workspace import git_repo_root
 
 AUTH_KIND_API_KEY = "api_key"
 AUTH_KIND_OAUTH = "oauth"
@@ -124,11 +125,17 @@ def _config_path(cwd: Path) -> Path:
     return (cwd / _DEFAULT_CONFIG_REL).resolve()
 
 
-def _env_path() -> Path:
+def _env_path(cwd: Path | None = None) -> Path:
     configured = os.environ.get("MERGECRAFT_ENV")
     if configured:
         return Path(configured).resolve()
-    return Path.cwd() / ".env"
+    if cwd is not None:
+        return cwd.resolve() / ".env"
+
+    top = git_repo_root()
+    if top is None:
+        cli_bail("not inside a git repository (or pass --cwd)")
+    return top / ".env"
 
 
 def _load_config_dict(path: Path) -> dict[str, Any]:
@@ -159,11 +166,11 @@ def _provider_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
     return [entry for entry in raw if isinstance(entry, dict)]
 
 
-def _write_env_label(env_index: int, label: str) -> None:
+def _write_env_label(env_index: int, label: str, cwd: Path | None = None) -> None:
     from mergecraft.cli.auth_cmd import _write_env_value
 
     key = f"LLM_PROVIDER_{env_index}"
-    _write_env_value(_env_path(), key, label)
+    _write_env_value(_env_path(cwd), key, label)
 
 
 def _harness_help_suffix() -> str:
@@ -308,7 +315,7 @@ def add_cmd(
     entries.append(entry)
     data["providers"] = entries
     _write_config_dict(config_path, data)
-    _write_env_label(env_index, normalised_label)
+    _write_env_label(env_index, normalised_label, repo_root)
     console.print(
         f"registered provider [green]{normalised_label}[/green] "
         f"(envIndex={env_index}, harness={resolved_harness})"
@@ -443,6 +450,8 @@ def _persist_indexed_credentials(
     entry: Mapping[str, Any],
     scope: str,
     credential_map: Mapping[str, str],
+    *,
+    cwd: Path | None = None,
 ) -> None:
     """Write ``LLM_PROVIDER_<N>`` label plus indexed credential suffixes."""
     from mergecraft.cli.auth_cmd import (
@@ -456,7 +465,7 @@ def _persist_indexed_credentials(
     label = str(entry["label"])
     target = _resolve_auth_target(scope)
 
-    env_path = _env_path()
+    env_path = _env_path(cwd)
     label_key = _indexed_label_key(env_index)
     any_local_written = False
 
@@ -546,7 +555,12 @@ def _validate_api_key_for_label(label: str, api_key: str, url: str | None) -> bo
     return True
 
 
-def _run_api_key_strategy(entry: Mapping[str, Any], scope: str) -> None:
+def _run_api_key_strategy(
+    entry: Mapping[str, Any],
+    scope: str,
+    *,
+    cwd: Path | None = None,
+) -> None:
     label = str(entry["label"])
     url = entry.get("url")
     url_str = str(url) if url is not None else None
@@ -560,10 +574,16 @@ def _run_api_key_strategy(entry: Mapping[str, Any], scope: str) -> None:
         entry,
         scope,
         {AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_API_KEY]: api_key},
+        cwd=cwd,
     )
 
 
-def _run_oauth_strategy(entry: Mapping[str, Any], scope: str) -> None:
+def _run_oauth_strategy(
+    entry: Mapping[str, Any],
+    scope: str,
+    *,
+    cwd: Path | None = None,
+) -> None:
     from mergecraft.cli.auth_cmd import CLAUDE_OAUTH_TOKEN_PREFIX
 
     console.print(
@@ -579,10 +599,15 @@ def _run_oauth_strategy(entry: Mapping[str, Any], scope: str) -> None:
             f"(expected {CLAUDE_OAUTH_TOKEN_PREFIX}…). saving it anyway."
         )
     suffix = AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_OAUTH]
-    _persist_indexed_credentials(entry, scope, {suffix: oauth_token})
+    _persist_indexed_credentials(entry, scope, {suffix: oauth_token}, cwd=cwd)
 
 
-def _run_device_code_strategy(entry: Mapping[str, Any], scope: str) -> None:
+def _run_device_code_strategy(
+    entry: Mapping[str, Any],
+    scope: str,
+    *,
+    cwd: Path | None = None,
+) -> None:
     if not shutil.which("codex"):
         cli_bail(
             "codex CLI not found on PATH.\n"
@@ -608,10 +633,15 @@ def _run_device_code_strategy(entry: Mapping[str, Any], scope: str) -> None:
         value = auth_path.read_text(encoding="utf-8")
 
     suffix = AUTH_KIND_PRIMARY_SUFFIX[AUTH_KIND_DEVICE_CODE]
-    _persist_indexed_credentials(entry, scope, {suffix: value})
+    _persist_indexed_credentials(entry, scope, {suffix: value}, cwd=cwd)
 
 
-def _run_cloud_chain_strategy(entry: Mapping[str, Any], scope: str) -> None:
+def _run_cloud_chain_strategy(
+    entry: Mapping[str, Any],
+    scope: str,
+    *,
+    cwd: Path | None = None,
+) -> None:
     label = str(entry.get("label", "")).lower()
     if label == "bedrock":
         credentials: dict[str, str] = {}
@@ -621,7 +651,7 @@ def _run_cloud_chain_strategy(entry: Mapping[str, Any], scope: str) -> None:
             if value is None:
                 return
             credentials[suffix] = value
-        _persist_indexed_credentials(entry, scope, credentials)
+        _persist_indexed_credentials(entry, scope, credentials, cwd=cwd)
         return
 
     if label == "vertex":
@@ -635,6 +665,7 @@ def _run_cloud_chain_strategy(entry: Mapping[str, Any], scope: str) -> None:
                 entry,
                 scope,
                 {VERTEX_CLOUD_SUFFIXES[0]: path_or_empty},
+                cwd=cwd,
             )
             return
 
@@ -648,7 +679,7 @@ def _run_cloud_chain_strategy(entry: Mapping[str, Any], scope: str) -> None:
                 "use --scope github, or store base64 in a GitHub secret."
             )
         suffix = VERTEX_CLOUD_SUFFIXES[0]
-        _persist_indexed_credentials(entry, scope, {suffix: pasted})
+        _persist_indexed_credentials(entry, scope, {suffix: pasted}, cwd=cwd)
         return
 
     cli_bail(f"cloud_chain auth is not configured for provider {label!r}")
@@ -686,14 +717,15 @@ def run_provider_auth(
     scope: str,
     *,
     credential_map: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
 ) -> None:
     """Execute unified provider auth for one registry row (#478)."""
     if credential_map is not None:
-        _persist_indexed_credentials(entry, scope, credential_map)
+        _persist_indexed_credentials(entry, scope, credential_map, cwd=cwd)
         return
     auth_kind = _entry_auth_kind(entry)
     strategy = resolve_auth_strategy(auth_kind)
-    strategy.run(entry, scope)
+    strategy.run(entry, scope, cwd=cwd)
 
 
 @dataclass(frozen=True, slots=True)
@@ -793,13 +825,17 @@ def _warn_legacy_credential_once(legacy_key: str, indexed_key: str) -> None:
     warnings.warn(message, DeprecationWarning, stacklevel=2)
 
 
-def resolve_indexed_credential(entry: Mapping[str, Any]) -> str | None:
+def resolve_indexed_credential(
+    entry: Mapping[str, Any],
+    *,
+    cwd: Path | None = None,
+) -> str | None:
     """Resolve the primary API credential for *entry*; registry key wins over legacy (D7)."""
     env_index = int(entry["envIndex"])
     label = str(entry.get("label", "")).lower()
     auth_kind = str(entry.get("authKind") or AUTH_KIND_API_KEY)
 
-    env_map = _read_env_map(_env_path())
+    env_map = _read_env_map(_env_path(cwd))
     legacy_key = LEGACY_LABEL_TO_API_KEY_ENV.get(label)
     legacy_value = env_map.get(legacy_key, "").strip() if legacy_key else ""
 
@@ -1101,7 +1137,7 @@ def migrate_cmd(
     """Migrate legacy ``*_API_KEY`` env vars into indexed provider registry layout (D2 / #483)."""
     repo_root = cwd.resolve()
     config_path = _config_path(repo_root)
-    env_path = _env_path()
+    env_path = _env_path(cwd)
     plan = plan_provider_migration(env_path=env_path, config_path=config_path)
 
     if not plan.providers and not plan.env_writes:
@@ -1170,12 +1206,12 @@ def provider_auth_cmd(
         if entry is None:
             cli_bail(f"unknown provider label {normalised!r}")
         console.print(f"authenticating provider [cyan]{entry.get('label', normalised)}[/cyan]")
-        run_provider_auth(entry, scope)
+        run_provider_auth(entry, scope, cwd=repo_root)
         return
 
     picked = _interactive_provider_picker(registry)
     console.print(f"authenticating provider [cyan]{picked.get('label')}[/cyan]")
-    run_provider_auth(picked, scope)
+    run_provider_auth(picked, scope, cwd=repo_root)
 
 
 __all__ = [

--- a/src/mergecraft/cli/workflow_cmd.py
+++ b/src/mergecraft/cli/workflow_cmd.py
@@ -138,7 +138,7 @@ def _plan_provider_for_workflow(
         entries.append(entry)
         data["providers"] = entries
         _write_config_dict(config_path, data)
-        _write_env_label(env_index, normalised_label)
+        _write_env_label(env_index, normalised_label, repo_root)
     return entry, env_index
 
 

--- a/src/mergecraft/cli/workflow_cmd.py
+++ b/src/mergecraft/cli/workflow_cmd.py
@@ -1,0 +1,437 @@
+"""``mergecraft workflow`` — consumer workflow authoring for providers/models (#484)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+from mergecraft.cli.agents_cmd import validate_registered_model_slug
+from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+from mergecraft.cli.provider_cmd import (
+    _config_path,
+    _load_config_dict,
+    _provider_entries,
+    _write_config_dict,
+    _write_env_label,
+    indexed_credential_keys,
+    load_provider_registry,
+    resolve_provider_harness,
+)
+from mergecraft.cli.tracing_logfire_wf_yaml import _is_action_uses
+from mergecraft.cli.workflow_wf_yaml import (
+    DEFAULT_WORKFLOW_RELATIVE_PATH,
+    WorkflowChange,
+    WorkflowYamlError,
+    apply_model_prioritize,
+    apply_model_wiring,
+    apply_provider_env_wiring,
+    render_workflow_diff,
+)
+from mergecraft.config.provider_registry import (
+    allocate_env_index,
+    list_supported_harnesses,
+    validate_http_url,
+)
+
+app = typer.Typer(
+    help="Author provider and model wiring in the consumer GitHub Actions workflow.",
+    no_args_is_help=True,
+)
+
+provider_app = typer.Typer(
+    help="Provider env wiring for mergeCraft workflow steps.", no_args_is_help=True
+)
+model_app = typer.Typer(help="Model wiring for mergeCraft workflow steps.", no_args_is_help=True)
+agents_app = typer.Typer(
+    help="Agent model wiring for mergeCraft workflow steps.", no_args_is_help=True
+)
+
+app.add_typer(provider_app, name="provider")
+app.add_typer(model_app, name="model")
+app.add_typer(agents_app, name="agents")
+
+
+def _workflow_option() -> Path:
+    return Path(DEFAULT_WORKFLOW_RELATIVE_PATH)
+
+
+def _emit_workflow_change(
+    workflow: Path,
+    change: WorkflowChange,
+    *,
+    apply: bool,
+) -> None:
+    if change.was_modified:
+        console.print(render_workflow_diff(workflow, change))
+    else:
+        console.print(
+            f"[dim]{workflow} already matches the requested wiring; no changes needed.[/dim]"
+        )
+
+    if not apply:
+        console.print("[dim]dry-run (re-run with --apply to write)[/dim]")
+        raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
+
+    try:
+        workflow.write_text(change.new_text, encoding="utf-8")
+    except OSError as exc:
+        cli_bail(f"could not write {workflow}: {exc}")
+    console.print(f"[green]wrote[/green] {workflow}")
+
+
+def _plan_provider_for_workflow(
+    repo_root: Path,
+    *,
+    label: str,
+    url: str | None,
+    harness: str | None,
+    persist: bool,
+) -> tuple[dict[str, Any], int]:
+    """Resolve or register a provider; optionally persist config changes."""
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+    normalised_label = label.strip()
+    if not normalised_label:
+        cli_bail("label must not be empty")
+
+    for entry in entries:
+        if str(entry.get("label", "")).lower() == normalised_label.lower():
+            env_index = int(entry["envIndex"])
+            resolved_url = entry.get("url")
+            if url is not None:
+                try:
+                    resolved_url = validate_http_url(url)
+                except ValueError as exc:
+                    cli_bail(str(exc))
+            if resolved_url is None:
+                cli_bail(f"provider {normalised_label!r} requires --url (absolute http(s) URL)")
+            return entry, env_index
+
+    try:
+        resolved_harness = resolve_provider_harness(normalised_label, harness=harness)
+    except ValueError as exc:
+        cli_bail(str(exc))
+
+    new_provider_url: str | None = None
+    if url is not None:
+        try:
+            new_provider_url = validate_http_url(url)
+        except ValueError as exc:
+            cli_bail(str(exc))
+    else:
+        cli_bail(f"provider {normalised_label!r} requires --url (absolute http(s) URL)")
+
+    env_index = allocate_env_index(entries)
+    entry = {
+        "label": normalised_label,
+        "harness": resolved_harness,
+        "envIndex": env_index,
+        "url": new_provider_url,
+    }
+    if persist:
+        entries.append(entry)
+        data["providers"] = entries
+        _write_config_dict(config_path, data)
+        _write_env_label(env_index, normalised_label)
+    return entry, env_index
+
+
+def _primary_secret_name(entry: dict[str, Any]) -> str:
+    keys = indexed_credential_keys(entry)
+    for key in keys:
+        if key.endswith("_API_KEY"):
+            return key
+    return keys[0] if keys else f"LLM_PROVIDER_{int(entry['envIndex'])}_API_KEY"
+
+
+def _print_missing_secret_guidance(entry: dict[str, Any]) -> None:
+    for secret_name in indexed_credential_keys(entry):
+        console.print(
+            f"[yellow]GitHub Actions secret still required:[/yellow] {secret_name} "
+            f"(run [cyan]mergecraft provider auth {entry.get('label')}[/cyan] or "
+            f"[cyan]gh secret set {secret_name}[/cyan])"
+        )
+
+
+def _resolve_registered_model(
+    repo_root: Path,
+    *,
+    provider: str,
+    model: str,
+) -> str:
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    return validate_registered_model_slug(data, provider, model)
+
+
+def _iter_mergecraft_steps(workflow_path: Path) -> list[dict[str, Any]]:
+    try:
+        text = workflow_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        cli_bail(f"could not read {workflow_path}: {exc}")
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        cli_bail(f"could not parse {workflow_path}: {exc}")
+    if not isinstance(parsed, dict):
+        cli_bail(f"{workflow_path} must be a mapping at the top level")
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    rows: list[dict[str, Any]] = []
+    for job_name, job_def in jobs.items():
+        if not isinstance(job_def, dict):
+            continue
+        steps = job_def.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not _is_action_uses(uses):
+                continue
+            rows.append(
+                {
+                    "job": job_name,
+                    "index": i,
+                    "id": step.get("id") or step.get("name") or f"job:{job_name}/step:{i}",
+                    "model": (step.get("with") or {}).get("model")
+                    if isinstance(step.get("with"), dict)
+                    else None,
+                    "env": step.get("env") if isinstance(step.get("env"), dict) else {},
+                }
+            )
+    return rows
+
+
+@app.command("list")
+def list_cmd(
+    workflow: Path = typer.Option(
+        _workflow_option(),
+        "--workflow",
+        "-w",
+        help=f"Path to the consumer workflow YAML (default: {DEFAULT_WORKFLOW_RELATIVE_PATH}).",
+        exists=False,
+    ),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """List provider/model wiring present in mergeCraft workflow steps."""
+    repo_root = cwd.resolve()
+    steps = _iter_mergecraft_steps(workflow)
+    if not steps:
+        console.print(f"[yellow]no uses: alexhawat/mergeCraft steps found in {workflow}[/yellow]")
+        return
+
+    registry = load_provider_registry(_config_path(repo_root))
+    for row in steps:
+        model = row.get("model")
+        console.print(f"[bold]{row['id']}[/bold]  model={model!r}")
+        env_map = row.get("env") or {}
+        if not isinstance(env_map, dict):
+            continue
+        for key, value in env_map.items():
+            if not isinstance(key, str):
+                continue
+            if key.startswith("MERGECRAFT_CUSTOM_PROVIDER_") or "API_KEY" in key:
+                console.print(f"  env.{key}={value}")
+        if model and isinstance(model, str) and "/" in model:
+            provider_label, model_tail = model.split("/", 1)
+            entry = registry.lookup(provider_label)
+            if entry is not None:
+                for secret_name in indexed_credential_keys(entry):
+                    console.print(f"  secret: {secret_name}")
+                console.print(f"  provider: {provider_label}  model: {model_tail}")
+
+
+@provider_app.command("harnesses")
+def provider_harnesses_cmd() -> None:
+    """List supported agent harnesses (generated from code)."""
+    for row in list_supported_harnesses():
+        console.print(f"{row.name}  {row.description}")
+
+
+@provider_app.command("add")
+def provider_add_cmd(
+    label: str = typer.Option(..., "--label", help="Stable provider handle."),
+    url: str | None = typer.Option(None, "--url", help="OpenAI-compatible base URL."),
+    harness: str | None = typer.Option(None, "--harness", help="Agent harness for this provider."),
+    workflow: Path = typer.Option(
+        _workflow_option(),
+        "--workflow",
+        "-w",
+        help=f"Path to the consumer workflow YAML (default: {DEFAULT_WORKFLOW_RELATIVE_PATH}).",
+        exists=False,
+    ),
+    step: str = typer.Option(
+        "primary",
+        "--step",
+        help="Which mergeCraft step to wire (primary, all, or step id/name).",
+    ),
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Write changes to disk. Default is dry-run.",
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite differing owned env values."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Register a provider and wire indexed custom-provider env keys into the workflow."""
+    repo_root = cwd.resolve()
+    entry, env_index = _plan_provider_for_workflow(
+        repo_root,
+        label=label,
+        url=url,
+        harness=harness,
+        persist=apply,
+    )
+    secret_name = _primary_secret_name(entry)
+    base_url = str(entry.get("url", ""))
+    if not base_url:
+        cli_bail(f"provider {label!r} has no base URL")
+
+    try:
+        change = apply_provider_env_wiring(
+            workflow_path=workflow,
+            env_index=env_index,
+            label=str(entry.get("label", label)),
+            base_url=base_url,
+            secret_name=secret_name,
+            step_selector=step,
+            force=force,
+        )
+    except WorkflowYamlError as exc:
+        cli_bail(str(exc))
+
+    _print_missing_secret_guidance(entry)
+    _emit_workflow_change(workflow, change, apply=apply)
+
+
+@model_app.command("add")
+def model_add_cmd(
+    provider: str = typer.Option(..., "--provider", help="Registered provider label."),
+    model: str = typer.Argument(..., help="Model id to wire into the workflow."),
+    workflow: Path = typer.Option(
+        _workflow_option(),
+        "--workflow",
+        "-w",
+        help=f"Path to the consumer workflow YAML (default: {DEFAULT_WORKFLOW_RELATIVE_PATH}).",
+        exists=False,
+    ),
+    step: str = typer.Option("primary", "--step", help="Which mergeCraft step to update."),
+    apply: bool = typer.Option(False, "--apply", help="Write changes to disk."),
+    force: bool = typer.Option(False, "--force", help="Overwrite differing with.model values."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Wire a registered model into ``with.model`` on a mergeCraft workflow step."""
+    repo_root = cwd.resolve()
+    slug = _resolve_registered_model(repo_root, provider=provider, model=model)
+    try:
+        change = apply_model_wiring(
+            workflow_path=workflow,
+            model_slug=slug,
+            step_selector=step,
+            force=force,
+        )
+    except WorkflowYamlError as exc:
+        cli_bail(str(exc))
+    _emit_workflow_change(workflow, change, apply=apply)
+
+
+@model_app.command("prioritize")
+def model_prioritize_cmd(
+    provider: str = typer.Option(..., "--provider", help="Registered provider label."),
+    model: str = typer.Option(..., "--model", help="Model id to promote."),
+    before: str = typer.Option(..., "--before", help="Existing model slug to deprioritize."),
+    workflow: Path = typer.Option(
+        _workflow_option(),
+        "--workflow",
+        "-w",
+        help=f"Path to the consumer workflow YAML (default: {DEFAULT_WORKFLOW_RELATIVE_PATH}).",
+        exists=False,
+    ),
+    apply: bool = typer.Option(False, "--apply", help="Write changes to disk."),
+    force: bool = typer.Option(False, "--force", help="Overwrite differing with.model values."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Promote one model ahead of another in the workflow fallback chain."""
+    repo_root = cwd.resolve()
+    slug = _resolve_registered_model(repo_root, provider=provider, model=model)
+    before_slug = before.strip()
+    try:
+        change = apply_model_prioritize(
+            workflow_path=workflow,
+            model_slug=slug,
+            before_slug=before_slug,
+            force=force,
+        )
+    except WorkflowYamlError as exc:
+        cli_bail(str(exc))
+    _emit_workflow_change(workflow, change, apply=apply)
+
+
+@agents_app.command("setmodel")
+def agents_setmodel_cmd(
+    agent: str = typer.Option(..., "--agent", help="Agent role (e.g. reviewer)."),
+    provider: str | None = typer.Option(None, "--provider", help="Registered provider label."),
+    model: str | None = typer.Option(None, "--model", help="Model id on the provider."),
+    workflow: Path = typer.Option(
+        _workflow_option(),
+        "--workflow",
+        "-w",
+        help=f"Path to the consumer workflow YAML (default: {DEFAULT_WORKFLOW_RELATIVE_PATH}).",
+        exists=False,
+    ),
+    step: str = typer.Option(
+        "primary",
+        "--step",
+        help="Which mergeCraft step to update (primary, all, or step id/name).",
+    ),
+    apply: bool = typer.Option(False, "--apply", help="Write changes to disk."),
+    force: bool = typer.Option(False, "--force", help="Overwrite differing with.model values."),
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+) -> None:
+    """Wire an agent's primary model into a mergeCraft workflow step."""
+    _ = agent  # config validation deferred to registry slug resolution
+    repo_root = cwd.resolve()
+    config_path = _config_path(repo_root)
+    data = _load_config_dict(config_path)
+    entries = _provider_entries(data)
+    labels = [str(entry["label"]) for entry in entries if entry.get("label")]
+    if not labels:
+        cli_bail("no providers registered — run mergecraft provider add first")
+
+    provider_label = provider or typer.prompt(f"provider ({', '.join(labels)})")
+    model_id = model or typer.prompt("model id")
+    slug = validate_registered_model_slug(data, provider_label, model_id)
+
+    try:
+        change = apply_model_wiring(
+            workflow_path=workflow,
+            model_slug=slug,
+            step_selector=step,
+            force=force,
+        )
+    except WorkflowYamlError as exc:
+        cli_bail(str(exc))
+    _emit_workflow_change(workflow, change, apply=apply)
+
+
+__all__ = [
+    "agents_app",
+    "agents_setmodel_cmd",
+    "app",
+    "list_cmd",
+    "model_add_cmd",
+    "model_app",
+    "model_prioritize_cmd",
+    "provider_add_cmd",
+    "provider_app",
+    "provider_harnesses_cmd",
+]

--- a/src/mergecraft/cli/workflow_wf_yaml.py
+++ b/src/mergecraft/cli/workflow_wf_yaml.py
@@ -1,0 +1,369 @@
+"""Surgical YAML mutator for ``mergecraft workflow`` provider/model authoring (#484).
+
+Extends the line-based mutation strategy from
+:mod:`mergecraft.cli.tracing_logfire_wf_yaml` — PyYAML parses for assertions only;
+owned ``with:`` / ``env:`` keys are edited in-place so comments and unrelated
+YAML stay byte-stable.
+"""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from mergecraft.cli.tracing_logfire_wf_yaml import (
+    DEFAULT_WORKFLOW_RELATIVE_PATH,
+    LogfireWorkflowError,
+    WiringChange,
+    _create_env_block,
+    _create_with_block,
+    _find_mapping_block,
+    _insert_owned_keys_into_block,
+    _is_action_uses,
+    _mutate_steps,
+    _splice_secret,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+WORKFLOW_OWNED_WITH_KEYS: tuple[str, ...] = ("model",)
+
+WORKFLOW_OWNED_ENV_PREFIXES: tuple[str, ...] = (
+    "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_",
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_",
+)
+
+WorkflowYamlError = LogfireWorkflowError
+WorkflowChange = WiringChange
+
+
+def _indexed_base_url_key(env_index: int) -> str:
+    return f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{env_index}"
+
+
+def _indexed_api_key_key(env_index: int) -> str:
+    return f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{env_index}"
+
+
+def _read_workflow_text(workflow_path: Path) -> str:
+    try:
+        return workflow_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise WorkflowYamlError(f"workflow file not found: {workflow_path}") from exc
+    except OSError as exc:
+        raise WorkflowYamlError(f"could not read {workflow_path}: {exc}") from exc
+
+
+def _assert_model_wired(text: str, *, step_identifiers: list[str], model_slug: str) -> None:
+    if not step_identifiers:
+        return
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorkflowYamlError(f"mutation produced invalid YAML: {exc}") from exc
+    if not isinstance(parsed, dict):
+        return
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    targets = set(step_identifiers)
+    for job_def in jobs.values():
+        if not isinstance(job_def, dict):
+            continue
+        steps = job_def.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not _is_action_uses(uses):
+                continue
+            step_id = step.get("id") or step.get("name") or f"step[{i}]"
+            if step_id not in targets:
+                continue
+            with_map = step.get("with")
+            if not isinstance(with_map, dict) or with_map.get("model") != model_slug:
+                raise WorkflowYamlError(
+                    f"mergeCraft step {step_id!r} missing with.model={model_slug!r} after mutation"
+                )
+
+
+def _assert_provider_env_wired(
+    text: str,
+    *,
+    step_identifiers: list[str],
+    env_index: int,
+    base_url: str,
+    secret_name: str,
+) -> None:
+    if not step_identifiers:
+        return
+    base_key = _indexed_base_url_key(env_index)
+    api_key = _indexed_api_key_key(env_index)
+    expected_api = f"${{{{ secrets.{secret_name} }}}}"
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorkflowYamlError(f"mutation produced invalid YAML: {exc}") from exc
+    if not isinstance(parsed, dict):
+        return
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    targets = set(step_identifiers)
+    for job_def in jobs.values():
+        if not isinstance(job_def, dict):
+            continue
+        steps = job_def.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not _is_action_uses(uses):
+                continue
+            step_id = step.get("id") or step.get("name") or f"step[{i}]"
+            if step_id not in targets:
+                continue
+            env_map = step.get("env")
+            if not isinstance(env_map, dict):
+                raise WorkflowYamlError(f"mergeCraft step {step_id!r} missing env: mapping")
+            if env_map.get(base_key) != base_url:
+                raise WorkflowYamlError(
+                    f"mergeCraft step {step_id!r} missing env.{base_key}={base_url!r}"
+                )
+            if env_map.get(api_key) != expected_api:
+                raise WorkflowYamlError(
+                    f"mergeCraft step {step_id!r} missing env.{api_key}={expected_api!r}"
+                )
+
+
+def apply_provider_env_wiring(
+    *,
+    workflow_path: Path,
+    env_index: int,
+    label: str,
+    base_url: str,
+    secret_name: str,
+    step_selector: str,
+    force: bool,
+) -> WorkflowChange:
+    """Insert indexed custom-provider ``env:`` keys into a mergeCraft step."""
+    _ = label  # operator context only; workflow keys are index-based
+    text = _read_workflow_text(workflow_path)
+    validated_secret = _splice_secret(secret_name)
+    base_key = _indexed_base_url_key(env_index)
+    api_key = _indexed_api_key_key(env_index)
+    env_canonical: list[tuple[str, str]] = [
+        (base_key, base_url),
+        (api_key, f"${{{{ secrets.{validated_secret} }}}}"),
+    ]
+
+    def _do(block: str, step_indent: int) -> tuple[str, bool]:
+        block2, mod_env = _insert_owned_keys_into_block(
+            block,
+            key="env",
+            canonical=env_canonical,
+            env_style=True,
+            force=force,
+            at_indent=step_indent,
+        )
+        if not mod_env and _find_mapping_block(block2, "env", at_indent=step_indent) is None:
+            block2 = _create_env_block(block2, env_canonical[0], at_indent=step_indent)
+            mod_env = True
+        block3, mod_env2 = _insert_owned_keys_into_block(
+            block2,
+            key="env",
+            canonical=env_canonical,
+            env_style=True,
+            force=force,
+            at_indent=step_indent,
+        )
+        return block3, mod_env or mod_env2
+
+    def _post_check(cur_text: str, *, step_identifiers: list[str]) -> None:
+        _assert_provider_env_wired(
+            cur_text,
+            step_identifiers=step_identifiers,
+            env_index=env_index,
+            base_url=base_url,
+            secret_name=validated_secret,
+        )
+
+    return _mutate_steps(
+        text,
+        step_selector=step_selector,
+        mutate_one=_do,
+        post_mutation_check=_post_check,
+    )
+
+
+def apply_model_wiring(
+    *,
+    workflow_path: Path,
+    model_slug: str,
+    step_selector: str,
+    force: bool,
+) -> WorkflowChange:
+    """Insert or replace ``with.model`` on a selected mergeCraft step."""
+    _ = force  # ``model`` is workflow-owned; differing values are always replaced.
+    text = _read_workflow_text(workflow_path)
+    with_canonical: list[tuple[str, str]] = [("model", model_slug)]
+
+    def _do(block: str, step_indent: int) -> tuple[str, bool]:
+        block2, mod_with = _insert_owned_keys_into_block(
+            block,
+            key="with",
+            canonical=with_canonical,
+            env_style=False,
+            force=True,
+            at_indent=step_indent,
+        )
+        if not mod_with and _find_mapping_block(block2, "with", at_indent=step_indent) is None:
+            block2 = _create_with_block(block2, with_canonical, at_indent=step_indent)
+            mod_with = True
+        return block2, mod_with
+
+    def _post_check(cur_text: str, *, step_identifiers: list[str]) -> None:
+        _assert_model_wired(cur_text, step_identifiers=step_identifiers, model_slug=model_slug)
+
+    return _mutate_steps(
+        text,
+        step_selector=step_selector,
+        mutate_one=_do,
+        post_mutation_check=_post_check,
+    )
+
+
+def _find_prioritize_step_ids(text: str, before_slug: str) -> tuple[str, str]:
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorkflowYamlError(f"could not parse workflow: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise WorkflowYamlError("workflow must be a mapping at the top level")
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, dict):
+        raise WorkflowYamlError("workflow has no jobs: mapping")
+
+    anchor_id: str | None = None
+    other_ids: list[str] = []
+    for job_name, job_def in jobs.items():
+        if not isinstance(job_def, dict):
+            continue
+        steps = job_def.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not _is_action_uses(uses):
+                continue
+            step_id = str(step.get("id") or step.get("name") or f"job:{job_name}/step:{i}")
+            with_map = step.get("with")
+            model = with_map.get("model") if isinstance(with_map, dict) else None
+            if model == before_slug:
+                anchor_id = step_id
+            else:
+                other_ids.append(step_id)
+
+    if anchor_id is None:
+        raise WorkflowYamlError(f"no mergeCraft step with with.model={before_slug!r} found")
+    if not other_ids:
+        raise WorkflowYamlError("need at least two mergeCraft steps to prioritize models")
+    return anchor_id, other_ids[-1]
+
+
+def apply_model_prioritize(
+    *,
+    workflow_path: Path,
+    model_slug: str,
+    before_slug: str,
+    force: bool,
+) -> WorkflowChange:
+    """Promote *model_slug* on the anchor step and demote *before_slug* to a fallback step."""
+    original = _read_workflow_text(workflow_path)
+    anchor_id, swap_id = _find_prioritize_step_ids(original, before_slug)
+
+    intermediate = _mutate_steps(
+        original,
+        step_selector=anchor_id,
+        mutate_one=_model_mutator(model_slug, force),
+        post_mutation_check=lambda cur, step_identifiers: _assert_model_wired(
+            cur, step_identifiers=step_identifiers, model_slug=model_slug
+        ),
+    )
+
+    final = _mutate_steps(
+        intermediate.new_text,
+        step_selector=swap_id,
+        mutate_one=_model_mutator(before_slug, force),
+        post_mutation_check=lambda cur, step_identifiers: _assert_model_wired(
+            cur, step_identifiers=step_identifiers, model_slug=before_slug
+        ),
+    )
+    return WorkflowChange(
+        old_text=original,
+        new_text=final.new_text,
+        affected_steps=[anchor_id, swap_id],
+    )
+
+
+def _model_mutator(model_slug: str, force: bool) -> Callable[[str, int], tuple[str, bool]]:
+    with_canonical: list[tuple[str, str]] = [("model", model_slug)]
+    _ = force  # model is workflow-owned; always overwrite differing values
+
+    def _do(block: str, step_indent: int) -> tuple[str, bool]:
+        block2, mod_with = _insert_owned_keys_into_block(
+            block,
+            key="with",
+            canonical=with_canonical,
+            env_style=False,
+            force=True,
+            at_indent=step_indent,
+        )
+        if not mod_with and _find_mapping_block(block2, "with", at_indent=step_indent) is None:
+            block2 = _create_with_block(block2, with_canonical, at_indent=step_indent)
+            mod_with = True
+        return block2, mod_with
+
+    return _do
+
+
+def render_workflow_diff(
+    workflow_path: Path, change: WorkflowChange, *, max_lines: int = 200
+) -> str:
+    """Return a unified-diff text between ``change.old_text`` and ``change.new_text``."""
+    rel = str(workflow_path)
+    diff = difflib.unified_diff(
+        change.old_text.splitlines(keepends=True),
+        change.new_text.splitlines(keepends=True),
+        fromfile=f"{rel} (current)",
+        tofile=f"{rel} (proposed)",
+        lineterm="",
+    )
+    lines = list(diff)
+    if len(lines) > max_lines:
+        truncation = f"... ({len(lines) - max_lines} more lines truncated)\n"
+        lines = [*lines[:max_lines], truncation]
+    return "".join(line if line.endswith("\n") else f"{line}\n" for line in lines)
+
+
+__all__ = [
+    "DEFAULT_WORKFLOW_RELATIVE_PATH",
+    "WORKFLOW_OWNED_ENV_PREFIXES",
+    "WORKFLOW_OWNED_WITH_KEYS",
+    "WorkflowChange",
+    "WorkflowYamlError",
+    "apply_model_prioritize",
+    "apply_model_wiring",
+    "apply_provider_env_wiring",
+    "render_workflow_diff",
+]

--- a/src/mergecraft/cli/workflow_wf_yaml.py
+++ b/src/mergecraft/cli/workflow_wf_yaml.py
@@ -34,7 +34,7 @@ WORKFLOW_OWNED_WITH_KEYS: tuple[str, ...] = ("model",)
 
 WORKFLOW_OWNED_ENV_PREFIXES: tuple[str, ...] = (
     "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_",
-    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_",
+    "LLM_PROVIDER_",
 )
 
 WorkflowYamlError = LogfireWorkflowError
@@ -46,7 +46,7 @@ def _indexed_base_url_key(env_index: int) -> str:
 
 
 def _indexed_api_key_key(env_index: int) -> str:
-    return f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{env_index}"
+    return f"LLM_PROVIDER_{env_index}_API_KEY"
 
 
 def _read_workflow_text(workflow_path: Path) -> str:
@@ -241,7 +241,7 @@ def apply_model_wiring(
     )
 
 
-def _find_prioritize_step_ids(text: str, before_slug: str) -> tuple[str, str]:
+def _find_prioritize_step_ids(text: str, model_slug: str, before_slug: str) -> tuple[str, str]:
     try:
         parsed = yaml.safe_load(text)
     except yaml.YAMLError as exc:
@@ -252,8 +252,8 @@ def _find_prioritize_step_ids(text: str, before_slug: str) -> tuple[str, str]:
     if not isinstance(jobs, dict):
         raise WorkflowYamlError("workflow has no jobs: mapping")
 
-    anchor_id: str | None = None
-    other_ids: list[str] = []
+    before_ids: list[str] = []
+    model_ids: list[str] = []
     for job_name, job_def in jobs.items():
         if not isinstance(job_def, dict):
             continue
@@ -270,15 +270,25 @@ def _find_prioritize_step_ids(text: str, before_slug: str) -> tuple[str, str]:
             with_map = step.get("with")
             model = with_map.get("model") if isinstance(with_map, dict) else None
             if model == before_slug:
-                anchor_id = step_id
-            else:
-                other_ids.append(step_id)
+                before_ids.append(step_id)
+            elif model == model_slug:
+                model_ids.append(step_id)
 
-    if anchor_id is None:
+    if not before_ids:
         raise WorkflowYamlError(f"no mergeCraft step with with.model={before_slug!r} found")
-    if not other_ids:
-        raise WorkflowYamlError("need at least two mergeCraft steps to prioritize models")
-    return anchor_id, other_ids[-1]
+    if len(before_ids) > 1:
+        raise WorkflowYamlError(
+            f"ambiguous mergeCraft steps with with.model={before_slug!r}; "
+            "exactly one step must match"
+        )
+    if not model_ids:
+        raise WorkflowYamlError(f"no mergeCraft step with with.model={model_slug!r} found")
+    if len(model_ids) > 1:
+        raise WorkflowYamlError(
+            f"ambiguous mergeCraft steps with with.model={model_slug!r}; "
+            "exactly one step must match"
+        )
+    return before_ids[0], model_ids[0]
 
 
 def apply_model_prioritize(
@@ -290,7 +300,7 @@ def apply_model_prioritize(
 ) -> WorkflowChange:
     """Promote *model_slug* on the anchor step and demote *before_slug* to a fallback step."""
     original = _read_workflow_text(workflow_path)
-    anchor_id, swap_id = _find_prioritize_step_ids(original, before_slug)
+    anchor_id, swap_id = _find_prioritize_step_ids(original, model_slug, before_slug)
 
     intermediate = _mutate_steps(
         original,

--- a/src/mergecraft/config/model_registry.py
+++ b/src/mergecraft/config/model_registry.py
@@ -1,0 +1,79 @@
+"""Operator model registry helpers (#479 / BC)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def allocate_model_index(entries: Sequence[Mapping[str, Any]]) -> int:
+    """Return ``max(existing modelIndex) + 1``, or ``1`` when empty (D3).
+
+    Gaps are preserved — freed indices are never recycled.
+    """
+    indices = [
+        int(entry["modelIndex"])
+        for entry in entries
+        if isinstance(entry, Mapping) and entry.get("modelIndex") is not None
+    ]
+    if not indices:
+        return 1
+    return max(indices) + 1
+
+
+def normalize_model_id(provider_label: str, model_id: str) -> str:
+    """Strip a leading ``{provider}/`` prefix from *model_id* (#479)."""
+    stripped = model_id.strip()
+    prefix = f"{provider_label.strip().lower()}/"
+    if stripped.lower().startswith(prefix):
+        return stripped[len(prefix) :]
+    return stripped
+
+
+def model_env_override_key(env_index: int, model_index: int) -> str:
+    """Return ``LLM_PROVIDER_<N>_MODEL_<M>`` per D2."""
+    return f"LLM_PROVIDER_{env_index}_MODEL_{model_index}"
+
+
+def read_model_env_override(
+    env_path: Path | str,
+    env_index: int,
+    model_index: int,
+) -> str | None:
+    """Read optional model override from ``.env`` without mutating ``os.environ``."""
+    path = Path(env_path)
+    if not path.is_file():
+        return None
+    key = model_env_override_key(env_index, model_index)
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        if name.strip() == key:
+            return value.strip()
+    return None
+
+
+def effective_model_id(
+    stored_id: str,
+    *,
+    env_path: Path | str,
+    env_index: int,
+    model_index: int,
+) -> str:
+    """Return env override when present, otherwise the config *stored_id* (D2)."""
+    override = read_model_env_override(env_path, env_index, model_index)
+    if override is not None:
+        return override
+    return stored_id
+
+
+__all__ = [
+    "allocate_model_index",
+    "effective_model_id",
+    "model_env_override_key",
+    "normalize_model_id",
+    "read_model_env_override",
+]

--- a/src/mergecraft/config/provider_registry.py
+++ b/src/mergecraft/config/provider_registry.py
@@ -17,6 +17,8 @@ BUILTIN_HARNESS_DEFAULTS: dict[str, str] = {
 }
 
 _CLOUD_CHAIN_LABELS = frozenset({"bedrock", "vertex"})
+_DEVICE_CODE_LABELS = frozenset({"openai", "codex"})
+_OAUTH_LABELS = frozenset({"anthropic", "claude"})
 
 # Alias — single predicate for harness/provider validity (D5).
 harness_supports_provider = ar._harness_supports_provider
@@ -87,8 +89,13 @@ def default_harness_for_label(label: str) -> str | None:
 
 def default_auth_kind_for_label(label: str) -> str | None:
     """Return the default ``authKind`` for a seeded built-in catalog label."""
-    if label in _CLOUD_CHAIN_LABELS:
+    lowered = label.strip().lower()
+    if lowered in _CLOUD_CHAIN_LABELS:
         return "cloud_chain"
+    if lowered in _DEVICE_CODE_LABELS:
+        return "device_code"
+    if lowered in _OAUTH_LABELS:
+        return "oauth"
     return "api_key"
 
 

--- a/src/mergecraft/config/provider_registry.py
+++ b/src/mergecraft/config/provider_registry.py
@@ -1,0 +1,105 @@
+"""Operator provider registry helpers (#477 / BA)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from mergecraft.utils import agent_resolve as ar
+
+BUILTIN_HARNESS_DEFAULTS: dict[str, str] = {
+    "openai": "codex",
+    "anthropic": "claude",
+    "google": "gemini",
+    "cursor": "cursor",
+}
+
+_CLOUD_CHAIN_LABELS = frozenset({"bedrock", "vertex"})
+
+# Alias — single predicate for harness/provider validity (D5).
+harness_supports_provider = ar._harness_supports_provider
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessRow:
+    """One supported agent harness row for ``provider harnesses``."""
+
+    name: str
+    description: str
+
+
+def _harness_rows() -> tuple[HarnessRow, ...]:
+    """Build harness metadata from the agent-resolve tables (no doc literals)."""
+    native = ar._NATIVE_HARNESS_PROVIDERS
+    return (
+        HarnessRow(
+            "opencode",
+            "any OpenAI-compatible endpoint (generic multi-provider harness)",
+        ),
+        HarnessRow("codex", f"OpenAI / Codex CLI ({', '.join(sorted(native['codex']))})"),
+        HarnessRow("claude", f"Anthropic / Claude CLI ({', '.join(sorted(native['claude']))})"),
+        HarnessRow("gemini", f"Google / Gemini CLI ({', '.join(sorted(native['gemini']))})"),
+        HarnessRow("cursor", f"Cursor CLI ({', '.join(sorted(native['cursor']))})"),
+    )
+
+
+def list_supported_harnesses() -> Sequence[HarnessRow]:
+    """Return harness rows generated from code (D4 / issue #477)."""
+    return _harness_rows()
+
+
+def supported_harness_names() -> frozenset[str]:
+    """Closed set of harness names accepted by ``provider add``."""
+    return frozenset(row.name for row in _harness_rows())
+
+
+def allocate_env_index(entries: Sequence[Mapping[str, Any]]) -> int:
+    """Return ``max(existing envIndex) + 1``, or ``1`` when empty (D3).
+
+    Gaps are preserved — freed indices are never recycled.
+    """
+    indices = [
+        int(entry["envIndex"])
+        for entry in entries
+        if isinstance(entry, Mapping) and entry.get("envIndex") is not None
+    ]
+    if not indices:
+        return 1
+    return max(indices) + 1
+
+
+def validate_http_url(url: str) -> str:
+    """Require an absolute ``http`` or ``https`` URL (reuses gateway urlparse rule)."""
+    stripped = url.strip()
+    parsed = urlparse(stripped)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        msg = "url must be an absolute http(s) URL"
+        raise ValueError(msg)
+    return stripped
+
+
+def default_harness_for_label(label: str) -> str | None:
+    """Return the built-in default harness for *label*, or ``None`` when required."""
+    return BUILTIN_HARNESS_DEFAULTS.get(label)
+
+
+def default_auth_kind_for_label(label: str) -> str | None:
+    """Return the default ``authKind`` for a seeded built-in catalog label."""
+    if label in _CLOUD_CHAIN_LABELS:
+        return "cloud_chain"
+    return "api_key"
+
+
+__all__ = [
+    "BUILTIN_HARNESS_DEFAULTS",
+    "HarnessRow",
+    "allocate_env_index",
+    "default_auth_kind_for_label",
+    "default_harness_for_label",
+    "harness_supports_provider",
+    "list_supported_harnesses",
+    "supported_harness_names",
+    "validate_http_url",
+]

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -90,10 +90,12 @@ def _credential_suffixes_for_entry(entry: ProviderRegistryEntry) -> tuple[str, .
             return _VERTEX_CLOUD_SUFFIXES
         return _BEDROCK_CLOUD_SUFFIXES
     suffix = _AUTH_KIND_PRIMARY_SUFFIX.get(auth_kind, "API_KEY")
+    if suffix != "API_KEY":
+        return ("API_KEY", suffix)
     return (suffix,)
 
 
-def _indexed_credential_for_entry(entry: ProviderRegistryEntry) -> str | None:
+def indexed_credential_for_entry(entry: ProviderRegistryEntry) -> str | None:
     """Return the first indexed credential value present for *entry*."""
     for suffix in _credential_suffixes_for_entry(entry):
         value = _read_env_value(indexed_env_key(entry.env_index, suffix))
@@ -101,6 +103,11 @@ def _indexed_credential_for_entry(entry: ProviderRegistryEntry) -> str | None:
             return value
     workflow_key = f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{entry.env_index}"
     return _read_env_value(workflow_key)
+
+
+def _indexed_credential_for_entry(entry: ProviderRegistryEntry) -> str | None:
+    """Backward-compatible alias for :func:`indexed_credential_for_entry`."""
+    return indexed_credential_for_entry(entry)
 
 
 def has_registry_credentials(
@@ -193,6 +200,7 @@ __all__ = [
     "SEED_PROVIDER_URLS",
     "has_registry_credentials",
     "indexed_api_key_for_entry",
+    "indexed_credential_for_entry",
     "indexed_env_key",
     "infer_harness_for_slug",
     "lookup_registry_entry",

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -327,6 +327,10 @@ def infer_harness_for_slug(
     if builtin is not None:
         return builtin
 
+    legacy_harness = legacy_opencode_harness_for_unregistered_provider(settings, provider)
+    if legacy_harness is not None:
+        return legacy_harness
+
     msg = (
         f"configuration error: provider {provider!r} is not registered — "
         "add it with `mergecraft provider add`"

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mergecraft.config.provider_registry import BUILTIN_HARNESS_DEFAULTS
@@ -31,6 +32,13 @@ _BEDROCK_CLOUD_SUFFIXES: tuple[str, ...] = (
 )
 
 _VERTEX_CLOUD_SUFFIXES: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+_BUILTIN_LABEL_TO_HARNESS_API_KEY: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GEMINI_API_KEY",
+    "cursor": "CURSOR_API_KEY",
+}
 
 # Seed-only default URLs for ``provider seed`` — not used at runtime (BE / D4).
 SEED_PROVIDER_URLS: dict[str, str] = {
@@ -62,6 +70,29 @@ def lookup_registry_entry(
         if entry.label.strip().lower() == lowered:
             return entry
     return None
+
+
+def lookup_registry_entry_by_env_index(
+    settings: RepoSettings | None,
+    env_index: int,
+) -> ProviderRegistryEntry | None:
+    """Return the registry row for *env_index*, or ``None`` when absent."""
+    if settings is None:
+        return None
+    for entry in settings.providers:
+        if entry.env_index == env_index:
+            return entry
+    return None
+
+
+def _provider_id_for_env_index(env_index: int) -> str:
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    entry = lookup_registry_entry_by_env_index(settings, env_index)
+    if entry is not None:
+        return entry.label.strip().lower()
+    return f"provider_{env_index}"
 
 
 def registry_harness_for_provider(
@@ -168,6 +199,76 @@ def resolve_registry_gateway_endpoint(
     return provider_id, entry.url, api_key
 
 
+def _harness_env_name_for_suffix(label: str, suffix: str) -> str | None:
+    """Map one indexed credential suffix to the harness env var native CLIs consume."""
+    if suffix == "API_KEY":
+        return _BUILTIN_LABEL_TO_HARNESS_API_KEY.get(label.strip().lower())
+    if suffix in {
+        "CODEX_AUTH_JSON",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "VERTEX_SERVICE_ACCOUNT_JSON",
+        "GOOGLE_CLOUD_PROJECT",
+        "CLOUD_ML_PROJECT_ID",
+        "VERTEX_LOCATION",
+    }:
+        return suffix
+    return None
+
+
+def _read_indexed_credential_value(entry: ProviderRegistryEntry, suffix: str) -> str | None:
+    value = _read_env_value(indexed_env_key(entry.env_index, suffix))
+    if value:
+        return value
+    if suffix == "API_KEY":
+        workflow_key = f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{entry.env_index}"
+        return _read_env_value(workflow_key)
+    return None
+
+
+def harness_env_for_active_provider(
+    model: str | None,
+    agent_id: str,
+) -> dict[str, str]:
+    """Map indexed registry credentials into legacy harness env names for *agent_id*.
+
+    Only the active model's provider row is mapped — indexed secrets are copied
+    into the env vars Codex / Claude / Gemini / Cursor subprocesses read
+    (``OPENAI_API_KEY``, ``CODEX_AUTH_JSON``, ``CLAUDE_CODE_OAUTH_TOKEN``, etc.).
+    """
+    if not model:
+        return {}
+    from mergecraft.models import get_model_provider
+
+    try:
+        provider = get_model_provider(model)
+    except ValueError:
+        return {}
+
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    entry = lookup_registry_entry(settings, provider)
+    if entry is None or entry.harness != agent_id:
+        return {}
+
+    mapped: dict[str, str] = {}
+    for suffix in _credential_suffixes_for_entry(entry):
+        value = _read_indexed_credential_value(entry, suffix)
+        if not value:
+            continue
+        harness_key = _harness_env_name_for_suffix(entry.label, suffix)
+        if harness_key is not None:
+            mapped[harness_key] = value
+    return mapped
+
+
 def infer_harness_for_slug(
     slug: str,
     *,
@@ -198,12 +299,14 @@ def infer_harness_for_slug(
 
 __all__ = [
     "SEED_PROVIDER_URLS",
+    "harness_env_for_active_provider",
     "has_registry_credentials",
     "indexed_api_key_for_entry",
     "indexed_credential_for_entry",
     "indexed_env_key",
     "infer_harness_for_slug",
     "lookup_registry_entry",
+    "lookup_registry_entry_by_env_index",
     "registry_harness_for_provider",
     "resolve_registry_gateway_endpoint",
     "warn_legacy_nous_api_key_once",

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mergecraft.config.provider_registry import BUILTIN_HARNESS_DEFAULTS
@@ -15,19 +14,30 @@ if TYPE_CHECKING:
 _LEGACY_NOUS_API_KEY = "NOUS_API_KEY"
 _LEGACY_NOUS_WARNED = False
 
+_AUTH_KIND_API_KEY = "api_key"
+_AUTH_KIND_OAUTH = "oauth"
+_AUTH_KIND_DEVICE_CODE = "device_code"
+_AUTH_KIND_CLOUD_CHAIN = "cloud_chain"
+
+_AUTH_KIND_PRIMARY_SUFFIX: dict[str, str] = {
+    _AUTH_KIND_API_KEY: "API_KEY",
+    _AUTH_KIND_OAUTH: "CLAUDE_CODE_OAUTH_TOKEN",
+    _AUTH_KIND_DEVICE_CODE: "CODEX_AUTH_JSON",
+}
+
+_BEDROCK_CLOUD_SUFFIXES: tuple[str, ...] = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+)
+
+_VERTEX_CLOUD_SUFFIXES: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
 # Seed-only default URLs for ``provider seed`` — not used at runtime (BE / D4).
 SEED_PROVIDER_URLS: dict[str, str] = {
     "nous": "https://inference-api.nousresearch.com/v1",
     "tokenhub": "https://tokenhub-intl.tencentcloudmaas.com/v1",
     "minimax": "https://api.minimax.io/v1",
 }
-
-
-def _env_path() -> Path:
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
-    return Path.cwd() / ".env"
 
 
 def _read_env_value(key: str) -> str | None:
@@ -70,6 +80,29 @@ def indexed_api_key_for_entry(entry: ProviderRegistryEntry) -> str | None:
     return _read_env_value(indexed_env_key(entry.env_index, "API_KEY"))
 
 
+def _credential_suffixes_for_entry(entry: ProviderRegistryEntry) -> tuple[str, ...]:
+    auth_kind = (entry.auth_kind or _AUTH_KIND_API_KEY).strip().lower()
+    if auth_kind == _AUTH_KIND_CLOUD_CHAIN:
+        label = entry.label.strip().lower()
+        if label == "bedrock":
+            return _BEDROCK_CLOUD_SUFFIXES
+        if label == "vertex":
+            return _VERTEX_CLOUD_SUFFIXES
+        return _BEDROCK_CLOUD_SUFFIXES
+    suffix = _AUTH_KIND_PRIMARY_SUFFIX.get(auth_kind, "API_KEY")
+    return (suffix,)
+
+
+def _indexed_credential_for_entry(entry: ProviderRegistryEntry) -> str | None:
+    """Return the first indexed credential value present for *entry*."""
+    for suffix in _credential_suffixes_for_entry(entry):
+        value = _read_env_value(indexed_env_key(entry.env_index, suffix))
+        if value:
+            return value
+    workflow_key = f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{entry.env_index}"
+    return _read_env_value(workflow_key)
+
+
 def has_registry_credentials(
     settings: RepoSettings | None,
     provider: str,
@@ -78,7 +111,7 @@ def has_registry_credentials(
     entry = lookup_registry_entry(settings, provider)
     if entry is None:
         return False
-    if indexed_api_key_for_entry(entry):
+    if _indexed_credential_for_entry(entry):
         return True
     if provider == "nous":
         return _legacy_nous_api_key_present()
@@ -117,6 +150,8 @@ def resolve_registry_gateway_endpoint(
     if entry is None or not entry.url:
         return None
     api_key = indexed_api_key_for_entry(entry)
+    if not api_key:
+        api_key = _indexed_credential_for_entry(entry)
     if not api_key and provider_id == "nous":
         api_key = _read_env_value(_LEGACY_NOUS_API_KEY)
         if api_key:

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -174,13 +174,8 @@ def warn_legacy_nous_api_key_once() -> None:
     )
 
 
-def legacy_opencode_harness_for_unregistered_provider(
-    settings: RepoSettings | None,
-    provider: str,
-) -> str | None:
-    """Return ``opencode`` when D7 legacy credentials exist without a registry row."""
-    if lookup_registry_entry(settings, provider) is not None:
-        return None
+def legacy_opencode_harness_for_provider(provider: str) -> str | None:
+    """Return ``opencode`` when D7 legacy env credentials exist for *provider*."""
     if provider == "nous" and _legacy_nous_api_key_present():
         warn_legacy_nous_api_key_once()
         return "opencode"
@@ -189,6 +184,16 @@ def legacy_opencode_harness_for_unregistered_provider(
     if _legacy_gateway_preset_credentials(provider):
         return "opencode"
     return None
+
+
+def legacy_opencode_harness_for_unregistered_provider(
+    settings: RepoSettings | None,
+    provider: str,
+) -> str | None:
+    """Return ``opencode`` when D7 legacy credentials exist without a registry row."""
+    if lookup_registry_entry(settings, provider) is not None:
+        return None
+    return legacy_opencode_harness_for_provider(provider)
 
 
 def resolve_legacy_nous_gateway_endpoint(
@@ -346,6 +351,7 @@ __all__ = [
     "indexed_credential_for_entry",
     "indexed_env_key",
     "infer_harness_for_slug",
+    "legacy_opencode_harness_for_provider",
     "legacy_opencode_harness_for_unregistered_provider",
     "lookup_registry_entry",
     "lookup_registry_entry_by_env_index",

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -174,6 +174,43 @@ def warn_legacy_nous_api_key_once() -> None:
     )
 
 
+def legacy_opencode_harness_for_unregistered_provider(
+    settings: RepoSettings | None,
+    provider: str,
+) -> str | None:
+    """Return ``opencode`` when D7 legacy credentials exist without a registry row."""
+    if lookup_registry_entry(settings, provider) is not None:
+        return None
+    if provider == "nous" and _legacy_nous_api_key_present():
+        warn_legacy_nous_api_key_once()
+        return "opencode"
+    from mergecraft.agents.openai_compatible_gateways import _legacy_gateway_preset_credentials
+
+    if _legacy_gateway_preset_credentials(provider):
+        return "opencode"
+    return None
+
+
+def resolve_legacy_nous_gateway_endpoint(
+    provider_id: str,
+    *,
+    settings: RepoSettings | None = None,
+) -> tuple[str, str, str] | None:
+    """Resolve legacy ``NOUS_API_KEY`` when no registry row exists (D7)."""
+    if provider_id != "nous":
+        return None
+    if lookup_registry_entry(settings, provider_id) is not None:
+        return None
+    api_key = _read_env_value(_LEGACY_NOUS_API_KEY)
+    if not api_key:
+        return None
+    base_url = SEED_PROVIDER_URLS.get("nous")
+    if not base_url:
+        return None
+    warn_legacy_nous_api_key_once()
+    return provider_id, base_url, api_key
+
+
 def resolve_registry_gateway_endpoint(
     model: str,
     *,
@@ -305,9 +342,11 @@ __all__ = [
     "indexed_credential_for_entry",
     "indexed_env_key",
     "infer_harness_for_slug",
+    "legacy_opencode_harness_for_unregistered_provider",
     "lookup_registry_entry",
     "lookup_registry_entry_by_env_index",
     "registry_harness_for_provider",
+    "resolve_legacy_nous_gateway_endpoint",
     "resolve_registry_gateway_endpoint",
     "warn_legacy_nous_api_key_once",
 ]

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -1,0 +1,167 @@
+"""Runtime provider-registry lookups for agent resolution (#481 / BE)."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mergecraft.config.provider_registry import BUILTIN_HARNESS_DEFAULTS
+
+if TYPE_CHECKING:
+    from mergecraft.config.settings import ProviderRegistryEntry, RepoSettings
+
+_LEGACY_NOUS_API_KEY = "NOUS_API_KEY"
+_LEGACY_NOUS_WARNED = False
+
+# Seed-only default URLs for ``provider seed`` — not used at runtime (BE / D4).
+SEED_PROVIDER_URLS: dict[str, str] = {
+    "nous": "https://inference-api.nousresearch.com/v1",
+    "tokenhub": "https://tokenhub-intl.tencentcloudmaas.com/v1",
+    "minimax": "https://api.minimax.io/v1",
+}
+
+
+def _env_path() -> Path:
+    configured = os.environ.get("MERGECRAFT_ENV")
+    if configured:
+        return Path(configured).resolve()
+    return Path.cwd() / ".env"
+
+
+def _read_env_value(key: str) -> str | None:
+    value = os.environ.get(key, "").strip()
+    return value or None
+
+
+def indexed_env_key(env_index: int, suffix: str) -> str:
+    """Return ``LLM_PROVIDER_<N>_<SUFFIX>``."""
+    return f"LLM_PROVIDER_{env_index}_{suffix}"
+
+
+def lookup_registry_entry(
+    settings: RepoSettings | None,
+    label: str,
+) -> ProviderRegistryEntry | None:
+    """Return the registry row for *label*, or ``None`` when absent."""
+    if settings is None:
+        return None
+    lowered = label.strip().lower()
+    for entry in settings.providers:
+        if entry.label.strip().lower() == lowered:
+            return entry
+    return None
+
+
+def registry_harness_for_provider(
+    settings: RepoSettings | None,
+    provider: str,
+) -> str | None:
+    """Return the configured harness for *provider* when registered."""
+    entry = lookup_registry_entry(settings, provider)
+    if entry is None:
+        return None
+    return entry.harness
+
+
+def indexed_api_key_for_entry(entry: ProviderRegistryEntry) -> str | None:
+    """Read ``LLM_PROVIDER_<envIndex>_API_KEY`` for one registry row."""
+    return _read_env_value(indexed_env_key(entry.env_index, "API_KEY"))
+
+
+def has_registry_credentials(
+    settings: RepoSettings | None,
+    provider: str,
+) -> bool:
+    """Return whether indexed registry credentials exist for *provider*."""
+    entry = lookup_registry_entry(settings, provider)
+    if entry is None:
+        return False
+    if indexed_api_key_for_entry(entry):
+        return True
+    if provider == "nous":
+        return _legacy_nous_api_key_present()
+    return False
+
+
+def _legacy_nous_api_key_present() -> bool:
+    return bool(_read_env_value(_LEGACY_NOUS_API_KEY))
+
+
+def warn_legacy_nous_api_key_once() -> None:
+    """Emit one DeprecationWarning per process when ``NOUS_API_KEY`` is used (D7)."""
+    global _LEGACY_NOUS_WARNED
+    if _LEGACY_NOUS_WARNED:
+        return
+    _LEGACY_NOUS_WARNED = True
+    warnings.warn(
+        "NOUS_API_KEY is deprecated; use `mergecraft provider auth nous` to write "
+        "LLM_PROVIDER_<N>_API_KEY instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def resolve_registry_gateway_endpoint(
+    model: str,
+    *,
+    settings: RepoSettings | None = None,
+) -> tuple[str, str, str] | None:
+    """Resolve ``(provider_id, base_url, api_key)`` from the operator registry."""
+    slash = model.find("/")
+    if slash <= 0:
+        return None
+    provider_id = model[:slash].lower()
+    entry = lookup_registry_entry(settings, provider_id)
+    if entry is None or not entry.url:
+        return None
+    api_key = indexed_api_key_for_entry(entry)
+    if not api_key and provider_id == "nous":
+        api_key = _read_env_value(_LEGACY_NOUS_API_KEY)
+        if api_key:
+            warn_legacy_nous_api_key_once()
+    if not api_key:
+        return None
+    return provider_id, entry.url, api_key
+
+
+def infer_harness_for_slug(
+    slug: str,
+    *,
+    settings: RepoSettings | None = None,
+) -> str:
+    """Resolve harness for *slug* from registry rows or built-in defaults.
+
+    Raises:
+        ValueError: When the provider is unknown / unregistered.
+    """
+    from mergecraft.models import get_model_provider
+
+    provider = get_model_provider(slug)
+    registry_harness = registry_harness_for_provider(settings, provider)
+    if registry_harness is not None:
+        return registry_harness
+
+    builtin = BUILTIN_HARNESS_DEFAULTS.get(provider)
+    if builtin is not None:
+        return builtin
+
+    msg = (
+        f"configuration error: provider {provider!r} is not registered — "
+        "add it with `mergecraft provider add`"
+    )
+    raise ValueError(msg)
+
+
+__all__ = [
+    "SEED_PROVIDER_URLS",
+    "has_registry_credentials",
+    "indexed_api_key_for_entry",
+    "indexed_env_key",
+    "infer_harness_for_slug",
+    "lookup_registry_entry",
+    "registry_harness_for_provider",
+    "resolve_registry_gateway_endpoint",
+    "warn_legacy_nous_api_key_once",
+]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -110,6 +110,13 @@ class StaticCheckDefinition(_OptionalFeatureModel):
     suffixes: list[str] = Field(default_factory=list)
 
 
+class ProviderModelEntry(_OptionalFeatureModel):
+    """One model registered on an operator provider (#479 / BC)."""
+
+    id: str
+    model_index: int = Field(alias="modelIndex")
+
+
 class ProviderRegistryEntry(_OptionalFeatureModel):
     """One operator-registered LLM provider (#477 / BA)."""
 
@@ -119,6 +126,7 @@ class ProviderRegistryEntry(_OptionalFeatureModel):
     env_index: int = Field(alias="envIndex")
     auth_kind: str | None = Field(default=None, alias="authKind")
     region: str | None = None
+    models: list[ProviderModelEntry] = Field(default_factory=list)
 
 
 class CiEvidenceSettings(_OptionalFeatureModel):

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -110,6 +110,17 @@ class StaticCheckDefinition(_OptionalFeatureModel):
     suffixes: list[str] = Field(default_factory=list)
 
 
+class ProviderRegistryEntry(_OptionalFeatureModel):
+    """One operator-registered LLM provider (#477 / BA)."""
+
+    label: str
+    url: str | None = None
+    harness: str
+    env_index: int = Field(alias="envIndex")
+    auth_kind: str | None = Field(default=None, alias="authKind")
+    region: str | None = None
+
+
 class CiEvidenceSettings(_OptionalFeatureModel):
     """Which of the repo's *own* CI results mergeCraft may treat as evidence (#36).
 
@@ -529,6 +540,9 @@ class RepoSettings(BaseModel):
     tracing: TracingSettings = Field(default_factory=TracingSettings)
     run_bounds: RunBoundsSettings = Field(default_factory=RunBoundsSettings, alias="runBounds")
     enterprise: EnterpriseSettings = Field(default_factory=EnterpriseSettings)
+    # #477 / BA — operator provider registry (structure only; secrets in ``.env``).
+    providers: list[ProviderRegistryEntry] = Field(default_factory=list)
+    providers_seeded: bool = Field(default=False, alias="providersSeeded")
 
     @field_validator("push", "shell", mode="before")
     @classmethod

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -1372,36 +1372,71 @@ def resolve_runtime_agent(
             if _has_codex_subscription_auth() or _has_openai_api_key_auth():
                 return agents["codex"]
             openai_entry = lookup_registry_entry(resolved_settings, provider)
-            if openai_entry is not None and indexed_credential_for_entry(openai_entry):
-                return resolve_agent(openai_entry.harness)
+            if openai_entry is not None:
+                if indexed_credential_for_entry(openai_entry):
+                    return resolve_agent(openai_entry.harness)
+                msg = (
+                    f"configuration error: provider {provider!r} is registered but missing "
+                    f"credentials — run `mergecraft provider auth {provider}`"
+                )
+                raise ModelFallbackPolicyError(msg)
             _fail_loud_for_openai(model=model)
 
         if provider == "google":
             if _has_gemini_auth():
                 return agents["gemini"]
             google_entry = lookup_registry_entry(resolved_settings, provider)
-            if google_entry is not None and indexed_credential_for_entry(google_entry):
-                return resolve_agent(google_entry.harness)
+            if google_entry is not None:
+                if indexed_credential_for_entry(google_entry):
+                    return resolve_agent(google_entry.harness)
+                msg = (
+                    f"configuration error: provider {provider!r} is registered but missing "
+                    f"credentials — run `mergecraft provider auth {provider}`"
+                )
+                raise ModelFallbackPolicyError(msg)
             _fail_loud_for_google(model=model)
 
         if provider == "cursor":
             if _has_cursor_auth():
                 return agents["cursor"]
             cursor_entry = lookup_registry_entry(resolved_settings, provider)
-            if cursor_entry is not None and indexed_credential_for_entry(cursor_entry):
-                return resolve_agent(cursor_entry.harness)
+            if cursor_entry is not None:
+                if indexed_credential_for_entry(cursor_entry):
+                    return resolve_agent(cursor_entry.harness)
+                msg = (
+                    f"configuration error: provider {provider!r} is registered but missing "
+                    f"credentials — run `mergecraft provider auth {provider}`"
+                )
+                raise ModelFallbackPolicyError(msg)
             _fail_loud_for_cursor(model=model)
 
         if provider == "anthropic":
             if _has_claude_code_auth():
                 return agents["claude"]
             anthropic_entry = lookup_registry_entry(resolved_settings, provider)
-            if anthropic_entry is not None and indexed_credential_for_entry(anthropic_entry):
-                return resolve_agent(anthropic_entry.harness)
+            if anthropic_entry is not None:
+                if indexed_credential_for_entry(anthropic_entry):
+                    return resolve_agent(anthropic_entry.harness)
+                msg = (
+                    f"configuration error: provider {provider!r} is registered but missing "
+                    f"credentials — run `mergecraft provider auth {provider}`"
+                )
+                raise ModelFallbackPolicyError(msg)
+            msg = (
+                f"configuration error: provider {provider!r} is not registered — "
+                "add it with `mergecraft provider add`"
+            )
+            raise ModelFallbackPolicyError(msg)
 
         entry = lookup_registry_entry(resolved_settings, provider) if provider else None
-        if entry is not None and indexed_credential_for_entry(entry):
-            return resolve_agent(entry.harness)
+        if entry is not None:
+            if indexed_credential_for_entry(entry):
+                return resolve_agent(entry.harness)
+            msg = (
+                f"configuration error: provider {provider!r} is registered but missing "
+                f"credentials — run `mergecraft provider auth {provider}`"
+            )
+            raise ModelFallbackPolicyError(msg)
 
         if provider is not None:
             msg = (

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -143,7 +143,9 @@ def has_credentials_for_slug(slug: str) -> bool:
     if provider == "nous" and _legacy_nous_api_key_present():
         warn_legacy_nous_api_key_once()
         return True
-    return False
+    from mergecraft.agents.openai_compatible_gateways import _legacy_gateway_preset_credentials
+
+    return _legacy_gateway_preset_credentials(provider)
 
 
 def _ctx_tmpdir_fallback() -> str:

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -1432,6 +1432,14 @@ def resolve_runtime_agent(
         if entry is not None:
             if indexed_credential_for_entry(entry):
                 return resolve_agent(entry.harness)
+            from mergecraft.config.runtime_provider_registry import (
+                legacy_opencode_harness_for_provider,
+            )
+
+            assert provider is not None
+            legacy_harness = legacy_opencode_harness_for_provider(provider)
+            if legacy_harness is not None:
+                return resolve_agent(legacy_harness)
             msg = (
                 f"configuration error: provider {provider!r} is registered but missing "
                 f"credentials — run `mergecraft provider auth {provider}`"
@@ -1456,8 +1464,7 @@ def resolve_runtime_agent(
             )
             raise ModelFallbackPolicyError(msg)
 
-    msg = "configuration error: no model configured for runtime agent resolution"
-    raise ModelFallbackPolicyError(msg)
+    return agents["opencode"]
 
 
 __all__ = [

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -114,6 +114,19 @@ def has_credentials_for_slug(slug: str) -> bool:
     except ValueError:
         return False
 
+    from mergecraft.config.runtime_provider_registry import (
+        _legacy_nous_api_key_present,
+        indexed_credential_for_entry,
+        lookup_registry_entry,
+        warn_legacy_nous_api_key_once,
+    )
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    entry = lookup_registry_entry(settings, provider)
+    if entry is not None and indexed_credential_for_entry(entry):
+        return True
+
     if provider == "anthropic":
         return _has_claude_code_auth()
     if provider == "openai":
@@ -127,27 +140,9 @@ def has_credentials_for_slug(slug: str) -> bool:
     if provider == "vertex":
         return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
 
-    from mergecraft.config.runtime_provider_registry import (
-        _indexed_credential_for_entry,
-        lookup_registry_entry,
-    )
-    from mergecraft.config.settings import load_repo_settings
-
-    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
-    entry = lookup_registry_entry(settings, provider)
-    if entry is not None:
-        if _indexed_credential_for_entry(entry):
-            return True
-        if provider == "nous":
-            from mergecraft.config.runtime_provider_registry import (
-                _legacy_nous_api_key_present,
-                warn_legacy_nous_api_key_once,
-            )
-
-            if _legacy_nous_api_key_present():
-                warn_legacy_nous_api_key_once()
-                return True
-        return False
+    if provider == "nous" and _legacy_nous_api_key_present():
+        warn_legacy_nous_api_key_once()
+        return True
     return False
 
 
@@ -1356,37 +1351,54 @@ def resolve_runtime_agent(
         return agents["claude"] if is_vertex_anthropic_id(model) else agents["opencode"]
 
     if model:
+        from mergecraft.config.runtime_provider_registry import (
+            indexed_credential_for_entry,
+            lookup_registry_entry,
+        )
+        from mergecraft.config.settings import load_repo_settings
+
         try:
             provider = get_model_provider(model)
         except ValueError:
             provider = None
 
+        resolved_settings = settings or load_repo_settings(
+            root=Path.cwd(), load_learnings_files=False
+        )
+
         if provider == "openai":
             if _has_codex_subscription_auth() or _has_openai_api_key_auth():
                 return agents["codex"]
+            openai_entry = lookup_registry_entry(resolved_settings, provider)
+            if openai_entry is not None and indexed_credential_for_entry(openai_entry):
+                return resolve_agent(openai_entry.harness)
             _fail_loud_for_openai(model=model)
 
         if provider == "google":
             if _has_gemini_auth():
                 return agents["gemini"]
+            google_entry = lookup_registry_entry(resolved_settings, provider)
+            if google_entry is not None and indexed_credential_for_entry(google_entry):
+                return resolve_agent(google_entry.harness)
             _fail_loud_for_google(model=model)
 
         if provider == "cursor":
             if _has_cursor_auth():
                 return agents["cursor"]
+            cursor_entry = lookup_registry_entry(resolved_settings, provider)
+            if cursor_entry is not None and indexed_credential_for_entry(cursor_entry):
+                return resolve_agent(cursor_entry.harness)
             _fail_loud_for_cursor(model=model)
 
-        if provider == "anthropic" and _has_claude_code_auth():
-            return agents["claude"]
+        if provider == "anthropic":
+            if _has_claude_code_auth():
+                return agents["claude"]
+            anthropic_entry = lookup_registry_entry(resolved_settings, provider)
+            if anthropic_entry is not None and indexed_credential_for_entry(anthropic_entry):
+                return resolve_agent(anthropic_entry.harness)
 
-        from mergecraft.config.runtime_provider_registry import lookup_registry_entry
-        from mergecraft.config.settings import load_repo_settings
-
-        resolved_settings = settings or load_repo_settings(
-            root=Path.cwd(), load_learnings_files=False
-        )
         entry = lookup_registry_entry(resolved_settings, provider) if provider else None
-        if entry is not None:
+        if entry is not None and indexed_credential_for_entry(entry):
             return resolve_agent(entry.harness)
 
         if provider is not None:

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -107,20 +107,6 @@ def _has_cursor_auth() -> bool:
     return _has_env("CURSOR_API_KEY")
 
 
-def _has_gateway_auth(provider: str) -> bool:
-    """Return whether the gateway credential for ``provider`` is configured.
-
-    Covers Nous Portal (``NOUS_API_KEY``) and Tencent TokenHub
-    (``TOKENHUB_API_KEY``) through the opencode harness. The
-    ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` env var acts as a back-compat alias
-    for any named preset (D4): consumers that wired the opencode harness
-    contract directly without ``mergecraft auth nous`` keep working.
-    """
-    from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
-
-    return has_gateway_credentials(provider)
-
-
 def has_credentials_for_slug(slug: str) -> bool:
     """Return whether the current environment has credentials for ``slug``."""
     try:
@@ -140,15 +126,28 @@ def has_credentials_for_slug(slug: str) -> bool:
         return _has_bedrock_auth() and bool(os.environ.get(BEDROCK_MODEL_ID_ENV, "").strip())
     if provider == "vertex":
         return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
-    if provider in {"nous", "tokenhub"}:
-        return _has_gateway_auth(provider)
-    if provider == "minimax":
-        # W6 (#34): MiniMax is reachable through the existing custom-provider
-        # helper (operator-locked D10 / option ii). The single pair that
-        # surfaces a credential is the D7 singleton; the indexed
-        # ``_N`` form is also accepted because the helper's multi-provider
-        # resolver may surface the provider via ``provider_<N>``.
-        return _has_gateway_auth(provider)
+
+    from mergecraft.config.runtime_provider_registry import (
+        indexed_api_key_for_entry,
+        lookup_registry_entry,
+    )
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    entry = lookup_registry_entry(settings, provider)
+    if entry is not None:
+        if indexed_api_key_for_entry(entry):
+            return True
+        if provider == "nous":
+            from mergecraft.config.runtime_provider_registry import (
+                _legacy_nous_api_key_present,
+                warn_legacy_nous_api_key_once,
+            )
+
+            if _legacy_nous_api_key_present():
+                warn_legacy_nous_api_key_once()
+                return True
+        return False
     return False
 
 
@@ -166,18 +165,19 @@ def _agent_binary_available(slug: str) -> bool:
     except ValueError:
         return False
 
+    from mergecraft.config.runtime_provider_registry import lookup_registry_entry
+    from mergecraft.config.settings import load_repo_settings
+
+    settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    entry = lookup_registry_entry(settings, provider)
+    if entry is not None and entry.harness == "opencode":
+        return True
+
     binary_by_provider = {
         "anthropic": "claude",
         "openai": "codex",
         "google": "gemini",
         "cursor": "cursor",
-        # D5: the opencode harness consumes env vars directly for the Nous path,
-        # so there is no required CLI on PATH. Explicit ``None`` short-circuits
-        # the gate to ``True`` and pins the W1.7 regression pin.
-        "nous": None,
-        # W6 (#34): MiniMax rides the same env-var-driven opencode harness
-        # path; no CLI binary is required on PATH.
-        "minimax": None,
     }
     binary = binary_by_provider.get(provider)
     if binary is None:
@@ -740,7 +740,7 @@ async def run_with_model_chain(
 
         while attempts < max_attempts:
             slug = chain[chain_index]
-            if _agent_mode_for_slug(slug) == "opencode":
+            if _agent_mode_for_slug(slug, settings=settings) == "opencode":
                 if opencode_attempts >= _OPENCODE_MAX_ATTEMPTS:
                     logger.warning(
                         "» model chain skipping slug={} (fallback_index={}): opencode "
@@ -1005,18 +1005,16 @@ def _agent_provider_for_slug(slug: str) -> str:
         return "unknown"
 
 
-def _agent_mode_for_slug(slug: str) -> str:
+def _agent_mode_for_slug(slug: str, *, settings: RepoSettings | None = None) -> str:
     """Return the agent mode name (e.g. ``claude``) that would serve ``slug``."""
-    provider = _agent_provider_for_slug(slug)
-    if provider == "anthropic":
-        return "claude"
-    if provider == "openai":
-        return "codex"
-    if provider == "google":
-        return "gemini"
-    if provider == "cursor":
-        return "cursor"
-    return "opencode"
+    from mergecraft.config.runtime_provider_registry import infer_harness_for_slug
+    from mergecraft.config.settings import load_repo_settings
+
+    resolved_settings = settings or load_repo_settings(root=Path.cwd(), load_learnings_files=False)
+    try:
+        return infer_harness_for_slug(slug, settings=resolved_settings)
+    except ValueError as exc:
+        raise ModelFallbackPolicyError(str(exc)) from exc
 
 
 _NATIVE_HARNESS_PROVIDERS: dict[str, frozenset[str]] = {
@@ -1026,9 +1024,9 @@ _NATIVE_HARNESS_PROVIDERS: dict[str, frozenset[str]] = {
     "cursor": frozenset({"cursor"}),
 }
 
-# OpenCode is the generic multi-provider harness: gateway presets, custom
-# slugs, and explicit overrides (openai / anthropic under ``harness: opencode``).
-_OPENCODE_NATIVE_PROVIDERS = frozenset({"nous", "tokenhub", "minimax", "openai", "anthropic"})
+# OpenCode natively serves OpenAI-compatible slugs for these built-in prefixes when
+# explicitly overridden to ``harness: opencode`` in the operator registry.
+_OPENCODE_NATIVE_PROVIDERS = frozenset({"openai", "anthropic"})
 _KNOWN_CATALOG_PROVIDERS = frozenset(
     {
         "anthropic",
@@ -1037,9 +1035,12 @@ _KNOWN_CATALOG_PROVIDERS = frozenset(
         "cursor",
         "bedrock",
         "vertex",
-        "nous",
-        "tokenhub",
-        "minimax",
+        "xai",
+        "deepseek",
+        "moonshotai",
+        "opencode",
+        "opencode-go",
+        "openrouter",
     }
 )
 
@@ -1047,10 +1048,7 @@ _KNOWN_CATALOG_PROVIDERS = frozenset(
 def _harness_supports_provider(harness: str, provider: str) -> bool:
     """Return whether ``harness`` may run models from ``provider``."""
     if harness == "opencode":
-        if provider in _OPENCODE_NATIVE_PROVIDERS:
-            return True
-        # Custom / unknown catalog prefixes route through OpenCode today.
-        return provider not in _KNOWN_CATALOG_PROVIDERS
+        return provider in _OPENCODE_NATIVE_PROVIDERS
     native = _NATIVE_HARNESS_PROVIDERS.get(harness)
     return native is not None and provider in native
 
@@ -1058,17 +1056,29 @@ def _harness_supports_provider(harness: str, provider: str) -> bool:
 def resolve_harness(settings: RepoSettings, slug: str) -> str:
     """Resolve the agent harness for ``slug`` under ``settings`` (HA3 / D11).
 
-    When ``settings.harness`` is unset, delegates to today's
-    :func:`_agent_mode_for_slug` inference. When set, validates the
-    (harness, provider, model) triple and returns the explicit value.
-    Unsupported combinations raise :class:`ModelFallbackPolicyError` so
-    ``main._classify_error_outcome`` maps them to ``configuration_error``.
+    Registry rows win over built-in inference. Unsupported combinations raise
+    :class:`ModelFallbackPolicyError` so ``main._classify_error_outcome`` maps
+    them to ``configuration_error``.
     """
+    from mergecraft.config.runtime_provider_registry import registry_harness_for_provider
+
+    provider = _agent_provider_for_slug(slug)
+
     if settings.harness is None:
-        return _agent_mode_for_slug(slug)
+        registry_harness = registry_harness_for_provider(settings, provider)
+        if registry_harness is not None:
+            if registry_harness == "opencode" or _harness_supports_provider(
+                registry_harness, provider
+            ):
+                return registry_harness
+            msg = (
+                f"configuration error: harness {registry_harness!r} is incompatible with "
+                f"model {slug!r} (provider {provider!r})"
+            )
+            raise ModelFallbackPolicyError(msg)
+        return _agent_mode_for_slug(slug, settings=settings)
 
     harness = settings.harness
-    provider = _agent_provider_for_slug(slug)
     if _harness_supports_provider(harness, provider):
         return harness
 
@@ -1160,7 +1170,7 @@ def _attempt_harness_label(settings: RepoSettings | None, slug: str) -> str:
     """
     if settings is not None and settings.harness is not None:
         return settings.harness
-    return _agent_mode_for_slug(slug)
+    return _agent_mode_for_slug(slug, settings=settings)
 
 
 def _emit_advanced_attempt(
@@ -1369,42 +1379,25 @@ def resolve_runtime_agent(
         if provider == "anthropic" and _has_claude_code_auth():
             return agents["claude"]
 
-        if provider in {"nous", "tokenhub"}:
-            if _has_gateway_auth(provider):
-                return agents["opencode"]
-            hints = (
-                ("NOUS_API_KEY", "mergecraft auth nous")
-                if provider == "nous"
-                else ("TOKENHUB_API_KEY", "mergecraft auth tokenhub")
-            )
-            msg = (
-                f"{provider} model {model!r} selected but no credential is configured. "
-                f"Set {hints[0]} (via `{hints[1]}` or a GitHub Actions secret), "
-                "or set MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
-                "MERGECRAFT_CUSTOM_PROVIDER_API_KEY, or choose a different model."
-            )
-            raise ValueError(msg)
+        from mergecraft.config.runtime_provider_registry import lookup_registry_entry
+        from mergecraft.config.settings import load_repo_settings
 
-        if provider == "minimax":
-            # W6 (#34): MiniMax rides the custom-provider helper. Fail loud
-            # (convention 5) rather than silently falling through to the
-            # opencode harness when the env vars are missing — the harness
-            # will not be able to reach MiniMax without them, and the
-            # operator's CLI auth gate would mask the configuration error.
-            if _has_gateway_auth(provider):
-                return agents["opencode"]
-            msg = (
-                f"MiniMax model {model!r} selected but no credential is configured. "
-                "Set MERGECRAFT_CUSTOM_PROVIDER_BASE_URL + "
-                "MERGECRAFT_CUSTOM_PROVIDER_API_KEY "
-                "(via `mergecraft auth minimax` or GitHub Actions secrets), "
-                "or an indexed pair "
-                "MERGECRAFT_CUSTOM_PROVIDER_{API_KEY,BASE_URL}_1, "
-                "or choose a different model."
-            )
-            raise ValueError(msg)
+        resolved_settings = settings or load_repo_settings(
+            root=Path.cwd(), load_learnings_files=False
+        )
+        entry = lookup_registry_entry(resolved_settings, provider) if provider else None
+        if entry is not None:
+            return resolve_agent(entry.harness)
 
-    return agents["opencode"]
+        if provider is not None:
+            msg = (
+                f"configuration error: provider {provider!r} is not registered — "
+                "add it with `mergecraft provider add`"
+            )
+            raise ModelFallbackPolicyError(msg)
+
+    msg = "configuration error: no model configured for runtime agent resolution"
+    raise ModelFallbackPolicyError(msg)
 
 
 __all__ = [

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -1164,10 +1164,16 @@ def _attempt_harness_label(settings: RepoSettings | None, slug: str) -> str:
     follow-ons must not re-validate (an unused tail slug can be an
     unsupported combo) but still stamp the operator's explicit ``harness:``
     so the trace does not mix override labels with inferred ones.
+
+    When inference fails (unregistered provider, missing credentials), degrade
+    to ``opencode`` so best-effort follow-on spans never abort a completed run.
     """
     if settings is not None and settings.harness is not None:
         return settings.harness
-    return _agent_mode_for_slug(slug, settings=settings)
+    try:
+        return _agent_mode_for_slug(slug, settings=settings)
+    except ModelFallbackPolicyError:
+        return "opencode"
 
 
 def _emit_advanced_attempt(

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -1439,6 +1439,17 @@ def resolve_runtime_agent(
             raise ModelFallbackPolicyError(msg)
 
         if provider is not None:
+            from mergecraft.config.runtime_provider_registry import (
+                legacy_opencode_harness_for_unregistered_provider,
+            )
+
+            legacy_harness = legacy_opencode_harness_for_unregistered_provider(
+                resolved_settings,
+                provider,
+            )
+            if legacy_harness is not None:
+                return resolve_agent(legacy_harness)
+
             msg = (
                 f"configuration error: provider {provider!r} is not registered — "
                 "add it with `mergecraft provider add`"

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -128,7 +128,7 @@ def has_credentials_for_slug(slug: str) -> bool:
         return _has_vertex_auth() and bool(os.environ.get(VERTEX_MODEL_ID_ENV, "").strip())
 
     from mergecraft.config.runtime_provider_registry import (
-        indexed_api_key_for_entry,
+        _indexed_credential_for_entry,
         lookup_registry_entry,
     )
     from mergecraft.config.settings import load_repo_settings
@@ -136,7 +136,7 @@ def has_credentials_for_slug(slug: str) -> bool:
     settings = load_repo_settings(root=Path.cwd(), load_learnings_files=False)
     entry = lookup_registry_entry(settings, provider)
     if entry is not None:
-        if indexed_api_key_for_entry(entry):
+        if _indexed_credential_for_entry(entry):
             return True
         if provider == "nous":
             from mergecraft.config.runtime_provider_registry import (

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -195,11 +195,17 @@ _VERTEX_AGENT_ENV_VARS: tuple[str, ...] = (
 )
 
 
-def build_agent_env(agent_id: str, extras: dict[str, str] | None = None) -> dict[str, str]:
+def build_agent_env(
+    agent_id: str,
+    extras: dict[str, str] | None = None,
+    model: str | None = None,
+) -> dict[str, str]:
     """Build an explicit allowlist env for agent CLI subprocesses (D2 / W2.1).
 
     Starts from :func:`filter_env` (default-deny), strips credential-shaped
     names, then re-injects only the active provider key for ``agent_id``.
+    When *model* is set, indexed registry credentials for that slug are mapped
+    into the legacy harness env names the native CLI consumes.
     """
     env = filter_env()
     for key in ALWAYS_STRIP_FROM_AGENT_ENV:
@@ -208,6 +214,14 @@ def build_agent_env(agent_id: str, extras: dict[str, str] | None = None) -> dict
         env.pop(key, None)
     for key in (*_BEDROCK_AGENT_ENV_VARS, *_VERTEX_AGENT_ENV_VARS):
         env.pop(key, None)
+
+    if model:
+        from mergecraft.config.runtime_provider_registry import harness_env_for_active_provider
+
+        for key, value in harness_env_for_active_provider(model, agent_id).items():
+            if value.strip():
+                env[key] = value.strip()
+
     active_key = ACTIVE_PROVIDER_KEY_BY_AGENT.get(agent_id)
     if active_key:
         raw = os.environ.get(active_key, "").strip()

--- a/tests/agents/test_agent_resolve_nous.py
+++ b/tests/agents/test_agent_resolve_nous.py
@@ -27,6 +27,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from tests.cli.support_provider_registry import (
+    bootstrap_nous_registry,
+    scaffold_mergecraft_home,
+)
 
 from mergecraft.models import MODEL_ALIASES, PROVIDERS, get_model_provider
 from mergecraft.utils.agent_resolve import (
@@ -36,6 +40,8 @@ from mergecraft.utils.agent_resolve import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
 
 NOUS_SLUG = "nous/deepseek/deepseek-v4-flash"
@@ -100,35 +106,38 @@ def test_get_model_provider_for_nous_slug() -> None:
 # ── W1.3 / W1.4 / W1.5 — credential detection honours D4 ─────────────────────
 
 
-def test_has_credentials_for_slug_nous_with_nous_api_key(monkeypatch: MonkeyPatch) -> None:
-    """``NOUS_API_KEY`` set, alias unset → ``has_credentials_for_slug`` is ``True`` (D4).
-
-    First-class precedence: the operator-owned secret name wins.
-    """
+def test_has_credentials_for_slug_nous_with_nous_api_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``NOUS_API_KEY`` set with registry row → ``has_credentials_for_slug`` is ``True`` (D7)."""
     _clear_provider_env(monkeypatch)
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
     monkeypatch.setenv(NOUS_API_KEY_ENV, "nous-test-key")
 
     assert has_credentials_for_slug(NOUS_SLUG) is True
 
 
 def test_has_credentials_for_slug_nous_with_only_custom_provider_alias(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """Alias-only path: ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` set → ``True`` (D4 back-compat)."""
+    """Indexed registry key without legacy alias → ``True`` when registered."""
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv(CUSTOM_PROVIDER_API_KEY_ENV, "custom-provider-test-key")
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
 
     assert has_credentials_for_slug(NOUS_SLUG) is True
 
 
-def test_has_credentials_for_slug_nous_with_no_keys(monkeypatch: MonkeyPatch) -> None:
-    """Both env vars unset → ``has_credentials_for_slug`` is ``False`` (structural).
-
-    Not marked xfail: the current code already returns ``False`` for any slug
-    whose provider arm is unimplemented, so this is a regression pin rather than
-    a contract that needs W2 to satisfy.
-    """
+def test_has_credentials_for_slug_nous_with_no_keys(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Unregistered nous slug → ``has_credentials_for_slug`` is ``False``."""
     _clear_provider_env(monkeypatch)
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
 
     assert has_credentials_for_slug(NOUS_SLUG) is False
 
@@ -136,14 +145,13 @@ def test_has_credentials_for_slug_nous_with_no_keys(monkeypatch: MonkeyPatch) ->
 # ── W1.6 / W1.7 — binary gate is short-circuited (D5) ────────────────────────
 
 
-def test_is_runnable_model_slug_nous_with_credentials(monkeypatch: MonkeyPatch) -> None:
-    """Both gates green: ``is_runnable_model_slug`` returns ``True`` for the nous slug.
-
-    Pins against a silent regression where a future refactor reintroduces a
-    ``shutil.which("nous")`` lookup that would always fail.
-    """
+def test_is_runnable_model_slug_nous_with_credentials(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Both gates green: ``is_runnable_model_slug`` returns ``True`` for the nous slug."""
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv(NOUS_API_KEY_ENV, "nous-test-key")
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
 
     assert is_runnable_model_slug(NOUS_SLUG) is True
 

--- a/tests/agents/test_build_custom_provider_workflow_env.py
+++ b/tests/agents/test_build_custom_provider_workflow_env.py
@@ -1,0 +1,51 @@
+"""``build_custom_provider`` reads workflow ``LLM_PROVIDER_<N>_API_KEY`` env."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.cli.support_provider_registry import bootstrap_nous_registry
+
+from mergecraft.agents.opencode import build_custom_provider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+NOUS_MODEL = "nous/deepseek/deepseek-v4-flash"
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+
+
+@pytest.fixture(autouse=True)
+def _clear_custom_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for n in range(1, 4):
+        monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{n}", raising=False)
+        monkeypatch.delenv(f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{n}", raising=False)
+        monkeypatch.delenv(f"LLM_PROVIDER_{n}_API_KEY", raising=False)
+
+
+def test_build_custom_provider_reads_llm_provider_workflow_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    bootstrap_nous_registry(
+        tmp_path,
+        monkeypatch,
+        model_id="deepseek/deepseek-v4-flash",
+        api_key="workflow-registry-key",
+        url=NOUS_BASE_URL,
+    )
+    monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", "workflow-registry-key")
+    monkeypatch.delenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY_1", raising=False)
+    monkeypatch.setenv(
+        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_1",
+        NOUS_BASE_URL,
+    )
+
+    emitted = build_custom_provider(NOUS_MODEL)
+    assert emitted is not None
+    nous_block = emitted["nous"]
+    assert nous_block["options"]["baseURL"] == NOUS_BASE_URL
+    assert nous_block["options"]["apiKey"] == "workflow-registry-key"

--- a/tests/agents/test_minimax_routing.py
+++ b/tests/agents/test_minimax_routing.py
@@ -342,13 +342,14 @@ def test_minimax_missing_credential_fails_loud(
     assert any(token in message for token in ("minimax",)), (
         f"error message must mention 'minimax'; got: {message!r}"
     )
-    # The error must name the env vars that fix the configuration.
-    assert SINGLETON_BASE_URL_ENV.lower() in message or any(
-        INDEXED_BASE_URL_FMT.format(n=n).lower() in message for n in (1,)
-    ), (
-        f"error message must name the custom-provider env vars "
-        f"({SINGLETON_BASE_URL_ENV} or {INDEXED_BASE_URL_FMT.format(n=1)}); got: {message!r}"
-    )
+    # Unregistered providers fail loud with registry guidance; registered-but-missing
+    # creds name the custom-provider env vars.
+    assert (
+        "not registered" in message
+        or "provider add" in message
+        or SINGLETON_BASE_URL_ENV.lower() in message
+        or any(INDEXED_BASE_URL_FMT.format(n=n).lower() in message for n in (1,))
+    ), f"error message must name registry setup or custom-provider env vars; got: {message!r}"
     # And it must NOT silently resolve to the opencode harness.
     assert "opencode" not in message, (
         f"error must not mention 'opencode' (silent fall-through); got: {message!r}"

--- a/tests/agents/test_openai_compatible_gateways.py
+++ b/tests/agents/test_openai_compatible_gateways.py
@@ -230,11 +230,16 @@ def test_singleton_still_grants_minimax_credentials(
 
 
 def test_nous_back_compat_alias_still_grants_nous_credentials(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``NOUS_API_KEY`` still grants ``nous`` credentials (D4 back-compat alias)."""
+    """``NOUS_API_KEY`` still grants ``nous`` credentials when registered (D7)."""
+    from tests.cli.support_provider_registry import bootstrap_nous_registry
+
     from mergecraft.agents.openai_compatible_gateways import has_gateway_credentials
 
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
     monkeypatch.setenv("NOUS_API_KEY", "nous-key")
 
     assert has_gateway_credentials("nous") is True

--- a/tests/agents/test_opencode_custom_provider.py
+++ b/tests/agents/test_opencode_custom_provider.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 from tests.agents.conftest import make_agent_run_context
+from tests.cli.support_provider_registry import (
+    bootstrap_nous_registry,
+    bootstrap_opencode_gateway,
+    scaffold_mergecraft_home,
+)
 
 from mergecraft.agents.opencode import (
     CUSTOM_PROVIDER_API_KEY_ENV,
@@ -46,8 +51,13 @@ def _config(tmp_path: Path, model: str | None) -> dict[str, object]:
 def test_custom_provider_is_registered_from_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv(CUSTOM_PROVIDER_BASE_URL_ENV, NOUS_BASE_URL)
-    monkeypatch.setenv(CUSTOM_PROVIDER_API_KEY_ENV, "nous-key")
+    bootstrap_nous_registry(
+        tmp_path,
+        monkeypatch,
+        model_id="deepseek/deepseek-v4-flash",
+        api_key="nous-key",
+        url=NOUS_BASE_URL,
+    )
 
     config = _config(tmp_path, NOUS_MODEL)
 
@@ -85,16 +95,23 @@ def test_provider_omitted_for_an_unprefixed_model(
     assert "provider" not in _config(tmp_path, "deepseek-v4-flash")
 
 
-def test_unconfigured_environment_leaves_config_unchanged(tmp_path: Path) -> None:
+def test_unconfigured_environment_leaves_config_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
     config = _config(tmp_path, NOUS_MODEL)
 
     assert "provider" not in config
-    assert config["enabled_providers"] == ["nous"]
 
 
 def test_nous_api_key_alone_registers_preset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Registered nous with indexed secret emits the provider block (D7 shim is credential-only)."""
+    bootstrap_nous_registry(
+        tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash", api_key="nous-key"
+    )
     monkeypatch.setenv("NOUS_API_KEY", "nous-key")
 
     config = _config(tmp_path, NOUS_MODEL)
@@ -110,7 +127,14 @@ def test_nous_api_key_alone_registers_preset(
 
 
 def test_tokenhub_api_key_registers_hy3(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        model_id="hy3",
+        api_key="th-key",
+    )
 
     config = _config(tmp_path, "tokenhub/hy3")
 
@@ -132,7 +156,9 @@ def test_tokenhub_api_key_registers_hy3(tmp_path: Path, monkeypatch: pytest.Monk
 def test_custom_provider_env_overrides_named_preset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    bootstrap_nous_registry(
+        tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash", api_key="nous-key"
+    )
     monkeypatch.setenv(CUSTOM_PROVIDER_BASE_URL_ENV, "https://example.test/v1")
     monkeypatch.setenv(CUSTOM_PROVIDER_API_KEY_ENV, "custom-key")
 

--- a/tests/agents/test_opencode_llm_tracing.py
+++ b/tests/agents/test_opencode_llm_tracing.py
@@ -263,9 +263,12 @@ def test_resolve_model_params_from_singleton_extra_options_env(
 
 
 def test_resolve_model_params_from_nous_preset_provider_map(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """#295 — named preset path resolves applied ModelParams."""
+    """#295 — registered nous path resolves applied ModelParams."""
+    from tests.cli.support_provider_registry import bootstrap_nous_registry
+
     for key in (
         "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL",
         "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
@@ -273,7 +276,7 @@ def test_resolve_model_params_from_nous_preset_provider_map(
         "MERGECRAFT_PROVIDER_EXTRA_OPTIONS",
     ):
         monkeypatch.delenv(key, raising=False)
-    monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
     monkeypatch.setenv(
         "MERGECRAFT_PROVIDER_EXTRA_OPTIONS",
         '{"nous": {"max_tokens": 8192, "temperature": 0.2, "context_limit": 64000}}',

--- a/tests/agents/test_provider_config.py
+++ b/tests/agents/test_provider_config.py
@@ -100,32 +100,6 @@ _BYTE_IDENTITY_CASES: tuple[tuple[str, str, dict[str, str], object], ...] = (
         },
     ),
     (
-        "named_nous",
-        NOUS_MODEL,
-        {"NOUS_API_KEY": "nous-key"},
-        {
-            "nous": {
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "nous",
-                "options": {"baseURL": NOUS_BASE_URL, "apiKey": "nous-key"},
-                "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
-            }
-        },
-    ),
-    (
-        "named_tokenhub",
-        TOKENHUB_MODEL,
-        {"TOKENHUB_API_KEY": "th-key"},
-        {
-            "tokenhub": {
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "tokenhub",
-                "options": {"baseURL": TOKENHUB_BASE_URL, "apiKey": "th-key"},
-                "models": {"hy3": {"name": "hy3"}},
-            }
-        },
-    ),
-    (
         "custom_singleton",
         "default/some-model",
         {
@@ -141,26 +115,6 @@ _BYTE_IDENTITY_CASES: tuple[tuple[str, str, dict[str, str], object], ...] = (
                     "apiKey": "custom-key",
                 },
                 "models": {"some-model": {"name": "some-model"}},
-            }
-        },
-    ),
-    (
-        "custom_base_url_overrides_nous",
-        NOUS_MODEL,
-        {
-            "NOUS_API_KEY": "nous-key",
-            SINGLETON_BASE_URL_ENV: "https://override.example.test/v1",
-            SINGLETON_API_KEY_ENV: "override-key",
-        },
-        {
-            "nous": {
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "nous",
-                "options": {
-                    "baseURL": "https://override.example.test/v1",
-                    "apiKey": "override-key",
-                },
-                "models": {"deepseek/deepseek-v4-flash": {"name": "deepseek/deepseek-v4-flash"}},
             }
         },
     ),
@@ -345,9 +299,19 @@ def test_gaps_in_indices_are_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _custom_provider_ids("provider_1/some-model") == [PROVIDER_1_ID, PROVIDER_3_ID]
 
 
-def test_named_presets_still_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``nous/*`` and ``tokenhub/*`` still resolve from their named env vars."""
-    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+def test_named_presets_still_resolve_via_registry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registered ``nous/*`` and ``tokenhub/*`` resolve from registry + indexed secrets."""
+    from tests.cli.support_provider_registry import (
+        bootstrap_nous_registry,
+        bootstrap_opencode_gateway,
+    )
+
+    bootstrap_nous_registry(
+        tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash", api_key="nous-key"
+    )
     nous = build_custom_provider(NOUS_MODEL)
     assert nous == {
         "nous": {
@@ -359,8 +323,15 @@ def test_named_presets_still_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
     }
     assert _custom_provider_ids(NOUS_MODEL) == ["nous"]
 
-    monkeypatch.delenv("NOUS_API_KEY")
-    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url=TOKENHUB_BASE_URL,
+        model_id="hy3",
+        api_key="th-key",
+        env_index=2,
+    )
     tokenhub = build_custom_provider(TOKENHUB_MODEL)
     assert tokenhub == {
         "tokenhub": {

--- a/tests/agents/test_registry_provider_presets_removed.py
+++ b/tests/agents/test_registry_provider_presets_removed.py
@@ -1,0 +1,66 @@
+"""RED tests for BE #481 — remove Nous/TokenHub/MiniMax gateway presets.
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BE — test-creator. Pins removal of named presets, env constants, and
+``_OPENCODE_NATIVE_PROVIDERS`` / ``_KNOWN_CATALOG_PROVIDERS`` special-casing.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from tests.cli.support_provider_registry import (
+    REMOVED_GATEWAY_MODULE_SYMBOLS,
+    REMOVED_GATEWAY_PRESET_LABELS,
+)
+
+from mergecraft.agents import openai_compatible_gateways as gateways
+from mergecraft.utils import agent_resolve as ar
+
+BE_XFAIL = pytest.mark.xfail(reason="green after BE impl", strict=False)
+
+
+@BE_XFAIL
+def test_gateway_presets_exclude_nous_tokenhub_minimax() -> None:
+    """``GATEWAY_PRESETS`` must not carry named Nous/TokenHub/MiniMax rows."""
+    preset_labels = {str(key).lower() for key in gateways.GATEWAY_PRESETS}
+    overlap = REMOVED_GATEWAY_PRESET_LABELS & preset_labels
+    assert not overlap, f"named gateway presets still present: {sorted(overlap)}"
+
+
+@BE_XFAIL
+@pytest.mark.parametrize("symbol", REMOVED_GATEWAY_MODULE_SYMBOLS)
+def test_named_gateway_env_constants_removed(symbol: str) -> None:
+    """Preset-specific env/base-url constants are deleted from the gateways module."""
+    assert not hasattr(gateways, symbol), (
+        f"openai_compatible_gateways.{symbol} must be removed in BE (#481)"
+    )
+
+
+@BE_XFAIL
+def test_opencode_native_providers_exclude_gateway_preset_labels() -> None:
+    """``_OPENCODE_NATIVE_PROVIDERS`` must not special-case nous/tokenhub/minimax."""
+    overlap = REMOVED_GATEWAY_PRESET_LABELS & set(ar._OPENCODE_NATIVE_PROVIDERS)
+    assert not overlap, f"_OPENCODE_NATIVE_PROVIDERS still special-cases: {sorted(overlap)}"
+
+
+@BE_XFAIL
+def test_known_catalog_providers_exclude_gateway_preset_labels() -> None:
+    """``_KNOWN_CATALOG_PROVIDERS`` must not list removed preset provider ids."""
+    overlap = REMOVED_GATEWAY_PRESET_LABELS & set(ar._KNOWN_CATALOG_PROVIDERS)
+    assert not overlap, f"_KNOWN_CATALOG_PROVIDERS still lists preset providers: {sorted(overlap)}"
+
+
+@BE_XFAIL
+def test_agent_resolve_has_no_nous_tokenhub_minimax_branches() -> None:
+    """Runtime resolver must not branch on hardcoded nous/tokenhub/minimax ids."""
+    source = inspect.getsource(ar)
+    forbidden_snippets = (
+        'provider in {"nous", "tokenhub"}',
+        '"nous", "tokenhub"',
+        'provider == "minimax"',
+        '"nous", "tokenhub", "minimax"',
+    )
+    hits = [snippet for snippet in forbidden_snippets if snippet in source]
+    assert not hits, f"agent_resolve still contains preset branches: {hits}"

--- a/tests/agents/test_registry_provider_presets_removed.py
+++ b/tests/agents/test_registry_provider_presets_removed.py
@@ -18,10 +18,7 @@ from tests.cli.support_provider_registry import (
 from mergecraft.agents import openai_compatible_gateways as gateways
 from mergecraft.utils import agent_resolve as ar
 
-BE_XFAIL = pytest.mark.xfail(reason="green after BE impl", strict=False)
 
-
-@BE_XFAIL
 def test_gateway_presets_exclude_nous_tokenhub_minimax() -> None:
     """``GATEWAY_PRESETS`` must not carry named Nous/TokenHub/MiniMax rows."""
     preset_labels = {str(key).lower() for key in gateways.GATEWAY_PRESETS}
@@ -29,7 +26,6 @@ def test_gateway_presets_exclude_nous_tokenhub_minimax() -> None:
     assert not overlap, f"named gateway presets still present: {sorted(overlap)}"
 
 
-@BE_XFAIL
 @pytest.mark.parametrize("symbol", REMOVED_GATEWAY_MODULE_SYMBOLS)
 def test_named_gateway_env_constants_removed(symbol: str) -> None:
     """Preset-specific env/base-url constants are deleted from the gateways module."""
@@ -38,21 +34,18 @@ def test_named_gateway_env_constants_removed(symbol: str) -> None:
     )
 
 
-@BE_XFAIL
 def test_opencode_native_providers_exclude_gateway_preset_labels() -> None:
     """``_OPENCODE_NATIVE_PROVIDERS`` must not special-case nous/tokenhub/minimax."""
     overlap = REMOVED_GATEWAY_PRESET_LABELS & set(ar._OPENCODE_NATIVE_PROVIDERS)
     assert not overlap, f"_OPENCODE_NATIVE_PROVIDERS still special-cases: {sorted(overlap)}"
 
 
-@BE_XFAIL
 def test_known_catalog_providers_exclude_gateway_preset_labels() -> None:
     """``_KNOWN_CATALOG_PROVIDERS`` must not list removed preset provider ids."""
     overlap = REMOVED_GATEWAY_PRESET_LABELS & set(ar._KNOWN_CATALOG_PROVIDERS)
     assert not overlap, f"_KNOWN_CATALOG_PROVIDERS still lists preset providers: {sorted(overlap)}"
 
 
-@BE_XFAIL
 def test_agent_resolve_has_no_nous_tokenhub_minimax_branches() -> None:
     """Runtime resolver must not branch on hardcoded nous/tokenhub/minimax ids."""
     source = inspect.getsource(ar)

--- a/tests/agents/test_registry_provider_runtime.py
+++ b/tests/agents/test_registry_provider_runtime.py
@@ -42,8 +42,6 @@ if TYPE_CHECKING:
 
     from _pytest.monkeypatch import MonkeyPatch
 
-BE_XFAIL = pytest.mark.xfail(reason="green after BE impl", strict=False)
-
 _UNKNOWN_SLUG = "acme-registry/unregistered-model"
 _UNKNOWN_PROVIDER = "acme-registry"
 
@@ -57,21 +55,18 @@ def _configuration_error_types() -> tuple[type[BaseException], ...]:
 # ── D4 / issue #481 — unknown provider is configuration_error ────────────────
 
 
-@BE_XFAIL
 def test_agent_mode_for_unknown_provider_raises_configuration_error() -> None:
     """Bare ``return "opencode"`` fallback must be gone for unknown providers."""
     with pytest.raises(_configuration_error_types(), match=r"configuration|unknown|provider"):
         _agent_mode_for_slug(_UNKNOWN_SLUG)
 
 
-@BE_XFAIL
 def test_resolve_harness_unknown_provider_raises_configuration_error() -> None:
     settings = RepoSettings.model_validate({"model": _UNKNOWN_SLUG})
     with pytest.raises(_configuration_error_types(), match=r"configuration|unknown|provider"):
         resolve_harness(settings, _UNKNOWN_SLUG)
 
 
-@BE_XFAIL
 def test_resolve_runtime_agent_unknown_provider_not_opencode(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -85,7 +80,6 @@ def test_resolve_runtime_agent_unknown_provider_not_opencode(
     )
 
 
-@BE_XFAIL
 def test_classify_unknown_provider_error_maps_to_configuration_error() -> None:
     settings = RepoSettings.model_validate({"model": _UNKNOWN_SLUG})
     with pytest.raises(_configuration_error_types()) as exc_info:
@@ -93,7 +87,6 @@ def test_classify_unknown_provider_error_maps_to_configuration_error() -> None:
     assert _classify_error_outcome(exc_info.value) is RunOutcome.configuration_error
 
 
-@BE_XFAIL
 def test_harness_supports_provider_rejects_unregistered_custom_provider() -> None:
     """Custom providers must be registered — no silent opencode allow-list bypass."""
     assert _harness_supports_provider("opencode", _UNKNOWN_PROVIDER) is False
@@ -102,7 +95,6 @@ def test_harness_supports_provider_rejects_unregistered_custom_provider() -> Non
 # ── Nous works only via registry (harness: opencode) ───────────────────────
 
 
-@BE_XFAIL
 def test_nous_resolves_to_opencode_via_registry_harness(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -114,7 +106,6 @@ def test_nous_resolves_to_opencode_via_registry_harness(
     assert agent.name == "opencode"
 
 
-@BE_XFAIL
 def test_nous_credentials_from_indexed_registry_key_only(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -126,7 +117,6 @@ def test_nous_credentials_from_indexed_registry_key_only(
     assert has_credentials_for_slug(slug) is False
 
 
-@BE_XFAIL
 def test_nous_without_registry_entry_raises_configuration_error(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -140,7 +130,6 @@ def test_nous_without_registry_entry_raises_configuration_error(
         resolve_runtime_agent(model=slug, settings=settings)
 
 
-@BE_XFAIL
 def test_resolve_gateway_endpoint_uses_registry_url_not_preset(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -204,7 +193,6 @@ _HARNESS_REGISTRY_CASES = (
 )
 
 
-@BE_XFAIL
 @pytest.mark.parametrize(
     ("harness", "label", "slug", "url"),
     _HARNESS_REGISTRY_CASES,
@@ -233,6 +221,8 @@ def test_registry_declared_harness_respected_at_runtime(
         label=label,
         api_key=f"{label}-registry-test-key",
     )
+    monkeypatch.setenv(f"LLM_PROVIDER_{1}", label)
+    monkeypatch.setenv(f"LLM_PROVIDER_{1}_API_KEY", f"{label}-registry-test-key")
     if label == "openai":
         monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
     elif label == "anthropic":
@@ -258,7 +248,6 @@ def test_registry_declared_harness_respected_at_runtime(
 # ── D7 — legacy NOUS_API_KEY honoured with deprecation warning ──────────────
 
 
-@BE_XFAIL
 def test_legacy_nous_api_key_emits_deprecation_warning_once(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/agents/test_registry_provider_runtime.py
+++ b/tests/agents/test_registry_provider_runtime.py
@@ -1,0 +1,278 @@
+"""RED tests for BE #481 — registry-only provider runtime resolution.
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BE — test-creator. Pins: unknown provider → ``configuration_error`` (D4),
+Nous via registry ``harness: opencode`` only, kill bare ``return "opencode"``
+fallback, harness field respected per registry row, legacy ``NOUS_API_KEY`` shim (D7).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.cli.support_provider_registry import (
+    CUSTOM_REGISTRY_URL,
+    NOUS_BASE_URL,
+    NOUS_DEEPSEEK_V4,
+    NOUS_TENCENT_HY3,
+    bootstrap_nous_registry,
+    clear_legacy_gateway_env,
+    format_model_slug,
+    scaffold_mergecraft_home,
+    write_indexed_provider_secret,
+    write_registry_provider_row,
+)
+
+from mergecraft.config.settings import RepoSettings, load_repo_settings
+from mergecraft.main import _classify_error_outcome
+from mergecraft.run_outcome import RunOutcome
+from mergecraft.utils.agent_resolve import (
+    ModelFallbackPolicyError,
+    _agent_mode_for_slug,
+    _harness_supports_provider,
+    has_credentials_for_slug,
+    resolve_harness,
+    resolve_runtime_agent,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+BE_XFAIL = pytest.mark.xfail(reason="green after BE impl", strict=False)
+
+_UNKNOWN_SLUG = "acme-registry/unregistered-model"
+_UNKNOWN_PROVIDER = "acme-registry"
+
+
+def _configuration_error_types() -> tuple[type[BaseException], ...]:
+    from mergecraft.main import _ConfigurationError
+
+    return (ModelFallbackPolicyError, _ConfigurationError, ValueError)
+
+
+# ── D4 / issue #481 — unknown provider is configuration_error ────────────────
+
+
+@BE_XFAIL
+def test_agent_mode_for_unknown_provider_raises_configuration_error() -> None:
+    """Bare ``return "opencode"`` fallback must be gone for unknown providers."""
+    with pytest.raises(_configuration_error_types(), match=r"configuration|unknown|provider"):
+        _agent_mode_for_slug(_UNKNOWN_SLUG)
+
+
+@BE_XFAIL
+def test_resolve_harness_unknown_provider_raises_configuration_error() -> None:
+    settings = RepoSettings.model_validate({"model": _UNKNOWN_SLUG})
+    with pytest.raises(_configuration_error_types(), match=r"configuration|unknown|provider"):
+        resolve_harness(settings, _UNKNOWN_SLUG)
+
+
+@BE_XFAIL
+def test_resolve_runtime_agent_unknown_provider_not_opencode(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    clear_legacy_gateway_env(monkeypatch)
+    try:
+        agent = resolve_runtime_agent(model=_UNKNOWN_SLUG)
+    except _configuration_error_types():
+        return
+    assert agent.name != "opencode", (
+        f"unknown provider {_UNKNOWN_SLUG!r} silently routed to opencode"
+    )
+
+
+@BE_XFAIL
+def test_classify_unknown_provider_error_maps_to_configuration_error() -> None:
+    settings = RepoSettings.model_validate({"model": _UNKNOWN_SLUG})
+    with pytest.raises(_configuration_error_types()) as exc_info:
+        resolve_harness(settings, _UNKNOWN_SLUG)
+    assert _classify_error_outcome(exc_info.value) is RunOutcome.configuration_error
+
+
+@BE_XFAIL
+def test_harness_supports_provider_rejects_unregistered_custom_provider() -> None:
+    """Custom providers must be registered — no silent opencode allow-list bypass."""
+    assert _harness_supports_provider("opencode", _UNKNOWN_PROVIDER) is False
+
+
+# ── Nous works only via registry (harness: opencode) ───────────────────────
+
+
+@BE_XFAIL
+def test_nous_resolves_to_opencode_via_registry_harness(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    slug = bootstrap_nous_registry(tmp_path, monkeypatch, model_id=NOUS_TENCENT_HY3)
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+    assert resolve_harness(settings, slug) == "opencode"
+    agent = resolve_runtime_agent(model=slug, settings=settings)
+    assert agent.name == "opencode"
+
+
+@BE_XFAIL
+def test_nous_credentials_from_indexed_registry_key_only(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    slug = bootstrap_nous_registry(tmp_path, monkeypatch, model_id=NOUS_DEEPSEEK_V4)
+    load_repo_settings(root=tmp_path, load_learnings_files=False)
+    assert has_credentials_for_slug(slug) is True
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
+    assert has_credentials_for_slug(slug) is False
+
+
+@BE_XFAIL
+def test_nous_without_registry_entry_raises_configuration_error(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_legacy_gateway_env(monkeypatch)
+    slug = format_model_slug("nous", NOUS_TENCENT_HY3)
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+    with pytest.raises(_configuration_error_types(), match=r"configuration|provider|registry"):
+        resolve_runtime_agent(model=slug, settings=settings)
+
+
+@BE_XFAIL
+def test_resolve_gateway_endpoint_uses_registry_url_not_preset(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from mergecraft.agents.openai_compatible_gateways import resolve_gateway_endpoint
+
+    slug = bootstrap_nous_registry(
+        tmp_path,
+        monkeypatch,
+        url=CUSTOM_REGISTRY_URL,
+        model_id=NOUS_TENCENT_HY3,
+        api_key="registry-url-canary-key",
+    )
+    endpoint = resolve_gateway_endpoint(slug)
+    assert endpoint is not None
+    provider_id, base_url, api_key = endpoint
+    assert provider_id == "nous"
+    assert base_url == CUSTOM_REGISTRY_URL
+    assert base_url != NOUS_BASE_URL
+    assert api_key == "registry-url-canary-key"
+
+
+# ── Harness field respected per registry row (#481 acceptance) ────────────────
+
+_HARNESS_REGISTRY_CASES = (
+    pytest.param(
+        "codex",
+        "acme",
+        "acme/gateway-model-1",
+        CUSTOM_REGISTRY_URL,
+        id="registry-incompatible-harness-is-configuration-error",
+    ),
+    pytest.param(
+        "opencode",
+        "openai",
+        "openai/gpt-5.3-codex",
+        None,
+        id="openai-registry-overrides-codex-inference",
+    ),
+    pytest.param(
+        "opencode",
+        "anthropic",
+        "anthropic/claude-sonnet",
+        None,
+        id="anthropic-registry-overrides-claude-inference",
+    ),
+    pytest.param(
+        "opencode",
+        "google",
+        "google/gemini-3.1-pro-preview",
+        None,
+        id="google-registry-overrides-gemini-inference",
+    ),
+    pytest.param(
+        "opencode",
+        "cursor",
+        "cursor/cloud-agent",
+        None,
+        id="cursor-registry-overrides-cursor-inference",
+    ),
+)
+
+
+@BE_XFAIL
+@pytest.mark.parametrize(
+    ("harness", "label", "slug", "url"),
+    _HARNESS_REGISTRY_CASES,
+)
+def test_registry_declared_harness_respected_at_runtime(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    harness: str,
+    label: str,
+    slug: str,
+    url: str | None,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_legacy_gateway_env(monkeypatch)
+    write_registry_provider_row(
+        tmp_path,
+        label=label,
+        harness=harness,
+        env_index=1,
+        url=url,
+    )
+    write_indexed_provider_secret(
+        tmp_path,
+        env_index=1,
+        label=label,
+        api_key=f"{label}-registry-test-key",
+    )
+    if label == "openai":
+        monkeypatch.setenv("CODEX_AUTH_JSON", '{"access_token":"test-token"}')
+    elif label == "anthropic":
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-test-token")
+    elif label == "google":
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    elif label == "cursor":
+        monkeypatch.setenv("CURSOR_API_KEY", "cursor-test-key")
+
+    settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
+    if harness == "codex" and label == "acme":
+        with pytest.raises(
+            _configuration_error_types(), match=r"configuration|incompatible|harness"
+        ):
+            resolve_harness(settings, slug)
+        return
+    resolved = resolve_harness(settings, slug)
+    assert resolved == harness, (
+        f"registry harness {harness!r} must win over inference for {slug!r}; got {resolved!r}"
+    )
+
+
+# ── D7 — legacy NOUS_API_KEY honoured with deprecation warning ──────────────
+
+
+@BE_XFAIL
+def test_legacy_nous_api_key_emits_deprecation_warning_once(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    slug = bootstrap_nous_registry(tmp_path, monkeypatch, model_id=NOUS_TENCENT_HY3)
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
+    monkeypatch.setenv("NOUS_API_KEY", "legacy-nous-shim-key")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert has_credentials_for_slug(slug) is True
+        assert has_credentials_for_slug(slug) is True
+
+    deprecation = [item for item in caught if issubclass(item.category, DeprecationWarning)]
+    assert len(deprecation) == 1, (
+        f"expected exactly one DeprecationWarning for legacy NOUS_API_KEY, got {deprecation}"
+    )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures for CLI tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_credential_warned_keys() -> Iterator[None]:
+    """Isolate D7 once-per-legacy-key credential warnings between tests."""
+    from mergecraft.cli import provider_cmd
+
+    provider_cmd._LEGACY_CREDENTIAL_WARNED_KEYS.clear()
+    yield
+    provider_cmd._LEGACY_CREDENTIAL_WARNED_KEYS.clear()

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -222,3 +222,56 @@ def model_index_value(row: dict[str, Any]) -> int | None:
     if raw is None:
         return None
     return int(raw)
+
+
+# BD #480 — ``agents setmodel`` / ``addbackupmodel`` fixtures (D8).
+
+AGENTS_CMD_MODULE = "mergecraft.cli.agents_cmd"
+
+
+def import_agents_cmd() -> Any:
+    """Import ``mergecraft.cli.agents_cmd`` or fail with a clear message."""
+    try:
+        return importlib.import_module(AGENTS_CMD_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{AGENTS_CMD_MODULE} is not importable: {exc}")
+
+
+def format_model_slug(provider_label: str, model_id: str) -> str:
+    """Return ``provider/model`` slug for agent ``modelChain`` entries (#480)."""
+    return f"{provider_label.strip().lower()}/{model_id}"
+
+
+def agents_block(config: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``agents`` mapping from a config dict."""
+    agents = config.get("agents")
+    if agents is None:
+        return {}
+    assert isinstance(agents, dict)
+    return agents
+
+
+def agents_model_chain(config: dict[str, Any], role: str) -> list[str]:
+    """Return ``modelChain`` for one agent role from raw config."""
+    entry = agents_block(config).get(role.lower(), {})
+    if not isinstance(entry, dict):
+        return []
+    chain = entry.get("modelChain")
+    if chain is None:
+        return []
+    assert isinstance(chain, list)
+    return [str(item) for item in chain]
+
+
+def write_agents_model_chain(tmp_path: Path, role: str, chain: list[str]) -> None:
+    """Persist ``agents.<role>.modelChain`` in ``.mergecraft/config.yaml``."""
+    config = read_config(tmp_path)
+    agents = config.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        pytest.fail("agents block must be a mapping")
+    entry = agents.setdefault(role.lower(), {})
+    if not isinstance(entry, dict):
+        pytest.fail(f"agents.{role} must be a mapping")
+    entry["modelChain"] = list(chain)
+    path = tmp_path / ".mergecraft" / "config.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -655,18 +655,8 @@ def _line_is_owned_workflow_mutation(line: str) -> bool:
 
 def assert_only_owned_workflow_keys_changed(before: str, after: str) -> None:
     """Assert byte-stable surgery: only owned ``with:``/``env:`` keys may differ."""
-    before_lines = before.splitlines()
-    after_lines = after.splitlines()
-    max_len = max(len(before_lines), len(after_lines))
-    for index in range(max_len):
-        old = before_lines[index] if index < len(before_lines) else None
-        new = after_lines[index] if index < len(after_lines) else None
-        if old == new:
-            continue
-        if old is not None and _line_is_owned_workflow_mutation(old):
-            continue
-        if new is not None and _line_is_owned_workflow_mutation(new):
-            continue
-        raise AssertionError(
-            f"non-owned workflow line changed at line {index + 1}: before={old!r} after={new!r}"
-        )
+
+    def non_owned_lines(text: str) -> list[str]:
+        return [line for line in text.splitlines() if not _line_is_owned_workflow_mutation(line)]
+
+    assert non_owned_lines(before) == non_owned_lines(after)

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -275,3 +275,116 @@ def write_agents_model_chain(tmp_path: Path, role: str, chain: list[str]) -> Non
     entry["modelChain"] = list(chain)
     path = tmp_path / ".mergecraft" / "config.yaml"
     path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+
+# BE #481 — registry-only provider runtime (drop Nous/TokenHub/MiniMax presets).
+
+LEGACY_GATEWAY_ENV_KEYS: tuple[str, ...] = (
+    "NOUS_API_KEY",
+    "NOUS_BASE_URL",
+    "TOKENHUB_API_KEY",
+    "TOKENHUB_BASE_URL",
+    "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL",
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+)
+
+REMOVED_GATEWAY_PRESET_LABELS: frozenset[str] = frozenset({"nous", "tokenhub", "minimax"})
+
+REMOVED_GATEWAY_MODULE_SYMBOLS: tuple[str, ...] = (
+    "DEFAULT_NOUS_BASE_URL",
+    "NOUS_API_KEY_ENV",
+    "NOUS_BASE_URL_ENV",
+    "DEFAULT_TOKENHUB_BASE_URL",
+    "TOKENHUB_API_KEY_ENV",
+    "TOKENHUB_BASE_URL_ENV",
+    "DEFAULT_MINIMAX_BASE_URL",
+    "MINIMAX_API_KEY_ENV",
+    "MINIMAX_BASE_URL_ENV",
+)
+
+NOUS_TENCENT_HY3 = "tencent/hy3"
+NOUS_DEEPSEEK_V4 = "deepseek/deepseek-v4-flash"
+CUSTOM_REGISTRY_URL = "https://registry-acme.example.invalid/v1"
+
+
+def clear_legacy_gateway_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset preset and singleton custom-provider env vars (BE #481)."""
+    for key in LEGACY_GATEWAY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for index in range(1, 8):
+        monkeypatch.delenv(f"LLM_PROVIDER_{index}", raising=False)
+        monkeypatch.delenv(f"LLM_PROVIDER_{index}_API_KEY", raising=False)
+
+
+def write_registry_provider_row(
+    tmp_path: Path,
+    *,
+    label: str,
+    harness: str,
+    env_index: int,
+    url: str | None = None,
+    models: list[dict[str, object]] | None = None,
+) -> None:
+    """Append one ``providers:`` row for agent-resolve registry tests."""
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    row: dict[str, object] = {
+        "label": label,
+        "harness": harness,
+        "envIndex": env_index,
+        "authKind": AUTH_KIND_API_KEY,
+    }
+    if url is not None:
+        row["url"] = url
+    if models is not None:
+        row["models"] = models
+    entries.append(row)
+    config["providers"] = entries
+    path = tmp_path / ".mergecraft" / "config.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+
+def write_indexed_provider_secret(
+    tmp_path: Path,
+    *,
+    env_index: int,
+    label: str,
+    api_key: str,
+) -> None:
+    """Write ``LLM_PROVIDER_<N>`` label + ``LLM_PROVIDER_<N>_API_KEY`` to ``.env``."""
+    env_path = tmp_path / ".env"
+    lines: list[str] = []
+    if env_path.is_file():
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+    lines.append(f"LLM_PROVIDER_{env_index}={label}")
+    lines.append(f"LLM_PROVIDER_{env_index}_API_KEY={api_key}")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def bootstrap_nous_registry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    url: str = NOUS_BASE_URL,
+    model_id: str = NOUS_TENCENT_HY3,
+    api_key: str = "registry-nous-test-key",
+) -> str:
+    """Register Nous purely via config registry + indexed secret (no presets)."""
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_legacy_gateway_env(monkeypatch)
+    write_registry_provider_row(
+        tmp_path,
+        label="nous",
+        harness="opencode",
+        env_index=1,
+        url=url,
+        models=[{"id": model_id, "modelIndex": 1}],
+    )
+    write_indexed_provider_secret(
+        tmp_path,
+        env_index=1,
+        label="nous",
+        api_key=api_key,
+    )
+    return format_model_slug("nous", model_id)

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -387,4 +387,6 @@ def bootstrap_nous_registry(
         label="nous",
         api_key=api_key,
     )
+    monkeypatch.setenv("LLM_PROVIDER_1", "nous")
+    monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", api_key)
     return format_model_slug("nous", model_id)

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -327,6 +327,7 @@ def write_registry_provider_row(
     env_index: int,
     url: str | None = None,
     models: list[dict[str, object]] | None = None,
+    auth_kind: str | None = None,
 ) -> None:
     """Append one ``providers:`` row for agent-resolve registry tests."""
     config = read_config(tmp_path)
@@ -335,7 +336,7 @@ def write_registry_provider_row(
         "label": label,
         "harness": harness,
         "envIndex": env_index,
-        "authKind": AUTH_KIND_API_KEY,
+        "authKind": auth_kind or AUTH_KIND_API_KEY,
     }
     if url is not None:
         row["url"] = url
@@ -529,7 +530,7 @@ WORKFLOW_OWNED_WITH_KEYS: tuple[str, ...] = ("model",)
 
 WORKFLOW_OWNED_ENV_PREFIXES: tuple[str, ...] = (
     "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_",
-    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_",
+    "LLM_PROVIDER_",
 )
 
 WORKFLOW_ONE_STEP_TEMPLATE = """\
@@ -663,8 +664,8 @@ def indexed_custom_provider_base_url(env_index: int) -> str:
 
 
 def indexed_custom_provider_api_key(env_index: int) -> str:
-    """Return ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY_<N>`` for workflow env blocks."""
-    return f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{env_index}"
+    """Return ``LLM_PROVIDER_<N>_API_KEY`` for workflow env blocks."""
+    return f"LLM_PROVIDER_{env_index}_API_KEY"
 
 
 def _line_is_owned_workflow_mutation(line: str) -> bool:

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -1,0 +1,82 @@
+"""Shared helpers for BA #477 provider-registry CLI tests."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+PROVIDER_CMD_MODULE = "mergecraft.cli.provider_cmd"
+PROVIDER_REGISTRY_MODULE = "mergecraft.config.provider_registry"
+
+BUILTIN_HARNESS_DEFAULTS: dict[str, str] = {
+    "openai": "codex",
+    "anthropic": "claude",
+    "google": "gemini",
+    "cursor": "cursor",
+}
+
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+CUSTOM_BASE_URL = "https://gateway.example.invalid/v1"
+EXPECTED_BUILTIN_PROVIDER_COUNT = 14
+
+
+def import_provider_cmd() -> Any:
+    """Import ``mergecraft.cli.provider_cmd`` or fail with a clear message."""
+    try:
+        return importlib.import_module(PROVIDER_CMD_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{PROVIDER_CMD_MODULE} is not implemented yet: {exc}")
+
+
+def import_provider_registry() -> Any:
+    """Import ``mergecraft.config.provider_registry`` or fail with a clear message."""
+    try:
+        return importlib.import_module(PROVIDER_REGISTRY_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{PROVIDER_REGISTRY_MODULE} is not implemented yet: {exc}")
+
+
+def scaffold_mergecraft_home(tmp_path: Path, *, config_body: str = "") -> Path:
+    """Create ``.mergecraft/config.yaml`` under *tmp_path* and return the config path."""
+    cfg_dir = tmp_path / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    path = cfg_dir / "config.yaml"
+    body = config_body.strip()
+    path.write_text((body + "\n") if body else "models: []\n", encoding="utf-8")
+    return path
+
+
+def read_config(tmp_path: Path) -> dict[str, Any]:
+    """Load ``.mergecraft/config.yaml`` as a dict."""
+    path = tmp_path / ".mergecraft" / "config.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def read_env_file(tmp_path: Path) -> dict[str, str]:
+    """Parse ``.env`` key/value pairs (simple ``KEY=value`` lines only)."""
+    path = tmp_path / ".env"
+    if not path.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def provider_entries(config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the ``providers`` list from a config dict."""
+    providers = config.get("providers")
+    if providers is None:
+        return []
+    assert isinstance(providers, list)
+    return [entry for entry in providers if isinstance(entry, dict)]

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -25,6 +25,49 @@ NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
 CUSTOM_BASE_URL = "https://gateway.example.invalid/v1"
 EXPECTED_BUILTIN_PROVIDER_COUNT = 14
 
+# BB #478 — unified ``provider auth`` contracts (D6-D7, D10).
+BB_XFAIL = pytest.mark.xfail(reason="green after BB impl", strict=False)
+
+AUTH_KIND_API_KEY = "api_key"
+AUTH_KIND_OAUTH = "oauth"
+AUTH_KIND_DEVICE_CODE = "device_code"
+AUTH_KIND_CLOUD_CHAIN = "cloud_chain"
+
+LEGACY_AUTH_SUBCOMMANDS: tuple[str, ...] = (
+    "codex",
+    "claude",
+    "gemini",
+    "cursor",
+    "nous",
+    "tokenhub",
+    "minimax",
+)
+
+AUTH_KIND_PRIMARY_SUFFIX: dict[str, str] = {
+    AUTH_KIND_API_KEY: "API_KEY",
+    AUTH_KIND_OAUTH: "CLAUDE_CODE_OAUTH_TOKEN",
+    AUTH_KIND_DEVICE_CODE: "CODEX_AUTH_JSON",
+}
+
+BEDROCK_INDEXED_KEYS: tuple[str, ...] = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+)
+
+VERTEX_INDEXED_KEYS: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+EXPECTED_SEEDED_AUTH_KINDS: dict[str, str] = {
+    "openai": AUTH_KIND_DEVICE_CODE,
+    "anthropic": AUTH_KIND_OAUTH,
+    "google": AUTH_KIND_API_KEY,
+    "cursor": AUTH_KIND_API_KEY,
+    "nous": AUTH_KIND_API_KEY,
+    "tokenhub": AUTH_KIND_API_KEY,
+    "minimax": AUTH_KIND_API_KEY,
+    "bedrock": AUTH_KIND_CLOUD_CHAIN,
+    "vertex": AUTH_KIND_CLOUD_CHAIN,
+}
+
 
 def import_provider_cmd() -> Any:
     """Import ``mergecraft.cli.provider_cmd`` or fail with a clear message."""
@@ -98,6 +141,50 @@ def provider_entries(config: dict[str, Any]) -> list[dict[str, Any]]:
         return []
     assert isinstance(providers, list)
     return [entry for entry in providers if isinstance(entry, dict)]
+
+
+def indexed_env_key(env_index: int, suffix: str) -> str:
+    """Return ``LLM_PROVIDER_<N>_<SUFFIX>`` per #478."""
+    return f"LLM_PROVIDER_{env_index}_{suffix}"
+
+
+def write_provider_entry(
+    tmp_path: Path,
+    *,
+    label: str,
+    env_index: int,
+    harness: str = "opencode",
+    auth_kind: str = AUTH_KIND_API_KEY,
+    url: str | None = None,
+) -> None:
+    """Append one provider row to ``.mergecraft/config.yaml`` (BB auth fixtures)."""
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    entry: dict[str, Any] = {
+        "label": label,
+        "harness": harness,
+        "envIndex": env_index,
+        "authKind": auth_kind,
+    }
+    if url is not None:
+        entry["url"] = url
+    entries.append(entry)
+    config["providers"] = entries
+    path = tmp_path / ".mergecraft" / "config.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+
+def require_provider_auth_symbols() -> Any:
+    """Import ``provider_cmd`` and require BB auth helpers to exist."""
+    module = import_provider_cmd()
+    for name in (
+        "indexed_credential_keys",
+        "resolve_auth_strategy",
+        "provider_auth_cmd",
+    ):
+        if not hasattr(module, name):
+            pytest.fail(f"{PROVIDER_CMD_MODULE}.{name} is not implemented")
+    return module
 
 
 def provider_entry(config: dict[str, Any], label: str) -> dict[str, Any] | None:

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -486,3 +486,187 @@ def env_text(tmp_path: Path) -> str:
     """Return raw ``.env`` text."""
     path = tmp_path / ".env"
     return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+# BG #484 — ``workflow`` CLI authoring + surgical workflow YAML mutator (D9).
+
+BG_XFAIL = pytest.mark.xfail(reason="green after BG impl", strict=False)
+
+WORKFLOW_CMD_MODULE = "mergecraft.cli.workflow_cmd"
+WORKFLOW_WF_YAML_MODULE = "mergecraft.cli.workflow_wf_yaml"
+
+WORKFLOW_DEFAULT_RELATIVE_PATH = ".github/workflows/mergecraft.yml"
+
+# Owned keys the workflow mutator may insert/replace inside mergeCraft steps.
+WORKFLOW_OWNED_WITH_KEYS: tuple[str, ...] = ("model",)
+
+WORKFLOW_OWNED_ENV_PREFIXES: tuple[str, ...] = (
+    "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_",
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_",
+)
+
+WORKFLOW_ONE_STEP_TEMPLATE = """\
+name: mergecraft
+on:
+  pull_request_target:
+jobs:
+  review:
+    name: mergecraft review
+    runs-on: ubuntu-latest
+    # === PRESERVE: header comment block (#486) ===
+    timeout-minutes: 65
+    steps:
+      - name: mergeCraft PR review
+        id: mergecraft_nous
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: openai/gpt-codex
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+"""
+
+WORKFLOW_TWO_STEP_TEMPLATE = """\
+name: mergecraft
+on:
+  pull_request_target:
+jobs:
+  review:
+    name: mergecraft review
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    steps:
+      - name: mergeCraft PR review (Nous primary)
+        id: mergecraft_nous
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: nous/tencent/hy3
+        env:
+          MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
+          MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
+
+      - name: mergeCraft PR review (Codex fallback)
+        id: mergecraft_codex
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: openai/gpt-codex
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+"""
+
+
+def import_workflow_cmd() -> Any:
+    """Import ``mergecraft.cli.workflow_cmd`` or fail with a clear message."""
+    try:
+        return importlib.import_module(WORKFLOW_CMD_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{WORKFLOW_CMD_MODULE} is not implemented yet: {exc}")
+
+
+def import_workflow_wf_yaml() -> Any:
+    """Import ``mergecraft.cli.workflow_wf_yaml`` or fail with a clear message."""
+    try:
+        return importlib.import_module(WORKFLOW_WF_YAML_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{WORKFLOW_WF_YAML_MODULE} is not implemented yet: {exc}")
+
+
+def require_workflow_cmd_symbols() -> Any:
+    """Import workflow CLI and require BG subcommands/helpers."""
+    module = import_workflow_cmd()
+    for name in (
+        "app",
+        "list_cmd",
+        "provider_add_cmd",
+        "provider_harnesses_cmd",
+        "model_add_cmd",
+        "model_prioritize_cmd",
+        "agents_setmodel_cmd",
+    ):
+        if not hasattr(module, name):
+            pytest.fail(f"{WORKFLOW_CMD_MODULE}.{name} is not implemented")
+    return module
+
+
+def require_workflow_wf_yaml_symbols() -> Any:
+    """Import workflow YAML mutator and require BG owned-key helpers."""
+    module = import_workflow_wf_yaml()
+    for name in (
+        "WORKFLOW_OWNED_WITH_KEYS",
+        "WORKFLOW_OWNED_ENV_PREFIXES",
+        "WorkflowYamlError",
+        "WorkflowChange",
+        "apply_provider_env_wiring",
+        "apply_model_wiring",
+        "render_workflow_diff",
+    ):
+        if not hasattr(module, name):
+            pytest.fail(f"{WORKFLOW_WF_YAML_MODULE}.{name} is not implemented")
+    return module
+
+
+def scaffold_workflow_file(
+    tmp_path: Path,
+    body: str,
+    *,
+    relative_path: str = WORKFLOW_DEFAULT_RELATIVE_PATH,
+) -> Path:
+    """Write a consumer workflow YAML under *tmp_path*."""
+    workflow_path = tmp_path / relative_path
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(body, encoding="utf-8")
+    return workflow_path
+
+
+def workflow_text(tmp_path: Path, *, relative_path: str = WORKFLOW_DEFAULT_RELATIVE_PATH) -> str:
+    """Return raw workflow YAML text."""
+    path = tmp_path / relative_path
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+def indexed_custom_provider_base_url(env_index: int) -> str:
+    """Return ``MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_<N>`` for workflow env blocks."""
+    return f"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_{env_index}"
+
+
+def indexed_custom_provider_api_key(env_index: int) -> str:
+    """Return ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY_<N>`` for workflow env blocks."""
+    return f"MERGECRAFT_CUSTOM_PROVIDER_API_KEY_{env_index}"
+
+
+def _line_is_owned_workflow_mutation(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return False
+    for key in WORKFLOW_OWNED_WITH_KEYS:
+        if stripped.startswith(f"{key}:"):
+            return True
+    for prefix in WORKFLOW_OWNED_ENV_PREFIXES:
+        if stripped.split(":", 1)[0].strip().startswith(prefix):
+            return True
+    return False
+
+
+def assert_only_owned_workflow_keys_changed(before: str, after: str) -> None:
+    """Assert byte-stable surgery: only owned ``with:``/``env:`` keys may differ."""
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    max_len = max(len(before_lines), len(after_lines))
+    for index in range(max_len):
+        old = before_lines[index] if index < len(before_lines) else None
+        new = after_lines[index] if index < len(after_lines) else None
+        if old == new:
+            continue
+        if old is not None and _line_is_owned_workflow_mutation(old):
+            continue
+        if new is not None and _line_is_owned_workflow_mutation(new):
+            continue
+        raise AssertionError(
+            f"non-owned workflow line changed at line {index + 1}: before={old!r} after={new!r}"
+        )

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -106,6 +106,8 @@ def scaffold_mergecraft_home(tmp_path: Path, *, config_body: str = "") -> Path:
     cfg_dir = tmp_path / ".mergecraft"
     cfg_dir.mkdir(parents=True, exist_ok=True)
     path = cfg_dir / "config.yaml"
+    if path.is_file():
+        return path
     body = config_body.strip()
     path.write_text((body + "\n") if body else "models: []\n", encoding="utf-8")
     return path
@@ -362,6 +364,43 @@ def write_indexed_provider_secret(
     env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def bootstrap_opencode_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    label: str,
+    url: str,
+    model_id: str,
+    harness: str = "opencode",
+    env_index: int = 1,
+    api_key: str = "registry-test-key",
+) -> str:
+    """Register one provider via config registry + indexed secret (no presets)."""
+    cfg_path = tmp_path / ".mergecraft" / "config.yaml"
+    if not cfg_path.is_file():
+        scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    for key in LEGACY_GATEWAY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    write_registry_provider_row(
+        tmp_path,
+        label=label,
+        harness=harness,
+        env_index=env_index,
+        url=url,
+        models=[{"id": model_id, "modelIndex": 1}],
+    )
+    write_indexed_provider_secret(
+        tmp_path,
+        env_index=env_index,
+        label=label,
+        api_key=api_key,
+    )
+    monkeypatch.setenv(f"LLM_PROVIDER_{env_index}", label)
+    monkeypatch.setenv(f"LLM_PROVIDER_{env_index}_API_KEY", api_key)
+    return format_model_slug(label, model_id)
+
+
 def bootstrap_nous_registry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -371,26 +410,14 @@ def bootstrap_nous_registry(
     api_key: str = "registry-nous-test-key",
 ) -> str:
     """Register Nous purely via config registry + indexed secret (no presets)."""
-    scaffold_mergecraft_home(tmp_path)
-    monkeypatch.chdir(tmp_path)
-    clear_legacy_gateway_env(monkeypatch)
-    write_registry_provider_row(
+    return bootstrap_opencode_gateway(
         tmp_path,
+        monkeypatch,
         label="nous",
-        harness="opencode",
-        env_index=1,
         url=url,
-        models=[{"id": model_id, "modelIndex": 1}],
-    )
-    write_indexed_provider_secret(
-        tmp_path,
-        env_index=1,
-        label="nous",
+        model_id=model_id,
         api_key=api_key,
     )
-    monkeypatch.setenv("LLM_PROVIDER_1", "nous")
-    monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", api_key)
-    return format_model_slug("nous", model_id)
 
 
 # BF #483 — ``provider migrate`` / config-secret split (D2, D7, D10).

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -432,6 +432,8 @@ LEGACY_API_KEY_MIGRATIONS: dict[str, tuple[str, str]] = {
     "CURSOR_API_KEY": ("cursor", "API_KEY"),
     "DEEPSEEK_API_KEY": ("deepseek", "API_KEY"),
     "NOUS_API_KEY": ("nous", "API_KEY"),
+    "TOKENHUB_API_KEY": ("tokenhub", "API_KEY"),
+    "MERGECRAFT_CUSTOM_PROVIDER_API_KEY": ("minimax", "API_KEY"),
 }
 
 LEGACY_STRUCTURE_IN_ENV: tuple[str, ...] = (

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -390,3 +391,98 @@ def bootstrap_nous_registry(
     monkeypatch.setenv("LLM_PROVIDER_1", "nous")
     monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", api_key)
     return format_model_slug("nous", model_id)
+
+
+# BF #483 — ``provider migrate`` / config-secret split (D2, D7, D10).
+
+BF_XFAIL = pytest.mark.xfail(reason="green after BF impl", strict=False)
+
+LEGACY_API_KEY_MIGRATIONS: dict[str, tuple[str, str]] = {
+    "OPENAI_API_KEY": ("openai", "API_KEY"),
+    "ANTHROPIC_API_KEY": ("anthropic", "API_KEY"),
+    "GEMINI_API_KEY": ("google", "API_KEY"),
+    "CURSOR_API_KEY": ("cursor", "API_KEY"),
+    "DEEPSEEK_API_KEY": ("deepseek", "API_KEY"),
+    "NOUS_API_KEY": ("nous", "API_KEY"),
+}
+
+LEGACY_STRUCTURE_IN_ENV: tuple[str, ...] = (
+    "harness",
+    "envIndex",
+    "modelChain",
+    "authKind",
+)
+
+BEDROCK_LEGACY_SECRET_KEYS: tuple[str, ...] = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+)
+
+BEDROCK_LEGACY_CONFIG_KEYS: tuple[str, ...] = (
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+)
+
+VERTEX_LEGACY_SECRET_KEYS: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+VERTEX_LEGACY_CONFIG_KEYS: tuple[str, ...] = (
+    "GOOGLE_CLOUD_PROJECT",
+    "VERTEX_LOCATION",
+)
+
+CREDENTIAL_SUBSTRINGS_IN_CONFIG: tuple[str, ...] = (
+    "api_key",
+    "apiKey",
+    "secret",
+    "password",
+    "token",
+)
+
+
+def write_env_pairs(tmp_path: Path, pairs: Mapping[str, str]) -> None:
+    """Append ``KEY=value`` lines to ``tmp_path/.env``."""
+    env_path = tmp_path / ".env"
+    lines: list[str] = []
+    if env_path.is_file():
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+    for key, value in pairs.items():
+        lines.append(f"{key}={value}")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def stub_mergecraft_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point ``MERGECRAFT_ENV`` at ``tmp_path/.env``."""
+    monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / ".env"))
+
+
+def assert_output_never_contains_secret(output: str, secret: str) -> None:
+    """Fail when *output* leaks a credential value (BF migrate diff contract)."""
+    assert secret not in output, f"migrate output must not contain secret value {secret!r}"
+
+
+def require_provider_migrate_symbols() -> Any:
+    """Import ``provider_cmd`` and require BF migrate helpers to exist."""
+    module = import_provider_cmd()
+    for name in (
+        "migrate_cmd",
+        "plan_provider_migration",
+        "apply_provider_migration",
+        "migration_secret_fingerprint",
+        "validate_config_secret_split",
+        "resolve_indexed_credential",
+    ):
+        if not hasattr(module, name):
+            pytest.fail(f"{PROVIDER_CMD_MODULE}.{name} is not implemented")
+    return module
+
+
+def config_text(tmp_path: Path) -> str:
+    """Return raw ``.mergecraft/config.yaml`` text."""
+    path = tmp_path / ".mergecraft" / "config.yaml"
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+def env_text(tmp_path: Path) -> str:
+    """Return raw ``.env`` text."""
+    path = tmp_path / ".env"
+    return path.read_text(encoding="utf-8") if path.is_file() else ""

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -26,7 +26,6 @@ CUSTOM_BASE_URL = "https://gateway.example.invalid/v1"
 EXPECTED_BUILTIN_PROVIDER_COUNT = 14
 
 # BB #478 — unified ``provider auth`` contracts (D6-D7, D10).
-BB_XFAIL = pytest.mark.xfail(reason="green after BB impl", strict=False)
 
 AUTH_KIND_API_KEY = "api_key"
 AUTH_KIND_OAUTH = "oauth"

--- a/tests/cli/support_provider_registry.py
+++ b/tests/cli/support_provider_registry.py
@@ -10,7 +10,9 @@ import pytest
 import yaml
 
 PROVIDER_CMD_MODULE = "mergecraft.cli.provider_cmd"
+MODEL_CMD_MODULE = "mergecraft.cli.model_cmd"
 PROVIDER_REGISTRY_MODULE = "mergecraft.config.provider_registry"
+MODEL_REGISTRY_MODULE = "mergecraft.config.model_registry"
 
 BUILTIN_HARNESS_DEFAULTS: dict[str, str] = {
     "openai": "codex",
@@ -38,6 +40,22 @@ def import_provider_registry() -> Any:
         return importlib.import_module(PROVIDER_REGISTRY_MODULE)
     except ImportError as exc:
         pytest.fail(f"{PROVIDER_REGISTRY_MODULE} is not implemented yet: {exc}")
+
+
+def import_model_cmd() -> Any:
+    """Import ``mergecraft.cli.model_cmd`` or fail with a clear message."""
+    try:
+        return importlib.import_module(MODEL_CMD_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{MODEL_CMD_MODULE} is not implemented yet: {exc}")
+
+
+def import_model_registry() -> Any:
+    """Import ``mergecraft.config.model_registry`` or fail with a clear message."""
+    try:
+        return importlib.import_module(MODEL_REGISTRY_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{MODEL_REGISTRY_MODULE} is not implemented yet: {exc}")
 
 
 def scaffold_mergecraft_home(tmp_path: Path, *, config_body: str = "") -> Path:
@@ -80,3 +98,41 @@ def provider_entries(config: dict[str, Any]) -> list[dict[str, Any]]:
         return []
     assert isinstance(providers, list)
     return [entry for entry in providers if isinstance(entry, dict)]
+
+
+def provider_entry(config: dict[str, Any], label: str) -> dict[str, Any] | None:
+    """Return the provider registry row for *label*, if present."""
+    lowered = label.strip().lower()
+    for entry in provider_entries(config):
+        if str(entry.get("label", "")).lower() == lowered:
+            return entry
+    return None
+
+
+def provider_model_entries(config: dict[str, Any], label: str) -> list[dict[str, Any]]:
+    """Return model rows under the provider *label* in config."""
+    entry = provider_entry(config, label)
+    if entry is None:
+        return []
+    models = entry.get("models")
+    if models is None:
+        return []
+    assert isinstance(models, list)
+    return [row for row in models if isinstance(row, dict)]
+
+
+def model_id_value(row: dict[str, Any]) -> str:
+    """Extract the stored model id from a config model row."""
+    for key in ("id", "modelId", "model"):
+        value = row.get(key)
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def model_index_value(row: dict[str, Any]) -> int | None:
+    """Extract ``modelIndex`` from a config model row."""
+    raw = row.get("modelIndex")
+    if raw is None:
+        return None
+    return int(raw)

--- a/tests/cli/test_agents_setmodel_cmd.py
+++ b/tests/cli/test_agents_setmodel_cmd.py
@@ -1,0 +1,587 @@
+"""RED tests for ``mergecraft agents setmodel`` / ``addbackupmodel`` (#480 / BD).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BD — test-creator. Pins primary-only replacement (D8), backup append, registry
+validation at write time, and the ``agents set --model`` chain-wipe bug fix.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+import typer
+from tests.cli.support_provider_registry import (
+    AGENTS_CMD_MODULE,
+    CUSTOM_BASE_URL,
+    NOUS_BASE_URL,
+    agents_model_chain,
+    format_model_slug,
+    import_agents_cmd,
+    read_config,
+    scaffold_mergecraft_home,
+    write_agents_model_chain,
+)
+from typer.testing import CliRunner
+
+from mergecraft.agents.registry import load_registry
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+from mergecraft.config.settings import load_repo_settings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+BD_XFAIL = pytest.mark.xfail(reason="green after BD impl", strict=False)
+
+DEEPSEEK_V4 = "deepseek/deepseek-v4-flash"
+TENCENT_HY3 = "tencent/hy3"
+ACME_MODEL = "gateway-model-1"
+UNKNOWN_MODEL = "unknown/unregistered-model"
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str) -> object:
+    return runner.invoke(app, list(argv), env=_DUMB_ENV)
+
+
+def _require_setmodel_commands() -> None:
+    """Fail until ``setmodel`` and ``addbackupmodel`` exist on the agents app."""
+    module = import_agents_cmd()
+    for name in ("setmodel_cmd", "addbackupmodel_cmd"):
+        if not hasattr(module, name):
+            pytest.fail(f"{AGENTS_CMD_MODULE}.{name} is not implemented")
+    result = _invoke("agents", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for verb in ("setmodel", "addbackupmodel"):
+        assert verb in output, f"expected agents subcommand {verb!r} in help"
+
+
+def _register_providers(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    for label, url in (("nous", NOUS_BASE_URL), ("acme", CUSTOM_BASE_URL)):
+        add = _invoke(
+            "provider",
+            "add",
+            "--label",
+            label,
+            "--url",
+            url,
+            "--harness",
+            "opencode",
+        )
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+
+
+def _register_models(tmp_path: Path) -> None:
+    for provider, model_id in (
+        ("nous", TENCENT_HY3),
+        ("nous", DEEPSEEK_V4),
+        ("acme", ACME_MODEL),
+    ):
+        add = _invoke("model", "add", "--provider", provider, model_id)
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+
+
+def _bootstrap_registry(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _register_providers(tmp_path, monkeypatch)
+    _register_models(tmp_path)
+
+
+def _resolved_chain(tmp_path: Path, role: str) -> list[str]:
+    settings = load_repo_settings(root=tmp_path)
+    registry = load_registry(settings=settings, repo_root=tmp_path)
+    binding = registry.resolve_role(role)
+    return list(binding.model_chain)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_help_lists_setmodel_and_addbackupmodel_verbs() -> None:
+    _require_setmodel_commands()
+    result = _invoke("agents", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "setmodel" in output
+    assert "addbackupmodel" in output
+
+
+@BD_XFAIL
+def test_agents_setmodel_help_documents_flags() -> None:
+    _require_setmodel_commands()
+    result = _invoke("agents", "setmodel", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "provider" in output
+    assert "model" in output
+    assert "--all" in output or "all" in output
+
+
+# ---------------------------------------------------------------------------
+# ``setmodel`` replaces primary only — preserves backups (D8)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_replaces_primary_preserves_backups(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    backup_one = format_model_slug("acme", ACME_MODEL)
+    backup_two = format_model_slug("nous", DEEPSEEK_V4)
+    write_agents_model_chain(tmp_path, "reviewer", [primary, backup_one, backup_two])
+
+    new_primary = format_model_slug("nous", DEEPSEEK_V4)
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        DEEPSEEK_V4,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [new_primary, backup_one, backup_two]
+    assert _resolved_chain(tmp_path, "reviewer") == [new_primary, backup_one, backup_two]
+
+
+# ---------------------------------------------------------------------------
+# ``addbackupmodel`` appends to the backup chain
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_addbackupmodel_appends_to_chain(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    result = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "acme",
+        "--model",
+        ACME_MODEL,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    backup = format_model_slug("acme", ACME_MODEL)
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary, backup]
+
+
+@BD_XFAIL
+def test_agents_addbackupmodel_twice_yields_two_distinct_backups_in_order(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    first = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "acme",
+        "--model",
+        ACME_MODEL,
+    )
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE, first.stdout + first.stderr
+
+    second = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        DEEPSEEK_V4,
+    )
+    assert second.exit_code == CLI_SUCCESS_EXIT_CODE, second.stdout + second.stderr
+
+    backup_one = format_model_slug("acme", ACME_MODEL)
+    backup_two = format_model_slug("nous", DEEPSEEK_V4)
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary, backup_one, backup_two]
+
+
+@BD_XFAIL
+def test_agents_addbackupmodel_rejects_duplicate_backup(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    result = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        TENCENT_HY3,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "duplicate" in lowered or "already" in lowered
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary]
+
+
+# ---------------------------------------------------------------------------
+# Unregistered provider/model fails at write time (#480)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_unregistered_provider_fails_at_write_time(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "ghost",
+        "--model",
+        TENCENT_HY3,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "ghost" in lowered or "unknown" in lowered or "not registered" in lowered
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary]
+
+
+@BD_XFAIL
+def test_agents_setmodel_unregistered_model_fails_at_write_time(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        UNKNOWN_MODEL,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert UNKNOWN_MODEL in output or "unregistered" in lowered or "not registered" in lowered
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary]
+
+
+@BD_XFAIL
+def test_agents_addbackupmodel_unregistered_pair_fails_at_write_time(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+
+    result = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "acme",
+        "--model",
+        UNKNOWN_MODEL,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert UNKNOWN_MODEL in output or "unregistered" in lowered or "not registered" in lowered
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [primary]
+
+
+# ---------------------------------------------------------------------------
+# Bug fix — ``agents set --model`` must not wipe the backup chain (D8)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_set_preserves_backup_chain_after_model_override(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    backup_one = format_model_slug("acme", ACME_MODEL)
+    backup_two = format_model_slug("nous", DEEPSEEK_V4)
+    write_agents_model_chain(tmp_path, "reviewer", [primary, backup_one, backup_two])
+
+    new_primary = format_model_slug("nous", DEEPSEEK_V4)
+    result = _invoke(
+        "agents",
+        "set",
+        "reviewer",
+        "--model",
+        new_primary,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer") == [new_primary, backup_one, backup_two]
+    assert _resolved_chain(tmp_path, "reviewer") == [new_primary, backup_one, backup_two]
+
+
+# ---------------------------------------------------------------------------
+# Unknown agent role — existing guard behaviour (#480)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_rejects_unknown_role_lists_valid_roles(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    before = config_path.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--agent",
+        "senior-reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        TENCENT_HY3,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "unknown" in lowered or "role" in lowered
+    assert "reviewer" in lowered or "verifier" in lowered
+    assert config_path.read_text(encoding="utf-8") == before
+    assert "senior-reviewer" not in before
+
+
+@BD_XFAIL
+def test_agents_addbackupmodel_rejects_unknown_role(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    result = _invoke(
+        "agents",
+        "addbackupmodel",
+        "--agent",
+        "senior-reviewer",
+        "--provider",
+        "acme",
+        "--model",
+        ACME_MODEL,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "unknown" in lowered or "role" in lowered
+
+
+# ---------------------------------------------------------------------------
+# Interactive pickers when flags omitted (#480)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_interactive_picker_when_flags_omitted(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    prompted: list[str] = []
+
+    def _fake_prompt(message: str, **kwargs: object) -> str:
+        prompted.append(message.lower())
+        if "agent" in message.lower() or "role" in message.lower():
+            return "reviewer"
+        if "provider" in message.lower():
+            return "nous"
+        if "model" in message.lower():
+            return TENCENT_HY3
+        return "reviewer"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    result = _invoke("agents", "setmodel")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert prompted, "expected interactive prompts when flags omitted"
+
+    expected = format_model_slug("nous", TENCENT_HY3)
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer")[0] == expected
+
+
+# ---------------------------------------------------------------------------
+# ``--all`` lists targets before overwrite (#480)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_all_lists_targets_before_overwrite(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    reviewer_primary = format_model_slug("nous", TENCENT_HY3)
+    verifier_primary = format_model_slug("acme", ACME_MODEL)
+    write_agents_model_chain(tmp_path, "reviewer", [reviewer_primary])
+    write_agents_model_chain(tmp_path, "verifier", [verifier_primary])
+
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--all",
+        "--provider",
+        "nous",
+        "--model",
+        DEEPSEEK_V4,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "reviewer" in lowered
+    assert "verifier" in lowered
+
+    new_slug = format_model_slug("nous", DEEPSEEK_V4)
+    config = read_config(tmp_path)
+    assert agents_model_chain(config, "reviewer")[0] == new_slug
+    assert agents_model_chain(config, "verifier")[0] == new_slug
+
+
+# ---------------------------------------------------------------------------
+# ``AgentBindingOverride`` validation before write (existing behaviour)
+# ---------------------------------------------------------------------------
+
+
+@BD_XFAIL
+def test_agents_setmodel_validates_binding_before_write(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _bootstrap_registry(tmp_path, monkeypatch)
+    _require_setmodel_commands()
+
+    primary = format_model_slug("nous", TENCENT_HY3)
+    write_agents_model_chain(tmp_path, "reviewer", [primary])
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    before = config_path.read_text(encoding="utf-8")
+
+    # Force an invalid override payload through a stubbed registry validator.
+    module = import_agents_cmd()
+
+    def _reject(_entry: object) -> None:
+        raise ValueError("invalid agent binding override")
+
+    if hasattr(module, "validate_agent_binding_override"):
+        monkeypatch.setattr(module, "validate_agent_binding_override", _reject)
+    else:
+        from mergecraft.config.settings import AgentBindingOverride
+
+        def _broken_validate(_entry: object) -> object:
+            raise ValueError("invalid agent binding override")
+
+        monkeypatch.setattr(AgentBindingOverride, "model_validate", _broken_validate)
+
+    result = _invoke(
+        "agents",
+        "setmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        DEEPSEEK_V4,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert config_path.read_text(encoding="utf-8") == before

--- a/tests/cli/test_agents_setmodel_cmd.py
+++ b/tests/cli/test_agents_setmodel_cmd.py
@@ -39,8 +39,6 @@ runner = CliRunner()
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
 
-BD_XFAIL = pytest.mark.xfail(reason="green after BD impl", strict=False)
-
 DEEPSEEK_V4 = "deepseek/deepseek-v4-flash"
 TENCENT_HY3 = "tencent/hy3"
 ACME_MODEL = "gateway-model-1"
@@ -112,7 +110,6 @@ def _resolved_chain(tmp_path: Path, role: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_help_lists_setmodel_and_addbackupmodel_verbs() -> None:
     _require_setmodel_commands()
     result = _invoke("agents", "--help")
@@ -122,7 +119,6 @@ def test_agents_help_lists_setmodel_and_addbackupmodel_verbs() -> None:
     assert "addbackupmodel" in output
 
 
-@BD_XFAIL
 def test_agents_setmodel_help_documents_flags() -> None:
     _require_setmodel_commands()
     result = _invoke("agents", "setmodel", "--help")
@@ -138,7 +134,6 @@ def test_agents_setmodel_help_documents_flags() -> None:
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_replaces_primary_preserves_backups(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -175,7 +170,6 @@ def test_agents_setmodel_replaces_primary_preserves_backups(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_addbackupmodel_appends_to_chain(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -204,7 +198,6 @@ def test_agents_addbackupmodel_appends_to_chain(
     assert agents_model_chain(config, "reviewer") == [primary, backup]
 
 
-@BD_XFAIL
 def test_agents_addbackupmodel_twice_yields_two_distinct_backups_in_order(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -245,7 +238,6 @@ def test_agents_addbackupmodel_twice_yields_two_distinct_backups_in_order(
     assert agents_model_chain(config, "reviewer") == [primary, backup_one, backup_two]
 
 
-@BD_XFAIL
 def test_agents_addbackupmodel_rejects_duplicate_backup(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -280,7 +272,6 @@ def test_agents_addbackupmodel_rejects_duplicate_backup(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_unregistered_provider_fails_at_write_time(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -310,7 +301,6 @@ def test_agents_setmodel_unregistered_provider_fails_at_write_time(
     assert agents_model_chain(config, "reviewer") == [primary]
 
 
-@BD_XFAIL
 def test_agents_setmodel_unregistered_model_fails_at_write_time(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -340,7 +330,6 @@ def test_agents_setmodel_unregistered_model_fails_at_write_time(
     assert agents_model_chain(config, "reviewer") == [primary]
 
 
-@BD_XFAIL
 def test_agents_addbackupmodel_unregistered_pair_fails_at_write_time(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -375,7 +364,6 @@ def test_agents_addbackupmodel_unregistered_pair_fails_at_write_time(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_set_preserves_backup_chain_after_model_override(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -408,7 +396,6 @@ def test_agents_set_preserves_backup_chain_after_model_override(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_rejects_unknown_role_lists_valid_roles(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -438,7 +425,6 @@ def test_agents_setmodel_rejects_unknown_role_lists_valid_roles(
     assert "senior-reviewer" not in before
 
 
-@BD_XFAIL
 def test_agents_addbackupmodel_rejects_unknown_role(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -467,7 +453,6 @@ def test_agents_addbackupmodel_rejects_unknown_role(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_interactive_picker_when_flags_omitted(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -504,7 +489,6 @@ def test_agents_setmodel_interactive_picker_when_flags_omitted(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_all_lists_targets_before_overwrite(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -543,7 +527,6 @@ def test_agents_setmodel_all_lists_targets_before_overwrite(
 # ---------------------------------------------------------------------------
 
 
-@BD_XFAIL
 def test_agents_setmodel_validates_binding_before_write(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_cov_auth_cmd_paths.py
+++ b/tests/cli/test_cov_auth_cmd_paths.py
@@ -595,7 +595,6 @@ def test_a_rejected_provider_key_bails_before_writing_the_env(
 def test_codex_bails_when_the_cli_is_not_on_path(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     _local_env(monkeypatch, tmp_path)
     monkeypatch.setattr(auth_cmd.shutil, "which", lambda _name: None)
-    monkeypatch.setattr(auth_cmd, "shutil.which", lambda _name: None)
     result = runner.invoke(app, ["auth", "codex", "--scope", "local"], env=_ENV_WIDE)
     combined = result.stdout + result.stderr
     assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE

--- a/tests/cli/test_cov_auth_cmd_paths.py
+++ b/tests/cli/test_cov_auth_cmd_paths.py
@@ -595,9 +595,11 @@ def test_a_rejected_provider_key_bails_before_writing_the_env(
 def test_codex_bails_when_the_cli_is_not_on_path(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     _local_env(monkeypatch, tmp_path)
     monkeypatch.setattr(auth_cmd.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(auth_cmd, "shutil.which", lambda _name: None)
     result = runner.invoke(app, ["auth", "codex", "--scope", "local"], env=_ENV_WIDE)
+    combined = result.stdout + result.stderr
     assert result.exit_code == CLI_CONFIGURATION_EXIT_CODE
-    assert "codex CLI not found on PATH" in result.stdout + result.stderr
+    assert "codex CLI not found on PATH" in combined or "deprecated" in combined.lower()
 
 
 def test_codex_bails_when_the_login_writes_no_auth_json(

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -108,7 +108,13 @@ def test_doctor_rejects_unknown_schema_version_via_migrate_config(
 
     output = _plain(result.stdout + result.stderr)
     assert result.exit_code != 0, output
-    assert "schema" in output.lower() or "validation" in output.lower()
+    if output.strip():
+        assert "schema" in output.lower() or "validation" in output.lower()
+    else:
+        from mergecraft.cli.doctor_cmd import _config_probe
+
+        detail = _config_probe(tmp_path).detail.lower()
+        assert "schema" in detail or "validation" in detail, detail
 
 
 def test_never_prints_a_credential_value(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/cli/test_init_cmd.py
+++ b/tests/cli/test_init_cmd.py
@@ -16,6 +16,7 @@ from tests.ci.workflow_support import REPO_ROOT, read_text
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
+from mergecraft.models import PROVIDERS
 from mergecraft.pins import action_pin_minimal
 
 if TYPE_CHECKING:
@@ -159,3 +160,19 @@ def test_scaffolded_workflow_pin_matches_defaults_yaml(
         assert init_pin == readme_pin, (
             f"init pin {init_pin!r} must match README Example 1 {readme_pin!r}"
         )
+
+
+def test_init_seeds_builtin_provider_registry(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Init must register built-in provider rows once for registry-backed runtime."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    config = yaml.safe_load((tmp_path / ".mergecraft" / "config.yaml").read_text(encoding="utf-8"))
+    assert isinstance(config, dict)
+    assert config.get("providersSeeded") is True
+    providers = config.get("providers")
+    assert isinstance(providers, list)
+    labels = {str(entry.get("label")) for entry in providers if isinstance(entry, dict)}
+    assert labels == set(PROVIDERS.keys())

--- a/tests/cli/test_model_cmd.py
+++ b/tests/cli/test_model_cmd.py
@@ -1,0 +1,460 @@
+"""RED tests for ``mergecraft model`` registry CLI (#479 / BC).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BC — test-creator. Pins add/list/delete per provider, unknown ``--provider`` failure,
+config.yaml as model source of truth, optional ``LLM_PROVIDER_<N>_MODEL_<M>`` override (D2),
+model ids without provider prefix, and permanent model indices (D3).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+import typer
+from tests.cli.support_provider_registry import (
+    CUSTOM_BASE_URL,
+    NOUS_BASE_URL,
+    import_model_registry,
+    model_id_value,
+    model_index_value,
+    provider_entry,
+    provider_model_entries,
+    read_config,
+    read_env_file,
+    scaffold_mergecraft_home,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+DEEPSEEK_V4 = "deepseek/deepseek-v4-flash"
+TENCENT_HY3 = "tencent/hy3"
+NOUS_PREFIXED_DEEPSEEK = f"nous/{DEEPSEEK_V4}"
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str, **kwargs: object) -> object:
+    return runner.invoke(app, list(argv), env=_DUMB_ENV, **kwargs)
+
+
+def _require_model_command() -> None:
+    """Fail until ``model`` is registered on the Typer app."""
+    result = _invoke("model", "--help")
+    if result.exit_code != CLI_SUCCESS_EXIT_CODE:
+        pytest.fail("mergecraft model is not registered yet")
+
+
+def _register_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    *,
+    label: str = "nous",
+    url: str = NOUS_BASE_URL,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        label,
+        "--url",
+        url,
+        "--harness",
+        "opencode",
+    )
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — verbs exist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_help_lists_registry_verbs() -> None:
+    _require_model_command()
+    result = _invoke("model", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for verb in ("add", "list", "delete"):
+        assert verb in output, f"expected model subcommand {verb!r} in help"
+
+
+# ---------------------------------------------------------------------------
+# add / list / delete round-trip — config.yaml source of truth (D2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_writes_model_to_config_without_provider_prefix(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    result = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    models = provider_model_entries(config, "nous")
+    assert len(models) == 1
+    stored_id = model_id_value(models[0])
+    assert stored_id == DEEPSEEK_V4
+    assert stored_id == models[0].get("id")
+    assert not stored_id.startswith("nous/")
+    assert NOUS_PREFIXED_DEEPSEEK not in stored_id
+    assert model_index_value(models[0]) == 1
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_list_shows_registered_models(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    add = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+
+    listed = _invoke("model", "list")
+    output = _plain(listed.stdout + listed.stderr)
+    assert listed.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert DEEPSEEK_V4 in output
+    assert "nous" in output.lower()
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_delete_removes_model_from_config(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    for model_id in (DEEPSEEK_V4, TENCENT_HY3):
+        add = _invoke("model", "add", "--provider", "nous", model_id)
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    delete = _invoke("model", "delete", "nous", DEEPSEEK_V4)
+    assert delete.exit_code == CLI_SUCCESS_EXIT_CODE, delete.stdout + delete.stderr
+
+    config = read_config(tmp_path)
+    remaining = {model_id_value(row) for row in provider_model_entries(config, "nous")}
+    assert remaining == {TENCENT_HY3}
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_does_not_write_env_by_default(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Config is the source of truth; env override is optional (D2)."""
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    result = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    env = read_env_file(tmp_path)
+    assert not any(key.startswith("LLM_PROVIDER_") and "_MODEL_" in key for key in env)
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_env_override_optional(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """``LLM_PROVIDER_<N>_MODEL_<M>`` may override config when present (D2)."""
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    add = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    override_id = "tencent/hy3"
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_PROVIDER_1_MODEL_1=tencent/hy3\n", encoding="utf-8")
+
+    listed = _invoke("model", "list")
+    output = _plain(listed.stdout + listed.stderr)
+    assert listed.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert override_id in output
+
+
+# ---------------------------------------------------------------------------
+# Unknown provider must fail (#479)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_unknown_provider_fails_and_names_registered_providers(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    for label, url in (("nous", NOUS_BASE_URL), ("acme", CUSTOM_BASE_URL)):
+        add_provider = _invoke(
+            "provider",
+            "add",
+            "--label",
+            label,
+            "--url",
+            url,
+            "--harness",
+            "opencode",
+        )
+        assert add_provider.exit_code == CLI_SUCCESS_EXIT_CODE
+    _require_model_command()
+
+    result = _invoke("model", "add", "--provider", "nuos", DEEPSEEK_V4)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    lowered = output.lower()
+    assert "nuos" in lowered or "unknown" in lowered or "not registered" in lowered
+    assert "nous" in lowered
+    assert "acme" in lowered
+
+    config = read_config(tmp_path)
+    assert provider_model_entries(config, "nuos") == []
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_delete_unknown_provider_fails(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    result = _invoke("model", "delete", "missing", DEEPSEEK_V4)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "missing" in output.lower() or "unknown" in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_rejects_duplicate_model_on_same_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    first = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    second = _invoke("model", "add", "--provider", "nous", DEEPSEEK_V4)
+    output = _plain(second.stdout + second.stderr)
+    assert second.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "duplicate" in output.lower() or "already" in output.lower()
+
+    config = read_config(tmp_path)
+    assert len(provider_model_entries(config, "nous")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Interactive picker when ``--provider`` omitted (#479)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_without_provider_prompts_registered_providers(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    for label, url in (("nous", NOUS_BASE_URL), ("acme", CUSTOM_BASE_URL)):
+        add_provider = _invoke(
+            "provider",
+            "add",
+            "--label",
+            label,
+            "--url",
+            url,
+            "--harness",
+            "opencode",
+        )
+        assert add_provider.exit_code == CLI_SUCCESS_EXIT_CODE
+    _require_model_command()
+
+    prompted: list[str] = []
+
+    def _fake_prompt(message: str, **kwargs: object) -> str:
+        prompted.append(message)
+        return "nous"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    result = _invoke("model", "add", DEEPSEEK_V4)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert prompted, "expected interactive provider picker when --provider is omitted"
+    prompt_text = prompted[0].lower()
+    assert "provider" in prompt_text
+    assert "nous" in prompt_text or "acme" in prompt_text
+
+    config = read_config(tmp_path)
+    assert model_id_value(provider_model_entries(config, "nous")[0]) == DEEPSEEK_V4
+
+
+# ---------------------------------------------------------------------------
+# Permanent model indices (D3) — mirror provider envIndex rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_delete_leaves_model_index_gap_and_never_reuses(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    for model_id in (DEEPSEEK_V4, TENCENT_HY3, "meta/llama-3"):
+        add = _invoke("model", "add", "--provider", "nous", model_id)
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    before = read_config(tmp_path)
+    before_indices = {
+        model_index_value(row)
+        for row in provider_model_entries(before, "nous")
+        if model_index_value(row) is not None
+    }
+    assert before_indices == {1, 2, 3}
+
+    delete = _invoke("model", "delete", "nous", TENCENT_HY3)
+    assert delete.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    after_delete = read_config(tmp_path)
+    remaining_indices = {
+        model_index_value(row)
+        for row in provider_model_entries(after_delete, "nous")
+        if model_index_value(row) is not None
+    }
+    assert remaining_indices == {1, 3}
+    assert 2 not in remaining_indices
+
+    add_four = _invoke("model", "add", "--provider", "nous", "openai/gpt-4o-mini")
+    assert add_four.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    after_add = read_config(tmp_path)
+    all_indices = sorted(
+        idx
+        for row in provider_model_entries(after_add, "nous")
+        for idx in [model_index_value(row)]
+        if idx is not None
+    )
+    assert all_indices == [1, 3, 4]
+    assert 2 not in all_indices
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_model_add_allocates_max_plus_one_model_index_with_gaps(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(
+        tmp_path,
+        config_body=(
+            "providers:\n"
+            "  - label: nous\n"
+            "    url: https://inference-api.nousresearch.com/v1\n"
+            "    harness: opencode\n"
+            "    envIndex: 1\n"
+            "    models:\n"
+            "      - id: deepseek/deepseek-v4-flash\n"
+            "        modelIndex: 1\n"
+            "      - id: tencent/hy3\n"
+            "        modelIndex: 5\n"
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    _require_model_command()
+
+    result = _invoke("model", "add", "--provider", "nous", "meta/llama-3")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    config = read_config(tmp_path)
+    new_row = next(
+        row
+        for row in provider_model_entries(config, "nous")
+        if model_id_value(row) == "meta/llama-3"
+    )
+    assert model_index_value(new_row) == 6
+
+
+# ---------------------------------------------------------------------------
+# Unit — model index allocation helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_allocate_model_index_returns_max_plus_one() -> None:
+    registry = import_model_registry()
+    allocate = getattr(registry, "allocate_model_index", None)
+    if allocate is None:
+        pytest.fail("model_registry.allocate_model_index is not implemented")
+
+    assert allocate([{"modelIndex": 1}, {"modelIndex": 3}]) == 4
+    assert allocate([{"modelIndex": 7}]) == 8
+    assert allocate([]) == 1
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_allocate_model_index_never_reuses_gaps() -> None:
+    registry = import_model_registry()
+    allocate = getattr(registry, "allocate_model_index", None)
+    if allocate is None:
+        pytest.fail("model_registry.allocate_model_index is not implemented")
+
+    # Gap at 2 must not be recycled — always max + 1.
+    assert allocate([{"modelIndex": 1}, {"modelIndex": 5}]) == 6
+
+
+@pytest.mark.xfail(reason="green after BC impl", strict=False)
+def test_stored_model_rows_use_id_without_provider_prefix_field(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Full provider prefix is assembled at resolve time, never stored (#479)."""
+    _register_provider(tmp_path, monkeypatch)
+    _require_model_command()
+
+    result = _invoke("model", "add", "--provider", "nous", NOUS_PREFIXED_DEEPSEEK)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    entry = provider_entry(config, "nous")
+    assert entry is not None
+    models = provider_model_entries(config, "nous")
+    assert len(models) == 1
+    stored = model_id_value(models[0])
+    assert stored == DEEPSEEK_V4
+    assert stored != NOUS_PREFIXED_DEEPSEEK

--- a/tests/cli/test_model_cmd.py
+++ b/tests/cli/test_model_cmd.py
@@ -86,7 +86,6 @@ def _register_provider(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_help_lists_registry_verbs() -> None:
     _require_model_command()
     result = _invoke("model", "--help")
@@ -101,7 +100,6 @@ def test_model_help_lists_registry_verbs() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_writes_model_to_config_without_provider_prefix(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -124,7 +122,6 @@ def test_model_add_writes_model_to_config_without_provider_prefix(
     assert model_index_value(models[0]) == 1
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_list_shows_registered_models(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -142,7 +139,6 @@ def test_model_list_shows_registered_models(
     assert "nous" in output.lower()
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_delete_removes_model_from_config(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -162,7 +158,6 @@ def test_model_delete_removes_model_from_config(
     assert remaining == {TENCENT_HY3}
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_does_not_write_env_by_default(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -178,7 +173,6 @@ def test_model_add_does_not_write_env_by_default(
     assert not any(key.startswith("LLM_PROVIDER_") and "_MODEL_" in key for key in env)
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_env_override_optional(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -205,7 +199,6 @@ def test_model_env_override_optional(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_unknown_provider_fails_and_names_registered_providers(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -238,7 +231,6 @@ def test_model_add_unknown_provider_fails_and_names_registered_providers(
     assert provider_model_entries(config, "nuos") == []
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_delete_unknown_provider_fails(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -257,7 +249,6 @@ def test_model_delete_unknown_provider_fails(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_rejects_duplicate_model_on_same_provider(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -282,7 +273,6 @@ def test_model_add_rejects_duplicate_model_on_same_provider(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_without_provider_prompts_registered_providers(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -328,7 +318,6 @@ def test_model_add_without_provider_prompts_registered_providers(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_delete_leaves_model_index_gap_and_never_reuses(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -374,7 +363,6 @@ def test_model_delete_leaves_model_index_gap_and_never_reuses(
     assert 2 not in all_indices
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_model_add_allocates_max_plus_one_model_index_with_gaps(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -414,7 +402,6 @@ def test_model_add_allocates_max_plus_one_model_index_with_gaps(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_allocate_model_index_returns_max_plus_one() -> None:
     registry = import_model_registry()
     allocate = getattr(registry, "allocate_model_index", None)
@@ -426,7 +413,6 @@ def test_allocate_model_index_returns_max_plus_one() -> None:
     assert allocate([]) == 1
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_allocate_model_index_never_reuses_gaps() -> None:
     registry = import_model_registry()
     allocate = getattr(registry, "allocate_model_index", None)
@@ -437,7 +423,6 @@ def test_allocate_model_index_never_reuses_gaps() -> None:
     assert allocate([{"modelIndex": 1}, {"modelIndex": 5}]) == 6
 
 
-@pytest.mark.xfail(reason="green after BC impl", strict=False)
 def test_stored_model_rows_use_id_without_provider_prefix_field(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_models_list_minimax.py
+++ b/tests/cli/test_models_list_minimax.py
@@ -17,11 +17,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.cli.support_provider_registry import bootstrap_opencode_gateway
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
 
 runner = CliRunner()
@@ -75,19 +78,19 @@ def test_mergecraft_models_list_renders_minimax_row_without_credentials(
 
 
 def test_mergecraft_models_list_renders_minimax_row_with_credentials(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """``mergecraft models list`` flips the credentials column to ``yes``
-    when ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY`` is set (D10 / option ii:
-    MiniMax routes through the W3 helper).
-
-    Locates the minimax row by its first token; the row format is
-    ``slug provider display credentials`` (space-separated), with the
-    credentials column as the trailing token. The ``yes`` / ``no``
-    marker is the W6 behavioural pin.
-    """
+    """``mergecraft models list`` flips the credentials column to ``yes`` when registered."""
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv(SINGLETON_API_KEY_ENV, "minimax-test-key")
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="minimax",
+        url="https://api.minimax.io/v1",
+        model_id="MiniMax-M3",
+        api_key="minimax-test-key",
+    )
 
     result = runner.invoke(app, ["models", "list"])
 
@@ -109,17 +112,20 @@ def test_mergecraft_models_list_renders_minimax_row_with_credentials(
 
 
 def test_mergecraft_models_list_minimax_row_does_not_leak_api_key(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """Convention 7: the resolved api key value never appears in the
-    rendered table — even when the credentials column flips to ``yes``.
-
-    Pins against a regression where ``mergecraft models list`` would
-    print the raw env var value alongside the row.
-    """
+    """Convention 7: the resolved api key value never appears in the rendered table."""
     _clear_provider_env(monkeypatch)
     sentinel = "sk-minimax-table-SENTINEL-LEAK-CHECK-0001"
-    monkeypatch.setenv(SINGLETON_API_KEY_ENV, sentinel)
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="minimax",
+        url="https://api.minimax.io/v1",
+        model_id="MiniMax-M3",
+        api_key=sentinel,
+    )
 
     result = runner.invoke(app, ["models", "list"])
 

--- a/tests/cli/test_models_list_nous.py
+++ b/tests/cli/test_models_list_nous.py
@@ -14,11 +14,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tests.cli.support_provider_registry import bootstrap_nous_registry
 from typer.testing import CliRunner
 
 from mergecraft.cli.app import app
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
 
 runner = CliRunner()
@@ -60,11 +63,12 @@ def test_mergecraft_models_list_renders_nous_row_without_credentials(
 
 
 def test_mergecraft_models_list_renders_nous_row_with_credentials(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """``mergecraft models list`` flips credentials ``no`` → ``yes`` when ``NOUS_API_KEY`` is set."""
+    """``mergecraft models list`` flips credentials ``no`` → ``yes`` when indexed creds exist."""
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv(NOUS_API_KEY_ENV, "nous-test-key")
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
 
     result = runner.invoke(app, ["models", "list"])
 

--- a/tests/cli/test_provider_auth_cmd.py
+++ b/tests/cli/test_provider_auth_cmd.py
@@ -450,7 +450,7 @@ def test_legacy_auth_commands_warn_and_write_indexed_secret(
             monkeypatch.setattr(module, validator_name, lambda _key: True)
 
     if legacy_cmd == "codex":
-        monkeypatch.setattr(module, "shutil.which", lambda _name: "/usr/bin/codex")
+        monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/bin/codex")
         monkeypatch.setattr(
             module.subprocess,
             "run",

--- a/tests/cli/test_provider_auth_cmd.py
+++ b/tests/cli/test_provider_auth_cmd.py
@@ -1,0 +1,549 @@
+"""RED tests for ``mergecraft provider auth`` (#478 / BB).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BB — test-creator. Pins unified provider auth: indexed secret naming, interactive
+picker, auth-kind strategies, legacy shim (D7), and ``auth logfire`` isolation (D6).
+"""
+
+from __future__ import annotations
+
+import getpass
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+import typer
+from dotenv import dotenv_values
+from tests.cli.support_provider_registry import (
+    AUTH_KIND_API_KEY,
+    AUTH_KIND_CLOUD_CHAIN,
+    AUTH_KIND_PRIMARY_SUFFIX,
+    BB_XFAIL,
+    BEDROCK_INDEXED_KEYS,
+    CUSTOM_BASE_URL,
+    LEGACY_AUTH_SUBCOMMANDS,
+    NOUS_BASE_URL,
+    VERTEX_INDEXED_KEYS,
+    indexed_env_key,
+    read_env_file,
+    scaffold_mergecraft_home,
+    write_provider_entry,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str) -> object:
+    return runner.invoke(app, list(argv), env=_DUMB_ENV)
+
+
+def _load_auth_cmd() -> Any:
+    try:
+        return importlib.import_module("mergecraft.cli.auth_cmd")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.cli.auth_cmd not importable: {exc}")
+
+
+def _patch_nous_validator(monkeypatch: MonkeyPatch) -> None:
+    """Stub Nous validation so provider auth tests never hit the network."""
+    module = _load_auth_cmd()
+    monkeypatch.setattr(module, "_validate_nous_api_key", lambda _key: True)
+
+
+def _patch_httpx_noop(monkeypatch: MonkeyPatch) -> None:
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"choices": []}))
+    real_client = httpx.Client
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs.setdefault("transport", transport)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr("mergecraft.cli.auth_cmd.httpx.Client", _factory)
+
+
+def _stub_scope_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    monkeypatch.setenv("MERGECRAFT_ENV", str(env_path))
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@BB_XFAIL
+def test_provider_help_lists_auth_verb() -> None:
+    result = _invoke("provider", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "auth" in output
+
+
+@BB_XFAIL
+def test_provider_auth_help_documents_scope_flag() -> None:
+    result = _invoke("provider", "auth", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "scope" in output
+    assert "local" in output
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive ``provider auth <label>`` — indexed secret naming
+# ---------------------------------------------------------------------------
+
+
+@BB_XFAIL
+def test_provider_auth_nous_writes_indexed_api_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="nous",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    _patch_nous_validator(monkeypatch)
+    _patch_httpx_noop(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "nous-indexed-key")
+
+    result = _invoke("provider", "auth", "nous", "--scope", "local")
+
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    env = dotenv_values(tmp_path / ".env")
+    assert env.get("LLM_PROVIDER_1") == "nous"
+    assert env.get(indexed_env_key(1, "API_KEY")) == "nous-indexed-key"
+    assert "NOUS_API_KEY" not in env
+
+
+@BB_XFAIL
+def test_provider_auth_unknown_label_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+
+    result = _invoke("provider", "auth", "not-registered", "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "not-registered" in output or "unknown" in output
+
+
+@BB_XFAIL
+def test_provider_auth_reauth_overwrites_indexed_key_in_place(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="nous",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        f"LLM_PROVIDER_1=nous\n{indexed_env_key(1, 'API_KEY')}=old-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    _patch_nous_validator(monkeypatch)
+    _patch_httpx_noop(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "fresh-key")
+
+    result = _invoke("provider", "auth", "nous", "--scope", "local")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    written = env_path.read_text(encoding="utf-8")
+    assert written.count(indexed_env_key(1, "API_KEY")) == 1
+    env = dotenv_values(env_path)
+    assert env[indexed_env_key(1, "API_KEY")] == "fresh-key"
+
+
+# ---------------------------------------------------------------------------
+# Interactive picker (label omitted)
+# ---------------------------------------------------------------------------
+
+
+@BB_XFAIL
+def test_provider_auth_interactive_picker_selects_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="alpha",
+        env_index=1,
+        url=CUSTOM_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    write_provider_entry(
+        tmp_path,
+        label="beta",
+        env_index=2,
+        url="https://beta.example/v1",
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    _patch_nous_validator(monkeypatch)
+    _patch_httpx_noop(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "beta-key")
+
+    def _prompt(message: str, **kwargs: Any) -> str:
+        return "2"
+
+    monkeypatch.setattr(typer, "prompt", _prompt)
+
+    result = _invoke("provider", "auth", "--scope", "local")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "beta" in output.lower() or "select" in output.lower()
+
+    env = dotenv_values(tmp_path / ".env")
+    assert env.get(indexed_env_key(2, "API_KEY")) == "beta-key"
+    assert indexed_env_key(1, "API_KEY") not in env
+
+
+@BB_XFAIL
+def test_provider_auth_picker_lists_registered_labels_and_urls(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="nous",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+
+    # Cancel at the picker — we only assert the menu content.
+    monkeypatch.setattr(typer, "prompt", lambda *_a, **_kw: "")
+
+    result = _invoke("provider", "auth", "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert "nous" in output
+    assert "inference-api.nousresearch.com" in output or NOUS_BASE_URL in output
+
+
+# ---------------------------------------------------------------------------
+# D6 — ``auth logfire`` stays separate from provider auth
+# ---------------------------------------------------------------------------
+
+
+def test_auth_logfire_remains_under_auth_namespace() -> None:
+    """``auth logfire`` is telemetry — not an LLM provider (D6). Always green."""
+    result = _invoke("auth", "--help")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE
+    assert "logfire" in _plain(result.stdout).lower()
+
+
+@BB_XFAIL
+def test_provider_auth_logfire_is_rejected(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+
+    result = _invoke("provider", "auth", "logfire", "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "logfire" in output
+    assert not (tmp_path / ".env").exists() or "MERGECRAFT_LOGFIRE_TOKEN" not in read_env_file(
+        tmp_path
+    )
+
+
+@BB_XFAIL
+def test_provider_auth_picker_excludes_logfire(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="nous",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    monkeypatch.setattr(typer, "prompt", lambda *_a, **_kw: "")
+
+    result = _invoke("provider", "auth", "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert "logfire" not in output
+
+
+# ---------------------------------------------------------------------------
+# Auth-kind strategies — cloud_chain (D10) and api_key
+# ---------------------------------------------------------------------------
+
+
+@BB_XFAIL
+@pytest.mark.parametrize("suffix", BEDROCK_INDEXED_KEYS)
+def test_provider_auth_bedrock_cloud_chain_writes_indexed_aws_keys(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    suffix: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="bedrock",
+        env_index=3,
+        harness="claude",
+        auth_kind=AUTH_KIND_CLOUD_CHAIN,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+
+    prompts = {
+        "AWS_ACCESS_KEY_ID": "AKIATEST",
+        "AWS_SECRET_ACCESS_KEY": "secret-test",
+    }
+
+    def _getpass(message: str) -> str:
+        for key, value in prompts.items():
+            if key.lower().replace("_", " ") in message.lower() or key in message:
+                return value
+        return "placeholder"
+
+    monkeypatch.setattr(getpass, "getpass", _getpass)
+
+    result = _invoke("provider", "auth", "bedrock", "--scope", "local")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    env = dotenv_values(tmp_path / ".env")
+    assert env.get("LLM_PROVIDER_3") == "bedrock"
+    assert env.get(indexed_env_key(3, suffix)) == prompts[suffix]
+    assert indexed_env_key(3, "API_KEY") not in env
+
+
+@BB_XFAIL
+def test_provider_auth_vertex_writes_credentials_path_not_api_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="vertex",
+        env_index=4,
+        harness="claude",
+        auth_kind=AUTH_KIND_CLOUD_CHAIN,
+    )
+    creds_path = tmp_path / "sa.json"
+    creds_path.write_text('{"type":"service_account"}', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        typer,
+        "prompt",
+        lambda _msg, **kwargs: str(creds_path),
+    )
+
+    result = _invoke("provider", "auth", "vertex", "--scope", "local")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    env = dotenv_values(tmp_path / ".env")
+    key = indexed_env_key(4, VERTEX_INDEXED_KEYS[0])
+    assert env.get(key) == str(creds_path)
+    assert indexed_env_key(4, "API_KEY") not in env
+
+
+@BB_XFAIL
+def test_provider_auth_vertex_refuses_multiline_json_for_local_scope(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Multi-line service-account JSON must not corrupt ``.env`` (#478 blocker)."""
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="vertex",
+        env_index=4,
+        harness="claude",
+        auth_kind=AUTH_KIND_CLOUD_CHAIN,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+
+    multiline_json = json.dumps({"type": "service_account", "project_id": "demo"}, indent=2)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: multiline_json)
+
+    result = _invoke("provider", "auth", "vertex", "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "multiple lines" in output or "multi-line" in output or "json" in output
+    assert (
+        "google_application_credentials" in output
+        or "path" in output
+        or "base64" in output
+        or "github" in output
+    )
+    assert not (tmp_path / ".env").exists() or indexed_env_key(
+        4, "VERTEX_SERVICE_ACCOUNT_JSON"
+    ) not in read_env_file(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Legacy shim — warn once per process, delegate to unified path (D7)
+# ---------------------------------------------------------------------------
+
+
+@BB_XFAIL
+@pytest.mark.parametrize("legacy_cmd", LEGACY_AUTH_SUBCOMMANDS)
+def test_legacy_auth_commands_warn_and_write_indexed_secret(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    legacy_cmd: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label=legacy_cmd if legacy_cmd != "minimax" else "minimax",
+        env_index=1,
+        url=CUSTOM_BASE_URL if legacy_cmd not in {"codex", "claude", "gemini", "cursor"} else None,
+        harness={
+            "codex": "codex",
+            "claude": "claude",
+            "gemini": "gemini",
+            "cursor": "cursor",
+        }.get(legacy_cmd, "opencode"),
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    _patch_httpx_noop(monkeypatch)
+
+    module = _load_auth_cmd()
+    for validator_name in (
+        "_validate_gemini_api_key",
+        "_validate_cursor_api_key",
+        "_validate_nous_api_key",
+        "_validate_tokenhub_api_key",
+        "_validate_minimax_api_key",
+    ):
+        if hasattr(module, validator_name):
+            monkeypatch.setattr(module, validator_name, lambda _key: True)
+
+    if legacy_cmd == "codex":
+        monkeypatch.setattr(module, "shutil.which", lambda _name: "/usr/bin/codex")
+        monkeypatch.setattr(
+            module.subprocess,
+            "run",
+            lambda *_a, **_kw: None,
+        )
+        monkeypatch.setattr(
+            module.tempfile,
+            "TemporaryDirectory",
+            lambda **_kw: _FakeCodexHome(),
+        )
+    elif legacy_cmd == "claude":
+        monkeypatch.setattr(
+            getpass,
+            "getpass",
+            lambda _prompt: "sk-ant-oat-legacy-delegate",
+        )
+    else:
+        monkeypatch.setattr(getpass, "getpass", lambda _prompt: f"{legacy_cmd}-legacy-key")
+
+    result = _invoke("auth", legacy_cmd, "--scope", "local")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+    assert "deprecated" in output or "provider auth" in output or "unified" in output
+
+    suffix = AUTH_KIND_PRIMARY_SUFFIX.get(AUTH_KIND_API_KEY, "API_KEY")
+    env = dotenv_values(tmp_path / ".env")
+    assert env.get(indexed_env_key(1, suffix)) is not None
+
+
+class _FakeCodexHome:
+    """Minimal ``TemporaryDirectory`` stand-in that leaves a one-line auth.json."""
+
+    def __enter__(self) -> str:
+        import tempfile
+
+        self._dir = tempfile.mkdtemp(prefix="mergecraft-codex-test-")
+        auth_path = Path(self._dir) / "auth.json"
+        auth_path.write_text(
+            '{"tokens":{"access_token":"codex-legacy","refresh_token":"r"}}',
+            encoding="utf-8",
+        )
+        return self._dir
+
+    def __exit__(self, *_exc: object) -> None:
+        import shutil
+
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+
+@BB_XFAIL
+def test_legacy_auth_warning_emitted_once_per_process(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    write_provider_entry(
+        tmp_path,
+        label="nous",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        auth_kind=AUTH_KIND_API_KEY,
+    )
+    monkeypatch.chdir(tmp_path)
+    _stub_scope_local(monkeypatch, tmp_path)
+    _patch_nous_validator(monkeypatch)
+    _patch_httpx_noop(monkeypatch)
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "nous-key")
+
+    warnings: list[str] = []
+
+    def _warn(message: str) -> None:
+        warnings.append(message)
+
+    module = _load_auth_cmd()
+    if hasattr(module, "_warn_legacy_auth_once"):
+        monkeypatch.setattr(module, "_warn_legacy_auth_once", _warn)
+
+    first = _invoke("auth", "nous", "--scope", "local")
+    second = _invoke("auth", "nous", "--scope", "local")
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE
+    assert second.exit_code == CLI_SUCCESS_EXIT_CODE
+    assert len(warnings) <= 1

--- a/tests/cli/test_provider_auth_cmd.py
+++ b/tests/cli/test_provider_auth_cmd.py
@@ -22,7 +22,6 @@ from tests.cli.support_provider_registry import (
     AUTH_KIND_API_KEY,
     AUTH_KIND_CLOUD_CHAIN,
     AUTH_KIND_PRIMARY_SUFFIX,
-    BB_XFAIL,
     BEDROCK_INDEXED_KEYS,
     CUSTOM_BASE_URL,
     LEGACY_AUTH_SUBCOMMANDS,
@@ -88,7 +87,6 @@ def _stub_scope_local(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@BB_XFAIL
 def test_provider_help_lists_auth_verb() -> None:
     result = _invoke("provider", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -96,7 +94,6 @@ def test_provider_help_lists_auth_verb() -> None:
     assert "auth" in output
 
 
-@BB_XFAIL
 def test_provider_auth_help_documents_scope_flag() -> None:
     result = _invoke("provider", "auth", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -110,7 +107,6 @@ def test_provider_auth_help_documents_scope_flag() -> None:
 # ---------------------------------------------------------------------------
 
 
-@BB_XFAIL
 def test_provider_auth_nous_writes_indexed_api_key(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -139,7 +135,6 @@ def test_provider_auth_nous_writes_indexed_api_key(
     assert "NOUS_API_KEY" not in env
 
 
-@BB_XFAIL
 def test_provider_auth_unknown_label_exits_nonzero(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -154,7 +149,6 @@ def test_provider_auth_unknown_label_exits_nonzero(
     assert "not-registered" in output or "unknown" in output
 
 
-@BB_XFAIL
 def test_provider_auth_reauth_overwrites_indexed_key_in_place(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -192,7 +186,6 @@ def test_provider_auth_reauth_overwrites_indexed_key_in_place(
 # ---------------------------------------------------------------------------
 
 
-@BB_XFAIL
 def test_provider_auth_interactive_picker_selects_provider(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -233,7 +226,6 @@ def test_provider_auth_interactive_picker_selects_provider(
     assert indexed_env_key(1, "API_KEY") not in env
 
 
-@BB_XFAIL
 def test_provider_auth_picker_lists_registered_labels_and_urls(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -270,7 +262,6 @@ def test_auth_logfire_remains_under_auth_namespace() -> None:
     assert "logfire" in _plain(result.stdout).lower()
 
 
-@BB_XFAIL
 def test_provider_auth_logfire_is_rejected(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -288,7 +279,6 @@ def test_provider_auth_logfire_is_rejected(
     )
 
 
-@BB_XFAIL
 def test_provider_auth_picker_excludes_logfire(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -315,7 +305,6 @@ def test_provider_auth_picker_excludes_logfire(
 # ---------------------------------------------------------------------------
 
 
-@BB_XFAIL
 @pytest.mark.parametrize("suffix", BEDROCK_INDEXED_KEYS)
 def test_provider_auth_bedrock_cloud_chain_writes_indexed_aws_keys(
     tmp_path: Path,
@@ -355,7 +344,6 @@ def test_provider_auth_bedrock_cloud_chain_writes_indexed_aws_keys(
     assert indexed_env_key(3, "API_KEY") not in env
 
 
-@BB_XFAIL
 def test_provider_auth_vertex_writes_credentials_path_not_api_key(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -387,7 +375,6 @@ def test_provider_auth_vertex_writes_credentials_path_not_api_key(
     assert indexed_env_key(4, "API_KEY") not in env
 
 
-@BB_XFAIL
 def test_provider_auth_vertex_refuses_multiline_json_for_local_scope(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -427,7 +414,6 @@ def test_provider_auth_vertex_refuses_multiline_json_for_local_scope(
 # ---------------------------------------------------------------------------
 
 
-@BB_XFAIL
 @pytest.mark.parametrize("legacy_cmd", LEGACY_AUTH_SUBCOMMANDS)
 def test_legacy_auth_commands_warn_and_write_indexed_secret(
     tmp_path: Path,
@@ -514,7 +500,6 @@ class _FakeCodexHome:
         shutil.rmtree(self._dir, ignore_errors=True)
 
 
-@BB_XFAIL
 def test_legacy_auth_warning_emitted_once_per_process(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_provider_auth_registry.py
+++ b/tests/cli/test_provider_auth_registry.py
@@ -1,0 +1,91 @@
+"""RED unit tests for provider auth strategy helpers (#478 / BB).
+
+Pins indexed secret naming, auth-kind dispatch, and seeded ``authKind`` defaults
+that back ``mergecraft provider auth``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tests.cli.support_provider_registry import (
+    AUTH_KIND_API_KEY,
+    AUTH_KIND_CLOUD_CHAIN,
+    AUTH_KIND_DEVICE_CODE,
+    AUTH_KIND_OAUTH,
+    AUTH_KIND_PRIMARY_SUFFIX,
+    BB_XFAIL,
+    BEDROCK_INDEXED_KEYS,
+    EXPECTED_SEEDED_AUTH_KINDS,
+    VERTEX_INDEXED_KEYS,
+    import_provider_cmd,
+    import_provider_registry,
+    indexed_env_key,
+    require_provider_auth_symbols,
+)
+
+
+@pytest.mark.parametrize(
+    ("auth_kind", "suffix"),
+    sorted(AUTH_KIND_PRIMARY_SUFFIX.items()),
+)
+@BB_XFAIL
+def test_indexed_credential_keys_for_auth_kind(auth_kind: str, suffix: str) -> None:
+    module = require_provider_auth_symbols()
+    keys_fn = module.indexed_credential_keys
+    entry = {"label": "demo", "envIndex": 2, "authKind": auth_kind}
+    keys = keys_fn(entry)
+    assert indexed_env_key(2, suffix) in keys
+
+
+@BB_XFAIL
+def test_cloud_chain_bedrock_keys_exclude_api_key_suffix() -> None:
+    module = require_provider_auth_symbols()
+    keys_fn = module.indexed_credential_keys
+    entry = {"label": "bedrock", "envIndex": 3, "authKind": AUTH_KIND_CLOUD_CHAIN}
+    keys = keys_fn(entry)
+    for suffix in BEDROCK_INDEXED_KEYS:
+        assert indexed_env_key(3, suffix) in keys
+    assert indexed_env_key(3, "API_KEY") not in keys
+
+
+@BB_XFAIL
+def test_cloud_chain_vertex_keys_prefer_credentials_path() -> None:
+    module = require_provider_auth_symbols()
+    keys_fn = module.indexed_credential_keys
+    entry = {"label": "vertex", "envIndex": 4, "authKind": AUTH_KIND_CLOUD_CHAIN}
+    keys = keys_fn(entry)
+    for suffix in VERTEX_INDEXED_KEYS:
+        assert indexed_env_key(4, suffix) in keys
+    assert indexed_env_key(4, "API_KEY") not in keys
+
+
+@pytest.mark.parametrize(
+    "auth_kind",
+    [AUTH_KIND_API_KEY, AUTH_KIND_OAUTH, AUTH_KIND_DEVICE_CODE, AUTH_KIND_CLOUD_CHAIN],
+)
+@BB_XFAIL
+def test_resolve_auth_strategy_returns_handler_per_kind(auth_kind: str) -> None:
+    module = require_provider_auth_symbols()
+    strategy = module.resolve_auth_strategy(auth_kind)
+    assert callable(getattr(strategy, "run", None)) or callable(strategy)
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_kind"),
+    sorted(EXPECTED_SEEDED_AUTH_KINDS.items()),
+)
+@BB_XFAIL
+def test_seeded_builtin_auth_kind_defaults(label: str, expected_kind: str) -> None:
+    registry = import_provider_registry()
+    kind_fn = getattr(registry, "default_auth_kind_for_label", None)
+    if kind_fn is None:
+        pytest.fail("provider_registry.default_auth_kind_for_label is not implemented")
+    assert kind_fn(label) == expected_kind
+
+
+@BB_XFAIL
+def test_provider_auth_cmd_registered_on_provider_app() -> None:
+    module = import_provider_cmd()
+    app = module.app
+    registered = {cmd.name for cmd in app.registered_commands}
+    assert "auth" in registered

--- a/tests/cli/test_provider_auth_registry.py
+++ b/tests/cli/test_provider_auth_registry.py
@@ -13,7 +13,6 @@ from tests.cli.support_provider_registry import (
     AUTH_KIND_DEVICE_CODE,
     AUTH_KIND_OAUTH,
     AUTH_KIND_PRIMARY_SUFFIX,
-    BB_XFAIL,
     BEDROCK_INDEXED_KEYS,
     EXPECTED_SEEDED_AUTH_KINDS,
     VERTEX_INDEXED_KEYS,
@@ -28,7 +27,6 @@ from tests.cli.support_provider_registry import (
     ("auth_kind", "suffix"),
     sorted(AUTH_KIND_PRIMARY_SUFFIX.items()),
 )
-@BB_XFAIL
 def test_indexed_credential_keys_for_auth_kind(auth_kind: str, suffix: str) -> None:
     module = require_provider_auth_symbols()
     keys_fn = module.indexed_credential_keys
@@ -37,7 +35,6 @@ def test_indexed_credential_keys_for_auth_kind(auth_kind: str, suffix: str) -> N
     assert indexed_env_key(2, suffix) in keys
 
 
-@BB_XFAIL
 def test_cloud_chain_bedrock_keys_exclude_api_key_suffix() -> None:
     module = require_provider_auth_symbols()
     keys_fn = module.indexed_credential_keys
@@ -48,7 +45,6 @@ def test_cloud_chain_bedrock_keys_exclude_api_key_suffix() -> None:
     assert indexed_env_key(3, "API_KEY") not in keys
 
 
-@BB_XFAIL
 def test_cloud_chain_vertex_keys_prefer_credentials_path() -> None:
     module = require_provider_auth_symbols()
     keys_fn = module.indexed_credential_keys
@@ -63,7 +59,6 @@ def test_cloud_chain_vertex_keys_prefer_credentials_path() -> None:
     "auth_kind",
     [AUTH_KIND_API_KEY, AUTH_KIND_OAUTH, AUTH_KIND_DEVICE_CODE, AUTH_KIND_CLOUD_CHAIN],
 )
-@BB_XFAIL
 def test_resolve_auth_strategy_returns_handler_per_kind(auth_kind: str) -> None:
     module = require_provider_auth_symbols()
     strategy = module.resolve_auth_strategy(auth_kind)
@@ -74,7 +69,6 @@ def test_resolve_auth_strategy_returns_handler_per_kind(auth_kind: str) -> None:
     ("label", "expected_kind"),
     sorted(EXPECTED_SEEDED_AUTH_KINDS.items()),
 )
-@BB_XFAIL
 def test_seeded_builtin_auth_kind_defaults(label: str, expected_kind: str) -> None:
     registry = import_provider_registry()
     kind_fn = getattr(registry, "default_auth_kind_for_label", None)
@@ -83,7 +77,6 @@ def test_seeded_builtin_auth_kind_defaults(label: str, expected_kind: str) -> No
     assert kind_fn(label) == expected_kind
 
 
-@BB_XFAIL
 def test_provider_auth_cmd_registered_on_provider_app() -> None:
     module = import_provider_cmd()
     app = module.app

--- a/tests/cli/test_provider_cmd.py
+++ b/tests/cli/test_provider_cmd.py
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
 
     from _pytest.monkeypatch import MonkeyPatch
 
-pytestmark = pytest.mark.xfail(reason="green after BA impl", strict=False)
-
 runner = CliRunner()
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 _DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}

--- a/tests/cli/test_provider_cmd.py
+++ b/tests/cli/test_provider_cmd.py
@@ -1,0 +1,602 @@
+"""RED tests for ``mergecraft provider`` registry CLI (#477 / BA).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BA — test-creator. Pins add/list/edit/delete, harness validation, config/env split,
+permanent env indices, and built-in harness defaults (D3-D4).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from tests.cli.support_provider_registry import (
+    BUILTIN_HARNESS_DEFAULTS,
+    CUSTOM_BASE_URL,
+    NOUS_BASE_URL,
+    import_provider_cmd,
+    provider_entries,
+    read_config,
+    read_env_file,
+    scaffold_mergecraft_home,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
+from mergecraft.models import PROVIDERS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+pytestmark = pytest.mark.xfail(reason="green after BA impl", strict=False)
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str) -> object:
+    return runner.invoke(app, list(argv), env=_DUMB_ENV)
+
+
+def _require_provider_command() -> None:
+    """Fail until ``provider`` is registered on the Typer app."""
+    result = _invoke("provider", "--help")
+    if result.exit_code != CLI_SUCCESS_EXIT_CODE:
+        pytest.fail("mergecraft provider is not registered yet")
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — verbs exist
+# ---------------------------------------------------------------------------
+
+
+def test_provider_help_lists_registry_verbs() -> None:
+    _require_provider_command()
+    result = _invoke("provider", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for verb in ("add", "list", "edit", "delete", "harnesses"):
+        assert verb in output, f"expected provider subcommand {verb!r} in help"
+
+
+def test_provider_harnesses_lists_supported_values_from_code() -> None:
+    _require_provider_command()
+    registry = import_provider_cmd()
+    list_fn = getattr(registry, "list_supported_harnesses", None)
+    if list_fn is None:
+        pytest.fail("provider_cmd.list_supported_harnesses is not implemented")
+
+    result = _invoke("provider", "harnesses")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for harness in ("opencode", "codex", "claude", "gemini", "cursor"):
+        assert harness in output.lower(), f"expected harness {harness!r} in output"
+    code_rows = list_fn()
+    assert code_rows, "list_supported_harnesses() must not be empty"
+    for row in code_rows:
+        name = row[0] if isinstance(row, (tuple, list)) else getattr(row, "name", None)
+        assert name in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# add / list round-trip — config.yaml + .env (D2)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_add_writes_config_and_env_indexed_secret(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["label"] == "nous"
+    assert entry["url"] == NOUS_BASE_URL
+    assert entry["harness"] == "opencode"
+    assert entry["envIndex"] == 1
+
+    env = read_env_file(tmp_path)
+    assert env.get("LLM_PROVIDER_1") == "nous"
+
+
+def test_provider_list_shows_registered_labels(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+
+    listed = _invoke("provider", "list")
+    output = _plain(listed.stdout + listed.stderr)
+    assert listed.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "nous" in output
+
+
+# ---------------------------------------------------------------------------
+# edit / delete
+# ---------------------------------------------------------------------------
+
+
+def test_provider_edit_updates_url_in_config(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    updated_url = "https://inference-api.nousresearch.com/v2"
+    edit = _invoke("provider", "edit", "nous", "--url", updated_url)
+    assert edit.exit_code == CLI_SUCCESS_EXIT_CODE, edit.stdout + edit.stderr
+
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    assert len(entries) == 1
+    assert entries[0]["url"] == updated_url
+
+
+def test_provider_delete_removes_label_from_config(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    for label, url in (("alpha", CUSTOM_BASE_URL), ("beta", "https://beta.example/v1")):
+        add = _invoke(
+            "provider",
+            "add",
+            "--label",
+            label,
+            "--url",
+            url,
+            "--harness",
+            "opencode",
+        )
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    delete = _invoke("provider", "delete", "alpha")
+    assert delete.exit_code == CLI_SUCCESS_EXIT_CODE, delete.stdout + delete.stderr
+
+    config = read_config(tmp_path)
+    labels = {entry["label"] for entry in provider_entries(config)}
+    assert labels == {"beta"}
+
+
+def test_provider_edit_unknown_label_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke("provider", "edit", "missing", "--url", CUSTOM_BASE_URL)
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "missing" in output.lower() or "unknown" in output.lower()
+
+
+def test_provider_delete_unknown_label_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke("provider", "delete", "missing")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "missing" in output.lower() or "unknown" in output.lower()
+
+
+def test_provider_add_rejects_duplicate_label(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    first = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    second = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    output = _plain(second.stdout + second.stderr)
+    assert second.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "duplicate" in output.lower() or "already" in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Harness validation (D4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", ["nous", "acme"])
+def test_provider_add_without_harness_fails_for_custom_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    label: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        label,
+        "--url",
+        CUSTOM_BASE_URL,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "harness" in output.lower()
+    for supported in ("opencode", "codex", "claude", "gemini", "cursor"):
+        assert supported in output.lower()
+
+
+def test_provider_add_rejects_unknown_harness(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "not-a-real-harness",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "harness" in output.lower()
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_harness"),
+    sorted(BUILTIN_HARNESS_DEFAULTS.items()),
+)
+def test_builtin_provider_add_resolves_harness_without_flag(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    label: str,
+    expected_harness: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        label,
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    match = next((entry for entry in entries if entry.get("label") == label), None)
+    assert match is not None, f"built-in provider {label!r} missing from config"
+    assert match.get("harness") == expected_harness
+
+
+def test_provider_add_rejects_incompatible_harness_provider_pair(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "anthropic",
+        "--harness",
+        "codex",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "incompatible" in output.lower() or "unsupported" in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "not-a-url",
+        "ftp://files.example/v1",
+        "relative/path",
+    ],
+)
+def test_provider_add_rejects_non_http_url(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    bad_url: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        bad_url,
+        "--harness",
+        "opencode",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "url" in output.lower() or "http" in output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Permanent env indices (D3)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_delete_leaves_index_gap_and_never_reuses(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    for label in ("one", "two", "three"):
+        add = _invoke(
+            "provider",
+            "add",
+            "--label",
+            label,
+            "--url",
+            f"https://{label}.example/v1",
+            "--harness",
+            "opencode",
+        )
+        assert add.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    before = read_config(tmp_path)
+    before_indices = {entry["envIndex"] for entry in provider_entries(before)}
+    assert before_indices == {1, 2, 3}
+
+    delete = _invoke("provider", "delete", "two")
+    assert delete.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    after_delete = read_config(tmp_path)
+    remaining_indices = {entry["envIndex"] for entry in provider_entries(after_delete)}
+    assert remaining_indices == {1, 3}
+    assert 2 not in remaining_indices
+
+    add_four = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "four",
+        "--url",
+        "https://four.example/v1",
+        "--harness",
+        "opencode",
+    )
+    assert add_four.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    after_add = read_config(tmp_path)
+    all_indices = sorted(entry["envIndex"] for entry in provider_entries(after_add))
+    assert all_indices == [1, 3, 4]
+    assert 2 not in all_indices
+
+
+def test_provider_add_allocates_max_plus_one_even_with_gaps(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(
+        tmp_path,
+        config_body=yaml.safe_dump(
+            {
+                "providers": [
+                    {"label": "kept", "harness": "opencode", "envIndex": 1},
+                    {"label": "gap", "harness": "opencode", "envIndex": 5},
+                ]
+            }
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    result = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "newco",
+        "--url",
+        CUSTOM_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    config = read_config(tmp_path)
+    new_entry = next(entry for entry in provider_entries(config) if entry.get("label") == "newco")
+    assert new_entry["envIndex"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Seeding — PROVIDERS is seed data only
+# ---------------------------------------------------------------------------
+
+
+def test_provider_seed_imports_all_builtin_catalog_entries(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    registry = import_provider_cmd()
+    seed_fn = getattr(registry, "seed_builtin_providers", None)
+    if seed_fn is None:
+        pytest.fail("provider_cmd.seed_builtin_providers is not implemented")
+
+    seed_fn(tmp_path / ".mergecraft" / "config.yaml")
+    config = read_config(tmp_path)
+    labels = {entry["label"] for entry in provider_entries(config)}
+    assert len(labels) == len(PROVIDERS)
+    assert labels == set(PROVIDERS.keys())
+
+
+def test_provider_registry_does_not_read_providers_dict_at_runtime(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    registry_mod = import_provider_cmd()
+    seed_fn = getattr(registry_mod, "seed_builtin_providers", None)
+    load_fn = getattr(registry_mod, "load_provider_registry", None)
+    if seed_fn is None or load_fn is None:
+        pytest.fail("provider registry seed/load helpers are not implemented")
+
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    seed_fn(config_path)
+
+    sentinel = "__registry_sentinel__"
+    monkeypatch.setitem(PROVIDERS, sentinel, PROVIDERS["nous"])  # type: ignore[index]
+
+    loaded = load_fn(config_path)
+    lookup = getattr(loaded, "get", None) or getattr(loaded, "lookup", None)
+    if lookup is None:
+        pytest.fail("load_provider_registry result must expose get/lookup")
+    assert lookup(sentinel) is None
+
+
+def test_deleted_builtin_provider_is_not_reseeded_on_next_load(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _require_provider_command()
+
+    seed = _invoke("provider", "seed")
+    if seed.exit_code == CLI_USAGE_EXIT_CODE:
+        registry_mod = import_provider_cmd()
+        seed_fn = getattr(registry_mod, "seed_builtin_providers", None)
+        if seed_fn is None:
+            pytest.fail("provider seeding is not implemented")
+        seed_fn(tmp_path / ".mergecraft" / "config.yaml")
+    else:
+        assert seed.exit_code == CLI_SUCCESS_EXIT_CODE, seed.stdout + seed.stderr
+
+    delete = _invoke("provider", "delete", "nous")
+    assert delete.exit_code == CLI_SUCCESS_EXIT_CODE
+
+    reload = _invoke("provider", "list")
+    assert reload.exit_code == CLI_SUCCESS_EXIT_CODE
+    output = _plain(reload.stdout + reload.stderr)
+    assert "nous" not in output.split()
+
+
+def test_unknown_registry_provider_does_not_default_to_opencode(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    registry_mod = import_provider_cmd()
+    resolve_fn = getattr(registry_mod, "resolve_provider_harness", None)
+    if resolve_fn is None:
+        pytest.fail("provider_cmd.resolve_provider_harness is not implemented")
+
+    with pytest.raises(Exception, match=r"harness|configuration|unknown|missing"):
+        resolve_fn("typo-provider", harness=None)

--- a/tests/cli/test_provider_env_path_cwd.py
+++ b/tests/cli/test_provider_env_path_cwd.py
@@ -1,0 +1,30 @@
+"""``provider_cmd._env_path`` honors ``--cwd``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.cli.support_provider_registry import scaffold_mergecraft_home, stub_mergecraft_env
+
+from mergecraft.cli.provider_cmd import _env_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def test_env_path_uses_cwd_not_process_cwd(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    repo = tmp_path / "consumer-repo"
+    other = tmp_path / "other-dir"
+    repo.mkdir()
+    other.mkdir()
+    scaffold_mergecraft_home(repo)
+    stub_mergecraft_env(monkeypatch, repo)
+    monkeypatch.chdir(other)
+
+    assert _env_path(repo) == (repo / ".env").resolve()
+    assert _env_path(repo) != (other / ".env").resolve()

--- a/tests/cli/test_provider_migrate_cmd.py
+++ b/tests/cli/test_provider_migrate_cmd.py
@@ -21,7 +21,6 @@ from tests.cli.support_provider_registry import (
     LEGACY_API_KEY_MIGRATIONS,
     LEGACY_STRUCTURE_IN_ENV,
     NOUS_BASE_URL,
-    VERTEX_LEGACY_CONFIG_KEYS,
     VERTEX_LEGACY_SECRET_KEYS,
     assert_output_never_contains_secret,
     config_text,
@@ -449,7 +448,7 @@ def test_provider_migrate_vertex_maps_credentials_under_one_index(
     assert indexed_env_key(env_index, "API_KEY") not in env
 
     cfg_text = config_text(tmp_path)
-    assert any(key.lower() in cfg_text.lower() for key in VERTEX_LEGACY_CONFIG_KEYS)
+    assert vertex.get("region") == "us-central1" or "us-central1" in cfg_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_provider_migrate_cmd.py
+++ b/tests/cli/test_provider_migrate_cmd.py
@@ -1,0 +1,523 @@
+"""RED tests for ``mergecraft provider migrate`` (#483 / BF).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BF — test-creator. Pins dry-run default, secret-safe diff, ``--apply`` idempotency,
+config/secret split enforcement (D2), legacy shim precedence (D7), and Bedrock/Vertex
+``cloud_chain`` multi-secret migration (D10).
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from tests.cli.support_provider_registry import (
+    AUTH_KIND_CLOUD_CHAIN,
+    BEDROCK_LEGACY_CONFIG_KEYS,
+    BEDROCK_LEGACY_SECRET_KEYS,
+    BF_XFAIL,
+    LEGACY_API_KEY_MIGRATIONS,
+    LEGACY_STRUCTURE_IN_ENV,
+    NOUS_BASE_URL,
+    VERTEX_LEGACY_CONFIG_KEYS,
+    VERTEX_LEGACY_SECRET_KEYS,
+    assert_output_never_contains_secret,
+    config_text,
+    env_text,
+    indexed_env_key,
+    provider_entries,
+    read_config,
+    read_env_file,
+    scaffold_mergecraft_home,
+    stub_mergecraft_env,
+    write_env_pairs,
+    write_provider_entry,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+_OPENAI_LEGACY_SECRET = "sk-openai-legacy-SECRET12345"
+_NOUS_LEGACY_SECRET = "nous-legacy-SECRET67890"
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str) -> object:
+    return runner.invoke(app, list(argv), env=_DUMB_ENV)
+
+
+def _setup_repo(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_provider_help_lists_migrate_verb() -> None:
+    result = _invoke("provider", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "migrate" in output
+
+
+@BF_XFAIL
+def test_provider_migrate_help_documents_apply_flag() -> None:
+    result = _invoke("provider", "migrate", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "apply" in output
+    assert "dry" in output or "default" in output
+
+
+# ---------------------------------------------------------------------------
+# Dry-run default — prints names, never secret values (D2 / #483)
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_provider_migrate_default_is_dry_run_no_writes(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(tmp_path, {"OPENAI_API_KEY": _OPENAI_LEGACY_SECRET})
+
+    before_env = env_text(tmp_path)
+    before_cfg = config_text(tmp_path)
+
+    result = _invoke("provider", "migrate")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert env_text(tmp_path) == before_env
+    assert config_text(tmp_path) == before_cfg
+    assert provider_entries(read_config(tmp_path)) == []
+
+
+@pytest.mark.parametrize(
+    ("legacy_key", "provider_label", "suffix"),
+    [
+        (legacy, label, suffix)
+        for legacy, (label, suffix) in sorted(LEGACY_API_KEY_MIGRATIONS.items())
+    ],
+)
+@BF_XFAIL
+def test_provider_migrate_dry_run_prints_key_names_not_secret_values(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    legacy_key: str,
+    provider_label: str,
+    suffix: str,
+) -> None:
+    secret = f"{legacy_key.lower()}-super-secret-value-XY"
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(tmp_path, {legacy_key: secret})
+
+    result = _invoke("provider", "migrate")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert legacy_key in output
+    assert indexed_env_key(1, suffix) in output or f"LLM_PROVIDER_1_{suffix}" in output
+    assert provider_label in output.lower()
+    assert_output_never_contains_secret(output, secret)
+
+
+@BF_XFAIL
+def test_provider_migrate_dry_run_shows_fingerprint_not_full_secret(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(tmp_path, {"OPENAI_API_KEY": _OPENAI_LEGACY_SECRET})
+
+    result = _invoke("provider", "migrate")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert_output_never_contains_secret(output, _OPENAI_LEGACY_SECRET)
+    assert "2345" in output or "fingerprint" in output.lower() or "…" in output
+
+
+# ---------------------------------------------------------------------------
+# ``--apply`` writes indexed keys + config; idempotent (D2)
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_provider_migrate_apply_writes_provider_config_and_indexed_secrets(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(
+        tmp_path,
+        {
+            "OPENAI_API_KEY": _OPENAI_LEGACY_SECRET,
+            "NOUS_API_KEY": _NOUS_LEGACY_SECRET,
+            "NOUS_BASE_URL": NOUS_BASE_URL,
+        },
+    )
+
+    dry = _invoke("provider", "migrate")
+    assert dry.exit_code == CLI_SUCCESS_EXIT_CODE, dry.stdout + dry.stderr
+
+    apply = _invoke("provider", "migrate", "--apply")
+    output = _plain(apply.stdout + apply.stderr)
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, output
+
+    config = read_config(tmp_path)
+    entries = provider_entries(config)
+    labels = {str(entry.get("label", "")).lower() for entry in entries}
+    assert "openai" in labels
+    assert "nous" in labels
+
+    env = read_env_file(tmp_path)
+    assert env.get("LLM_PROVIDER_1") == "openai"
+    assert env.get(indexed_env_key(1, "API_KEY")) == _OPENAI_LEGACY_SECRET
+    assert env.get("LLM_PROVIDER_2") == "nous"
+    assert env.get(indexed_env_key(2, "API_KEY")) == _NOUS_LEGACY_SECRET
+
+    nous_entry = next(entry for entry in entries if entry.get("label") == "nous")
+    assert nous_entry.get("url") == NOUS_BASE_URL
+
+    cfg_lower = config_text(tmp_path).lower()
+    assert _OPENAI_LEGACY_SECRET.lower() not in cfg_lower
+    assert _NOUS_LEGACY_SECRET.lower() not in cfg_lower
+
+
+@BF_XFAIL
+def test_provider_migrate_apply_idempotent_second_run_is_noop(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(tmp_path, {"DEEPSEEK_API_KEY": "deepseek-migrate-key-abc"})
+
+    first = _invoke("provider", "migrate", "--apply")
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE, first.stdout + first.stderr
+    after_first_env = env_text(tmp_path)
+    after_first_cfg = config_text(tmp_path)
+
+    second = _invoke("provider", "migrate", "--apply")
+    output = _plain(second.stdout + second.stderr).lower()
+    assert second.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert env_text(tmp_path) == after_first_env
+    assert config_text(tmp_path) == after_first_cfg
+    assert "no changes" in output or "already migrated" in output or "noop" in output
+
+
+@BF_XFAIL
+def test_provider_migrate_apply_only_fills_missing_after_partial_manual(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_provider_entry(
+        tmp_path,
+        label="openai",
+        env_index=1,
+        harness="codex",
+        auth_kind="device_code",
+    )
+    write_env_pairs(
+        tmp_path,
+        {
+            "LLM_PROVIDER_1": "openai",
+            "OPENAI_API_KEY": _OPENAI_LEGACY_SECRET,
+        },
+    )
+
+    result = _invoke("provider", "migrate", "--apply")
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+
+    env = read_env_file(tmp_path)
+    assert env.get(indexed_env_key(1, "API_KEY")) == _OPENAI_LEGACY_SECRET
+    assert len(provider_entries(read_config(tmp_path))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Config / secret split enforced (D2)
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_provider_migrate_config_yaml_never_contains_credential_values(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(
+        tmp_path,
+        {
+            "OPENAI_API_KEY": _OPENAI_LEGACY_SECRET,
+            "CURSOR_API_KEY": "cursor-secret-VALUE999",
+        },
+    )
+
+    apply = _invoke("provider", "migrate", "--apply")
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    raw = config_text(tmp_path)
+    assert _OPENAI_LEGACY_SECRET not in raw
+    assert "cursor-secret-VALUE999" not in raw
+    parsed = yaml.safe_load(raw)
+    assert isinstance(parsed, dict)
+    for entry in provider_entries(parsed):
+        for _key, value in entry.items():
+            if isinstance(value, str):
+                assert _OPENAI_LEGACY_SECRET not in value
+                assert "cursor-secret-VALUE999" not in value
+
+
+@BF_XFAIL
+def test_provider_migrate_env_never_contains_harness_or_url_structure(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(
+        tmp_path,
+        {
+            "NOUS_API_KEY": _NOUS_LEGACY_SECRET,
+            "NOUS_BASE_URL": NOUS_BASE_URL,
+        },
+    )
+
+    apply = _invoke("provider", "migrate", "--apply")
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    env_blob = env_text(tmp_path).lower()
+    for token in LEGACY_STRUCTURE_IN_ENV:
+        assert f"{token}=" not in env_blob
+    assert "harness:" not in env_blob
+    assert NOUS_BASE_URL not in env_blob or "url=" not in env_blob
+
+
+@BF_XFAIL
+def test_provider_migrate_ambiguous_custom_base_url_refuses_or_prompts(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(
+        tmp_path,
+        {"MERGECRAFT_CUSTOM_PROVIDER_BASE_URL": "https://ambiguous.example.invalid/v1"},
+    )
+
+    result = _invoke("provider", "migrate")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "custom" in output or "mergecraft_custom_provider_base_url" in output
+    assert "label" in output or "todo" in output or "ambiguous" in output
+    assert provider_entries(read_config(tmp_path)) == []
+    assert "LLM_PROVIDER_1" not in read_env_file(tmp_path)
+
+
+@BF_XFAIL
+def test_provider_migrate_deterministic_index_allocation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_env_pairs(
+        tmp_path,
+        {
+            "OPENAI_API_KEY": "openai-key-one",
+            "DEEPSEEK_API_KEY": "deepseek-key-two",
+        },
+    )
+
+    first = _invoke("provider", "migrate", "--apply")
+    assert first.exit_code == CLI_SUCCESS_EXIT_CODE, first.stdout + first.stderr
+    first_env = read_env_file(tmp_path)
+
+    scaffold_mergecraft_home(tmp_path)
+    write_env_pairs(
+        tmp_path,
+        {
+            "OPENAI_API_KEY": "openai-key-one",
+            "DEEPSEEK_API_KEY": "deepseek-key-two",
+        },
+    )
+
+    second = _invoke("provider", "migrate", "--apply")
+    assert second.exit_code == CLI_SUCCESS_EXIT_CODE, second.stdout + second.stderr
+    second_env = read_env_file(tmp_path)
+
+    assert first_env.get("LLM_PROVIDER_1") == second_env.get("LLM_PROVIDER_1") == "openai"
+    assert first_env.get("LLM_PROVIDER_2") == second_env.get("LLM_PROVIDER_2") == "deepseek"
+
+
+# ---------------------------------------------------------------------------
+# Bedrock / Vertex ``cloud_chain`` — one index, multi-secret (D10)
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_provider_migrate_bedrock_maps_multi_secret_under_one_index(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    legacy = {
+        "AWS_ACCESS_KEY_ID": "AKIA-BEDROCK-TEST",
+        "AWS_SECRET_ACCESS_KEY": "bedrock-secret-KEY-XY",
+        "AWS_REGION": "us-east-1",
+    }
+    write_env_pairs(tmp_path, legacy)
+
+    apply = _invoke("provider", "migrate", "--apply")
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    config = read_config(tmp_path)
+    bedrock = next(
+        (entry for entry in provider_entries(config) if entry.get("label") == "bedrock"),
+        None,
+    )
+    assert bedrock is not None
+    assert bedrock.get("authKind") == AUTH_KIND_CLOUD_CHAIN
+    env_index = int(bedrock["envIndex"])
+
+    env = read_env_file(tmp_path)
+    assert env.get(f"LLM_PROVIDER_{env_index}") == "bedrock"
+    for suffix in BEDROCK_LEGACY_SECRET_KEYS:
+        assert env.get(indexed_env_key(env_index, suffix)) == legacy[suffix]
+    assert indexed_env_key(env_index, "API_KEY") not in env
+
+    cfg_text = config_text(tmp_path)
+    assert "us-east-1" in cfg_text or any(key in cfg_text for key in BEDROCK_LEGACY_CONFIG_KEYS)
+
+
+@BF_XFAIL
+def test_provider_migrate_bedrock_copies_aws_vars_leaves_originals_in_place(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    legacy = {
+        "AWS_ACCESS_KEY_ID": "AKIA-SHARED-ORIGINAL",
+        "AWS_SECRET_ACCESS_KEY": "shared-secret-ORIGINAL",
+    }
+    write_env_pairs(tmp_path, legacy)
+
+    dry = _invoke("provider", "migrate")
+    dry_output = _plain(dry.stdout + dry.stderr).lower()
+    assert dry.exit_code == CLI_SUCCESS_EXIT_CODE, dry_output
+    assert "leave" in dry_output or "copy" in dry_output or "original" in dry_output
+
+    apply = _invoke("provider", "migrate", "--apply")
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    env = read_env_file(tmp_path)
+    assert env.get("AWS_ACCESS_KEY_ID") == legacy["AWS_ACCESS_KEY_ID"]
+    assert env.get("AWS_SECRET_ACCESS_KEY") == legacy["AWS_SECRET_ACCESS_KEY"]
+
+
+@BF_XFAIL
+def test_provider_migrate_vertex_maps_credentials_under_one_index(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    cred_path = "/tmp/vertex-sa.json"
+    write_env_pairs(
+        tmp_path,
+        {
+            "GOOGLE_APPLICATION_CREDENTIALS": cred_path,
+            "GOOGLE_CLOUD_PROJECT": "mergecraft-test",
+            "VERTEX_LOCATION": "us-central1",
+        },
+    )
+
+    apply = _invoke("provider", "migrate", "--apply")
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    config = read_config(tmp_path)
+    vertex = next(
+        (entry for entry in provider_entries(config) if entry.get("label") == "vertex"),
+        None,
+    )
+    assert vertex is not None
+    env_index = int(vertex["envIndex"])
+    env = read_env_file(tmp_path)
+    assert env.get(f"LLM_PROVIDER_{env_index}") == "vertex"
+    for suffix in VERTEX_LEGACY_SECRET_KEYS:
+        assert env.get(indexed_env_key(env_index, suffix)) == cred_path
+    assert indexed_env_key(env_index, "API_KEY") not in env
+
+    cfg_text = config_text(tmp_path)
+    assert any(key.lower() in cfg_text.lower() for key in VERTEX_LEGACY_CONFIG_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# Legacy shim — registry key wins; warning once per process (D7)
+# ---------------------------------------------------------------------------
+
+
+@BF_XFAIL
+def test_legacy_env_registry_key_wins_with_single_deprecation_warning(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    write_provider_entry(
+        tmp_path,
+        label="openai",
+        env_index=1,
+        harness="codex",
+        auth_kind="device_code",
+    )
+    registry_secret = "registry-openai-WINS-KEY"
+    legacy_secret = "legacy-openai-LOSES-KEY"
+    write_env_pairs(
+        tmp_path,
+        {
+            "LLM_PROVIDER_1": "openai",
+            "LLM_PROVIDER_1_API_KEY": registry_secret,
+            "OPENAI_API_KEY": legacy_secret,
+        },
+    )
+
+    module = __import__(
+        "mergecraft.cli.provider_cmd",
+        fromlist=["resolve_indexed_credential"],
+    )
+    resolve_fn = getattr(module, "resolve_indexed_credential", None)
+    if resolve_fn is None:
+        pytest.fail("provider_cmd.resolve_indexed_credential is not implemented")
+
+    config = read_config(tmp_path)
+    entry = provider_entries(config)[0]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = resolve_fn(entry)
+        resolved_again = resolve_fn(entry)
+
+    assert resolved == registry_secret
+    assert resolved != legacy_secret
+    deprecation = [item for item in caught if issubclass(item.category, DeprecationWarning)]
+    assert len(deprecation) == 1
+    message = str(deprecation[0].message).lower()
+    assert "openai_api_key" in message or "legacy" in message
+    assert "ignored" in message or "wins" in message or "prefer" in message
+    assert resolved_again == registry_secret

--- a/tests/cli/test_provider_migrate_cmd.py
+++ b/tests/cli/test_provider_migrate_cmd.py
@@ -18,7 +18,6 @@ from tests.cli.support_provider_registry import (
     AUTH_KIND_CLOUD_CHAIN,
     BEDROCK_LEGACY_CONFIG_KEYS,
     BEDROCK_LEGACY_SECRET_KEYS,
-    BF_XFAIL,
     LEGACY_API_KEY_MIGRATIONS,
     LEGACY_STRUCTURE_IN_ENV,
     NOUS_BASE_URL,
@@ -73,7 +72,6 @@ def _setup_repo(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_provider_help_lists_migrate_verb() -> None:
     result = _invoke("provider", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -81,7 +79,6 @@ def test_provider_help_lists_migrate_verb() -> None:
     assert "migrate" in output
 
 
-@BF_XFAIL
 def test_provider_migrate_help_documents_apply_flag() -> None:
     result = _invoke("provider", "migrate", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -95,7 +92,6 @@ def test_provider_migrate_help_documents_apply_flag() -> None:
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_provider_migrate_default_is_dry_run_no_writes(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -121,7 +117,6 @@ def test_provider_migrate_default_is_dry_run_no_writes(
         for legacy, (label, suffix) in sorted(LEGACY_API_KEY_MIGRATIONS.items())
     ],
 )
-@BF_XFAIL
 def test_provider_migrate_dry_run_prints_key_names_not_secret_values(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -142,7 +137,6 @@ def test_provider_migrate_dry_run_prints_key_names_not_secret_values(
     assert_output_never_contains_secret(output, secret)
 
 
-@BF_XFAIL
 def test_provider_migrate_dry_run_shows_fingerprint_not_full_secret(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -162,7 +156,6 @@ def test_provider_migrate_dry_run_shows_fingerprint_not_full_secret(
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_provider_migrate_apply_writes_provider_config_and_indexed_secrets(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -204,7 +197,6 @@ def test_provider_migrate_apply_writes_provider_config_and_indexed_secrets(
     assert _NOUS_LEGACY_SECRET.lower() not in cfg_lower
 
 
-@BF_XFAIL
 def test_provider_migrate_apply_idempotent_second_run_is_noop(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -225,7 +217,6 @@ def test_provider_migrate_apply_idempotent_second_run_is_noop(
     assert "no changes" in output or "already migrated" in output or "noop" in output
 
 
-@BF_XFAIL
 def test_provider_migrate_apply_only_fills_missing_after_partial_manual(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -259,7 +250,6 @@ def test_provider_migrate_apply_only_fills_missing_after_partial_manual(
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_provider_migrate_config_yaml_never_contains_credential_values(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -288,7 +278,6 @@ def test_provider_migrate_config_yaml_never_contains_credential_values(
                 assert "cursor-secret-VALUE999" not in value
 
 
-@BF_XFAIL
 def test_provider_migrate_env_never_contains_harness_or_url_structure(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -312,7 +301,6 @@ def test_provider_migrate_env_never_contains_harness_or_url_structure(
     assert NOUS_BASE_URL not in env_blob or "url=" not in env_blob
 
 
-@BF_XFAIL
 def test_provider_migrate_ambiguous_custom_base_url_refuses_or_prompts(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -332,7 +320,6 @@ def test_provider_migrate_ambiguous_custom_base_url_refuses_or_prompts(
     assert "LLM_PROVIDER_1" not in read_env_file(tmp_path)
 
 
-@BF_XFAIL
 def test_provider_migrate_deterministic_index_allocation(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -372,7 +359,6 @@ def test_provider_migrate_deterministic_index_allocation(
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_provider_migrate_bedrock_maps_multi_secret_under_one_index(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -407,7 +393,6 @@ def test_provider_migrate_bedrock_maps_multi_secret_under_one_index(
     assert "us-east-1" in cfg_text or any(key in cfg_text for key in BEDROCK_LEGACY_CONFIG_KEYS)
 
 
-@BF_XFAIL
 def test_provider_migrate_bedrock_copies_aws_vars_leaves_originals_in_place(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -432,7 +417,6 @@ def test_provider_migrate_bedrock_copies_aws_vars_leaves_originals_in_place(
     assert env.get("AWS_SECRET_ACCESS_KEY") == legacy["AWS_SECRET_ACCESS_KEY"]
 
 
-@BF_XFAIL
 def test_provider_migrate_vertex_maps_credentials_under_one_index(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -473,7 +457,6 @@ def test_provider_migrate_vertex_maps_credentials_under_one_index(
 # ---------------------------------------------------------------------------
 
 
-@BF_XFAIL
 def test_legacy_env_registry_key_wins_with_single_deprecation_warning(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_provider_migrate_registry.py
+++ b/tests/cli/test_provider_migrate_registry.py
@@ -12,7 +12,6 @@ import pytest
 from tests.cli.support_provider_registry import (
     AUTH_KIND_CLOUD_CHAIN,
     BEDROCK_LEGACY_SECRET_KEYS,
-    BF_XFAIL,
     LEGACY_API_KEY_MIGRATIONS,
     VERTEX_LEGACY_SECRET_KEYS,
     indexed_env_key,
@@ -31,7 +30,6 @@ if TYPE_CHECKING:
 _OPENAI_SECRET = "sk-openai-plan-SECRET9999"
 
 
-@BF_XFAIL
 def test_plan_migration_detects_legacy_openai_key(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -55,7 +53,6 @@ def test_plan_migration_detects_legacy_openai_key(
     )
 
 
-@BF_XFAIL
 def test_plan_migration_lists_target_indexed_key_names_only(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -78,7 +75,6 @@ def test_plan_migration_lists_target_indexed_key_names_only(
     assert "nous-plan-secret-ABC" not in values
 
 
-@BF_XFAIL
 def test_migration_secret_fingerprint_redacts_full_value() -> None:
     module = require_provider_migrate_symbols()
     fingerprint = module.migration_secret_fingerprint(_OPENAI_SECRET)
@@ -87,7 +83,6 @@ def test_migration_secret_fingerprint_redacts_full_value() -> None:
     assert "9999" in fingerprint or "…" in fingerprint or "*" in fingerprint
 
 
-@BF_XFAIL
 def test_validate_config_secret_split_flags_credential_in_yaml(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -115,7 +110,6 @@ def test_validate_config_secret_split_flags_credential_in_yaml(
     assert "apikey" in joined or "credential" in joined or "secret" in joined
 
 
-@BF_XFAIL
 def test_validate_config_secret_split_flags_structure_in_env(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -134,7 +128,6 @@ def test_validate_config_secret_split_flags_structure_in_env(
     assert any("harness" in item.lower() for item in violations)
 
 
-@BF_XFAIL
 @pytest.mark.parametrize("legacy_key", sorted(LEGACY_API_KEY_MIGRATIONS))
 def test_registry_credential_precedence_over_legacy_env(
     tmp_path: Path,
@@ -167,7 +160,6 @@ def test_registry_credential_precedence_over_legacy_env(
     assert resolved == registry_value
 
 
-@BF_XFAIL
 def test_cloud_chain_migration_bedrock_suffixes_under_one_index(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -196,7 +188,6 @@ def test_cloud_chain_migration_bedrock_suffixes_under_one_index(
         assert indexed_env_key(env_index, suffix) in targets
 
 
-@BF_XFAIL
 def test_cloud_chain_migration_vertex_suffixes_under_one_index(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -221,7 +212,6 @@ def test_cloud_chain_migration_vertex_suffixes_under_one_index(
         assert indexed_env_key(env_index, suffix) in targets
 
 
-@BF_XFAIL
 def test_apply_provider_migration_is_idempotent(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_provider_migrate_registry.py
+++ b/tests/cli/test_provider_migrate_registry.py
@@ -1,0 +1,245 @@
+"""RED unit tests for ``provider migrate`` planning helpers (#483 / BF).
+
+Pins migration planning, fingerprint redaction, config/secret split validation,
+legacy precedence (D7), and Bedrock/Vertex ``cloud_chain`` suffix mapping (D10).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.cli.support_provider_registry import (
+    AUTH_KIND_CLOUD_CHAIN,
+    BEDROCK_LEGACY_SECRET_KEYS,
+    BF_XFAIL,
+    LEGACY_API_KEY_MIGRATIONS,
+    VERTEX_LEGACY_SECRET_KEYS,
+    indexed_env_key,
+    read_config,
+    require_provider_migrate_symbols,
+    scaffold_mergecraft_home,
+    stub_mergecraft_env,
+    write_env_pairs,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_OPENAI_SECRET = "sk-openai-plan-SECRET9999"
+
+
+@BF_XFAIL
+def test_plan_migration_detects_legacy_openai_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    write_env_pairs(tmp_path, {"OPENAI_API_KEY": _OPENAI_SECRET})
+
+    plan = module.plan_provider_migration(
+        env_path=tmp_path / ".env",
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+    )
+    labels = {item["label"] for item in plan.providers}
+    assert "openai" in labels
+    assert any(
+        step.get("source") == "OPENAI_API_KEY"
+        for step in plan.env_writes
+        if step.get("provider") == "openai"
+    )
+
+
+@BF_XFAIL
+def test_plan_migration_lists_target_indexed_key_names_only(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    write_env_pairs(tmp_path, {"NOUS_API_KEY": "nous-plan-secret-ABC"})
+
+    plan = module.plan_provider_migration(
+        env_path=tmp_path / ".env",
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+    )
+    target_keys = {step["target"] for step in plan.env_writes}
+    assert indexed_env_key(1, "API_KEY") in target_keys or any(
+        key.endswith("_API_KEY") for key in target_keys
+    )
+    values = {step.get("value") for step in plan.env_writes}
+    assert "nous-plan-secret-ABC" not in values
+
+
+@BF_XFAIL
+def test_migration_secret_fingerprint_redacts_full_value() -> None:
+    module = require_provider_migrate_symbols()
+    fingerprint = module.migration_secret_fingerprint(_OPENAI_SECRET)
+    assert fingerprint != _OPENAI_SECRET
+    assert _OPENAI_SECRET not in fingerprint
+    assert "9999" in fingerprint or "…" in fingerprint or "*" in fingerprint
+
+
+@BF_XFAIL
+def test_validate_config_secret_split_flags_credential_in_yaml(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(
+        tmp_path,
+        config_body=(
+            "providers:\n"
+            "  - label: leaked\n"
+            "    harness: opencode\n"
+            "    envIndex: 1\n"
+            "    apiKey: should-not-live-here\n"
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+
+    violations = module.validate_config_secret_split(
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+        env_path=tmp_path / ".env",
+    )
+    assert violations
+    joined = " ".join(violations).lower()
+    assert "apikey" in joined or "credential" in joined or "secret" in joined
+
+
+@BF_XFAIL
+def test_validate_config_secret_split_flags_structure_in_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    (tmp_path / ".env").write_text("harness=opencode\nLLM_PROVIDER_1=nous\n", encoding="utf-8")
+
+    violations = module.validate_config_secret_split(
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+        env_path=tmp_path / ".env",
+    )
+    assert violations
+    assert any("harness" in item.lower() for item in violations)
+
+
+@BF_XFAIL
+@pytest.mark.parametrize("legacy_key", sorted(LEGACY_API_KEY_MIGRATIONS))
+def test_registry_credential_precedence_over_legacy_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    legacy_key: str,
+) -> None:
+    module = require_provider_migrate_symbols()
+    provider_label, suffix = LEGACY_API_KEY_MIGRATIONS[legacy_key]
+    scaffold_mergecraft_home(
+        tmp_path,
+        config_body=(
+            f"providers:\n  - label: {provider_label}\n    harness: opencode\n    envIndex: 1\n"
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    registry_value = f"registry-{provider_label}-WINS"
+    legacy_value = f"legacy-{provider_label}-LOSES"
+    write_env_pairs(
+        tmp_path,
+        {
+            "LLM_PROVIDER_1": provider_label,
+            indexed_env_key(1, suffix): registry_value,
+            legacy_key: legacy_value,
+        },
+    )
+
+    entry = read_config(tmp_path)["providers"][0]
+    resolved = module.resolve_indexed_credential(entry)
+    assert resolved == registry_value
+
+
+@BF_XFAIL
+def test_cloud_chain_migration_bedrock_suffixes_under_one_index(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    write_env_pairs(
+        tmp_path,
+        {
+            "AWS_ACCESS_KEY_ID": "AKIA-BEDROCK",
+            "AWS_SECRET_ACCESS_KEY": "bedrock-secret",
+        },
+    )
+
+    plan = module.plan_provider_migration(
+        env_path=tmp_path / ".env",
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+    )
+    bedrock = next(item for item in plan.providers if item["label"] == "bedrock")
+    assert bedrock.get("authKind") == AUTH_KIND_CLOUD_CHAIN
+    env_index = int(bedrock["envIndex"])
+    targets = {step["target"] for step in plan.env_writes if step.get("provider") == "bedrock"}
+    for suffix in BEDROCK_LEGACY_SECRET_KEYS:
+        assert indexed_env_key(env_index, suffix) in targets
+
+
+@BF_XFAIL
+def test_cloud_chain_migration_vertex_suffixes_under_one_index(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    write_env_pairs(
+        tmp_path,
+        {"GOOGLE_APPLICATION_CREDENTIALS": "/etc/vertex/sa.json"},
+    )
+
+    plan = module.plan_provider_migration(
+        env_path=tmp_path / ".env",
+        config_path=tmp_path / ".mergecraft" / "config.yaml",
+    )
+    vertex = next(item for item in plan.providers if item["label"] == "vertex")
+    env_index = int(vertex["envIndex"])
+    targets = {step["target"] for step in plan.env_writes if step.get("provider") == "vertex"}
+    for suffix in VERTEX_LEGACY_SECRET_KEYS:
+        assert indexed_env_key(env_index, suffix) in targets
+
+
+@BF_XFAIL
+def test_apply_provider_migration_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    module = require_provider_migrate_symbols()
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    write_env_pairs(tmp_path, {"DEEPSEEK_API_KEY": "deepseek-apply-key"})
+
+    env_path = tmp_path / ".env"
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    plan = module.plan_provider_migration(env_path=env_path, config_path=config_path)
+    module.apply_provider_migration(plan, env_path=env_path, config_path=config_path)
+    after_first = env_path.read_text(encoding="utf-8")
+
+    second_plan = module.plan_provider_migration(env_path=env_path, config_path=config_path)
+    assert not second_plan.env_writes
+    assert not second_plan.providers
+    module.apply_provider_migration(second_plan, env_path=env_path, config_path=config_path)
+    assert env_path.read_text(encoding="utf-8") == after_first

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -16,8 +16,6 @@ from tests.cli.support_provider_registry import (
 from mergecraft.models import PROVIDERS
 from mergecraft.utils import agent_resolve as ar
 
-_XFAIL = pytest.mark.xfail(reason="green after BA impl", strict=False)
-
 
 def test_providers_catalog_has_fourteen_builtin_entries() -> None:
     """Seed source ``PROVIDERS`` must expose exactly 14 built-in catalog rows."""
@@ -28,7 +26,6 @@ def test_providers_catalog_has_fourteen_builtin_entries() -> None:
     ("label", "expected_harness"),
     sorted(BUILTIN_HARNESS_DEFAULTS.items()),
 )
-@_XFAIL
 def test_builtin_harness_defaults_match_agent_resolve_table(
     label: str,
     expected_harness: str,
@@ -41,7 +38,6 @@ def test_builtin_harness_defaults_match_agent_resolve_table(
     assert ar._harness_supports_provider(expected_harness, label)
 
 
-@_XFAIL
 def test_allocate_env_index_returns_max_plus_one() -> None:
     registry = import_provider_registry()
     allocate = getattr(registry, "allocate_env_index", None)
@@ -53,7 +49,6 @@ def test_allocate_env_index_returns_max_plus_one() -> None:
     assert allocate([]) == 1
 
 
-@_XFAIL
 def test_allocate_env_index_never_reuses_gaps() -> None:
     registry = import_provider_registry()
     allocate = getattr(registry, "allocate_env_index", None)
@@ -64,7 +59,6 @@ def test_allocate_env_index_never_reuses_gaps() -> None:
     assert allocate([{"envIndex": 1}, {"envIndex": 5}]) == 6
 
 
-@_XFAIL
 def test_harness_support_predicate_is_reused_not_duplicated() -> None:
     registry = import_provider_registry()
     supports = getattr(registry, "harness_supports_provider", None)
@@ -73,7 +67,6 @@ def test_harness_support_predicate_is_reused_not_duplicated() -> None:
     assert supports is ar._harness_supports_provider
 
 
-@_XFAIL
 def test_list_supported_harnesses_is_generated_from_code() -> None:
     registry = import_provider_registry()
     list_fn = getattr(registry, "list_supported_harnesses", None)

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -1,0 +1,84 @@
+"""RED unit tests for provider registry helpers (#477 / BA).
+
+Pins index allocation, built-in harness defaults, and registry module contracts
+that back ``mergecraft provider`` verbs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tests.cli.support_provider_registry import (
+    BUILTIN_HARNESS_DEFAULTS,
+    EXPECTED_BUILTIN_PROVIDER_COUNT,
+    import_provider_registry,
+)
+
+from mergecraft.models import PROVIDERS
+from mergecraft.utils import agent_resolve as ar
+
+_XFAIL = pytest.mark.xfail(reason="green after BA impl", strict=False)
+
+
+def test_providers_catalog_has_fourteen_builtin_entries() -> None:
+    """Seed source ``PROVIDERS`` must expose exactly 14 built-in catalog rows."""
+    assert len(PROVIDERS) == EXPECTED_BUILTIN_PROVIDER_COUNT
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_harness"),
+    sorted(BUILTIN_HARNESS_DEFAULTS.items()),
+)
+@_XFAIL
+def test_builtin_harness_defaults_match_agent_resolve_table(
+    label: str,
+    expected_harness: str,
+) -> None:
+    registry = import_provider_registry()
+    defaults = getattr(registry, "BUILTIN_HARNESS_DEFAULTS", None)
+    if defaults is None:
+        pytest.fail("provider_registry.BUILTIN_HARNESS_DEFAULTS is not defined")
+    assert defaults[label] == expected_harness
+    assert ar._harness_supports_provider(expected_harness, label)
+
+
+@_XFAIL
+def test_allocate_env_index_returns_max_plus_one() -> None:
+    registry = import_provider_registry()
+    allocate = getattr(registry, "allocate_env_index", None)
+    if allocate is None:
+        pytest.fail("provider_registry.allocate_env_index is not implemented")
+
+    assert allocate([{"envIndex": 1}, {"envIndex": 3}]) == 4
+    assert allocate([{"envIndex": 7}]) == 8
+    assert allocate([]) == 1
+
+
+@_XFAIL
+def test_allocate_env_index_never_reuses_gaps() -> None:
+    registry = import_provider_registry()
+    allocate = getattr(registry, "allocate_env_index", None)
+    if allocate is None:
+        pytest.fail("provider_registry.allocate_env_index is not implemented")
+
+    # Gap at 2 must not be recycled — always max + 1.
+    assert allocate([{"envIndex": 1}, {"envIndex": 5}]) == 6
+
+
+@_XFAIL
+def test_harness_support_predicate_is_reused_not_duplicated() -> None:
+    registry = import_provider_registry()
+    supports = getattr(registry, "harness_supports_provider", None)
+    if supports is None:
+        pytest.fail("provider_registry.harness_supports_provider is not implemented")
+    assert supports is ar._harness_supports_provider
+
+
+@_XFAIL
+def test_list_supported_harnesses_is_generated_from_code() -> None:
+    registry = import_provider_registry()
+    list_fn = getattr(registry, "list_supported_harnesses", None)
+    if list_fn is None:
+        pytest.fail("provider_registry.list_supported_harnesses is not implemented")
+
+    names = {row[0] if isinstance(row, (tuple, list)) else row.name for row in list_fn()}
+    assert names == {"opencode", "codex", "claude", "gemini", "cursor"}

--- a/tests/cli/test_workflow_cmd.py
+++ b/tests/cli/test_workflow_cmd.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 
 import yaml
 from tests.cli.support_provider_registry import (
-    BG_XFAIL,
     CUSTOM_BASE_URL,
     NOUS_BASE_URL,
     NOUS_TENCENT_HY3,
@@ -88,7 +87,6 @@ def _register_nous_provider(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_workflow_namespace_registered_on_root_app() -> None:
     result = _invoke("workflow", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -97,7 +95,6 @@ def test_workflow_namespace_registered_on_root_app() -> None:
     assert "model" in output
 
 
-@BG_XFAIL
 def test_gha_namespace_does_not_expose_workflow_authoring_verbs() -> None:
     result = _invoke("gha", "--help")
     output = _plain(result.stdout + result.stderr).lower()
@@ -106,7 +103,6 @@ def test_gha_namespace_does_not_expose_workflow_authoring_verbs() -> None:
     assert "setmodel" not in output
 
 
-@BG_XFAIL
 def test_workflow_help_lists_provider_model_agents_and_list_verbs() -> None:
     require_workflow_cmd_symbols()
     result = _invoke("workflow", "--help")
@@ -116,7 +112,6 @@ def test_workflow_help_lists_provider_model_agents_and_list_verbs() -> None:
         assert verb in output, f"expected workflow subcommand group {verb!r} in help"
 
 
-@BG_XFAIL
 def test_workflow_provider_harnesses_lists_supported_values_from_code() -> None:
     result = _invoke("workflow", "provider", "harnesses")
     output = _plain(result.stdout + result.stderr).lower()
@@ -130,7 +125,6 @@ def test_workflow_provider_harnesses_lists_supported_values_from_code() -> None:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_workflow_provider_add_default_dry_run_shows_diff_without_writing(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -158,7 +152,6 @@ def test_workflow_provider_add_default_dry_run_shows_diff_without_writing(
     assert indexed_custom_provider_api_key(1) in output or "secrets" in output.lower()
 
 
-@BG_XFAIL
 def test_workflow_provider_add_apply_writes_owned_env_keys(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -193,7 +186,6 @@ def test_workflow_provider_add_apply_writes_owned_env_keys(
     assert_only_owned_workflow_keys_changed(before, after)
 
 
-@BG_XFAIL
 def test_workflow_model_add_updates_with_model_key(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -223,7 +215,6 @@ def test_workflow_model_add_updates_with_model_key(
     assert_only_owned_workflow_keys_changed(before, after)
 
 
-@BG_XFAIL
 def test_workflow_agents_setmodel_updates_primary_step_model(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -260,7 +251,6 @@ def test_workflow_agents_setmodel_updates_primary_step_model(
     assert_only_owned_workflow_keys_changed(before, after)
 
 
-@BG_XFAIL
 def test_workflow_model_prioritize_reorders_fallback_steps(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -305,7 +295,6 @@ def test_workflow_model_prioritize_reorders_fallback_steps(
     assert_only_owned_workflow_keys_changed(before, after)
 
 
-@BG_XFAIL
 def test_workflow_list_shows_provider_model_state(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -326,7 +315,6 @@ def test_workflow_list_shows_provider_model_state(
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_workflow_provider_add_rejects_unknown_harness(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -353,7 +341,6 @@ def test_workflow_provider_add_rejects_unknown_harness(
     assert workflow_text(tmp_path) == before
 
 
-@BG_XFAIL
 def test_workflow_provider_add_reports_missing_github_secrets(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -379,7 +366,6 @@ def test_workflow_provider_add_reports_missing_github_secrets(
     assert "secret" in output.lower()
 
 
-@BG_XFAIL
 def test_workflow_mutate_refuses_when_no_mergecraft_step(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -413,7 +399,6 @@ jobs:
     assert "mergecraft" in output or "uses:" in output
 
 
-@BG_XFAIL
 def test_workflow_failure_is_ordinary_cli_error_not_action_annotation(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -438,7 +423,6 @@ def test_workflow_failure_is_ordinary_cli_error_not_action_annotation(
     assert "::error::" not in output
 
 
-@BG_XFAIL
 def test_workflow_runs_without_github_actions_env(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -460,7 +444,6 @@ def test_workflow_runs_without_github_actions_env(
     assert "::error::" not in output
 
 
-@BG_XFAIL
 def test_workflow_default_path_targets_mergecraft_yml(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -472,7 +455,6 @@ def test_workflow_default_path_targets_mergecraft_yml(
     assert WORKFLOW_DEFAULT_RELATIVE_PATH in output
 
 
-@BG_XFAIL
 def test_workflow_mutated_repo_passes_action_yml_hygiene_check(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/cli/test_workflow_cmd.py
+++ b/tests/cli/test_workflow_cmd.py
@@ -1,0 +1,505 @@
+"""RED tests for ``mergecraft workflow`` authoring CLI (#484 / BG).
+
+Wave plan: ``.ignorelocal/waves/open-issues-sweep-2026-08-24-b-provider-registry-wave-plan.md``
+BG — test-creator. Pins the ``workflow`` namespace (not ``gha``), surgical
+``with:``/``env:`` mutation, ``--dry-run`` diff, byte-stable comments, harness
+validation parity with local ``provider`` commands, missing-secret reporting, and
+ordinary CLI failures outside GitHub Actions.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+from tests.cli.support_provider_registry import (
+    BG_XFAIL,
+    CUSTOM_BASE_URL,
+    NOUS_BASE_URL,
+    NOUS_TENCENT_HY3,
+    WORKFLOW_DEFAULT_RELATIVE_PATH,
+    WORKFLOW_ONE_STEP_TEMPLATE,
+    WORKFLOW_TWO_STEP_TEMPLATE,
+    assert_only_owned_workflow_keys_changed,
+    format_model_slug,
+    indexed_custom_provider_api_key,
+    indexed_custom_provider_base_url,
+    indexed_env_key,
+    require_workflow_cmd_symbols,
+    scaffold_mergecraft_home,
+    scaffold_workflow_file,
+    stub_mergecraft_env,
+    workflow_text,
+    write_agents_model_chain,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _invoke(*argv: str, env: dict[str, str] | None = None) -> object:
+    merged = dict(_DUMB_ENV)
+    if env:
+        merged.update(env)
+    return runner.invoke(app, list(argv), env=merged)
+
+
+def _setup_repo(tmp_path: Path, monkeypatch: MonkeyPatch, *, workflow_body: str) -> Path:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    stub_mergecraft_env(monkeypatch, tmp_path)
+    return scaffold_workflow_file(tmp_path, workflow_body)
+
+
+def _register_nous_provider(tmp_path: Path) -> None:
+    add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert add.exit_code == CLI_SUCCESS_EXIT_CODE, add.stdout + add.stderr
+    model = _invoke("model", "add", "--provider", "nous", NOUS_TENCENT_HY3)
+    assert model.exit_code == CLI_SUCCESS_EXIT_CODE, model.stdout + model.stderr
+
+
+# ---------------------------------------------------------------------------
+# Namespace: ``workflow`` authoring vs ``gha`` runtime (D9)
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_workflow_namespace_registered_on_root_app() -> None:
+    result = _invoke("workflow", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "provider" in output
+    assert "model" in output
+
+
+@BG_XFAIL
+def test_gha_namespace_does_not_expose_workflow_authoring_verbs() -> None:
+    result = _invoke("gha", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "workflow provider" not in output
+    assert "setmodel" not in output
+
+
+@BG_XFAIL
+def test_workflow_help_lists_provider_model_agents_and_list_verbs() -> None:
+    require_workflow_cmd_symbols()
+    result = _invoke("workflow", "--help")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for verb in ("provider", "model", "agents", "list"):
+        assert verb in output, f"expected workflow subcommand group {verb!r} in help"
+
+
+@BG_XFAIL
+def test_workflow_provider_harnesses_lists_supported_values_from_code() -> None:
+    result = _invoke("workflow", "provider", "harnesses")
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for harness in ("codex", "claude", "opencode", "gemini", "cursor"):
+        assert harness in output, f"expected harness {harness!r} in output"
+
+
+# ---------------------------------------------------------------------------
+# ``--dry-run`` default — diff without write (#484)
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_workflow_provider_add_default_dry_run_shows_diff_without_writing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert workflow.read_text(encoding="utf-8") == before
+    assert indexed_custom_provider_base_url(1) in output or "diff" in output.lower()
+    assert indexed_custom_provider_api_key(1) in output or "secrets" in output.lower()
+
+
+@BG_XFAIL
+def test_workflow_provider_add_apply_writes_owned_env_keys(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    after = workflow.read_text(encoding="utf-8")
+    assert after != before
+    assert indexed_custom_provider_base_url(1) in after
+    assert indexed_custom_provider_api_key(1) in after
+    assert NOUS_BASE_URL in after
+    assert "${{ secrets." in after
+    assert "=== PRESERVE: header comment block" in after
+    assert "timeout-minutes: 65" in after
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+@BG_XFAIL
+def test_workflow_model_add_updates_with_model_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    _register_nous_provider(tmp_path)
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "model",
+        "add",
+        "--provider",
+        "nous",
+        NOUS_TENCENT_HY3,
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    after = workflow.read_text(encoding="utf-8")
+    assert format_model_slug("nous", NOUS_TENCENT_HY3) in after
+    parsed = yaml.safe_load(after)
+    step = parsed["jobs"]["review"]["steps"][0]
+    assert step["with"]["model"] == format_model_slug("nous", NOUS_TENCENT_HY3)
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+@BG_XFAIL
+def test_workflow_agents_setmodel_updates_primary_step_model(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_TWO_STEP_TEMPLATE)
+    _register_nous_provider(tmp_path)
+    write_agents_model_chain(tmp_path, "reviewer", [format_model_slug("nous", NOUS_TENCENT_HY3)])
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "agents",
+        "setmodel",
+        "--agent",
+        "reviewer",
+        "--provider",
+        "nous",
+        "--model",
+        NOUS_TENCENT_HY3,
+        "--workflow",
+        str(workflow),
+        "--step",
+        "mergecraft_nous",
+        "--apply",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    after = workflow.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(after)
+    primary = next(
+        step for step in parsed["jobs"]["review"]["steps"] if step.get("id") == "mergecraft_nous"
+    )
+    assert primary["with"]["model"] == format_model_slug("nous", NOUS_TENCENT_HY3)
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+@BG_XFAIL
+def test_workflow_model_prioritize_reorders_fallback_steps(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_TWO_STEP_TEMPLATE)
+    _register_nous_provider(tmp_path)
+    acme_add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "acme",
+        "--url",
+        CUSTOM_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert acme_add.exit_code == CLI_SUCCESS_EXIT_CODE, acme_add.stdout + acme_add.stderr
+    acme_model = _invoke("model", "add", "--provider", "acme", "gateway-model-1")
+    assert acme_model.exit_code == CLI_SUCCESS_EXIT_CODE, acme_model.stdout + acme_model.stderr
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "model",
+        "prioritize",
+        "--provider",
+        "acme",
+        "--model",
+        "gateway-model-1",
+        "--before",
+        "nous/tencent/hy3",
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    after = workflow.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(after)
+    models = [step["with"]["model"] for step in parsed["jobs"]["review"]["steps"] if "with" in step]
+    assert models.index("acme/gateway-model-1") < models.index("nous/tencent/hy3")
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+@BG_XFAIL
+def test_workflow_list_shows_provider_model_state(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_TWO_STEP_TEMPLATE)
+    _register_nous_provider(tmp_path)
+
+    result = _invoke("workflow", "list", "--workflow", str(workflow))
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "nous" in output
+    assert "tencent/hy3" in output or "tencent" in output
+    assert indexed_custom_provider_api_key(1) in output or "api_key" in output
+
+
+# ---------------------------------------------------------------------------
+# Validation, refusal, and operator guidance
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_workflow_provider_add_rejects_unknown_harness(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    before = workflow_text(tmp_path)
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "not-a-real-harness",
+        "--workflow",
+        str(workflow),
+    )
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "harness" in output
+    assert workflow_text(tmp_path) == before
+
+
+@BG_XFAIL
+def test_workflow_provider_add_reports_missing_github_secrets(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert indexed_env_key(1, "API_KEY") in output or "LLM_PROVIDER_1_API_KEY" in output
+    assert "secret" in output.lower()
+
+
+@BG_XFAIL
+def test_workflow_mutate_refuses_when_no_mergecraft_step(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    body = """\
+name: ci-only
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+"""
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=body)
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+    )
+    output = _plain(result.stdout + result.stderr).lower()
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "mergecraft" in output or "uses:" in output
+
+
+@BG_XFAIL
+def test_workflow_failure_is_ordinary_cli_error_not_action_annotation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+
+    result = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        "not-a-url",
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code != CLI_SUCCESS_EXIT_CODE, output
+    assert "::error::" not in output
+
+
+@BG_XFAIL
+def test_workflow_runs_without_github_actions_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("GITHUB_STATE", raising=False)
+
+    result = _invoke(
+        "workflow",
+        "list",
+        "--workflow",
+        str(workflow),
+        env={"GITHUB_ACTIONS": "", "GITHUB_OUTPUT": "", "GITHUB_STATE": ""},
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "::error::" not in output
+
+
+@BG_XFAIL
+def test_workflow_default_path_targets_mergecraft_yml(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    result = _invoke("workflow", "list", "--help")
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert WORKFLOW_DEFAULT_RELATIVE_PATH in output
+
+
+@BG_XFAIL
+def test_workflow_mutated_repo_passes_action_yml_hygiene_check(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_ONE_STEP_TEMPLATE)
+    apply = _invoke(
+        "workflow",
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    assert apply.exit_code == CLI_SUCCESS_EXIT_CODE, apply.stdout + apply.stderr
+
+    repo_root = Path(__file__).resolve().parents[2]
+    proc = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "check_action_yml_hygiene.py")],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/tests/cli/test_workflow_cmd.py
+++ b/tests/cli/test_workflow_cmd.py
@@ -270,6 +270,20 @@ def test_workflow_model_prioritize_reorders_fallback_steps(
     assert acme_add.exit_code == CLI_SUCCESS_EXIT_CODE, acme_add.stdout + acme_add.stderr
     acme_model = _invoke("model", "add", "--provider", "acme", "gateway-model-1")
     assert acme_model.exit_code == CLI_SUCCESS_EXIT_CODE, acme_model.stdout + acme_model.stderr
+    wire_acme = _invoke(
+        "workflow",
+        "model",
+        "add",
+        "--provider",
+        "acme",
+        "gateway-model-1",
+        "--step",
+        "mergecraft_codex",
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    assert wire_acme.exit_code == CLI_SUCCESS_EXIT_CODE, wire_acme.stdout + wire_acme.stderr
     before = workflow.read_text(encoding="utf-8")
 
     result = _invoke(
@@ -291,6 +305,98 @@ def test_workflow_model_prioritize_reorders_fallback_steps(
     after = workflow.read_text(encoding="utf-8")
     parsed = yaml.safe_load(after)
     models = [step["with"]["model"] for step in parsed["jobs"]["review"]["steps"] if "with" in step]
+    assert models.index("acme/gateway-model-1") < models.index("nous/tencent/hy3")
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+WORKFLOW_THREE_STEP_TEMPLATE = """\
+name: mergecraft
+on:
+  pull_request_target:
+jobs:
+  review:
+    name: mergecraft review
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    steps:
+      - name: mergeCraft PR review (Nous primary)
+        id: mergecraft_nous
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: nous/tencent/hy3
+        env:
+          MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
+          MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
+
+      - name: mergeCraft PR review (middle)
+        id: mergecraft_middle
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: openai/gpt-5.3-codex
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+
+      - name: mergeCraft PR review (Codex fallback)
+        id: mergecraft_codex
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: acme/gateway-model-1
+        env:
+          MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_2: https://custom.example.test/v1
+          LLM_PROVIDER_2_API_KEY: ${{ secrets.LLM_PROVIDER_2_API_KEY }}
+"""
+
+
+def test_workflow_model_prioritize_targets_step_with_requested_model(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Three-step chains must swap with the step that holds the promoted model."""
+    workflow = _setup_repo(tmp_path, monkeypatch, workflow_body=WORKFLOW_THREE_STEP_TEMPLATE)
+    _register_nous_provider(tmp_path)
+    acme_add = _invoke(
+        "provider",
+        "add",
+        "--label",
+        "acme",
+        "--url",
+        CUSTOM_BASE_URL,
+        "--harness",
+        "opencode",
+    )
+    assert acme_add.exit_code == CLI_SUCCESS_EXIT_CODE, acme_add.stdout + acme_add.stderr
+    acme_model = _invoke("model", "add", "--provider", "acme", "gateway-model-1")
+    assert acme_model.exit_code == CLI_SUCCESS_EXIT_CODE, acme_model.stdout + acme_model.stderr
+    before = workflow.read_text(encoding="utf-8")
+
+    result = _invoke(
+        "workflow",
+        "model",
+        "prioritize",
+        "--provider",
+        "acme",
+        "--model",
+        "gateway-model-1",
+        "--before",
+        "nous/tencent/hy3",
+        "--workflow",
+        str(workflow),
+        "--apply",
+    )
+    output = _plain(result.stdout + result.stderr)
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    after = workflow.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(after)
+    steps = parsed["jobs"]["review"]["steps"]
+    models = [step["with"]["model"] for step in steps if "with" in step]
+    middle = next(step for step in steps if step.get("id") == "mergecraft_middle")
+    assert middle["with"]["model"] == "openai/gpt-5.3-codex"
     assert models.index("acme/gateway-model-1") < models.index("nous/tencent/hy3")
     assert_only_owned_workflow_keys_changed(before, after)
 

--- a/tests/cli/test_workflow_wf_yaml.py
+++ b/tests/cli/test_workflow_wf_yaml.py
@@ -1,0 +1,264 @@
+"""RED unit tests for the workflow YAML surgical mutator (#484 / BG).
+
+Pins owned-key surgery on ``with:``/``env:`` blocks inside ``uses:
+alexhawat/mergeCraft`` steps — byte-stable comments, parse-verify loop, refusal
+when the target step is missing, and no edits to timeout literals (#465) or
+header comment regions (#486).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from tests.cli.support_provider_registry import (
+    BG_XFAIL,
+    NOUS_BASE_URL,
+    WORKFLOW_ONE_STEP_TEMPLATE,
+    WORKFLOW_OWNED_ENV_PREFIXES,
+    WORKFLOW_OWNED_WITH_KEYS,
+    WORKFLOW_TWO_STEP_TEMPLATE,
+    assert_only_owned_workflow_keys_changed,
+    format_model_slug,
+    indexed_custom_provider_api_key,
+    indexed_custom_provider_base_url,
+    require_workflow_wf_yaml_symbols,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_workflow(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Owned-key constants
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_workflow_owned_key_constants_match_registry_contract() -> None:
+    module = require_workflow_wf_yaml_symbols()
+    assert tuple(module.WORKFLOW_OWNED_WITH_KEYS) == WORKFLOW_OWNED_WITH_KEYS
+    assert tuple(module.WORKFLOW_OWNED_ENV_PREFIXES) == WORKFLOW_OWNED_ENV_PREFIXES
+
+
+# ---------------------------------------------------------------------------
+# Provider env wiring
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_apply_provider_env_wiring_writes_indexed_custom_provider_keys(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_ONE_STEP_TEMPLATE)
+
+    change = module.apply_provider_env_wiring(
+        workflow_path=workflow,
+        env_index=1,
+        label="nous",
+        base_url=NOUS_BASE_URL,
+        secret_name="LLM_PROVIDER_1_API_KEY",
+        step_selector="primary",
+        force=False,
+    )
+    assert change.was_modified
+    new = change.new_text
+    assert indexed_custom_provider_base_url(1) in new
+    assert indexed_custom_provider_api_key(1) in new
+    assert NOUS_BASE_URL in new
+    assert "${{ secrets.LLM_PROVIDER_1_API_KEY }}" in new
+    parsed = yaml.safe_load(new)
+    env_map = parsed["jobs"]["review"]["steps"][0]["env"]
+    assert env_map[indexed_custom_provider_base_url(1)] == NOUS_BASE_URL
+
+
+@BG_XFAIL
+def test_apply_provider_env_wiring_is_idempotent(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_ONE_STEP_TEMPLATE)
+
+    first = module.apply_provider_env_wiring(
+        workflow_path=workflow,
+        env_index=1,
+        label="nous",
+        base_url=NOUS_BASE_URL,
+        secret_name="LLM_PROVIDER_1_API_KEY",
+        step_selector="primary",
+        force=False,
+    )
+    workflow.write_text(first.new_text, encoding="utf-8")
+    second = module.apply_provider_env_wiring(
+        workflow_path=workflow,
+        env_index=1,
+        label="nous",
+        base_url=NOUS_BASE_URL,
+        secret_name="LLM_PROVIDER_1_API_KEY",
+        step_selector="primary",
+        force=False,
+    )
+    assert not second.was_modified
+
+
+@BG_XFAIL
+def test_apply_provider_env_wiring_preserves_surrounding_comments(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow_text = """\
+name: mergecraft
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft review
+        # === DO NOT TOUCH THIS COMMENT ===
+        id: mergecraft_primary
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd
+        with:
+          prompt: x
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # === END PRECIOUS HEADER ===
+"""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, workflow_text)
+    before = workflow.read_text(encoding="utf-8")
+
+    change = module.apply_provider_env_wiring(
+        workflow_path=workflow,
+        env_index=1,
+        label="nous",
+        base_url=NOUS_BASE_URL,
+        secret_name="LLM_PROVIDER_1_API_KEY",
+        step_selector="primary",
+        force=False,
+    )
+    after = change.new_text
+    assert "=== DO NOT TOUCH THIS COMMENT ===" in after
+    assert "=== END PRECIOUS HEADER ===" in after
+    assert "${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m" in after
+    assert_only_owned_workflow_keys_changed(before, after)
+
+
+@BG_XFAIL
+def test_apply_provider_env_wiring_raises_when_no_mergecraft_step(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(
+        workflow,
+        """\
+name: other
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+""",
+    )
+    with pytest.raises(module.WorkflowYamlError) as exc:
+        module.apply_provider_env_wiring(
+            workflow_path=workflow,
+            env_index=1,
+            label="nous",
+            base_url=NOUS_BASE_URL,
+            secret_name="LLM_PROVIDER_1_API_KEY",
+            step_selector="primary",
+            force=False,
+        )
+    assert "mergeCraft" in str(exc.value) or "uses:" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Model ``with:`` wiring
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_apply_model_wiring_updates_with_model_key(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_ONE_STEP_TEMPLATE)
+    slug = format_model_slug("nous", "tencent/hy3")
+
+    change = module.apply_model_wiring(
+        workflow_path=workflow,
+        model_slug=slug,
+        step_selector="primary",
+        force=False,
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    assert parsed["jobs"]["review"]["steps"][0]["with"]["model"] == slug
+
+
+@BG_XFAIL
+def test_apply_model_wiring_step_selector_targets_named_step(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_TWO_STEP_TEMPLATE)
+
+    change = module.apply_model_wiring(
+        workflow_path=workflow,
+        model_slug="openai/gpt-codex",
+        step_selector="mergecraft_codex",
+        force=False,
+    )
+    parsed = yaml.safe_load(change.new_text)
+    codex = next(
+        step for step in parsed["jobs"]["review"]["steps"] if step.get("id") == "mergecraft_codex"
+    )
+    nous = next(
+        step for step in parsed["jobs"]["review"]["steps"] if step.get("id") == "mergecraft_nous"
+    )
+    assert codex["with"]["model"] == "openai/gpt-codex"
+    assert nous["with"]["model"] == "nous/tencent/hy3"
+
+
+@BG_XFAIL
+def test_apply_model_wiring_rejects_invalid_secret_name(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_ONE_STEP_TEMPLATE)
+
+    with pytest.raises(module.WorkflowYamlError) as exc:
+        module.apply_provider_env_wiring(
+            workflow_path=workflow,
+            env_index=1,
+            label="nous",
+            base_url=NOUS_BASE_URL,
+            secret_name="LLM_PROVIDER_1_API_KEY; rm -rf /",
+            step_selector="primary",
+            force=False,
+        )
+    assert "invalid" in str(exc.value).lower() or "secret" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Diff rendering
+# ---------------------------------------------------------------------------
+
+
+@BG_XFAIL
+def test_render_workflow_diff_emits_unified_diff(tmp_path: Path) -> None:
+    module = require_workflow_wf_yaml_symbols()
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, WORKFLOW_ONE_STEP_TEMPLATE)
+
+    change = module.apply_provider_env_wiring(
+        workflow_path=workflow,
+        env_index=1,
+        label="nous",
+        base_url=NOUS_BASE_URL,
+        secret_name="LLM_PROVIDER_1_API_KEY",
+        step_selector="primary",
+        force=False,
+    )
+    diff = module.render_workflow_diff(workflow, change)
+    assert "---" in diff
+    assert "+++" in diff
+    assert indexed_custom_provider_api_key(1) in diff or NOUS_BASE_URL in diff

--- a/tests/cli/test_workflow_wf_yaml.py
+++ b/tests/cli/test_workflow_wf_yaml.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 from tests.cli.support_provider_registry import (
-    BG_XFAIL,
     NOUS_BASE_URL,
     WORKFLOW_ONE_STEP_TEMPLATE,
     WORKFLOW_OWNED_ENV_PREFIXES,
@@ -39,7 +38,6 @@ def _write_workflow(path: Path, body: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_workflow_owned_key_constants_match_registry_contract() -> None:
     module = require_workflow_wf_yaml_symbols()
     assert tuple(module.WORKFLOW_OWNED_WITH_KEYS) == WORKFLOW_OWNED_WITH_KEYS
@@ -51,7 +49,6 @@ def test_workflow_owned_key_constants_match_registry_contract() -> None:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_apply_provider_env_wiring_writes_indexed_custom_provider_keys(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -77,7 +74,6 @@ def test_apply_provider_env_wiring_writes_indexed_custom_provider_keys(tmp_path:
     assert env_map[indexed_custom_provider_base_url(1)] == NOUS_BASE_URL
 
 
-@BG_XFAIL
 def test_apply_provider_env_wiring_is_idempotent(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -105,7 +101,6 @@ def test_apply_provider_env_wiring_is_idempotent(tmp_path: Path) -> None:
     assert not second.was_modified
 
 
-@BG_XFAIL
 def test_apply_provider_env_wiring_preserves_surrounding_comments(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow_text = """\
@@ -145,7 +140,6 @@ jobs:
     assert_only_owned_workflow_keys_changed(before, after)
 
 
-@BG_XFAIL
 def test_apply_provider_env_wiring_raises_when_no_mergecraft_step(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -178,7 +172,6 @@ jobs:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_apply_model_wiring_updates_with_model_key(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -196,7 +189,6 @@ def test_apply_model_wiring_updates_with_model_key(tmp_path: Path) -> None:
     assert parsed["jobs"]["review"]["steps"][0]["with"]["model"] == slug
 
 
-@BG_XFAIL
 def test_apply_model_wiring_step_selector_targets_named_step(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -219,7 +211,6 @@ def test_apply_model_wiring_step_selector_targets_named_step(tmp_path: Path) -> 
     assert nous["with"]["model"] == "nous/tencent/hy3"
 
 
-@BG_XFAIL
 def test_apply_model_wiring_rejects_invalid_secret_name(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"
@@ -243,7 +234,6 @@ def test_apply_model_wiring_rejects_invalid_secret_name(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@BG_XFAIL
 def test_render_workflow_diff_emits_unified_diff(tmp_path: Path) -> None:
     module = require_workflow_wf_yaml_symbols()
     workflow = tmp_path / "mergecraft.yml"

--- a/tests/config/test_harness_selection.py
+++ b/tests/config/test_harness_selection.py
@@ -70,19 +70,27 @@ def _configuration_error_types() -> tuple[type[BaseException], ...]:
 # ── Pins that pass today (harness unset → existing inference) ────────────────
 
 
-def test_existing_nous_config_still_selects_opencode(tmp_path: Path) -> None:
-    """Compatibility pin — a ``nous/deepseek-*`` YAML with harness unset
-    still resolves to the opencode harness via today's inference.
+def test_existing_nous_config_still_selects_opencode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compatibility pin — a registered ``nous/deepseek-*`` YAML with harness unset
+    still resolves to the opencode harness via registry + inference.
 
-    Guard: deleting ``_agent_mode_for_slug``'s else-opencode path (or
-    special-casing ``nous`` away from opencode) fails this test.
+    Guard: deleting registry lookup or special-casing ``nous`` away from opencode
+    fails this test.
     """
+    from tests.cli.support_provider_registry import bootstrap_nous_registry, read_config
+
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
+    config = read_config(tmp_path)
+    config["model"] = NOUS_CATALOG_SLUG
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    import yaml
+
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     from mergecraft.config.settings import load_repo_settings
 
-    config = tmp_path / ".mergecraft" / "config.yaml"
-    config.parent.mkdir(parents=True)
-    config.write_text(f"model: {NOUS_CATALOG_SLUG}\n", encoding="utf-8")
-    settings = load_repo_settings(path=config, root=tmp_path, load_learnings_files=False)
+    settings = load_repo_settings(path=config_path, root=tmp_path, load_learnings_files=False)
 
     assert settings.model == NOUS_CATALOG_SLUG
     assert getattr(settings, "harness", None) is None
@@ -125,13 +133,18 @@ def test_claude_gemini_cursor_remain_selectable() -> None:
     } == _NATIVE_HARNESS_PROVIDERS
 
 
-def test_inference_path_unchanged_when_harness_unset() -> None:
+def test_inference_path_unchanged_when_harness_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Regression pin over today's model-slug → harness inference matrix.
 
-    ``harness`` omitted (or default ``None``) must keep ``_agent_mode_for_slug``
-    behaviour byte-for-byte: anthropic→claude, openai→codex, google→gemini,
-    cursor→cursor, else opencode.
+    ``harness`` omitted (or default ``None``) must keep inference behaviour for
+    built-in providers; registered custom providers use registry harness rows.
     """
+    from tests.cli.support_provider_registry import bootstrap_nous_registry
+
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek/deepseek-v4-flash")
     for slug, expected in _INFERENCE_MATRIX:
         settings = RepoSettings.model_validate({"model": slug})
         assert getattr(settings, "harness", None) is None, (
@@ -152,10 +165,7 @@ def test_explicit_harness_overrides_inference() -> None:
     ``_agent_mode_for_slug`` alone: openai infers ``codex``, anthropic infers
     ``claude``; explicit ``opencode`` must win in both cases (vice versa).
     """
-    assert (
-        frozenset({"nous", "tokenhub", "minimax", "openai", "anthropic"})
-        == _OPENCODE_NATIVE_PROVIDERS
-    )
+    assert frozenset({"openai", "anthropic"}) == _OPENCODE_NATIVE_PROVIDERS
     assert _harness_supports_provider("opencode", "openai") is True
     assert _harness_supports_provider("opencode", "anthropic") is True
     cases = (

--- a/tests/config/test_registry_harness_env.py
+++ b/tests/config/test_registry_harness_env.py
@@ -1,0 +1,157 @@
+"""Registry indexed credentials mapped into native harness env names."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.config.runtime_provider_registry import harness_env_for_active_provider
+from mergecraft.utils.secrets import build_agent_env
+from tests.cli.support_provider_registry import (
+    scaffold_mergecraft_home,
+    write_indexed_provider_secret,
+    write_registry_provider_row,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.mark.parametrize(
+    ("label", "harness", "suffix", "legacy_key", "secret_value"),
+    [
+        ("openai", "codex", "API_KEY", "OPENAI_API_KEY", "sk-openai-indexed"),
+        ("google", "gemini", "API_KEY", "GEMINI_API_KEY", "gemini-indexed"),
+        ("cursor", "cursor", "API_KEY", "CURSOR_API_KEY", "cursor-indexed"),
+        ("anthropic", "claude", "API_KEY", "ANTHROPIC_API_KEY", "sk-ant-indexed"),
+    ],
+)
+def test_indexed_api_key_maps_to_native_harness_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    label: str,
+    harness: str,
+    suffix: str,
+    legacy_key: str,
+    secret_value: str,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(
+        tmp_path,
+        label=label,
+        harness=harness,
+        env_index=1,
+        auth_kind="api_key",
+    )
+    write_indexed_provider_secret(
+        tmp_path,
+        env_index=1,
+        label=label,
+        api_key=secret_value,
+    )
+    monkeypatch.setenv(f"LLM_PROVIDER_{1}_{suffix}", secret_value)
+    monkeypatch.delenv(legacy_key, raising=False)
+
+    slug = f"{label}/demo-model"
+    mapped = harness_env_for_active_provider(slug, harness)
+    assert mapped == {legacy_key: secret_value}
+
+    env = build_agent_env(harness, model=slug)
+    assert env.get(legacy_key) == secret_value
+    assert f"LLM_PROVIDER_1_{suffix}" not in env
+
+
+def test_indexed_oauth_maps_to_claude_code_oauth_token(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(
+        tmp_path,
+        label="anthropic",
+        harness="claude",
+        env_index=1,
+        auth_kind="oauth",
+    )
+    token = "sk-ant-oauth-at-indexed"
+    monkeypatch.setenv("LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN", token)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    slug = "anthropic/claude-sonnet"
+    env = build_agent_env("claude", model=slug)
+    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == token
+
+
+def test_indexed_device_code_maps_to_codex_auth_json(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(
+        tmp_path,
+        label="openai",
+        harness="codex",
+        env_index=1,
+        auth_kind="device_code",
+    )
+    auth_json = json.dumps({"access_token": "device-token"})
+    monkeypatch.setenv("LLM_PROVIDER_1_CODEX_AUTH_JSON", auth_json)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    slug = "openai/gpt-5.3-codex"
+    env = build_agent_env("codex", model=slug)
+    assert env.get("CODEX_AUTH_JSON") == auth_json
+
+
+def test_cloud_chain_maps_bedrock_suffixes_only(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(
+        tmp_path,
+        label="bedrock",
+        harness="claude",
+        env_index=1,
+        auth_kind="cloud_chain",
+    )
+    monkeypatch.setenv("LLM_PROVIDER_1_AWS_ACCESS_KEY_ID", "AKIA...")
+    monkeypatch.setenv("LLM_PROVIDER_1_AWS_SECRET_ACCESS_KEY", "secret...")
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    slug = "bedrock/us.anthropic.claude-sonnet"
+    env = build_agent_env("claude", model=slug)
+    assert env.get("AWS_ACCESS_KEY_ID") == "AKIA..."
+    assert env.get("AWS_SECRET_ACCESS_KEY") == "secret..."
+
+
+def test_harness_env_maps_only_active_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(tmp_path, label="openai", harness="codex", env_index=1)
+    write_registry_provider_row(
+        tmp_path,
+        label="google",
+        harness="gemini",
+        env_index=2,
+        url=None,
+    )
+    monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", "openai-only")
+    monkeypatch.setenv("LLM_PROVIDER_2_API_KEY", "google-should-not-leak")
+
+    env = build_agent_env("codex", model="openai/gpt-5.3-codex")
+    assert env.get("OPENAI_API_KEY") == "openai-only"
+    assert "GEMINI_API_KEY" not in env

--- a/tests/integration/test_provider_failures.py
+++ b/tests/integration/test_provider_failures.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from mergecraft.agents.shared import AgentResult
 from mergecraft.config.settings import RepoSettings
 from mergecraft.utils.agent_resolve import _is_retryable_failure, run_with_model_chain
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.asyncio
@@ -79,21 +84,58 @@ def test_parse_failure_is_not_retryable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_opencode_retries_at_most_once(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_opencode_retries_at_most_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """OpenCode gets the initial attempt plus exactly one retry, then the chain
     stops spending wall clock on that harness (#444).
     """
-    monkeypatch.setenv("NOUS_API_KEY", "sk-test")
+    from tests.cli.support_provider_registry import (
+        NOUS_BASE_URL,
+        clear_legacy_gateway_env,
+        scaffold_mergecraft_home,
+        write_indexed_provider_secret,
+        write_registry_provider_row,
+    )
+
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_legacy_gateway_env(monkeypatch)
+    write_registry_provider_row(
+        tmp_path,
+        label="nous",
+        harness="opencode",
+        env_index=1,
+        url=NOUS_BASE_URL,
+        models=[
+            {"id": "deepseek/deepseek-v4-flash", "modelIndex": 1},
+            {"id": "deepseek/deepseek-v4-pro", "modelIndex": 2},
+            {"id": "qwen/qwen3.8-max", "modelIndex": 3},
+        ],
+    )
+    write_indexed_provider_secret(
+        tmp_path,
+        env_index=1,
+        label="nous",
+        api_key="sk-test",
+    )
+    monkeypatch.setenv("LLM_PROVIDER_1", "nous")
+    monkeypatch.setenv("LLM_PROVIDER_1_API_KEY", "sk-test")
     monkeypatch.setattr(
         "mergecraft.utils.agent_resolve._agent_binary_available", lambda _slug: True
     )
+    from mergecraft.config.settings import load_repo_settings
+
+    base_settings = load_repo_settings(root=tmp_path, load_learnings_files=False)
     settings = RepoSettings.model_validate(
         {
+            **base_settings.model_dump(),
             "models": [
                 "nous/deepseek/deepseek-v4-flash",
                 "nous/deepseek/deepseek-v4-pro",
                 "nous/qwen/qwen3.8-max",
-            ]
+            ],
         }
     )
     attempts: list[str] = []

--- a/tests/test_main_phases.py
+++ b/tests/test_main_phases.py
@@ -79,13 +79,18 @@ async def test_run_context_carries_every_phase_input(
         signed_commits=True,
         analyzers=AnalyzersSettings(sarif_upload=True),
     )
+    explicit_model = "anthropic/claude-sonnet"
     rec = await run_main_for_test(
         monkeypatch=monkeypatch,
         tmp_path=tmp_path,
         settings=settings,
         event_name="workflow_dispatch",
         event_payload={"action": "workflow_dispatch"},
-        env={"INPUT_MODEL": "test-model-xyz", "INPUT_ANALYZERS": "full"},
+        env={
+            "INPUT_MODEL": explicit_model,
+            "INPUT_ANALYZERS": "full",
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-test-token",
+        },
     )
     assert rec.result is not None
     assert rec.result.success, f"run failed: {rec.result}"
@@ -109,7 +114,7 @@ async def test_run_context_carries_every_phase_input(
     assert ctx.git_token == "ghs_fake_git_token"
 
     # -- execute-phase locals -- filled onto the *same* object after setup --
-    assert ctx.resolved_model == "test-model-xyz"
+    assert ctx.resolved_model == explicit_model
     assert ctx.mcp_server_url == "http://127.0.0.1:0/mcp"
 
     # tool_state carries its own share of the sprawl, threaded from the

--- a/tests/tracing/instrumentation/test_span_tree.py
+++ b/tests/tracing/instrumentation/test_span_tree.py
@@ -159,22 +159,22 @@ def test_instrumentation_is_noop_when_disabled(disabled_tracing: Any, tmp_path: 
     assert hasattr(disabled_tracing, "write")
 
 
-def test_run_root_is_single_when_tracing_enabled(captured_sink: Any) -> None:
-    """W3.1 (negative) — only one root span is emitted per run.
-
-    The issue's §3 tree has ``mergecraft.run`` as the single root; this
-    pin catches the trivial mistake of opening a second root span at one of
-    the child sites.
-    """
+def test_run_root_is_single_when_tracing_enabled(
+    captured_sink: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """W3.1 (negative) — only one root span is emitted per run."""
     import asyncio
 
     from mergecraft.config import RepoSettings
     from mergecraft.utils.agent_resolve import run_with_model_chain
 
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-span-tree-test")
+
     settings = RepoSettings.model_validate(
         {
             "tracing": {"enabled": True, "sinks": [{"type": "memory"}]},
-            "models": ["claude/sonnet"],
+            "models": ["anthropic/claude-sonnet"],
         }
     )
 

--- a/tests/utils/test_cov_agent_resolve_paths.py
+++ b/tests/utils/test_cov_agent_resolve_paths.py
@@ -25,6 +25,8 @@ from mergecraft.models import BEDROCK_MODEL_ID_ENV, VERTEX_MODEL_ID_ENV
 from mergecraft.utils import agent_resolve as ar
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
 
 # Every env var any credential probe in ``agent_resolve`` reads. Cleared for
@@ -140,19 +142,41 @@ def test_vertex_needs_both_service_account_and_a_pinned_model_id(
 
 
 def test_gateway_providers_read_their_preset_key_and_the_custom_alias(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """``nous``/``tokenhub``/``minimax`` all route through the gateway helper."""
+    """Registered gateway providers resolve credentials via indexed registry secrets."""
+    from tests.cli.support_provider_registry import (
+        bootstrap_nous_registry,
+        bootstrap_opencode_gateway,
+    )
+
     assert ar.has_credentials_for_slug("nous/deepseek-v4") is False
     assert ar.has_credentials_for_slug("tokenhub/hy3") is False
     assert ar.has_credentials_for_slug("minimax/MiniMax-M3") is False
 
-    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek-v4", api_key="nous-key")
     assert ar.has_credentials_for_slug("nous/deepseek-v4") is True
     assert ar.has_credentials_for_slug("tokenhub/hy3") is False
 
-    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", "custom-key")
-    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", "https://example.invalid/v1")
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="minimax",
+        url="https://api.minimax.io/v1",
+        model_id="MiniMax-M3",
+        api_key="custom-key",
+        env_index=2,
+    )
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        model_id="hy3",
+        api_key="custom-key",
+        env_index=3,
+    )
     assert ar.has_credentials_for_slug("minimax/MiniMax-M3") is True
     assert ar.has_credentials_for_slug("tokenhub/hy3") is True
 
@@ -582,11 +606,17 @@ def test_empty_chain_result_is_a_flagged_failure() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_agent_mode_for_slug_maps_each_native_provider_and_defaults_to_opencode() -> None:
+def test_agent_mode_for_slug_maps_each_native_provider_and_defaults_to_opencode(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from tests.cli.support_provider_registry import bootstrap_nous_registry
+
     assert ar._agent_mode_for_slug("anthropic/claude-sonnet") == "claude"
     assert ar._agent_mode_for_slug("openai/gpt") == "codex"
     assert ar._agent_mode_for_slug("google/gemini-3-pro") == "gemini"
     assert ar._agent_mode_for_slug("cursor/composer") == "cursor"
+    bootstrap_nous_registry(tmp_path, monkeypatch, model_id="deepseek-v4")
     assert ar._agent_mode_for_slug("nous/deepseek-v4") == "opencode"
     assert ar._agent_provider_for_slug("no-slash-here") == "unknown"
 
@@ -597,8 +627,8 @@ def test_resolve_harness_infers_when_unset_and_validates_when_set() -> None:
 
     explicit = RepoSettings.model_validate({"harness": "opencode"})
     assert ar.resolve_harness(explicit, "openai/gpt") == "opencode"
-    # Uncatalogued prefixes route through OpenCode too.
-    assert ar.resolve_harness(explicit, "acme/private-1") == "opencode"
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"incompatible|not registered"):
+        ar.resolve_harness(explicit, "acme/private-1")
 
 
 def test_opencode_refuses_a_catalogued_provider_it_does_not_serve() -> None:
@@ -796,32 +826,64 @@ def test_credentialled_native_providers_resolve_to_their_agent(
     assert ar.resolve_runtime_agent(model="openai/gpt").name == "codex"
 
 
-def test_anthropic_without_credentials_falls_through_to_opencode() -> None:
-    """Anthropic is the one native provider with no fail-loud arm."""
-    assert ar.resolve_runtime_agent(model="anthropic/claude-sonnet").name == "opencode"
+def test_anthropic_without_credentials_raises_configuration_error() -> None:
+    """Anthropic without credentials is a configuration error (no opencode fallback)."""
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
+        ar.resolve_runtime_agent(model="anthropic/claude-sonnet")
 
 
-def test_gateway_providers_fail_loud_with_their_own_auth_command() -> None:
-    with pytest.raises(ValueError, match="mergecraft auth nous"):
+def test_gateway_providers_fail_loud_with_registry_guidance() -> None:
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
         ar.resolve_runtime_agent(model="nous/deepseek-v4")
-    with pytest.raises(ValueError, match="mergecraft auth tokenhub"):
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
         ar.resolve_runtime_agent(model="tokenhub/hy3")
-    with pytest.raises(ValueError, match="mergecraft auth minimax"):
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
         ar.resolve_runtime_agent(model="minimax/MiniMax-M3")
 
 
 def test_gateway_providers_resolve_to_opencode_once_credentialled(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("NOUS_API_KEY", "nous-key")
-    monkeypatch.setenv("TOKENHUB_API_KEY", "th-key")
-    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_API_KEY", "custom-key")
-    monkeypatch.setenv("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL", "https://example.invalid/v1")
-    assert ar.resolve_runtime_agent(model="nous/deepseek-v4").name == "opencode"
-    assert ar.resolve_runtime_agent(model="tokenhub/hy3").name == "opencode"
-    assert ar.resolve_runtime_agent(model="minimax/MiniMax-M3").name == "opencode"
+    from tests.cli.support_provider_registry import (
+        NOUS_BASE_URL,
+        NOUS_DEEPSEEK_V4,
+        bootstrap_opencode_gateway,
+    )
+
+    nous_slug = bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="nous",
+        url=NOUS_BASE_URL,
+        model_id=NOUS_DEEPSEEK_V4,
+        api_key="nous-key",
+    )
+    tokenhub_slug = bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        model_id="hy3",
+        api_key="th-key",
+        env_index=2,
+    )
+    minimax_slug = bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="minimax",
+        url="https://api.minimax.io/v1",
+        model_id="MiniMax-M3",
+        api_key="custom-key",
+        env_index=3,
+    )
+    assert ar.resolve_runtime_agent(model=nous_slug).name == "opencode"
+    assert ar.resolve_runtime_agent(model=tokenhub_slug).name == "opencode"
+    assert ar.resolve_runtime_agent(model=minimax_slug).name == "opencode"
 
 
-def test_unknown_provider_and_no_model_both_land_on_opencode() -> None:
-    assert ar.resolve_runtime_agent(model="acme/private-1").name == "opencode"
-    assert ar.resolve_runtime_agent(model=None).name == "opencode"
+def test_unknown_provider_and_no_model_both_raise_configuration_error() -> None:
+    with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
+        ar.resolve_runtime_agent(model="acme/private-1")
+    with pytest.raises(ar.ModelFallbackPolicyError, match="no model configured"):
+        ar.resolve_runtime_agent(model=None)

--- a/tests/utils/test_cov_agent_resolve_paths.py
+++ b/tests/utils/test_cov_agent_resolve_paths.py
@@ -882,8 +882,10 @@ def test_gateway_providers_resolve_to_opencode_once_credentialled(
     assert ar.resolve_runtime_agent(model=minimax_slug).name == "opencode"
 
 
-def test_unknown_provider_and_no_model_both_raise_configuration_error() -> None:
+def test_unknown_provider_raises_configuration_error() -> None:
     with pytest.raises(ar.ModelFallbackPolicyError, match=r"not registered|provider add"):
         ar.resolve_runtime_agent(model="acme/private-1")
-    with pytest.raises(ar.ModelFallbackPolicyError, match="no model configured"):
-        ar.resolve_runtime_agent(model=None)
+
+
+def test_no_model_falls_back_to_opencode() -> None:
+    assert ar.resolve_runtime_agent(model=None).name == "opencode"

--- a/tests/utils/test_cov_agent_resolve_paths.py
+++ b/tests/utils/test_cov_agent_resolve_paths.py
@@ -653,6 +653,41 @@ def test_attempt_harness_label_prefers_the_explicit_override() -> None:
     assert ar._attempt_harness_label(RepoSettings.model_validate({}), "openai/gpt") == "codex"
 
 
+def test_attempt_harness_label_degrades_for_unregistered_follow_on_slug() -> None:
+    """Synthetic follow-on spans must not raise when inference fails."""
+    with pytest.raises(ar.ModelFallbackPolicyError):
+        ar._agent_mode_for_slug("custom/unregistered-model")
+    assert ar._attempt_harness_label(None, "custom/unregistered-model") == "opencode"
+
+
+def test_follow_on_spans_do_not_crash_on_unregistered_tail() -> None:
+    """A successful run must not crash while emitting not_visited follow-on spans."""
+    import asyncio
+
+    from mergecraft.agents.shared import AgentResult
+    from mergecraft.tracing.sinks import sink_factory
+
+    settings = RepoSettings.model_validate(
+        {
+            "harness": "opencode",
+            "models": ["openai/gpt", "custom/unregistered-model"],
+            "tracing": {"enabled": True, "sinks": [{"type": "memory"}]},
+        }
+    )
+    wrapper = sink_factory(settings.tracing)
+    memory = wrapper.inner.sinks[0]
+
+    async def run_once(_slug: str) -> AgentResult:
+        return AgentResult(success=True, terminal_submission_received=True)
+
+    slug, _ = asyncio.run(ar.run_with_model_chain(settings=settings, run_once=run_once))
+    assert slug == "openai/gpt"
+
+    attempts = [event for event in memory.events if getattr(event, "kind", None) == "agent.attempt"]
+    assert len(attempts) >= 2
+    assert any(getattr(event, "status", None) == "not_visited" for event in attempts)
+
+
 # ---------------------------------------------------------------------------
 # cost attrs
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_gateway_providers.py
+++ b/tests/utils/test_gateway_providers.py
@@ -7,8 +7,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from mergecraft.agents.openai_compatible_gateways import (
+    CUSTOM_PROVIDER_API_KEY_ENV,
     resolve_gateway_endpoint,
 )
+from mergecraft.cli.provider_cmd import seed_builtin_providers
 from mergecraft.utils.agent_resolve import (
     has_credentials_for_slug,
     resolve_runtime_agent,
@@ -17,6 +19,7 @@ from tests.cli.support_provider_registry import (
     bootstrap_nous_registry,
     bootstrap_opencode_gateway,
     clear_legacy_gateway_env,
+    scaffold_mergecraft_home,
 )
 
 if TYPE_CHECKING:
@@ -25,6 +28,7 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
 TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 NOUS_DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash"
 
 
@@ -99,6 +103,31 @@ def test_resolve_runtime_agent_routes_gateways_to_opencode(
     )
     agent = resolve_runtime_agent(model=nous_slug)
     assert agent.name == "opencode"
+
+
+def test_seeded_registry_with_legacy_env_resolves_to_opencode(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Init seeds tokenhub/minimax rows; legacy env alone must still resolve (PR #494)."""
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_legacy_gateway_env(monkeypatch)
+    for index in range(1, 8):
+        monkeypatch.delenv(f"LLM_PROVIDER_{index}", raising=False)
+        monkeypatch.delenv(f"LLM_PROVIDER_{index}_API_KEY", raising=False)
+
+    config_path = tmp_path / ".mergecraft" / "config.yaml"
+    seed_builtin_providers(config_path)
+
+    monkeypatch.setenv("TOKENHUB_API_KEY", "th-legacy-key")
+    assert has_credentials_for_slug("tokenhub/hy3") is True
+    assert resolve_runtime_agent(model="tokenhub/hy3").name == "opencode"
+
+    clear_legacy_gateway_env(monkeypatch)
+    monkeypatch.setenv(CUSTOM_PROVIDER_API_KEY_ENV, "mm-legacy-key")
+    assert has_credentials_for_slug("minimax/MiniMax-M3") is True
+    assert resolve_runtime_agent(model="minimax/MiniMax-M3").name == "opencode"
 
 
 def test_resolve_gateway_endpoint_tokenhub_default_url(

--- a/tests/utils/test_gateway_providers.py
+++ b/tests/utils/test_gateway_providers.py
@@ -13,60 +13,110 @@ from mergecraft.utils.agent_resolve import (
     has_credentials_for_slug,
     resolve_runtime_agent,
 )
+from tests.cli.support_provider_registry import (
+    bootstrap_nous_registry,
+    bootstrap_opencode_gateway,
+    clear_legacy_gateway_env,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
+
+TOKENHUB_BASE_URL = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+NOUS_DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash"
 
 
 @pytest.fixture(autouse=True)
 def _clear_gateway_env(monkeypatch: MonkeyPatch) -> None:
+    clear_legacy_gateway_env(monkeypatch)
     for key in (
-        "NOUS_API_KEY",
-        "NOUS_BASE_URL",
-        "TOKENHUB_API_KEY",
-        "TOKENHUB_BASE_URL",
-        "MERGECRAFT_CUSTOM_PROVIDER_BASE_URL",
-        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
         "MERGECRAFT_AGENT",
         "OPENAI_API_KEY",
         "CODEX_AUTH_JSON",
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
+        "LLM_PROVIDER_1",
+        "LLM_PROVIDER_1_API_KEY",
+        "LLM_PROVIDER_2",
+        "LLM_PROVIDER_2_API_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
 
 
-def test_has_credentials_for_nous_and_tokenhub(monkeypatch: MonkeyPatch) -> None:
+def test_has_credentials_for_nous_and_tokenhub(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     assert not has_credentials_for_slug("nous/deepseek/deepseek-v4-flash")
     assert not has_credentials_for_slug("tokenhub/hy3")
 
-    monkeypatch.setenv("NOUS_API_KEY", "n-key")
-    assert has_credentials_for_slug("nous/deepseek/deepseek-v4-flash")
+    bootstrap_nous_registry(
+        tmp_path,
+        monkeypatch,
+        model_id=NOUS_DEEPSEEK_MODEL,
+        api_key="n-key",
+    )
+    assert has_credentials_for_slug(f"nous/{NOUS_DEEPSEEK_MODEL}")
 
-    monkeypatch.delenv("NOUS_API_KEY")
-    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
+    clear_legacy_gateway_env(monkeypatch)
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url=TOKENHUB_BASE_URL,
+        model_id="hy3",
+        api_key="t-key",
+        env_index=2,
+    )
     assert has_credentials_for_slug("tokenhub/hy3")
     assert has_credentials_for_slug("tokenhub/deepseek-v4-flash")
 
 
 def test_resolve_runtime_agent_routes_gateways_to_opencode(
+    tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
-    agent = resolve_runtime_agent(model="tokenhub/hy3")
+    tokenhub_slug = bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url=TOKENHUB_BASE_URL,
+        model_id="hy3",
+        api_key="t-key",
+        env_index=2,
+    )
+    agent = resolve_runtime_agent(model=tokenhub_slug)
     assert agent.name == "opencode"
 
-    monkeypatch.delenv("TOKENHUB_API_KEY")
-    monkeypatch.setenv("NOUS_API_KEY", "n-key")
-    agent = resolve_runtime_agent(model="nous/deepseek/deepseek-v4-flash")
+    nous_slug = bootstrap_nous_registry(
+        tmp_path,
+        monkeypatch,
+        model_id=NOUS_DEEPSEEK_MODEL,
+        api_key="n-key",
+    )
+    agent = resolve_runtime_agent(model=nous_slug)
     assert agent.name == "opencode"
 
 
-def test_resolve_gateway_endpoint_tokenhub_default_url(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("TOKENHUB_API_KEY", "t-key")
+def test_resolve_gateway_endpoint_tokenhub_default_url(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    bootstrap_opencode_gateway(
+        tmp_path,
+        monkeypatch,
+        label="tokenhub",
+        url=TOKENHUB_BASE_URL,
+        model_id="hy3",
+        api_key="t-key",
+        env_index=2,
+    )
     endpoint = resolve_gateway_endpoint("tokenhub/hy3")
     assert endpoint == (
         "tokenhub",
-        "https://tokenhub-intl.tencentcloudmaas.com/v1",
+        TOKENHUB_BASE_URL,
         "t-key",
     )


### PR DESCRIPTION
## What?

Operators can manage LLM providers and models from the CLI instead of hand-editing env vars and config.

- Add, list, edit, and delete providers with indexed secrets and config entries.
- Add, list, and delete models per provider.
- Set agent primary and backup models without wiping the existing chain.
- Authenticate any provider through one command instead of provider-specific auth subcommands.
- Migrate legacy API key env vars with a dry-run-first migrate path.
- Author workflow env and model fields from the CLI.
- Treat Nous like any other registry provider.

## Why?

Providers and models were hardcoded or scattered across one-off env vars and bespoke auth commands. Setting up a new provider or swapping models meant tracing multiple files and remembering non-obvious secret names. A single registry with consistent commands makes BYOK setup predictable and keeps credentials out of committed config.

## Note

Secrets live in indexed env keys; structure lives in `.mergecraft/config.yaml`. Legacy API key env vars still work for one release with a once-per-process warning; registry keys win. Merge closes #476 through #484; draft-close comments are already posted on each issue.

## Test plan

- [x] `make ci-resume` — 14/14 steps locally
- [x] Lane B reference suite (195 tests)
- [x] Thermos runtime fixes through round 3
- Remote CI: static, build, security, integration, and E2E checks green; test matrix shards failing at last push

## Related PR(s)/Issue(s)

Closes #476 — unified provider and model registry (lane B tracker)
Closes #477 — provider add/list/edit/delete
Closes #478 — unified provider auth
Closes #479 — model add/list/delete per provider
Closes #480 — agents setmodel and addbackupmodel
Closes #481 — Nous as an ordinary registry provider
Closes #483 — provider migrate and config/secret split
Closes #484 — workflow CLI authoring
