### PR TITLE
fix(ci): resolve empty GITHUB_BASE_REF on push events

### DIFF
--- a/scripts/check_coverage_ratchet.py
+++ b/scripts/check_coverage_ratchet.py
@@ -66,10 +66,28 @@ def _fail_under_from_git_ref(repo_root: Path, ref: str) -> float | None:
     return float(floor)
 
 
+def _default_base_branch() -> str:
+    """Resolve the branch used for merge-base ``fail_under`` comparisons.
+
+    ``GITHUB_BASE_REF`` is set for pull requests but empty on ``push`` /
+    ``workflow_dispatch``. Treat blank values as unset and fall back to the
+    branch being built (``GITHUB_REF``), then ``pre-0.0.1``.
+    """
+    explicit = (os.environ.get("GITHUB_BASE_REF") or "").strip()
+    if explicit:
+        return explicit
+    ref = (os.environ.get("GITHUB_REF") or "").strip()
+    if ref.startswith("refs/heads/"):
+        branch = ref.removeprefix("refs/heads/").strip()
+        if branch:
+            return branch
+    return "pre-0.0.1"
+
+
 def _merge_base_ref(repo_root: Path, *, base_ref: str | None = None) -> str | None:
     if base_ref is not None:
         return base_ref
-    base_branch = os.environ.get("GITHUB_BASE_REF", "pre-0.0.1")
+    base_branch = _default_base_branch()
     remote_base = f"origin/{base_branch}"
     result = subprocess.run(
         ["git", "merge-base", "HEAD", remote_base],
@@ -97,7 +115,7 @@ def _fail_under_from_merge_base(
     base_ref: str | None = None,
 ) -> tuple[float | None, str | None]:
     root = _repo_root(repo_root)
-    base_branch = os.environ.get("GITHUB_BASE_REF", "pre-0.0.1")
+    base_branch = _default_base_branch()
     remote_base = f"origin/{base_branch}"
     merge_base = _merge_base_ref(root, base_ref=base_ref)
     if merge_base is None:

--- a/tests/ci/test_coverage_ratchet.py
+++ b/tests/ci/test_coverage_ratchet.py
@@ -125,3 +125,22 @@ def test_ratchet_passes_within_margin(tmp_path: Path) -> None:
     report = _coverage_json(tmp_path, floor + 1.0)
     rc = _run_ratchet(check, report, margin=5.0)
     assert rc == 0
+
+
+def test_ratchet_passes_when_github_base_ref_empty_on_push(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Push events expose ``GITHUB_BASE_REF=""``; must not resolve to ``origin/``."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_BASE_REF", "")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/pre-0.0.1")
+
+    module = _load_ratchet()
+    check = getattr(module, "check_coverage_ratchet", None) or getattr(module, "main", None)
+    assert callable(check)
+    floor = _fail_under()
+    report = _coverage_json(tmp_path, floor + 1.0)
+    rc = _run_ratchet(check, report, margin=5.0)
+    assert rc == 0


### PR DESCRIPTION
## Summary
- Fix coverage ratchet merge-base lookup on push events where `GITHUB_BASE_REF` is an empty string (not unset), which produced invalid `origin/` refs and failed CI across all test shards and the coverage gate.
- Fall back to `GITHUB_REF`'s branch name, then `pre-0.0.1`, when the base ref is blank.
- Add regression test simulating push CI env (`GITHUB_BASE_REF=""`, `GITHUB_REF=refs/heads/pre-0.0.1`).

## Root cause
Run `32840245755` (push of PR #500 merge to `pre-0.0.1`) failed with:
```
merge-base lookup failed for HEAD vs origin/
```
Only 3 ratchet contract tests failed per shard (not a broad suite regression); multiple CI jobs appeared red because the same tests run in each shard plus `coverage-gate`.

## Test plan
- [x] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/ci/test_coverage_ratchet.py tests/ci/test_coverage_ratchet_honesty.py` with push-like CI env
- [x] Ruff check/format on touched files