### PR TITLE
tests: lane A privilege boundary RED suite

### DIFF
--- a/docs/test-plans/audit-remediation-privilege.md
+++ b/docs/test-plans/audit-remediation-privilege.md
@@ -1,0 +1,38 @@
+"""Lane A AP1 — contract → test mapping for privilege & execution boundary."""
+
+# Audit remediation — lane A (privilege & execution)
+
+| Contract | Finding | Green wave | Test module |
+| --- | --- | --- | --- |
+| Root-side git ignores hostile `.git/config` | MCB-01 | AP2 | `tests/security/test_hostile_git_config.py` |
+| `git_argv` pins safe config keys | MCB-01 | AP2 | `tests/utils/test_git_hardening.py` |
+| `.git` not chowned to agent | D3 | AP2 | `tests/utils/test_privilege_chown.py` |
+| Manifest rev leading-dash guard | MCB-33 | AP2 | `tests/xrepo/test_rev_parse_guards.py` |
+| Bare `["git", …]` lint checker | D2 | AP2 | `tests/ci/test_git_argv_lint.py` |
+| Capability probes not CI-gated | MCB-09 | AP3 | `tests/analyzers/test_sandbox_probes.py` |
+| Skip finding visible | MCB-09 | AP3 | `tests/analyzers/test_sandbox_skip_visibility.py` |
+| Unsandboxed shell fail-closed | MCB-07 | AP3 | `tests/mcp/test_shell_fallback.py` |
+| Netns absence removes capability | MCB-10 | AP3 | `tests/mcp/test_network_namespace.py` |
+| No secrets in argv | MCB-08 | AP4 | `tests/mcp/test_shell_spawn_argv.py` |
+| Git invariant in every branch | MCB-25 | AP4 | `tests/mcp/test_shell_git_invariant.py` |
+| OpenCode review permissions | MCB-06 | AP5 | `tests/agents/test_opencode_permissions.py` |
+| Review integrity canaries | MCB-06 | AP5 | `tests/security/test_review_canary.py` |
+| Image identity gate | MCB-24 | AP6 | `tests/utils/test_privilege_identity.py` |
+| Hardened setpriv argv | MCB-32 | AP6 | `tests/utils/test_privilege_identity.py` |
+| Uid-independent prep tests | MCB-24 | AP6 | `tests/prep/test_prep_fail_closed.py` |
+| Prep env allowlist | MCB-22 | AP7 | `tests/prep/test_prep_env.py` |
+| Lockfile selection order | MCB-22 | AP7 | `tests/prep/test_prep_selection.py` |
+| Dedicated prep venv | MCB-22 | AP7 | `tests/prep/test_prep_venv.py` |
+
+## Host vs container (D17 / D18)
+
+| Suite | Host | Container (`mergecraft:lane-a`) |
+| --- | --- | --- |
+| AP1.1 git hardening | yes | optional |
+| AP1.2 sandbox probes (real mount/unshare) | partial | yes for mount probes |
+| AP1.3 shell argv | yes (mocked Popen) | yes for sudo branch |
+| AP1.4 OpenCode | yes | no |
+| AP1.5 privilege identity / setpriv | partial | yes |
+| AP1.6 prep | yes | no |
+
+Cross-wave reds use `@pytest.mark.xfail(strict=False)` until the greening wave lands.

--- a/docs/test-plans/audit-remediation-privilege.md
+++ b/docs/test-plans/audit-remediation-privilege.md
@@ -1,38 +1,123 @@
-"""Lane A AP1 — contract → test mapping for privilege & execution boundary."""
+# Audit remediation lane A — privilege & execution boundary — test plan
 
-# Audit remediation — lane A (privilege & execution)
+Wave plan: `.ignorelocal/waves/10-audit-remediation-a-privilege-execution-wave-plan.md`
+Authoring wave: **AP1** (RED). Implementation: **AP2–AP7**.
+xfail-reconciliation: per impl wave as each AP2–AP7 lands.
 
-| Contract | Finding | Green wave | Test module |
-| --- | --- | --- | --- |
-| Root-side git ignores hostile `.git/config` | MCB-01 | AP2 | `tests/security/test_hostile_git_config.py` |
-| `git_argv` pins safe config keys | MCB-01 | AP2 | `tests/utils/test_git_hardening.py` |
-| `.git` not chowned to agent | D3 | AP2 | `tests/utils/test_privilege_chown.py` |
-| Manifest rev leading-dash guard | MCB-33 | AP2 | `tests/xrepo/test_rev_parse_guards.py` |
-| Bare `["git", …]` lint checker | D2 | AP2 | `tests/ci/test_git_argv_lint.py` |
-| Capability probes not CI-gated | MCB-09 | AP3 | `tests/analyzers/test_sandbox_probes.py` |
-| Skip finding visible | MCB-09 | AP3 | `tests/analyzers/test_sandbox_skip_visibility.py` |
-| Unsandboxed shell fail-closed | MCB-07 | AP3 | `tests/mcp/test_shell_fallback.py` |
-| Netns absence removes capability | MCB-10 | AP3 | `tests/mcp/test_network_namespace.py` |
-| No secrets in argv | MCB-08 | AP4 | `tests/mcp/test_shell_spawn_argv.py` |
-| Git invariant in every branch | MCB-25 | AP4 | `tests/mcp/test_shell_git_invariant.py` |
-| OpenCode review permissions | MCB-06 | AP5 | `tests/agents/test_opencode_permissions.py` |
-| Review integrity canaries | MCB-06 | AP5 | `tests/security/test_review_canary.py` |
-| Image identity gate | MCB-24 | AP6 | `tests/utils/test_privilege_identity.py` |
-| Hardened setpriv argv | MCB-32 | AP6 | `tests/utils/test_privilege_identity.py` |
-| Uid-independent prep tests | MCB-24 | AP6 | `tests/prep/test_prep_fail_closed.py` |
-| Prep env allowlist | MCB-22 | AP7 | `tests/prep/test_prep_env.py` |
-| Lockfile selection order | MCB-22 | AP7 | `tests/prep/test_prep_selection.py` |
-| Dedicated prep venv | MCB-22 | AP7 | `tests/prep/test_prep_venv.py` |
+Locked decisions: **D2** (single `git_argv` helper + lint checker), **D5–D8** (capability
+not `CI`, fail-closed absent not degraded), **D9** (`sudo --preserve-env` by name),
+**D11** (image identity not uid), **D12** (prep venv isolation), **D14a** (tests-only in AP1),
+**D15** (real git at boundaries), **D17/D18** (container vs host split).
 
 ## Host vs container (D17 / D18)
 
-| Suite | Host | Container (`mergecraft:lane-a`) |
-| --- | --- | --- |
-| AP1.1 git hardening | yes | optional |
-| AP1.2 sandbox probes (real mount/unshare) | partial | yes for mount probes |
-| AP1.3 shell argv | yes (mocked Popen) | yes for sudo branch |
-| AP1.4 OpenCode | yes | no |
-| AP1.5 privilege identity / setpriv | partial | yes |
-| AP1.6 prep | yes | no |
+| Runs on host (macOS worktree) | Requires action image (`docker build -t mergecraft:lane-a .` + privileged run) |
+| --- | --- |
+| AP1.1 git hardening + hostile config (real `git`) | AP3/AP4/AP6 namespace / mount / `setpriv` proofs at Final |
+| AP1.4 OpenCode permissions + review canaries | — |
+| AP1.6 prep isolation (mocked subprocess) | — |
+| AP1.2/AP1.3 shell argv tests (mocked `Popen`) | Live `unshare`/`mount` if extending beyond mocks |
 
