### PR TITLE
security: harden root-side git and protect .git ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
+  pinned safe-config keys; ``make lint`` enforces the route via
+  ``scripts/check_git_argv.py`` (MCB-01)
+- ``prepare_workspace_for_agent`` no longer recursively chowns ``.git``; sandbox shell
+  binds every registered workspace root's ``.git`` read-only (MCB-01 / D3)
+- Linked-repo ``_rev_parse_commit`` rejects leading-dash revs, validates pinned SHA
+  shape, and passes ``--end-of-options`` before the rev (MCB-33)
+
 ### Changed
 
 - Public MCP consumer docs: ``docs/mcp.md`` (install copy per runtime, OpenAI vs

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-
 	$(RUFF) check src tests scripts
 	$(RUFF) format --check src tests scripts
 	$(UV) run python scripts/check_loguru_only.py
+	$(UV) run python scripts/check_git_argv.py
 	$(UV) run python scripts/check_cli_consoles.py
 	$(MAKE) action-yml-hygiene-check
 	$(MAKE) hook-pins-check

--- a/scripts/check_git_argv.py
+++ b/scripts/check_git_argv.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard: bare ``["git", …]`` list literals must not appear outside git_hardening.
+
+Root-side git must route through :func:`mergecraft.utils.git_hardening.git_argv`
+so hostile ``.git/config`` cannot execute. This checker fails ``make lint`` when
+any ``src/mergecraft/**/*.py`` file outside ``utils/git_hardening.py`` embeds a
+list literal whose first element is the string ``git``.
+
+Module: scripts.check_git_argv
+Depends: ast, pathlib, sys
+
+Exports:
+    main — CLI entry; scans for forbidden bare git list literals.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MERGECRAFT_SRC = REPO / "src" / "mergecraft"
+_ALLOWED_REL = "src/mergecraft/utils/git_hardening.py"
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _is_git_list_literal(node: ast.AST) -> bool:
+    if not isinstance(node, ast.List):
+        return False
+    if not node.elts:
+        return False
+    first = node.elts[0]
+    return isinstance(first, ast.Constant) and first.value == "git"
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[int] = []
+
+    def visit_List(self, node: ast.List) -> None:
+        if _is_git_list_literal(node):
+            self.violations.append(node.lineno)
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path) -> list[int]:
+    rel = _rel(path)
+    if rel == _ALLOWED_REL:
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    tree = ast.parse(source, filename=rel)
+    visitor = _Visitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main() -> int:
+    """Scan mergecraft sources (or explicit paths) for bare git list literals."""
+    if len(sys.argv) > 1:
+        targets = [Path(arg) for arg in sys.argv[1:]]
+    else:
+        if not MERGECRAFT_SRC.is_dir():
+            print(f"missing source tree: {MERGECRAFT_SRC}", file=sys.stderr)
+            return 1
+        targets = sorted(MERGECRAFT_SRC.rglob("*.py"))
+
+    violations: list[str] = []
+    for path in targets:
+        for lineno in _scan_file(path):
+            violations.append(f"{_rel(path)}:{lineno}: bare ['git', …] list literal")
+
+    if violations:
+        print(
+            "route git subprocess argv through mergecraft.utils.git_hardening.git_argv:",
+            file=sys.stderr,
+        )
+        for item in violations:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mergecraft/agents/shared.py
+++ b/src/mergecraft/agents/shared.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 from loguru import logger
 
 from mergecraft.mcp.endpoints import mcp_role_url as _mcp_role_url
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -85,7 +86,7 @@ def spawn_agent_cli(
 def get_git_status(cwd: str | None = None) -> str:
     try:
         return subprocess.check_output(
-            ["git", "status", "--porcelain"],
+            git_argv(["status", "--porcelain"]),
             cwd=cwd,
             text=True,
             timeout=10,

--- a/src/mergecraft/analyzers/baseline_suppression.py
+++ b/src/mergecraft/analyzers/baseline_suppression.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from mergecraft.analyzers.scope import DiffScope, changed_paths_from_scope, parse_diff_scope
 from mergecraft.review_policy.paths import normalize_repo_path
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -77,7 +78,7 @@ def should_run_baseline_suppression(*, diff_text: str, base_comparison: str) -> 
 def _checkout_base_worktree(repo_root: Path, base_ref: str) -> Path | None:
     worktree = Path(tempfile.mkdtemp(prefix="mergecraft-base-"))
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "worktree", "add", "--detach", str(worktree), base_ref],
+        git_argv(["-C", str(repo_root), "worktree", "add", "--detach", str(worktree), base_ref]),
         capture_output=True,
         text=True,
         check=False,
@@ -95,7 +96,7 @@ def _checkout_base_worktree(repo_root: Path, base_ref: str) -> Path | None:
 
 def _remove_base_worktree(repo_root: Path, worktree: Path) -> None:
     subprocess.run(
-        ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(worktree)],
+        git_argv(["-C", str(repo_root), "worktree", "remove", "--force", str(worktree)]),
         capture_output=True,
         text=True,
         check=False,

--- a/src/mergecraft/analyzers/contracts.py
+++ b/src/mergecraft/analyzers/contracts.py
@@ -16,6 +16,7 @@ from mergecraft.analyzers.parsers.squawk_json import parse_squawk_json
 from mergecraft.analyzers.paths import safe_repo_relative_path
 from mergecraft.analyzers.registry import _matches_detect_patterns, get_manifest
 from mergecraft.analyzers.resolve import AnalyzerPlan, resolve_analyzer
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -61,7 +62,7 @@ def _fixture_base_rel(head_path: str) -> str:
 
 def _git_ref_available(repo_root: Path, base_ref: str) -> bool:
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{base_ref}^{{commit}}"],
+        git_argv(["-C", str(repo_root), "rev-parse", "--verify", f"{base_ref}^{{commit}}"]),
         capture_output=True,
         text=True,
         check=False,
@@ -78,7 +79,7 @@ def _resolve_base_file(repo_root: Path, head_path: str, base_ref: str) -> Path |
     if not _git_ref_available(repo_root, base_ref):
         return None
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "show", f"{base_ref}:{head_path}"],
+        git_argv(["-C", str(repo_root), "show", f"{base_ref}:{head_path}"]),
         capture_output=True,
         text=True,
         check=False,

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import TrustTier
 
