### PR TITLE
security: narrow OpenCode review file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- OpenCode review sessions deny ``webfetch``, ``external_directory``, and
+  ``edit``; ``read`` is allowlisted to the checkout and evidence scratch
+  instead of ``*`` (MCB-06)
+- Post-run checkout integrity verification via
+  ``security.review_integrity`` hashes the tree before review and fails closed
+  on mutation (MCB-06)
 - Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
   pinned safe-config keys; ``make lint`` enforces the route via
   ``scripts/check_git_argv.py`` (MCB-01)

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Final
 import httpx
 from loguru import logger
 
-from mergecraft.agents.gates import build_opencode_native_fs_permission
+from mergecraft.agents.gates import GIT_NATIVE_READ_DENY_OPENCODE
 from mergecraft.agents.openai_compatible_gateways import (
     CUSTOM_PROVIDER_API_KEY_ENV,
     CUSTOM_PROVIDER_BASE_URL_ENV,
@@ -39,6 +39,8 @@ from mergecraft.agents.shared import (
     resolve_cache_read,
     spawn_agent_cli,
 )
+from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.security.review_integrity import hash_tree, verify_tree_unchanged
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.genai import (
     ModelParams,
@@ -313,21 +315,48 @@ def _custom_provider_ids(model: str | None) -> list[str]:
     return [endpoint[0]]
 
 
+def _checkout_root(ctx: AgentRunContext) -> Path:
+    return Path(primary_repo_state(ctx.tool_state).dir or os.getcwd()).resolve()
+
+
+def _evidence_dir(ctx: AgentRunContext) -> Path:
+    from mergecraft.evidence.run_packet import resolve_packet_path
+
+    repo = primary_repo_state(ctx.tool_state)
+    slug = f"{repo.owner}-{repo.name}"
+    return resolve_packet_path(tmpdir=ctx.tmpdir, change_slug=slug).parent
+
+
+def _build_review_mode_read_allowlist(checkout: Path, evidence: Path) -> dict[str, str]:
+    """Read paths allowlisted to the checkout and evidence scratch (MCB-06 / D4)."""
+    roots = (checkout.resolve(), evidence.resolve())
+    read: dict[str, str] = dict(GIT_NATIVE_READ_DENY_OPENCODE)
+    for root in roots:
+        root_posix = root.as_posix()
+        read[root_posix] = "allow"
+        read[f"{root_posix}/*"] = "allow"
+        read[f"{root_posix}/**"] = "allow"
+    return read
+
+
+def _build_review_mode_permissions(ctx: AgentRunContext) -> dict[str, object]:
+    return {
+        "bash": "deny",
+        "edit": "deny",
+        "read": _build_review_mode_read_allowlist(_checkout_root(ctx), _evidence_dir(ctx)),
+        "webfetch": "deny",
+        "external_directory": "deny",
+        "skill": "allow",
+    }
+
+
 def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
     from mergecraft.agents.harness_render import render_for_run
 
-    fs_perm = build_opencode_native_fs_permission()
     render_result = render_for_run(ctx, "opencode")
     agent_block = render_result.payload["agent"] if isinstance(render_result.payload, dict) else {}
     config: dict[str, object] = {
-        "permission": {
-            "bash": "deny",
-            "edit": fs_perm["edit"],
-            "read": fs_perm["read"],
-            "webfetch": "allow",
-            "external_directory": "allow",
-            "skill": "allow",
-        },
+        "permission": _build_review_mode_permissions(ctx),
         "mcp": {
             MERGECRAFT_MCP_NAME: {
                 "type": "remote",
@@ -646,12 +675,36 @@ async def _prompt_session_http(
     return AgentResult(success=True, output=output or None, usage=usage)
 
 
+def _capture_integrity_baseline(ctx: AgentRunContext) -> tuple[Path, str] | None:
+    checkout = _checkout_root(ctx)
+    try:
+        return checkout, hash_tree(checkout)
+    except OSError as exc:
+        logger.warning("review integrity baseline skipped for {}: {}", checkout, exc)
+        return None
+
+
+def _apply_integrity_gate(
+    result: AgentResult,
+    baseline: tuple[Path, str] | None,
+) -> AgentResult:
+    if baseline is None:
+        return result
+    checkout, digest = baseline
+    try:
+        verify_tree_unchanged(checkout, digest)
+    except RuntimeError as exc:
+        return AgentResult(success=False, error=str(exc))
+    return result
+
+
 async def _run(ctx: AgentRunContext) -> AgentResult:
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
+    baseline = _capture_integrity_baseline(ctx)
     model = ctx.resolved_model
     config_json = build_security_config(ctx, model)
     config_path = Path(ctx.tmpdir) / "opencode.json"
@@ -675,7 +728,10 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         handle = _boot_opencode_server(cli=cli, env=env, cwd=os.getcwd())
     except Exception as err:
         logger.info("opencode serve unavailable ({}), falling back to run", err)
-        return await _run_cli_fallback(cli=cli, ctx=ctx, env=env)
+        return _apply_integrity_gate(
+            await _run_cli_fallback(cli=cli, ctx=ctx, env=env),
+            baseline,
+        )
 
     assert handle is not None
     try:
@@ -689,14 +745,20 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
                 json={"title": "mergecraft"},
             )
             if created.status_code >= 400:
-                return AgentResult(
-                    success=False,
-                    error=f"failed to create opencode session: {created.text[:300]}",
+                return _apply_integrity_gate(
+                    AgentResult(
+                        success=False,
+                        error=f"failed to create opencode session: {created.text[:300]}",
+                    ),
+                    baseline,
                 )
             session = created.json()
             session_id = str(session.get("id") or session.get("sessionID") or "")
             if not session_id:
-                return AgentResult(success=False, error="opencode session missing id")
+                return _apply_integrity_gate(
+                    AgentResult(success=False, error="opencode session missing id"),
+                    baseline,
+                )
 
         model_obj = _parse_model(model)
         system = ctx.instructions.system
@@ -743,12 +805,18 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
             # own tail the operator gets a bare "timed out:" and no lead (#449).
             tail = handle.recent_output()
             detail = f"{exc}\n\nrecent opencode serve output:\n{tail}" if tail else str(exc)
-            return AgentResult(
-                success=False,
-                error=detail,
-                metadata={"retryable": True},
+            return _apply_integrity_gate(
+                AgentResult(
+                    success=False,
+                    error=detail,
+                    metadata={"retryable": True},
+                ),
+                baseline,
             )
-        return await finalize_agent_result(ctx, result)
+        return _apply_integrity_gate(
+            await finalize_agent_result(ctx, result),
+            baseline,
+        )
     finally:
         handle.close()
 

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -1,0 +1,86 @@
+"""Post-run integrity helpers for read-only review sessions (MCB-06 / AP5).
+
+Lane C's MCB-19 (AG2) reuses these helpers — import from here rather than
+duplicating checkout/config fingerprint logic.
+
+Exports:
+    hash_tree: Fingerprint a checkout tree before agent execution.
+    verify_tree_unchanged: Fail closed when the tree changed during review.
+    assert_checkout_read_boundary: Reject paths outside the checkout read allowlist.
+    scan_local_sinks_for_secrets: Detect provider secrets in local log sinks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+_SINK_SUFFIXES: frozenset[str] = frozenset({".log", ".txt", ".jsonl", ".ndjson"})
+_SINK_NAMES: frozenset[str] = frozenset({"stdout", "stderr", "output"})
+
+
+def _iter_tree_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_file())
+
+
+def hash_tree(root: Path) -> str:
+    """Return a stable digest of every file under ``root``."""
+    resolved = root.resolve()
+    digest = hashlib.sha256()
+    for path in _iter_tree_files(resolved):
+        rel = path.relative_to(resolved).as_posix()
+        digest.update(rel.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def verify_tree_unchanged(root: Path, before_digest: str) -> None:
+    """Raise ``RuntimeError`` when the checkout changed during a read-only review."""
+    current = hash_tree(root)
+    if current != before_digest:
+        msg = f"checkout integrity failure: tree changed during read-only review ({root})"
+        raise RuntimeError(msg)
+
+
+def assert_checkout_read_boundary(checkout: Path, paths: Sequence[Path]) -> None:
+    """Raise ``PermissionError`` when any path falls outside ``checkout``."""
+    root = checkout.resolve()
+    for raw in paths:
+        candidate = raw.resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as err:
+            msg = f"path {candidate} is outside checkout boundary {root}"
+            raise PermissionError(msg) from err
+
+
+def _is_sink_file(path: Path) -> bool:
+    if path.suffix.lower() in _SINK_SUFFIXES:
+        return True
+    return path.name in _SINK_NAMES
+
+
+def scan_local_sinks_for_secrets(search_root: Path, *, secrets: Sequence[str]) -> str:
+    """Return concatenated sink contents that contain any ``secrets`` literal."""
+    resolved = search_root.resolve()
+    if not resolved.is_dir():
+        return ""
+    hits: list[str] = []
+    for path in sorted(resolved.rglob("*")):
+        if not path.is_file() or not _is_sink_file(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if any(secret and secret in text for secret in secrets):
+            hits.append(text)
+    return "\n".join(hits)


### PR DESCRIPTION
## What?

Review-mode OpenCode sessions get an allowlisted read scope confined to the checkout, with web fetch, external directory access, and edit denied.

## Why?

Broad filesystem and network permissions let a review agent read provider secrets and files outside the repository during an untrusted session.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] Scoped pytest: `tests/agents/test_opencode_permissions.py`, `tests/security/test_review_canary.py`

## Related PR(s)/Issue(s)

Depends on #513