-Cross-wave reds use `@pytest.mark.xfail(strict=False)` until the greening wave lands.
+## xfail schedule
+
+All cross-wave markers use `strict=False` and name the greening wave in `reason`.
+
+| Greening wave | Test files | Marker reason prefix |
+| --- | --- | --- |
+| AP2 | `test_hostile_git_config.py`, `test_git_hardening.py`, `test_privilege_chown.py`, `test_rev_parse_guards.py`, `test_git_argv_lint.py` | `green after AP2` |
+| AP3 | `test_sandbox_probes.py`, `test_sandbox_skip_visibility.py`, `test_shell_fallback.py`, `test_network_namespace.py` (inverted rows) | `green after AP3` |
+| AP4 | `test_shell_spawn_argv.py`, `test_shell_git_invariant.py` | `green after AP4` |
+| AP5 | `test_opencode_permissions.py` (except `test_bash_stays_denied`), `test_review_canary.py` | `green after AP5` |
+| AP6 | `test_privilege_identity.py` | `green after AP6` |
+| AP7 | `test_prep_env.py`, `test_prep_selection.py`, `test_prep_venv.py` | `green after AP7` |
+
+`test_bash_stays_denied` is **not** xfailing — bash denial is already true on trunk.
+
+## Contract → coverage matrix
+
+### AP1.1 — root-side git (AP2, MCB-01 / MCB-33)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_root_side_status_does_not_execute_fsmonitor` | `tests/security/test_hostile_git_config.py` | Real `git status` via `_run_git`; `core.fsmonitor` sentinel must not appear |
+| `test_root_side_diff_does_not_execute_diff_external` | same | Real `git diff`; `diff.external` sentinel must not appear |
+| `test_commit_path_does_not_execute_fsmonitor` | same | Commit path must pin safe config (not only `hooksPath`) |
+| `test_insteadof_rewrite_does_not_leak_git_config_value_0` | same | `url.<host>.insteadOf` rewrite cannot fire on hardened argv |
+| `test_xrepo_checkout_is_equally_protected` | same | `xrepo.review._rev_parse_commit` equally hardened (H-7) |
+| `test_git_argv_pins_every_safe_config_key` | `tests/utils/test_git_hardening.py` | `GIT_SAFE_CONFIG` / `git_argv()` pins every D2 key |
+| `test_prepare_workspace_does_not_chown_dot_git` | `tests/utils/test_privilege_chown.py` | D3 — recursive chown skips `.git` |
+| `test_leading_dash_rev_is_rejected` | `tests/xrepo/test_rev_parse_guards.py` | MCB-33 leading-dash rev rejected |
+| `test_rev_parse_passes_end_of_options` | same | `--end-of-options` before rev in hardened argv |
+| `test_bare_git_list_literal_fails_the_checker` | `tests/ci/test_git_argv_lint.py` | D2 — `scripts/check_git_argv.py` rejects bare `["git", …]` |
+
+Fixtures: `tests/security/hostile_git_fixtures.py` (per-test repos); corpus
+`tests/security/fixtures/hostile-repo/` rebuilt via `build_hostile_repo.sh` (AP1.4b).
+
+### AP1.2 — sandbox capability (AP3, MCB-07/09/10/35)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_probe_does_not_consult_ci_env_var` | `tests/analyzers/test_sandbox_probes.py` | D5 — probe runs without `CI` as the answer |
+| `test_all_probes_share_one_privilege_ladder` | same | One sudo/unshare ladder across probes |
+| `test_probe_capabilities_is_cached` | same | MCB-35 — `lru_cache` on `probe_capabilities` |
+| `test_reset_detection_cache_clears_probe_cache` | same | D13 — cache cleared with `reset_detection_cache` |
+| `test_skipped_untrusted_analyzers_emit_a_finding` | `tests/analyzers/test_sandbox_skip_visibility.py` | D7 — `rule_id: analyzers.sandbox-unavailable` |
+| `test_unsandboxed_shell_refuses_by_default` | `tests/mcp/test_shell_fallback.py` | D8 — default refuse without isolation |
+| `test_allow_unsandboxed_env_var_overrides` | same | `MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1` opt-out |
+| `test_fallback_branch_masks_container_sockets_when_it_runs` | same | MCB-07 — fallback passes `wrapped` (socket mask) |
+| `test_untrusted_shell_absent_when_netns_unavailable` | `tests/mcp/test_network_namespace.py` | MCB-10 / D6 — shell tool absent when netns missing |
+| `test_unshare_argv_skips_net_when_probe_unavailable` | same | Inverted — spawn fails closed instead of omitting `--net` |
+| `test_network_namespace_available_true_when_unshare_net_succeeds_without_ci` | same | D5 — probe without `CI=true` |
+
+### AP1.3 — sudo argv + git invariant (AP4, MCB-08/25)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_no_provider_key_value_appears_in_any_branch_argv` | `tests/mcp/test_shell_spawn_argv.py` | D9 — no `PROVIDER_KEY_ENV_VARS` value in argv (all branches) |
+| `test_sudo_branch_uses_preserve_env_by_name` | same | `sudo --preserve-env=<names>`, not `sudo env KEY=val` |
+| `test_git_dir_is_read_only_in_every_branch` | `tests/mcp/test_shell_git_invariant.py` | D10 — `.git` ro bind in every spawn branch |
+| `test_git_binary_unavailable_in_untrusted_namespace` | same | Git binary masked/unavailable in namespace |
+
+### AP1.4 — OpenCode permissions (AP5, MCB-06)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_review_mode_denies_webfetch` | `tests/agents/test_opencode_permissions.py` | Review mode denies `webfetch` |
+| `test_review_mode_denies_external_directory` | same | Denies `external_directory` |
+| `test_review_mode_denies_edit` | same | Denies broad `edit` |
+| `test_review_mode_read_is_allowlisted_to_the_checkout` | same | Read allowlisted to checkout, not `*` |
+| `test_bash_stays_denied` | same | Guard — bash stays `deny` |
+| `test_outside_checkout_canary_is_unreadable` | `tests/security/test_review_canary.py` | Outside-checkout read boundary |
+| `test_provider_key_canary_does_not_reach_a_local_sink` | same | Provider key not in local sinks |
+| `test_config_yaml_is_unwritable_during_review` | same | `.mergecraft/config.yaml` integrity |
+
+### AP1.5 — privilege identity (AP6, MCB-24/32)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `_uid_independent_privilege_boundary` (autouse) | `tests/prep/test_prep_fail_closed.py` | AP1.4b — monkeypatch `prepare_workspace_for_agent` |
+| `test_root_outside_action_image_refuses_with_policy_message` | `tests/utils/test_privilege_identity.py` | D11 — policy refusal + diagnostic |
+| `test_allow_root_env_var_overrides` | same | `MERGECRAFT_ALLOW_ROOT=1` override |
+| `test_in_action_image_detects_is_sandbox_and_opt_dir` | same | `_in_action_image()` keys on `IS_SANDBOX` + `/opt/mergecraft` |
+| `test_setpriv_argv_carries_no_new_privs_and_cleared_caps` | same | MCB-32 — `--no-new-privs`, cap clearing |
+
+### AP1.6 — prep isolation (AP7, MCB-22)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_prep_env_is_a_real_allowlist` | `tests/prep/test_prep_env.py` | No `ANTHROPIC_API_KEY` / `GITHUB_TOKEN` in prep env |
+| `test_uv_lock_wins_over_a_stray_requirements_txt` | `tests/prep/test_prep_selection.py` | `uv.lock` wins over `requirements.txt` |
+| `test_cwd_is_threaded_not_read_twice` | same | Explicit cwd threading (not double `Path.cwd()`) |
+| `test_install_targets_a_dedicated_virtualenv` | `tests/prep/test_prep_venv.py` | D12 — install targets prep venv, not reviewer interpreter |
+
+## Imports of not-yet-existing symbols
+
+Symbols in `mergecraft.utils.git_hardening`, `mergecraft.security.review_integrity`,
+`mergecraft.prep.python._prep_env`, `utils.privilege._in_action_image`, and
+`scripts/check_git_argv.py` are imported **inside test bodies** (or via lazy
+`getattr`/`pytest.fail`) so collection succeeds before AP2–AP7 land.
+
+## Status
+
+AP1 RED suite authored on `wave/ap1-privilege-red`. Assertions fail or xfail pending
+AP2–AP7 implementation. Collection, `make lint`, and `make typecheck` must stay clean.

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -5,16 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from mergecraft.agents.opencode import build_security_config
 from mergecraft.agents.shared import AgentRunContext
 from mergecraft.mcp.tool_state import init_tool_state
