### PR TITLE
ci: add Claude as a cross-vendor review backstop

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -321,6 +321,9 @@ jobs:
       # verdict and the approval gate fails closed on every PR at once. Anthropic
       # credentials fail independently of both.
       HAS_CLAUDE: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # Duplicated verbatim as `approval-gate.env.HAS_AUTH` (jobs cannot share an
+      # `env` expression). Adding a provider here without updating that copy
+      # fails the required gate OPEN — see the comment there.
       HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
       # The default github.token cannot submit an "Approve" review — GitHub
       # silently downgrades any attempt to a comment (a documented platform
@@ -826,7 +829,15 @@ jobs:
       contents: read
       checks: read
     env:
-      HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # Must stay character-for-character identical to the `review` job's
+      # HAS_AUTH. GitHub has no way to share one `env` expression across jobs,
+      # so the predicate is duplicated — and it drifted once already: Claude was
+      # added to the review job's copy and not to this one, which fails the gate
+      # OPEN on a Claude-only repo (the review runs, this job's only real step
+      # is skipped, and the required check goes green with no
+      # `mergecraft-approval=success` anywhere). When adding a provider, update
+      # both copies. `tests/ci/test_approval_gate_auth_predicate.py` pins them.
+      HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Fail when mergeCraft would not approve
         # Gate directly on the `mergecraft-approval` check-run, decoupled from the

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -22,7 +22,10 @@
 #
 # Provider priority: Tencent HY3 via the Nous Portal is primary; OpenAI
 # (Codex) is the one-shot fallback when Nous is absent or its review posts no
-# verdict. Claude is not used.
+# verdict; Anthropic (Claude) is the cross-vendor backstop when an earlier rung
+# fails RETRYABLY (quota ceiling, timeout, transport death) without posting a
+# verdict. The two fallbacks route on different signals on purpose — see the
+# comments on each decide step.
 #
 # Codex reviews previously posted mergecraft-approval=neutral because every tool
 # call failed with "MCP server 'mergecraft' was not ready for this step". Root
@@ -54,6 +57,8 @@
 # - NOUS_API_KEY — Nous Portal API key — primary (Tencent HY3 via nous/tencent/hy3)
 # - CODEX_AUTH_JSON — ChatGPT/Codex subscription (`mergecraft auth codex`) — fallback
 # - OPENAI_API_KEY — OpenAI API key (same Codex harness as CODEX_AUTH_JSON)
+# - CLAUDE_CODE_OAUTH_TOKEN — Claude Pro/Max subscription (`mergecraft auth claude`) — backstop
+# - ANTHROPIC_API_KEY — Anthropic API key (same claude harness as CLAUDE_CODE_OAUTH_TOKEN)
 # The job skips gracefully when none are set (e.g. fork PRs). Without
 # NOUS_API_KEY the primary is inert and Codex is the only reviewer; without
 # CODEX_AUTH_JSON / OPENAI_API_KEY, Nous is the only reviewer.
