### PR TITLE
fix(ci): tracing extra and enterprise reset for sink handoff

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,9 @@ jobs:
           # tag builds. Full history is what makes those answers truthful.
           fetch-depth: 0
       - uses: ./.github/actions/bootstrap
+        env:
+          # Exporter unit tests run in coverage-measure (D14 / TH8) — match ci.yml.
+          MERGECRAFT_UV_EXTRAS: tracing
       - name: make ci
         run: make ci
 

--- a/src/mergecraft/tracing/tracer.py
+++ b/src/mergecraft/tracing/tracer.py
@@ -431,6 +431,15 @@ def reset_process_tracer_cache() -> None:
         _PENDING_SINK.set(None)
     except ImportError:
         pass
+    # Enterprise telemetry opt-out/off is process-local; a prior test that bound
+    # it without the enterprise package conftest must not make ``sink_factory``
+    # skip OTLP children when ``claim_sink`` rebuilds after a discarded handoff.
+    try:
+        from mergecraft.enterprise.runtime import reset_enterprise_runtime
+
+        reset_enterprise_runtime()
+    except ImportError:
+        pass
 
 
 def resolve_trace_id(*, pin: bool = False) -> str:


### PR DESCRIPTION
## Summary
- **ci-cd.yml**: install the `tracing` uv extra in Full verify bootstrap (matches `ci.yml` coverage-gate) so `coverage-measure` OTLP exporter tests resolve `OTLPSink` instead of `NullSink`.
- **tracer.py**: clear enterprise telemetry binding in `reset_process_tracer_cache()` so a leaked `opt-out`/`off` state cannot make `sink_factory` skip OTLP children when `claim_sink` rebuilds after discarding a stale memory handoff.

## Root cause
`make ci` in CI/CD Full verify bootstrapped without `MERGECRAFT_UV_EXTRAS=tracing`, while sharded PR CI and the coverage-gate job already sync tracing. Without logfire/otel installed, `claim_sink` correctly degrades to `NullSink` — the handoff discard path worked, but OTLP construction could not run.

Secondary: enterprise `ContextVar` opt-out could leak across tests that only reset the tracer cache, also yielding `NullSink` for OTLP sinks in full-suite ordering.

## Test plan
- [x] `tests/tracing/exporters/test_claim_sink_handoff.py` (2 tests)
- [x] `tests/tracing/streaming/` (14 tests)
- [x] Enterprise opt-out ordering: `test_telemetry_off_skips_remote_sinks` + claim_sink handoff tests
- [x] Manual simulation: opt-out bind → memory handoff → `reset_process_tracer_cache` → `claim_sink(otel)` → `OTLPSink`
- [x] `make typecheck` on touched paths; ruff on `tracer.py`