### PR TITLE
security: gate privilege drop on action image identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,30 @@ jobs:
       - name: Integration suite (self-skips without live secrets)
         run: make test-integration
 
+  privilege-root:
+    name: Verify (root container privilege py3.14)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build action image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: mergecraft:lane-a
+          cache-from: type=gha,scope=mergeCraft-slim-privilege
+          cache-to: type=gha,mode=max,scope=mergeCraft-slim-privilege
+      - name: Privilege identity + trust-ordering (root and uid 65534)
+        run: |
+          chmod +x docker/e2e/run_in_image_privilege.sh
+          docker/e2e/run_in_image_privilege.sh mergecraft:lane-a
+
   mutation-advisory:
     name: Verify (mutation advisory py3.14)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Privilege drop gates on action-image identity (``IS_SANDBOX`` + ``/opt/mergecraft``)
+  instead of uid alone; root outside the image refuses with a policy diagnostic and
+  ``MERGECRAFT_ALLOW_ROOT=1`` override (MCB-24 / D11)
+- ``setpriv`` argv carries ``--no-new-privs``, ``--inh-caps=-all``, and
+  ``--bounding-set=-all``; fails closed when ``setpriv`` lacks ``--bounding-set``
+  support (MCB-32)
 - Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
   pinned safe-config keys; ``make lint`` enforces the route via
   ``scripts/check_git_argv.py`` (MCB-01)

--- a/docker/e2e/run_in_image_privilege.sh
+++ b/docker/e2e/run_in_image_privilege.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Run lane-A privilege identity + trust-ordering suites inside the action image (AP6 / D14b).
+# Host macOS lacks setpriv; root-container behaviour is verified here, not on the host.
+set -euo pipefail
+
+IMAGE="${1:?image tag required}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "» in-image privilege suite (root): ${IMAGE}"
+docker run --rm \
+  -v "${ROOT}:/workspace:ro" \
+  -w /workspace \
+  --entrypoint /bin/bash \
+  "${IMAGE}" \
+  -lc '
+set -euo pipefail
+uv pip install --python /opt/mergecraft/.venv/bin/python \
+  "pytest==9.1.1" "pytest-asyncio==1.3.0"
+export PYTHONPATH=/workspace
+export PYTEST_ADDOPTS="-p no:cacheprovider"
+PYTEST=(/opt/mergecraft/.venv/bin/python -m pytest)
+STABLE_TESTS=(
+  tests/prep/test_prep_fail_closed.py
+  tests/security/test_trust_ordering.py
+  tests/security/test_trust_ordering_attacks.py
+)
+# AP1.5 RED markers remain until test-creator reconciles — --runxfail avoids XPASS ratchet.
+PRIVILEGE_IDENTITY_TESTS=(tests/utils/test_privilege_identity.py)
+run_suite() {
+  echo "» pytest as uid=$(id -u)"
+  "${PYTEST[@]}" "${STABLE_TESTS[@]}" -q --tb=short -m "not integration"
+  "${PYTEST[@]}" "${PRIVILEGE_IDENTITY_TESTS[@]}" --runxfail -q --tb=short -m "not integration"
+}
+run_suite
+echo "» pytest as uid=65534 (nobody)"
+runuser -u nobody -- env PYTHONPATH=/workspace PYTEST_ADDOPTS="-p no:cacheprovider" \
+  bash -lc "
+    ${PYTEST[*]} ${STABLE_TESTS[*]} -q --tb=short -m \"not integration\"
+    ${PYTEST[*]} ${PRIVILEGE_IDENTITY_TESTS[*]} --runxfail -q --tb=short -m \"not integration\"
+  "
+'
+
+echo "» in-image privilege suite OK"

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -19,14 +19,17 @@ alongside the ``setpriv`` argv wrap, using the same fail-closed resolution.
 
 from __future__ import annotations
 
+import functools
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
 _DEFAULT_AGENT_USER = "mergecraft"
+_ALLOW_ROOT_ENV = "MERGECRAFT_ALLOW_ROOT"
 
 if TYPE_CHECKING:
     import pwd
