### PR TITLE
tracing: export Logfire spans from CI reviews

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -511,9 +511,14 @@ jobs:
           # See HAS_BOT_TOKEN above — falls back to github.token when the PAT
           # isn't configured (e.g. a fork of this repo without the secret).
           token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          tracing: "true"
+          tracing-to: logfire
+          logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
         env:
           MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
           MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
+          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_REGION: eu
 
       - name: Decide Codex fallback after Nous
         id: fallback
@@ -617,9 +622,14 @@ jobs:
           status_checks: enabled
           # See the matching comment on the Nous step above.
           token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          tracing: "true"
+          tracing-to: logfire
+          logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_REGION: eu
 
       - name: mergeCraft review incomplete (non-fatal)
         if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The Action image now installs the `[tracing]` extra
+  (`uv sync --frozen --no-dev --extra tracing`). Without it, a workflow wired
+  with `tracing-to: logfire` looked correct and exported nothing: the sink
+  factory degrades a `logfire`/`otel` sink to `NullSink` and only logs a
+  warning, so every Action review since tracing shipped silently dropped its
+  spans. Verified against `uv.lock` — omitting the extra uninstalls logfire
+  plus its seven OpenTelemetry dependencies
+- `mergecraft.yml` now actually passes the tracing inputs it has supported
+  since W8.5. Both review steps (Nous and the Codex fallback) carry
+  `tracing: "true"`, `tracing-to: logfire`, `logfire-token`, and the
+  `MERGECRAFT_TRACING_PROJECT` / `MERGECRAFT_TRACING_REGION` env pair
+
+### Added
+
+- `mergecraft tracing logfire wire-workflow --region us|eu` writes
+  `MERGECRAFT_TRACING_REGION` into the wired step's `env:`. Logfire serves
+  region-specific OTLP hosts and the resolver defaults to `us`, so an EU write
+  token (`pylf_v{N}_eu_…`) previously posted spans to the wrong host with no
+  way to fix it short of hand-editing the workflow. The key is owned (so
+  `unwire-workflow` strips it) but not required, keeping a region-less wire
+  complete rather than partial
+
 ### Changed
 
 - Public MCP consumer docs: ``docs/mcp.md`` (install copy per runtime, OpenAI vs

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,12 @@ WORKDIR /opt/mergecraft
 COPY pyproject.toml uv.lock README.md hatch_build.py ./
 COPY src/mergecraft ./src/mergecraft
 
-RUN uv sync --frozen --no-dev \
+# ``--extra tracing`` installs logfire + the OpenTelemetry SDK/exporter. Without
+# it the sink factory degrades a ``logfire`` / ``otel`` sink to ``NullSink``
+# with a warning (src/mergecraft/tracing/sinks.py), so an Action run wired with
+# ``tracing-to: logfire`` would silently export nothing. The extra is exact-pinned
+# in pyproject and covered by ``uv.lock``, so ``--frozen`` still applies.
+RUN uv sync --frozen --no-dev --extra tracing \
     && useradd -m -u 10001 -s /bin/bash mergecraft \
     && chown -R mergecraft:mergecraft /opt/mergecraft \
     && rm -f /opt/mergecraft/.venv/lib/python3.14/site-packages/merge_craft-*.dist-info/uv_cache.json \

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -57,6 +57,44 @@ sets). The Action input `logfire-token` maps to the runtime
 `MERGECRAFT_LOGFIRE_TOKEN` env var; the project label is read from
 `MERGECRAFT_TRACING_PROJECT` or the YAML `tracing.sinks[].project` field.
 