-
-_XFAIL = pytest.mark.xfail(
-    reason="green after AP5: review-mode permission block in opencode.py",
-    strict=False,
-)
 
 
 def _ctx(tmp_path: Path) -> AgentRunContext:
@@ -37,27 +30,31 @@ def _permissions(tmp_path: Path) -> dict[str, object]:
     return perms
 
 
-@_XFAIL
 def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("webfetch") == "deny"
 
 
-@_XFAIL
 def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("external_directory") == "deny"
 
 
-@_XFAIL
 def test_review_mode_denies_edit(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("edit") == "deny"
 
 
-@_XFAIL
 def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
     read = _permissions(tmp_path).get("read")
     assert read != {"*": "allow"}
     assert isinstance(read, dict)
     assert any(str(tmp_path) in str(v) or v == "allow" for v in read.values())
+
+
+def test_review_mode_denies_git_config_under_checkout(tmp_path: Path) -> None:
+    read = _permissions(tmp_path).get("read")
+    assert isinstance(read, dict)
+    checkout = tmp_path.resolve().as_posix()
+    assert read.get(f"{checkout}/.git/config") == "deny"
+    assert read.get(f"{checkout}/.git/**") == "deny"
 
 
 def test_bash_stays_denied(tmp_path: Path) -> None:

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -11,7 +11,7 @@ from mergecraft.agents.opencode import build_security_config
 from mergecraft.agents.shared import AgentRunContext
 from mergecraft.mcp.tool_state import init_tool_state
 
-pytestmark = pytest.mark.xfail(
+_XFAIL = pytest.mark.xfail(
     reason="green after AP5: review-mode permission block in opencode.py",
     strict=False,
 )
@@ -37,18 +37,22 @@ def _permissions(tmp_path: Path) -> dict[str, object]:
     return perms
 
 
+@_XFAIL
 def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("webfetch") == "deny"
 
 
+@_XFAIL
 def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("external_directory") == "deny"
 
 
+@_XFAIL
 def test_review_mode_denies_edit(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("edit") == "deny"
 
 
+@_XFAIL
 def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
     read = _permissions(tmp_path).get("read")
     assert read != {"*": "allow"}
@@ -57,4 +61,5 @@ def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None
 
 
 def test_bash_stays_denied(tmp_path: Path) -> None:
+    """Guard — bash denial is already true on trunk; must not regress under AP5."""
     assert _permissions(tmp_path).get("bash") == "deny"

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -1,0 +1,60 @@
+"""Lane A AP1.4 — OpenCode review-mode permission narrowing (MCB-06 / D4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mergecraft.agents.opencode import build_security_config
+from mergecraft.agents.shared import AgentRunContext
+from mergecraft.mcp.tool_state import init_tool_state
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP5: review-mode permission block in opencode.py",
+    strict=False,
+)
+
+
+def _ctx(tmp_path: Path) -> AgentRunContext:
+    return AgentRunContext(
+        payload={"shell": "restricted", "push": "restricted"},
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions="review",
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_auth_token="token",
+    )
+
+
+def _permissions(tmp_path: Path) -> dict[str, object]:
+    raw = build_security_config(_ctx(tmp_path), "anthropic/claude-sonnet")
+    config = json.loads(raw)
+    perms = config.get("permission")
+    assert isinstance(perms, dict)
+    return perms
+
+
+def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("webfetch") == "deny"
+
+
+def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("external_directory") == "deny"
+
+
+def test_review_mode_denies_edit(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("edit") == "deny"
+
+
+def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
+    read = _permissions(tmp_path).get("read")
+    assert read != {"*": "allow"}
+    assert isinstance(read, dict)
+    assert any(str(tmp_path) in str(v) or v == "allow" for v in read.values())
+
+
+def test_bash_stays_denied(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("bash") == "deny"

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -7,11 +7,6 @@ import pytest
 from mergecraft.analyzers import sandbox as sandbox_mod
 from mergecraft.mcp import shell as shell_mod
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: capability probes replace CI short-circuit",
-    strict=False,
-)
-
 
 @pytest.fixture(autouse=True)
 def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -1,0 +1,85 @@
+"""Lane A AP1.2 — sandbox capability probes (MCB-07/09/10/35)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.analyzers import sandbox as sandbox_mod
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: capability probes replace CI short-circuit",
+    strict=False,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    shell_mod.reset_detection_cache()
+    if hasattr(sandbox_mod, "reset_detection_cache"):
+        sandbox_mod.reset_detection_cache()
+    if hasattr(sandbox_mod.probe_capabilities, "cache_clear"):
+        sandbox_mod.probe_capabilities.cache_clear()
+
+
+def test_probe_does_not_consult_ci_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        calls.append(list(cmd))
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    caps = sandbox_mod.probe_capabilities()
+    assert any("unshare" in " ".join(c) or "mount" in " ".join(c) for c in calls), (
+        "probes must attempt real capabilities even when CI is unset"
+    )
+    assert caps.pid_namespace or caps.unavailable_reasons
+
+
+def test_all_probes_share_one_privilege_ladder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every probe must share the same sudo/unshare fallback policy (D5)."""
+    monkeypatch.setenv("CI", "true")
+    seen: list[str] = []
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        seen.append(cmd[0])
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    sudo_hits = sum(1 for c in seen if c == "sudo")
+    unshare_hits = sum(1 for c in seen if c == "unshare")
+    assert sudo_hits == 0 or unshare_hits == 0 or sudo_hits > 0, (
+        "mixed privilege ladders across probes are forbidden"
+    )
+
+
+def test_probe_capabilities_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal calls
+        calls += 1
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    sandbox_mod.probe_capabilities()
+    assert calls == 1, "probe_capabilities must be lru_cached (MCB-35)"
+
+
+def test_reset_detection_cache_clears_probe_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal calls
+        calls += 1
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    shell_mod.reset_detection_cache()
+    sandbox_mod.probe_capabilities()
+    assert calls == 2, "reset_detection_cache must clear probe_capabilities cache"

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: analyzers.sandbox-unavailable finding",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -1,0 +1,45 @@
+"""Lane A AP1.2 — skipped untrusted analyzers emit a user-visible finding (MCB-09 / D7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: analyzers.sandbox-unavailable finding",
+    strict=False,
+)
+
+
+def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.analyzers.sandbox import plan_sandbox
+
+    monkeypatch.setattr(
+        "mergecraft.analyzers.sandbox.probe_capabilities",
+        lambda: type(
+            "C",
+            (),
+            {
+                "pid_namespace": False,
+                "network_namespace": False,
+                "read_only_bind": False,
+                "tmpfs": False,
+                "cgroup_memory": False,
+                "rlimit_nproc": True,
+                "unavailable_reasons": ["pid namespace unavailable"],
+            },
+        )(),
+    )
+    plan = plan_sandbox(
+        repo_root=Path("/tmp/repo"),
+        scratch_dir=Path("/tmp/scratch"),
+        trust_tier="untrusted",
+        manifests=(),
+    )
+    assert plan.can_run is False
+    assert plan.skip_reason is not None
+    finding = getattr(plan, "skip_finding", None) or getattr(plan, "finding", None)
+    assert finding is not None, (
+        "skipped untrusted tier must emit analyzers.sandbox-unavailable finding"
+    )

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -13,8 +13,10 @@ pytestmark = pytest.mark.xfail(
 
 
 def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.analyzers.manifest import load_manifest_file
     from mergecraft.analyzers.sandbox import plan_sandbox
 
+    manifest = load_manifest_file(Path("tests/analyzers/fixtures/manifests/valid-actionlint.yaml"))
     monkeypatch.setattr(
         "mergecraft.analyzers.sandbox.probe_capabilities",
         lambda: type(
@@ -32,10 +34,10 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
         )(),
     )
     plan = plan_sandbox(
+        manifest=manifest,
+        tier="untrusted",
         repo_root=Path("/tmp/repo"),
         scratch_dir=Path("/tmp/scratch"),
-        trust_tier="untrusted",
-        manifests=(),
     )
     assert plan.can_run is False
     assert plan.skip_reason is not None
@@ -43,3 +45,7 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
     assert finding is not None, (
         "skipped untrusted tier must emit analyzers.sandbox-unavailable finding"
     )
+    rule_id = getattr(finding, "rule_id", None) or (
+        finding.get("rule_id") if isinstance(finding, dict) else None
+    )
+    assert rule_id == "analyzers.sandbox-unavailable"

--- a/tests/ci/test_git_argv_lint.py
+++ b/tests/ci/test_git_argv_lint.py
@@ -6,13 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: scripts/check_git_argv.py wired into make lint",
-    strict=False,
-)
-
 _REPO = Path(__file__).resolve().parents[2]
 _CHECKER = _REPO / "scripts" / "check_git_argv.py"
 

--- a/tests/ci/test_git_argv_lint.py
+++ b/tests/ci/test_git_argv_lint.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.1 — ``check_git_argv`` lint gate (D2)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: scripts/check_git_argv.py wired into make lint",
+    strict=False,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_CHECKER = _REPO / "scripts" / "check_git_argv.py"
+
+
+def test_bare_git_list_literal_fails_the_checker(tmp_path: Path) -> None:
+    assert _CHECKER.is_file(), "scripts/check_git_argv.py must exist"
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'evil = ["git", "status"]\n',
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [sys.executable, str(_CHECKER), str(probe)],
+        cwd=_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode != 0, "bare ['git', …] literal must fail the checker"

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -1,4 +1,9 @@
-"""W12.7 — network-namespace probe + ``unshare --net`` argv shaping (``#35``)."""
+"""W12.7 — network-namespace probe + ``unshare --net`` argv shaping (``#35``).
+
+**Contract change (lane A / MCB-10):** when netns is unavailable the untrusted
+shell capability is **absent** — mergeCraft must not silently drop ``--net`` and
+continue. Tests below pin the new fail-closed contract; green after **AP3**.
+"""
 
 from __future__ import annotations
 
@@ -7,45 +12,46 @@ import pytest
 from mergecraft.mcp import shell as shell_mod
 from mergecraft.mcp.shell import _unshare_argv, network_namespace_available
 
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: netns absence removes untrusted shell capability",
+    strict=False,
+)
+
 
 @pytest.fixture(autouse=True)
 def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shell_mod, "_detected_netns", None)
+    shell_mod.reset_detection_cache()
 
 
 def test_network_namespace_available_false_outside_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable."""
+    """Capability probe must not treat CI as the answer (D5)."""
     monkeypatch.delenv("CI", raising=False)
+
+    class _Result:
+        returncode = 0
+
+    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is False
 
 
 def test_network_namespace_available_true_when_unshare_net_succeeds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — CI probe caches success when ``unshare --net true`` returns 0."""
-    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("CI", raising=False)
 
     class _Result:
         returncode = 0
 
     monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is True
-    # Cached — second call must not re-probe.
-    monkeypatch.setattr(
-        shell_mod.subprocess,
-        "run",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("re-probed")),
-    )
-    assert network_namespace_available() is True
 
 
 def test_network_namespace_available_false_when_unshare_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — ``OSError`` from missing ``unshare`` caches unavailable."""
-    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("CI", raising=False)
 
     def _boom(*_a: object, **_k: object) -> object:
         raise OSError("unshare not found")
@@ -57,7 +63,6 @@ def test_network_namespace_available_false_when_unshare_missing(
 def test_unshare_argv_omits_net_when_isolation_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — trusted / non-isolate path never appends ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     argv = _unshare_argv(isolate_network=False)
     assert argv[:4] == ["unshare", "--pid", "--fork", "--mount-proc"]
@@ -67,14 +72,23 @@ def test_unshare_argv_omits_net_when_isolation_disabled(
 def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-def test_unshare_argv_skips_net_when_probe_unavailable(
+def test_untrusted_shell_absent_when_netns_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — without netns, argv stays PID-only (credential isolation fallback)."""
+    """MCB-10 — missing netns removes the capability; do not spawn with ``--net`` dropped."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    assert "--net" not in _unshare_argv(isolate_network=True)
+    from unittest.mock import MagicMock
+
+    with pytest.raises((RuntimeError, PermissionError)):
+        shell_mod._spawn_shell(
+            "echo ok",
+            env={},
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=True,
+        )

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -34,28 +34,52 @@ def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     shell_mod.reset_detection_cache()
 
 
-def test_network_namespace_available_false_outside_ci(
+def test_network_namespace_available_false_when_probe_reports_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable (trunk)."""
+    """D5 — netns follows the capability probe, not ``CI``."""
+    from mergecraft.analyzers import sandbox as sandbox_mod
+
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(
+        sandbox_mod,
+        "probe_capabilities",
+        lambda: sandbox_mod.SandboxCapabilities(
+            pid_namespace=True,
+            network_namespace=False,
+            read_only_bind=True,
+            tmpfs=True,
+            cgroup_memory=False,
+            rlimit_nproc=True,
+            pid_namespace_method="unshare",
+        ),
+    )
+    shell_mod._reset_shell_detection_globals()
     assert network_namespace_available() is False
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: probe capability instead of sensing CI",
-    strict=False,
-)
 def test_network_namespace_available_true_when_unshare_net_succeeds_without_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """D5 — ``CI`` may hint but must not be the answer; probe ``unshare --net`` anyway."""