@@ -222,7 +224,7 @@ def _find_references(
     """Return (capped references, whether more references existed than the cap)."""
     try:
         result = subprocess.run(
-            ["git", "-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol],
+            git_argv(["-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol]),
             capture_output=True,
             text=True,
             timeout=15,

--- a/src/mergecraft/build_metadata.py
+++ b/src/mergecraft/build_metadata.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from mergecraft._build_metadata import __commit__ as _baked_commit
+from mergecraft.utils.git_hardening import git_argv
 
 
 @lru_cache(maxsize=1)
@@ -34,7 +35,7 @@ def _git_head_commit(root: Path) -> str | None:
         return None
     try:
         output = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
+            git_argv(["rev-parse", "HEAD"]),
             cwd=root,
             text=True,
             stderr=subprocess.DEVNULL,

--- a/src/mergecraft/cli/analyzers_cmd.py
+++ b/src/mergecraft/cli/analyzers_cmd.py
@@ -19,6 +19,7 @@ from mergecraft.analyzers.sarif import export_sarif
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.target_dir import target_dir as resolve_target_dir
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import AnalyzerManifest
@@ -33,7 +34,7 @@ app = typer.Typer(
 def _git_changed_files(target_dir: Path) -> list[str]:
     try:
         completed = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            git_argv(["diff", "--name-only", "HEAD"]),
             cwd=target_dir,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -24,6 +24,7 @@ from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
     CLI_USAGE_EXIT_CODE,
 )
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.workspace import git_repo_root
 
 if TYPE_CHECKING:
@@ -105,7 +106,7 @@ def _get_gh_token() -> str:
 def _parse_git_remote() -> tuple[str, str]:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["remote", "get-url", "origin"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):  # fmt: skip
         cli_bail("not a git repository or no 'origin' remote found.")

--- a/src/mergecraft/cli/describe_cmd.py
+++ b/src/mergecraft/cli/describe_cmd.py
@@ -31,6 +31,7 @@ from mergecraft.pr.similar import (
     find_similar_issues,
 )
 from mergecraft.review.split_advisor import recommend_pr_split
+from mergecraft.utils.git_hardening import git_argv
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -38,7 +39,7 @@ def _read_diff(repo_root: Path) -> str:
         return ""
     try:
         completed = subprocess.run(
-            ["git", "diff", "HEAD"],
+            git_argv(["diff", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/doctor_cmd.py
+++ b/src/mergecraft/cli/doctor_cmd.py
@@ -25,6 +25,7 @@ from mergecraft.evidence.run_manifest import runtime_tool_stamp
 from mergecraft.mcp.ports import port_available, read_env_port
 from mergecraft.models import MODEL_ALIASES
 from mergecraft.utils.agent_resolve import has_credentials_for_slug
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -63,7 +64,7 @@ class AgentCliProvenance:
 def _git_probe(cwd: Path) -> ProbeResult:
     try:
         completed = subprocess.run(
-            ["git", "--version"],
+            git_argv(["--version"]),
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -23,6 +23,7 @@ from mergecraft.review.completed import (
     lookup_finding_packet_in_review,
 )
 from mergecraft.review.explain import finding_explain_payload
+from mergecraft.utils.git_hardening import git_argv
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -30,7 +31,7 @@ def _read_diff(repo_root: Path) -> str:
         return ""
     try:
         completed = subprocess.run(
-            ["git", "diff", "HEAD"],
+            git_argv(["diff", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/init_cmd.py
+++ b/src/mergecraft/cli/init_cmd.py
@@ -14,6 +14,7 @@ from mergecraft.cli.provider_cmd import seed_builtin_providers
 from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
 from mergecraft.pins import action_pin_minimal
 from mergecraft.review.completed import COMPLETED_REVIEWS_GITIGNORE_LINE
+from mergecraft.utils.git_hardening import git_argv
 
 DEFAULT_CONFIG: dict[str, object] = {
     "models": ["anthropic/claude-sonnet"],
@@ -113,7 +114,7 @@ def _ensure_reviews_gitignore(root: Path) -> None:
 def _parse_git_remote() -> tuple[str, str] | None:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
+            git_argv(["remote", "get-url", "origin"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/cli/plan_cmd.py
+++ b/src/mergecraft/cli/plan_cmd.py
@@ -24,6 +24,7 @@ from mergecraft.utils.agent_resolve import (
     resolve_model,
     resolve_runtime_agent,
 )
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.offline_diff import materialize_diff
 from mergecraft.utils.run_bounds import resolve_run_bounds
 from mergecraft.utils.source_resolve import SourceResolverSpec, resolve_workspace
@@ -32,7 +33,7 @@ from mergecraft.utils.source_resolve import SourceResolverSpec, resolve_workspac
 def _git_changed_files(repo_root: Path) -> list[str]:
     try:
         completed = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            git_argv(["diff", "--name-only", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -40,6 +40,7 @@ from mergecraft.cli.tracing_logfire_wf_yaml import (
     remove_logfire_wiring,
     render_workflow_diff,
 )
+from mergecraft.utils.git_hardening import git_argv
 
 # ``MERGECRAFT_TRACING_REGION`` selects the Logfire OTLP data region; it is
 # written by ``tracing logfire enable --region`` and read by the precedence
@@ -96,7 +97,7 @@ def _parse_repo_slug() -> str:
 
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
+            git_argv(["remote", "get-url", "origin"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/cli/watch_cmd.py
+++ b/src/mergecraft/cli/watch_cmd.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.yes import OpOptions, op
 
 REQUEST_TIMEOUT_MS = 35_000
@@ -33,7 +34,7 @@ def _get_gh_token() -> str:
 def _parse_git_remote() -> tuple[str, str]:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["remote", "get-url", "origin"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):  # fmt: skip
         cli_bail("not a git repository or no 'origin' remote found.")

--- a/src/mergecraft/context/git_history.py
+++ b/src/mergecraft/context/git_history.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
 
 from mergecraft.context.provenance import ContextItem
+from mergecraft.utils.git_hardening import git_argv
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +61,7 @@ def targeted_blame(
 
 def _git_rev_parse(repo_root: Path, ref: str) -> str:
     completed = subprocess.run(
-        ["git", "rev-parse", ref],
+        git_argv(["rev-parse", ref]),
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -77,14 +78,15 @@ def _run_blame(
     end_line: int,
 ) -> tuple[BlameEntry, ...]:
     completed = subprocess.run(
-        [
-            "git",
-            "blame",
-            "-L",
-            f"{start_line},{end_line}",
-            "--line-porcelain",
-            path,
-        ],
+        git_argv(
+            [
+                "blame",
+                "-L",
+                f"{start_line},{end_line}",
+                "--line-porcelain",
+                path,
+            ]
+        ),
         cwd=repo_root,
         capture_output=True,
         text=True,

--- a/src/mergecraft/context/operator.py
+++ b/src/mergecraft/context/operator.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
 from mergecraft.context.repo_paths import is_excluded_repo_path
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -112,7 +113,7 @@ def _search_indexed(*, repo_root: Path, query: str) -> list[str]:
     tokens = [part for part in query.split() if part]
     if not tokens:
         return []
-    command = ["git", "grep", "-l", "-I", "-i", "-F"]
+    command = git_argv(["grep", "-l", "-I", "-i", "-F"])
     for token in tokens:
         command.extend(["-e", token])
     command.append("HEAD")

--- a/src/mergecraft/context/repo_paths.py
+++ b/src/mergecraft/context/repo_paths.py
@@ -10,6 +10,8 @@ from typing import IO, TYPE_CHECKING
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
@@ -47,7 +49,7 @@ def git_ls_tree_paths(
     """List tracked paths under ``tree_sha``, applying context exclusions."""
     try:
         completed = subprocess.run(
-            ["git", "ls-tree", "-r", "--name-only", tree_sha],
+            git_argv(["ls-tree", "-r", "--name-only", tree_sha]),
             cwd=repo_root,
             capture_output=True,
             text=True,
@@ -92,7 +94,7 @@ def _git_show_text_bounded(repo_root: Path, spec: str, max_bytes: int) -> str | 
     """
     try:
         proc = subprocess.Popen(
-            ["git", "cat-file", "--batch"],
+            git_argv(["cat-file", "--batch"]),
             cwd=repo_root,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -151,7 +153,7 @@ def git_show_text(
         return _git_show_text_bounded(repo_root, spec, max_bytes)
     try:
         completed = subprocess.run(
-            ["git", "show", spec],
+            git_argv(["show", spec]),
             cwd=repo_root,
             capture_output=True,
             check=False,
@@ -170,7 +172,7 @@ def git_blob_sha(repo_root: Path, tree_sha: str, rel_path: str) -> str:
     """Return the git blob SHA for ``rel_path`` at ``tree_sha``."""
     try:
         completed = subprocess.run(
-            ["git", "rev-parse", f"{tree_sha}:{rel_path}"],
+            git_argv(["rev-parse", f"{tree_sha}:{rel_path}"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/evals/benchmark.py
+++ b/src/mergecraft/evals/benchmark.py
@@ -42,6 +42,7 @@ from mergecraft.evals.store import (
     replay_case,
 )
 from mergecraft.modes import modes
+from mergecraft.utils.git_hardening import git_argv
 
 RESULT_SET_SCHEMA_VERSION: Final[str] = "1.4.0"
 DEFAULT_RESULTS_DIR: Final[Path] = Path("evals/results")
@@ -399,7 +400,7 @@ def corpus_class_for(case: Case) -> str:
 def _git_head_sha() -> str:
     try:
         out = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
+            git_argv(["rev-parse", "HEAD"]),
             stderr=subprocess.DEVNULL,
             text=True,
         )
@@ -412,7 +413,7 @@ def _git_corpus_commit() -> str:
     """Pin the eval case tree, not bare HEAD (reproducible corpus snapshot)."""
     try:
         out = subprocess.check_output(
-            ["git", "rev-parse", "HEAD:evals/cases"],
+            git_argv(["rev-parse", "HEAD:evals/cases"]),
             stderr=subprocess.DEVNULL,
             text=True,
         )

--- a/src/mergecraft/evals/convergence_benchmark.py
+++ b/src/mergecraft/evals/convergence_benchmark.py
@@ -37,6 +37,7 @@ from mergecraft.evals.convergence_store import convergence_rounds_from_case, lis
 from mergecraft.evals.scoring import DEFAULT_LINE_SLACK
 from mergecraft.evals.store import DEFAULT_BANK_DIR
 from mergecraft.findings.ledger import FindingLedger
+from mergecraft.utils.git_hardening import git_argv
 
 RECALL_PASS_CORPUS_PATH: Final[Path] = Path("evals/corpora/recall_pass_corpus.json")
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
@@ -55,7 +56,7 @@ class RecallPassCorpusReport(BaseModel):
 def _git_head_sha() -> str:
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["rev-parse", "HEAD"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (OSError, subprocess.CalledProcessError):
         return "unknown"
@@ -64,7 +65,7 @@ def _git_head_sha() -> str:
 def _git_corpus_commit() -> str:
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "HEAD:evals/bank"],
+            git_argv(["rev-parse", "HEAD:evals/bank"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -34,6 +34,7 @@ from mergecraft.mcp.git_guards import (
 )
 from mergecraft.mcp.shared import ToolClass, execute, repository_mutation_class_for_push, tool
 from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -107,7 +108,7 @@ def _validate_path_confinement(global_opts: list[str], cwd: str) -> None:
 
 def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) -> str:
     result = subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         env=env or os.environ.copy(),
         capture_output=True,
@@ -488,7 +489,7 @@ def commit_changes_tool(ctx: ToolContext):
                 "reason": "nothing to commit",
             }
         _run_git(["add", "-A"], cwd=cwd)
-        _run_git(["-c", "core.hooksPath=/dev/null", "commit", "-m", message], cwd=cwd)
+        _run_git(["commit", "-m", message], cwd=cwd)
         sha = _run_git(["rev-parse", "HEAD"], cwd=cwd).strip()
         # The commit is local either way — the push policy decides nothing about
         # the response, it only records why no remote update was attempted.

--- a/src/mergecraft/mcp/pr.py
+++ b/src/mergecraft/mcp/pr.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.shared import ToolClass, execute, tool
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 def _current_branch(cwd: str) -> str:
     return subprocess.check_output(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        git_argv(["rev-parse", "--abbrev-ref", "HEAD"]),
         cwd=cwd,
         text=True,
         timeout=10,

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -22,6 +22,7 @@ from mergecraft.utils.process_group import kill_process_group
 from mergecraft.utils.secrets import resolve_env
 from mergecraft.utils.workspace import (
     WorkspacePathError,
+    allowed_workspace_roots,
     git_repo_root,
     resolve_allowed_working_directory,
 )
@@ -258,6 +259,23 @@ def _unshare_argv(*, isolate_network: bool) -> list[str]:
     return argv
 
 
+def _git_readonly_bind_mounts() -> str:
+    """Shell fragment: bind every registered checkout ``.git`` read-only."""
+    parts: list[str] = []
+    seen: set[str] = set()
+    for root in allowed_workspace_roots():
+        key = str(root)
+        if key in seen:
+            continue
+        seen.add(key)
+        escaped = key.replace("'", "'\\''")
+        parts.append(
+            f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
+            f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
+        )
+    return "".join(parts)
+
+
 def _spawn_shell(
     command: str,
     *,
@@ -275,13 +293,10 @@ def _spawn_shell(
         )
         raise RuntimeError(msg)
 
-    repo_root = os.environ.get("GITHUB_WORKSPACE") or primary_repo_state_dir_safe(cwd)
-    escaped = repo_root.replace("'", "'\\''")
     fs_mounts = (
         "mkdir -p /var/lib/mergecraft 2>/dev/null; "
         "mount -t tmpfs tmpfs /var/lib/mergecraft 2>/dev/null; "
-        f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
-        f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
+        f"{_git_readonly_bind_mounts()}"
     )
     proc_cleanup = (
         "umount /proc 2>/dev/null; umount /proc 2>/dev/null; mount -t proc proc /proc 2>/dev/null;"

--- a/src/mergecraft/pr/similar.py
+++ b/src/mergecraft/pr/similar.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
@@ -84,7 +86,7 @@ def _git_change_candidates(repo_root: Path) -> list[dict[str, object]]:
         return []
     try:
         completed = subprocess.run(
-            ["git", "log", "-n", "30", "--pretty=format:%H\t%s", "--name-only"],
+            git_argv(["log", "-n", "30", "--pretty=format:%H\t%s", "--name-only"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -1,0 +1,40 @@
+"""Pinned git argv for root-side subprocess invocations (MCB-01 / D2).
+
+Every mergeCraft process that shells out to ``git`` while still privileged must
+route through :func:`git_argv` so agent-writable ``.git/config`` cannot execute
+hooks, fsmonitor, diff drivers, or other config-driven side effects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+GIT_SAFE_CONFIG: Final[tuple[str, ...]] = (
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "diff.external=",
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "uploadpack.packObjectsHook=",
+    "-c",
+    "core.sshCommand=ssh",
+    "-c",
+    "core.gitProxy=",
+    "-c",
+    "protocol.ext.allow=never",
+    "-c",
+    "core.pager=cat",
+)
+
+
+def git_argv(args: Sequence[str]) -> list[str]:
+    """Return ``git`` argv with every safe-config pin prepended before *args*."""
+    return ["git", *GIT_SAFE_CONFIG, *args]
+
+
+__all__ = ["GIT_SAFE_CONFIG", "git_argv"]

--- a/src/mergecraft/utils/git_ref.py
+++ b/src/mergecraft/utils/git_ref.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from mergecraft.utils.git_hardening import git_argv
+
 _SHA_REF = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 _GIT_FETCH_TIMEOUT_S = 30.0
 
@@ -13,7 +15,7 @@ _GIT_FETCH_TIMEOUT_S = 30.0
 def _default_repo_root() -> Path:
     """Return the git worktree root, or editable-layout repo root as fallback."""
     result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
+        git_argv(["rev-parse", "--show-toplevel"]),
         capture_output=True,
         text=True,
         check=False,
@@ -30,14 +32,14 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     workdir = cwd or _default_repo_root()
     candidates: list[list[str]]
     if _SHA_REF.fullmatch(ref):
-        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
+        candidates = [git_argv(["rev-parse", "--verify", f"{ref}^{{commit}}"])]
     elif ref.startswith("v"):
-        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
+        candidates = [git_argv(["rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"])]
     else:
         candidates = [
-            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"],
+            git_argv(["rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"]),
+            git_argv(["rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"]),
+            git_argv(["rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]),
         ]
     for cmd in candidates:
         if (
@@ -55,7 +57,7 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
         return False
     # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
     fetch = subprocess.run(
-        ["git", "fetch", "origin", ref, "--depth=1"],
+        git_argv(["fetch", "origin", ref, "--depth=1"]),
         cwd=workdir,
         capture_output=True,
         check=False,
@@ -64,7 +66,7 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     if fetch.returncode != 0:
         return False
     verify = subprocess.run(
-        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        git_argv(["rev-parse", "--verify", f"{ref}^{{commit}}"]),
         cwd=workdir,
         capture_output=True,
         check=False,

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from mergecraft.mcp.tool_state import ToolState
     from mergecraft.types import ShellPermission
@@ -161,7 +163,7 @@ def _prepare_temp_dir_for_agent(path: str) -> None:
 
 def _git_config(repo_dir: str, key: str, value: str) -> None:
     subprocess.run(
-        ["git", "config", "--local", key, value],
+        git_argv(["config", "--local", key, value]),
         cwd=repo_dir,
         check=False,
         capture_output=True,
@@ -172,7 +174,7 @@ def _git_config(repo_dir: str, key: str, value: str) -> None:
 def _git_get(repo_dir: str, key: str) -> str:
     try:
         return subprocess.check_output(
-            ["git", "config", "--get", key],
+            git_argv(["config", "--get", key]),
             cwd=repo_dir,
             text=True,
             stderr=subprocess.DEVNULL,
@@ -204,7 +206,7 @@ def scrub_clone_credentials(repo_dir: Path | str) -> None:
         "credential.useHttpPath",
     ):
         subprocess.run(
-            ["git", "config", "--local", "--unset-all", key],
+            git_argv(["config", "--local", "--unset-all", key]),
             cwd=root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/utils/instructions.py
+++ b/src/mergecraft/utils/instructions.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from mergecraft.review_taxonomy import WITHDRAWN_FINDINGS_HEADING
 from mergecraft.types import MERGECRAFT_MCP_NAME, format_mcp_tool_ref
 from mergecraft.utils.fence import Fence, fence_unless_trusted, render_untrusted
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.config.settings import LearningsHeading, RepoInfo
@@ -181,7 +182,7 @@ def _build_runtime_context(
     try:
         git_status = (
             subprocess.check_output(
-                ["git", "status", "--short"],
+                git_argv(["status", "--short"]),
                 text=True,
                 stderr=subprocess.DEVNULL,
             ).strip()

--- a/src/mergecraft/utils/offline_diff.py
+++ b/src/mergecraft/utils/offline_diff.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 _DEFAULT_BASES = ("main", "master", "develop", "trunk")
 _MAX_UNTRACKED_FILE_BYTES = 256 * 1024
 
@@ -33,7 +35,7 @@ def _run_git(
 
         timeout_s = timeout_for_external_operation("git_diff")
     return subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         check=False,
         capture_output=True,

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -257,7 +257,19 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     if not target:
         return
     subprocess.run(
-        ["chown", "-R", f"{pw.pw_uid}:{pw.pw_gid}", target],
+        [
+            "find",
+            target,
+            "-path",
+            f"{target}/.git",
+            "-prune",
+            "-o",
+            "-exec",
+            "chown",
+            f"{pw.pw_uid}:{pw.pw_gid}",
+            "{}",
+            "+",
+        ],
         check=False,
         capture_output=True,
         text=True,

--- a/src/mergecraft/utils/source_resolve.py
+++ b/src/mergecraft/utils/source_resolve.py
@@ -15,6 +15,7 @@ from urllib.parse import unquote, urlparse
 from loguru import logger
 
 from mergecraft.security.egress import SsrfBlockedError, guard_external_url
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.git_setup import git_env_for_token, scrub_clone_credentials
 from mergecraft.utils.offline_diff import DiffMaterialization, materialize_diff
 from mergecraft.utils.workspace import register_workspace_root
@@ -99,7 +100,7 @@ def validate_clone_url(url: str) -> None:
 
 def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) -> str:
     result = subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         env=env or os.environ.copy(),
         capture_output=True,

--- a/src/mergecraft/utils/workspace.py
+++ b/src/mergecraft/utils/workspace.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -43,7 +45,7 @@ def add_safe_directory(path: str) -> None:
     if resolved in _safe_directories_added:
         return
     subprocess.run(
-        ["git", "config", "--global", "--add", "safe.directory", resolved],
+        git_argv(["config", "--global", "--add", "safe.directory", resolved]),
         check=False,
         capture_output=True,
         text=True,
@@ -89,7 +91,7 @@ def git_repo_root(start: str | None = None) -> Path | None:
     """
     try:
         completed = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            git_argv(["rev-parse", "--show-toplevel"]),
             cwd=start,
             check=False,
             capture_output=True,

--- a/src/mergecraft/xrepo/review.py
+++ b/src/mergecraft/xrepo/review.py
@@ -9,11 +9,14 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from mergecraft.mcp.git_guards import reject_if_leading_dash
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.xrepo.blast_radius import (
     ChangedContract,
     CrossRepoImpact,
     resolve_cross_repo_dependents,
 )
+from mergecraft.xrepo.citations import validate_pinned_sha
 from mergecraft.xrepo.contract_index import ContractIndex, index_contracts_at_commit
 from mergecraft.xrepo.linked_repos import (
     LinkedRepoEntry,
@@ -111,8 +114,21 @@ def _changed_from_index(*, repo: str, commit: str, index: ContractIndex) -> list
 
 
 def _rev_parse_commit(repo_root: Path, rev: str) -> str:
+    stripped = rev.strip()
+    reject_if_leading_dash(stripped, "rev")
+    if stripped != "HEAD":
+        validate_pinned_sha(stripped)
     completed = subprocess.run(
-        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{rev}^{{commit}}"],
+        git_argv(
+            [
+                "-C",
+                str(repo_root),
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{stripped}^{{commit}}",
+            ]
+        ),
         capture_output=True,
         check=False,
         text=True,
@@ -136,7 +152,7 @@ def _require_head_matches_pin(repo_root: Path, commit_sha: str) -> None:
         msg = f"linked repo HEAD {head} does not match pinned {pin}"
         raise ValueError(msg)
     dirty = subprocess.run(
-        ["git", "-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"],
+        git_argv(["-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"]),
         capture_output=True,
         check=False,
         text=True,


### PR DESCRIPTION
## What?

Routes every elevated git invocation through one hardened argv helper with a lint gate, and stops recursive ownership changes from handing the repository metadata directory to the dropped user.

## Why?

Agent-writable repository configuration can execute arbitrary commands when root runs git. Chowning the metadata directory to the agent made that attack surface writable after privilege drop.

## Test plan

- [ ] `make lint` (includes new git argv checker)
- [ ] `make typecheck`
- [ ] Scoped pytest: `tests/security/`, `tests/utils/`, `tests/xrepo/`, `tests/ci/test_git_argv_lint.py`

## Related PR(s)/Issue(s)

Depends on #512