+Rather than editing the workflow by hand, let the CLI write it:
+
+```bash
+mergecraft tracing logfire wire-workflow --step all --region eu   # dry-run diff
+mergecraft tracing logfire wire-workflow --step all --region eu --apply
+```
+
+This inserts `tracing: "true"`, `tracing-to: logfire`, and
+`logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` into the step's `with:`, plus
+`MERGECRAFT_TRACING_PROJECT` (and, with `--region`, `MERGECRAFT_TRACING_REGION`)
+into its `env:`. `unwire-workflow` strips all of them.
+
+### Data region
+
+Logfire serves region-specific OTLP ingest hosts — `logfire-us.pydantic.dev`
+and `logfire-eu.pydantic.dev` — and the resolver **defaults to `us`**. A write
+token is regional: `pylf_v{N}_eu_…` belongs to the EU project and its spans are
+rejected by the US host. Set the region explicitly whenever the token is not a
+US one:
+
+| Surface | How |
+| ------- | --- |
+| Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+
+Both paths converge on the same precedence layer
+(`cli/tracing_precedence.py`) and the same resolver
+(`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`
+shape carry identical meaning.
+
+### The `[tracing]` extra in the Action image
+
+The Action runs from `Dockerfile`, which installs
+`uv sync --frozen --no-dev --extra tracing`. Without that extra the sink
+factory degrades a `logfire` / `otel` sink to `NullSink` with a warning
+(`src/mergecraft/tracing/sinks.py`) — the workflow looks correctly wired and
+exports nothing. If you fork the image build, keep the extra.
+
 ## Config schema
 
 ```yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire unwire-workflow` | Remove Logfire tracing wiring from the consumer workflow. |
-| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow. |
+| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow (`--region us\|eu` also writes `MERGECRAFT_TRACING_REGION`). |
 | `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire unwire-workflow` | Remove Logfire tracing wiring from the consumer workflow. |
-| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow (`--region us\|eu` also writes `MERGECRAFT_TRACING_REGION`). |
+| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow. |
 | `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1657,6 +1657,44 @@ sets). The Action input `logfire-token` maps to the runtime
 `MERGECRAFT_LOGFIRE_TOKEN` env var; the project label is read from
 `MERGECRAFT_TRACING_PROJECT` or the YAML `tracing.sinks[].project` field.
 
+Rather than editing the workflow by hand, let the CLI write it:
+
+```bash
+mergecraft tracing logfire wire-workflow --step all --region eu   # dry-run diff
+mergecraft tracing logfire wire-workflow --step all --region eu --apply
+```
+
+This inserts `tracing: "true"`, `tracing-to: logfire`, and
+`logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` into the step's `with:`, plus
+`MERGECRAFT_TRACING_PROJECT` (and, with `--region`, `MERGECRAFT_TRACING_REGION`)
+into its `env:`. `unwire-workflow` strips all of them.
+
+### Data region
+
+Logfire serves region-specific OTLP ingest hosts — `logfire-us.pydantic.dev`
+and `logfire-eu.pydantic.dev` — and the resolver **defaults to `us`**. A write
+token is regional: `pylf_v{N}_eu_…` belongs to the EU project and its spans are
+rejected by the US host. Set the region explicitly whenever the token is not a
+US one:
+
+| Surface | How |
+| ------- | --- |
+| Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+
+Both paths converge on the same precedence layer
+(`cli/tracing_precedence.py`) and the same resolver
+(`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`
+shape carry identical meaning.
+
+### The `[tracing]` extra in the Action image
+
+The Action runs from `Dockerfile`, which installs
+`uv sync --frozen --no-dev --extra tracing`. Without that extra the sink
+factory degrades a `logfire` / `otel` sink to `NullSink` with a warning
+(`src/mergecraft/tracing/sinks.py`) — the workflow looks correctly wired and
+exports nothing. If you fork the image build, keep the extra.
+
 ## Config schema
 
 ```yaml

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -392,6 +392,16 @@ def logfire_wire_workflow(
             "target a specific step exactly."
         ),
     ),