+    from mergecraft.analyzers import sandbox as sandbox_mod
+
     monkeypatch.delenv("CI", raising=False)
 
-    class _Result:
-        returncode = 0
-
-    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
+    monkeypatch.setattr(
+        sandbox_mod,
+        "probe_capabilities",
+        lambda: sandbox_mod.SandboxCapabilities(
+            pid_namespace=True,
+            network_namespace=True,
+            read_only_bind=True,
+            tmpfs=True,
+            cgroup_memory=False,
+            rlimit_nproc=True,
+            pid_namespace_method="unshare",
+        ),
+    )
+    shell_mod._reset_shell_detection_globals()
     assert network_namespace_available() is True
 
 
@@ -86,19 +110,15 @@ def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
+    monkeypatch.setattr(shell_mod, "_network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: netns absence must not silently omit --net",
-    strict=False,
-)
 def test_unshare_argv_skips_net_when_probe_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """MCB-10 inversion — isolate_network with no netns must fail closed, not omit ``--net``."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(shell_mod, "_network_namespace_available", lambda: False)
     with pytest.raises((RuntimeError, PermissionError, OSError)):
         _spawn_shell(
             "echo ok",
@@ -134,17 +154,15 @@ def _tool_ctx(
     )
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: untrusted shell absent when netns unavailable",
-    strict=False,
-)
 def test_untrusted_shell_absent_when_netns_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """D6 — missing netns removes the shell tool registration."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    import mergecraft.mcp.server as server_mod
