### PR TITLE
prep: isolate language toolchain installs in venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binds every registered workspace root's ``.git`` read-only (MCB-01 / D3)
 - Linked-repo ``_rev_parse_commit`` rejects leading-dash revs, validates pinned SHA
   shape, and passes ``--end-of-options`` before the rev (MCB-33)
+- Python ``prep`` installs into ``.mergecraft/prep-scratch/prep-venv`` with a
+  default-deny env allowlist so PR build deps cannot mutate the reviewer's
+  interpreter or inherit provider credentials (MCB-22 / D12)
+
+### Fixed
+
+- ``prep`` lockfile selection prefers ``uv.lock`` over a stray ``requirements.txt``;
+  ``should_run`` threads one ``cwd`` into ``run`` instead of reading ``Path.cwd()``
+  twice (MCB-22)
 
 ### Changed
 

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -6,14 +6,45 @@ import asyncio
 import os
 import re
 import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 from loguru import logger
 
 from mergecraft.prep.types import PrepOptions, PrepResult, PythonPackageManager
 
 _BUILD_SYSTEM_RE = re.compile(r"^\s*\[\s*build-system\s*\]", re.MULTILINE)
+
+_PREP_ENV_ALLOWLIST: Final[frozenset[str]] = frozenset(
+    {
+        "HOME",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "LANG",
+        "LC_ALL",
+        "NO_PROXY",
+        "PATH",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
+        "PIP_TRUSTED_HOST",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "TERM",
+        "TMPDIR",
+        "UV_EXTRA_INDEX_URL",
+        "UV_INDEX_URL",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+
+
+def _prep_env() -> dict[str, str]:
+    """Return a default-deny env mapping for prep subprocesses."""
+    return {key: value for key, value in os.environ.items() if key in _PREP_ENV_ALLOWLIST}
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,17 +63,17 @@ def _declares_build_system(path: Path) -> bool:
 
 
 _PYTHON_CONFIGS: tuple[_PythonConfig, ...] = (
-    _PythonConfig("requirements.txt", "pip", ["pip", "install", "-r", "requirements.txt"]),
     _PythonConfig("uv.lock", "uv", ["uv", "sync", "--frozen"]),
+    _PythonConfig("poetry.lock", "poetry", ["poetry", "install", "--no-interaction"]),
+    _PythonConfig("Pipfile.lock", "pipenv", ["pipenv", "sync"]),
+    _PythonConfig("requirements.txt", "pip", ["pip", "install", "-r", "requirements.txt"]),
     _PythonConfig(
         "pyproject.toml",
         "pip",
         ["pip", "install", "."],
         requires_build_system=True,
     ),
-    _PythonConfig("Pipfile.lock", "pipenv", ["pipenv", "sync"]),
     _PythonConfig("Pipfile", "pipenv", ["pipenv", "install"]),
-    _PythonConfig("poetry.lock", "poetry", ["poetry", "install", "--no-interaction"]),
     _PythonConfig("setup.py", "pip", ["pip", "install", "-e", "."]),
 )
 
@@ -62,32 +93,95 @@ def _config_applies(config: _PythonConfig, cwd: Path) -> bool:
     return True
 
 
+def _prep_venv_dir(cwd: Path) -> Path:
+    return cwd / ".mergecraft" / "prep-scratch" / "prep-venv"
+
+
+def _prep_venv_python(venv: Path) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _prep_venv_bin(venv: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / f"{name}.exe"
+    return venv / "bin" / name
+
+
+def _adapt_install_cmd(config: _PythonConfig, venv: Path, cwd: Path) -> tuple[str, list[str]]:
+    pip = str(_prep_venv_bin(venv, "pip"))
+    if config.tool == "pip":
+        if config.file == "requirements.txt":
+            return pip, ["install", "-r", str(cwd / "requirements.txt")]
+        if config.file == "setup.py":
+            return pip, ["install", "-e", str(cwd)]
+        if config.file == "pyproject.toml":
+            return pip, ["install", str(cwd)]
+    if config.tool == "uv":
+        return "uv", [
+            "sync",
+            "--frozen",
+            "--directory",
+            str(cwd),
+            "--python",
+            str(_prep_venv_python(venv)),
+        ]
+    cmd, *args = config.install_cmd
+    return cmd, args
+
+
+def _adapt_tool_install(tool: str, venv: Path) -> tuple[str, list[str]]:
+    install_cmd = _TOOL_INSTALL[tool]
+    pip = str(_prep_venv_bin(venv, "pip"))
+    return pip, install_cmd[1:]
+
+
 async def _run_cmd(cmd: str, args: list[str]) -> tuple[int, str]:
     proc = await asyncio.create_subprocess_exec(
         cmd,
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        env={**os.environ, "PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")},
+        env=_prep_env(),
     )
     stdout_b, stderr_b = await proc.communicate()
     out = b"\n".join(part for part in (stdout_b, stderr_b) if part).decode(
         "utf-8", errors="replace"
     )
-    return proc.returncode or 0, out.strip()
+    returncode = proc.returncode if proc.returncode is not None else -1
+    return returncode, out.strip()
+
+
+async def _ensure_prep_venv(cwd: Path) -> tuple[Path | None, str | None]:
+    venv = _prep_venv_dir(cwd)
+    if _prep_venv_python(venv).is_file():
+        return venv, None
+    venv.parent.mkdir(parents=True, exist_ok=True)
+    python = shutil.which("python3") or shutil.which("python")
+    if python is None:
+        return None, "python interpreter not found"
+    code, out = await _run_cmd(python, ["-m", "venv", str(venv.resolve())])
+    if code != 0:
+        return None, out or "failed to create prep virtualenv"
+    return venv, None
 
 
 class InstallPythonDependencies:
     name = "installPythonDependencies"
 
+    def __init__(self) -> None:
+        self._work_cwd: Path | None = None
+
     def should_run(self) -> bool:
         if not (shutil.which("python3") or shutil.which("python")):
             return False
-        cwd = Path.cwd()
-        return any(_config_applies(c, cwd) for c in _PYTHON_CONFIGS)
+        self._work_cwd = Path.cwd()
+        return any(_config_applies(c, self._work_cwd) for c in _PYTHON_CONFIGS)
 
     async def run(self, options: PrepOptions) -> PrepResult:
-        cwd = Path.cwd()
+        cwd = self._work_cwd if self._work_cwd is not None else Path.cwd()
+        self._work_cwd = None
         config = next((c for c in _PYTHON_CONFIGS if _config_applies(c, cwd)), None)
         if config is None:
             return PrepResult(
@@ -118,11 +212,23 @@ class InstallPythonDependencies:
                 ],
             )
 
-        if shutil.which(config.tool) is None:
+        venv, venv_issue = await _ensure_prep_venv(cwd)
+        if venv is None:
+            return PrepResult(
+                language="python",
+                package_manager=config.tool,
+                config_file=config.file,
+                dependencies_installed=False,
+                issues=[venv_issue or "failed to create prep virtualenv"],
+            )
+
+        tool_cmd = config.tool
+        if shutil.which(tool_cmd) is None:
             install_cmd = _TOOL_INSTALL.get(config.tool)
             if install_cmd:
                 logger.info("» {} not found, attempting to install...", config.tool)
-                code, out = await _run_cmd(install_cmd[0], install_cmd[1:])
+                pip_cmd, pip_args = _adapt_tool_install(config.tool, venv)
+                code, out = await _run_cmd(pip_cmd, pip_args)
                 if code != 0:
                     return PrepResult(
                         language="python",
@@ -132,7 +238,7 @@ class InstallPythonDependencies:
                         issues=[out or f"failed to install {config.tool}"],
                     )
 
-        cmd, *args = config.install_cmd
+        cmd, args = _adapt_install_cmd(config, venv, cwd)
         logger.info("» running: {} {}", cmd, " ".join(args))
         code, out = await _run_cmd(cmd, args)
         if code != 0:
@@ -154,4 +260,10 @@ class InstallPythonDependencies:
 
 install_python_dependencies = InstallPythonDependencies()
 
-__all__ = ["InstallPythonDependencies", "install_python_dependencies"]
+__all__ = [
+    "_PYTHON_CONFIGS",
+    "InstallPythonDependencies",
+    "_config_applies",
+    "_prep_env",
+    "install_python_dependencies",
+]


### PR DESCRIPTION
## What?

Prep installs project dependencies into a dedicated virtual environment instead of the interpreter running the reviewer, with a real env allowlist and corrected lockfile selection order.

## Why?

Installing into the running interpreter could downgrade pinned dependencies and break the review mid-run. Env scrub was ineffective and selection order favored stray requirements files over lockfiles.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] Scoped pytest: `tests/prep/`

## Related PR(s)/Issue(s)

Depends on #513