+    region: str | None = typer.Option(
+        None,
+        "--region",
+        help=(
+            "Logfire data region: 'us' or 'eu'. When given, writes "
+            "``MERGECRAFT_TRACING_REGION`` into the step's ``env:``. Omit to leave "
+            "the key alone (the resolver defaults to 'us'). An EU write token "
+            "(``pylf_v{N}_eu_…``) needs --region eu or spans go to the US host."
+        ),
+    ),
     apply: bool = typer.Option(
         False,
         "--apply",
@@ -415,6 +425,7 @@ def logfire_wire_workflow(
         mergecraft tracing logfire wire-workflow
         mergecraft tracing logfire wire-workflow --workflow .github/workflows/ci.yml \
             --secret LOGFIRE_TOKEN --project-var LOGFIRE_PROJECT --apply
+        mergecraft tracing logfire wire-workflow --region eu --step all --apply
 
     Refuses to add an obvious mismatch (e.g. existing ``tracing-to: otel``)
     unless ``--force`` is given. Dry-run by default; ``--apply`` writes.
@@ -423,6 +434,10 @@ def logfire_wire_workflow(
         cli_bail("--secret cannot be empty")
     if not project_var:
         cli_bail("--project-var cannot be empty")
+    if region is not None:
+        region = region.strip().lower()
+        if region not in _VALID_REGIONS:
+            cli_bail(f"--region must be one of: {', '.join(_VALID_REGIONS)} (got {region!r}).")
     try:
         proposed = apply_logfire_wiring(
             workflow_path=workflow,
@@ -430,6 +445,7 @@ def logfire_wire_workflow(
             project_var_name=project_var,
             step_selector=step,
             force=force,
+            region=region,
         )
     except LogfireWorkflowError as exc:
         cli_bail(str(exc))

--- a/src/mergecraft/cli/tracing_logfire_wf_yaml.py
+++ b/src/mergecraft/cli/tracing_logfire_wf_yaml.py
@@ -1007,7 +1007,7 @@ def apply_logfire_wiring(
         if not mod_env and _find_mapping_block(block2, "env", at_indent=step_indent) is None:
             # ``env:`` block is genuinely absent -- create one immediately
             # after the ``with:`` block (or after ``uses:`` if no ``with:``).
-            block3 = _create_env_block(block2, env_canonical[0], at_indent=step_indent)
+            block3 = _create_env_block(block2, env_canonical, at_indent=step_indent)
             mod_env = True
         return block3, mod_with or mod_env
 
@@ -1079,12 +1079,14 @@ def _create_with_block(
     return block[: m.end()] + insertion + block[m.end() :]
 
 
-def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | None = None) -> str:
+def _create_env_block(
+    block: str, canonical: list[tuple[str, str]], at_indent: int | None = None
+) -> str:
     """Insert a fresh ``env:`` block immediately after the ``with:`` block.
 
     When the step has no ``with:`` block the new ``env:`` is appended after
     the ``uses:`` line (the canonical sibling placement). The new block holds
-    a single child line ``MERGECRAFT_TRACING_PROJECT`` at the canonical
+    one child line per entry in *canonical*, in order, at the canonical
     child indent -- which we derive from the existing ``with:`` block's
     observed child indent when present (falling back to ``+2``), so the
     new ``env:`` mirrors the workflow's own style even on non-canonical
@@ -1097,7 +1099,17 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
     inside a block scalar from being mistaken for the step's real ``with:``
     mapping.
     """
-    canonical_key, canonical_value = canonical
+    if not canonical:
+        msg = "_create_env_block requires at least one canonical entry"
+        raise LogfireWorkflowError(msg)
+
+    def _children(child_indent: str) -> str:
+        # Every owned key the caller asked for, not just the first. Rendering
+        # a subset here silently drops keys (e.g. MERGECRAFT_TRACING_REGION)
+        # on the env-less step shape, and the wired-semantics check would not
+        # catch it because only REQUIRED_ENV_KEYS is asserted.
+        return "".join(f"{child_indent}{key}: {value}\n" for key, value in canonical)
+
     # Prefer inserting after the ``with:`` block (its trailing `block_end`).
     with_block = _find_mapping_block(block, "with", at_indent=at_indent)
     if with_block is not None:
@@ -1111,7 +1123,7 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
         # path, but be defensive for callers that go straight here).
         child_ws = _derive_child_indent(block, with_block[0], with_block[1], with_block[2])
         env_child_indent = child_ws if child_ws is not None else with_indent + "  "
-        insertion = f"{with_indent}env:\n{env_child_indent}{canonical_key}: {canonical_value}\n"
+        insertion = f"{with_indent}env:\n" + _children(env_child_indent)
         return block[:with_end] + insertion + block[with_end:]
     # No ``with:`` -- fall back to inserting after ``uses:``. Match both
     # step shapes documented by the README -- multi-line
@@ -1128,7 +1140,7 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
         )
     indent_str = " " * at_indent if at_indent is not None else ""
     env_indent = indent_str + "  "
-    insertion = f"{indent_str}env:\n{env_indent}{canonical_key}: {canonical_value}\n"
+    insertion = f"{indent_str}env:\n" + _children(env_indent)
     return block[: m.end()] + insertion + block[m.end() :]
 
 

--- a/src/mergecraft/cli/tracing_logfire_wf_yaml.py
+++ b/src/mergecraft/cli/tracing_logfire_wf_yaml.py
@@ -75,7 +75,17 @@ def _is_action_uses(uses: str, action_uses: str = _ACTION_USES) -> bool:
 # Owned keys -- every key whose value this module is willing to insert
 # or strip. Kept as tuples so callers (and tests) can import them.
 OWNED_WITH_KEYS: tuple[str, ...] = ("tracing", "tracing-to", "logfire-token")
-OWNED_ENV_KEYS: tuple[str, ...] = ("MERGECRAFT_TRACING_PROJECT",)
+OWNED_ENV_KEYS: tuple[str, ...] = (
+    "MERGECRAFT_TRACING_PROJECT",
+    "MERGECRAFT_TRACING_REGION",
+)
+
+# The subset of ``OWNED_ENV_KEYS`` that must be present after a wire for the
+# result to count as fully wired. ``MERGECRAFT_TRACING_REGION`` is opt-in
+# (``wire-workflow --region``) because the resolver already defaults to ``us``
+# when it is absent, so a wire that omits it is complete, not partial. It still
+# belongs to ``OWNED_ENV_KEYS`` so ``unwire-workflow`` strips it.
+REQUIRED_ENV_KEYS: tuple[str, ...] = ("MERGECRAFT_TRACING_PROJECT",)
 
 # Indent units. The upstream convention is two-space indent for keys under a
 # step (``uses:`` at 8 spaces, ``with:``/``env:`` at 8 spaces, children at
@@ -864,7 +874,7 @@ def _assert_wired_semantics(text: str, *, step_identifiers: list[str]) -> None:
                     "cannot carry MERGECRAFT_TRACING_PROJECT"
                 )
             else:
-                for key in OWNED_ENV_KEYS:
+                for key in REQUIRED_ENV_KEYS:
                     if key not in env_map:
                         unwired.append(f"{step_id}: missing env.{key}")
     missing = targets - seen_targets
@@ -926,8 +936,18 @@ def apply_logfire_wiring(
     project_var_name: str,
     step_selector: str,
     force: bool,
+    region: str | None = None,
 ) -> WiringChange:
-    """Insert the four owned keys into every selected ``uses:`` step in ``workflow_path``."""
+    """Insert the owned keys into every selected ``uses:`` step in ``workflow_path``.
+
+    When *region* is ``"us"`` / ``"eu"``, an additional
+    ``MERGECRAFT_TRACING_REGION`` entry is written into the step's ``env:``
+    mapping. Logfire serves region-specific OTLP ingest hosts
+    (``logfire-us.pydantic.dev`` / ``logfire-eu.pydantic.dev``) and the
+    resolver defaults to ``us``; an EU write token therefore needs this key or
+    its spans are posted to the wrong host. ``None`` (the default) leaves the
+    key alone, preserving the pre-existing wiring shape.
+    """
     try:
         text = workflow_path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
@@ -945,6 +965,11 @@ def apply_logfire_wiring(
     env_canonical: list[tuple[str, str]] = [
         ("MERGECRAFT_TRACING_PROJECT", f"${{{{ vars.{_splice_secret(project_var_name)} }}}}"),
     ]
+    if region is not None:
+        normalised = region.strip().lower()
+        if normalised not in {"us", "eu"}:
+            raise LogfireWorkflowError(f"region must be 'us' or 'eu' (got {region!r})")
+        env_canonical.append(("MERGECRAFT_TRACING_REGION", normalised))
 
     def _do(block: str, step_indent: int) -> tuple[str, bool]:
         # Order matters: insert ``with:`` keys first so an existing ``env:``
@@ -1146,6 +1171,7 @@ __all__ = [
     "DEFAULT_WORKFLOW_RELATIVE_PATH",
     "OWNED_ENV_KEYS",
     "OWNED_WITH_KEYS",
+    "REQUIRED_ENV_KEYS",
     "LogfireWorkflowError",
     "WiringChange",
     "apply_logfire_wiring",

--- a/src/mergecraft/cli/workflow_wf_yaml.py
+++ b/src/mergecraft/cli/workflow_wf_yaml.py
@@ -175,7 +175,7 @@ def apply_provider_env_wiring(
             at_indent=step_indent,
         )
         if not mod_env and _find_mapping_block(block2, "env", at_indent=step_indent) is None:
-            block2 = _create_env_block(block2, env_canonical[0], at_indent=step_indent)
+            block2 = _create_env_block(block2, env_canonical, at_indent=step_indent)
             mod_env = True
         block3, mod_env2 = _insert_owned_keys_into_block(
             block2,

--- a/tests/cli/test_tracing_logfire_wf_yaml.py
+++ b/tests/cli/test_tracing_logfire_wf_yaml.py
@@ -28,6 +28,7 @@ from mergecraft.cli.tracing_logfire_wf_yaml import (
     DEFAULT_WORKFLOW_RELATIVE_PATH,
     OWNED_ENV_KEYS,
     OWNED_WITH_KEYS,
+    REQUIRED_ENV_KEYS,
     LogfireWorkflowError,
     apply_logfire_wiring,
     remove_logfire_wiring,
@@ -131,8 +132,13 @@ def test_apply_logfire_wiring_adds_four_keys_to_one_step(tmp_path: Path) -> None
     new = change.new_text
     for key in OWNED_WITH_KEYS:
         assert f"{key}:" in new, f"missing {key} after wiring"
-    for key in OWNED_ENV_KEYS:
+    for key in REQUIRED_ENV_KEYS:
         assert f"{key}:" in new, f"missing {key} after wiring"
+    # ``MERGECRAFT_TRACING_REGION`` is opt-in (``--region``): it is owned for
+    # removal but must not be written by a default wire.
+    assert "MERGECRAFT_TRACING_REGION" in OWNED_ENV_KEYS
+    assert "MERGECRAFT_TRACING_REGION" not in REQUIRED_ENV_KEYS
+    assert "MERGECRAFT_TRACING_REGION:" not in new
     # The merged YAML re-parses cleanly.
     parsed = yaml.safe_load(new)
     assert parsed["jobs"]["review"]["steps"][0]["uses"].startswith("alexhawat/mergeCraft@")
@@ -169,6 +175,96 @@ def test_apply_logfire_wiring_is_idempotent(tmp_path: Path) -> None:
     )
     assert not second.was_modified
     assert second.new_text == first.new_text
+
+
+def test_apply_logfire_wiring_region_writes_env_key(tmp_path: Path) -> None:
+    """``--region eu`` writes MERGECRAFT_TRACING_REGION so EU tokens reach the EU host."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    env = parsed["jobs"]["review"]["steps"][0]["env"]
+    assert env["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+
+
+def test_apply_logfire_wiring_region_is_normalised(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="  EU  ",
+    )
+    parsed = yaml.safe_load(change.new_text)
+    assert parsed["jobs"]["review"]["steps"][0]["env"]["MERGECRAFT_TRACING_REGION"] == "eu"
+
+
+def test_apply_logfire_wiring_rejects_unknown_region(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    with pytest.raises(LogfireWorkflowError, match="region must be"):
+        apply_logfire_wiring(
+            workflow_path=workflow,
+            secret_name="LOGFIRE_TOKEN",
+            project_var_name="LOGFIRE_PROJECT",
+            step_selector="primary",
+            force=False,
+            region="apac",
+        )
+
+
+def test_apply_logfire_wiring_region_is_idempotent(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    first = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(first.new_text, encoding="utf-8")
+    second = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert not second.was_modified
+    assert second.new_text == first.new_text
+
+
+def test_removal_strips_region_key(tmp_path: Path) -> None:
+    """``MERGECRAFT_TRACING_REGION`` is owned, so unwire must strip it too."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    wired = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(wired.new_text, encoding="utf-8")
+    removed = remove_logfire_wiring(workflow_path=workflow, step_selector="primary")
+    assert removed.was_modified
+    assert "MERGECRAFT_TRACING_REGION" not in removed.new_text
 
 
 def test_apply_logfire_wiring_step_all_wires_two_steps(tmp_path: Path) -> None:

--- a/tests/cli/test_tracing_logfire_wf_yaml.py
+++ b/tests/cli/test_tracing_logfire_wf_yaml.py
@@ -423,6 +423,120 @@ jobs:
     assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
 
 
+NO_ENV_TEMPLATE = """\
+name: mergecraft
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft review
+        id: mergecraft_primary
+        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        with:
+          prompt: x
+"""
+
+NO_ENV_NO_WITH_TEMPLATE = """\
+name: mergecraft
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft review
+        id: mergecraft_primary
+        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+"""
+
+
+def test_region_survives_when_the_step_has_no_env_block(tmp_path: Path) -> None:
+    """A created ``env:`` must carry every owned key, not just the first.
+
+    Regression: the fallback that creates a missing ``env:`` mapping rendered
+    only ``env_canonical[0]``, silently dropping MERGECRAFT_TRACING_REGION.
+    ``_assert_wired_semantics`` did not catch it because it asserts only
+    REQUIRED_ENV_KEYS, so the command reported success while an EU token kept
+    posting to the default US endpoint.
+    """
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    env = parsed["jobs"]["review"]["steps"][0]["env"]
+    assert env["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+
+
+def test_region_survives_when_the_step_has_neither_env_nor_with(tmp_path: Path) -> None:
+    """The ``uses:``-anchored creation path owns the same defect shape."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_NO_WITH_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    step = parsed["jobs"]["review"]["steps"][0]
+    assert step["env"]["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert step["env"]["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+    assert step["with"]["tracing-to"] == "logfire"
+
+
+def test_env_less_wire_then_unwire_round_trips(tmp_path: Path) -> None:
+    """A created env block must be fully strippable, region included."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    wired = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(wired.new_text, encoding="utf-8")
+    removed = remove_logfire_wiring(workflow_path=workflow, step_selector="primary")
+    assert "MERGECRAFT_TRACING_REGION" not in removed.new_text
+    assert "MERGECRAFT_TRACING_PROJECT" not in removed.new_text
+
+
+def test_env_less_wire_is_idempotent_with_region(tmp_path: Path) -> None:
+    """Re-wiring a step whose env block this command created is a no-op."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    first = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(first.new_text, encoding="utf-8")
+    second = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert not second.was_modified
+    assert second.new_text == first.new_text
+
+
 # ---------------------------------------------------------------------------
 # Phase 2 -- render_workflow_diff
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What?

Reviews running in CI now export their traces to Logfire. Three separate gaps each independently prevented a single span from leaving the runner, so all three had to close before anything shipped.

- The review workflow now passes the tracing settings the action has accepted since tracing landed.
- The Action image now carries the tracing dependencies, so a configured remote destination is a real one rather than a silent no-op.
- Workflow wiring can now target a data region, so a European token reaches a European host.

## Why?

Tracing was configured, credentialed, and documented, and none of it ran. The write token has been in repository secrets since 11 August. Every review since then dropped its spans with nothing to tell an operator anything was wrong.

That mattered most exactly when it was needed. A review that runs long, picks the wrong model, or blocks a merge leaves no record of which tools it called or where its time went, because the runner is gone by the time anyone asks.

Each gap was individually invisible. Absent settings look identical to tracing being switched off. Absent dependencies degrade to a no-op behind a single log line nobody reads. A wrong region fails at the far end, after the run has finished.

Setting the region by hand would have fixed one repository and left the next person to rediscover it, so the wiring command learned to write it instead.

## Note

Nothing takes effect until this reaches the default branch and the action pin is bumped to a commit containing the new image. Reviews resolve both the workflow and the pin from the default branch, so the review on this branch still runs untraced.

The `LOGFIRE_PROJECT` repository variable is set separately and already in place. It is informational, since Logfire routes by token.

Local and CI setup now converge on the same three settings, so a working `.env` maps directly onto a workflow step.

## Test plan

- [x] `make typecheck` (mypy strict, 497 files) and `make pyright`-equivalent ruff pass
- [x] `uv run pytest tests/cli tests/tracing tests/action -m "not integration"` — 1205 passed, 8 xfailed
- [x] `uv lock --check` clean, so `--frozen` still holds in the image build
- [x] Confirmed against the lock that dropping the extra uninstalls logfire and its seven OpenTelemetry dependencies, which is the silent no-op path
- [x] `scripts/check_action_yml_hygiene.py` passes on a clean worktree of the branch tip

`make lint` fails in working checkouts that hold stray untracked `mergecraft-*` directories, because the hygiene script walks the whole repository root. Reproduced with this branch stashed, so it predates it.

## Related PR(s)/Issue(s)

Review-performance findings from the same run analysis: #526, #527, #528, #529, #530.