+
+    monkeypatch.setattr(server_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(server_mod, "detect_sandbox_method", lambda: "unshare")
     names = {spec.name for spec in build_common_tools(_tool_ctx(tmp_path, trust_tier="untrusted"))}
     assert "shell" not in names
     assert "kill_background" not in names

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -2,20 +2,31 @@
 
 **Contract change (lane A / MCB-10):** when netns is unavailable the untrusted
 shell capability is **absent** — mergeCraft must not silently drop ``--net`` and
-continue. Tests below pin the new fail-closed contract; green after **AP3**.
+continue. Inverted expectations below are ``xfail`` until **AP3** lands.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Literal
+from unittest.mock import MagicMock
+
 import pytest
 
 from mergecraft.mcp import shell as shell_mod
-from mergecraft.mcp.shell import _unshare_argv, network_namespace_available
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: netns absence removes untrusted shell capability",
-    strict=False,
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
 )
+from mergecraft.mcp.server import build_common_tools
+from mergecraft.mcp.shell import _spawn_shell, _unshare_argv, network_namespace_available
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+TrustTier = Literal["trusted", "untrusted"]
 
 
 @pytest.fixture(autouse=True)
@@ -26,19 +37,19 @@ def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_network_namespace_available_false_outside_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Capability probe must not treat CI as the answer (D5)."""
+    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable (trunk)."""
     monkeypatch.delenv("CI", raising=False)
-
-    class _Result:
-        returncode = 0
-
-    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is False
 
 
-def test_network_namespace_available_true_when_unshare_net_succeeds(
+@pytest.mark.xfail(
+    reason="green after AP3: probe capability instead of sensing CI",
+    strict=False,
+)
+def test_network_namespace_available_true_when_unshare_net_succeeds_without_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """D5 — ``CI`` may hint but must not be the answer; probe ``unshare --net`` anyway."""
     monkeypatch.delenv("CI", raising=False)
 
     class _Result:
@@ -51,7 +62,8 @@ def test_network_namespace_available_true_when_unshare_net_succeeds(
 def test_network_namespace_available_false_when_unshare_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("CI", raising=False)
+    """W12.7 — ``OSError`` from missing ``unshare`` caches unavailable."""
+    monkeypatch.setenv("CI", "true")
 
     def _boom(*_a: object, **_k: object) -> object:
         raise OSError("unshare not found")
@@ -63,6 +75,7 @@ def test_network_namespace_available_false_when_unshare_missing(
 def test_unshare_argv_omits_net_when_isolation_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """W12.7 — trusted / non-isolate path never appends ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     argv = _unshare_argv(isolate_network=False)
     assert argv[:4] == ["unshare", "--pid", "--fork", "--mount-proc"]
@@ -72,19 +85,22 @@ def test_unshare_argv_omits_net_when_isolation_disabled(
 def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-def test_untrusted_shell_absent_when_netns_unavailable(
+@pytest.mark.xfail(
+    reason="green after AP3: netns absence must not silently omit --net",
+    strict=False,
+)
+def test_unshare_argv_skips_net_when_probe_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MCB-10 — missing netns removes the capability; do not spawn with ``--net`` dropped."""
+    """MCB-10 inversion — isolate_network with no netns must fail closed, not omit ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    from unittest.mock import MagicMock
-
-    with pytest.raises((RuntimeError, PermissionError)):
-        shell_mod._spawn_shell(
+    with pytest.raises((RuntimeError, PermissionError, OSError)):
+        _spawn_shell(
             "echo ok",
             env={},
             cwd="/tmp",
@@ -92,3 +108,43 @@ def test_untrusted_shell_absent_when_netns_unavailable(
             stderr=MagicMock(),
             isolate_network=True,
         )
+
+
+def _tool_ctx(
+    tmp_path: Path,
+    *,
+    trust_tier: TrustTier = "untrusted",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        trust_tier=trust_tier,
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after AP3: untrusted shell absent when netns unavailable",
+    strict=False,
+)
+def test_untrusted_shell_absent_when_netns_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D6 — missing netns removes the shell tool registration."""
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    names = {spec.name for spec in build_common_tools(_tool_ctx(tmp_path, trust_tier="untrusted"))}
+    assert "shell" not in names
+    assert "kill_background" not in names

--- a/tests/mcp/test_shell_fallback.py
+++ b/tests/mcp/test_shell_fallback.py
@@ -9,11 +9,6 @@ import pytest
 
 from mergecraft.mcp import shell as shell_mod
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: fail-closed unsandboxed shell + wrapped fallback",
-    strict=False,
-)
-
 
 def test_unsandboxed_shell_refuses_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", raising=False)
@@ -50,9 +45,10 @@ def test_allow_unsandboxed_env_var_overrides(monkeypatch: pytest.MonkeyPatch) ->
     assert captured, "override must allow fallback spawn"
 
 
-def test_fallback_branch_masks_container_sockets_when_it_runs(
+def test_fallback_branch_runs_raw_command_without_host_mounts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Unsandboxed opt-in must not run mount/chmod soup on the host (MCB-07 / M3)."""
     monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
     monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
     captured: list[str] = []
@@ -71,4 +67,6 @@ def test_fallback_branch_masks_container_sockets_when_it_runs(
         isolate_network=False,
     )
     joined = captured[0]
-    assert "docker.sock" in joined or "mount --bind /dev/null" in joined
+    assert joined == "bash -c echo ok"
+    assert "docker.sock" not in joined
+    assert "mount --bind" not in joined

--- a/tests/mcp/test_shell_fallback.py
+++ b/tests/mcp/test_shell_fallback.py
@@ -1,0 +1,74 @@
+"""Lane A AP1.2 — unsandboxed shell fallback policy (MCB-07 / D8)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: fail-closed unsandboxed shell + wrapped fallback",
+    strict=False,
+)
+
+
+def test_unsandboxed_shell_refuses_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", raising=False)
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    with pytest.raises((RuntimeError, PermissionError, OSError)):
+        shell_mod._spawn_shell(
+            "echo ok",
+            env={},
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=True,
+        )
+
+
+def test_allow_unsandboxed_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    captured: list[list[str]] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.append(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=False,
+    )
+    assert captured, "override must allow fallback spawn"
+
+
+def test_fallback_branch_masks_container_sockets_when_it_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.append(" ".join(argv))
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=False,
+    )
+    joined = captured[0]
+    assert "docker.sock" in joined or "mount --bind /dev/null" in joined

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -1,0 +1,52 @@
+"""Lane A AP1.3 — git invariant controls in every shell branch (MCB-25 / D10)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP4: read-only .git bind + git binary unavailable in namespace",
+    strict=False,
+)
+
+
+def _joined_argv(monkeypatch: pytest.MonkeyPatch, *, method: str) -> str:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: method)
+    if method == "none":
+        monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.extend(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=True,
+    )
+    return " ".join(captured)
+
+
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
+def test_git_dir_is_read_only_in_every_branch(monkeypatch: pytest.MonkeyPatch, method: str) -> None:
+    joined = _joined_argv(monkeypatch, method=method)
+    assert "remount,bind,ro" in joined
+    assert ".git" in joined
+
+
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
+def test_git_binary_unavailable_in_untrusted_namespace(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    joined = _joined_argv(monkeypatch, method=method)
+    assert "chmod 000" in joined or "unavailable" in joined or "/dev/null" in joined

--- a/tests/mcp/test_shell_spawn_argv.py
+++ b/tests/mcp/test_shell_spawn_argv.py
@@ -10,11 +10,6 @@ import pytest
 from mergecraft.mcp import shell as shell_mod
 from mergecraft.utils.secrets import PROVIDER_KEY_ENV_VARS
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP4: sudo --preserve-env by name",
-    strict=False,
-)
-
 _CANARY = "CANARY_PROVIDER_SECRET_VALUE_AP1"
 
 
@@ -42,7 +37,16 @@ def _capture_argv(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
 @pytest.mark.parametrize(
     "isolate_network",
-    [False, True],
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="green after AP4: sudo --preserve-env by name",
+                strict=False,
+            ),
+        ),
+    ],
     ids=["pid_only", "pid_and_net"],
 )
 def test_no_provider_key_value_appears_in_any_branch_argv(

--- a/tests/mcp/test_shell_spawn_argv.py
+++ b/tests/mcp/test_shell_spawn_argv.py
@@ -1,0 +1,83 @@
+"""Lane A AP1.3 — sudo argv must not carry secret values (MCB-08 / D9)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+from mergecraft.utils.secrets import PROVIDER_KEY_ENV_VARS
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP4: sudo --preserve-env by name",
+    strict=False,
+)
+
+_CANARY = "CANARY_PROVIDER_SECRET_VALUE_AP1"
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_sudo_unshare(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "sudo-unshare")
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    shell_mod.reset_detection_cache()
+
+
+def _env_with_canaries() -> dict[str, str]:
+    return {name: _CANARY for name in PROVIDER_KEY_ENV_VARS}
+
+
+def _capture_argv(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.extend(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "isolate_network",
+    [False, True],
+    ids=["pid_only", "pid_and_net"],
+)
+def test_no_provider_key_value_appears_in_any_branch_argv(
+    monkeypatch: pytest.MonkeyPatch, isolate_network: bool
+) -> None:
+    for method in ("unshare", "sudo-unshare", "none"):
+        monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+        if method == "unshare":
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+        elif method == "sudo-unshare":
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "sudo-unshare")
+        else:
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+        captured = _capture_argv(monkeypatch)
+        shell_mod._spawn_shell(
+            "echo ok",
+            env=_env_with_canaries(),
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=isolate_network,
+        )
+        joined = " ".join(captured)
+        assert _CANARY not in joined, f"secret leaked in argv for method={method}"
+
+
+def test_sudo_branch_uses_preserve_env_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_argv(monkeypatch)
+    env = {"ANTHROPIC_API_KEY": "sekret", "PATH": "/usr/bin"}
+    shell_mod._spawn_shell(
+        "echo ok",
+        env=env,
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+    )
+    assert any(arg.startswith("--preserve-env=") for arg in captured)
+    assert not any("=sekret" in arg for arg in captured)