@@ -41,6 +44,57 @@ def agent_user_name() -> str:
     return (
         os.environ.get("MERGECRAFT_AGENT_USER", _DEFAULT_AGENT_USER).strip() or _DEFAULT_AGENT_USER
     )
+
+
+def _in_action_image() -> bool:
+    """Return whether the process is running inside the mergeCraft action image.
+
+      Keys on ``IS_SANDBOX=1`` and ``/opt/mergecraft`` — both set by the Dockerfile
+    (D11). Root policy gates on this identity rather than inferring posture from uid
+      alone (MCB-24).
+    """
+    return os.environ.get("IS_SANDBOX") == "1" and Path("/opt/mergecraft").is_dir()
+
+
+def _allow_root_override() -> bool:
+    return os.environ.get(_ALLOW_ROOT_ENV, "").strip() == "1"
+
+
+def _refuse_root_outside_action_image() -> None:
+    """Abort when root runs outside the action image without an explicit override."""
+    if os.getuid() != 0:
+        return
+    if _in_action_image() or _allow_root_override():
+        return
+    logger.error(
+        "refusing to run as root outside the mergeCraft action image — "
+        "this is deliberate policy, not a missing /etc/passwd entry; "
+        "set {}=1 to override for local development",
+        _ALLOW_ROOT_ENV,
+    )
+    raise _raise_configuration_error(
+        "refusing to run as root outside the mergeCraft action image — "
+        "this is deliberate policy, not a missing passwd entry; "
+        f"set {_ALLOW_ROOT_ENV}=1 to override for local development"
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def _setpriv_supports_bounding_set() -> bool:
+    """Return whether the image ``setpriv`` supports ``--bounding-set`` (util-linux ≥ 2.33)."""
+    setpriv = shutil.which("setpriv")
+    if setpriv is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [setpriv, "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return "--bounding-set" in proc.stdout + proc.stderr
 
 
 def _raise_configuration_error(message: str) -> _ConfigurationError:
@@ -71,6 +125,7 @@ def _resolve_privilege_drop_user() -> pwd.struct_passwd | None:
     """
     if os.getuid() != 0:
         return None
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     try:
         import pwd
@@ -123,6 +178,7 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
     """
     if os.getuid() != 0:
         return list(cmd)
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     if shutil.which("setpriv") is None:
         logger.error(
@@ -135,7 +191,26 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
             "is unavailable and the run cannot proceed as root"
         )
     _resolve_privilege_drop_user()
-    return ["setpriv", f"--reuid={user}", f"--regid={user}", "--init-groups", *cmd]
+    if not _setpriv_supports_bounding_set():
+        logger.error(
+            "setpriv on PATH does not support --bounding-set (util-linux ≥ 2.33 required); "
+            "refusing to run the agent subprocess as root without capability clearing"
+        )
+        raise _raise_configuration_error(
+            "setpriv does not support --bounding-set in this image; hardened privilege "
+            "drop (--inh-caps=-all, --bounding-set=-all, --no-new-privs) cannot be "
+            "applied and the run cannot proceed as root"
+        )
+    return [
+        "setpriv",
+        "--no-new-privs",
+        "--inh-caps=-all",
+        "--bounding-set=-all",
+        f"--reuid={user}",
+        f"--regid={user}",
+        "--init-groups",
+        *cmd,
+    ]
 
 
 def _path_owned_by_uid(path: str, uid: int) -> bool:
@@ -222,6 +297,7 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     """
     if os.getuid() != 0:
         return
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     try:
         import pwd


### PR DESCRIPTION
## What?

Privilege drop runs only inside the action container image, keyed on image identity markers rather than ambient user id. setpriv carries no-new-privileges and clears capabilities. Root outside the image fails closed with a policy message and override env var.

## Why?

Test outcome and production behavior diverged when the runner uid was not root. setpriv without capability clearing left residual elevation paths.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] Scoped pytest: `tests/utils/test_privilege_identity.py`, `tests/prep/test_prep_fail_closed.py`
- [ ] Container verification (D17) for setpriv argv assertions on macOS

## Related PR(s)/Issue(s)

Depends on #513