@@ -298,15 +303,25 @@ jobs:
       (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    # > 2× MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES + checkout/setup slack (D8).
-    timeout-minutes: 65
+    # > 3× MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES + checkout/setup slack (D8).
+    # Three rungs now (Nous -> Codex -> Claude). This is a worst-case ceiling,
+    # not an expected cost: the Claude rung only runs when an earlier rung
+    # failed retryably, and a rung that dies on a quota ceiling returns in
+    # seconds rather than consuming its budget.
+    timeout-minutes: 95
     env:
       IS_SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
       # Nous/DeepSeek primary; Codex fallback when Nous auth is absent or the
       # Nous review does not post a mergecraft-approval verdict.
       HAS_CODEX: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
       HAS_NOUS: ${{ secrets.NOUS_API_KEY != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
-      HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # Claude is the cross-vendor backstop. Nous and Codex can go down together
+      # for reasons that have nothing to do with this repo — a shared account
+      # quota ceiling is the common one — and when they do, the cascade posts no
+      # verdict and the approval gate fails closed on every PR at once. Anthropic
+      # credentials fail independently of both.
+      HAS_CLAUDE: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
       # The default github.token cannot submit an "Approve" review — GitHub
       # silently downgrades any attempt to a comment (a documented platform
       # restriction, independent of PR author). A PAT from a genuinely
@@ -348,7 +363,7 @@ jobs:
           if [ "${IS_SAME_REPO}" != "true" ]; then
             echo "::notice title=mergecraft skipped::Fork PR — review skipped (same as before)."
           else
-            echo "::notice title=mergecraft skipped::Configure CODEX_AUTH_JSON (mergecraft auth codex), OPENAI_API_KEY, or NOUS_API_KEY to enable mergeCraft reviews."
+            echo "::notice title=mergecraft skipped::Configure CODEX_AUTH_JSON (mergecraft auth codex), OPENAI_API_KEY, NOUS_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN (mergecraft auth claude) to enable mergeCraft reviews."
           fi
 
       # Composed in a step rather than inline in `with:` so the CI-context clause
@@ -399,15 +414,21 @@ jobs:
             echo "MERGECRAFT_PROMPT_EOF"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Record mergecraft-approval baseline before the Nous review
+      - name: Record mergecraft-approval baseline before the review cascade
         id: approval_baseline
-        # The fallback below must judge THIS Nous attempt, not a verdict an
+        # Every fallback below must judge THIS run's attempts, not a verdict an
         # earlier run left on the same head SHA (a re-run, or the enforce step's
         # own retry loop). Capturing the newest check-run id first makes "did
-        # Nous post a verdict?" answerable by identity rather than by recency.
+        # this attempt post a verdict?" answerable by identity rather than by
+        # recency.
+        #
+        # Gated on HAS_AUTH rather than on a specific provider pair: the Claude
+        # rung needs this baseline even when Nous is absent, and reading it is
+        # cheap. Narrowing it to HAS_NOUS && HAS_CODEX left BASELINE_ID empty on
+        # a Codex-only repo, which would make a stale verdict from a previous
+        # run look like a fresh one and silently skip the backstop.
         if: >-
-          env.HAS_NOUS == 'true' &&
-          env.HAS_CODEX == 'true' &&
+          env.HAS_AUTH == 'true' &&
           github.event_name == 'pull_request_target'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -621,6 +642,106 @@ jobs:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
+      - name: Decide Claude backstop after the provider cascade
+        id: claude_fallback
+        # Gated on a RETRYABLE provider failure, not on "no verdict posted".
+        #
+        # That is deliberately the opposite rule from the Nous -> Codex fallback
+        # above, because the two rungs exist for different failures. Codex backs
+        # up a Nous run that exits 0 while posting nothing usable (the
+        # mergecraft-approval=neutral / MCP handshake symptom), so it MUST route
+        # on verdict absence. Claude backs up a provider that could not run at
+        # all — quota ceiling, timeout, transport death — which the action
+        # surfaces by exiting non-zero, i.e. a step outcome of `failure` under
+        # continue-on-error.
+        #
+        # Routing Claude on verdict absence too would spend a third full attempt
+        # (and a third provider's quota) every time a reviewer legitimately
+        # declines to post one. Routing it on outcome keeps the backstop for the
+        # case it was added for: every earlier rung was unable to review.
+        #
+        # The verdict re-check below is a safety net, not the trigger: a rung can
+        # exit non-zero *after* posting a good verdict (the exhaustion arrives on
+        # a later retry), and re-reviewing then would overwrite a real verdict.
+        if: >-
+          env.HAS_CLAUDE == 'true' &&
+          (
+            steps.mergecraft_nous.outcome == 'failure' ||
+            steps.mergecraft_codex.outcome == 'failure'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASELINE_ID: ${{ steps.approval_baseline.outputs.id }}
+          NOUS_OUTCOME: ${{ steps.mergecraft_nous.outcome }}
+          CODEX_OUTCOME: ${{ steps.mergecraft_codex.outcome }}
+        run: |
+          set -euo pipefail
+          need="true"
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            latest=""
+            for attempt in $(seq 1 3); do
+              if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq '[.check_runs[]? | select(.name == "mergecraft-approval")]
+                | sort_by(.completed_at // .started_at) | last
+                | "\(.id // "")|\(.conclusion // "")"')"; then
+                break
+              fi
+              echo "check-runs query failed (attempt ${attempt}/3); retrying in 3s…" >&2
+              sleep 3
+            done
+            id="${latest%%|*}"
+            conclusion="${latest#*|}"
+            # Same identity rule as the Codex fallback: a verdict only counts
+            # when it is NOT the one that was already on this SHA beforehand.
+            if [ -n "${id}" ] && [ "${id}" = "${BASELINE_ID}" ]; then
+              echo "mergecraft-approval ${id} predates this run — treating as no verdict."
+              conclusion=""
+            fi
+            case "${conclusion}" in
+              failure|success)
+                need="false"
+                echo "mergecraft-approval=${conclusion} — a rung posted a verdict despite failing later; not spending the Claude backstop."
+                ;;
+            esac
+          fi
+          if [ "${need}" = "true" ]; then
+            echo "::notice title=mergecraft Claude backstop::A provider failed retryably (nous=${NOUS_OUTCOME:-skipped}, codex=${CODEX_OUTCOME:-skipped}) and no verdict was posted; retrying with anthropic/claude-sonnet."
+          fi
+          echo "need=${need}" >> "${GITHUB_OUTPUT}"
+
+      - name: mergeCraft PR review (Claude)
+        # Two ways in: as the backstop after a retryable provider failure, or as
+        # the sole reviewer when Claude is the only credential this repo has.
+        # Without the second clause, a Claude-only repo would satisfy HAS_AUTH,
+        # skip the "not configured" notice, run no review at all, and fail the
+        # gate closed with no diagnostic.
+        if: >-
+          env.HAS_CLAUDE == 'true' &&
+          (
+            steps.claude_fallback.outputs.need == 'true' ||
+            (env.HAS_NOUS != 'true' && env.HAS_CODEX != 'true')
+          )
+        id: mergecraft_claude
+        continue-on-error: true
+        # Same mandatory full-SHA pin as the rungs above — keep all three in
+        # lockstep when bumping, and mirror to the sevn-side workflow.
+        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
+        with:
+          prompt: ${{ steps.prompt.outputs.text }}
+          timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
+          model: anthropic/claude-sonnet
+          push: disabled
+          shell: disabled
+          status_checks: enabled
+          # See the matching comment on the Nous step above.
+          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: mergeCraft review incomplete (non-fatal)
         if: >-
           env.HAS_AUTH == 'true' &&
@@ -639,7 +760,8 @@ jobs:
               env.HAS_NOUS != 'true' &&
               steps.mergecraft_codex.outcome != 'success'
             )
-          )
+          ) &&
+          steps.mergecraft_claude.outcome != 'success'
         run: |
           echo "::notice title=mergecraft incomplete::Review step did not finish successfully (see its log — e.g. provider session limit or a runtime error). Approval enforcement in the approval-gate job will fail closed on this."
 

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -757,8 +757,10 @@ jobs:
         id: mergecraft_claude
         continue-on-error: true
         # Same mandatory full-SHA pin as the rungs above — keep all three in
-        # lockstep when bumping, and mirror to the sevn-side workflow.
-        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
+        # lockstep when bumping, and mirror to the sevn-side workflow. This rung
+        # was authored against the pre-#533 pin; carried to b34e9f25 on the merge
+        # so all three rungs run the same product code (#532).
+        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -768,9 +770,14 @@ jobs:
           status_checks: enabled
           # See the matching comment on the Nous step above.
           token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          tracing: "true"
+          tracing-to: logfire
+          logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_REGION: eu
 
       - name: mergeCraft review incomplete (non-fatal)
         if: >-

--- a/tests/ci/support_review_timeout_budget.py
+++ b/tests/ci/support_review_timeout_budget.py
@@ -24,8 +24,10 @@ DECLARED_ATTEMPT_TIMEOUT_ENV = "MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES"
 # per-attempt review time. D8: job > sum(attempts) + checkout slack.
 CHECKOUT_AND_SETUP_SLACK_MINUTES = 10
 
-# Worst-case sequential path: primary Nous attempt then Codex fallback.
-MAX_SEQUENTIAL_REVIEW_ATTEMPTS = 2
+# Worst-case sequential path: primary Nous attempt, Codex fallback on verdict
+# absence, then the Claude backstop on a retryable failure (#524). All three can
+# run in one job, so the job budget must cover 3x the per-attempt ceiling.
+MAX_SEQUENTIAL_REVIEW_ATTEMPTS = 3
 
 _MERGECRAFT_USES = re.compile(r"^\s+uses:\s+alexhawat/mergeCraft@", re.MULTILINE)
 _DURATION = re.compile(r"^(\d+)\s*([mhs])$", re.IGNORECASE)

--- a/tests/ci/test_approval_gate_auth_predicate.py
+++ b/tests/ci/test_approval_gate_auth_predicate.py
@@ -1,0 +1,78 @@
+"""The approval gate's ``HAS_AUTH`` must cover every provider the review job does.
+
+GitHub cannot share one ``env`` expression across jobs, so ``HAS_AUTH`` is
+declared twice in ``mergecraft.yml`` — once on ``review`` and once on
+``approval-gate`` — and the two drifted: Claude was added to the review job's
+copy only. On a Claude-only repo that fails the required check **open**: the
+review job runs the Claude rung, the gate job computes ``HAS_AUTH=false``, its
+only real step (``Fail when mergeCraft would not approve``) is skipped, and the
+job exits green with no ``mergecraft-approval=success`` anywhere.
+
+These tests pin the two copies together and evaluate the Claude-only case
+directly, so a provider added to one copy and not the other stays red.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tests.ci.workflow_support import job, load_workflow
+
+_WORKFLOW = "mergecraft.yml"
+_REVIEW_JOB = "review"
+_GATE_JOB = "approval-gate"
+_GATE_STEP = "Fail when mergeCraft would not approve"
+
+# Every credential that lets the review job actually review.
+PROVIDER_SECRETS = (
+    "CODEX_AUTH_JSON",
+    "OPENAI_API_KEY",
+    "NOUS_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+)
+
+_SECRET_REF = re.compile(r"secrets\.([A-Z0-9_]+)\s*!=\s*''")
+
+
+def _has_auth(job_name: str) -> str:
+    expression = job(load_workflow(_WORKFLOW), job_name)["env"]["HAS_AUTH"]
+    assert isinstance(expression, str)
+    return expression
+
+
+def _secrets_in(expression: str) -> set[str]:
+    return set(_SECRET_REF.findall(expression))
+
+
+def test_both_copies_of_has_auth_are_identical() -> None:
+    review = _has_auth(_REVIEW_JOB)
+    gate = _has_auth(_GATE_JOB)
+    assert review == gate, (
+        "review.env.HAS_AUTH and approval-gate.env.HAS_AUTH have drifted; "
+        "the gate skips itself for any provider missing from its copy"
+    )
+
+
+def test_has_auth_covers_every_provider_secret() -> None:
+    for job_name in (_REVIEW_JOB, _GATE_JOB):
+        missing = set(PROVIDER_SECRETS) - _secrets_in(_has_auth(job_name))
+        assert not missing, f"{job_name}.env.HAS_AUTH omits {sorted(missing)}"
+
+
+def test_claude_only_repo_still_arms_the_gate() -> None:
+    """A repo whose only credential is Anthropic must not skip the gate step."""
+    claude_only = {"CLAUDE_CODE_OAUTH_TOKEN": "token"}
+    for job_name in (_REVIEW_JOB, _GATE_JOB):
+        armed = any(claude_only.get(name, "") != "" for name in _secrets_in(_has_auth(job_name)))
+        assert armed, (
+            f"{job_name}.env.HAS_AUTH is false on a Claude-only repo; "
+            "the required check would pass without an approval verdict"
+        )
+
+
+def test_gate_step_is_still_gated_on_has_auth() -> None:
+    """Guards the premise: these tests only matter while the step reads HAS_AUTH."""
+    steps = job(load_workflow(_WORKFLOW), _GATE_JOB)["steps"]
+    step = next(s for s in steps if s.get("name") == _GATE_STEP)
+    assert "env.HAS_AUTH == 'true'" in step["if"]


### PR DESCRIPTION
## Why

Nous and Codex can fail together for reasons that have nothing to do with the PR under review — a shared account quota ceiling being the common one. When that happens the cascade posts no verdict, and `mergecraft review` fails closed on **every open PR at once**, with no remedy but waiting for the quota to reset.

This is not hypothetical. #521 sat red through two full reset windows:

```
2026-08-26T21:13:54Z  {"type":"error","message":"You've hit your usage limit ...
                       or try again at Aug 27th, 2026 12:35 AM."}
2026-08-27T07:05:57Z  {"type":"error","message":"You've hit your usage limit ...
                       or try again at 10:00 AM."}
```

The second one died *five minutes into a real review*, after ~72 MCP tool calls. `HAS_NOUS: false` on this repo, so Codex is the only reviewer and there is nothing to absorb it.

## What

Anthropic as a third rung. It fails independently of both existing providers, so one vendor's quota ceiling no longer takes self-review down.

**The two fallbacks route on deliberately different signals**, because they back up different failures:

| Rung | Routes on | Backs up |
|---|---|---|
| Nous → Codex | **verdict absence** | a run that exits 0 while posting nothing usable (`mergecraft-approval=neutral`, the MCP handshake symptom) |
| * → Claude | **retryable failure** | a provider that could not run at all — quota, timeout, transport death — surfaced as a non-zero exit (step outcome `failure` under `continue-on-error`) |

Routing Claude on verdict absence too would spend a third attempt, and a third vendor's quota, every time a reviewer legitimately declines to post one.

**The consequence of the narrower rule, stated plainly:** a rung that exits 0 without posting a verdict does **not** wake the Claude backstop. That case remains Codex's job. This is the intended trade-off, not an oversight.

The decide step still re-checks the verdict before firing — as a safety net, not a trigger. A rung can exit non-zero *after* posting a good verdict (exhaustion arriving on a later retry); re-reviewing then would overwrite real signal.

## Supporting changes

- `HAS_CLAUDE`, and `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` folded into `HAS_AUTH`.
- **The Claude step also runs as sole reviewer when it is the only credential.** Without that clause a Claude-only repo would satisfy `HAS_AUTH`, skip the "not configured" notice, run no review at all, and fail the gate closed with no diagnostic.
- **The approval baseline is now captured for the whole cascade** (`HAS_AUTH`) rather than only when `HAS_NOUS && HAS_CODEX`. On a Codex-only repo — i.e. this one — it was never captured, which would make a stale verdict from a previous run look fresh and silently skip the backstop.
- The incomplete notice is suppressed when Claude rescues the run.
- Job `timeout-minutes` 65 → 95. A worst-case ceiling for three rungs, not an expected cost: a rung that dies on a quota ceiling returns in seconds, not 25 minutes.

## No image or product change needed

- The action image already ships the Claude CLI — `Dockerfile:81` symlinks it and asserts `claude --version` at build time.
- `resolve_runtime_agent()` routes `anthropic/*` to the `claude` harness (not opencode).
- `models.py:70` defines `anthropic` → `claude-sonnet` → `anthropic/claude-sonnet-5`.

## Verification

- `actionlint` clean.
- YAML parses; step count as expected.
- Truth-tabled every rung combination against the literal YAML expressions:

| scenario | claude runs | incomplete notice |
|---|---|---|
| codex quota, claude set | **yes** | no |
| codex quota, no claude | no | yes (unchanged) |
| codex neutral (exit 0) | no *(by design)* | no |
| codex real verdict | no | no |
| codex died **after** verdict | no *(verdict preserved)* | yes |
| claude-only repo | **yes** (sole reviewer) | no |
| nous quota, codex ok | no | no |
| nous + codex both quota | **yes** | no |

## Operator step required

This only takes effect once **`CLAUDE_CODE_OAUTH_TOKEN`** (or `ANTHROPIC_API_KEY`) is set on the repo:

```bash
mergecraft auth claude
```

Until then `HAS_CLAUDE` is false and the cascade behaves exactly as today.

## Timing note

`pull_request_target` resolves this workflow from the **default branch**, so this must land on `main` before any review benefits from it — including this PR's own review, and #521's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUxC7oFAe6XykSaq6TfULu