--- a/tests/prep/test_prep_env.py
+++ b/tests/prep/test_prep_env.py
@@ -1,0 +1,23 @@
+"""Lane A AP1.6 — prep environment allowlist (MCB-22)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: _prep_env allowlist",
+    strict=False,
+)
+
+
+def test_prep_env_is_a_real_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.prep.python import _prep_env
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sekret")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_sekret")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", "/tmp")
+    env = _prep_env()
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert env.get("PATH") == "/usr/bin"

--- a/tests/prep/test_prep_env.py
+++ b/tests/prep/test_prep_env.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: _prep_env allowlist",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_prep_env_is_a_real_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/prep/test_prep_fail_closed.py
+++ b/tests/prep/test_prep_fail_closed.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
+import pytest
 from tests.support.run_main_harness import FakeAgent, run_main_for_test
 
 from mergecraft.agents.shared import AgentResult
@@ -37,7 +38,19 @@ from mergecraft.utils.github import GitHubClient
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
+
+@pytest.fixture(autouse=True)
+def _uid_independent_privilege_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCB-24 — prep fail-closed cases must not depend on ambient uid (AP1.4b)."""
+
+    def _noop_prepare_workspace_for_agent(_workspace: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "mergecraft.main.prepare_workspace_for_agent",
+        _noop_prepare_workspace_for_agent,
+    )
+
 
 _SKIP_ISSUE = (
     "skipped: python dependency installation can execute arbitrary code "

--- a/tests/prep/test_prep_selection.py
+++ b/tests/prep/test_prep_selection.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-
-import pytest
+from typing import TYPE_CHECKING
 
 from mergecraft.prep.python import _config_applies
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: uv.lock wins over requirements.txt",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_uv_lock_wins_over_a_stray_requirements_txt(tmp_path: Path) -> None:

--- a/tests/prep/test_prep_selection.py
+++ b/tests/prep/test_prep_selection.py
@@ -1,0 +1,39 @@
+"""Lane A AP1.6 — prep lockfile selection order (MCB-22)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mergecraft.prep.python import _config_applies
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: uv.lock wins over requirements.txt",
+    strict=False,
+)
+
+
+def test_uv_lock_wins_over_a_stray_requirements_txt(tmp_path: Path) -> None:
+    from mergecraft.prep import python as prep_python
+
+    (tmp_path / "requirements.txt").write_text("httpx==0.1\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    chosen = next(c for c in prep_python._PYTHON_CONFIGS if _config_applies(c, tmp_path))
+    assert chosen.file == "uv.lock"
+
+
+def test_cwd_is_threaded_not_read_twice(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from mergecraft.prep.python import InstallPythonDependencies
+
+    calls = 0
+
+    def _cwd() -> Path:
+        nonlocal calls
+        calls += 1
+        return tmp_path
+
+    monkeypatch.setattr("mergecraft.prep.python.Path.cwd", _cwd)
+    inst = InstallPythonDependencies()
+    _ = inst.should_run()
+    assert calls == 1, "should_run must read cwd once; run receives explicit cwd after AP7"

--- a/tests/prep/test_prep_venv.py
+++ b/tests/prep/test_prep_venv.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.6 — prep installs into a dedicated virtualenv (MCB-22 / D12)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: dedicated prep-venv target",
+    strict=False,
+)
+
+
+@pytest.mark.asyncio
+async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
+    from mergecraft.prep.python import InstallPythonDependencies
+    from mergecraft.prep.types import PrepOptions
+
+    (tmp_path / "requirements.txt").write_text("httpx==0.28.1\n", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    async def _fake_run(cmd: str, args: list[str]) -> tuple[int, str]:
+        captured.append([cmd, *args])
+        return 0, ""
+
+    import mergecraft.prep.python as prep_python
+
+    prep_python._run_cmd = _fake_run  # type: ignore[method-assign]
+    inst = InstallPythonDependencies()
+    result = await inst.run(PrepOptions(ignore_scripts=False))
+    assert result.dependencies_installed is True
+    joined = " ".join(" ".join(c) for c in captured)
+    assert "prep-venv" in joined or ".venv" in joined

--- a/tests/prep/test_prep_venv.py
+++ b/tests/prep/test_prep_venv.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: dedicated prep-venv target",
-    strict=False,
-)
-
 
 @pytest.mark.asyncio
 async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
@@ -20,7 +15,7 @@ async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
     (tmp_path / "requirements.txt").write_text("httpx==0.28.1\n", encoding="utf-8")
     captured: list[list[str]] = []
 
-    async def _fake_run(cmd: str, args: list[str]) -> tuple[int, str]:
+    async def _fake_run(cmd: str, args: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
         captured.append([cmd, *args])
         return 0, ""
 

--- a/tests/security/fixtures/build_hostile_repo.sh
+++ b/tests/security/fixtures/build_hostile_repo.sh
@@ -72,4 +72,14 @@ ln -s "${OUTSIDE}" "${REPO}/home-escape"
 git add home-escape
 git commit -m "attack: add workspace escape symlink"
 
+# MCB-01 vectors for lane A AP1.4b — hostile .git/config entries.
+cat >>"${REPO}/.git/config" <<CFG
+
+[core]
+	fsmonitor = /bin/false
+	diff.external = /bin/false
+[url "https://attacker.example/"]
+	insteadOf = https://github.com/
+CFG
+
 echo "built ${REPO}"

--- a/tests/security/fixtures/build_hostile_repo.sh
+++ b/tests/security/fixtures/build_hostile_repo.sh
@@ -73,13 +73,20 @@ git add home-escape
 git commit -m "attack: add workspace escape symlink"
 
 # MCB-01 vectors for lane A AP1.4b — hostile .git/config entries.
-cat >>"${REPO}/.git/config" <<CFG
-
-[core]
-	fsmonitor = /bin/false
-	diff.external = /bin/false
-[url "https://attacker.example/"]
-	insteadOf = https://github.com/
-CFG
+evil_fsmonitor="${ROOT}/evil-fsmonitor.sh"
+cat >"${evil_fsmonitor}" <<'SH'
+#!/bin/sh
+touch /tmp/mergecraft-hostile-fsmonitor-pwned
+SH
+chmod +x "${evil_fsmonitor}"
+evil_diff="${ROOT}/evil-diff.sh"
+cat >"${evil_diff}" <<'SH'
+#!/bin/sh
+touch /tmp/mergecraft-hostile-diff-external-pwned
+SH
+chmod +x "${evil_diff}"
+git config core.fsmonitor "${evil_fsmonitor}"
+git config diff.external "${evil_diff}"
+git config url.https://attacker.example/.insteadOf https://github.com/
 
 echo "built ${REPO}"

--- a/tests/security/hostile_git_fixtures.py
+++ b/tests/security/hostile_git_fixtures.py
@@ -1,0 +1,79 @@
+"""Shared helpers for hostile ``.git/config`` RED tests (lane A / AP1)."""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class HostileGitRepo:
+    """Real git checkout with attacker-controlled ``.git/config`` entries."""
+
+    root: Path
+    fsmonitor_sentinel: Path
+    diff_external_sentinel: Path
+    insteadof_leak_path: Path
+
+
+def _git(repo: Path, *args: str) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+
+
+def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
+    """Create a throwaway repo whose ``.git/config`` models MCB-01 vectors."""
+    repo = tmp_path / "hostile-git"
+    repo.mkdir()
+    fsmonitor_sentinel = tmp_path / "fsmonitor-pwned"
+    diff_external_sentinel = tmp_path / "diff-external-pwned"
+    insteadof_leak_path = tmp_path / "insteadof-leaked.txt"
+
+    evil_fsmonitor = tmp_path / "evil-fsmonitor.sh"
+    evil_fsmonitor.write_text(
+        f"#!/bin/sh\ntouch {fsmonitor_sentinel}\n",
+        encoding="utf-8",
+    )
+    evil_fsmonitor.chmod(evil_fsmonitor.stat().st_mode | stat.S_IXUSR)
+
+    evil_diff = tmp_path / "evil-diff.sh"
+    evil_diff.write_text(
+        f"#!/bin/sh\ntouch {diff_external_sentinel}\n",
+        encoding="utf-8",
+    )
+    evil_diff.chmod(evil_diff.stat().st_mode | stat.S_IXUSR)
+
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "hostile@example.com")
+    _git(repo, "config", "user.name", "hostile")
+    (repo / "README.md").write_text("hostile\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+
+    config_path = repo / ".git" / "config"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + f"""
+[core]
+\tfsmonitor = {evil_fsmonitor}
+\tdiff.external = {evil_diff}
+[url "https://attacker.example/"]
+\tinsteadOf = https://github.com/
+""",
+        encoding="utf-8",
+    )
+
+    return HostileGitRepo(
+        root=repo,
+        fsmonitor_sentinel=fsmonitor_sentinel,
+        diff_external_sentinel=diff_external_sentinel,
+        insteadof_leak_path=insteadof_leak_path,
+    )

--- a/tests/security/hostile_git_fixtures.py
+++ b/tests/security/hostile_git_fixtures.py
@@ -64,7 +64,8 @@ def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
         + f"""
 [core]
 \tfsmonitor = {evil_fsmonitor}
-\tdiff.external = {evil_diff}
+[diff]
+\texternal = {evil_diff}
 [url "https://attacker.example/"]
 \tinsteadOf = https://github.com/
 """,

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -1,0 +1,61 @@
+"""Lane A AP1.1 — root-side git must not execute hostile ``.git/config`` (MCB-01)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mergecraft.mcp.git import _run_git
+from mergecraft.xrepo.review import _rev_parse_commit
+from tests.security.hostile_git_fixtures import HostileGitRepo, build_hostile_git_repo
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: git_hardening routes every root-side git call",
+    strict=False,
+)
+
+
+def test_root_side_status_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
+    _run_git(["status", "--porcelain"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_root_side_diff_does_not_execute_diff_external(hostile_git_repo: HostileGitRepo) -> None:
+    _run_git(["diff", "HEAD"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.diff_external_sentinel.exists()
+
+
+def test_commit_path_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
+    """``commit_changes`` path must pin safe git config (hooksPath alone is insufficient)."""
+    (hostile_git_repo.root / "tracked.txt").write_text("x\n", encoding="utf-8")
+    _run_git(["add", "tracked.txt"], cwd=str(hostile_git_repo.root))
+    _run_git(["commit", "-m", "test"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_insteadof_rewrite_does_not_leak_git_config_value_0(
+    hostile_git_repo: HostileGitRepo,
+) -> None:
+    completed = subprocess.run(
+        ["git", "config", "--get", "url.https://attacker.example/.insteadof"],
+        cwd=hostile_git_repo.root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.stdout.strip() == "https://github.com/"
+    _run_git(["status"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_xrepo_checkout_is_equally_protected(hostile_git_repo: HostileGitRepo) -> None:
+    """H-7: xrepo ``_rev_parse_commit`` must use hardened git argv."""
+    _rev_parse_commit(hostile_git_repo.root, "HEAD")
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+@pytest.fixture
+def hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
+    return build_hostile_git_repo(tmp_path)

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -11,11 +11,6 @@ from mergecraft.mcp.git import _run_git
 from mergecraft.xrepo.review import _rev_parse_commit
 from tests.security.hostile_git_fixtures import HostileGitRepo, build_hostile_git_repo
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: git_hardening routes every root-side git call",
-    strict=False,
-)
-
 
 def test_root_side_status_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
     _run_git(["status", "--porcelain"], cwd=str(hostile_git_repo.root))

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP5: checkout/config integrity helper",
-    strict=False,
-)
-
 _OUTSIDE_CANARY = "MERGECRAFT_OUTSIDE_CHECKOUT_CANARY_AP1"
 _PROVIDER_CANARY = "MERGECRAFT_PROVIDER_KEY_CANARY_AP1"
 

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -1,0 +1,53 @@
+"""Lane A AP1.4 — post-run integrity canaries for review sessions (MCB-06)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP5: checkout/config integrity helper",
+    strict=False,
+)
+
+_OUTSIDE_CANARY = "MERGECRAFT_OUTSIDE_CHECKOUT_CANARY_AP1"
+_PROVIDER_CANARY = "MERGECRAFT_PROVIDER_KEY_CANARY_AP1"
+
+
+def test_outside_checkout_canary_is_unreadable(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import assert_checkout_read_boundary
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    canary = outside / _OUTSIDE_CANARY
+    canary.write_text("secret\n", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        assert_checkout_read_boundary(checkout, [canary])
+
+
+def test_provider_key_canary_does_not_reach_a_local_sink(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import scan_local_sinks_for_secrets
+
+    sink = tmp_path / "sink.log"
+    sink.write_text("benign\n", encoding="utf-8")
+    assert _PROVIDER_CANARY not in scan_local_sinks_for_secrets(
+        tmp_path, secrets=[_PROVIDER_CANARY]
+    )
+
+
+def test_config_yaml_is_unwritable_during_review(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import hash_tree, verify_tree_unchanged
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    config_dir = checkout / ".mergecraft"
+    config_dir.mkdir()
+    config = config_dir / "config.yaml"
+    config.write_text("review: true\n", encoding="utf-8")
+    before = hash_tree(checkout)
+    config.write_text("review: false\n", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        verify_tree_unchanged(checkout, before)

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.1 — ``git_argv`` pins every safe config key (MCB-01 / D2)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: utils/git_hardening.py lands",
+    strict=False,
+)
+
+_EXPECTED_SAFE_KEYS: tuple[str, ...] = (
+    "core.fsmonitor=false",
+    "diff.external=",
+    "core.hooksPath=/dev/null",
+    "uploadpack.packObjectsHook=",
+    "core.sshCommand=ssh",
+    "core.gitProxy=",
+    "protocol.ext.allow=never",
+    "core.pager=cat",
+)
+
+
+def test_git_argv_pins_every_safe_config_key() -> None:
+    from mergecraft.utils.git_hardening import GIT_SAFE_CONFIG, git_argv
+
+    flat = " ".join(GIT_SAFE_CONFIG)
+    for key in _EXPECTED_SAFE_KEYS:
+        assert key in flat, f"missing safe config pin: {key}"
+    argv = git_argv(["status"])
+    assert argv[0] == "git"
+    assert argv[-1] == "status"
+    for key in _EXPECTED_SAFE_KEYS:
+        assert key.split("=")[0] in flat

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -2,13 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: utils/git_hardening.py lands",
-    strict=False,
-)
-
 _EXPECTED_SAFE_KEYS: tuple[str, ...] = (
     "core.fsmonitor=false",
     "diff.external=",

--- a/tests/utils/test_privilege_chown.py
+++ b/tests/utils/test_privilege_chown.py
@@ -1,0 +1,44 @@
+"""Lane A AP1.1 — ``prepare_workspace_for_agent`` must not chown ``.git`` (D3)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import mergecraft.utils.privilege as privilege
+from mergecraft.utils.privilege import prepare_workspace_for_agent
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: prune .git from recursive chown",
+    strict=False,
+)
+
+
+def test_prepare_workspace_does_not_chown_dot_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    dot_git = repo / ".git"
+    assert dot_git.exists()
+    before_uid = dot_git.stat().st_uid
+
+    class _Pw:
+        pw_uid = 10001
+        pw_gid = 10001
+        pw_name = "mergecraft"
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(__import__("sys").modules, "pwd", fake_pwd)
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+
+    prepare_workspace_for_agent(str(repo))
+
+    after_uid = dot_git.stat().st_uid
+    assert after_uid == before_uid, ".git must not be chowned to the agent user"

--- a/tests/utils/test_privilege_chown.py
+++ b/tests/utils/test_privilege_chown.py
@@ -11,12 +11,11 @@ import pytest
 import mergecraft.utils.privilege as privilege
 from mergecraft.utils.privilege import prepare_workspace_for_agent
 
-pytestmark = pytest.mark.xfail(
+
+@pytest.mark.xfail(
     reason="green after AP2: prune .git from recursive chown",
     strict=False,
 )
-
-
 def test_prepare_workspace_does_not_chown_dot_git(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/utils/test_privilege_identity.py
+++ b/tests/utils/test_privilege_identity.py
@@ -1,0 +1,67 @@
+"""Lane A AP1.5 — privilege identity gates (MCB-24 / MCB-32 / D11)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.utils.privilege import wrap_agent_command
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
+
+
+def test_root_outside_action_image_refuses_with_policy_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mergecraft.main import _ConfigurationError
+
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.delenv("MERGECRAFT_ALLOW_ROOT", raising=False)
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: False)
+    with pytest.raises(_ConfigurationError, match=r"policy|action image|MERGECRAFT_ALLOW_ROOT"):
+        wrap_agent_command(["echo", "hi"])
+
+
+def test_allow_root_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_ALLOW_ROOT", "1")
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: False)
+    monkeypatch.setattr("mergecraft.utils.privilege.shutil.which", lambda _n: "/usr/bin/setpriv")
+    wrapped = wrap_agent_command(["echo", "hi"])
+    assert wrapped[0] == "setpriv"
+
+
+def test_in_action_image_detects_is_sandbox_and_opt_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.utils.privilege import _in_action_image
+
+    monkeypatch.setenv("IS_SANDBOX", "1")
+    monkeypatch.setattr(
+        "mergecraft.utils.privilege.Path.is_dir",
+        lambda self: str(self).endswith("/opt/mergecraft"),
+    )
+    assert _in_action_image() is True
+
+
+def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    from unittest.mock import MagicMock
+
+    class _Pw:
+        pw_uid = 10001
+        pw_gid = 10001
+        pw_name = "mergecraft"
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: True)
+    monkeypatch.setattr("mergecraft.utils.privilege.shutil.which", lambda _n: "/usr/bin/setpriv")
+    argv = wrap_agent_command(["agent"])
+    assert "--no-new-privs" in argv
+    assert "--inh-caps=-all" in argv
+    assert "--bounding-set=-all" in argv

--- a/tests/utils/test_privilege_identity.py
+++ b/tests/utils/test_privilege_identity.py
@@ -6,11 +6,6 @@ import pytest
 
 from mergecraft.utils.privilege import wrap_agent_command
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP6: image identity gate + hardened setpriv argv",
-    strict=False,
-)
-
 
 def test_root_outside_action_image_refuses_with_policy_message(
     monkeypatch: pytest.MonkeyPatch,
@@ -24,6 +19,10 @@ def test_root_outside_action_image_refuses_with_policy_message(
         wrap_agent_command(["echo", "hi"])
 
 
+@pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
 def test_allow_root_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
     monkeypatch.setenv("MERGECRAFT_ALLOW_ROOT", "1")
@@ -44,6 +43,10 @@ def test_in_action_image_detects_is_sandbox_and_opt_dir(monkeypatch: pytest.Monk
     assert _in_action_image() is True
 
 
+@pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
 def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -1,0 +1,55 @@
+"""Lane A AP1.1 — manifest / xrepo rev guards (MCB-33)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mergecraft.xrepo.review import _rev_parse_commit
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: reject_if_leading_dash + --end-of-options in _rev_parse_commit",
+    strict=False,
+)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "linked"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    (repo / "f").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "f"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def test_leading_dash_rev_is_rejected(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    with pytest.raises(ValueError, match=r"dash|ref|rev"):
+        _rev_parse_commit(repo, "-evil")
+
+
+def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert _rev_parse_commit(repo, sha) == sha

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -9,11 +9,6 @@ import pytest
 
 from mergecraft.xrepo.review import _rev_parse_commit
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: reject_if_leading_dash + --end-of-options in _rev_parse_commit",
-    strict=False,
-)
-
 
 def _init_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "linked"

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -43,9 +43,17 @@ def test_leading_dash_rev_is_rejected(tmp_path: Path) -> None:
         _rev_parse_commit(repo, "-evil")
 
 
-def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
+def test_rev_parse_passes_end_of_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _init_repo(tmp_path)
-    sha = subprocess.run(
+    seen: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _record_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.append(list(cmd))
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(subprocess, "run", _record_run)
+    sha = real_run(
         ["git", "rev-parse", "HEAD"],
         cwd=repo,
         capture_output=True,
@@ -53,3 +61,4 @@ def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
         check=True,
     ).stdout.strip()
     assert _rev_parse_commit(repo, sha) == sha
+    assert any("--end-of-options" in argv for argv in seen)


### PR DESCRIPTION
## What?

Adds failing tests that lock in expected behavior for twelve audit findings around privilege dropping, sandbox isolation, git hardening, and prep isolation.

## Why?

Security remediation needs tests that fail until the implementation lands. Observable outcomes at real boundaries (real git against real repositories) so regressions cannot hide behind mocks.

## Note

Tests use `xfail(strict=False)` until the implementation waves land. Container-only cases are documented in `docs/test-plans/audit-remediation-privilege.md`.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] Scoped pytest: `tests/security/`, `tests/mcp/`, `tests/prep/`, `tests/utils/`, `tests/analyzers/`, `tests/agents/`
