### PR TITLE
release: promote lane A hardening and Logfire tracing to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,30 @@ jobs:
       - name: Integration suite (self-skips without live secrets)
         run: make test-integration
 
+  privilege-root:
+    name: Verify (root container privilege py3.14)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build action image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: mergecraft:lane-a
+          cache-from: type=gha,scope=mergeCraft-slim-privilege
+          cache-to: type=gha,mode=max,scope=mergeCraft-slim-privilege
+      - name: Privilege identity + trust-ordering (root and uid 65534)
+        run: |
+          chmod +x docker/e2e/run_in_image_privilege.sh
+          docker/e2e/run_in_image_privilege.sh mergecraft:lane-a
+
   mutation-advisory:
     name: Verify (mutation advisory py3.14)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build action image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -511,9 +511,14 @@ jobs:
           # See HAS_BOT_TOKEN above — falls back to github.token when the PAT
           # isn't configured (e.g. a fork of this repo without the secret).
           token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          tracing: "true"
+          tracing-to: logfire
+          logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
         env:
           MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
           MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
+          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_REGION: eu
 
       - name: Decide Codex fallback after Nous
         id: fallback
@@ -617,9 +622,14 @@ jobs:
           status_checks: enabled
           # See the matching comment on the Nous step above.
           token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          tracing: "true"
+          tracing-to: logfire
+          logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_REGION: eu
 
       - name: mergeCraft review incomplete (non-fatal)
         if: >-

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -493,7 +493,17 @@ jobs:
         # pull_request_target resolves this workflow and action pin from the repo
         # default branch (main), not the PR head — self-review PRs cannot bump the
         # pin until after merge.
-        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
+        # 2026-08-27 (tenth bump, PR #533): re-bumped to b34e9f25 — the ninth pin
+        # had drifted 107 commits on src/mergecraft/, so every review since
+        # 2026-08-23 ran product code that stale. Two concrete costs: the image at
+        # 5b9ded9f has no `[tracing]` extra, so #531's Logfire wiring resolves to a
+        # NullSink and exports nothing; and analyzer defects already fixed by #458 /
+        # #459 still appeared in Action logs, which is how #527 came to be filed
+        # against bugs that no longer existed. `make action-pin-check` detects this
+        # correctly but is wired into no gate — see #532, which fixes the guard.
+        # b34e9f25 is the pre-0.0.1 tip this PR promotes; it carries the Dockerfile
+        # `--extra tracing` line and the lane A hardening from #519.
+        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -608,7 +618,17 @@ jobs:
         # pull_request_target resolves this workflow and action pin from the repo
         # default branch (main), not the PR head — self-review PRs cannot bump the
         # pin until after merge.
-        uses: alexhawat/mergeCraft@5b9ded9ff3a27090f5c6d3cf722b2452596360bd # pre-0.0.1 (PR #457)
+        # 2026-08-27 (tenth bump, PR #533): re-bumped to b34e9f25 — the ninth pin
+        # had drifted 107 commits on src/mergecraft/, so every review since
+        # 2026-08-23 ran product code that stale. Two concrete costs: the image at
+        # 5b9ded9f has no `[tracing]` extra, so #531's Logfire wiring resolves to a
+        # NullSink and exports nothing; and analyzer defects already fixed by #458 /
+        # #459 still appeared in Action logs, which is how #527 came to be filed
+        # against bugs that no longer existed. `make action-pin-check` detects this
+        # correctly but is wired into no gate — see #532, which fixes the guard.
+        # b34e9f25 is the pre-0.0.1 tip this PR promotes; it carries the Dockerfile
+        # `--extra tracing` line and the lane A hardening from #519.
+        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,12 @@ evals/results/structural-replay-convergence-*.json
 !/.mergecraft/xrepo-brief.md
 
 /.agents
+
+# Local wave agent kit (operator tooling; pack/unpack via scripts/wave_agents_kit.sh)
+/.github/agents/wave-plan-executor.md
+/.github/agents/test-creator.md
+/docs/_standards/invariants.md
+/scripts/wave_close.py
+/scripts/sync_agent_prompts.py
+/scripts/wave_agents_kit.sh
+/tests/scripts/test_wave_close.py

--- a/.mergecraft/config.yaml
+++ b/.mergecraft/config.yaml
@@ -15,10 +15,11 @@
 prApproveEnabled: true
 
 # Dogfood self-review on this sweep PR exhausted the 2M default
-# (Codex: 2_196_957 tokens). Give the fallback enough headroom to post
-# mergecraft-approval so the gate is not fail-closed on budget.
+# (Codex: 2_196_957 tokens). Raised again after lane-A integration reviews
+# reported ~4.25M input tokens on large PRs while the 3M cap still failed
+# closed after a completed terminal verdict.
 runBounds:
-  tokenBudget: 3000000
+  tokenBudget: 5000000
 
 # First-wave CI SARIF as review evidence (#464 / D8). Artifact names must match
 # the uploads in .github/workflows/ci.yml — not mergecraft.yml.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ make ci         # full pre-merge gate
 - **MCP:** `mergecraft mcp serve` (HTTP, Bearer-required per-run token on an ephemeral port;
   reviewer role at `/mcp/reviewer`) and `mergecraft mcp list` — see [`docs/cli.md`](docs/cli.md)
 
-### Local development overrides
+**Optional local overrides**
 
 On hosts without Linux namespace isolation (`unshare`), mergeCraft refuses to run the MCP
 shell tool and may refuse root outside the Action image. For local debugging only:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,19 @@ make ci         # full pre-merge gate
 - **MCP:** `mergecraft mcp serve` (HTTP, Bearer-required per-run token on an ephemeral port;
   reviewer role at `/mcp/reviewer`) and `mergecraft mcp list` — see [`docs/cli.md`](docs/cli.md)
 
+### Local development overrides
+
+On hosts without Linux namespace isolation (`unshare`), mergeCraft refuses to run the MCP
+shell tool and may refuse root outside the Action image. For local debugging only:
+
+- `MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1` — allow the unsandboxed shell fallback when PID
+  namespace isolation is unavailable.
+- `MERGECRAFT_ALLOW_ROOT=1` — allow running as root outside the Action container image.
+- `MERGECRAFT_PROBE_ALLOW_SUDO=1` — allow the isolation probe to retry with `sudo`
+  when `CI` is unset (local capability probing only).
+
+Do not set these in CI or production workflows.
+
 ## Rules for agents
 
 - Do not weaken trust-tier or fail-closed security behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (MCB-09 / D7)
 - ``sudo-unshare`` shell spawn passes env by name via ``--preserve-env`` with
   ``env=env`` on ``Popen`` so provider keys never appear in argv (MCB-08)
-- Untrusted shell namespace hides every ``git`` binary and binds ``.git``
-  read-only in all spawn branches, including the unsandboxed fallback (MCB-25)
+- Namespaced shell spawn hides every ``git`` binary and binds ``.git`` read-only
+  inside ``unshare`` / ``sudo-unshare`` branches; unsandboxed opt-in runs the raw
+  command without host mount soup (MCB-25)
 - Python ``prep`` installs into ``.mergecraft/prep-scratch/prep-venv`` with a
   default-deny env allowlist so PR build deps cannot mutate the reviewer's
   interpreter or inherit provider credentials (MCB-22 / D12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binds every registered workspace root's ``.git`` read-only (MCB-01 / D3)
 - Linked-repo ``_rev_parse_commit`` rejects leading-dash revs, validates pinned SHA
   shape, and passes ``--end-of-options`` before the rev (MCB-33)
+- Sandbox capability probes run real isolation checks instead of gating on ``CI``;
+  untrusted MCP shell refuses unsandboxed spawn unless
+  ``MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1`` (MCB-07 / MCB-10)
+- Skipped untrusted analyzers emit a ``Minor`` finding
+  (``rule_id: analyzers.sandbox-unavailable``) naming missing isolation primitives
+  (MCB-09 / D7)
 
 ### Changed
+
+- ``probe_capabilities()`` is ``lru_cache``-backed; ``reset_detection_cache()`` clears
+  the probe cache for xdist isolation (MCB-35 / D13)
+- ``detect_sandbox_method()`` and ``network_namespace_available()`` delegate to the
+  cached capability probe with one unified privilege ladder (D5)
 
 - Public MCP consumer docs: ``docs/mcp.md`` (install copy per runtime, OpenAI vs
   Anthropic sections), README ``For LLM / Agents`` row linking public stdio install,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1`` (MCB-07 / MCB-10)
 - Skipped untrusted analyzers emit a ``Minor`` finding
   (``rule_id: analyzers.sandbox-unavailable``) naming missing isolation primitives
+- ``sudo-unshare`` shell spawn passes env by name via ``--preserve-env`` with
+  ``env=env`` on ``Popen`` so provider keys never appear in argv (MCB-08)
+- Untrusted shell namespace hides every ``git`` binary and binds ``.git``
+  read-only in all spawn branches, including the unsandboxed fallback (MCB-25)
   (MCB-09 / D7)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The self-review Action pin on both review steps moves to `b34e9f25`. The
+  previous pin (`5b9ded9f`, 23 August) had drifted 107 commits on
+  `src/mergecraft/`, so every review since then ran product code that stale.
+  The image at that pin carries no `[tracing]` extra, which would have left
+  the Logfire wiring exporting nothing, and analyzer defects already fixed by
+  #458 / #459 kept surfacing in Action logs. `make action-pin-check` reports
+  the drift correctly but gates nothing; #532 tracks wiring it into `make ci`
+
 ### Security
 
 - OpenCode review sessions deny ``webfetch``, ``external_directory``, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binds every registered workspace root's ``.git`` read-only (MCB-01 / D3)
 - Linked-repo ``_rev_parse_commit`` rejects leading-dash revs, validates pinned SHA
   shape, and passes ``--end-of-options`` before the rev (MCB-33)
+- Python ``prep`` installs into ``.mergecraft/prep-scratch/prep-venv`` with a
+  default-deny env allowlist so PR build deps cannot mutate the reviewer's
+  interpreter or inherit provider credentials (MCB-22 / D12)
+
+### Fixed
+
+- ``prep`` lockfile selection prefers ``uv.lock`` over a stray ``requirements.txt``;
+  ``should_run`` threads one ``cwd`` into ``run`` instead of reading ``Path.cwd()``
+  twice (MCB-22)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
+  pinned safe-config keys; ``make lint`` enforces the route via
+  ``scripts/check_git_argv.py`` (MCB-01)
+- ``prepare_workspace_for_agent`` no longer recursively chowns ``.git``; sandbox shell
+  binds every registered workspace root's ``.git`` read-only (MCB-01 / D3)
+- Linked-repo ``_rev_parse_commit`` rejects leading-dash revs, validates pinned SHA
+  shape, and passes ``--end-of-options`` before the rev (MCB-33)
+
 ### Changed
 
 - Public MCP consumer docs: ``docs/mcp.md`` (install copy per runtime, OpenAI vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- OpenCode review sessions deny ``webfetch``, ``external_directory``, and
+  ``edit``; ``read`` is allowlisted to the checkout and evidence scratch
+  instead of ``*`` (MCB-06)
+- Post-run checkout integrity verification via
+  ``security.review_integrity`` hashes the tree before review and fails closed
+  on mutation (MCB-06)
 - Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
   pinned safe-config keys; ``make lint`` enforces the route via
   ``scripts/check_git_argv.py`` (MCB-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The Action image now installs the `[tracing]` extra
+  (`uv sync --frozen --no-dev --extra tracing`). Without it, a workflow wired
+  with `tracing-to: logfire` looked correct and exported nothing: the sink
+  factory degrades a `logfire`/`otel` sink to `NullSink` and only logs a
+  warning, so every Action review since tracing shipped silently dropped its
+  spans. Verified against `uv.lock` — omitting the extra uninstalls logfire
+  plus its seven OpenTelemetry dependencies
+- `mergecraft.yml` now actually passes the tracing inputs it has supported
+  since W8.5. Both review steps (Nous and the Codex fallback) carry
+  `tracing: "true"`, `tracing-to: logfire`, `logfire-token`, and the
+  `MERGECRAFT_TRACING_PROJECT` / `MERGECRAFT_TRACING_REGION` env pair
+
+### Added
+
+- `mergecraft tracing logfire wire-workflow --region us|eu` writes
+  `MERGECRAFT_TRACING_REGION` into the wired step's `env:`. Logfire serves
+  region-specific OTLP hosts and the resolver defaults to `us`, so an EU write
+  token (`pylf_v{N}_eu_…`) previously posted spans to the wrong host with no
+  way to fix it short of hand-editing the workflow. The key is owned (so
+  `unwire-workflow` strips it) but not required, keeping a region-less wire
+  complete rather than partial
+
 ### Changed
 
 - Public MCP consumer docs: ``docs/mcp.md`` (install copy per runtime, OpenAI vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Privilege drop gates on action-image identity (``IS_SANDBOX`` + ``/opt/mergecraft``)
+  instead of uid alone; root outside the image refuses with a policy diagnostic and
+  ``MERGECRAFT_ALLOW_ROOT=1`` override (MCB-24 / D11)
+- ``setpriv`` argv carries ``--no-new-privs``, ``--inh-caps=-all``, and
+  ``--bounding-set=-all``; fails closed when ``setpriv`` lacks ``--bounding-set``
+  support (MCB-32)
 - Root-side ``git`` subprocesses route through ``utils/git_hardening.git_argv`` with
   pinned safe-config keys; ``make lint`` enforces the route via
   ``scripts/check_git_argv.py`` (MCB-01)

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,12 @@ WORKDIR /opt/mergecraft
 COPY pyproject.toml uv.lock README.md hatch_build.py ./
 COPY src/mergecraft ./src/mergecraft
 
-RUN uv sync --frozen --no-dev \
+# ``--extra tracing`` installs logfire + the OpenTelemetry SDK/exporter. Without
+# it the sink factory degrades a ``logfire`` / ``otel`` sink to ``NullSink``
+# with a warning (src/mergecraft/tracing/sinks.py), so an Action run wired with
+# ``tracing-to: logfire`` would silently export nothing. The extra is exact-pinned
+# in pyproject and covered by ``uv.lock``, so ``--frozen`` still applies.
+RUN uv sync --frozen --no-dev --extra tracing \
     && useradd -m -u 10001 -s /bin/bash mergecraft \
     && chown -R mergecraft:mergecraft /opt/mergecraft \
     && rm -f /opt/mergecraft/.venv/lib/python3.14/site-packages/merge_craft-*.dist-info/uv_cache.json \

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-
 	$(RUFF) check src tests scripts
 	$(RUFF) format --check src tests scripts
 	$(UV) run python scripts/check_loguru_only.py
+	$(UV) run python scripts/check_git_argv.py
 	$(UV) run python scripts/check_cli_consoles.py
 	$(MAKE) action-yml-hygiene-check
 	$(MAKE) hook-pins-check

--- a/docker/e2e/run_in_image_privilege.sh
+++ b/docker/e2e/run_in_image_privilege.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Run lane-A privilege identity + trust-ordering suites inside the action image (AP6 / D14b).
+# Host macOS lacks setpriv; root-container behaviour is verified here, not on the host.
+set -euo pipefail
+
+IMAGE="${1:?image tag required}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "» in-image privilege suite (root): ${IMAGE}"
+docker run --rm \
+  -v "${ROOT}:/workspace:ro" \
+  -w /workspace \
+  --entrypoint /bin/bash \
+  "${IMAGE}" \
+  -lc '
+set -euo pipefail
+uv pip install --python /opt/mergecraft/.venv/bin/python \
+  "pytest==9.1.1" "pytest-asyncio==1.3.0"
+export PYTHONPATH=/workspace
+export PYTEST_ADDOPTS="-p no:cacheprovider"
+PYTEST=(/opt/mergecraft/.venv/bin/python -m pytest)
+STABLE_TESTS=(
+  tests/prep/test_prep_fail_closed.py
+  tests/security/test_trust_ordering.py
+  tests/security/test_trust_ordering_attacks.py
+)
+# AP1.5 RED markers remain until test-creator reconciles — --runxfail avoids XPASS ratchet.
+PRIVILEGE_IDENTITY_TESTS=(tests/utils/test_privilege_identity.py)
+run_suite() {
+  echo "» pytest as uid=$(id -u)"
+  "${PYTEST[@]}" "${STABLE_TESTS[@]}" -q --tb=short -m "not integration"
+  "${PYTEST[@]}" "${PRIVILEGE_IDENTITY_TESTS[@]}" --runxfail -q --tb=short -m "not integration"
+}
+run_suite
+echo "» pytest as uid=65534 (nobody)"
+runuser -u nobody -- env PYTHONPATH=/workspace PYTEST_ADDOPTS="-p no:cacheprovider" \
+  bash -lc "
+    ${PYTEST[*]} ${STABLE_TESTS[*]} -q --tb=short -m \"not integration\"
+    ${PYTEST[*]} ${PRIVILEGE_IDENTITY_TESTS[*]} --runxfail -q --tb=short -m \"not integration\"
+  "
+'
+
+echo "» in-image privilege suite OK"

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -57,6 +57,44 @@ sets). The Action input `logfire-token` maps to the runtime
 `MERGECRAFT_LOGFIRE_TOKEN` env var; the project label is read from
 `MERGECRAFT_TRACING_PROJECT` or the YAML `tracing.sinks[].project` field.
 
+Rather than editing the workflow by hand, let the CLI write it:
+
+```bash
+mergecraft tracing logfire wire-workflow --step all --region eu   # dry-run diff
+mergecraft tracing logfire wire-workflow --step all --region eu --apply
+```
+
+This inserts `tracing: "true"`, `tracing-to: logfire`, and
+`logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` into the step's `with:`, plus
+`MERGECRAFT_TRACING_PROJECT` (and, with `--region`, `MERGECRAFT_TRACING_REGION`)
+into its `env:`. `unwire-workflow` strips all of them.
+
+### Data region
+
+Logfire serves region-specific OTLP ingest hosts — `logfire-us.pydantic.dev`
+and `logfire-eu.pydantic.dev` — and the resolver **defaults to `us`**. A write
+token is regional: `pylf_v{N}_eu_…` belongs to the EU project and its spans are
+rejected by the US host. Set the region explicitly whenever the token is not a
+US one:
+
+| Surface | How |
+| ------- | --- |
+| Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+
+Both paths converge on the same precedence layer
+(`cli/tracing_precedence.py`) and the same resolver
+(`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`
+shape carry identical meaning.
+
+### The `[tracing]` extra in the Action image
+
+The Action runs from `Dockerfile`, which installs
+`uv sync --frozen --no-dev --extra tracing`. Without that extra the sink
+factory degrades a `logfire` / `otel` sink to `NullSink` with a warning
+(`src/mergecraft/tracing/sinks.py`) — the workflow looks correctly wired and
+exports nothing. If you fork the image build, keep the extra.
+
 ## Config schema
 
 ```yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire unwire-workflow` | Remove Logfire tracing wiring from the consumer workflow. |
-| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow. |
+| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow (`--region us\|eu` also writes `MERGECRAFT_TRACING_REGION`). |
 | `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft tracing logfire disable` | Disable Logfire tracing by removing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire enable` | Enable Logfire tracing by writing the token + project locally and on GitHub. |
 | `mergecraft tracing logfire unwire-workflow` | Remove Logfire tracing wiring from the consumer workflow. |
-| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow (`--region us\|eu` also writes `MERGECRAFT_TRACING_REGION`). |
+| `mergecraft tracing logfire wire-workflow` | Wire Logfire tracing into the consumer workflow. |
 | `mergecraft update` | Reinstall mergecraft from GitHub using `uv tool install --reinstall`. |
 | `mergecraft version` | Show the mergeCraft package version. |
 | `mergecraft watch --pr N` | Stream a PR/issue timeline as one JSON line per new event. |

--- a/docs/test-plans/audit-remediation-privilege.md
+++ b/docs/test-plans/audit-remediation-privilege.md
@@ -1,4 +1,4 @@
-"""Lane A AP1 — contract → test mapping for privilege & execution boundary."""
+# Lane A AP1 — contract → test mapping for privilege & execution boundary
 
 # Audit remediation — lane A (privilege & execution)
 

--- a/docs/test-plans/audit-remediation-privilege.md
+++ b/docs/test-plans/audit-remediation-privilege.md
@@ -1,0 +1,38 @@
+"""Lane A AP1 — contract → test mapping for privilege & execution boundary."""
+
+# Audit remediation — lane A (privilege & execution)
+
+| Contract | Finding | Green wave | Test module |
+| --- | --- | --- | --- |
+| Root-side git ignores hostile `.git/config` | MCB-01 | AP2 | `tests/security/test_hostile_git_config.py` |
+| `git_argv` pins safe config keys | MCB-01 | AP2 | `tests/utils/test_git_hardening.py` |
+| `.git` not chowned to agent | D3 | AP2 | `tests/utils/test_privilege_chown.py` |
+| Manifest rev leading-dash guard | MCB-33 | AP2 | `tests/xrepo/test_rev_parse_guards.py` |
+| Bare `["git", …]` lint checker | D2 | AP2 | `tests/ci/test_git_argv_lint.py` |
+| Capability probes not CI-gated | MCB-09 | AP3 | `tests/analyzers/test_sandbox_probes.py` |
+| Skip finding visible | MCB-09 | AP3 | `tests/analyzers/test_sandbox_skip_visibility.py` |
+| Unsandboxed shell fail-closed | MCB-07 | AP3 | `tests/mcp/test_shell_fallback.py` |
+| Netns absence removes capability | MCB-10 | AP3 | `tests/mcp/test_network_namespace.py` |
+| No secrets in argv | MCB-08 | AP4 | `tests/mcp/test_shell_spawn_argv.py` |
+| Git invariant in every branch | MCB-25 | AP4 | `tests/mcp/test_shell_git_invariant.py` |
+| OpenCode review permissions | MCB-06 | AP5 | `tests/agents/test_opencode_permissions.py` |
+| Review integrity canaries | MCB-06 | AP5 | `tests/security/test_review_canary.py` |
+| Image identity gate | MCB-24 | AP6 | `tests/utils/test_privilege_identity.py` |
+| Hardened setpriv argv | MCB-32 | AP6 | `tests/utils/test_privilege_identity.py` |
+| Uid-independent prep tests | MCB-24 | AP6 | `tests/prep/test_prep_fail_closed.py` |
+| Prep env allowlist | MCB-22 | AP7 | `tests/prep/test_prep_env.py` |
+| Lockfile selection order | MCB-22 | AP7 | `tests/prep/test_prep_selection.py` |
+| Dedicated prep venv | MCB-22 | AP7 | `tests/prep/test_prep_venv.py` |
+
+## Host vs container (D17 / D18)
+
+| Suite | Host | Container (`mergecraft:lane-a`) |
+| --- | --- | --- |
+| AP1.1 git hardening | yes | optional |
+| AP1.2 sandbox probes (real mount/unshare) | partial | yes for mount probes |
+| AP1.3 shell argv | yes (mocked Popen) | yes for sudo branch |
+| AP1.4 OpenCode | yes | no |
+| AP1.5 privilege identity / setpriv | partial | yes |
+| AP1.6 prep | yes | no |
+
+Cross-wave reds use `@pytest.mark.xfail(strict=False)` until the greening wave lands.

--- a/docs/test-plans/audit-remediation-privilege.md
+++ b/docs/test-plans/audit-remediation-privilege.md
@@ -1,38 +1,123 @@
-"""Lane A AP1 — contract → test mapping for privilege & execution boundary."""
+# Audit remediation lane A — privilege & execution boundary — test plan
 
-# Audit remediation — lane A (privilege & execution)
+Wave plan: `.ignorelocal/waves/10-audit-remediation-a-privilege-execution-wave-plan.md`
+Authoring wave: **AP1** (RED). Implementation: **AP2–AP7**.
+xfail-reconciliation: per impl wave as each AP2–AP7 lands.
 
-| Contract | Finding | Green wave | Test module |
-| --- | --- | --- | --- |
-| Root-side git ignores hostile `.git/config` | MCB-01 | AP2 | `tests/security/test_hostile_git_config.py` |
-| `git_argv` pins safe config keys | MCB-01 | AP2 | `tests/utils/test_git_hardening.py` |
-| `.git` not chowned to agent | D3 | AP2 | `tests/utils/test_privilege_chown.py` |
-| Manifest rev leading-dash guard | MCB-33 | AP2 | `tests/xrepo/test_rev_parse_guards.py` |
-| Bare `["git", …]` lint checker | D2 | AP2 | `tests/ci/test_git_argv_lint.py` |
-| Capability probes not CI-gated | MCB-09 | AP3 | `tests/analyzers/test_sandbox_probes.py` |
-| Skip finding visible | MCB-09 | AP3 | `tests/analyzers/test_sandbox_skip_visibility.py` |
-| Unsandboxed shell fail-closed | MCB-07 | AP3 | `tests/mcp/test_shell_fallback.py` |
-| Netns absence removes capability | MCB-10 | AP3 | `tests/mcp/test_network_namespace.py` |
-| No secrets in argv | MCB-08 | AP4 | `tests/mcp/test_shell_spawn_argv.py` |
-| Git invariant in every branch | MCB-25 | AP4 | `tests/mcp/test_shell_git_invariant.py` |
-| OpenCode review permissions | MCB-06 | AP5 | `tests/agents/test_opencode_permissions.py` |
-| Review integrity canaries | MCB-06 | AP5 | `tests/security/test_review_canary.py` |
-| Image identity gate | MCB-24 | AP6 | `tests/utils/test_privilege_identity.py` |
-| Hardened setpriv argv | MCB-32 | AP6 | `tests/utils/test_privilege_identity.py` |
-| Uid-independent prep tests | MCB-24 | AP6 | `tests/prep/test_prep_fail_closed.py` |
-| Prep env allowlist | MCB-22 | AP7 | `tests/prep/test_prep_env.py` |
-| Lockfile selection order | MCB-22 | AP7 | `tests/prep/test_prep_selection.py` |
-| Dedicated prep venv | MCB-22 | AP7 | `tests/prep/test_prep_venv.py` |
+Locked decisions: **D2** (single `git_argv` helper + lint checker), **D5–D8** (capability
+not `CI`, fail-closed absent not degraded), **D9** (`sudo --preserve-env` by name),
+**D11** (image identity not uid), **D12** (prep venv isolation), **D14a** (tests-only in AP1),
+**D15** (real git at boundaries), **D17/D18** (container vs host split).
 
 ## Host vs container (D17 / D18)
 
-| Suite | Host | Container (`mergecraft:lane-a`) |
-| --- | --- | --- |
-| AP1.1 git hardening | yes | optional |
-| AP1.2 sandbox probes (real mount/unshare) | partial | yes for mount probes |
-| AP1.3 shell argv | yes (mocked Popen) | yes for sudo branch |
-| AP1.4 OpenCode | yes | no |
-| AP1.5 privilege identity / setpriv | partial | yes |
-| AP1.6 prep | yes | no |
+| Runs on host (macOS worktree) | Requires action image (`docker build -t mergecraft:lane-a .` + privileged run) |
+| --- | --- |
+| AP1.1 git hardening + hostile config (real `git`) | AP3/AP4/AP6 namespace / mount / `setpriv` proofs at Final |
+| AP1.4 OpenCode permissions + review canaries | — |
+| AP1.6 prep isolation (mocked subprocess) | — |
+| AP1.2/AP1.3 shell argv tests (mocked `Popen`) | Live `unshare`/`mount` if extending beyond mocks |
 
-Cross-wave reds use `@pytest.mark.xfail(strict=False)` until the greening wave lands.
+## xfail schedule
+
+All cross-wave markers use `strict=False` and name the greening wave in `reason`.
+
+| Greening wave | Test files | Marker reason prefix |
+| --- | --- | --- |
+| AP2 | `test_hostile_git_config.py`, `test_git_hardening.py`, `test_privilege_chown.py`, `test_rev_parse_guards.py`, `test_git_argv_lint.py` | `green after AP2` |
+| AP3 | `test_sandbox_probes.py`, `test_sandbox_skip_visibility.py`, `test_shell_fallback.py`, `test_network_namespace.py` (inverted rows) | `green after AP3` |
+| AP4 | `test_shell_spawn_argv.py`, `test_shell_git_invariant.py` | `green after AP4` |
+| AP5 | `test_opencode_permissions.py` (except `test_bash_stays_denied`), `test_review_canary.py` | `green after AP5` |
+| AP6 | `test_privilege_identity.py` | `green after AP6` |
+| AP7 | `test_prep_env.py`, `test_prep_selection.py`, `test_prep_venv.py` | `green after AP7` |
+
+`test_bash_stays_denied` is **not** xfailing — bash denial is already true on trunk.
+
+## Contract → coverage matrix
+
+### AP1.1 — root-side git (AP2, MCB-01 / MCB-33)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_root_side_status_does_not_execute_fsmonitor` | `tests/security/test_hostile_git_config.py` | Real `git status` via `_run_git`; `core.fsmonitor` sentinel must not appear |
+| `test_root_side_diff_does_not_execute_diff_external` | same | Real `git diff`; `diff.external` sentinel must not appear |
+| `test_commit_path_does_not_execute_fsmonitor` | same | Commit path must pin safe config (not only `hooksPath`) |
+| `test_insteadof_rewrite_does_not_leak_git_config_value_0` | same | `url.<host>.insteadOf` rewrite cannot fire on hardened argv |
+| `test_xrepo_checkout_is_equally_protected` | same | `xrepo.review._rev_parse_commit` equally hardened (H-7) |
+| `test_git_argv_pins_every_safe_config_key` | `tests/utils/test_git_hardening.py` | `GIT_SAFE_CONFIG` / `git_argv()` pins every D2 key |
+| `test_prepare_workspace_does_not_chown_dot_git` | `tests/utils/test_privilege_chown.py` | D3 — recursive chown skips `.git` |
+| `test_leading_dash_rev_is_rejected` | `tests/xrepo/test_rev_parse_guards.py` | MCB-33 leading-dash rev rejected |
+| `test_rev_parse_passes_end_of_options` | same | `--end-of-options` before rev in hardened argv |
+| `test_bare_git_list_literal_fails_the_checker` | `tests/ci/test_git_argv_lint.py` | D2 — `scripts/check_git_argv.py` rejects bare `["git", …]` |
+
+Fixtures: `tests/security/hostile_git_fixtures.py` (per-test repos); corpus
+`tests/security/fixtures/hostile-repo/` rebuilt via `build_hostile_repo.sh` (AP1.4b).
+
+### AP1.2 — sandbox capability (AP3, MCB-07/09/10/35)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_probe_does_not_consult_ci_env_var` | `tests/analyzers/test_sandbox_probes.py` | D5 — probe runs without `CI` as the answer |
+| `test_all_probes_share_one_privilege_ladder` | same | One sudo/unshare ladder across probes |
+| `test_probe_capabilities_is_cached` | same | MCB-35 — `lru_cache` on `probe_capabilities` |
+| `test_reset_detection_cache_clears_probe_cache` | same | D13 — cache cleared with `reset_detection_cache` |
+| `test_skipped_untrusted_analyzers_emit_a_finding` | `tests/analyzers/test_sandbox_skip_visibility.py` | D7 — `rule_id: analyzers.sandbox-unavailable` |
+| `test_unsandboxed_shell_refuses_by_default` | `tests/mcp/test_shell_fallback.py` | D8 — default refuse without isolation |
+| `test_allow_unsandboxed_env_var_overrides` | same | `MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1` opt-out |
+| `test_fallback_branch_masks_container_sockets_when_it_runs` | same | MCB-07 — fallback passes `wrapped` (socket mask) |
+| `test_untrusted_shell_absent_when_netns_unavailable` | `tests/mcp/test_network_namespace.py` | MCB-10 / D6 — shell tool absent when netns missing |
+| `test_unshare_argv_skips_net_when_probe_unavailable` | same | Inverted — spawn fails closed instead of omitting `--net` |
+| `test_network_namespace_available_true_when_unshare_net_succeeds_without_ci` | same | D5 — probe without `CI=true` |
+
+### AP1.3 — sudo argv + git invariant (AP4, MCB-08/25)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_no_provider_key_value_appears_in_any_branch_argv` | `tests/mcp/test_shell_spawn_argv.py` | D9 — no `PROVIDER_KEY_ENV_VARS` value in argv (all branches) |
+| `test_sudo_branch_uses_preserve_env_by_name` | same | `sudo --preserve-env=<names>`, not `sudo env KEY=val` |
+| `test_git_dir_is_read_only_in_every_branch` | `tests/mcp/test_shell_git_invariant.py` | D10 — `.git` ro bind in every spawn branch |
+| `test_git_binary_unavailable_in_untrusted_namespace` | same | Git binary masked/unavailable in namespace |
+
+### AP1.4 — OpenCode permissions (AP5, MCB-06)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_review_mode_denies_webfetch` | `tests/agents/test_opencode_permissions.py` | Review mode denies `webfetch` |
+| `test_review_mode_denies_external_directory` | same | Denies `external_directory` |
+| `test_review_mode_denies_edit` | same | Denies broad `edit` |
+| `test_review_mode_read_is_allowlisted_to_the_checkout` | same | Read allowlisted to checkout, not `*` |
+| `test_bash_stays_denied` | same | Guard — bash stays `deny` |
+| `test_outside_checkout_canary_is_unreadable` | `tests/security/test_review_canary.py` | Outside-checkout read boundary |
+| `test_provider_key_canary_does_not_reach_a_local_sink` | same | Provider key not in local sinks |
+| `test_config_yaml_is_unwritable_during_review` | same | `.mergecraft/config.yaml` integrity |
+
+### AP1.5 — privilege identity (AP6, MCB-24/32)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `_uid_independent_privilege_boundary` (autouse) | `tests/prep/test_prep_fail_closed.py` | AP1.4b — monkeypatch `prepare_workspace_for_agent` |
+| `test_root_outside_action_image_refuses_with_policy_message` | `tests/utils/test_privilege_identity.py` | D11 — policy refusal + diagnostic |
+| `test_allow_root_env_var_overrides` | same | `MERGECRAFT_ALLOW_ROOT=1` override |
+| `test_in_action_image_detects_is_sandbox_and_opt_dir` | same | `_in_action_image()` keys on `IS_SANDBOX` + `/opt/mergecraft` |
+| `test_setpriv_argv_carries_no_new_privs_and_cleared_caps` | same | MCB-32 — `--no-new-privs`, cap clearing |
+
+### AP1.6 — prep isolation (AP7, MCB-22)
+
+| Test | File | Contract |
+| --- | --- | --- |
+| `test_prep_env_is_a_real_allowlist` | `tests/prep/test_prep_env.py` | No `ANTHROPIC_API_KEY` / `GITHUB_TOKEN` in prep env |
+| `test_uv_lock_wins_over_a_stray_requirements_txt` | `tests/prep/test_prep_selection.py` | `uv.lock` wins over `requirements.txt` |
+| `test_cwd_is_threaded_not_read_twice` | same | Explicit cwd threading (not double `Path.cwd()`) |
+| `test_install_targets_a_dedicated_virtualenv` | `tests/prep/test_prep_venv.py` | D12 — install targets prep venv, not reviewer interpreter |
+
+## Imports of not-yet-existing symbols
+
+Symbols in `mergecraft.utils.git_hardening`, `mergecraft.security.review_integrity`,
+`mergecraft.prep.python._prep_env`, `utils.privilege._in_action_image`, and
+`scripts/check_git_argv.py` are imported **inside test bodies** (or via lazy
+`getattr`/`pytest.fail`) so collection succeeds before AP2–AP7 land.
+
+## Status
+
+AP1 RED suite authored on `wave/ap1-privilege-red`. Assertions fail or xfail pending
+AP2–AP7 implementation. Collection, `make lint`, and `make typecheck` must stay clean.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1657,6 +1657,44 @@ sets). The Action input `logfire-token` maps to the runtime
 `MERGECRAFT_LOGFIRE_TOKEN` env var; the project label is read from
 `MERGECRAFT_TRACING_PROJECT` or the YAML `tracing.sinks[].project` field.
 
+Rather than editing the workflow by hand, let the CLI write it:
+
+```bash
+mergecraft tracing logfire wire-workflow --step all --region eu   # dry-run diff
+mergecraft tracing logfire wire-workflow --step all --region eu --apply
+```
+
+This inserts `tracing: "true"`, `tracing-to: logfire`, and
+`logfire-token: ${{ secrets.LOGFIRE_TOKEN }}` into the step's `with:`, plus
+`MERGECRAFT_TRACING_PROJECT` (and, with `--region`, `MERGECRAFT_TRACING_REGION`)
+into its `env:`. `unwire-workflow` strips all of them.
+
+### Data region
+
+Logfire serves region-specific OTLP ingest hosts — `logfire-us.pydantic.dev`
+and `logfire-eu.pydantic.dev` — and the resolver **defaults to `us`**. A write
+token is regional: `pylf_v{N}_eu_…` belongs to the EU project and its spans are
+rejected by the US host. Set the region explicitly whenever the token is not a
+US one:
+
+| Surface | How |
+| ------- | --- |
+| Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+
+Both paths converge on the same precedence layer
+(`cli/tracing_precedence.py`) and the same resolver
+(`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`
+shape carry identical meaning.
+
+### The `[tracing]` extra in the Action image
+
+The Action runs from `Dockerfile`, which installs
+`uv sync --frozen --no-dev --extra tracing`. Without that extra the sink
+factory degrades a `logfire` / `otel` sink to `NullSink` with a warning
+(`src/mergecraft/tracing/sinks.py`) — the workflow looks correctly wired and
+exports nothing. If you fork the image build, keep the extra.
+
 ## Config schema
 
 ```yaml

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -545,6 +545,19 @@ make ci         # full pre-merge gate
 - **MCP:** `mergecraft mcp serve` (HTTP, Bearer-required per-run token on an ephemeral port;
   reviewer role at `/mcp/reviewer`) and `mergecraft mcp list` — see [`docs/cli.md`](docs/cli.md)
 
+**Optional local overrides**
+
+On hosts without Linux namespace isolation (`unshare`), mergeCraft refuses to run the MCP
+shell tool and may refuse root outside the Action image. For local debugging only:
+
+- `MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1` — allow the unsandboxed shell fallback when PID
+  namespace isolation is unavailable.
+- `MERGECRAFT_ALLOW_ROOT=1` — allow running as root outside the Action container image.
+- `MERGECRAFT_PROBE_ALLOW_SUDO=1` — allow the isolation probe to retry with `sudo`
+  when `CI` is unset (local capability probing only).
+
+Do not set these in CI or production workflows.
+
 ## Rules for agents
 
 - Do not weaken trust-tier or fail-closed security behaviour

--- a/scripts/check_git_argv.py
+++ b/scripts/check_git_argv.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard: bare ``["git", …]`` list literals must not appear outside git_hardening.
+
+Root-side git must route through :func:`mergecraft.utils.git_hardening.git_argv`
+so hostile ``.git/config`` cannot execute. This checker fails ``make lint`` when
+any ``src/mergecraft/**/*.py`` file outside ``utils/git_hardening.py`` embeds a
+list literal whose first element is the string ``git``.
+
+Module: scripts.check_git_argv
+Depends: ast, pathlib, sys
+
+Exports:
+    main — CLI entry; scans for forbidden bare git list literals.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MERGECRAFT_SRC = REPO / "src" / "mergecraft"
+_ALLOWED_REL = "src/mergecraft/utils/git_hardening.py"
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _is_git_list_literal(node: ast.AST) -> bool:
+    if not isinstance(node, ast.List):
+        return False
+    if not node.elts:
+        return False
+    first = node.elts[0]
+    return isinstance(first, ast.Constant) and first.value == "git"
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[int] = []
+
+    def visit_List(self, node: ast.List) -> None:
+        if _is_git_list_literal(node):
+            self.violations.append(node.lineno)
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path) -> list[int]:
+    rel = _rel(path)
+    if rel == _ALLOWED_REL:
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    tree = ast.parse(source, filename=rel)
+    visitor = _Visitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main() -> int:
+    """Scan mergecraft sources (or explicit paths) for bare git list literals."""
+    if len(sys.argv) > 1:
+        targets = [Path(arg) for arg in sys.argv[1:]]
+    else:
+        if not MERGECRAFT_SRC.is_dir():
+            print(f"missing source tree: {MERGECRAFT_SRC}", file=sys.stderr)
+            return 1
+        targets = sorted(MERGECRAFT_SRC.rglob("*.py"))
+
+    violations: list[str] = []
+    for path in targets:
+        for lineno in _scan_file(path):
+            violations.append(f"{_rel(path)}:{lineno}: bare ['git', …] list literal")
+
+    if violations:
+        print(
+            "route git subprocess argv through mergecraft.utils.git_hardening.git_argv:",
+            file=sys.stderr,
+        )
+        for item in violations:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_git_argv.py
+++ b/scripts/check_git_argv.py
@@ -22,6 +22,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 MERGECRAFT_SRC = REPO / "src" / "mergecraft"
 _ALLOWED_REL = "src/mergecraft/utils/git_hardening.py"
+_SUBPROCESS_ATTRS = frozenset({"create_subprocess_exec", "Popen", "run"})
 
 
 def _rel(path: Path) -> str:
@@ -31,13 +32,16 @@ def _rel(path: Path) -> str:
         return path.as_posix()
 
 
-def _is_git_list_literal(node: ast.AST) -> bool:
-    if not isinstance(node, ast.List):
+def _is_git_constant(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value == "git"
+
+
+def _is_git_list_or_tuple(node: ast.AST) -> bool:
+    if not isinstance(node, (ast.List, ast.Tuple)):
         return False
     if not node.elts:
         return False
-    first = node.elts[0]
-    return isinstance(first, ast.Constant) and first.value == "git"
+    return _is_git_constant(node.elts[0])
 
 
 class _Visitor(ast.NodeVisitor):
@@ -45,7 +49,22 @@ class _Visitor(ast.NodeVisitor):
         self.violations: list[int] = []
 
     def visit_List(self, node: ast.List) -> None:
-        if _is_git_list_literal(node):
+        if _is_git_list_or_tuple(node):
+            self.violations.append(node.lineno)
+        self.generic_visit(node)
+
+    def visit_Tuple(self, node: ast.Tuple) -> None:
+        if _is_git_list_or_tuple(node):
+            self.violations.append(node.lineno)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in _SUBPROCESS_ATTRS
+            and node.args
+            and _is_git_constant(node.args[0])
+        ):
             self.violations.append(node.lineno)
         self.generic_visit(node)
 
@@ -77,7 +96,7 @@ def main() -> int:
     violations: list[str] = []
     for path in targets:
         for lineno in _scan_file(path):
-            violations.append(f"{_rel(path)}:{lineno}: bare ['git', …] list literal")
+            violations.append(f"{_rel(path)}:{lineno}: bare git subprocess argv")
 
     if violations:
         print(

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Final
 import httpx
 from loguru import logger
 
-from mergecraft.agents.gates import build_opencode_native_fs_permission
+from mergecraft.agents.gates import GIT_NATIVE_READ_DENY_OPENCODE
 from mergecraft.agents.openai_compatible_gateways import (
     CUSTOM_PROVIDER_API_KEY_ENV,
     CUSTOM_PROVIDER_BASE_URL_ENV,
@@ -39,6 +39,8 @@ from mergecraft.agents.shared import (
     resolve_cache_read,
     spawn_agent_cli,
 )
+from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.security.review_integrity import hash_tree, verify_tree_unchanged
 from mergecraft.tracing import current_tracer
 from mergecraft.tracing.genai import (
     ModelParams,
@@ -313,21 +315,48 @@ def _custom_provider_ids(model: str | None) -> list[str]:
     return [endpoint[0]]
 
 
+def _checkout_root(ctx: AgentRunContext) -> Path:
+    return Path(primary_repo_state(ctx.tool_state).dir or os.getcwd()).resolve()
+
+
+def _evidence_dir(ctx: AgentRunContext) -> Path:
+    from mergecraft.evidence.run_packet import resolve_packet_path
+
+    repo = primary_repo_state(ctx.tool_state)
+    slug = f"{repo.owner}-{repo.name}"
+    return resolve_packet_path(tmpdir=ctx.tmpdir, change_slug=slug).parent
+
+
+def _build_review_mode_read_allowlist(checkout: Path, evidence: Path) -> dict[str, str]:
+    """Read paths allowlisted to the checkout and evidence scratch (MCB-06 / D4)."""
+    roots = (checkout.resolve(), evidence.resolve())
+    read: dict[str, str] = dict(GIT_NATIVE_READ_DENY_OPENCODE)
+    for root in roots:
+        root_posix = root.as_posix()
+        read[root_posix] = "allow"
+        read[f"{root_posix}/*"] = "allow"
+        read[f"{root_posix}/**"] = "allow"
+    return read
+
+
+def _build_review_mode_permissions(ctx: AgentRunContext) -> dict[str, object]:
+    return {
+        "bash": "deny",
+        "edit": "deny",
+        "read": _build_review_mode_read_allowlist(_checkout_root(ctx), _evidence_dir(ctx)),
+        "webfetch": "deny",
+        "external_directory": "deny",
+        "skill": "allow",
+    }
+
+
 def build_security_config(ctx: AgentRunContext, model: str | None) -> str:
     from mergecraft.agents.harness_render import render_for_run
 
-    fs_perm = build_opencode_native_fs_permission()
     render_result = render_for_run(ctx, "opencode")
     agent_block = render_result.payload["agent"] if isinstance(render_result.payload, dict) else {}
     config: dict[str, object] = {
-        "permission": {
-            "bash": "deny",
-            "edit": fs_perm["edit"],
-            "read": fs_perm["read"],
-            "webfetch": "allow",
-            "external_directory": "allow",
-            "skill": "allow",
-        },
+        "permission": _build_review_mode_permissions(ctx),
         "mcp": {
             MERGECRAFT_MCP_NAME: {
                 "type": "remote",
@@ -646,12 +675,36 @@ async def _prompt_session_http(
     return AgentResult(success=True, output=output or None, usage=usage)
 
 
+def _capture_integrity_baseline(ctx: AgentRunContext) -> tuple[Path, str] | None:
+    checkout = _checkout_root(ctx)
+    try:
+        return checkout, hash_tree(checkout)
+    except OSError as exc:
+        logger.warning("review integrity baseline skipped for {}: {}", checkout, exc)
+        return None
+
+
+def _apply_integrity_gate(
+    result: AgentResult,
+    baseline: tuple[Path, str] | None,
+) -> AgentResult:
+    if baseline is None:
+        return result
+    checkout, digest = baseline
+    try:
+        verify_tree_unchanged(checkout, digest)
+    except RuntimeError as exc:
+        return AgentResult(success=False, error=str(exc))
+    return result
+
+
 async def _run(ctx: AgentRunContext) -> AgentResult:
     try:
         cli = await _install(None)
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
+    baseline = _capture_integrity_baseline(ctx)
     model = ctx.resolved_model
     config_json = build_security_config(ctx, model)
     config_path = Path(ctx.tmpdir) / "opencode.json"
@@ -675,7 +728,10 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         handle = _boot_opencode_server(cli=cli, env=env, cwd=os.getcwd())
     except Exception as err:
         logger.info("opencode serve unavailable ({}), falling back to run", err)
-        return await _run_cli_fallback(cli=cli, ctx=ctx, env=env)
+        return _apply_integrity_gate(
+            await _run_cli_fallback(cli=cli, ctx=ctx, env=env),
+            baseline,
+        )
 
     assert handle is not None
     try:
@@ -689,14 +745,20 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
                 json={"title": "mergecraft"},
             )
             if created.status_code >= 400:
-                return AgentResult(
-                    success=False,
-                    error=f"failed to create opencode session: {created.text[:300]}",
+                return _apply_integrity_gate(
+                    AgentResult(
+                        success=False,
+                        error=f"failed to create opencode session: {created.text[:300]}",
+                    ),
+                    baseline,
                 )
             session = created.json()
             session_id = str(session.get("id") or session.get("sessionID") or "")
             if not session_id:
-                return AgentResult(success=False, error="opencode session missing id")
+                return _apply_integrity_gate(
+                    AgentResult(success=False, error="opencode session missing id"),
+                    baseline,
+                )
 
         model_obj = _parse_model(model)
         system = ctx.instructions.system
@@ -743,12 +805,18 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
             # own tail the operator gets a bare "timed out:" and no lead (#449).
             tail = handle.recent_output()
             detail = f"{exc}\n\nrecent opencode serve output:\n{tail}" if tail else str(exc)
-            return AgentResult(
-                success=False,
-                error=detail,
-                metadata={"retryable": True},
+            return _apply_integrity_gate(
+                AgentResult(
+                    success=False,
+                    error=detail,
+                    metadata={"retryable": True},
+                ),
+                baseline,
             )
-        return await finalize_agent_result(ctx, result)
+        return _apply_integrity_gate(
+            await finalize_agent_result(ctx, result),
+            baseline,
+        )
     finally:
         handle.close()
 

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -330,12 +330,18 @@ def _evidence_dir(ctx: AgentRunContext) -> Path:
 def _build_review_mode_read_allowlist(checkout: Path, evidence: Path) -> dict[str, str]:
     """Read paths allowlisted to the checkout and evidence scratch (MCB-06 / D4)."""
     roots = (checkout.resolve(), evidence.resolve())
-    read: dict[str, str] = dict(GIT_NATIVE_READ_DENY_OPENCODE)
+    read: dict[str, str] = {}
     for root in roots:
         root_posix = root.as_posix()
         read[root_posix] = "allow"
         read[f"{root_posix}/*"] = "allow"
         read[f"{root_posix}/**"] = "allow"
+    # Deny rules after broad allow patterns — matches gates.py spread order.
+    read.update(GIT_NATIVE_READ_DENY_OPENCODE)
+    for root in roots:
+        root_posix = root.as_posix()
+        read[f"{root_posix}/.git/config"] = "deny"
+        read[f"{root_posix}/.git/**"] = "deny"
     return read
 
 

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -726,18 +726,26 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    baseline = _capture_integrity_baseline(ctx)
-    if baseline is None:
-        return AgentResult(
-            success=False,
-            error="review integrity baseline could not be captured; refusing read-only review",
-        )
     model = ctx.resolved_model
     config_json = build_security_config(ctx, model)
     config_dir = _evidence_dir(ctx)
     config_dir.mkdir(parents=True, exist_ok=True)
     config_path = config_dir / "opencode.json"
     config_path.write_text(config_json, encoding="utf-8")
+
+    # Baseline AFTER our own writes, before the agent runs. ``_evidence_dir``
+    # falls back to ``<tmpdir>/evidence`` when neither MERGECRAFT_EVIDENCE_DIR
+    # nor RUNNER_TEMP is set (evidence/run_packet.py:71); when that tmpdir sits
+    # inside the checkout, hashing first would make ``opencode.json`` — a file
+    # mergeCraft itself just wrote — read as tampering, and every review would
+    # fail closed. The gate still covers the whole agent session, which is the
+    # mutation this check exists to catch.
+    baseline = _capture_integrity_baseline(ctx)
+    if baseline is None:
+        return AgentResult(
+            success=False,
+            error="review integrity baseline could not be captured; refusing read-only review",
+        )
     extras: dict[str, str] = {
         "OPENCODE_CONFIG_CONTENT": config_json,
         "OPENCODE_CONFIG": str(config_path),

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -327,6 +327,19 @@ def _evidence_dir(ctx: AgentRunContext) -> Path:
     return resolve_packet_path(tmpdir=ctx.tmpdir, change_slug=slug).parent
 
 
+def _build_review_mode_external_directory_allowlist(
+    checkout: Path, evidence: Path
+) -> dict[str, str]:
+    """Allow only the checkout and evidence scratch roots (MCB-06 / D4)."""
+    perms: dict[str, str] = {"*": "deny"}
+    for root in (checkout.resolve(), evidence.resolve()):
+        root_posix = root.as_posix()
+        perms[root_posix] = "allow"
+        perms[f"{root_posix}/*"] = "allow"
+        perms[f"{root_posix}/**"] = "allow"
+    return perms
+
+
 def _build_review_mode_read_allowlist(checkout: Path, evidence: Path) -> dict[str, str]:
     """Read paths allowlisted to the checkout and evidence scratch (MCB-06 / D4)."""
     roots = (checkout.resolve(), evidence.resolve())
@@ -346,12 +359,14 @@ def _build_review_mode_read_allowlist(checkout: Path, evidence: Path) -> dict[st
 
 
 def _build_review_mode_permissions(ctx: AgentRunContext) -> dict[str, object]:
+    checkout = _checkout_root(ctx)
+    evidence = _evidence_dir(ctx)
     return {
         "bash": "deny",
         "edit": "deny",
-        "read": _build_review_mode_read_allowlist(_checkout_root(ctx), _evidence_dir(ctx)),
+        "read": _build_review_mode_read_allowlist(checkout, evidence),
         "webfetch": "deny",
-        "external_directory": "deny",
+        "external_directory": _build_review_mode_external_directory_allowlist(checkout, evidence),
         "skill": "allow",
     }
 
@@ -719,7 +734,9 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         )
     model = ctx.resolved_model
     config_json = build_security_config(ctx, model)
-    config_path = Path(ctx.tmpdir) / "opencode.json"
+    config_dir = _evidence_dir(ctx)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "opencode.json"
     config_path.write_text(config_json, encoding="utf-8")
     extras: dict[str, str] = {
         "OPENCODE_CONFIG_CONTENT": config_json,

--- a/src/mergecraft/agents/opencode.py
+++ b/src/mergecraft/agents/opencode.py
@@ -680,7 +680,8 @@ def _capture_integrity_baseline(ctx: AgentRunContext) -> tuple[Path, str] | None
     try:
         return checkout, hash_tree(checkout)
     except OSError as exc:
-        logger.warning("review integrity baseline skipped for {}: {}", checkout, exc)
+        msg = f"review integrity baseline failed for {checkout}: {exc}"
+        logger.error(msg)
         return None
 
 
@@ -705,6 +706,11 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         return AgentResult(success=False, error=str(err))
 
     baseline = _capture_integrity_baseline(ctx)
+    if baseline is None:
+        return AgentResult(
+            success=False,
+            error="review integrity baseline could not be captured; refusing read-only review",
+        )
     model = ctx.resolved_model
     config_json = build_security_config(ctx, model)
     config_path = Path(ctx.tmpdir) / "opencode.json"

--- a/src/mergecraft/agents/shared.py
+++ b/src/mergecraft/agents/shared.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 from loguru import logger
 
 from mergecraft.mcp.endpoints import mcp_role_url as _mcp_role_url
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -85,7 +86,7 @@ def spawn_agent_cli(
 def get_git_status(cwd: str | None = None) -> str:
     try:
         return subprocess.check_output(
-            ["git", "status", "--porcelain"],
+            git_argv(["status", "--porcelain"]),
             cwd=cwd,
             text=True,
             timeout=10,

--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -418,11 +418,10 @@ def run_adapter(
         scratch_dir=scratch_dir,
     )
     if not sandbox_decision.can_run:
-        skip_findings: list[Finding] = []
-        if sandbox_decision.skip_finding is not None:
-            skip_findings = [sandbox_decision.skip_finding]
+        from mergecraft.analyzers.sandbox import sandbox_skip_findings
+
         return AdapterRunResult(
-            findings=skip_findings,
+            findings=sandbox_skip_findings(sandbox_decision),
             skipped=True,
             skip_reason=sandbox_decision.skip_reason,
         )

--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -418,8 +418,11 @@ def run_adapter(
         scratch_dir=scratch_dir,
     )
     if not sandbox_decision.can_run:
+        skip_findings: list[Finding] = []
+        if sandbox_decision.skip_finding is not None:
+            skip_findings = [sandbox_decision.skip_finding]
         return AdapterRunResult(
-            findings=[],
+            findings=skip_findings,
             skipped=True,
             skip_reason=sandbox_decision.skip_reason,
         )

--- a/src/mergecraft/analyzers/baseline_suppression.py
+++ b/src/mergecraft/analyzers/baseline_suppression.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from mergecraft.analyzers.scope import DiffScope, changed_paths_from_scope, parse_diff_scope
 from mergecraft.review_policy.paths import normalize_repo_path
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -77,7 +78,7 @@ def should_run_baseline_suppression(*, diff_text: str, base_comparison: str) -> 
 def _checkout_base_worktree(repo_root: Path, base_ref: str) -> Path | None:
     worktree = Path(tempfile.mkdtemp(prefix="mergecraft-base-"))
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "worktree", "add", "--detach", str(worktree), base_ref],
+        git_argv(["-C", str(repo_root), "worktree", "add", "--detach", str(worktree), base_ref]),
         capture_output=True,
         text=True,
         check=False,
@@ -95,7 +96,7 @@ def _checkout_base_worktree(repo_root: Path, base_ref: str) -> Path | None:
 
 def _remove_base_worktree(repo_root: Path, worktree: Path) -> None:
     subprocess.run(
-        ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(worktree)],
+        git_argv(["-C", str(repo_root), "worktree", "remove", "--force", str(worktree)]),
         capture_output=True,
         text=True,
         check=False,

--- a/src/mergecraft/analyzers/contracts.py
+++ b/src/mergecraft/analyzers/contracts.py
@@ -16,6 +16,7 @@ from mergecraft.analyzers.parsers.squawk_json import parse_squawk_json
 from mergecraft.analyzers.paths import safe_repo_relative_path
 from mergecraft.analyzers.registry import _matches_detect_patterns, get_manifest
 from mergecraft.analyzers.resolve import AnalyzerPlan, resolve_analyzer
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
@@ -61,7 +62,7 @@ def _fixture_base_rel(head_path: str) -> str:
 
 def _git_ref_available(repo_root: Path, base_ref: str) -> bool:
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{base_ref}^{{commit}}"],
+        git_argv(["-C", str(repo_root), "rev-parse", "--verify", f"{base_ref}^{{commit}}"]),
         capture_output=True,
         text=True,
         check=False,
@@ -78,7 +79,7 @@ def _resolve_base_file(repo_root: Path, head_path: str, base_ref: str) -> Path |
     if not _git_ref_available(repo_root, base_ref):
         return None
     result = subprocess.run(
-        ["git", "-C", str(repo_root), "show", f"{base_ref}:{head_path}"],
+        git_argv(["-C", str(repo_root), "show", f"{base_ref}:{head_path}"]),
         capture_output=True,
         text=True,
         check=False,

--- a/src/mergecraft/analyzers/contracts.py
+++ b/src/mergecraft/analyzers/contracts.py
@@ -112,7 +112,7 @@ def _run_argv(
     changed_files: list[str],
     tier: TrustTier,
     scratch_suffix: str = "",
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, list[Finding]]:
     return run_argv(
         manifest=manifest,
         repo_root=repo_root,
@@ -187,7 +187,7 @@ def _run_oasdiff(
 
         binary = provisioned.argv[0] if provisioned.argv else "oasdiff"
         argv = (binary, "breaking", "--format", "json", str(base_path), str(head_path))
-        raw, err = _run_argv(
+        raw, err, skip_findings = _run_argv(
             manifest=manifest,
             repo_root=repo_root,
             argv=argv,
@@ -197,7 +197,11 @@ def _run_oasdiff(
         )
         if err and not raw:
             logger.info("{}", err)
-            return AdapterRunResult(findings=[], skipped=True, skip_reason=err)
+            return AdapterRunResult(
+                findings=skip_findings,
+                skipped=True,
+                skip_reason=err,
+            )
         if not raw:
             continue
         parsed = parse_oasdiff_json(raw, manifest=manifest, repo_root=repo_root)
@@ -245,7 +249,7 @@ def _run_squawk(
 
     binary = provisioned.argv[0] if provisioned.argv else "squawk"
     argv = (binary, "--reporter=json", "--assume-in-transaction", *paths)
-    raw, err = _run_argv(
+    raw, err, skip_findings = _run_argv(
         manifest=manifest,
         repo_root=repo_root,
         argv=argv,
@@ -254,7 +258,11 @@ def _run_squawk(
     )
     if err and not raw:
         logger.info("{}", err)
-        return AdapterRunResult(findings=[], skipped=True, skip_reason=err)
+        return AdapterRunResult(
+            findings=skip_findings,
+            skipped=True,
+            skip_reason=err,
+        )
     if not raw:
         return AdapterRunResult(findings=[])
 
@@ -320,7 +328,7 @@ def _run_buf(
             "--error-format",
             "json",
         )
-        raw, err = _run_argv(
+        raw, err, skip_findings = _run_argv(
             manifest=manifest,
             repo_root=repo_root,
             argv=breaking_argv,
@@ -330,7 +338,11 @@ def _run_buf(
         )
         if err and not raw:
             logger.info("{}", err)
-            return AdapterRunResult(findings=[], skipped=True, skip_reason=err)
+            return AdapterRunResult(
+                findings=skip_findings,
+                skipped=True,
+                skip_reason=err,
+            )
         if raw:
             findings.extend(
                 parse_buf_breaking_json(
@@ -342,7 +354,7 @@ def _run_buf(
             )
 
         lint_argv = (binary, "lint", str(head_path), "--error-format", "json")
-        lint_raw, _ = _run_argv(
+        lint_raw, _, _ = _run_argv(
             manifest=manifest,
             repo_root=repo_root,
             argv=lint_argv,

--- a/src/mergecraft/analyzers/execution.py
+++ b/src/mergecraft/analyzers/execution.py
@@ -24,6 +24,7 @@ from mergecraft.analyzers.sandbox import plan_sandbox
 from mergecraft.analyzers.trust import build_analyzer_env
 
 if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
     from mergecraft.analyzers.manifest import AnalyzerManifest
 
 TrustTier = Literal["trusted", "untrusted"]
@@ -187,12 +188,14 @@ def run_argv(
     changed_files: list[str],
     tier: TrustTier,
     scratch_suffix: str = "",
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, list[Finding]]:
     """Provision, sandbox, run, and return raw analyzer output."""
+    from mergecraft.analyzers.sandbox import sandbox_skip_findings
+
     plan = resolve_analyzer(manifest=manifest, repo_root=repo_root, managed_available=True)
     provisioned = provision_resolved_plan(plan, manifest=manifest, repo_root=repo_root)
     if provisioned is None:
-        return None, plan.reason or f"skipped {manifest.id}: provisioning failed"
+        return None, plan.reason or f"skipped {manifest.id}: provisioning failed", []
 
     finalized = finalize_plan(
         replace(provisioned, argv=argv, cwd=repo_root),
@@ -202,7 +205,7 @@ def run_argv(
         tier=tier,
     )
     if finalized.mode == "skip":
-        return None, finalized.reason or f"skipped {manifest.id}"
+        return None, finalized.reason or f"skipped {manifest.id}", []
 
     scratch = repo_root / ".mergecraft" / "analyzer-scratch" / f"{manifest.id}{scratch_suffix}"
     scratch.mkdir(parents=True, exist_ok=True)
@@ -213,18 +216,18 @@ def run_argv(
         scratch_dir=scratch,
     )
     if not sandbox.can_run:
-        return None, sandbox.skip_reason
+        return None, sandbox.skip_reason, sandbox_skip_findings(sandbox)
 
     outcome = run_plan(finalized, sandbox_context=sandbox.context)
     if not outcome.ran:
-        return None, outcome.output
+        return None, outcome.output, []
 
     raw = (
         Path(outcome.output_path).read_text(encoding="utf-8")
         if outcome.output_path
         else outcome.output
     )
-    return raw, None
+    return raw, None, []
 
 
 __all__ = [

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import TrustTier
 
@@ -222,7 +224,7 @@ def _find_references(
     """Return (capped references, whether more references existed than the cap)."""
     try:
         result = subprocess.run(
-            ["git", "-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol],
+            git_argv(["-C", cwd, "grep", "-nw", "-F", "--no-color", "-e", symbol]),
             capture_output=True,
             text=True,
             timeout=15,

--- a/src/mergecraft/analyzers/pipeline.py
+++ b/src/mergecraft/analyzers/pipeline.py
@@ -339,6 +339,8 @@ def run_analyzer_pipeline(
                     continue
 
                 if result.skipped:
+                    if result.findings:
+                        raw_findings.extend(result.findings)
                     rows.append(
                         AnalyzerStatusRow(
                             id=manifest.id,

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -133,19 +133,14 @@ def _early_unavailable_outcome(plan: AnalyzerPlan) -> AnalyzerOutcome | None:
 def _sandboxed_argv(
     plan: AnalyzerPlan, sandbox_context: SandboxContext | None
 ) -> tuple[list[str], Callable[[], None] | None]:
-    """Wrap ``plan.argv`` in an unshare/sudo-unshare sandbox when the context calls for one."""
+    """Wrap ``plan.argv`` in namespace isolation when the sandbox context requires it."""
     run_argv = list(plan.argv)
     if sandbox_context is None or not sandbox_context.read_only_source or sys.platform == "win32":
         return run_argv, None
     preexec_fn = lambda: _sandbox_preexec(sandbox_context)  # noqa: E731
-    from mergecraft.mcp.shell import detect_sandbox_method
+    from mergecraft.analyzers.sandbox import build_analyzer_sandbox_argv
 
-    method = detect_sandbox_method()
-    if method == "unshare":
-        run_argv = ["unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
-    elif method == "sudo-unshare":
-        run_argv = ["sudo", "unshare", "--pid", "--fork", "--mount-proc", *plan.argv]
-    return run_argv, preexec_fn
+    return build_analyzer_sandbox_argv(plan.argv, context=sandbox_context), preexec_fn
 
 
 def _run_subprocess(

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -97,12 +97,22 @@ class SandboxPlan:
     context: SandboxContext | None = None
 
 
+_PROBE_TEST_DOUBLE: dict[str, str] = {
+    "pid": "1",
+    "pid_method": "unshare",
+    "net": "1",
+    "bind": "1",
+    "tmpfs": "1",
+}
+
+
 def _parse_probe_output(stdout: bytes) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for line in stdout.decode("utf-8", errors="replace").splitlines():
-        match = _PROBE_FIELD_RE.match(line.strip())
-        if match is not None:
-            parsed[match.group(1)] = match.group(2)
+        for token in line.split():
+            match = _PROBE_FIELD_RE.match(token.strip())
+            if match is not None:
+                parsed[match.group(1)] = match.group(2)
     return parsed
 
 
@@ -114,22 +124,17 @@ def _run_isolation_probe() -> dict[str, str]:
             capture_output=True,
             check=False,
         )
-    except OSError:
-        return {}
+    except (OSError, ValueError):
+        # ValueError: argv-inspection tests mock ``subprocess.Popen`` with a
+        # MagicMock whose communicate() cannot model probe output.
+        return dict(_PROBE_TEST_DOUBLE)
     if result.returncode != 0:
         return {}
     parsed = _parse_probe_output(getattr(result, "stdout", b"") or b"")
     if parsed:
         return parsed
-    # Real probe scripts always emit key=value lines; empty stdout with rc=0 is a
-    # test double that cannot model per-capability results.
-    return {
-        "pid": "1",
-        "pid_method": "unshare",
-        "net": "1",
-        "bind": "1",
-        "tmpfs": "1",
-    }
+    # rc=0 with empty stdout: test double that cannot model per-capability results.
+    return dict(_PROBE_TEST_DOUBLE)
 
 
 def _probe_cgroup_memory() -> tuple[bool, str | None]:

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -29,8 +29,12 @@ _sudo_allowed() {
 _run_probe() {
   local use_sudo=$1
   local unshare_cmd=unshare
+  local mount_cmd=mount
+  local umount_cmd=umount
   if [ "$use_sudo" = 1 ]; then
     unshare_cmd="sudo unshare"
+    mount_cmd="sudo mount"
+    umount_cmd="sudo umount"
   fi
   pid=0 pid_method=none net=0 bind=0 tmpfs=0
   if $unshare_cmd --pid --fork --mount-proc true 2>/dev/null; then
@@ -49,14 +53,14 @@ _run_probe() {
   tmp=$(mktemp -d)
   target="$tmp/ro-target"; mkdir -p "$target"; echo x >"$target/file"
   mnt="$tmp/mnt"; mkdir -p "$mnt"
-  if mount --bind "$target" "$mnt" 2>/dev/null \
-    && mount -o remount,bind,ro "$mnt" 2>/dev/null \
-    && umount "$mnt" 2>/dev/null; then
+  if $mount_cmd --bind "$target" "$mnt" 2>/dev/null \
+    && $mount_cmd -o remount,bind,ro "$mnt" 2>/dev/null \
+    && $umount_cmd "$mnt" 2>/dev/null; then
     bind=1
   fi
   scratch="$tmp/scratch"; mkdir -p "$scratch"
-  if mount -t tmpfs tmpfs "$scratch" 2>/dev/null \
-    && umount "$scratch" 2>/dev/null; then
+  if $mount_cmd -t tmpfs tmpfs "$scratch" 2>/dev/null \
+    && $umount_cmd "$scratch" 2>/dev/null; then
     tmpfs=1
   fi
   rm -rf "$tmp"

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import os
 import re
 import resource
 import subprocess
@@ -117,6 +118,8 @@ def _parse_probe_output(stdout: bytes) -> dict[str, str]:
 
 
 def _run_isolation_probe() -> dict[str, str]:
+    if os.environ.get("MERGECRAFT_PROBE_TEST_DOUBLE") == "1":
+        return dict(_PROBE_TEST_DOUBLE)
     try:
         result = subprocess.run(
             ["bash", "-c", _ISOLATION_PROBE_SCRIPT],
@@ -125,16 +128,10 @@ def _run_isolation_probe() -> dict[str, str]:
             check=False,
         )
     except (OSError, ValueError):
-        # ValueError: argv-inspection tests mock ``subprocess.Popen`` with a
-        # MagicMock whose communicate() cannot model probe output.
-        return dict(_PROBE_TEST_DOUBLE)
+        return {}
     if result.returncode != 0:
         return {}
-    parsed = _parse_probe_output(getattr(result, "stdout", b"") or b"")
-    if parsed:
-        return parsed
-    # rc=0 with empty stdout: test double that cannot model per-capability results.
-    return dict(_PROBE_TEST_DOUBLE)
+    return _parse_probe_output(getattr(result, "stdout", b"") or b"")
 
 
 def _probe_cgroup_memory() -> tuple[bool, str | None]:
@@ -289,9 +286,10 @@ def plan_sandbox(
         msg = "plan_sandbox requires tier or trust_tier"
         raise TypeError(msg)
 
-    skipped_tool_ids = [m.id for m in manifests]
-    if manifest is not None:
-        skipped_tool_ids.append(manifest.id)
+    skipped_ids = [m.id for m in manifests]
+    if manifest is not None and manifest.id not in skipped_ids:
+        skipped_ids.append(manifest.id)
+    skipped_tool_ids = skipped_ids
 
     limits = SandboxLimits(
         timeout_s=manifest.timeout_s if manifest is not None else 300,

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -23,16 +23,19 @@ NetworkDefault = Literal["deny", "allow"]
 PidNamespaceMethod = Literal["unshare", "sudo-unshare", "none"]
 
 _ISOLATION_PROBE_SCRIPT = """
+_sudo_allowed() {
+  [ "${CI:-}" = true ] || [ "${MERGECRAFT_PROBE_ALLOW_SUDO:-}" = 1 ]
+}
 probe() {
   pid=0 pid_method=none net=0 bind=0 tmpfs=0
   if unshare --pid --fork --mount-proc true 2>/dev/null; then
     pid=1 pid_method=unshare
-  elif sudo unshare --pid --fork --mount-proc true 2>/dev/null; then
+  elif _sudo_allowed && sudo unshare --pid --fork --mount-proc true 2>/dev/null; then
     pid=1 pid_method=sudo-unshare
   fi
   if unshare --net true 2>/dev/null; then
     net=1
-  elif sudo unshare --net true 2>/dev/null; then
+  elif _sudo_allowed && sudo unshare --net true 2>/dev/null; then
     net=1
   fi
   tmp=$(mktemp -d)
@@ -51,7 +54,7 @@ probe() {
   rm -rf "$tmp"
   echo "pid=$pid pid_method=$pid_method net=$net bind=$bind tmpfs=$tmpfs"
 }
-probe || { { [ "${CI:-}" = true ] || [ "${MERGECRAFT_PROBE_ALLOW_SUDO:-}" = 1 ]; } && sudo bash -c "$(declare -f probe); probe"; }
+probe || { _sudo_allowed && sudo bash -c "$(declare -f _sudo_allowed); $(declare -f probe); probe"; }
 """.strip()
 
 _PROBE_FIELD_RE = re.compile(r"^(pid|pid_method|net|bind|tmpfs)=(.+)$")

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -51,7 +51,7 @@ probe() {
   rm -rf "$tmp"
   echo "pid=$pid pid_method=$pid_method net=$net bind=$bind tmpfs=$tmpfs"
 }
-probe || sudo bash -c "$(declare -f probe); probe"
+probe || { { [ "${CI:-}" = true ] || [ "${MERGECRAFT_PROBE_ALLOW_SUDO:-}" = 1 ]; } && sudo bash -c "$(declare -f probe); probe"; }
 """.strip()
 
 _PROBE_FIELD_RE = re.compile(r"^(pid|pid_method|net|bind|tmpfs)=(.+)$")
@@ -118,7 +118,10 @@ def _parse_probe_output(stdout: bytes) -> dict[str, str]:
 
 
 def _run_isolation_probe() -> dict[str, str]:
-    if os.environ.get("MERGECRAFT_PROBE_TEST_DOUBLE") == "1":
+    if (
+        os.environ.get("PYTEST_CURRENT_TEST")
+        and os.environ.get("MERGECRAFT_PROBE_TEST_DOUBLE") == "1"
+    ):
         return dict(_PROBE_TEST_DOUBLE)
     try:
         result = subprocess.run(
@@ -197,12 +200,19 @@ def probe_capabilities() -> SandboxCapabilities:
     return caps
 
 
+def sandbox_skip_findings(plan: SandboxPlan) -> list[Finding]:
+    """Return user-visible findings when sandbox planning refuses execution."""
+    if plan.skip_finding is not None:
+        return [plan.skip_finding]
+    return []
+
+
 def reset_detection_cache() -> None:
     """Clear cached sandbox probes (xdist isolation / #421)."""
     probe_capabilities.cache_clear()
-    from mergecraft.mcp.shell import reset_detection_cache as reset_shell_detection_cache
+    from mergecraft.mcp.shell import _reset_shell_detection_globals
 
-    reset_shell_detection_cache()
+    _reset_shell_detection_globals()
 
 
 def _required_for_untrusted(caps: SandboxCapabilities) -> list[str]:
@@ -342,4 +352,5 @@ __all__ = [
     "plan_sandbox",
     "probe_capabilities",
     "reset_detection_cache",
+    "sandbox_skip_findings",
 ]

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -26,16 +26,24 @@ _ISOLATION_PROBE_SCRIPT = """
 _sudo_allowed() {
   [ "${CI:-}" = true ] || [ "${MERGECRAFT_PROBE_ALLOW_SUDO:-}" = 1 ]
 }
-probe() {
-  pid=0 pid_method=none net=0 bind=0 tmpfs=0
-  if unshare --pid --fork --mount-proc true 2>/dev/null; then
-    pid=1 pid_method=unshare
-  elif _sudo_allowed && sudo unshare --pid --fork --mount-proc true 2>/dev/null; then
-    pid=1 pid_method=sudo-unshare
+_run_probe() {
+  local use_sudo=$1
+  local unshare_cmd=unshare
+  if [ "$use_sudo" = 1 ]; then
+    unshare_cmd="sudo unshare"
   fi
-  if unshare --net true 2>/dev/null; then
-    net=1
-  elif _sudo_allowed && sudo unshare --net true 2>/dev/null; then
+  pid=0 pid_method=none net=0 bind=0 tmpfs=0
+  if $unshare_cmd --pid --fork --mount-proc true 2>/dev/null; then
+    pid=1
+  fi
+  if [ "$pid" = 1 ]; then
+  if [ "$use_sudo" = 1 ]; then
+    pid_method=sudo-unshare
+  else
+    pid_method=unshare
+  fi
+  fi
+  if $unshare_cmd --net true 2>/dev/null; then
     net=1
   fi
   tmp=$(mktemp -d)
@@ -52,9 +60,12 @@ probe() {
     tmpfs=1
   fi
   rm -rf "$tmp"
-  echo "pid=$pid pid_method=$pid_method net=$net bind=$bind tmpfs=$tmpfs"
 }
-probe || { _sudo_allowed && sudo bash -c "$(declare -f _sudo_allowed); $(declare -f probe); probe"; }
+_run_probe 0
+if [ "$pid" = 0 ] && _sudo_allowed; then
+  _run_probe 1
+fi
+echo "pid=$pid pid_method=$pid_method net=$net bind=$bind tmpfs=$tmpfs"
 """.strip()
 
 _PROBE_FIELD_RE = re.compile(r"^(pid|pid_method|net|bind|tmpfs)=(.+)$")

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -426,7 +426,21 @@ def build_analyzer_sandbox_argv(
 
     method = detect_sandbox_method()
     wrapped = build_analyzer_sandbox_command(argv, context=context)
-    unshare_argv = _analyzer_unshare_argv(isolate_network=True)
+    # An analyzer that declares ``network_allowlist`` needs egress to do its job
+    # at all: ``osv-scanner`` fetches from api.osv.dev, ``trivy`` from
+    # ghcr.io / trivy-db.github.io. ``unshare --net`` gives a namespace with no
+    # external connectivity, so isolating those would not harden them, it would
+    # break them -- and silently, because an analyzer that errors is reported
+    # unavailable rather than as a finding, so dependency-vuln scanning would
+    # just stop producing results.
+    #
+    # LIMITATION: this honours the manifest's *declared* intent. Nothing yet
+    # restricts a network-declaring analyzer to the hosts it listed -- the
+    # allowlist reaches ``SandboxContext`` and is discarded at
+    # ``trust.py:228``. Until egress filtering exists, declaring a non-empty
+    # allowlist buys host networking, not filtered networking. Analyzers with
+    # an empty allowlist keep full network isolation.
+    unshare_argv = _analyzer_unshare_argv(isolate_network=not context.network_allowlist)
     if method == "sudo-unshare":
         return ["sudo", *unshare_argv, "bash", "-c", wrapped]
     if method == "unshare":

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -268,8 +268,8 @@ def _sandbox_unavailable_finding(
         confidence="certain",
         message=message,
         path=str(repo_root),
-        start_line=1,
-        end_line=1,
+        start_line=None,
+        end_line=None,
         source="analyzer",
     )
 
@@ -360,12 +360,90 @@ def plan_sandbox(
     return SandboxPlan(can_run=True, context=context)
 
 
+_SANDBOX_SOCKET_MASK_PATHS = (
+    "/var/run/docker.sock",
+    "/run/docker.sock",
+    "/var/run/podman/podman.sock",
+    "/run/podman/podman.sock",
+    "/run/containerd/containerd.sock",
+    "/var/run/crio/crio.sock",
+)
+
+_PROC_PREP_FRAGMENT = (
+    "umount /proc 2>/dev/null; umount /proc 2>/dev/null; mount -t proc proc /proc 2>/dev/null; "
+)
+
+
+def _shell_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def analyzer_isolation_mount_fragment(context: SandboxContext) -> str:
+    """Shell fragment: read-only repo bind and tmpfs scratch for untrusted analyzers."""
+    repo = _shell_single_quote(str(context.repo_root.resolve()))
+    scratch = _shell_single_quote(str(context.scratch_dir.resolve()))
+    return (
+        f"mkdir -p {scratch}; "
+        f"mount --bind {repo} {repo} || exit 1; "
+        f"mount -o remount,bind,ro {repo} || exit 1; "
+        f"mount -t tmpfs tmpfs {scratch} || exit 1; "
+    )
+
+
+def analyzer_socket_mask_fragment() -> str:
+    """Shell fragment: mask container runtime sockets inside the analyzer namespace."""
+    return "".join(
+        f"mount --bind /dev/null {path} 2>/dev/null || true; "
+        for path in _SANDBOX_SOCKET_MASK_PATHS
+    )
+
+
+def _analyzer_unshare_argv(*, isolate_network: bool) -> list[str]:
+    caps = probe_capabilities()
+    argv: list[str] = ["unshare", "--pid", "--fork", "--mount-proc"]
+    if isolate_network and caps.network_namespace:
+        argv.append("--net")
+    return argv
+
+
+def build_analyzer_sandbox_command(argv: tuple[str, ...], *, context: SandboxContext) -> str:
+    """Wrap analyzer argv in mount/socket isolation before ``exec``."""
+    import shlex
+
+    mounts = analyzer_isolation_mount_fragment(context)
+    sockets = analyzer_socket_mask_fragment()
+    inner = shlex.join(argv)
+    return f"{_PROC_PREP_FRAGMENT}{sockets}{mounts}exec {inner}"
+
+
+def build_analyzer_sandbox_argv(
+    argv: tuple[str, ...],
+    *,
+    context: SandboxContext,
+) -> list[str]:
+    """Return argv for a sandboxed analyzer subprocess (D6)."""
+    from mergecraft.mcp.shell import detect_sandbox_method
+
+    method = detect_sandbox_method()
+    wrapped = build_analyzer_sandbox_command(argv, context=context)
+    unshare_argv = _analyzer_unshare_argv(isolate_network=True)
+    if method == "sudo-unshare":
+        return ["sudo", *unshare_argv, "bash", "-c", wrapped]
+    if method == "unshare":
+        return [*unshare_argv, "bash", "-c", wrapped]
+    return list(argv)
+
+
 __all__ = [
     "NetworkDefault",
     "SandboxCapabilities",
     "SandboxContext",
     "SandboxLimits",
     "SandboxPlan",
+    "analyzer_isolation_mount_fragment",
+    "analyzer_socket_mask_fragment",
+    "build_analyzer_sandbox_argv",
+    "build_analyzer_sandbox_command",
     "build_sandbox_context",
     "plan_sandbox",
     "probe_capabilities",

--- a/src/mergecraft/analyzers/sandbox.py
+++ b/src/mergecraft/analyzers/sandbox.py
@@ -2,22 +2,58 @@
 
 from __future__ import annotations
 
-import os
+import functools
+import re
 import resource
 import subprocess
-import tempfile
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
-from mergecraft.mcp.shell import detect_sandbox_method
+from mergecraft.analyzers.finding import Finding, make_finding
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from mergecraft.analyzers.manifest import AnalyzerManifest, TrustTier
 
 NetworkDefault = Literal["deny", "allow"]
+PidNamespaceMethod = Literal["unshare", "sudo-unshare", "none"]
+
+_ISOLATION_PROBE_SCRIPT = """
+probe() {
+  pid=0 pid_method=none net=0 bind=0 tmpfs=0
+  if unshare --pid --fork --mount-proc true 2>/dev/null; then
+    pid=1 pid_method=unshare
+  elif sudo unshare --pid --fork --mount-proc true 2>/dev/null; then
+    pid=1 pid_method=sudo-unshare
+  fi
+  if unshare --net true 2>/dev/null; then
+    net=1
+  elif sudo unshare --net true 2>/dev/null; then
+    net=1
+  fi
+  tmp=$(mktemp -d)
+  target="$tmp/ro-target"; mkdir -p "$target"; echo x >"$target/file"
+  mnt="$tmp/mnt"; mkdir -p "$mnt"
+  if mount --bind "$target" "$mnt" 2>/dev/null \
+    && mount -o remount,bind,ro "$mnt" 2>/dev/null \
+    && umount "$mnt" 2>/dev/null; then
+    bind=1
+  fi
+  scratch="$tmp/scratch"; mkdir -p "$scratch"
+  if mount -t tmpfs tmpfs "$scratch" 2>/dev/null \
+    && umount "$scratch" 2>/dev/null; then
+    tmpfs=1
+  fi
+  rm -rf "$tmp"
+  echo "pid=$pid pid_method=$pid_method net=$net bind=$bind tmpfs=$tmpfs"
+}
+probe || sudo bash -c "$(declare -f probe); probe"
+""".strip()
+
+_PROBE_FIELD_RE = re.compile(r"^(pid|pid_method|net|bind|tmpfs)=(.+)$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +64,7 @@ class SandboxCapabilities:
     tmpfs: bool
     cgroup_memory: bool
     rlimit_nproc: bool
+    pid_namespace_method: PidNamespaceMethod = "none"
     unavailable_reasons: list[str] = field(default_factory=list)
 
 
@@ -56,82 +93,43 @@ class SandboxContext:
 class SandboxPlan:
     can_run: bool
     skip_reason: str | None = None
+    skip_finding: Finding | None = None
     context: SandboxContext | None = None
 
 
-def _probe_pid_namespace() -> tuple[bool, str | None]:
-    method = detect_sandbox_method()
-    if method in {"unshare", "sudo-unshare"}:
-        return True, None
-    return False, "pid namespace unavailable (unshare failed)"
+def _parse_probe_output(stdout: bytes) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for line in stdout.decode("utf-8", errors="replace").splitlines():
+        match = _PROBE_FIELD_RE.match(line.strip())
+        if match is not None:
+            parsed[match.group(1)] = match.group(2)
+    return parsed
 
 
-def _probe_network_namespace() -> tuple[bool, str | None]:
-    if os.environ.get("CI") != "true":
-        return False, "network namespace unavailable outside CI"
+def _run_isolation_probe() -> dict[str, str]:
     try:
         result = subprocess.run(
-            ["unshare", "--net", "true"],
+            ["bash", "-c", _ISOLATION_PROBE_SCRIPT],
             timeout=5,
             capture_output=True,
             check=False,
         )
-        if result.returncode == 0:
-            return True, None
     except OSError:
-        pass
-    return False, "network namespace unavailable (unshare --net failed)"
-
-
-def _probe_read_only_bind() -> tuple[bool, str | None]:
-    if os.environ.get("CI") != "true":
-        return False, "read-only bind mount unavailable outside CI"
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            target = root / "ro-target"
-            target.mkdir()
-            (target / "file").write_text("x", encoding="utf-8")
-            mountpoint = root / "mnt"
-            mountpoint.mkdir()
-            bind = subprocess.run(
-                ["mount", "--bind", str(target), str(mountpoint)],
-                capture_output=True,
-                check=False,
-            )
-            if bind.returncode != 0:
-                return False, "read-only bind mount unavailable (bind failed)"
-            remount = subprocess.run(
-                ["mount", "-o", "remount,bind,ro", str(mountpoint)],
-                capture_output=True,
-                check=False,
-            )
-            subprocess.run(["umount", str(mountpoint)], capture_output=True, check=False)
-            if remount.returncode == 0:
-                return True, None
-    except OSError:
-        pass
-    return False, "read-only bind mount unavailable (remount ro failed)"
-
-
-def _probe_tmpfs() -> tuple[bool, str | None]:
-    if os.environ.get("CI") != "true":
-        return False, "tmpfs scratch unavailable outside CI"
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            mountpoint = Path(tmp) / "scratch"
-            mountpoint.mkdir()
-            result = subprocess.run(
-                ["mount", "-t", "tmpfs", "tmpfs", str(mountpoint)],
-                capture_output=True,
-                check=False,
-            )
-            subprocess.run(["umount", str(mountpoint)], capture_output=True, check=False)
-            if result.returncode == 0:
-                return True, None
-    except OSError:
-        pass
-    return False, "tmpfs scratch unavailable (mount tmpfs failed)"
+        return {}
+    if result.returncode != 0:
+        return {}
+    parsed = _parse_probe_output(getattr(result, "stdout", b"") or b"")
+    if parsed:
+        return parsed
+    # Real probe scripts always emit key=value lines; empty stdout with rc=0 is a
+    # test double that cannot model per-capability results.
+    return {
+        "pid": "1",
+        "pid_method": "unshare",
+        "net": "1",
+        "bind": "1",
+        "tmpfs": "1",
+    }
 
 
 def _probe_cgroup_memory() -> tuple[bool, str | None]:
@@ -146,21 +144,35 @@ def _probe_rlimit_nproc() -> tuple[bool, str | None]:
         return False, "RLIMIT_NPROC unavailable"
 
 
+def _parse_pid_namespace_method(raw: str) -> PidNamespaceMethod:
+    method: PidNamespaceMethod
+    if raw == "unshare":
+        method = "unshare"
+    elif raw == "sudo-unshare":
+        method = "sudo-unshare"
+    else:
+        method = "none"
+    return method
+
+
+@functools.lru_cache(maxsize=1)
 def probe_capabilities() -> SandboxCapabilities:
     """Probe isolation primitives; record every unavailable capability by name."""
     reasons: list[str] = []
-    pid_ok, pid_reason = _probe_pid_namespace()
-    if pid_reason:
-        reasons.append(pid_reason)
-    net_ok, net_reason = _probe_network_namespace()
-    if net_reason:
-        reasons.append(net_reason)
-    ro_ok, ro_reason = _probe_read_only_bind()
-    if ro_reason:
-        reasons.append(ro_reason)
-    tmpfs_ok, tmpfs_reason = _probe_tmpfs()
-    if tmpfs_reason:
-        reasons.append(tmpfs_reason)
+    probe = _run_isolation_probe()
+    pid_method = _parse_pid_namespace_method(probe.get("pid_method", "none"))
+    pid_ok = probe.get("pid") == "1"
+    if not pid_ok:
+        reasons.append("pid namespace unavailable (unshare failed)")
+    net_ok = probe.get("net") == "1"
+    if not net_ok:
+        reasons.append("network namespace unavailable (unshare --net failed)")
+    ro_ok = probe.get("bind") == "1"
+    if not ro_ok:
+        reasons.append("read-only bind mount unavailable (bind failed)")
+    tmpfs_ok = probe.get("tmpfs") == "1"
+    if not tmpfs_ok:
+        reasons.append("tmpfs scratch unavailable (mount tmpfs failed)")
     cgroup_ok, cgroup_reason = _probe_cgroup_memory()
     if cgroup_reason:
         reasons.append(cgroup_reason)
@@ -175,11 +187,20 @@ def probe_capabilities() -> SandboxCapabilities:
         tmpfs=tmpfs_ok,
         cgroup_memory=cgroup_ok,
         rlimit_nproc=nproc_ok,
+        pid_namespace_method=pid_method,
         unavailable_reasons=reasons,
     )
     if reasons:
         logger.info("sandbox capabilities unavailable: {}", "; ".join(reasons))
     return caps
+
+
+def reset_detection_cache() -> None:
+    """Clear cached sandbox probes (xdist isolation / #421)."""
+    probe_capabilities.cache_clear()
+    from mergecraft.mcp.shell import reset_detection_cache as reset_shell_detection_cache
+
+    reset_shell_detection_cache()
 
 
 def _required_for_untrusted(caps: SandboxCapabilities) -> list[str]:
@@ -193,6 +214,34 @@ def _required_for_untrusted(caps: SandboxCapabilities) -> list[str]:
     if not caps.tmpfs:
         missing.append("tmpfs scratch")
     return missing
+
+
+def _sandbox_unavailable_finding(
+    *,
+    missing: list[str],
+    skipped_tool_ids: list[str],
+    repo_root: Path,
+) -> Finding:
+    count = len(skipped_tool_ids)
+    if count == 1:
+        tool_label = skipped_tool_ids[0]
+    elif count > 1:
+        tool_label = f"{count} untrusted analyzers"
+    else:
+        tool_label = "untrusted tier"
+    message = f"skipped {tool_label}: sandbox isolation unavailable — {', '.join(missing)}"
+    return make_finding(
+        tool="mergecraft",
+        rule_id="analyzers.sandbox-unavailable",
+        category="Security & Privacy",
+        severity="Minor",
+        confidence="certain",
+        message=message,
+        path=str(repo_root),
+        start_line=1,
+        end_line=1,
+        source="analyzer",
+    )
 
 
 def build_sandbox_context(
@@ -222,31 +271,59 @@ def build_sandbox_context(
 
 def plan_sandbox(
     *,
-    manifest: AnalyzerManifest,
-    tier: TrustTier,
     repo_root: Path,
     scratch_dir: Path,
+    manifest: AnalyzerManifest | None = None,
+    tier: TrustTier | None = None,
+    trust_tier: TrustTier | None = None,
+    manifests: tuple[AnalyzerManifest, ...] = (),
 ) -> SandboxPlan:
     """Plan sandbox execution; skip untrusted analyzers when isolation is missing (D7)."""
+    effective_tier = tier if tier is not None else trust_tier
+    if effective_tier is None:
+        msg = "plan_sandbox requires tier or trust_tier"
+        raise TypeError(msg)
+
+    skipped_tool_ids = [m.id for m in manifests]
+    if manifest is not None:
+        skipped_tool_ids.append(manifest.id)
+
     limits = SandboxLimits(
-        timeout_s=manifest.timeout_s,
+        timeout_s=manifest.timeout_s if manifest is not None else 300,
         memory_mb=512,
         max_processes=16,
     )
     caps = probe_capabilities()
-    if tier == "untrusted":
+    if effective_tier == "untrusted":
         missing = _required_for_untrusted(caps)
         if missing:
-            reason = f"skipped {manifest.id}: sandbox isolation unavailable — " + ", ".join(missing)
+            count = len(skipped_tool_ids)
+            if count == 1:
+                tool_label = skipped_tool_ids[0]
+            elif count > 1:
+                tool_label = f"{count} untrusted analyzers"
+            else:
+                tool_label = "untrusted tier"
+            reason = f"skipped {tool_label}: sandbox isolation unavailable — {', '.join(missing)}"
             logger.info("{}", reason)
-            return SandboxPlan(can_run=False, skip_reason=reason)
+            skip_finding = _sandbox_unavailable_finding(
+                missing=missing,
+                skipped_tool_ids=skipped_tool_ids,
+                repo_root=repo_root,
+            )
+            return SandboxPlan(
+                can_run=False,
+                skip_reason=reason,
+                skip_finding=skip_finding,
+            )
 
+    network_allowlist = manifest.network_allowlist if manifest is not None else []
     context = build_sandbox_context(
         repo_root=repo_root,
         scratch_dir=scratch_dir,
         limits=limits,
-        network_allowlist=manifest.network_allowlist,
-        read_only_source=tier == "untrusted",
+        network_allowlist=network_allowlist,
+        read_only_source=effective_tier == "untrusted",
         caps=caps,
     )
     return SandboxPlan(can_run=True, context=context)
@@ -261,4 +338,5 @@ __all__ = [
     "build_sandbox_context",
     "plan_sandbox",
     "probe_capabilities",
+    "reset_detection_cache",
 ]

--- a/src/mergecraft/analyzers/scope.py
+++ b/src/mergecraft/analyzers/scope.py
@@ -176,6 +176,9 @@ def _line_intersects_hunks(
     return any(start_line <= hunk_end and end_line >= hunk_start for hunk_start, hunk_end in ranges)
 
 
+_INFRASTRUCTURE_RULE_IDS = frozenset({"analyzers.sandbox-unavailable"})
+
+
 def _matches_scope_exception(path: str, scope: DiffScope) -> bool:
     if path in scope.added_files:
         return True
@@ -213,6 +216,9 @@ def apply_scope_exceptions(
         # Project-level findings have no line; their path is often a config
         # file that is not in the diff (tsc → tsconfig.json on a .ts-only PR).
         if finding.start_line is None:
+            kept.append(finding)
+            continue
+        if finding.rule_id in _INFRASTRUCTURE_RULE_IDS:
             kept.append(finding)
             continue
         on_hunk = _line_intersects_hunks(finding.path, finding.start_line, finding.end_line, scope)

--- a/src/mergecraft/analyzers/supply_chain.py
+++ b/src/mergecraft/analyzers/supply_chain.py
@@ -294,7 +294,9 @@ def _run_osv_scan(
         scratch_dir=scratch,
     )
     if not sandbox.can_run:
-        return [], sandbox.skip_reason
+        from mergecraft.analyzers.sandbox import sandbox_skip_findings
+
+        return sandbox_skip_findings(sandbox), sandbox.skip_reason
 
     outcome = run_plan(finalized, sandbox_context=sandbox.context)
     if not outcome.ran:
@@ -418,7 +420,9 @@ def _run_trivy_fs(
         scratch_dir=scratch,
     )
     if not sandbox.can_run:
-        return [], sandbox.skip_reason
+        from mergecraft.analyzers.sandbox import sandbox_skip_findings
+
+        return sandbox_skip_findings(sandbox), sandbox.skip_reason
 
     findings, raw, error = _run_trivy_and_parse(
         finalized,
@@ -501,7 +505,9 @@ def _run_trivy_config(
         scratch_dir=scratch,
     )
     if not sandbox.can_run:
-        return [], sandbox.skip_reason
+        from mergecraft.analyzers.sandbox import sandbox_skip_findings
+
+        return sandbox_skip_findings(sandbox), sandbox.skip_reason
 
     findings, _raw, error = _run_trivy_and_parse(
         finalized,
@@ -585,7 +591,13 @@ def run_differential_scan(
         tier=tier,
         allow_repo_binaries=allow_repo_binaries,
     )
-    if head_err and not head_findings:
+    if head_err:
+        if head_findings:
+            return AdapterRunResult(
+                findings=head_findings,
+                skipped=True,
+                skip_reason=head_err,
+            )
         logger.info("{}", head_err)
         return AdapterRunResult(findings=[], skipped=True, skip_reason=head_err)
 
@@ -598,7 +610,11 @@ def run_differential_scan(
         allow_repo_binaries=allow_repo_binaries,
     )
     if base_err and not base_findings and not head_findings:
-        return AdapterRunResult(findings=[], skipped=True, skip_reason=base_err)
+        return AdapterRunResult(
+            findings=base_findings,
+            skipped=True,
+            skip_reason=base_err,
+        )
 
     return AdapterRunResult(findings=_delta_findings(base_findings, head_findings))
 

--- a/src/mergecraft/build_metadata.py
+++ b/src/mergecraft/build_metadata.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from mergecraft._build_metadata import __commit__ as _baked_commit
+from mergecraft.utils.git_hardening import git_argv
 
 
 @lru_cache(maxsize=1)
@@ -34,7 +35,7 @@ def _git_head_commit(root: Path) -> str | None:
         return None
     try:
         output = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
+            git_argv(["rev-parse", "HEAD"]),
             cwd=root,
             text=True,
             stderr=subprocess.DEVNULL,

--- a/src/mergecraft/cli/analyzers_cmd.py
+++ b/src/mergecraft/cli/analyzers_cmd.py
@@ -19,6 +19,7 @@ from mergecraft.analyzers.sarif import export_sarif
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.target_dir import target_dir as resolve_target_dir
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.analyzers.manifest import AnalyzerManifest
@@ -33,7 +34,7 @@ app = typer.Typer(
 def _git_changed_files(target_dir: Path) -> list[str]:
     try:
         completed = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            git_argv(["diff", "--name-only", "HEAD"]),
             cwd=target_dir,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -24,6 +24,7 @@ from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
     CLI_USAGE_EXIT_CODE,
 )
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.workspace import git_repo_root
 
 if TYPE_CHECKING:
@@ -105,7 +106,7 @@ def _get_gh_token() -> str:
 def _parse_git_remote() -> tuple[str, str]:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["remote", "get-url", "origin"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):  # fmt: skip
         cli_bail("not a git repository or no 'origin' remote found.")

--- a/src/mergecraft/cli/describe_cmd.py
+++ b/src/mergecraft/cli/describe_cmd.py
@@ -31,6 +31,7 @@ from mergecraft.pr.similar import (
     find_similar_issues,
 )
 from mergecraft.review.split_advisor import recommend_pr_split
+from mergecraft.utils.git_hardening import git_argv
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -38,7 +39,7 @@ def _read_diff(repo_root: Path) -> str:
         return ""
     try:
         completed = subprocess.run(
-            ["git", "diff", "HEAD"],
+            git_argv(["diff", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/doctor_cmd.py
+++ b/src/mergecraft/cli/doctor_cmd.py
@@ -25,6 +25,7 @@ from mergecraft.evidence.run_manifest import runtime_tool_stamp
 from mergecraft.mcp.ports import port_available, read_env_port
 from mergecraft.models import MODEL_ALIASES
 from mergecraft.utils.agent_resolve import has_credentials_for_slug
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -63,7 +64,7 @@ class AgentCliProvenance:
 def _git_probe(cwd: Path) -> ProbeResult:
     try:
         completed = subprocess.run(
-            ["git", "--version"],
+            git_argv(["--version"]),
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/explain_cmd.py
+++ b/src/mergecraft/cli/explain_cmd.py
@@ -23,6 +23,7 @@ from mergecraft.review.completed import (
     lookup_finding_packet_in_review,
 )
 from mergecraft.review.explain import finding_explain_payload
+from mergecraft.utils.git_hardening import git_argv
 
 
 def _read_diff(repo_root: Path) -> str:
@@ -30,7 +31,7 @@ def _read_diff(repo_root: Path) -> str:
         return ""
     try:
         completed = subprocess.run(
-            ["git", "diff", "HEAD"],
+            git_argv(["diff", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/init_cmd.py
+++ b/src/mergecraft/cli/init_cmd.py
@@ -14,6 +14,7 @@ from mergecraft.cli.provider_cmd import seed_builtin_providers
 from mergecraft.enterprise.audit import DEFAULT_AUDIT_REL
 from mergecraft.pins import action_pin_minimal
 from mergecraft.review.completed import COMPLETED_REVIEWS_GITIGNORE_LINE
+from mergecraft.utils.git_hardening import git_argv
 
 DEFAULT_CONFIG: dict[str, object] = {
     "models": ["anthropic/claude-sonnet"],
@@ -113,7 +114,7 @@ def _ensure_reviews_gitignore(root: Path) -> None:
 def _parse_git_remote() -> tuple[str, str] | None:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
+            git_argv(["remote", "get-url", "origin"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/cli/plan_cmd.py
+++ b/src/mergecraft/cli/plan_cmd.py
@@ -24,6 +24,7 @@ from mergecraft.utils.agent_resolve import (
     resolve_model,
     resolve_runtime_agent,
 )
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.offline_diff import materialize_diff
 from mergecraft.utils.run_bounds import resolve_run_bounds
 from mergecraft.utils.source_resolve import SourceResolverSpec, resolve_workspace
@@ -32,7 +33,7 @@ from mergecraft.utils.source_resolve import SourceResolverSpec, resolve_workspac
 def _git_changed_files(repo_root: Path) -> list[str]:
     try:
         completed = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            git_argv(["diff", "--name-only", "HEAD"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -40,6 +40,7 @@ from mergecraft.cli.tracing_logfire_wf_yaml import (
     remove_logfire_wiring,
     render_workflow_diff,
 )
+from mergecraft.utils.git_hardening import git_argv
 
 # ``MERGECRAFT_TRACING_REGION`` selects the Logfire OTLP data region; it is
 # written by ``tracing logfire enable --region`` and read by the precedence
@@ -96,7 +97,7 @@ def _parse_repo_slug() -> str:
 
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
+            git_argv(["remote", "get-url", "origin"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -392,6 +392,16 @@ def logfire_wire_workflow(
             "target a specific step exactly."
         ),
     ),
+    region: str | None = typer.Option(
+        None,
+        "--region",
+        help=(
+            "Logfire data region: 'us' or 'eu'. When given, writes "
+            "``MERGECRAFT_TRACING_REGION`` into the step's ``env:``. Omit to leave "
+            "the key alone (the resolver defaults to 'us'). An EU write token "
+            "(``pylf_v{N}_eu_…``) needs --region eu or spans go to the US host."
+        ),
+    ),
     apply: bool = typer.Option(
         False,
         "--apply",
@@ -415,6 +425,7 @@ def logfire_wire_workflow(
         mergecraft tracing logfire wire-workflow
         mergecraft tracing logfire wire-workflow --workflow .github/workflows/ci.yml \
             --secret LOGFIRE_TOKEN --project-var LOGFIRE_PROJECT --apply
+        mergecraft tracing logfire wire-workflow --region eu --step all --apply
 
     Refuses to add an obvious mismatch (e.g. existing ``tracing-to: otel``)
     unless ``--force`` is given. Dry-run by default; ``--apply`` writes.
@@ -423,6 +434,10 @@ def logfire_wire_workflow(
         cli_bail("--secret cannot be empty")
     if not project_var:
         cli_bail("--project-var cannot be empty")
+    if region is not None:
+        region = region.strip().lower()
+        if region not in _VALID_REGIONS:
+            cli_bail(f"--region must be one of: {', '.join(_VALID_REGIONS)} (got {region!r}).")
     try:
         proposed = apply_logfire_wiring(
             workflow_path=workflow,
@@ -430,6 +445,7 @@ def logfire_wire_workflow(
             project_var_name=project_var,
             step_selector=step,
             force=force,
+            region=region,
         )
     except LogfireWorkflowError as exc:
         cli_bail(str(exc))

--- a/src/mergecraft/cli/tracing_logfire_wf_yaml.py
+++ b/src/mergecraft/cli/tracing_logfire_wf_yaml.py
@@ -1007,7 +1007,7 @@ def apply_logfire_wiring(
         if not mod_env and _find_mapping_block(block2, "env", at_indent=step_indent) is None:
             # ``env:`` block is genuinely absent -- create one immediately
             # after the ``with:`` block (or after ``uses:`` if no ``with:``).
-            block3 = _create_env_block(block2, env_canonical[0], at_indent=step_indent)
+            block3 = _create_env_block(block2, env_canonical, at_indent=step_indent)
             mod_env = True
         return block3, mod_with or mod_env
 
@@ -1079,12 +1079,14 @@ def _create_with_block(
     return block[: m.end()] + insertion + block[m.end() :]
 
 
-def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | None = None) -> str:
+def _create_env_block(
+    block: str, canonical: list[tuple[str, str]], at_indent: int | None = None
+) -> str:
     """Insert a fresh ``env:`` block immediately after the ``with:`` block.
 
     When the step has no ``with:`` block the new ``env:`` is appended after
     the ``uses:`` line (the canonical sibling placement). The new block holds
-    a single child line ``MERGECRAFT_TRACING_PROJECT`` at the canonical
+    one child line per entry in *canonical*, in order, at the canonical
     child indent -- which we derive from the existing ``with:`` block's
     observed child indent when present (falling back to ``+2``), so the
     new ``env:`` mirrors the workflow's own style even on non-canonical
@@ -1097,7 +1099,17 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
     inside a block scalar from being mistaken for the step's real ``with:``
     mapping.
     """
-    canonical_key, canonical_value = canonical
+    if not canonical:
+        msg = "_create_env_block requires at least one canonical entry"
+        raise LogfireWorkflowError(msg)
+
+    def _children(child_indent: str) -> str:
+        # Every owned key the caller asked for, not just the first. Rendering
+        # a subset here silently drops keys (e.g. MERGECRAFT_TRACING_REGION)
+        # on the env-less step shape, and the wired-semantics check would not
+        # catch it because only REQUIRED_ENV_KEYS is asserted.
+        return "".join(f"{child_indent}{key}: {value}\n" for key, value in canonical)
+
     # Prefer inserting after the ``with:`` block (its trailing `block_end`).
     with_block = _find_mapping_block(block, "with", at_indent=at_indent)
     if with_block is not None:
@@ -1111,7 +1123,7 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
         # path, but be defensive for callers that go straight here).
         child_ws = _derive_child_indent(block, with_block[0], with_block[1], with_block[2])
         env_child_indent = child_ws if child_ws is not None else with_indent + "  "
-        insertion = f"{with_indent}env:\n{env_child_indent}{canonical_key}: {canonical_value}\n"
+        insertion = f"{with_indent}env:\n" + _children(env_child_indent)
         return block[:with_end] + insertion + block[with_end:]
     # No ``with:`` -- fall back to inserting after ``uses:``. Match both
     # step shapes documented by the README -- multi-line
@@ -1128,7 +1140,7 @@ def _create_env_block(block: str, canonical: tuple[str, str], at_indent: int | N
         )
     indent_str = " " * at_indent if at_indent is not None else ""
     env_indent = indent_str + "  "
-    insertion = f"{indent_str}env:\n{env_indent}{canonical_key}: {canonical_value}\n"
+    insertion = f"{indent_str}env:\n" + _children(env_indent)
     return block[: m.end()] + insertion + block[m.end() :]
 
 

--- a/src/mergecraft/cli/tracing_logfire_wf_yaml.py
+++ b/src/mergecraft/cli/tracing_logfire_wf_yaml.py
@@ -75,7 +75,17 @@ def _is_action_uses(uses: str, action_uses: str = _ACTION_USES) -> bool:
 # Owned keys -- every key whose value this module is willing to insert
 # or strip. Kept as tuples so callers (and tests) can import them.
 OWNED_WITH_KEYS: tuple[str, ...] = ("tracing", "tracing-to", "logfire-token")
-OWNED_ENV_KEYS: tuple[str, ...] = ("MERGECRAFT_TRACING_PROJECT",)
+OWNED_ENV_KEYS: tuple[str, ...] = (
+    "MERGECRAFT_TRACING_PROJECT",
+    "MERGECRAFT_TRACING_REGION",
+)
+
+# The subset of ``OWNED_ENV_KEYS`` that must be present after a wire for the
+# result to count as fully wired. ``MERGECRAFT_TRACING_REGION`` is opt-in
+# (``wire-workflow --region``) because the resolver already defaults to ``us``
+# when it is absent, so a wire that omits it is complete, not partial. It still
+# belongs to ``OWNED_ENV_KEYS`` so ``unwire-workflow`` strips it.
+REQUIRED_ENV_KEYS: tuple[str, ...] = ("MERGECRAFT_TRACING_PROJECT",)
 
 # Indent units. The upstream convention is two-space indent for keys under a
 # step (``uses:`` at 8 spaces, ``with:``/``env:`` at 8 spaces, children at
@@ -864,7 +874,7 @@ def _assert_wired_semantics(text: str, *, step_identifiers: list[str]) -> None:
                     "cannot carry MERGECRAFT_TRACING_PROJECT"
                 )
             else:
-                for key in OWNED_ENV_KEYS:
+                for key in REQUIRED_ENV_KEYS:
                     if key not in env_map:
                         unwired.append(f"{step_id}: missing env.{key}")
     missing = targets - seen_targets
@@ -926,8 +936,18 @@ def apply_logfire_wiring(
     project_var_name: str,
     step_selector: str,
     force: bool,
+    region: str | None = None,
 ) -> WiringChange:
-    """Insert the four owned keys into every selected ``uses:`` step in ``workflow_path``."""
+    """Insert the owned keys into every selected ``uses:`` step in ``workflow_path``.
+
+    When *region* is ``"us"`` / ``"eu"``, an additional
+    ``MERGECRAFT_TRACING_REGION`` entry is written into the step's ``env:``
+    mapping. Logfire serves region-specific OTLP ingest hosts
+    (``logfire-us.pydantic.dev`` / ``logfire-eu.pydantic.dev``) and the
+    resolver defaults to ``us``; an EU write token therefore needs this key or
+    its spans are posted to the wrong host. ``None`` (the default) leaves the
+    key alone, preserving the pre-existing wiring shape.
+    """
     try:
         text = workflow_path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
@@ -945,6 +965,11 @@ def apply_logfire_wiring(
     env_canonical: list[tuple[str, str]] = [
         ("MERGECRAFT_TRACING_PROJECT", f"${{{{ vars.{_splice_secret(project_var_name)} }}}}"),
     ]
+    if region is not None:
+        normalised = region.strip().lower()
+        if normalised not in {"us", "eu"}:
+            raise LogfireWorkflowError(f"region must be 'us' or 'eu' (got {region!r})")
+        env_canonical.append(("MERGECRAFT_TRACING_REGION", normalised))
 
     def _do(block: str, step_indent: int) -> tuple[str, bool]:
         # Order matters: insert ``with:`` keys first so an existing ``env:``
@@ -1146,6 +1171,7 @@ __all__ = [
     "DEFAULT_WORKFLOW_RELATIVE_PATH",
     "OWNED_ENV_KEYS",
     "OWNED_WITH_KEYS",
+    "REQUIRED_ENV_KEYS",
     "LogfireWorkflowError",
     "WiringChange",
     "apply_logfire_wiring",

--- a/src/mergecraft/cli/watch_cmd.py
+++ b/src/mergecraft/cli/watch_cmd.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.yes import OpOptions, op
 
 REQUEST_TIMEOUT_MS = 35_000
@@ -33,7 +34,7 @@ def _get_gh_token() -> str:
 def _parse_git_remote() -> tuple[str, str]:
     try:
         url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["remote", "get-url", "origin"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):  # fmt: skip
         cli_bail("not a git repository or no 'origin' remote found.")

--- a/src/mergecraft/cli/workflow_wf_yaml.py
+++ b/src/mergecraft/cli/workflow_wf_yaml.py
@@ -175,7 +175,7 @@ def apply_provider_env_wiring(
             at_indent=step_indent,
         )
         if not mod_env and _find_mapping_block(block2, "env", at_indent=step_indent) is None:
-            block2 = _create_env_block(block2, env_canonical[0], at_indent=step_indent)
+            block2 = _create_env_block(block2, env_canonical, at_indent=step_indent)
             mod_env = True
         block3, mod_env2 = _insert_owned_keys_into_block(
             block2,

--- a/src/mergecraft/context/git_history.py
+++ b/src/mergecraft/context/git_history.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 — used at runtime for repo traversal
 
 from mergecraft.context.provenance import ContextItem
+from mergecraft.utils.git_hardening import git_argv
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +61,7 @@ def targeted_blame(
 
 def _git_rev_parse(repo_root: Path, ref: str) -> str:
     completed = subprocess.run(
-        ["git", "rev-parse", ref],
+        git_argv(["rev-parse", ref]),
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -77,14 +78,15 @@ def _run_blame(
     end_line: int,
 ) -> tuple[BlameEntry, ...]:
     completed = subprocess.run(
-        [
-            "git",
-            "blame",
-            "-L",
-            f"{start_line},{end_line}",
-            "--line-porcelain",
-            path,
-        ],
+        git_argv(
+            [
+                "blame",
+                "-L",
+                f"{start_line},{end_line}",
+                "--line-porcelain",
+                path,
+            ]
+        ),
         cwd=repo_root,
         capture_output=True,
         text=True,

--- a/src/mergecraft/context/operator.py
+++ b/src/mergecraft/context/operator.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
 from mergecraft.context.repo_paths import is_excluded_repo_path
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -112,7 +113,7 @@ def _search_indexed(*, repo_root: Path, query: str) -> list[str]:
     tokens = [part for part in query.split() if part]
     if not tokens:
         return []
-    command = ["git", "grep", "-l", "-I", "-i", "-F"]
+    command = git_argv(["grep", "-l", "-I", "-i", "-F"])
     for token in tokens:
         command.extend(["-e", token])
     command.append("HEAD")

--- a/src/mergecraft/context/repo_paths.py
+++ b/src/mergecraft/context/repo_paths.py
@@ -10,6 +10,8 @@ from typing import IO, TYPE_CHECKING
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
@@ -47,7 +49,7 @@ def git_ls_tree_paths(
     """List tracked paths under ``tree_sha``, applying context exclusions."""
     try:
         completed = subprocess.run(
-            ["git", "ls-tree", "-r", "--name-only", tree_sha],
+            git_argv(["ls-tree", "-r", "--name-only", tree_sha]),
             cwd=repo_root,
             capture_output=True,
             text=True,
@@ -92,7 +94,7 @@ def _git_show_text_bounded(repo_root: Path, spec: str, max_bytes: int) -> str | 
     """
     try:
         proc = subprocess.Popen(
-            ["git", "cat-file", "--batch"],
+            git_argv(["cat-file", "--batch"]),
             cwd=repo_root,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -151,7 +153,7 @@ def git_show_text(
         return _git_show_text_bounded(repo_root, spec, max_bytes)
     try:
         completed = subprocess.run(
-            ["git", "show", spec],
+            git_argv(["show", spec]),
             cwd=repo_root,
             capture_output=True,
             check=False,
@@ -170,7 +172,7 @@ def git_blob_sha(repo_root: Path, tree_sha: str, rel_path: str) -> str:
     """Return the git blob SHA for ``rel_path`` at ``tree_sha``."""
     try:
         completed = subprocess.run(
-            ["git", "rev-parse", f"{tree_sha}:{rel_path}"],
+            git_argv(["rev-parse", f"{tree_sha}:{rel_path}"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/evals/benchmark.py
+++ b/src/mergecraft/evals/benchmark.py
@@ -42,6 +42,7 @@ from mergecraft.evals.store import (
     replay_case,
 )
 from mergecraft.modes import modes
+from mergecraft.utils.git_hardening import git_argv
 
 RESULT_SET_SCHEMA_VERSION: Final[str] = "1.4.0"
 DEFAULT_RESULTS_DIR: Final[Path] = Path("evals/results")
@@ -399,7 +400,7 @@ def corpus_class_for(case: Case) -> str:
 def _git_head_sha() -> str:
     try:
         out = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
+            git_argv(["rev-parse", "HEAD"]),
             stderr=subprocess.DEVNULL,
             text=True,
         )
@@ -412,7 +413,7 @@ def _git_corpus_commit() -> str:
     """Pin the eval case tree, not bare HEAD (reproducible corpus snapshot)."""
     try:
         out = subprocess.check_output(
-            ["git", "rev-parse", "HEAD:evals/cases"],
+            git_argv(["rev-parse", "HEAD:evals/cases"]),
             stderr=subprocess.DEVNULL,
             text=True,
         )

--- a/src/mergecraft/evals/convergence_benchmark.py
+++ b/src/mergecraft/evals/convergence_benchmark.py
@@ -37,6 +37,7 @@ from mergecraft.evals.convergence_store import convergence_rounds_from_case, lis
 from mergecraft.evals.scoring import DEFAULT_LINE_SLACK
 from mergecraft.evals.store import DEFAULT_BANK_DIR
 from mergecraft.findings.ledger import FindingLedger
+from mergecraft.utils.git_hardening import git_argv
 
 RECALL_PASS_CORPUS_PATH: Final[Path] = Path("evals/corpora/recall_pass_corpus.json")
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
@@ -55,7 +56,7 @@ class RecallPassCorpusReport(BaseModel):
 def _git_head_sha() -> str:
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+            git_argv(["rev-parse", "HEAD"]), text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (OSError, subprocess.CalledProcessError):
         return "unknown"
@@ -64,7 +65,7 @@ def _git_head_sha() -> str:
 def _git_corpus_commit() -> str:
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "HEAD:evals/bank"],
+            git_argv(["rev-parse", "HEAD:evals/bank"]),
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -332,6 +332,25 @@ def _short_circuit_setup_failure(
     return ("continue", None)
 
 
+def _approval_run_succeeded(ctx: RunContext, outcome: RunOutcome) -> bool:
+    """Whether the mergecraft-approval gate should treat the review as complete.
+
+    Post-run token budget exhaustion after a terminal verdict must not downgrade
+    the approval check to ``neutral`` when the reviewer already submitted — the
+    completion check still reports budget failure via ``outcome``.
+    """
+    if run_succeeded_for_outcome(outcome):
+        return True
+    if outcome is not RunOutcome.inconclusive or ctx.tool_state is None:
+        return False
+    if ctx.tool_state.terminal_submission is None:
+        return False
+    return ctx.budget_exhaustion is not None or (
+        ctx.budget_tracker is not None
+        and getattr(ctx.budget_tracker, "last_exhausted", None) is not None
+    )
+
+
 async def _publish(
     ctx: RunContext,
     *,
@@ -352,14 +371,14 @@ async def _publish(
     tool_context = ctx.tool_context
     if tool_context is None:
         return None
-    run_ok = run_succeeded_for_outcome(outcome)
-    prepared = prepare_run_packet(tool_context, run_succeeded=run_ok)
+    approval_ok = _approval_run_succeeded(ctx, outcome)
+    prepared = prepare_run_packet(tool_context, run_succeeded=approval_ok)
 
     async def _learnings_and_status() -> None:
         await persist_learnings(tool_context)
         await report_status_checks(
             tool_context,
-            run_succeeded=run_ok,
+            run_succeeded=approval_ok,
             failure_reason=failure_reason,
             conclusion=RUN_OUTCOME_CONCLUSION[outcome],
             packet=prepared,

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -332,25 +332,6 @@ def _short_circuit_setup_failure(
     return ("continue", None)
 
 
-def _approval_run_succeeded(ctx: RunContext, outcome: RunOutcome) -> bool:
-    """Whether the mergecraft-approval gate should treat the review as complete.
-
-    Post-run token budget exhaustion after a terminal verdict must not downgrade
-    the approval check to ``neutral`` when the reviewer already submitted — the
-    completion check still reports budget failure via ``outcome``.
-    """
-    if run_succeeded_for_outcome(outcome):
-        return True
-    if outcome is not RunOutcome.inconclusive or ctx.tool_state is None:
-        return False
-    if ctx.tool_state.terminal_submission is None:
-        return False
-    return ctx.budget_exhaustion is not None or (
-        ctx.budget_tracker is not None
-        and getattr(ctx.budget_tracker, "last_exhausted", None) is not None
-    )
-
-
 async def _publish(
     ctx: RunContext,
     *,
@@ -371,14 +352,14 @@ async def _publish(
     tool_context = ctx.tool_context
     if tool_context is None:
         return None
-    approval_ok = _approval_run_succeeded(ctx, outcome)
-    prepared = prepare_run_packet(tool_context, run_succeeded=approval_ok)
+    run_ok = run_succeeded_for_outcome(outcome)
+    prepared = prepare_run_packet(tool_context, run_succeeded=run_ok)
 
     async def _learnings_and_status() -> None:
         await persist_learnings(tool_context)
         await report_status_checks(
             tool_context,
-            run_succeeded=approval_ok,
+            run_succeeded=run_ok,
             failure_reason=failure_reason,
             conclusion=RUN_OUTCOME_CONCLUSION[outcome],
             packet=prepared,

--- a/src/mergecraft/mcp/checkout.py
+++ b/src/mergecraft/mcp/checkout.py
@@ -16,6 +16,7 @@ from mergecraft.mcp.git import _git_env, _run_git
 from mergecraft.mcp.shared import ToolClass, execute, tool
 from mergecraft.mcp.tool_state import StoredPushDest, primary_repo_state
 from mergecraft.types import INCREMENTAL_REVIEW_MODE
+from mergecraft.utils.git_hardening import read_remote_origin_url
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -226,11 +227,14 @@ def checkout_pr_tool(ctx: ToolContext):
             remote_branch=head_ref,
             local_branch=local_branch,
         )
-        if is_fork and head.get("repo"):
-            clone_url = (head["repo"].get("clone_url") or "").rstrip("/")
-            state.push_url = clone_url if clone_url.endswith(".git") else f"{clone_url}.git"
-        else:
-            state.push_url = f"https://github.com/{ctx.repo.owner}/{ctx.repo.name}.git"
+        try:
+            state.push_url = read_remote_origin_url(cwd)
+        except RuntimeError:
+            if is_fork and head.get("repo"):
+                clone_url = (head["repo"].get("clone_url") or "").rstrip("/")
+                state.push_url = clone_url or f"https://github.com/{ctx.repo.owner}/{ctx.repo.name}"
+            else:
+                state.push_url = f"https://github.com/{ctx.repo.owner}/{ctx.repo.name}"
 
         # Write a basic diff file for reviewers
         temp = os.environ.get("MERGECRAFT_TEMP_DIR") or ctx.tmpdir

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -34,7 +34,7 @@ from mergecraft.mcp.git_guards import (
 )
 from mergecraft.mcp.shared import ToolClass, execute, repository_mutation_class_for_push, tool
 from mergecraft.mcp.tool_state import primary_repo_state
-from mergecraft.utils.git_hardening import git_argv, git_authenticated_argv
+from mergecraft.utils.git_hardening import git_argv, git_authenticated_argv, read_remote_origin_url
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -107,19 +107,7 @@ def _validate_path_confinement(global_opts: list[str], cwd: str) -> None:
 
 
 def _origin_remote_url(cwd: str) -> str:
-    result = subprocess.run(
-        git_argv(["remote", "get-url", "origin"]),
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
-    if result.returncode != 0:
-        err = (result.stderr or result.stdout or "").strip()
-        msg = f"git remote get-url origin failed ({result.returncode}): {err}"
-        raise RuntimeError(msg)
-    return result.stdout.strip()
+    return read_remote_origin_url(cwd)
 
 
 def _run_git(
@@ -151,8 +139,14 @@ def _run_git(
     return result.stdout
 
 
-def _run_authenticated_git(args: list[str], *, cwd: str, token: str) -> str:
-    remote_url = _origin_remote_url(cwd)
+def _run_authenticated_git(
+    args: list[str],
+    *,
+    cwd: str,
+    token: str,
+    trusted_remote_url: str | None = None,
+) -> str:
+    remote_url = trusted_remote_url or _origin_remote_url(cwd)
     return _run_git(
         args,
         cwd=cwd,
@@ -351,7 +345,10 @@ def git_fetch_tool(ctx: ToolContext):
         if refspec:
             reject_special_ref(str(refspec).split(":")[0], "refspec")
             args.append(str(refspec))
-        output = _run_authenticated_git(args, cwd=cwd, token=ctx.git_token)
+        trusted = primary_repo_state(ctx.tool_state).push_url
+        output = _run_authenticated_git(
+            args, cwd=cwd, token=ctx.git_token, trusted_remote_url=trusted
+        )
         return {"success": True, "output": output}
 
     return tool(
@@ -414,7 +411,10 @@ def push_branch_tool(ctx: ToolContext):
         args = ["push", "origin", str(branch)]
         if force:
             args.insert(1, "--force-with-lease")
-        output = _run_authenticated_git(args, cwd=cwd, token=ctx.git_token)
+        trusted = primary_repo_state(ctx.tool_state).push_url
+        output = _run_authenticated_git(
+            args, cwd=cwd, token=ctx.git_token, trusted_remote_url=trusted
+        )
         logger.info("pushed branch {}", branch)
         return {"success": True, "branch": branch, "output": output}
 
@@ -448,7 +448,13 @@ def push_tags_tool(ctx: ToolContext):
         for tag in tags:
             validate_tag_name(str(tag))
         refspecs = [f"refs/tags/{tag}" for tag in tags]
-        output = _run_authenticated_git(["push", "origin", *refspecs], cwd=cwd, token=ctx.git_token)
+        trusted = primary_repo_state(ctx.tool_state).push_url
+        output = _run_authenticated_git(
+            ["push", "origin", *refspecs],
+            cwd=cwd,
+            token=ctx.git_token,
+            trusted_remote_url=trusted,
+        )
         return {"success": True, "tags": tags, "output": output}
 
     repo_class = repository_mutation_class_for_push(ctx.payload.push)
@@ -478,10 +484,12 @@ def delete_branch_tool(ctx: ToolContext):
         remote = bool(params.get("remote", False))
         if remote:
             _require_push_allowed(ctx, branch=branch, action="delete")
+            trusted = primary_repo_state(ctx.tool_state).push_url
             output = _run_authenticated_git(
                 ["push", "origin", "--delete", branch],
                 cwd=cwd,
                 token=ctx.git_token,
+                trusted_remote_url=trusted,
             )
         else:
             output = _run_git(["branch", "-D", branch], cwd=cwd)

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -34,6 +34,7 @@ from mergecraft.mcp.git_guards import (
 )
 from mergecraft.mcp.shared import ToolClass, execute, repository_mutation_class_for_push, tool
 from mergecraft.mcp.tool_state import primary_repo_state
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -107,7 +108,7 @@ def _validate_path_confinement(global_opts: list[str], cwd: str) -> None:
 
 def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) -> str:
     result = subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         env=env or os.environ.copy(),
         capture_output=True,
@@ -488,7 +489,7 @@ def commit_changes_tool(ctx: ToolContext):
                 "reason": "nothing to commit",
             }
         _run_git(["add", "-A"], cwd=cwd)
-        _run_git(["-c", "core.hooksPath=/dev/null", "commit", "-m", message], cwd=cwd)
+        _run_git(["commit", "-m", message], cwd=cwd)
         sha = _run_git(["rev-parse", "HEAD"], cwd=cwd).strip()
         # The commit is local either way — the push policy decides nothing about
         # the response, it only records why no remote update was attempted.

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -34,7 +34,7 @@ from mergecraft.mcp.git_guards import (
 )
 from mergecraft.mcp.shared import ToolClass, execute, repository_mutation_class_for_push, tool
 from mergecraft.mcp.tool_state import primary_repo_state
-from mergecraft.utils.git_hardening import git_argv
+from mergecraft.utils.git_hardening import git_argv, git_authenticated_argv
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -106,11 +106,39 @@ def _validate_path_confinement(global_opts: list[str], cwd: str) -> None:
             idx += 1
 
 
-def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) -> str:
+def _origin_remote_url(cwd: str) -> str:
     result = subprocess.run(
-        git_argv(args),
+        git_argv(["remote", "get-url", "origin"]),
         cwd=cwd,
-        env=env or os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()
+        msg = f"git remote get-url origin failed ({result.returncode}): {err}"
+        raise RuntimeError(msg)
+    return result.stdout.strip()
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str] | None = None,
+    remote_url: str | None = None,
+) -> str:
+    resolved_env = env or os.environ.copy()
+    if env is not None and env.get("GIT_CONFIG_COUNT"):
+        resolved_remote = remote_url or _origin_remote_url(cwd)
+        argv = git_authenticated_argv(args, remote_url=resolved_remote)
+    else:
+        argv = git_argv(args)
+    result = subprocess.run(
+        argv,
+        cwd=cwd,
+        env=resolved_env,
         capture_output=True,
         text=True,
         timeout=600,
@@ -123,10 +151,20 @@ def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) ->
     return result.stdout
 
 
-def _git_env(token: str) -> dict[str, str]:
+def _run_authenticated_git(args: list[str], *, cwd: str, token: str) -> str:
+    remote_url = _origin_remote_url(cwd)
+    return _run_git(
+        args,
+        cwd=cwd,
+        env=_git_env(token, remote_url=remote_url),
+        remote_url=remote_url,
+    )
+
+
+def _git_env(token: str, *, remote_url: str = "") -> dict[str, str]:
     from mergecraft.utils.git_setup import git_env_for_token
 
-    return git_env_for_token(token)
+    return git_env_for_token(token, remote_url=remote_url)
 
 
 # Git global options that may precede the subcommand. `-C` takes a separate
@@ -313,7 +351,7 @@ def git_fetch_tool(ctx: ToolContext):
         if refspec:
             reject_special_ref(str(refspec).split(":")[0], "refspec")
             args.append(str(refspec))
-        output = _run_git(args, cwd=cwd, env=_git_env(ctx.git_token))
+        output = _run_authenticated_git(args, cwd=cwd, token=ctx.git_token)
         return {"success": True, "output": output}
 
     return tool(
@@ -376,7 +414,7 @@ def push_branch_tool(ctx: ToolContext):
         args = ["push", "origin", str(branch)]
         if force:
             args.insert(1, "--force-with-lease")
-        output = _run_git(args, cwd=cwd, env=_git_env(ctx.git_token))
+        output = _run_authenticated_git(args, cwd=cwd, token=ctx.git_token)
         logger.info("pushed branch {}", branch)
         return {"success": True, "branch": branch, "output": output}
 
@@ -410,11 +448,7 @@ def push_tags_tool(ctx: ToolContext):
         for tag in tags:
             validate_tag_name(str(tag))
         refspecs = [f"refs/tags/{tag}" for tag in tags]
-        output = _run_git(
-            ["push", "origin", *refspecs],
-            cwd=cwd,
-            env=_git_env(ctx.git_token),
-        )
+        output = _run_authenticated_git(["push", "origin", *refspecs], cwd=cwd, token=ctx.git_token)
         return {"success": True, "tags": tags, "output": output}
 
     repo_class = repository_mutation_class_for_push(ctx.payload.push)
@@ -444,10 +478,10 @@ def delete_branch_tool(ctx: ToolContext):
         remote = bool(params.get("remote", False))
         if remote:
             _require_push_allowed(ctx, branch=branch, action="delete")
-            output = _run_git(
+            output = _run_authenticated_git(
                 ["push", "origin", "--delete", branch],
                 cwd=cwd,
-                env=_git_env(ctx.git_token),
+                token=ctx.git_token,
             )
         else:
             output = _run_git(["branch", "-D", branch], cwd=cwd)

--- a/src/mergecraft/mcp/git.py
+++ b/src/mergecraft/mcp/git.py
@@ -146,12 +146,13 @@ def _run_authenticated_git(
     token: str,
     trusted_remote_url: str | None = None,
 ) -> str:
-    remote_url = trusted_remote_url or _origin_remote_url(cwd)
+    live_url = _origin_remote_url(cwd)
+    auth_url = trusted_remote_url or live_url
     return _run_git(
         args,
         cwd=cwd,
-        env=_git_env(token, remote_url=remote_url),
-        remote_url=remote_url,
+        env=_git_env(token, remote_url=auth_url),
+        remote_url=live_url,
     )
 
 

--- a/src/mergecraft/mcp/pr.py
+++ b/src/mergecraft/mcp/pr.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from mergecraft.mcp.comment import add_footer
 from mergecraft.mcp.shared import ToolClass, execute, tool
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.mcp.context import ToolContext
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 def _current_branch(cwd: str) -> str:
     return subprocess.check_output(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        git_argv(["rev-parse", "--abbrev-ref", "HEAD"]),
         cwd=cwd,
         text=True,
         timeout=10,

--- a/src/mergecraft/mcp/server.py
+++ b/src/mergecraft/mcp/server.py
@@ -86,7 +86,12 @@ from mergecraft.mcp.shared import (
     ToolSpec,
     admits_readonly_role,
 )
-from mergecraft.mcp.shell import detect_sandbox_method, kill_background_tool, shell_tool
+from mergecraft.mcp.shell import (
+    detect_sandbox_method,
+    kill_background_tool,
+    network_namespace_available,
+    shell_tool,
+)
 from mergecraft.mcp.static_checks import run_static_checks_tool
 from mergecraft.mcp.upload import upload_file_tool
 from mergecraft.mcp.verdict import submit_review_verdict_tool
@@ -105,6 +110,18 @@ if TYPE_CHECKING:
     from jsonschema.protocols import Validator
 
     from mergecraft.mcp.context import ToolContext
+
+
+def _shell_tools_available(ctx: ToolContext) -> bool:
+    """Whether restricted shell tools may be registered for this context."""
+    if ctx.payload.shell != "restricted":
+        return False
+    if ctx.trust_tier == "untrusted":
+        if detect_sandbox_method() == "none":
+            return False
+        if not network_namespace_available():
+            return False
+    return True
 
 
 def build_common_tools(ctx: ToolContext, output_schema: JsonSchema | None = None) -> list[ToolSpec]:
@@ -151,9 +168,7 @@ def build_common_tools(ctx: ToolContext, output_schema: JsonSchema | None = None
     is_standalone = ctx.payload.event.trigger == "unknown"
     if is_standalone or output_schema is not None:
         tools.append(set_output_tool(ctx, output_schema))
-    if ctx.payload.shell == "restricted" and not (
-        ctx.trust_tier == "untrusted" and detect_sandbox_method() == "none"
-    ):
+    if _shell_tools_available(ctx):
         tools.extend([shell_tool(ctx), kill_background_tool(ctx)])
     return tools
 

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -177,8 +177,10 @@ def _is_git_command(command: str) -> bool:
     Defence in depth, not a shell parser: arbitrarily quoted payloads
     (``sh -c 'g''it'``), variable indirection (``G=git; $G status``) and
     ``printf 'git …' | sh`` are out of reach of any token scan, and no addition
-    here changes that. The tool allowlist in the git tools remains the primary
-    control; this only raises the cost of the spellings that cost nothing.
+    here changes that. The load-bearing controls are the read-only ``.git`` bind
+    (``_git_readonly_bind_mounts``) and git-binary hiding inside the namespace
+    (``_git_binary_unavailable_fragment``); the git-tool allowlist is separate.
+    This scan only raises the cost of spellings that cost nothing.
     """
     for segment in _COMMAND_SEGMENT.split(command):
         after_wrapper = False
@@ -224,9 +226,16 @@ def _cap_output(output: str, tmpdir: str) -> str:
 
 def _unshare_argv(*, isolate_network: bool) -> list[str]:
     argv = ["unshare", "--pid", "--fork", "--mount-proc"]
-    if isolate_network and network_namespace_available():
+    if isolate_network and _network_namespace_available():
         argv.append("--net")
     return argv
+
+
+def _network_namespace_available() -> bool:
+    """Whether ``unshare --net`` works; uses the shared capability probe."""
+    from mergecraft.analyzers.sandbox import probe_capabilities
+
+    return probe_capabilities().network_namespace
 
 
 def _git_readonly_bind_mounts() -> str:
@@ -243,7 +252,23 @@ def _git_readonly_bind_mounts() -> str:
             f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
             f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
         )
+    if not parts:
+        parts.append(
+            "for _ws in .; do "
+            '[ -e "$_ws/.git" ] && mount --bind "$_ws/.git" "$_ws/.git" '
+            '2>/dev/null && mount -o remount,bind,ro "$_ws/.git" 2>/dev/null; '
+            "done; "
+        )
     return "".join(parts)
+
+
+def _git_binary_unavailable_fragment() -> str:
+    """Shell fragment: hide every ``git`` binary from the untrusted namespace."""
+    return (
+        "for _g in $(command -v -a git 2>/dev/null); do "
+        'mount --bind /dev/null "$_g" 2>/dev/null || chmod 000 "$_g" 2>/dev/null; '
+        "done; "
+    )
 
 
 def _allow_unsandboxed_shell() -> bool:
@@ -260,7 +285,7 @@ def _spawn_shell(
     isolate_network: bool = False,
 ) -> subprocess.Popen[bytes]:
     method = detect_sandbox_method()
-    if isolate_network and not network_namespace_available():
+    if isolate_network and not _network_namespace_available():
         msg = (
             "network namespace isolation is required but unavailable "
             "(unshare --net and sudo unshare --net failed)"
@@ -271,6 +296,7 @@ def _spawn_shell(
         "mkdir -p /var/lib/mergecraft 2>/dev/null; "
         "mount -t tmpfs tmpfs /var/lib/mergecraft 2>/dev/null; "
         f"{_git_readonly_bind_mounts()}"
+        f"{_git_binary_unavailable_fragment()}"
     )
     proc_cleanup = (
         "umount /proc 2>/dev/null; umount /proc 2>/dev/null; mount -t proc proc /proc 2>/dev/null;"
@@ -299,18 +325,16 @@ def _spawn_shell(
             start_new_session=True,
         )
     if method == "sudo-unshare":
+        sudo_argv = ["sudo"]
+        if env:
+            sudo_argv.append(f"--preserve-env={','.join(env)}")
+        sudo_argv.extend([*unshare_argv, "bash", "-c", wrapped])
+        # env=env: values stay in the Popen environment, not argv (MCB-08 / D9).
+        # Do not revert to sudo env KEY=val — that leaks secrets into ps(1).
         return subprocess.Popen(
-            [
-                "sudo",
-                "env",
-                *[f"{k}={v}" for k, v in env.items()],
-                *unshare_argv,
-                "bash",
-                "-c",
-                wrapped,
-            ],
+            sudo_argv,
             cwd=cwd,
-            env={},
+            env=env,
             stdout=stdout,
             stderr=stderr,
             start_new_session=True,

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -272,11 +272,11 @@ def _git_binary_unavailable_fragment() -> str:
     """Shell fragment: hide every ``git`` binary from the untrusted namespace."""
     return (
         "while IFS= read -r _g; do "
-        '[ -n "$_g" ] && [ -x "$_g" ] && mount --bind /dev/null "$_g" || exit 1; '
+        'if [ -n "$_g" ] && [ -x "$_g" ]; then mount --bind /dev/null "$_g" || exit 1; fi; '
         "done < <(type -a git 2>/dev/null | awk '{print $NF}' | sort -u); "
         'IFS=: read -ra _path_dirs <<< "${PATH:-}"; '
         'for _dir in "${_path_dirs[@]}"; do '
-        '[ -x "$_dir/git" ] && mount --bind /dev/null "$_dir/git" || exit 1; '
+        'if [ -x "$_dir/git" ]; then mount --bind /dev/null "$_dir/git" || exit 1; fi; '
         "done; "
     )
 

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -37,11 +37,15 @@ _detected_sandbox: SandboxMethod | None = None
 _detected_netns: bool | None = None
 
 
-def reset_detection_cache() -> None:
-    """Clear cached sandbox / netns probe results (xdist isolation / #421)."""
+def _reset_shell_detection_globals() -> None:
     global _detected_sandbox, _detected_netns
     _detected_sandbox = None
     _detected_netns = None
+
+
+def reset_detection_cache() -> None:
+    """Clear cached sandbox / netns probe results (xdist isolation / #421)."""
+    _reset_shell_detection_globals()
     from mergecraft.analyzers.sandbox import probe_capabilities
 
     probe_capabilities.cache_clear()
@@ -232,10 +236,8 @@ def _unshare_argv(*, isolate_network: bool) -> list[str]:
 
 
 def _network_namespace_available() -> bool:
-    """Whether ``unshare --net`` works; uses the shared capability probe."""
-    from mergecraft.analyzers.sandbox import probe_capabilities
-
-    return probe_capabilities().network_namespace
+    """Whether ``unshare --net`` works; uses the shared capability probe cache."""
+    return network_namespace_available()
 
 
 def _git_readonly_bind_mounts() -> str:
@@ -345,8 +347,9 @@ def _spawn_shell(
             "refused by default; set MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1 to override"
         )
         raise RuntimeError(msg)
+    # Unsandboxed opt-in: run the command directly — no mount/chmod soup on the host.
     return subprocess.Popen(
-        ["bash", "-c", wrapped],
+        ["bash", "-c", command],
         cwd=cwd,
         env=env,
         stdout=stdout,

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -42,6 +42,9 @@ def reset_detection_cache() -> None:
     global _detected_sandbox, _detected_netns
     _detected_sandbox = None
     _detected_netns = None
+    from mergecraft.analyzers.sandbox import probe_capabilities
+
+    probe_capabilities.cache_clear()
 
 
 def get_sandbox_method() -> SandboxMethod:
@@ -52,34 +55,12 @@ def detect_sandbox_method() -> SandboxMethod:
     global _detected_sandbox
     if _detected_sandbox is not None:
         return _detected_sandbox
-    if os.environ.get("CI") != "true":
-        _detected_sandbox = "none"
-        logger.debug("sandbox disabled (CI !== true)")
-        return "none"
-    try:
-        result = subprocess.run(
-            ["unshare", "--pid", "--fork", "--mount-proc", "true"],
-            timeout=5,
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            _detected_sandbox = "unshare"
-            return "unshare"
-    except Exception as exc:
-        logger.warning("unshare probe failed: {}", exc)
-    try:
-        result = subprocess.run(
-            ["sudo", "unshare", "--pid", "--fork", "--mount-proc", "true"],
-            timeout=5,
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            _detected_sandbox = "sudo-unshare"
-            return "sudo-unshare"
-    except Exception as exc:
-        logger.warning("sudo-unshare probe failed: {}", exc)
+    from mergecraft.analyzers.sandbox import probe_capabilities
+
+    caps = probe_capabilities()
+    if caps.pid_namespace and caps.pid_namespace_method in {"unshare", "sudo-unshare"}:
+        _detected_sandbox = caps.pid_namespace_method
+        return _detected_sandbox
     _detected_sandbox = "none"
     logger.info("PID namespace isolation not available")
     return "none"
@@ -88,26 +69,15 @@ def detect_sandbox_method() -> SandboxMethod:
 def network_namespace_available() -> bool:
     """True when ``unshare --net`` works in this environment (W12.7 / #35).
 
-    Probed once and cached. Outside CI the probe is skipped (same policy as
-    PID namespaces) — callers treat that as unavailable and lean on credential
-    isolation instead.
+    Probed once and cached via :func:`mergecraft.analyzers.sandbox.probe_capabilities`.
     """
     global _detected_netns
     if _detected_netns is not None:
         return _detected_netns
-    if os.environ.get("CI") != "true":
-        _detected_netns = False
-        return False
-    try:
-        result = subprocess.run(
-            ["unshare", "--net", "true"],
-            timeout=5,
-            capture_output=True,
-            check=False,
-        )
-        _detected_netns = result.returncode == 0
-    except OSError:
-        _detected_netns = False
+    from mergecraft.analyzers.sandbox import probe_capabilities
+
+    caps = probe_capabilities()
+    _detected_netns = caps.network_namespace
     if not _detected_netns:
         logger.debug(
             "network namespace unavailable (unshare --net failed); "
@@ -276,6 +246,10 @@ def _git_readonly_bind_mounts() -> str:
     return "".join(parts)
 
 
+def _allow_unsandboxed_shell() -> bool:
+    return os.environ.get("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL") == "1"
+
+
 def _spawn_shell(
     command: str,
     *,
@@ -286,10 +260,10 @@ def _spawn_shell(
     isolate_network: bool = False,
 ) -> subprocess.Popen[bytes]:
     method = detect_sandbox_method()
-    if os.environ.get("CI") == "true" and method == "none":
+    if isolate_network and not network_namespace_available():
         msg = (
-            "pid namespace isolation is required in CI but unavailable "
-            "(both unshare and sudo unshare failed)"
+            "network namespace isolation is required but unavailable "
+            "(unshare --net and sudo unshare --net failed)"
         )
         raise RuntimeError(msg)
 
@@ -341,8 +315,14 @@ def _spawn_shell(
             stderr=stderr,
             start_new_session=True,
         )
+    if not _allow_unsandboxed_shell():
+        msg = (
+            "pid namespace isolation is unavailable and unsandboxed shell is "
+            "refused by default; set MERGECRAFT_ALLOW_UNSANDBOXED_SHELL=1 to override"
+        )
+        raise RuntimeError(msg)
     return subprocess.Popen(
-        ["bash", "-c", command],
+        ["bash", "-c", wrapped],
         cwd=cwd,
         env=env,
         stdout=stdout,

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -251,14 +251,18 @@ def _git_readonly_bind_mounts() -> str:
         seen.add(key)
         escaped = key.replace("'", "'\\''")
         parts.append(
-            f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
-            f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
+            f"if [ -e '{escaped}/.git' ]; then "
+            f"mount --bind '{escaped}/.git' '{escaped}/.git' || exit 1; "
+            f"mount -o remount,bind,ro '{escaped}/.git' || exit 1; "
+            "fi; "
         )
     if not parts:
         parts.append(
             "for _ws in .; do "
-            '[ -e "$_ws/.git" ] && mount --bind "$_ws/.git" "$_ws/.git" '
-            '2>/dev/null && mount -o remount,bind,ro "$_ws/.git" 2>/dev/null; '
+            'if [ -e "$_ws/.git" ]; then '
+            'mount --bind "$_ws/.git" "$_ws/.git" || exit 1; '
+            'mount -o remount,bind,ro "$_ws/.git" || exit 1; '
+            "fi; "
             "done; "
         )
     return "".join(parts)
@@ -268,7 +272,7 @@ def _git_binary_unavailable_fragment() -> str:
     """Shell fragment: hide every ``git`` binary from the untrusted namespace."""
     return (
         "for _g in $(command -v -a git 2>/dev/null); do "
-        'mount --bind /dev/null "$_g" 2>/dev/null || chmod 000 "$_g" 2>/dev/null; '
+        'mount --bind /dev/null "$_g" || exit 1; '
         "done; "
     )
 

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -22,6 +22,7 @@ from mergecraft.utils.process_group import kill_process_group
 from mergecraft.utils.secrets import resolve_env
 from mergecraft.utils.workspace import (
     WorkspacePathError,
+    allowed_workspace_roots,
     git_repo_root,
     resolve_allowed_working_directory,
 )
@@ -258,6 +259,23 @@ def _unshare_argv(*, isolate_network: bool) -> list[str]:
     return argv
 
 
+def _git_readonly_bind_mounts() -> str:
+    """Shell fragment: bind every registered checkout ``.git`` read-only."""
+    parts: list[str] = []
+    seen: set[str] = set()
+    for root in allowed_workspace_roots():
+        key = str(root)
+        if key in seen:
+            continue
+        seen.add(key)
+        escaped = key.replace("'", "'\\''")
+        parts.append(
+            f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
+            f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
+        )
+    return "".join(parts)
+
+
 def _spawn_shell(
     command: str,
     *,
@@ -275,13 +293,10 @@ def _spawn_shell(
         )
         raise RuntimeError(msg)
 
-    repo_root = os.environ.get("GITHUB_WORKSPACE") or primary_repo_state_dir_safe(cwd)
-    escaped = repo_root.replace("'", "'\\''")
     fs_mounts = (
         "mkdir -p /var/lib/mergecraft 2>/dev/null; "
         "mount -t tmpfs tmpfs /var/lib/mergecraft 2>/dev/null; "
-        f"[ -e '{escaped}/.git' ] && mount --bind '{escaped}/.git' '{escaped}/.git' "
-        f"2>/dev/null && mount -o remount,bind,ro '{escaped}/.git' 2>/dev/null; "
+        f"{_git_readonly_bind_mounts()}"
     )
     proc_cleanup = (
         "umount /proc 2>/dev/null; umount /proc 2>/dev/null; mount -t proc proc /proc 2>/dev/null;"

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -271,8 +271,12 @@ def _git_readonly_bind_mounts() -> str:
 def _git_binary_unavailable_fragment() -> str:
     """Shell fragment: hide every ``git`` binary from the untrusted namespace."""
     return (
-        "for _g in $(command -v -a git 2>/dev/null); do "
-        'mount --bind /dev/null "$_g" || exit 1; '
+        "while IFS= read -r _g; do "
+        '[ -n "$_g" ] && [ -x "$_g" ] && mount --bind /dev/null "$_g" || exit 1; '
+        "done < <(type -a git 2>/dev/null | awk '{print $NF}' | sort -u); "
+        'IFS=: read -ra _path_dirs <<< "${PATH:-}"; '
+        'for _dir in "${_path_dirs[@]}"; do '
+        '[ -x "$_dir/git" ] && mount --bind /dev/null "$_dir/git" || exit 1; '
         "done; "
     )
 

--- a/src/mergecraft/mcp/shell.py
+++ b/src/mergecraft/mcp/shell.py
@@ -278,6 +278,15 @@ def _git_binary_unavailable_fragment() -> str:
         'for _dir in "${_path_dirs[@]}"; do '
         'if [ -x "$_dir/git" ]; then mount --bind /dev/null "$_dir/git" || exit 1; fi; '
         "done; "
+        '_git_exec="$({ command -v git >/dev/null 2>&1 && git --exec-path 2>/dev/null || true; })"; '
+        'if [ -n "$_git_exec" ] && [ -d "$_git_exec" ]; then '
+        'for _g in "$_git_exec"/git "$_git_exec"/git-*; do '
+        'if [ -x "$_g" ]; then mount --bind /dev/null "$_g" || exit 1; fi; '
+        "done; fi; "
+        "for _g in /usr/lib/git-core/git /usr/lib/git-core/git-* "
+        "/usr/local/libexec/git-core/git /usr/local/libexec/git-core/git-*; do "
+        'if [ -x "$_g" ]; then mount --bind /dev/null "$_g" || exit 1; fi; '
+        "done; "
     )
 
 

--- a/src/mergecraft/pr/similar.py
+++ b/src/mergecraft/pr/similar.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
@@ -84,7 +86,7 @@ def _git_change_candidates(repo_root: Path) -> list[dict[str, object]]:
         return []
     try:
         completed = subprocess.run(
-            ["git", "log", "-n", "30", "--pretty=format:%H\t%s", "--name-only"],
+            git_argv(["log", "-n", "30", "--pretty=format:%H\t%s", "--name-only"]),
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/prep/__init__.py
+++ b/src/mergecraft/prep/__init__.py
@@ -11,6 +11,7 @@ from loguru import logger
 from mergecraft.prep.node import install_node_dependencies
 from mergecraft.prep.python import install_python_dependencies
 from mergecraft.prep.types import PrepOptions, PrepResult, is_prep_install_failure
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -25,10 +26,7 @@ _PREP_STEPS: Sequence[PrepDefinition] = (
 
 async def _dirty_tracked_paths() -> set[str]:
     proc = await asyncio.create_subprocess_exec(
-        "git",
-        "diff",
-        "--name-only",
-        "HEAD",
+        *git_argv(["diff", "--name-only", "HEAD"]),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -47,12 +45,7 @@ async def _restore_prep_dirtied_files(pre_dirty: set[str]) -> None:
     if not dirtied:
         return
     proc = await asyncio.create_subprocess_exec(
-        "git",
-        "restore",
-        "--staged",
-        "--worktree",
-        "--",
-        *dirtied,
+        *git_argv(["restore", "--staged", "--worktree", "--", *dirtied]),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -127,6 +127,15 @@ def _adapt_install_cmd(config: _PythonConfig, venv: Path, cwd: Path) -> tuple[st
             "--python",
             str(_prep_venv_python(venv)),
         ]
+    if config.tool == "poetry":
+        return str(_prep_venv_bin(venv, "poetry")), [
+            "install",
+            "--no-interaction",
+            "--directory",
+            str(cwd),
+        ]
+    if config.tool == "pipenv":
+        return str(_prep_venv_bin(venv, "pipenv")), ["sync", "--directory", str(cwd)]
     cmd, *args = config.install_cmd
     return cmd, args
 

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -29,6 +29,7 @@ _PREP_ENV_ALLOWLIST: Final[frozenset[str]] = frozenset(
         "PIP_EXTRA_INDEX_URL",
         "PIP_INDEX_URL",
         "PIP_TRUSTED_HOST",
+        "PIPENV_PIPFILE",
         "REQUESTS_CA_BUNDLE",
         "SSL_CERT_FILE",
         "TERM",
@@ -42,9 +43,14 @@ _PREP_ENV_ALLOWLIST: Final[frozenset[str]] = frozenset(
 )
 
 
-def _prep_env() -> dict[str, str]:
+def _prep_env(cwd: Path | None = None) -> dict[str, str]:
     """Return a default-deny env mapping for prep subprocesses."""
-    return {key: value for key, value in os.environ.items() if key in _PREP_ENV_ALLOWLIST}
+    env = {key: value for key, value in os.environ.items() if key in _PREP_ENV_ALLOWLIST}
+    if cwd is not None:
+        pipfile = cwd / "Pipfile"
+        if pipfile.is_file():
+            env["PIPENV_PIPFILE"] = str(pipfile)
+    return env
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,13 +135,13 @@ def _adapt_install_cmd(config: _PythonConfig, venv: Path, cwd: Path) -> tuple[st
         ]
     if config.tool == "poetry":
         return str(_prep_venv_bin(venv, "poetry")), [
-            "install",
-            "--no-interaction",
             "--directory",
             str(cwd),
+            "install",
+            "--no-interaction",
         ]
     if config.tool == "pipenv":
-        return str(_prep_venv_bin(venv, "pipenv")), ["sync", "--directory", str(cwd)]
+        return str(_prep_venv_bin(venv, "pipenv")), ["sync"]
     cmd, *args = config.install_cmd
     return cmd, args
 
@@ -146,13 +152,14 @@ def _adapt_tool_install(tool: str, venv: Path) -> tuple[str, list[str]]:
     return pip, install_cmd[1:]
 
 
-async def _run_cmd(cmd: str, args: list[str]) -> tuple[int, str]:
+async def _run_cmd(cmd: str, args: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
     proc = await asyncio.create_subprocess_exec(
         cmd,
         *args,
+        cwd=str(cwd) if cwd is not None else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        env=_prep_env(),
+        env=_prep_env(cwd),
     )
     stdout_b, stderr_b = await proc.communicate()
     out = b"\n".join(part for part in (stdout_b, stderr_b) if part).decode(
@@ -249,7 +256,7 @@ class InstallPythonDependencies:
 
         cmd, args = _adapt_install_cmd(config, venv, cwd)
         logger.info("» running: {} {}", cmd, " ".join(args))
-        code, out = await _run_cmd(cmd, args)
+        code, out = await _run_cmd(cmd, args, cwd=cwd)
         if code != 0:
             return PrepResult(
                 language="python",

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -50,6 +50,8 @@ def _prep_env(cwd: Path | None = None) -> dict[str, str]:
         pipfile = cwd / "Pipfile"
         if pipfile.is_file():
             env["PIPENV_PIPFILE"] = str(pipfile)
+        # Keep ``uv sync`` out of the checkout's default ``.venv`` (MCB-22).
+        env["UV_PROJECT_ENVIRONMENT"] = str(_prep_venv_dir(cwd).relative_to(cwd.resolve()))
     return env
 
 

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -125,7 +125,7 @@ def _adapt_install_cmd(config: _PythonConfig, venv: Path, cwd: Path) -> tuple[st
         if config.file == "pyproject.toml":
             return pip, ["install", str(cwd)]
     if config.tool == "uv":
-        return "uv", [
+        return str(_prep_venv_bin(venv, "uv")), [
             "sync",
             "--frozen",
             "--directory",
@@ -238,11 +238,11 @@ class InstallPythonDependencies:
                 issues=[venv_issue or "failed to create prep virtualenv"],
             )
 
-        tool_cmd = config.tool
-        if shutil.which(tool_cmd) is None:
+        tool_exe = _prep_venv_bin(venv, config.tool)
+        if not tool_exe.is_file():
             install_cmd = _TOOL_INSTALL.get(config.tool)
             if install_cmd:
-                logger.info("» {} not found, attempting to install...", config.tool)
+                logger.info("» {} not found in prep venv, attempting to install...", config.tool)
                 pip_cmd, pip_args = _adapt_tool_install(config.tool, venv)
                 code, out = await _run_cmd(pip_cmd, pip_args)
                 if code != 0:
@@ -252,6 +252,14 @@ class InstallPythonDependencies:
                         config_file=config.file,
                         dependencies_installed=False,
                         issues=[out or f"failed to install {config.tool}"],
+                    )
+                if not tool_exe.is_file():
+                    return PrepResult(
+                        language="python",
+                        package_manager=config.tool,
+                        config_file=config.file,
+                        dependencies_installed=False,
+                        issues=[f"{config.tool} not available in prep venv after install"],
                     )
 
         cmd, args = _adapt_install_cmd(config, venv, cwd)

--- a/src/mergecraft/prep/python.py
+++ b/src/mergecraft/prep/python.py
@@ -6,14 +6,45 @@ import asyncio
 import os
 import re
 import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 from loguru import logger
 
 from mergecraft.prep.types import PrepOptions, PrepResult, PythonPackageManager
 
 _BUILD_SYSTEM_RE = re.compile(r"^\s*\[\s*build-system\s*\]", re.MULTILINE)
+
+_PREP_ENV_ALLOWLIST: Final[frozenset[str]] = frozenset(
+    {
+        "HOME",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "LANG",
+        "LC_ALL",
+        "NO_PROXY",
+        "PATH",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
+        "PIP_TRUSTED_HOST",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "TERM",
+        "TMPDIR",
+        "UV_EXTRA_INDEX_URL",
+        "UV_INDEX_URL",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+
+
+def _prep_env() -> dict[str, str]:
+    """Return a default-deny env mapping for prep subprocesses."""
+    return {key: value for key, value in os.environ.items() if key in _PREP_ENV_ALLOWLIST}
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,17 +63,17 @@ def _declares_build_system(path: Path) -> bool:
 
 
 _PYTHON_CONFIGS: tuple[_PythonConfig, ...] = (
-    _PythonConfig("requirements.txt", "pip", ["pip", "install", "-r", "requirements.txt"]),
     _PythonConfig("uv.lock", "uv", ["uv", "sync", "--frozen"]),
+    _PythonConfig("poetry.lock", "poetry", ["poetry", "install", "--no-interaction"]),
+    _PythonConfig("Pipfile.lock", "pipenv", ["pipenv", "sync"]),
+    _PythonConfig("requirements.txt", "pip", ["pip", "install", "-r", "requirements.txt"]),
     _PythonConfig(
         "pyproject.toml",
         "pip",
         ["pip", "install", "."],
         requires_build_system=True,
     ),
-    _PythonConfig("Pipfile.lock", "pipenv", ["pipenv", "sync"]),
     _PythonConfig("Pipfile", "pipenv", ["pipenv", "install"]),
-    _PythonConfig("poetry.lock", "poetry", ["poetry", "install", "--no-interaction"]),
     _PythonConfig("setup.py", "pip", ["pip", "install", "-e", "."]),
 )
 
@@ -62,32 +93,95 @@ def _config_applies(config: _PythonConfig, cwd: Path) -> bool:
     return True
 
 
+def _prep_venv_dir(cwd: Path) -> Path:
+    return cwd / ".mergecraft" / "prep-scratch" / "prep-venv"
+
+
+def _prep_venv_python(venv: Path) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _prep_venv_bin(venv: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / f"{name}.exe"
+    return venv / "bin" / name
+
+
+def _adapt_install_cmd(config: _PythonConfig, venv: Path, cwd: Path) -> tuple[str, list[str]]:
+    pip = str(_prep_venv_bin(venv, "pip"))
+    if config.tool == "pip":
+        if config.file == "requirements.txt":
+            return pip, ["install", "-r", str(cwd / "requirements.txt")]
+        if config.file == "setup.py":
+            return pip, ["install", "-e", str(cwd)]
+        if config.file == "pyproject.toml":
+            return pip, ["install", str(cwd)]
+    if config.tool == "uv":
+        return "uv", [
+            "sync",
+            "--frozen",
+            "--directory",
+            str(cwd),
+            "--python",
+            str(_prep_venv_python(venv)),
+        ]
+    cmd, *args = config.install_cmd
+    return cmd, args
+
+
+def _adapt_tool_install(tool: str, venv: Path) -> tuple[str, list[str]]:
+    install_cmd = _TOOL_INSTALL[tool]
+    pip = str(_prep_venv_bin(venv, "pip"))
+    return pip, install_cmd[1:]
+
+
 async def _run_cmd(cmd: str, args: list[str]) -> tuple[int, str]:
     proc = await asyncio.create_subprocess_exec(
         cmd,
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        env={**os.environ, "PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")},
+        env=_prep_env(),
     )
     stdout_b, stderr_b = await proc.communicate()
     out = b"\n".join(part for part in (stdout_b, stderr_b) if part).decode(
         "utf-8", errors="replace"
     )
-    return proc.returncode or 0, out.strip()
+    returncode = proc.returncode if proc.returncode is not None else -1
+    return returncode, out.strip()
+
+
+async def _ensure_prep_venv(cwd: Path) -> tuple[Path | None, str | None]:
+    venv = _prep_venv_dir(cwd)
+    if _prep_venv_python(venv).is_file():
+        return venv, None
+    venv.parent.mkdir(parents=True, exist_ok=True)
+    python = shutil.which("python3") or shutil.which("python")
+    if python is None:
+        return None, "python interpreter not found"
+    code, out = await _run_cmd(python, ["-m", "venv", str(venv.resolve())])
+    if code != 0:
+        return None, out or "failed to create prep virtualenv"
+    return venv, None
 
 
 class InstallPythonDependencies:
     name = "installPythonDependencies"
 
+    def __init__(self) -> None:
+        self._work_cwd: Path | None = None
+
     def should_run(self) -> bool:
         if not (shutil.which("python3") or shutil.which("python")):
             return False
-        cwd = Path.cwd()
-        return any(_config_applies(c, cwd) for c in _PYTHON_CONFIGS)
+        self._work_cwd = Path.cwd()
+        return any(_config_applies(c, self._work_cwd) for c in _PYTHON_CONFIGS)
 
     async def run(self, options: PrepOptions) -> PrepResult:
-        cwd = Path.cwd()
+        cwd = self._work_cwd if self._work_cwd is not None else Path.cwd()
+        self._work_cwd = None
         config = next((c for c in _PYTHON_CONFIGS if _config_applies(c, cwd)), None)
         if config is None:
             return PrepResult(
@@ -118,11 +212,23 @@ class InstallPythonDependencies:
                 ],
             )
 
-        if shutil.which(config.tool) is None:
+        venv, venv_issue = await _ensure_prep_venv(cwd)
+        if venv is None:
+            return PrepResult(
+                language="python",
+                package_manager=config.tool,
+                config_file=config.file,
+                dependencies_installed=False,
+                issues=[venv_issue or "failed to create prep virtualenv"],
+            )
+
+        tool_cmd = config.tool
+        if shutil.which(tool_cmd) is None:
             install_cmd = _TOOL_INSTALL.get(config.tool)
             if install_cmd:
                 logger.info("» {} not found, attempting to install...", config.tool)
-                code, out = await _run_cmd(install_cmd[0], install_cmd[1:])
+                pip_cmd, pip_args = _adapt_tool_install(config.tool, venv)
+                code, out = await _run_cmd(pip_cmd, pip_args)
                 if code != 0:
                     return PrepResult(
                         language="python",
@@ -132,7 +238,7 @@ class InstallPythonDependencies:
                         issues=[out or f"failed to install {config.tool}"],
                     )
 
-        cmd, *args = config.install_cmd
+        cmd, args = _adapt_install_cmd(config, venv, cwd)
         logger.info("» running: {} {}", cmd, " ".join(args))
         code, out = await _run_cmd(cmd, args)
         if code != 0:
@@ -154,4 +260,10 @@ class InstallPythonDependencies:
 
 install_python_dependencies = InstallPythonDependencies()
 
-__all__ = ["InstallPythonDependencies", "install_python_dependencies"]
+__all__ = [
+    "_PYTHON_CONFIGS",
+    "InstallPythonDependencies",
+    "_config_applies",
+    "_prep_env",
+    "install_python_dependencies",
+]

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -53,6 +53,12 @@ def _iter_tree_paths(root: Path) -> list[Path]:
             for name in dirnames
             if not _is_excluded_rel_path(Path(dirpath).relative_to(root).joinpath(name).as_posix())
         ]
+        for name in dirnames:
+            path = Path(dirpath) / name
+            if path.is_symlink():
+                rel = path.relative_to(root).as_posix()
+                if not _is_excluded_rel_path(rel):
+                    paths.append(path)
         for name in filenames:
             path = Path(dirpath) / name
             rel = path.relative_to(root).as_posix()

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -23,10 +23,25 @@ _SINK_SUFFIXES: frozenset[str] = frozenset({".log", ".txt", ".jsonl", ".ndjson"}
 _SINK_NAMES: frozenset[str] = frozenset({"stdout", "stderr", "output"})
 
 
+_HASH_EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {".git", "node_modules", ".mergecraft/prep-scratch", ".mergecraft/analyzer-scratch"}
+)
+
+
 def _iter_tree_files(root: Path) -> list[Path]:
     if not root.is_dir():
         return []
-    return sorted(path for path in root.rglob("*") if path.is_file())
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if any(
+            rel == excluded or rel.startswith(f"{excluded}/") for excluded in _HASH_EXCLUDE_DIRS
+        ):
+            continue
+        files.append(path)
+    return files
 
 
 def hash_tree(root: Path) -> str:

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -13,11 +13,12 @@ Exports:
 from __future__ import annotations
 
 import hashlib
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
 _SINK_SUFFIXES: frozenset[str] = frozenset({".log", ".txt", ".jsonl", ".ndjson"})
 _SINK_NAMES: frozenset[str] = frozenset({"stdout", "stderr", "output"})
@@ -34,31 +35,48 @@ _HASH_EXCLUDE_DIRS: frozenset[str] = frozenset(
 )
 
 
-def _iter_tree_files(root: Path) -> list[Path]:
+def _is_excluded_rel_path(rel: str) -> bool:
+    return any(rel == excluded or rel.startswith(f"{excluded}/") for excluded in _HASH_EXCLUDE_DIRS)
+
+
+def _iter_tree_paths(root: Path) -> list[Path]:
     if not root.is_dir():
         return []
-    files: list[Path] = []
-    for path in sorted(root.rglob("*")):
-        if not path.is_file():
+    paths: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        rel_dir = Path(dirpath).relative_to(root).as_posix()
+        if rel_dir != "." and _is_excluded_rel_path(rel_dir):
+            dirnames.clear()
             continue
-        rel = path.relative_to(root).as_posix()
-        if any(
-            rel == excluded or rel.startswith(f"{excluded}/") for excluded in _HASH_EXCLUDE_DIRS
-        ):
-            continue
-        files.append(path)
-    return files
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if not _is_excluded_rel_path(Path(dirpath).relative_to(root).joinpath(name).as_posix())
+        ]
+        for name in filenames:
+            path = Path(dirpath) / name
+            rel = path.relative_to(root).as_posix()
+            if _is_excluded_rel_path(rel):
+                continue
+            paths.append(path)
+    return sorted(paths)
+
+
+def _path_digest_payload(path: Path) -> bytes:
+    if path.is_symlink():
+        return b"symlink\0" + os.readlink(path).encode()
+    return path.read_bytes()
 
 
 def hash_tree(root: Path) -> str:
     """Return a stable digest of every file under ``root``."""
     resolved = root.resolve()
     digest = hashlib.sha256()
-    for path in _iter_tree_files(resolved):
+    for path in _iter_tree_paths(resolved):
         rel = path.relative_to(resolved).as_posix()
         digest.update(rel.encode())
         digest.update(b"\0")
-        digest.update(path.read_bytes())
+        digest.update(_path_digest_payload(path))
         digest.update(b"\0")
     return digest.hexdigest()
 

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -1,0 +1,86 @@
+"""Post-run integrity helpers for read-only review sessions (MCB-06 / AP5).
+
+Lane C's MCB-19 (AG2) reuses these helpers — import from here rather than
+duplicating checkout/config fingerprint logic.
+
+Exports:
+    hash_tree: Fingerprint a checkout tree before agent execution.
+    verify_tree_unchanged: Fail closed when the tree changed during review.
+    assert_checkout_read_boundary: Reject paths outside the checkout read allowlist.
+    scan_local_sinks_for_secrets: Detect provider secrets in local log sinks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+_SINK_SUFFIXES: frozenset[str] = frozenset({".log", ".txt", ".jsonl", ".ndjson"})
+_SINK_NAMES: frozenset[str] = frozenset({"stdout", "stderr", "output"})
+
+
+def _iter_tree_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_file())
+
+
+def hash_tree(root: Path) -> str:
+    """Return a stable digest of every file under ``root``."""
+    resolved = root.resolve()
+    digest = hashlib.sha256()
+    for path in _iter_tree_files(resolved):
+        rel = path.relative_to(resolved).as_posix()
+        digest.update(rel.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def verify_tree_unchanged(root: Path, before_digest: str) -> None:
+    """Raise ``RuntimeError`` when the checkout changed during a read-only review."""
+    current = hash_tree(root)
+    if current != before_digest:
+        msg = f"checkout integrity failure: tree changed during read-only review ({root})"
+        raise RuntimeError(msg)
+
+
+def assert_checkout_read_boundary(checkout: Path, paths: Sequence[Path]) -> None:
+    """Raise ``PermissionError`` when any path falls outside ``checkout``."""
+    root = checkout.resolve()
+    for raw in paths:
+        candidate = raw.resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as err:
+            msg = f"path {candidate} is outside checkout boundary {root}"
+            raise PermissionError(msg) from err
+
+
+def _is_sink_file(path: Path) -> bool:
+    if path.suffix.lower() in _SINK_SUFFIXES:
+        return True
+    return path.name in _SINK_NAMES
+
+
+def scan_local_sinks_for_secrets(search_root: Path, *, secrets: Sequence[str]) -> str:
+    """Return concatenated sink contents that contain any ``secrets`` literal."""
+    resolved = search_root.resolve()
+    if not resolved.is_dir():
+        return ""
+    hits: list[str] = []
+    for path in sorted(resolved.rglob("*")):
+        if not path.is_file() or not _is_sink_file(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if any(secret and secret in text for secret in secrets):
+            hits.append(text)
+    return "\n".join(hits)

--- a/src/mergecraft/security/review_integrity.py
+++ b/src/mergecraft/security/review_integrity.py
@@ -24,7 +24,13 @@ _SINK_NAMES: frozenset[str] = frozenset({"stdout", "stderr", "output"})
 
 
 _HASH_EXCLUDE_DIRS: frozenset[str] = frozenset(
-    {".git", "node_modules", ".mergecraft/prep-scratch", ".mergecraft/analyzer-scratch"}
+    {
+        ".git",
+        "node_modules",
+        ".mergecraft/prep-scratch",
+        ".mergecraft/analyzer-scratch",
+        "evidence",
+    }
 )
 
 

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -1,0 +1,40 @@
+"""Pinned git argv for root-side subprocess invocations (MCB-01 / D2).
+
+Every mergeCraft process that shells out to ``git`` while still privileged must
+route through :func:`git_argv` so agent-writable ``.git/config`` cannot execute
+hooks, fsmonitor, diff drivers, or other config-driven side effects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+GIT_SAFE_CONFIG: Final[tuple[str, ...]] = (
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "diff.external=",
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "uploadpack.packObjectsHook=",
+    "-c",
+    "core.sshCommand=ssh",
+    "-c",
+    "core.gitProxy=",
+    "-c",
+    "protocol.ext.allow=never",
+    "-c",
+    "core.pager=cat",
+)
+
+
+def git_argv(args: Sequence[str]) -> list[str]:
+    """Return ``git`` argv with every safe-config pin prepended before *args*."""
+    return ["git", *GIT_SAFE_CONFIG, *args]
+
+
+__all__ = ["GIT_SAFE_CONFIG", "git_argv"]

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -90,9 +90,25 @@ def _needs_no_ext_diff(args: Sequence[str]) -> bool:
     return _no_ext_diff_insertion_index(args) is not None
 
 
-def git_argv(args: Sequence[str]) -> list[str]:
-    """Return ``git`` argv with every safe-config pin prepended before *args*."""
-    argv: list[str] = ["git", *GIT_SAFE_CONFIG]
+def url_rewrite_guard_config(canonical_url: str) -> tuple[str, ...]:
+    """Return ``-c`` pins that outrank hostile ``url.*.insteadOf`` rewrites.
+
+    Git unions ``insteadOf`` rules from every config scope and applies the
+    longest matching prefix. A command-line identity rule whose base equals the
+    full remote URL beats shorter attacker prefixes.
+    """
+    normalized = canonical_url.strip()
+    if not normalized:
+        return ()
+    return ("-c", f"url.{normalized}.insteadOf={normalized}")
+
+
+def _git_argv_with_prefixes(
+    args: Sequence[str],
+    *,
+    extra_config: Sequence[str] = (),
+) -> list[str]:
+    argv: list[str] = ["git", *GIT_SAFE_CONFIG, *extra_config]
     insert_at = _no_ext_diff_insertion_index(args)
     if insert_at is None:
         argv.extend(args)
@@ -103,9 +119,25 @@ def git_argv(args: Sequence[str]) -> list[str]:
     return argv
 
 
+def git_argv(args: Sequence[str]) -> list[str]:
+    """Return ``git`` argv with every safe-config pin prepended before *args*."""
+    return _git_argv_with_prefixes(args)
+
+
+def git_authenticated_argv(args: Sequence[str], *, remote_url: str) -> list[str]:
+    """Return hardened argv for authenticated fetch/push against *remote_url*."""
+    return _git_argv_with_prefixes(args, extra_config=url_rewrite_guard_config(remote_url))
+
+
 def git_global_config_argv(args: Sequence[str]) -> list[str]:
     """Return ``git config`` argv for global writes (no repo-local safe pins)."""
     return ["git", "config", *args]
 
 
-__all__ = ["GIT_SAFE_CONFIG", "git_argv", "git_global_config_argv"]
+__all__ = [
+    "GIT_SAFE_CONFIG",
+    "git_argv",
+    "git_authenticated_argv",
+    "git_global_config_argv",
+    "url_rewrite_guard_config",
+]

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -16,25 +16,95 @@ GIT_SAFE_CONFIG: Final[tuple[str, ...]] = (
     "-c",
     "core.fsmonitor=false",
     "-c",
-    "diff.external=",
-    "-c",
     "core.hooksPath=/dev/null",
     "-c",
-    "uploadpack.packObjectsHook=",
-    "-c",
     "core.sshCommand=ssh",
-    "-c",
-    "core.gitProxy=",
     "-c",
     "protocol.ext.allow=never",
     "-c",
     "core.pager=cat",
 )
 
+_GLOBAL_OPTS_TAKING_VALUE: Final[frozenset[str]] = frozenset(
+    {"-C", "--git-dir", "--work-tree", "--namespace"}
+)
+_PATCH_SUBCOMMANDS: Final[frozenset[str]] = frozenset(
+    {"diff", "show", "range-diff", "format-patch"}
+)
+_LOG_PATCH_FLAGS: Final[frozenset[str]] = frozenset(
+    {"-p", "--patch", "-U", "--unified", "-W", "--function-context"}
+)
+
+
+def _skip_global_opts(args: Sequence[str], start: int) -> int:
+    """Return index of the first subcommand token after git global options."""
+    idx = start
+    while idx < len(args):
+        tok = args[idx]
+        if tok in _GLOBAL_OPTS_TAKING_VALUE:
+            idx += 2
+            continue
+        if tok.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
+            idx += 1
+            continue
+        if tok.startswith("-"):
+            idx += 1
+            continue
+        return idx
+    return idx
+
+
+def _has_patch_flags(args: Sequence[str], start: int) -> bool:
+    for tok in args[start:]:
+        if tok in _LOG_PATCH_FLAGS:
+            return True
+        if tok.startswith("-") and not tok.startswith("--") and "p" in tok[1:]:
+            return True
+    return False
+
+
+def _no_ext_diff_insertion_index(args: Sequence[str]) -> int | None:
+    """Return index in *args* where ``--no-ext-diff`` should be inserted."""
+    sub_idx = _skip_global_opts(args, 0)
+    if sub_idx >= len(args):
+        return None
+    subcommand = args[sub_idx]
+    if subcommand in _PATCH_SUBCOMMANDS:
+        return sub_idx + 1
+    if subcommand == "log" and _has_patch_flags(args, sub_idx + 1):
+        return sub_idx + 1
+    if subcommand == "stash":
+        show_idx = sub_idx + 1
+        if (
+            show_idx < len(args)
+            and args[show_idx] == "show"
+            and _has_patch_flags(args, show_idx + 1)
+        ):
+            return show_idx + 1
+    return None
+
+
+def _needs_no_ext_diff(args: Sequence[str]) -> bool:
+    """Return whether *args* invoke git's external diff driver."""
+    return _no_ext_diff_insertion_index(args) is not None
+
 
 def git_argv(args: Sequence[str]) -> list[str]:
     """Return ``git`` argv with every safe-config pin prepended before *args*."""
-    return ["git", *GIT_SAFE_CONFIG, *args]
+    argv: list[str] = ["git", *GIT_SAFE_CONFIG]
+    insert_at = _no_ext_diff_insertion_index(args)
+    if insert_at is None:
+        argv.extend(args)
+        return argv
+    argv.extend(args[:insert_at])
+    argv.append("--no-ext-diff")
+    argv.extend(args[insert_at:])
+    return argv
 
 
-__all__ = ["GIT_SAFE_CONFIG", "git_argv"]
+def git_global_config_argv(args: Sequence[str]) -> list[str]:
+    """Return ``git config`` argv for global writes (no repo-local safe pins)."""
+    return ["git", "config", *args]
+
+
+__all__ = ["GIT_SAFE_CONFIG", "git_argv", "git_global_config_argv"]

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -34,6 +34,7 @@ _PATCH_SUBCOMMANDS: Final[frozenset[str]] = frozenset(
 _LOG_PATCH_FLAGS: Final[frozenset[str]] = frozenset(
     {"-p", "--patch", "-U", "--unified", "-W", "--function-context"}
 )
+_DIFF_HARDENING_FLAGS: Final[tuple[str, ...]] = ("--no-ext-diff", "--no-textconv")
 
 
 def _skip_global_opts(args: Sequence[str], start: int) -> int:
@@ -97,7 +98,7 @@ def git_argv(args: Sequence[str]) -> list[str]:
         argv.extend(args)
         return argv
     argv.extend(args[:insert_at])
-    argv.append("--no-ext-diff")
+    argv.extend(_DIFF_HARDENING_FLAGS)
     argv.extend(args[insert_at:])
     return argv
 

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -91,6 +91,30 @@ def _needs_no_ext_diff(args: Sequence[str]) -> bool:
     return _no_ext_diff_insertion_index(args) is not None
 
 
+def normalize_git_remote_url(url: str) -> str:
+    """Return *url* stripped of surrounding whitespace and a trailing slash."""
+    return url.strip().rstrip("/")
+
+
+def git_remote_identity_urls(url: str) -> tuple[str, ...]:
+    """Return HTTPS remote URL forms that need identity ``insteadOf`` pins.
+
+    ``actions/checkout`` stores ``remote.origin.url`` without a ``.git`` suffix
+    while other call sites may use the suffixed form. Pinning every equivalent
+    shape prevents a shorter hostile ``https://github.com/`` prefix from winning
+    when the live remote omits ``.git``.
+    """
+    base = normalize_git_remote_url(url)
+    if not base:
+        return ()
+    variants: set[str] = {base}
+    if base.endswith(".git"):
+        variants.add(base[: -len(".git")])
+    elif base.startswith(("http://", "https://")):
+        variants.add(f"{base}.git")
+    return tuple(sorted(variants, key=len, reverse=True))
+
+
 def read_remote_origin_url(cwd: str) -> str:
     """Return ``remote.origin.url`` without ``insteadOf`` expansion.
 
@@ -119,12 +143,19 @@ def url_rewrite_guard_config(canonical_url: str) -> tuple[str, ...]:
 
     Git unions ``insteadOf`` rules from every config scope and applies the
     longest matching prefix. A command-line identity rule whose base equals the
-    full remote URL beats shorter attacker prefixes.
+    full remote URL beats shorter attacker prefixes. Every equivalent remote
+    shape (with and without a ``.git`` suffix) is pinned so the guard matches
+    the live ``remote.origin.url`` from ``actions/checkout``.
     """
-    normalized = canonical_url.strip()
-    if not normalized:
-        return ()
-    return ("-c", f"url.{normalized}.insteadOf={normalized}")
+    pins: list[str] = []
+    seen: set[str] = set()
+    for variant in git_remote_identity_urls(canonical_url):
+        entry = f"url.{variant}.insteadOf={variant}"
+        if entry in seen:
+            continue
+        seen.add(entry)
+        pins.extend(("-c", entry))
+    return tuple(pins)
 
 
 def _git_argv_with_prefixes(
@@ -163,6 +194,8 @@ __all__ = [
     "git_argv",
     "git_authenticated_argv",
     "git_global_config_argv",
+    "git_remote_identity_urls",
+    "normalize_git_remote_url",
     "read_remote_origin_url",
     "url_rewrite_guard_config",
 ]

--- a/src/mergecraft/utils/git_hardening.py
+++ b/src/mergecraft/utils/git_hardening.py
@@ -7,6 +7,7 @@ hooks, fsmonitor, diff drivers, or other config-driven side effects.
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
@@ -90,6 +91,29 @@ def _needs_no_ext_diff(args: Sequence[str]) -> bool:
     return _no_ext_diff_insertion_index(args) is not None
 
 
+def read_remote_origin_url(cwd: str) -> str:
+    """Return ``remote.origin.url`` without ``insteadOf`` expansion.
+
+    ``git remote get-url`` applies checkout-local ``url.*.insteadOf`` rules,
+    so a hostile ``.git/config`` can make it return an attacker URL. Reading
+    the stored config key avoids that rewrite while still reflecting what the
+    checkout declares as origin.
+    """
+    result = subprocess.run(
+        git_argv(["config", "--get", "remote.origin.url"]),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()
+        msg = f"git config --get remote.origin.url failed ({result.returncode}): {err}"
+        raise RuntimeError(msg)
+    return result.stdout.strip()
+
+
 def url_rewrite_guard_config(canonical_url: str) -> tuple[str, ...]:
     """Return ``-c`` pins that outrank hostile ``url.*.insteadOf`` rewrites.
 
@@ -139,5 +163,6 @@ __all__ = [
     "git_argv",
     "git_authenticated_argv",
     "git_global_config_argv",
+    "read_remote_origin_url",
     "url_rewrite_guard_config",
 ]

--- a/src/mergecraft/utils/git_ref.py
+++ b/src/mergecraft/utils/git_ref.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from mergecraft.utils.git_hardening import git_argv
+
 _SHA_REF = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 _GIT_FETCH_TIMEOUT_S = 30.0
 
@@ -13,7 +15,7 @@ _GIT_FETCH_TIMEOUT_S = 30.0
 def _default_repo_root() -> Path:
     """Return the git worktree root, or editable-layout repo root as fallback."""
     result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
+        git_argv(["rev-parse", "--show-toplevel"]),
         capture_output=True,
         text=True,
         check=False,
@@ -30,14 +32,14 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     workdir = cwd or _default_repo_root()
     candidates: list[list[str]]
     if _SHA_REF.fullmatch(ref):
-        candidates = [["git", "rev-parse", "--verify", f"{ref}^{{commit}}"]]
+        candidates = [git_argv(["rev-parse", "--verify", f"{ref}^{{commit}}"])]
     elif ref.startswith("v"):
-        candidates = [["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]]
+        candidates = [git_argv(["rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"])]
     else:
         candidates = [
-            ["git", "rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"],
-            ["git", "rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"],
+            git_argv(["rev-parse", "--verify", f"refs/heads/{ref}^{{commit}}"]),
+            git_argv(["rev-parse", "--verify", f"refs/remotes/origin/{ref}^{{commit}}"]),
+            git_argv(["rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}"]),
         ]
     for cmd in candidates:
         if (
@@ -55,7 +57,7 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
         return False
     # CI checkouts use fetch-depth: 1 — pinned SHAs may not be in the object db.
     fetch = subprocess.run(
-        ["git", "fetch", "origin", ref, "--depth=1"],
+        git_argv(["fetch", "origin", ref, "--depth=1"]),
         cwd=workdir,
         capture_output=True,
         check=False,
@@ -64,7 +66,7 @@ def git_ref_exists(ref: str, *, cwd: Path | None = None) -> bool:
     if fetch.returncode != 0:
         return False
     verify = subprocess.run(
-        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        git_argv(["rev-parse", "--verify", f"{ref}^{{commit}}"]),
         cwd=workdir,
         capture_output=True,
         check=False,

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -183,14 +183,35 @@ def _git_get(repo_dir: str, key: str) -> str:
         return ""
 
 
-def git_env_for_token(token: str) -> dict[str, str]:
+def _auth_header_prefixes(remote_url: str) -> tuple[str, ...]:
+    """Return ``http.<url>`` prefixes that may receive bearer auth headers."""
+    normalized = remote_url.strip()
+    if normalized.startswith("git@"):
+        host = normalized.split("@", 1)[1].split(":", 1)[0]
+        return (f"https://{host}/",)
+    if normalized.startswith(("http://", "https://")):
+        from urllib.parse import urlparse
+
+        parsed = urlparse(normalized)
+        if parsed.scheme and parsed.netloc:
+            return (f"{parsed.scheme}://{parsed.netloc}/",)
+    return ("https://github.com/", "https://api.github.com/")
+
+
+def git_env_for_token(token: str, *, remote_url: str = "") -> dict[str, str]:
     """Build git subprocess env with header-based auth — never URL-embedded (D5)."""
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
-    if token:
-        env["GIT_CONFIG_COUNT"] = "1"
-        env["GIT_CONFIG_KEY_0"] = "http.extraHeader"
-        env["GIT_CONFIG_VALUE_0"] = f"Authorization: Bearer {token}"
+    if not token:
+        return env
+    pairs = [
+        (f"http.{prefix}.extraHeader", f"Authorization: Bearer {token}")
+        for prefix in _auth_header_prefixes(remote_url)
+    ]
+    env["GIT_CONFIG_COUNT"] = str(len(pairs))
+    for index, (key, value) in enumerate(pairs):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
     return env
 
 

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -335,7 +335,13 @@ def setup_git(
         with contextlib.suppress(OSError):
             askpass_path.unlink()
     os.environ["GIT_TERMINAL_PROMPT"] = "0"
-    push_url = f"https://github.com/{owner}/{name}.git"
+    from mergecraft.utils.git_hardening import read_remote_origin_url
+
+    try:
+        push_url = read_remote_origin_url(repo_dir)
+    except RuntimeError:
+        # Match actions/checkout: origin URL without a .git suffix.
+        push_url = f"https://github.com/{owner}/{name}"
     repo_state.push_url = push_url
     logger.info("» git credentials brokered for {}", f"{owner}/{name}")
 

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from mergecraft.mcp.tool_state import ToolState
     from mergecraft.types import ShellPermission
@@ -161,7 +163,7 @@ def _prepare_temp_dir_for_agent(path: str) -> None:
 
 def _git_config(repo_dir: str, key: str, value: str) -> None:
     subprocess.run(
-        ["git", "config", "--local", key, value],
+        git_argv(["config", "--local", key, value]),
         cwd=repo_dir,
         check=False,
         capture_output=True,
@@ -172,7 +174,7 @@ def _git_config(repo_dir: str, key: str, value: str) -> None:
 def _git_get(repo_dir: str, key: str) -> str:
     try:
         return subprocess.check_output(
-            ["git", "config", "--get", key],
+            git_argv(["config", "--get", key]),
             cwd=repo_dir,
             text=True,
             stderr=subprocess.DEVNULL,
@@ -204,7 +206,7 @@ def scrub_clone_credentials(repo_dir: Path | str) -> None:
         "credential.useHttpPath",
     ):
         subprocess.run(
-            ["git", "config", "--local", "--unset-all", key],
+            git_argv(["config", "--local", "--unset-all", key]),
             cwd=root,
             capture_output=True,
             text=True,

--- a/src/mergecraft/utils/instructions.py
+++ b/src/mergecraft/utils/instructions.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from mergecraft.review_taxonomy import WITHDRAWN_FINDINGS_HEADING
 from mergecraft.types import MERGECRAFT_MCP_NAME, format_mcp_tool_ref
 from mergecraft.utils.fence import Fence, fence_unless_trusted, render_untrusted
+from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
     from mergecraft.config.settings import LearningsHeading, RepoInfo
@@ -181,7 +182,7 @@ def _build_runtime_context(
     try:
         git_status = (
             subprocess.check_output(
-                ["git", "status", "--short"],
+                git_argv(["status", "--short"]),
                 text=True,
                 stderr=subprocess.DEVNULL,
             ).strip()

--- a/src/mergecraft/utils/offline_diff.py
+++ b/src/mergecraft/utils/offline_diff.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 _DEFAULT_BASES = ("main", "master", "develop", "trunk")
 _MAX_UNTRACKED_FILE_BYTES = 256 * 1024
 
@@ -33,7 +35,7 @@ def _run_git(
 
         timeout_s = timeout_for_external_operation("git_diff")
     return subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         check=False,
         capture_output=True,

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -342,6 +342,7 @@ def prepare_workspace_for_agent(workspace: str) -> None:
             "-o",
             "-exec",
             "chown",
+            "-h",
             f"{pw.pw_uid}:{pw.pw_gid}",
             "{}",
             "+",

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -19,14 +19,17 @@ alongside the ``setpriv`` argv wrap, using the same fail-closed resolution.
 
 from __future__ import annotations
 
+import functools
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
 _DEFAULT_AGENT_USER = "mergecraft"
+_ALLOW_ROOT_ENV = "MERGECRAFT_ALLOW_ROOT"
 
 if TYPE_CHECKING:
     import pwd
@@ -41,6 +44,57 @@ def agent_user_name() -> str:
     return (
         os.environ.get("MERGECRAFT_AGENT_USER", _DEFAULT_AGENT_USER).strip() or _DEFAULT_AGENT_USER
     )
+
+
+def _in_action_image() -> bool:
+    """Return whether the process is running inside the mergeCraft action image.
+
+      Keys on ``IS_SANDBOX=1`` and ``/opt/mergecraft`` — both set by the Dockerfile
+    (D11). Root policy gates on this identity rather than inferring posture from uid
+      alone (MCB-24).
+    """
+    return os.environ.get("IS_SANDBOX") == "1" and Path("/opt/mergecraft").is_dir()
+
+
+def _allow_root_override() -> bool:
+    return os.environ.get(_ALLOW_ROOT_ENV, "").strip() == "1"
+
+
+def _refuse_root_outside_action_image() -> None:
+    """Abort when root runs outside the action image without an explicit override."""
+    if os.getuid() != 0:
+        return
+    if _in_action_image() or _allow_root_override():
+        return
+    logger.error(
+        "refusing to run as root outside the mergeCraft action image — "
+        "this is deliberate policy, not a missing /etc/passwd entry; "
+        "set {}=1 to override for local development",
+        _ALLOW_ROOT_ENV,
+    )
+    raise _raise_configuration_error(
+        "refusing to run as root outside the mergeCraft action image — "
+        "this is deliberate policy, not a missing passwd entry; "
+        f"set {_ALLOW_ROOT_ENV}=1 to override for local development"
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def _setpriv_supports_bounding_set() -> bool:
+    """Return whether the image ``setpriv`` supports ``--bounding-set`` (util-linux ≥ 2.33)."""
+    setpriv = shutil.which("setpriv")
+    if setpriv is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [setpriv, "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return "--bounding-set" in proc.stdout + proc.stderr
 
 
 def _raise_configuration_error(message: str) -> _ConfigurationError:
@@ -71,6 +125,7 @@ def _resolve_privilege_drop_user() -> pwd.struct_passwd | None:
     """
     if os.getuid() != 0:
         return None
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     try:
         import pwd
@@ -123,6 +178,7 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
     """
     if os.getuid() != 0:
         return list(cmd)
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     if shutil.which("setpriv") is None:
         logger.error(
@@ -135,7 +191,26 @@ def wrap_agent_command(cmd: list[str]) -> list[str]:
             "is unavailable and the run cannot proceed as root"
         )
     _resolve_privilege_drop_user()
-    return ["setpriv", f"--reuid={user}", f"--regid={user}", "--init-groups", *cmd]
+    if not _setpriv_supports_bounding_set():
+        logger.error(
+            "setpriv on PATH does not support --bounding-set (util-linux ≥ 2.33 required); "
+            "refusing to run the agent subprocess as root without capability clearing"
+        )
+        raise _raise_configuration_error(
+            "setpriv does not support --bounding-set in this image; hardened privilege "
+            "drop (--inh-caps=-all, --bounding-set=-all, --no-new-privs) cannot be "
+            "applied and the run cannot proceed as root"
+        )
+    return [
+        "setpriv",
+        "--no-new-privs",
+        "--inh-caps=-all",
+        "--bounding-set=-all",
+        f"--reuid={user}",
+        f"--regid={user}",
+        "--init-groups",
+        *cmd,
+    ]
 
 
 def _path_owned_by_uid(path: str, uid: int) -> bool:
@@ -222,6 +297,7 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     """
     if os.getuid() != 0:
         return
+    _refuse_root_outside_action_image()
     user = agent_user_name()
     try:
         import pwd

--- a/src/mergecraft/utils/privilege.py
+++ b/src/mergecraft/utils/privilege.py
@@ -257,7 +257,19 @@ def prepare_workspace_for_agent(workspace: str) -> None:
     if not target:
         return
     subprocess.run(
-        ["chown", "-R", f"{pw.pw_uid}:{pw.pw_gid}", target],
+        [
+            "find",
+            target,
+            "-path",
+            f"{target}/.git",
+            "-prune",
+            "-o",
+            "-exec",
+            "chown",
+            f"{pw.pw_uid}:{pw.pw_gid}",
+            "{}",
+            "+",
+        ],
         check=False,
         capture_output=True,
         text=True,

--- a/src/mergecraft/utils/run_bounds.py
+++ b/src/mergecraft/utils/run_bounds.py
@@ -137,11 +137,11 @@ def record_agent_usage(tracker: BudgetTracker | None, usage: AgentUsage | None) 
     """Charge resolved agent usage against the per-run budget tracker."""
     if tracker is None or usage is None:
         return
+    # ``AgentUsage.input_tokens`` already folds disjoint Anthropic cache reads
+    # and cache writes per D16 / #273. ``cache_read_tokens`` /
+    # ``cache_write_tokens`` are observability fields only — adding them again
+    # here double-counts OpenAI-style cached input against the run budget.
     token_total = usage.input_tokens + usage.output_tokens
-    if usage.cache_read_tokens:
-        token_total += usage.cache_read_tokens
-    if usage.cache_write_tokens:
-        token_total += usage.cache_write_tokens
     tracker.record_tokens(token_total)
     if usage.cost_usd is not None:
         tracker.record_cost(usage.cost_usd)

--- a/src/mergecraft/utils/source_resolve.py
+++ b/src/mergecraft/utils/source_resolve.py
@@ -15,6 +15,7 @@ from urllib.parse import unquote, urlparse
 from loguru import logger
 
 from mergecraft.security.egress import SsrfBlockedError, guard_external_url
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.utils.git_setup import git_env_for_token, scrub_clone_credentials
 from mergecraft.utils.offline_diff import DiffMaterialization, materialize_diff
 from mergecraft.utils.workspace import register_workspace_root
@@ -99,7 +100,7 @@ def validate_clone_url(url: str) -> None:
 
 def _run_git(args: list[str], *, cwd: str, env: dict[str, str] | None = None) -> str:
     result = subprocess.run(
-        ["git", *args],
+        git_argv(args),
         cwd=cwd,
         env=env or os.environ.copy(),
         capture_output=True,

--- a/src/mergecraft/utils/workspace.py
+++ b/src/mergecraft/utils/workspace.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from mergecraft.utils.git_hardening import git_argv
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -43,7 +45,7 @@ def add_safe_directory(path: str) -> None:
     if resolved in _safe_directories_added:
         return
     subprocess.run(
-        ["git", "config", "--global", "--add", "safe.directory", resolved],
+        git_argv(["config", "--global", "--add", "safe.directory", resolved]),
         check=False,
         capture_output=True,
         text=True,
@@ -89,7 +91,7 @@ def git_repo_root(start: str | None = None) -> Path | None:
     """
     try:
         completed = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            git_argv(["rev-parse", "--show-toplevel"]),
             cwd=start,
             check=False,
             capture_output=True,

--- a/src/mergecraft/utils/workspace.py
+++ b/src/mergecraft/utils/workspace.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from mergecraft.utils.git_hardening import git_argv
+from mergecraft.utils.git_hardening import git_argv, git_global_config_argv
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -45,7 +45,7 @@ def add_safe_directory(path: str) -> None:
     if resolved in _safe_directories_added:
         return
     subprocess.run(
-        git_argv(["config", "--global", "--add", "safe.directory", resolved]),
+        git_global_config_argv(["--global", "--add", "safe.directory", resolved]),
         check=False,
         capture_output=True,
         text=True,

--- a/src/mergecraft/xrepo/review.py
+++ b/src/mergecraft/xrepo/review.py
@@ -9,11 +9,14 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from mergecraft.mcp.git_guards import reject_if_leading_dash
+from mergecraft.utils.git_hardening import git_argv
 from mergecraft.xrepo.blast_radius import (
     ChangedContract,
     CrossRepoImpact,
     resolve_cross_repo_dependents,
 )
+from mergecraft.xrepo.citations import validate_pinned_sha
 from mergecraft.xrepo.contract_index import ContractIndex, index_contracts_at_commit
 from mergecraft.xrepo.linked_repos import (
     LinkedRepoEntry,
@@ -111,8 +114,21 @@ def _changed_from_index(*, repo: str, commit: str, index: ContractIndex) -> list
 
 
 def _rev_parse_commit(repo_root: Path, rev: str) -> str:
+    stripped = rev.strip()
+    reject_if_leading_dash(stripped, "rev")
+    if stripped != "HEAD":
+        validate_pinned_sha(stripped)
     completed = subprocess.run(
-        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{rev}^{{commit}}"],
+        git_argv(
+            [
+                "-C",
+                str(repo_root),
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{stripped}^{{commit}}",
+            ]
+        ),
         capture_output=True,
         check=False,
         text=True,
@@ -136,7 +152,7 @@ def _require_head_matches_pin(repo_root: Path, commit_sha: str) -> None:
         msg = f"linked repo HEAD {head} does not match pinned {pin}"
         raise ValueError(msg)
     dirty = subprocess.run(
-        ["git", "-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"],
+        git_argv(["-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"]),
         capture_output=True,
         check=False,
         text=True,

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -292,7 +292,7 @@ def test_security_config_without_a_model_omits_model_and_provider_keys(tmp_path:
     assert "enabled_providers" not in config
     assert "provider" not in config
     assert config["permission"]["bash"] == "deny"
-    assert config["permission"]["webfetch"] == "allow"
+    assert config["permission"]["webfetch"] == "deny"
 
 
 def test_unprefixed_model_registers_no_enabled_providers(tmp_path: Path) -> None:
@@ -1001,7 +1001,8 @@ async def test_run_falls_back_to_the_cli_when_serve_cannot_boot(
     assert result.success is True
     assert result.output == "cli fallback output"
     # The config file is still written before the boot attempt.
-    assert (tmp_path / "opencode.json").is_file()
+    evidence_dir = oc._evidence_dir(ctx)
+    assert (evidence_dir / "opencode.json").is_file()
 
 
 async def test_run_reports_a_session_creation_failure(

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -5,16 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from mergecraft.agents.opencode import build_security_config
 from mergecraft.agents.shared import AgentRunContext
 from mergecraft.mcp.tool_state import init_tool_state
-
-_XFAIL = pytest.mark.xfail(
-    reason="green after AP5: review-mode permission block in opencode.py",
-    strict=False,
-)
 
 
 def _ctx(tmp_path: Path) -> AgentRunContext:
@@ -37,27 +30,31 @@ def _permissions(tmp_path: Path) -> dict[str, object]:
     return perms
 
 
-@_XFAIL
 def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("webfetch") == "deny"
 
 
-@_XFAIL
 def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("external_directory") == "deny"
 
 
-@_XFAIL
 def test_review_mode_denies_edit(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("edit") == "deny"
 
 
-@_XFAIL
 def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
     read = _permissions(tmp_path).get("read")
     assert read != {"*": "allow"}
     assert isinstance(read, dict)
     assert any(str(tmp_path) in str(v) or v == "allow" for v in read.values())
+
+
+def test_review_mode_denies_git_config_under_checkout(tmp_path: Path) -> None:
+    read = _permissions(tmp_path).get("read")
+    assert isinstance(read, dict)
+    checkout = tmp_path.resolve().as_posix()
+    assert read.get(f"{checkout}/.git/config") == "deny"
+    assert read.get(f"{checkout}/.git/**") == "deny"
 
 
 def test_bash_stays_denied(tmp_path: Path) -> None:

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -11,7 +11,7 @@ from mergecraft.agents.opencode import build_security_config
 from mergecraft.agents.shared import AgentRunContext
 from mergecraft.mcp.tool_state import init_tool_state
 
-pytestmark = pytest.mark.xfail(
+_XFAIL = pytest.mark.xfail(
     reason="green after AP5: review-mode permission block in opencode.py",
     strict=False,
 )
@@ -37,18 +37,22 @@ def _permissions(tmp_path: Path) -> dict[str, object]:
     return perms
 
 
+@_XFAIL
 def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("webfetch") == "deny"
 
 
+@_XFAIL
 def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("external_directory") == "deny"
 
 
+@_XFAIL
 def test_review_mode_denies_edit(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("edit") == "deny"
 
 
+@_XFAIL
 def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
     read = _permissions(tmp_path).get("read")
     assert read != {"*": "allow"}
@@ -57,4 +61,5 @@ def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None
 
 
 def test_bash_stays_denied(tmp_path: Path) -> None:
+    """Guard — bash denial is already true on trunk; must not regress under AP5."""
     assert _permissions(tmp_path).get("bash") == "deny"

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -34,8 +34,24 @@ def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
     assert _permissions(tmp_path).get("webfetch") == "deny"
 
 
-def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
-    assert _permissions(tmp_path).get("external_directory") == "deny"
+def test_review_mode_external_directory_allowlists_checkout_and_evidence(
+    tmp_path: Path,
+) -> None:
+    from tests.agents.conftest import make_agent_run_context
+
+    from mergecraft.agents.opencode import _evidence_dir
+
+    ctx = make_agent_run_context(tmp_path, resolved_model="anthropic/claude-sonnet")
+    external = _permissions(tmp_path).get("external_directory")
+    assert isinstance(external, dict)
+    checkout = tmp_path.resolve().as_posix()
+    evidence = _evidence_dir(ctx).resolve().as_posix()
+    assert external.get("*") == "deny"
+    assert external.get(checkout) == "allow"
+    assert external.get(f"{checkout}/**") == "allow"
+    assert evidence != checkout
+    assert external.get(evidence) == "allow"
+    assert external.get(f"{evidence}/**") == "allow"
 
 
 def test_review_mode_denies_edit(tmp_path: Path) -> None:

--- a/tests/agents/test_opencode_permissions.py
+++ b/tests/agents/test_opencode_permissions.py
@@ -1,0 +1,60 @@
+"""Lane A AP1.4 — OpenCode review-mode permission narrowing (MCB-06 / D4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mergecraft.agents.opencode import build_security_config
+from mergecraft.agents.shared import AgentRunContext
+from mergecraft.mcp.tool_state import init_tool_state
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP5: review-mode permission block in opencode.py",
+    strict=False,
+)
+
+
+def _ctx(tmp_path: Path) -> AgentRunContext:
+    return AgentRunContext(
+        payload={"shell": "restricted", "push": "restricted"},
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions="review",
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_auth_token="token",
+    )
+
+
+def _permissions(tmp_path: Path) -> dict[str, object]:
+    raw = build_security_config(_ctx(tmp_path), "anthropic/claude-sonnet")
+    config = json.loads(raw)
+    perms = config.get("permission")
+    assert isinstance(perms, dict)
+    return perms
+
+
+def test_review_mode_denies_webfetch(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("webfetch") == "deny"
+
+
+def test_review_mode_denies_external_directory(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("external_directory") == "deny"
+
+
+def test_review_mode_denies_edit(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("edit") == "deny"
+
+
+def test_review_mode_read_is_allowlisted_to_the_checkout(tmp_path: Path) -> None:
+    read = _permissions(tmp_path).get("read")
+    assert read != {"*": "allow"}
+    assert isinstance(read, dict)
+    assert any(str(tmp_path) in str(v) or v == "allow" for v in read.values())
+
+
+def test_bash_stays_denied(tmp_path: Path) -> None:
+    assert _permissions(tmp_path).get("bash") == "deny"

--- a/tests/agents/test_privilege_drop_directory_ownership.py
+++ b/tests/agents/test_privilege_drop_directory_ownership.py
@@ -66,6 +66,8 @@ def _simulate_root_privilege_drop(monkeypatch: MonkeyPatch) -> list[list[str]]:
     calls land in, so callers can assert on the chowned path.
     """
     monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege_module, "_in_action_image", lambda: True)
+    monkeypatch.setattr(privilege_module, "_setpriv_supports_bounding_set", lambda: True)
     fake_pwd = MagicMock()
     fake_pwd.getpwnam.return_value = _FakePw()
     monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
@@ -91,9 +93,10 @@ def test_claude_write_mcp_config_chowns_config_dir_under_privilege_drop(
 
     config_dir = tmp_path / ".claude"
     assert calls, "prepare_workspace_for_agent must chown the newly created config dir"
-    assert calls[-1][0] == "chown"
-    assert calls[-1][-1] == str(config_dir)
-    assert calls[-1][2] == "1001:1001"
+    chown_call = next(c for c in calls if c[0] == "find")
+    assert "chown" in chown_call
+    assert chown_call[1] == str(config_dir)
+    assert chown_call[-3] == "1001:1001"
 
 
 def test_gemini_write_mcp_config_chowns_gemini_home_under_privilege_drop(
@@ -106,8 +109,9 @@ def test_gemini_write_mcp_config_chowns_gemini_home_under_privilege_drop(
 
     gemini_home = tmp_path / ".gemini"
     assert calls, "prepare_workspace_for_agent must chown the newly created gemini home"
-    assert calls[-1][0] == "chown"
-    assert calls[-1][-1] == str(gemini_home)
+    chown_call = next(c for c in calls if c[0] == "find")
+    assert "chown" in chown_call
+    assert chown_call[1] == str(gemini_home)
 
 
 def test_write_mcp_config_does_not_chown_when_not_root(

--- a/tests/agents/test_privilege_drop_home_wiring.py
+++ b/tests/agents/test_privilege_drop_home_wiring.py
@@ -71,6 +71,8 @@ def _simulate_root_privilege_drop(monkeypatch: MonkeyPatch) -> None:
     and the current (inherited, GitHub-Actions-container-style) ``HOME`` is
     NOT owned by the resolved agent uid — the exact live-bug scenario."""
     monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege_module, "_in_action_image", lambda: True)
+    monkeypatch.setattr(privilege_module, "_setpriv_supports_bounding_set", lambda: True)
     monkeypatch.setattr(
         privilege_module.shutil,
         "which",
@@ -232,11 +234,10 @@ def test_build_env_chowns_codex_home_under_privilege_drop(
 ) -> None:
     _simulate_root_privilege_drop(monkeypatch)
 
-    captured: dict[str, Any] = {}
+    captured: list[list[str]] = []
 
     def _fake_chown_run(cmd: list[str], **kwargs: object) -> object:
-        captured["cmd"] = cmd
-        captured["kwargs"] = kwargs
+        captured.append(list(cmd))
         return MagicMock(returncode=0)
 
     monkeypatch.setattr(privilege_module.subprocess, "run", _fake_chown_run)
@@ -254,11 +255,11 @@ def test_build_env_chowns_codex_home_under_privilege_drop(
     ctx = make_agent_run_context(tmp_path, resolved_model="gpt-5.6-sol")
     env = codex_module._build_env(ctx)
 
-    assert captured["cmd"][0] == "chown"
-    assert captured["cmd"][1] == "-R"
-    assert captured["cmd"][2] == "1001:1001"
     codex_home = codex_module._codex_home(ctx)
-    assert captured["cmd"][3] == str(codex_home)
+    chown_call = next(c for c in captured if c[0] == "find")
+    assert "chown" in chown_call
+    assert chown_call[1] == str(codex_home)
+    assert chown_call[-3] == "1001:1001"
     assert env["CODEX_HOME"] == str(codex_home)
 
 
@@ -296,10 +297,10 @@ def test_gemini_write_mcp_config_chowns_gemini_home_under_privilege_drop(
 ) -> None:
     _simulate_root_privilege_drop(monkeypatch)
 
-    captured: dict[str, Any] = {}
+    captured: list[list[str]] = []
 
     def _fake_chown_run(cmd: list[str], **kwargs: object) -> object:
-        captured["cmd"] = cmd
+        captured.append(list(cmd))
         return MagicMock(returncode=0)
 
     monkeypatch.setattr(privilege_module.subprocess, "run", _fake_chown_run)
@@ -307,9 +308,11 @@ def test_gemini_write_mcp_config_chowns_gemini_home_under_privilege_drop(
     ctx = make_agent_run_context(tmp_path, resolved_model="gemini-pro")
     gemini_module.write_mcp_config(ctx)
 
-    assert captured["cmd"][0] == "chown"
-    assert captured["cmd"][2] == "1001:1001"
-    assert captured["cmd"][3] == str(gemini_module._gemini_home(ctx))
+    gemini_home = gemini_module._gemini_home(ctx)
+    chown_call = next(c for c in captured if c[0] == "find")
+    assert "chown" in chown_call
+    assert chown_call[1] == str(gemini_home)
+    assert chown_call[-3] == "1001:1001"
 
 
 def test_gemini_write_mcp_config_does_not_chown_when_not_root(
@@ -339,10 +342,10 @@ def test_claude_write_mcp_config_chowns_config_dir_under_privilege_drop(
 ) -> None:
     _simulate_root_privilege_drop(monkeypatch)
 
-    captured: dict[str, Any] = {}
+    captured: list[list[str]] = []
 
     def _fake_chown_run(cmd: list[str], **kwargs: object) -> object:
-        captured["cmd"] = cmd
+        captured.append(list(cmd))
         return MagicMock(returncode=0)
 
     monkeypatch.setattr(privilege_module.subprocess, "run", _fake_chown_run)
@@ -350,9 +353,11 @@ def test_claude_write_mcp_config_chowns_config_dir_under_privilege_drop(
     ctx = make_agent_run_context(tmp_path, resolved_model="claude-sonnet")
     claude_module.write_mcp_config(ctx)
 
-    assert captured["cmd"][0] == "chown"
-    assert captured["cmd"][2] == "1001:1001"
-    assert captured["cmd"][3] == str(tmp_path / ".claude")
+    config_dir = tmp_path / ".claude"
+    chown_call = next(c for c in captured if c[0] == "find")
+    assert "chown" in chown_call
+    assert chown_call[1] == str(config_dir)
+    assert chown_call[-3] == "1001:1001"
 
 
 def test_claude_write_mcp_config_does_not_chown_when_not_root(

--- a/tests/analyzers/test_sandbox.py
+++ b/tests/analyzers/test_sandbox.py
@@ -10,11 +10,12 @@ from tests.analyzers.support import import_module
 def test_capability_probe_records_unavailable_primitives_by_name() -> None:
     sandbox = import_module("mergecraft.analyzers.sandbox")
     caps = sandbox.probe_capabilities()
-    # W0.4 probe: non-privileged Action container — net ns, tmpfs, ro bind all FAIL.
     assert hasattr(caps, "network_namespace")
     assert hasattr(caps, "pid_namespace")
-    assert caps.unavailable_reasons
-    assert any("net" in r.lower() or "unshare" in r.lower() for r in caps.unavailable_reasons)
+    if caps.unavailable_reasons:
+        assert all(isinstance(r, str) and r for r in caps.unavailable_reasons)
+    if not caps.network_namespace:
+        assert any("net" in r.lower() or "unshare" in r.lower() for r in caps.unavailable_reasons)
 
 
 def test_untrusted_analyzer_skipped_when_required_capability_missing(tmp_path: Path) -> None:

--- a/tests/analyzers/test_sandbox_execution.py
+++ b/tests/analyzers/test_sandbox_execution.py
@@ -1,0 +1,132 @@
+"""Lane A — analyzer sandbox execution must enforce probed capabilities (D6)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mergecraft.analyzers import sandbox as sandbox_mod
+from mergecraft.analyzers.run import _sandboxed_argv
+from mergecraft.analyzers.sandbox import SandboxContext, SandboxLimits, build_sandbox_context
+from mergecraft.mcp import shell as shell_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    shell_mod.reset_detection_cache()
+    sandbox_mod.reset_detection_cache()
+
+
+def _full_caps() -> sandbox_mod.SandboxCapabilities:
+    return sandbox_mod.SandboxCapabilities(
+        pid_namespace=True,
+        network_namespace=True,
+        read_only_bind=True,
+        tmpfs=True,
+        cgroup_memory=False,
+        rlimit_nproc=True,
+        pid_namespace_method="unshare",
+    )
+
+
+def _sandbox_context(tmp_path: Path) -> SandboxContext:
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    return build_sandbox_context(
+        repo_root=tmp_path,
+        scratch_dir=scratch,
+        limits=SandboxLimits(timeout_s=30, memory_mb=256, max_processes=8),
+        network_allowlist=[],
+        read_only_source=True,
+        caps=_full_caps(),
+    )
+
+
+def test_sandboxed_argv_wires_net_ro_bind_and_tmpfs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    monkeypatch.setattr(sandbox_mod, "probe_capabilities", lambda: _full_caps())
+    shell_mod._reset_shell_detection_globals()
+
+    from mergecraft.analyzers.resolve import AnalyzerPlan
+
+    plan = AnalyzerPlan(
+        manifest_id="actionlint",
+        argv=("echo", "probe"),
+        cwd=tmp_path,
+        mode="native",
+    )
+    argv, _preexec = _sandboxed_argv(plan, _sandbox_context(tmp_path))
+    joined = " ".join(argv)
+    assert argv[:4] == ["unshare", "--pid", "--fork", "--mount-proc"]
+    assert "--net" in argv
+    assert "remount,bind,ro" in joined
+    assert "tmpfs" in joined
+    assert str(tmp_path) in joined
+    assert "bash" in argv
+    assert "exec echo probe" in joined
+
+
+def test_sandboxed_argv_uses_sudo_unshare_when_detected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "sudo-unshare")
+    monkeypatch.setattr(sandbox_mod, "probe_capabilities", lambda: _full_caps())
+    shell_mod._reset_shell_detection_globals()
+
+    from mergecraft.analyzers.resolve import AnalyzerPlan
+
+    plan = AnalyzerPlan(
+        manifest_id="actionlint",
+        argv=("true",),
+        cwd=tmp_path,
+        mode="native",
+    )
+    argv, _preexec = _sandboxed_argv(plan, _sandbox_context(tmp_path))
+    assert argv[0] == "sudo"
+    assert "--net" in argv
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace mounts require Linux")
+def test_sandboxed_execution_blocks_repo_write_and_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caps = _full_caps()
+    monkeypatch.setattr(sandbox_mod, "probe_capabilities", lambda: caps)
+    shell_mod._reset_shell_detection_globals()
+    method = shell_mod.detect_sandbox_method()
+    if method == "none":
+        pytest.skip("PID namespace isolation unavailable on this host")
+
+    context = _sandbox_context(tmp_path)
+    marker = tmp_path / "sandbox-write-probe"
+    probe_script = (
+        f"touch {marker} 2>/dev/null && echo WRITE_OK || echo WRITE_BLOCKED; "
+        "curl -fsS --max-time 2 https://example.com >/dev/null 2>&1 "
+        "&& echo NET_OK || echo NET_BLOCKED"
+    )
+    from mergecraft.analyzers.resolve import AnalyzerPlan
+
+    plan = AnalyzerPlan(
+        manifest_id="probe",
+        argv=("bash", "-c", probe_script),
+        cwd=tmp_path,
+        mode="native",
+    )
+    argv, preexec = _sandboxed_argv(plan, context)
+    completed = subprocess.run(
+        argv,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        preexec_fn=preexec,
+    )
+    output = (completed.stdout or "") + (completed.stderr or "")
+    assert "WRITE_BLOCKED" in output, output
+    assert "NET_BLOCKED" in output, output
+    assert not marker.exists()

--- a/tests/analyzers/test_sandbox_execution.py
+++ b/tests/analyzers/test_sandbox_execution.py
@@ -95,14 +95,20 @@ def test_sandboxed_argv_uses_sudo_unshare_when_detected(
 def test_sandboxed_execution_blocks_repo_write_and_network(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    caps = _full_caps()
-    monkeypatch.setattr(sandbox_mod, "probe_capabilities", lambda: caps)
-    shell_mod._reset_shell_detection_globals()
-    method = shell_mod.detect_sandbox_method()
-    if method == "none":
+    caps = sandbox_mod.probe_capabilities()
+    if not caps.pid_namespace or caps.pid_namespace_method == "none":
         pytest.skip("PID namespace isolation unavailable on this host")
 
-    context = _sandbox_context(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    context = build_sandbox_context(
+        repo_root=tmp_path,
+        scratch_dir=scratch,
+        limits=SandboxLimits(timeout_s=30, memory_mb=256, max_processes=8),
+        network_allowlist=[],
+        read_only_source=True,
+        caps=caps,
+    )
     marker = tmp_path / "sandbox-write-probe"
     probe_script = (
         f"touch {marker} 2>/dev/null && echo WRITE_OK || echo WRITE_BLOCKED; "

--- a/tests/analyzers/test_sandbox_network_allowlist.py
+++ b/tests/analyzers/test_sandbox_network_allowlist.py
@@ -1,0 +1,89 @@
+"""An analyzer declaring ``network_allowlist`` must keep egress (#533 review).
+
+``build_analyzer_sandbox_argv`` hardcoded ``isolate_network=True``, so every
+sandboxed analyzer got ``unshare --net`` -- a namespace with no external
+connectivity. ``osv-scanner`` and ``trivy`` are ``trust: untrusted`` with
+non-empty allowlists and cannot work without egress, so both broke on any host
+where ``unshare --net`` succeeds. The failure is silent: an erroring analyzer is
+reported unavailable, not as a finding.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.analyzers import sandbox as sandbox_mod
+from mergecraft.analyzers.sandbox import (
+    SandboxCapabilities,
+    SandboxLimits,
+    build_analyzer_sandbox_argv,
+    build_sandbox_context,
+)
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _context(tmp_path: Path, allowlist: list[str]) -> object:
+    return build_sandbox_context(
+        repo_root=tmp_path,
+        scratch_dir=tmp_path / "scratch",
+        limits=SandboxLimits(timeout_s=60, memory_mb=512, max_processes=64),
+        network_allowlist=allowlist,
+        read_only_source=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _force_full_isolation(monkeypatch: MonkeyPatch) -> None:
+    """Pin the host-dependent halves so the argv is a pure function of the manifest.
+
+    Without this the test passes vacuously on macOS and on GitHub's runners
+    alike, where ``unshare --net`` is unavailable and ``--net`` is never
+    appended for any input -- which is precisely the environment blind spot
+    that let the regression through.
+    """
+    caps = SandboxCapabilities(
+        pid_namespace=True,
+        network_namespace=True,
+        read_only_bind=True,
+        tmpfs=True,
+        cgroup_memory=True,
+        rlimit_nproc=True,
+        pid_namespace_method="unshare",
+        unavailable_reasons=[],
+    )
+    monkeypatch.setattr(sandbox_mod, "probe_capabilities", lambda: caps)
+    monkeypatch.setattr(sandbox_mod, "detect_sandbox_method", lambda: "unshare", raising=False)
+    monkeypatch.setattr("mergecraft.mcp.shell.detect_sandbox_method", lambda: "unshare")
+
+
+def test_declared_network_allowlist_keeps_egress(tmp_path: Path) -> None:
+    argv = build_analyzer_sandbox_argv(
+        ("osv-scanner", "--format", "json", "."),
+        context=_context(tmp_path, ["https://api.osv.dev", "https://deps.dev"]),
+    )
+    assert "--net" not in argv, (
+        f"an analyzer declaring network_allowlist must not be network-isolated; got {argv!r}"
+    )
+
+
+def test_empty_allowlist_still_isolates_the_network(tmp_path: Path) -> None:
+    argv = build_analyzer_sandbox_argv(
+        ("ruff", "check", "."),
+        context=_context(tmp_path, []),
+    )
+    assert "--net" in argv, (
+        f"an analyzer declaring no network needs must stay isolated; got {argv!r}"
+    )
+
+
+def test_pid_isolation_is_unconditional(tmp_path: Path) -> None:
+    """Relaxing the network must not relax process isolation."""
+    for allowlist in ([], ["https://api.osv.dev"]):
+        argv = build_analyzer_sandbox_argv(("tool",), context=_context(tmp_path, allowlist))
+        assert "--pid" in argv, f"pid isolation lost for allowlist={allowlist!r}: {argv!r}"
+        assert "--mount-proc" in argv, f"proc isolation lost for allowlist={allowlist!r}: {argv!r}"

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -7,11 +7,6 @@ import pytest
 from mergecraft.analyzers import sandbox as sandbox_mod
 from mergecraft.mcp import shell as shell_mod
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: capability probes replace CI short-circuit",
-    strict=False,
-)
-
 
 @pytest.fixture(autouse=True)
 def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -42,6 +42,8 @@ def test_all_probes_share_one_privilege_ladder(monkeypatch: pytest.MonkeyPatch) 
         assert "_run_probe 0" in script
         assert 'if [ "$pid" = 0 ] && _sudo_allowed' in script
         assert "probe ||" not in script
+        assert 'mount_cmd="sudo mount"' in script
+        assert 'umount_cmd="sudo umount"' in script
         return type(
             "R",
             (),
@@ -56,6 +58,8 @@ def test_all_probes_share_one_privilege_ladder(monkeypatch: pytest.MonkeyPatch) 
     assert caps.pid_namespace is True
     assert caps.pid_namespace_method == "sudo-unshare"
     assert caps.network_namespace is True
+    assert caps.read_only_bind is True
+    assert caps.tmpfs is True
 
 
 def test_probe_capabilities_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -1,0 +1,85 @@
+"""Lane A AP1.2 — sandbox capability probes (MCB-07/09/10/35)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.analyzers import sandbox as sandbox_mod
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: capability probes replace CI short-circuit",
+    strict=False,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    shell_mod.reset_detection_cache()
+    if hasattr(sandbox_mod, "reset_detection_cache"):
+        sandbox_mod.reset_detection_cache()
+    if hasattr(sandbox_mod.probe_capabilities, "cache_clear"):
+        sandbox_mod.probe_capabilities.cache_clear()
+
+
+def test_probe_does_not_consult_ci_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        calls.append(list(cmd))
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    caps = sandbox_mod.probe_capabilities()
+    assert any("unshare" in " ".join(c) or "mount" in " ".join(c) for c in calls), (
+        "probes must attempt real capabilities even when CI is unset"
+    )
+    assert caps.pid_namespace or caps.unavailable_reasons
+
+
+def test_all_probes_share_one_privilege_ladder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every probe must share the same sudo/unshare fallback policy (D5)."""
+    monkeypatch.setenv("CI", "true")
+    seen: list[str] = []
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        seen.append(cmd[0])
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    sudo_hits = sum(1 for c in seen if c == "sudo")
+    unshare_hits = sum(1 for c in seen if c == "unshare")
+    assert sudo_hits == 0 or unshare_hits == 0 or sudo_hits > 0, (
+        "mixed privilege ladders across probes are forbidden"
+    )
+
+
+def test_probe_capabilities_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal calls
+        calls += 1
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    sandbox_mod.probe_capabilities()
+    assert calls == 1, "probe_capabilities must be lru_cached (MCB-35)"
+
+
+def test_reset_detection_cache_clears_probe_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal calls
+        calls += 1
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
+    sandbox_mod.probe_capabilities()
+    shell_mod.reset_detection_cache()
+    sandbox_mod.probe_capabilities()
+    assert calls == 2, "reset_detection_cache must clear probe_capabilities cache"

--- a/tests/analyzers/test_sandbox_probes.py
+++ b/tests/analyzers/test_sandbox_probes.py
@@ -35,20 +35,27 @@ def test_probe_does_not_consult_ci_env_var(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_all_probes_share_one_privilege_ladder(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every probe must share the same sudo/unshare fallback policy (D5)."""
-    monkeypatch.setenv("CI", "true")
-    seen: list[str] = []
+    monkeypatch.setenv("MERGECRAFT_PROBE_ALLOW_SUDO", "1")
 
     def _fake_run(cmd: list[str], **_kwargs: object) -> object:
-        seen.append(cmd[0])
-        return type("R", (), {"returncode": 1})()
+        script = cmd[-1]
+        assert "_run_probe 0" in script
+        assert 'if [ "$pid" = 0 ] && _sudo_allowed' in script
+        assert "probe ||" not in script
+        return type(
+            "R",
+            (),
+            {
+                "returncode": 0,
+                "stdout": b"pid=1 pid_method=sudo-unshare net=1 bind=1 tmpfs=1\n",
+            },
+        )()
 
     monkeypatch.setattr(sandbox_mod.subprocess, "run", _fake_run)
-    sandbox_mod.probe_capabilities()
-    sudo_hits = sum(1 for c in seen if c == "sudo")
-    unshare_hits = sum(1 for c in seen if c == "unshare")
-    assert sudo_hits == 0 or unshare_hits == 0 or sudo_hits > 0, (
-        "mixed privilege ladders across probes are forbidden"
-    )
+    caps = sandbox_mod.probe_capabilities()
+    assert caps.pid_namespace is True
+    assert caps.pid_namespace_method == "sudo-unshare"
+    assert caps.network_namespace is True
 
 
 def test_probe_capabilities_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -9,6 +9,22 @@ if TYPE_CHECKING:
     import pytest
 
 
+def _missing_caps() -> object:
+    return type(
+        "C",
+        (),
+        {
+            "pid_namespace": False,
+            "network_namespace": False,
+            "read_only_bind": False,
+            "tmpfs": False,
+            "cgroup_memory": False,
+            "rlimit_nproc": True,
+            "unavailable_reasons": ["pid namespace unavailable"],
+        },
+    )()
+
+
 def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:
     from mergecraft.analyzers.manifest import load_manifest_file
     from mergecraft.analyzers.sandbox import plan_sandbox
@@ -16,19 +32,7 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
     manifest = load_manifest_file(Path("tests/analyzers/fixtures/manifests/valid-actionlint.yaml"))
     monkeypatch.setattr(
         "mergecraft.analyzers.sandbox.probe_capabilities",
-        lambda: type(
-            "C",
-            (),
-            {
-                "pid_namespace": False,
-                "network_namespace": False,
-                "read_only_bind": False,
-                "tmpfs": False,
-                "cgroup_memory": False,
-                "rlimit_nproc": True,
-                "unavailable_reasons": ["pid namespace unavailable"],
-            },
-        )(),
+        lambda: _missing_caps(),
     )
     plan = plan_sandbox(
         manifest=manifest,
@@ -46,3 +50,73 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
         finding.get("rule_id") if isinstance(finding, dict) else None
     )
     assert rule_id == "analyzers.sandbox-unavailable"
+    assert finding.start_line is None
+
+
+def test_sandbox_unavailable_finding_survives_diff_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mergecraft.analyzers.manifest import load_manifest_file
+    from mergecraft.analyzers.sandbox import plan_sandbox
+    from mergecraft.analyzers.scope import scope_findings
+
+    manifest = load_manifest_file(Path("tests/analyzers/fixtures/manifests/valid-actionlint.yaml"))
+    monkeypatch.setattr(
+        "mergecraft.analyzers.sandbox.probe_capabilities",
+        lambda: _missing_caps(),
+    )
+    plan = plan_sandbox(
+        manifest=manifest,
+        tier="untrusted",
+        repo_root=Path("/tmp/repo"),
+        scratch_dir=Path("/tmp/scratch"),
+    )
+    assert plan.skip_finding is not None
+    diff = """diff --git a/src/app.py b/src/app.py
+@@ -1,3 +1,4 @@
+ def run():
++    return 1
+     pass
+"""
+    kept = scope_findings([plan.skip_finding], diff_text=diff)
+    assert len(kept) == 1
+    assert kept[0].rule_id == "analyzers.sandbox-unavailable"
+
+
+def test_sandbox_unavailable_finding_survives_pipeline_scoping(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from mergecraft.analyzers import pipeline
+    from mergecraft.analyzers.registry import get_manifest
+
+    settings_mod = __import__("mergecraft.config.settings", fromlist=["AnalyzersSettings"])
+    monkeypatch.setattr(
+        pipeline,
+        "_analyzers_settings",
+        lambda _root: settings_mod.AnalyzersSettings(),
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "detect_enabled",
+        lambda **_: [get_manifest("actionlint")],
+    )
+    monkeypatch.setattr(
+        "mergecraft.analyzers.sandbox.probe_capabilities",
+        lambda: _missing_caps(),
+    )
+
+    diff = """diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+@@ -1,3 +1,4 @@
+ name: ci
++  pull_request:
+ jobs: {}
+"""
+    state = pipeline.run_analyzer_pipeline(
+        repo_root=tmp_path,
+        changed_files=[".github/workflows/ci.yml"],
+        tier="untrusted",
+        diff_text=diff,
+    )
+    rule_ids = [row.get("rule_id") for row in state.findings]
+    assert "analyzers.sandbox-unavailable" in rule_ids
+    assert state.findings, "sandbox-unavailable finding must appear in review output"

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: analyzers.sandbox-unavailable finding",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -1,0 +1,45 @@
+"""Lane A AP1.2 — skipped untrusted analyzers emit a user-visible finding (MCB-09 / D7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: analyzers.sandbox-unavailable finding",
+    strict=False,
+)
+
+
+def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.analyzers.sandbox import plan_sandbox
+
+    monkeypatch.setattr(
+        "mergecraft.analyzers.sandbox.probe_capabilities",
+        lambda: type(
+            "C",
+            (),
+            {
+                "pid_namespace": False,
+                "network_namespace": False,
+                "read_only_bind": False,
+                "tmpfs": False,
+                "cgroup_memory": False,
+                "rlimit_nproc": True,
+                "unavailable_reasons": ["pid namespace unavailable"],
+            },
+        )(),
+    )
+    plan = plan_sandbox(
+        repo_root=Path("/tmp/repo"),
+        scratch_dir=Path("/tmp/scratch"),
+        trust_tier="untrusted",
+        manifests=(),
+    )
+    assert plan.can_run is False
+    assert plan.skip_reason is not None
+    finding = getattr(plan, "skip_finding", None) or getattr(plan, "finding", None)
+    assert finding is not None, (
+        "skipped untrusted tier must emit analyzers.sandbox-unavailable finding"
+    )

--- a/tests/analyzers/test_sandbox_skip_visibility.py
+++ b/tests/analyzers/test_sandbox_skip_visibility.py
@@ -13,8 +13,10 @@ pytestmark = pytest.mark.xfail(
 
 
 def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.analyzers.manifest import load_manifest_file
     from mergecraft.analyzers.sandbox import plan_sandbox
 
+    manifest = load_manifest_file(Path("tests/analyzers/fixtures/manifests/valid-actionlint.yaml"))
     monkeypatch.setattr(
         "mergecraft.analyzers.sandbox.probe_capabilities",
         lambda: type(
@@ -32,10 +34,10 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
         )(),
     )
     plan = plan_sandbox(
+        manifest=manifest,
+        tier="untrusted",
         repo_root=Path("/tmp/repo"),
         scratch_dir=Path("/tmp/scratch"),
-        trust_tier="untrusted",
-        manifests=(),
     )
     assert plan.can_run is False
     assert plan.skip_reason is not None
@@ -43,3 +45,7 @@ def test_skipped_untrusted_analyzers_emit_a_finding(monkeypatch: pytest.MonkeyPa
     assert finding is not None, (
         "skipped untrusted tier must emit analyzers.sandbox-unavailable finding"
     )
+    rule_id = getattr(finding, "rule_id", None) or (
+        finding.get("rule_id") if isinstance(finding, dict) else None
+    )
+    assert rule_id == "analyzers.sandbox-unavailable"

--- a/tests/ci/test_git_argv_lint.py
+++ b/tests/ci/test_git_argv_lint.py
@@ -6,13 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: scripts/check_git_argv.py wired into make lint",
-    strict=False,
-)
-
 _REPO = Path(__file__).resolve().parents[2]
 _CHECKER = _REPO / "scripts" / "check_git_argv.py"
 

--- a/tests/ci/test_git_argv_lint.py
+++ b/tests/ci/test_git_argv_lint.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.1 — ``check_git_argv`` lint gate (D2)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: scripts/check_git_argv.py wired into make lint",
+    strict=False,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_CHECKER = _REPO / "scripts" / "check_git_argv.py"
+
+
+def test_bare_git_list_literal_fails_the_checker(tmp_path: Path) -> None:
+    assert _CHECKER.is_file(), "scripts/check_git_argv.py must exist"
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        'evil = ["git", "status"]\n',
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [sys.executable, str(_CHECKER), str(probe)],
+        cwd=_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode != 0, "bare ['git', …] literal must fail the checker"

--- a/tests/cli/test_cov_analyzers_cmd_paths.py
+++ b/tests/cli/test_cov_analyzers_cmd_paths.py
@@ -435,7 +435,7 @@ def test_lock_skips_repo_native_and_declared_unavailable_tools(
     assert captured["path"] == tmp_path / ".mergecraft" / "analyzers.lock"
     assert captured["merge"] is True
     assert "lockfile updated" in text
-    assert "(1 tools)" in text
+    assert "(1 tools)" in _plain_oneline(result)
 
 
 def test_lock_reuses_an_existing_entry_unless_refresh_is_passed(

--- a/tests/cli/test_tracing_logfire_wf_yaml.py
+++ b/tests/cli/test_tracing_logfire_wf_yaml.py
@@ -28,6 +28,7 @@ from mergecraft.cli.tracing_logfire_wf_yaml import (
     DEFAULT_WORKFLOW_RELATIVE_PATH,
     OWNED_ENV_KEYS,
     OWNED_WITH_KEYS,
+    REQUIRED_ENV_KEYS,
     LogfireWorkflowError,
     apply_logfire_wiring,
     remove_logfire_wiring,
@@ -131,8 +132,13 @@ def test_apply_logfire_wiring_adds_four_keys_to_one_step(tmp_path: Path) -> None
     new = change.new_text
     for key in OWNED_WITH_KEYS:
         assert f"{key}:" in new, f"missing {key} after wiring"
-    for key in OWNED_ENV_KEYS:
+    for key in REQUIRED_ENV_KEYS:
         assert f"{key}:" in new, f"missing {key} after wiring"
+    # ``MERGECRAFT_TRACING_REGION`` is opt-in (``--region``): it is owned for
+    # removal but must not be written by a default wire.
+    assert "MERGECRAFT_TRACING_REGION" in OWNED_ENV_KEYS
+    assert "MERGECRAFT_TRACING_REGION" not in REQUIRED_ENV_KEYS
+    assert "MERGECRAFT_TRACING_REGION:" not in new
     # The merged YAML re-parses cleanly.
     parsed = yaml.safe_load(new)
     assert parsed["jobs"]["review"]["steps"][0]["uses"].startswith("alexhawat/mergeCraft@")
@@ -169,6 +175,96 @@ def test_apply_logfire_wiring_is_idempotent(tmp_path: Path) -> None:
     )
     assert not second.was_modified
     assert second.new_text == first.new_text
+
+
+def test_apply_logfire_wiring_region_writes_env_key(tmp_path: Path) -> None:
+    """``--region eu`` writes MERGECRAFT_TRACING_REGION so EU tokens reach the EU host."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    env = parsed["jobs"]["review"]["steps"][0]["env"]
+    assert env["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+
+
+def test_apply_logfire_wiring_region_is_normalised(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="  EU  ",
+    )
+    parsed = yaml.safe_load(change.new_text)
+    assert parsed["jobs"]["review"]["steps"][0]["env"]["MERGECRAFT_TRACING_REGION"] == "eu"
+
+
+def test_apply_logfire_wiring_rejects_unknown_region(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    with pytest.raises(LogfireWorkflowError, match="region must be"):
+        apply_logfire_wiring(
+            workflow_path=workflow,
+            secret_name="LOGFIRE_TOKEN",
+            project_var_name="LOGFIRE_PROJECT",
+            step_selector="primary",
+            force=False,
+            region="apac",
+        )
+
+
+def test_apply_logfire_wiring_region_is_idempotent(tmp_path: Path) -> None:
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    first = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(first.new_text, encoding="utf-8")
+    second = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert not second.was_modified
+    assert second.new_text == first.new_text
+
+
+def test_removal_strips_region_key(tmp_path: Path) -> None:
+    """``MERGECRAFT_TRACING_REGION`` is owned, so unwire must strip it too."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, ONE_STEP_TEMPLATE)
+    wired = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(wired.new_text, encoding="utf-8")
+    removed = remove_logfire_wiring(workflow_path=workflow, step_selector="primary")
+    assert removed.was_modified
+    assert "MERGECRAFT_TRACING_REGION" not in removed.new_text
 
 
 def test_apply_logfire_wiring_step_all_wires_two_steps(tmp_path: Path) -> None:

--- a/tests/cli/test_tracing_logfire_wf_yaml.py
+++ b/tests/cli/test_tracing_logfire_wf_yaml.py
@@ -423,6 +423,120 @@ jobs:
     assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
 
 
+NO_ENV_TEMPLATE = """\
+name: mergecraft
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft review
+        id: mergecraft_primary
+        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+        with:
+          prompt: x
+"""
+
+NO_ENV_NO_WITH_TEMPLATE = """\
+name: mergecraft
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft review
+        id: mergecraft_primary
+        uses: alexhawat/mergeCraft@f5b070bddce40099dab77778231cac3456a55157 # pre-0.0.1
+"""
+
+
+def test_region_survives_when_the_step_has_no_env_block(tmp_path: Path) -> None:
+    """A created ``env:`` must carry every owned key, not just the first.
+
+    Regression: the fallback that creates a missing ``env:`` mapping rendered
+    only ``env_canonical[0]``, silently dropping MERGECRAFT_TRACING_REGION.
+    ``_assert_wired_semantics`` did not catch it because it asserts only
+    REQUIRED_ENV_KEYS, so the command reported success while an EU token kept
+    posting to the default US endpoint.
+    """
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    env = parsed["jobs"]["review"]["steps"][0]["env"]
+    assert env["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert env["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+
+
+def test_region_survives_when_the_step_has_neither_env_nor_with(tmp_path: Path) -> None:
+    """The ``uses:``-anchored creation path owns the same defect shape."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_NO_WITH_TEMPLATE)
+    change = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert change.was_modified
+    parsed = yaml.safe_load(change.new_text)
+    step = parsed["jobs"]["review"]["steps"][0]
+    assert step["env"]["MERGECRAFT_TRACING_REGION"] == "eu"
+    assert step["env"]["MERGECRAFT_TRACING_PROJECT"] == "${{ vars.LOGFIRE_PROJECT }}"
+    assert step["with"]["tracing-to"] == "logfire"
+
+
+def test_env_less_wire_then_unwire_round_trips(tmp_path: Path) -> None:
+    """A created env block must be fully strippable, region included."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    wired = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(wired.new_text, encoding="utf-8")
+    removed = remove_logfire_wiring(workflow_path=workflow, step_selector="primary")
+    assert "MERGECRAFT_TRACING_REGION" not in removed.new_text
+    assert "MERGECRAFT_TRACING_PROJECT" not in removed.new_text
+
+
+def test_env_less_wire_is_idempotent_with_region(tmp_path: Path) -> None:
+    """Re-wiring a step whose env block this command created is a no-op."""
+    workflow = tmp_path / "mergecraft.yml"
+    _write_workflow(workflow, NO_ENV_TEMPLATE)
+    first = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    workflow.write_text(first.new_text, encoding="utf-8")
+    second = apply_logfire_wiring(
+        workflow_path=workflow,
+        secret_name="LOGFIRE_TOKEN",
+        project_var_name="LOGFIRE_PROJECT",
+        step_selector="primary",
+        force=False,
+        region="eu",
+    )
+    assert not second.was_modified
+    assert second.new_text == first.new_text
+
+
 # ---------------------------------------------------------------------------
 # Phase 2 -- render_workflow_diff
 # ---------------------------------------------------------------------------

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -107,18 +107,19 @@ def test_git_ref_exists_fetches_shallow_checkout_sha(monkeypatch: pytest.MonkeyP
     def fake_run(cmd: list[str], **kwargs: object) -> object:
         nonlocal rev_parse_attempts
         calls.append(cmd)
-        if cmd[:3] == ["git", "rev-parse", "--verify"] and len(cmd) > 3 and sha in cmd[3]:
+        joined = " ".join(cmd)
+        if "rev-parse" in cmd and "--verify" in cmd and sha in joined:
             rev_parse_attempts += 1
             if rev_parse_attempts == 1:
                 return type("R", (), {"returncode": 1})()
             return type("R", (), {"returncode": 0})()
-        if cmd[:3] == ["git", "fetch", "origin"] and len(cmd) > 3 and cmd[3] == sha:
+        if "fetch" in cmd and "origin" in cmd and sha in cmd:
             return type("R", (), {"returncode": 0})()
         return type("R", (), {"returncode": 1})()
 
     monkeypatch.setattr("mergecraft.utils.git_ref.subprocess.run", fake_run)
     assert support.git_ref_exists(sha) is True
-    assert any(cmd[:3] == ["git", "fetch", "origin"] for cmd in calls), (
+    assert any("fetch" in cmd and "origin" in cmd for cmd in calls), (
         "git_ref_exists must fetch missing SHAs before re-verify (landing_readme contract)"
     )
 

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -1,4 +1,9 @@
-"""W12.7 — network-namespace probe + ``unshare --net`` argv shaping (``#35``)."""
+"""W12.7 — network-namespace probe + ``unshare --net`` argv shaping (``#35``).
+
+**Contract change (lane A / MCB-10):** when netns is unavailable the untrusted
+shell capability is **absent** — mergeCraft must not silently drop ``--net`` and
+continue. Tests below pin the new fail-closed contract; green after **AP3**.
+"""
 
 from __future__ import annotations
 
@@ -7,45 +12,46 @@ import pytest
 from mergecraft.mcp import shell as shell_mod
 from mergecraft.mcp.shell import _unshare_argv, network_namespace_available
 
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: netns absence removes untrusted shell capability",
+    strict=False,
+)
+
 
 @pytest.fixture(autouse=True)
 def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shell_mod, "_detected_netns", None)
+    shell_mod.reset_detection_cache()
 
 
 def test_network_namespace_available_false_outside_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable."""
+    """Capability probe must not treat CI as the answer (D5)."""
     monkeypatch.delenv("CI", raising=False)
+
+    class _Result:
+        returncode = 0
+
+    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is False
 
 
 def test_network_namespace_available_true_when_unshare_net_succeeds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — CI probe caches success when ``unshare --net true`` returns 0."""
-    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("CI", raising=False)
 
     class _Result:
         returncode = 0
 
     monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is True
-    # Cached — second call must not re-probe.
-    monkeypatch.setattr(
-        shell_mod.subprocess,
-        "run",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("re-probed")),
-    )
-    assert network_namespace_available() is True
 
 
 def test_network_namespace_available_false_when_unshare_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — ``OSError`` from missing ``unshare`` caches unavailable."""
-    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("CI", raising=False)
 
     def _boom(*_a: object, **_k: object) -> object:
         raise OSError("unshare not found")
@@ -57,7 +63,6 @@ def test_network_namespace_available_false_when_unshare_missing(
 def test_unshare_argv_omits_net_when_isolation_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — trusted / non-isolate path never appends ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     argv = _unshare_argv(isolate_network=False)
     assert argv[:4] == ["unshare", "--pid", "--fork", "--mount-proc"]
@@ -67,14 +72,23 @@ def test_unshare_argv_omits_net_when_isolation_disabled(
 def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-def test_unshare_argv_skips_net_when_probe_unavailable(
+def test_untrusted_shell_absent_when_netns_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — without netns, argv stays PID-only (credential isolation fallback)."""
+    """MCB-10 — missing netns removes the capability; do not spawn with ``--net`` dropped."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    assert "--net" not in _unshare_argv(isolate_network=True)
+    from unittest.mock import MagicMock
+
+    with pytest.raises((RuntimeError, PermissionError)):
+        shell_mod._spawn_shell(
+            "echo ok",
+            env={},
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=True,
+        )

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -34,28 +34,52 @@ def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     shell_mod.reset_detection_cache()
 
 
-def test_network_namespace_available_false_outside_ci(
+def test_network_namespace_available_false_when_probe_reports_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable (trunk)."""
+    """D5 — netns follows the capability probe, not ``CI``."""
+    from mergecraft.analyzers import sandbox as sandbox_mod
+
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(
+        sandbox_mod,
+        "probe_capabilities",
+        lambda: sandbox_mod.SandboxCapabilities(
+            pid_namespace=True,
+            network_namespace=False,
+            read_only_bind=True,
+            tmpfs=True,
+            cgroup_memory=False,
+            rlimit_nproc=True,
+            pid_namespace_method="unshare",
+        ),
+    )
+    shell_mod._reset_shell_detection_globals()
     assert network_namespace_available() is False
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: probe capability instead of sensing CI",
-    strict=False,
-)
 def test_network_namespace_available_true_when_unshare_net_succeeds_without_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """D5 — ``CI`` may hint but must not be the answer; probe ``unshare --net`` anyway."""
+    from mergecraft.analyzers import sandbox as sandbox_mod
+
     monkeypatch.delenv("CI", raising=False)
 
-    class _Result:
-        returncode = 0
-
-    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
+    monkeypatch.setattr(
+        sandbox_mod,
+        "probe_capabilities",
+        lambda: sandbox_mod.SandboxCapabilities(
+            pid_namespace=True,
+            network_namespace=True,
+            read_only_bind=True,
+            tmpfs=True,
+            cgroup_memory=False,
+            rlimit_nproc=True,
+            pid_namespace_method="unshare",
+        ),
+    )
+    shell_mod._reset_shell_detection_globals()
     assert network_namespace_available() is True
 
 
@@ -86,19 +110,15 @@ def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
+    monkeypatch.setattr(shell_mod, "_network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: netns absence must not silently omit --net",
-    strict=False,
-)
 def test_unshare_argv_skips_net_when_probe_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """MCB-10 inversion — isolate_network with no netns must fail closed, not omit ``--net``."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(shell_mod, "_network_namespace_available", lambda: False)
     with pytest.raises((RuntimeError, PermissionError, OSError)):
         _spawn_shell(
             "echo ok",
@@ -134,17 +154,15 @@ def _tool_ctx(
     )
 
 
-@pytest.mark.xfail(
-    reason="green after AP3: untrusted shell absent when netns unavailable",
-    strict=False,
-)
 def test_untrusted_shell_absent_when_netns_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """D6 — missing netns removes the shell tool registration."""
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    import mergecraft.mcp.server as server_mod
+
+    monkeypatch.setattr(server_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(server_mod, "detect_sandbox_method", lambda: "unshare")
     names = {spec.name for spec in build_common_tools(_tool_ctx(tmp_path, trust_tier="untrusted"))}
     assert "shell" not in names
     assert "kill_background" not in names

--- a/tests/mcp/test_network_namespace.py
+++ b/tests/mcp/test_network_namespace.py
@@ -2,20 +2,31 @@
 
 **Contract change (lane A / MCB-10):** when netns is unavailable the untrusted
 shell capability is **absent** — mergeCraft must not silently drop ``--net`` and
-continue. Tests below pin the new fail-closed contract; green after **AP3**.
+continue. Inverted expectations below are ``xfail`` until **AP3** lands.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Literal
+from unittest.mock import MagicMock
+
 import pytest
 
 from mergecraft.mcp import shell as shell_mod
-from mergecraft.mcp.shell import _unshare_argv, network_namespace_available
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: netns absence removes untrusted shell capability",
-    strict=False,
+from mergecraft.mcp.context import (
+    PayloadEvent,
+    RepoIdentity,
+    ResolvedPayload,
+    ToolContext,
 )
+from mergecraft.mcp.server import build_common_tools
+from mergecraft.mcp.shell import _spawn_shell, _unshare_argv, network_namespace_available
+from mergecraft.mcp.tool_state import init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+TrustTier = Literal["trusted", "untrusted"]
 
 
 @pytest.fixture(autouse=True)
@@ -26,19 +37,19 @@ def _reset_netns_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_network_namespace_available_false_outside_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Capability probe must not treat CI as the answer (D5)."""
+    """W12.7 — non-CI hosts skip the probe and treat netns as unavailable (trunk)."""
     monkeypatch.delenv("CI", raising=False)
-
-    class _Result:
-        returncode = 0
-
-    monkeypatch.setattr(shell_mod.subprocess, "run", lambda *a, **k: _Result())
     assert network_namespace_available() is False
 
 
-def test_network_namespace_available_true_when_unshare_net_succeeds(
+@pytest.mark.xfail(
+    reason="green after AP3: probe capability instead of sensing CI",
+    strict=False,
+)
+def test_network_namespace_available_true_when_unshare_net_succeeds_without_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """D5 — ``CI`` may hint but must not be the answer; probe ``unshare --net`` anyway."""
     monkeypatch.delenv("CI", raising=False)
 
     class _Result:
@@ -51,7 +62,8 @@ def test_network_namespace_available_true_when_unshare_net_succeeds(
 def test_network_namespace_available_false_when_unshare_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("CI", raising=False)
+    """W12.7 — ``OSError`` from missing ``unshare`` caches unavailable."""
+    monkeypatch.setenv("CI", "true")
 
     def _boom(*_a: object, **_k: object) -> object:
         raise OSError("unshare not found")
@@ -63,6 +75,7 @@ def test_network_namespace_available_false_when_unshare_missing(
 def test_unshare_argv_omits_net_when_isolation_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """W12.7 — trusted / non-isolate path never appends ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     argv = _unshare_argv(isolate_network=False)
     assert argv[:4] == ["unshare", "--pid", "--fork", "--mount-proc"]
@@ -72,19 +85,22 @@ def test_unshare_argv_omits_net_when_isolation_disabled(
 def test_unshare_argv_adds_net_when_available_and_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """W12.7 — untrusted shell adds ``--net`` only when the probe says ok."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     assert "--net" in _unshare_argv(isolate_network=True)
 
 
-def test_untrusted_shell_absent_when_netns_unavailable(
+@pytest.mark.xfail(
+    reason="green after AP3: netns absence must not silently omit --net",
+    strict=False,
+)
+def test_unshare_argv_skips_net_when_probe_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MCB-10 — missing netns removes the capability; do not spawn with ``--net`` dropped."""
+    """MCB-10 inversion — isolate_network with no netns must fail closed, not omit ``--net``."""
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
-    from unittest.mock import MagicMock
-
-    with pytest.raises((RuntimeError, PermissionError)):
-        shell_mod._spawn_shell(
+    with pytest.raises((RuntimeError, PermissionError, OSError)):
+        _spawn_shell(
             "echo ok",
             env={},
             cwd="/tmp",
@@ -92,3 +108,43 @@ def test_untrusted_shell_absent_when_netns_unavailable(
             stderr=MagicMock(),
             isolate_network=True,
         )
+
+
+def _tool_ctx(
+    tmp_path: Path,
+    *,
+    trust_tier: TrustTier = "untrusted",
+) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token="test-token"),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        trust_tier=trust_tier,
+    )
+
+
+@pytest.mark.xfail(
+    reason="green after AP3: untrusted shell absent when netns unavailable",
+    strict=False,
+)
+def test_untrusted_shell_absent_when_netns_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D6 — missing netns removes the shell tool registration."""
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    names = {spec.name for spec in build_common_tools(_tool_ctx(tmp_path, trust_tier="untrusted"))}
+    assert "shell" not in names
+    assert "kill_background" not in names

--- a/tests/mcp/test_shell_fallback.py
+++ b/tests/mcp/test_shell_fallback.py
@@ -9,11 +9,6 @@ import pytest
 
 from mergecraft.mcp import shell as shell_mod
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP3: fail-closed unsandboxed shell + wrapped fallback",
-    strict=False,
-)
-
 
 def test_unsandboxed_shell_refuses_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", raising=False)
@@ -50,9 +45,10 @@ def test_allow_unsandboxed_env_var_overrides(monkeypatch: pytest.MonkeyPatch) ->
     assert captured, "override must allow fallback spawn"
 
 
-def test_fallback_branch_masks_container_sockets_when_it_runs(
+def test_fallback_branch_runs_raw_command_without_host_mounts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Unsandboxed opt-in must not run mount/chmod soup on the host (MCB-07 / M3)."""
     monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
     monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
     captured: list[str] = []
@@ -71,4 +67,6 @@ def test_fallback_branch_masks_container_sockets_when_it_runs(
         isolate_network=False,
     )
     joined = captured[0]
-    assert "docker.sock" in joined or "mount --bind /dev/null" in joined
+    assert joined == "bash -c echo ok"
+    assert "docker.sock" not in joined
+    assert "mount --bind" not in joined

--- a/tests/mcp/test_shell_fallback.py
+++ b/tests/mcp/test_shell_fallback.py
@@ -1,0 +1,74 @@
+"""Lane A AP1.2 — unsandboxed shell fallback policy (MCB-07 / D8)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP3: fail-closed unsandboxed shell + wrapped fallback",
+    strict=False,
+)
+
+
+def test_unsandboxed_shell_refuses_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", raising=False)
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    with pytest.raises((RuntimeError, PermissionError, OSError)):
+        shell_mod._spawn_shell(
+            "echo ok",
+            env={},
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=True,
+        )
+
+
+def test_allow_unsandboxed_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    captured: list[list[str]] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.append(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=False,
+    )
+    assert captured, "override must allow fallback spawn"
+
+
+def test_fallback_branch_masks_container_sockets_when_it_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.append(" ".join(argv))
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=False,
+    )
+    joined = captured[0]
+    assert "docker.sock" in joined or "mount --bind /dev/null" in joined

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -1,0 +1,52 @@
+"""Lane A AP1.3 — git invariant controls in every shell branch (MCB-25 / D10)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP4: read-only .git bind + git binary unavailable in namespace",
+    strict=False,
+)
+
+
+def _joined_argv(monkeypatch: pytest.MonkeyPatch, *, method: str) -> str:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: method)
+    if method == "none":
+        monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.extend(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    shell_mod._spawn_shell(
+        "echo ok",
+        env={},
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+        isolate_network=True,
+    )
+    return " ".join(captured)
+
+
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
+def test_git_dir_is_read_only_in_every_branch(monkeypatch: pytest.MonkeyPatch, method: str) -> None:
+    joined = _joined_argv(monkeypatch, method=method)
+    assert "remount,bind,ro" in joined
+    assert ".git" in joined
+
+
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
+def test_git_binary_unavailable_in_untrusted_namespace(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    joined = _joined_argv(monkeypatch, method=method)
+    assert "chmod 000" in joined or "unavailable" in joined or "/dev/null" in joined

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.xfail(
 
 def _joined_argv(monkeypatch: pytest.MonkeyPatch, *, method: str) -> str:
     monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: method)
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     if method == "none":
         monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
     captured: list[str] = []
@@ -37,16 +38,23 @@ def _joined_argv(monkeypatch: pytest.MonkeyPatch, *, method: str) -> str:
     return " ".join(captured)
 
 
-@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
-def test_git_dir_is_read_only_in_every_branch(monkeypatch: pytest.MonkeyPatch, method: str) -> None:
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare"])
+def test_git_dir_is_read_only_in_sandboxed_branches(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
     joined = _joined_argv(monkeypatch, method=method)
     assert "remount,bind,ro" in joined
     assert ".git" in joined
 
 
-@pytest.mark.parametrize("method", ["unshare", "sudo-unshare", "none"])
+@pytest.mark.parametrize("method", ["unshare", "sudo-unshare"])
 def test_git_binary_unavailable_in_untrusted_namespace(
     monkeypatch: pytest.MonkeyPatch, method: str
 ) -> None:
     joined = _joined_argv(monkeypatch, method=method)
     assert "chmod 000" in joined or "unavailable" in joined or "/dev/null" in joined
+
+
+def test_unsandboxed_branch_skips_namespace_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    joined = _joined_argv(monkeypatch, method="none")
+    assert joined == "bash -c echo ok"

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -84,10 +84,12 @@ def test_git_core_binary_is_unavailable_in_live_namespace(
     monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
     captured: list[str] = []
 
+    real_popen = subprocess.Popen
+
     def _popen(argv: list[str], **_kwargs: Any) -> object:
         captured.extend(argv)
         # Run the wrapped bash -c for real to prove git-core is masked.
-        return subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return real_popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
     proc = shell_mod._spawn_shell(

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -78,18 +78,24 @@ def test_git_core_binary_is_unavailable_in_live_namespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Debian action images expose git via ``/usr/lib/git-core`` outside PATH."""
+    from mergecraft.analyzers import sandbox as sandbox_mod
     from mergecraft.mcp import shell as shell_mod
 
-    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
-    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
-    captured: list[str] = []
+    shell_mod.reset_detection_cache()
+    sandbox_mod.reset_detection_cache()
+    method = shell_mod.detect_sandbox_method()
+    if method == "none":
+        pytest.skip("PID namespace isolation unavailable on this host")
+    if not shell_mod.network_namespace_available():
+        pytest.skip("network namespace isolation unavailable on this host")
 
+    captured: list[str] = []
     real_popen = subprocess.Popen
 
-    def _popen(argv: list[str], **_kwargs: Any) -> object:
+    def _popen(argv: list[str], **kwargs: Any) -> object:
         captured.extend(argv)
         # Run the wrapped bash -c for real to prove git-core is masked.
-        return real_popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return real_popen(argv, **kwargs)
 
     monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
     proc = shell_mod._spawn_shell(
@@ -102,10 +108,12 @@ def test_git_core_binary_is_unavailable_in_live_namespace(
         stderr=subprocess.PIPE,
         isolate_network=True,
     )
-    stdout, _stderr = proc.communicate(timeout=30)
-    text = stdout.decode("utf-8", errors="replace")
-    assert "EXEC:" not in text, text
-    assert "DONE" in text
+    stdout, stderr = proc.communicate(timeout=30)
+    out_text = stdout.decode("utf-8", errors="replace")
+    err_text = stderr.decode("utf-8", errors="replace")
+    assert proc.returncode == 0, (out_text, err_text)
+    assert "EXEC:" not in out_text, (out_text, err_text)
+    assert "DONE" in out_text, (out_text, err_text)
 
 
 def test_unsandboxed_branch_skips_namespace_mounts(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -50,6 +50,18 @@ def test_git_binary_unavailable_in_untrusted_namespace(
     assert "chmod 000" in joined or "unavailable" in joined or "/dev/null" in joined
 
 
+def test_git_binary_hide_skips_path_dirs_without_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PATH dirs lacking git must not abort the hide loop (MCB-25)."""
+    joined = _joined_argv(monkeypatch, method="unshare")
+    assert 'if [ -x "$_dir/git" ]; then mount --bind /dev/null "$_dir/git" || exit 1; fi' in joined
+    assert '[ -x "$_dir/git" ] && mount --bind /dev/null "$_dir/git" || exit 1' not in joined
+    assert (
+        'if [ -n "$_g" ] && [ -x "$_g" ]; then mount --bind /dev/null "$_g" || exit 1; fi' in joined
+    )
+
+
 def test_unsandboxed_branch_skips_namespace_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
     joined = _joined_argv(monkeypatch, method="none")
     assert joined == "bash -c echo ok"

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -60,6 +62,48 @@ def test_git_binary_hide_skips_path_dirs_without_git(
     assert (
         'if [ -n "$_g" ] && [ -x "$_g" ]; then mount --bind /dev/null "$_g" || exit 1; fi' in joined
     )
+
+
+def test_git_exec_path_and_git_core_binaries_are_masked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    joined = _joined_argv(monkeypatch, method="unshare")
+    assert "git --exec-path" in joined
+    assert '"/git"' in joined or '"/git-*"' in joined or "/git-core/git" in joined
+    assert "/usr/lib/git-core/git" in joined
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="live namespace mounts require Linux")
+def test_git_core_binary_is_unavailable_in_live_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Debian action images expose git via ``/usr/lib/git-core`` outside PATH."""
+    from mergecraft.mcp import shell as shell_mod
+
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: True)
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> object:
+        captured.extend(argv)
+        # Run the wrapped bash -c for real to prove git-core is masked.
+        return subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    proc = shell_mod._spawn_shell(
+        "for _g in /usr/lib/git-core/git /usr/lib/git-core/git-upload-pack; do "
+        'if [ -x "$_g" ]; then "$_g" --version >/dev/null 2>&1 && echo "EXEC:$_g"; fi; '
+        "done; echo DONE",
+        env={},
+        cwd="/tmp",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        isolate_network=True,
+    )
+    stdout, _stderr = proc.communicate(timeout=30)
+    text = stdout.decode("utf-8", errors="replace")
+    assert "EXEC:" not in text, text
+    assert "DONE" in text
 
 
 def test_unsandboxed_branch_skips_namespace_mounts(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mcp/test_shell_git_invariant.py
+++ b/tests/mcp/test_shell_git_invariant.py
@@ -9,11 +9,6 @@ import pytest
 
 from mergecraft.mcp import shell as shell_mod
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP4: read-only .git bind + git binary unavailable in namespace",
-    strict=False,
-)
-
 
 def _joined_argv(monkeypatch: pytest.MonkeyPatch, *, method: str) -> str:
     monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: method)

--- a/tests/mcp/test_shell_spawn_argv.py
+++ b/tests/mcp/test_shell_spawn_argv.py
@@ -10,11 +10,6 @@ import pytest
 from mergecraft.mcp import shell as shell_mod
 from mergecraft.utils.secrets import PROVIDER_KEY_ENV_VARS
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP4: sudo --preserve-env by name",
-    strict=False,
-)
-
 _CANARY = "CANARY_PROVIDER_SECRET_VALUE_AP1"
 
 
@@ -42,7 +37,16 @@ def _capture_argv(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
 @pytest.mark.parametrize(
     "isolate_network",
-    [False, True],
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="green after AP4: sudo --preserve-env by name",
+                strict=False,
+            ),
+        ),
+    ],
     ids=["pid_only", "pid_and_net"],
 )
 def test_no_provider_key_value_appears_in_any_branch_argv(

--- a/tests/mcp/test_shell_spawn_argv.py
+++ b/tests/mcp/test_shell_spawn_argv.py
@@ -39,19 +39,20 @@ def _capture_argv(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     "isolate_network",
     [
         False,
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="green after AP4: sudo --preserve-env by name",
-                strict=False,
-            ),
-        ),
+        True,
     ],
     ids=["pid_only", "pid_and_net"],
 )
 def test_no_provider_key_value_appears_in_any_branch_argv(
     monkeypatch: pytest.MonkeyPatch, isolate_network: bool
 ) -> None:
+    # The netns probe is a property of the host, not of argv construction:
+    # macOS has no network namespaces and GitHub's runners fail
+    # ``unshare --net`` too, so without this stub the isolate_network=True case
+    # raises in shell.py:307 before reaching the assertion below. Stubbing it
+    # makes the branch reachable and the result host-independent -- which is
+    # what let the previous xfail(strict=False) sit here silently either way.
+    monkeypatch.setattr(shell_mod, "_network_namespace_available", lambda: True)
     for method in ("unshare", "sudo-unshare", "none"):
         monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
         if method == "unshare":

--- a/tests/mcp/test_shell_spawn_argv.py
+++ b/tests/mcp/test_shell_spawn_argv.py
@@ -1,0 +1,83 @@
+"""Lane A AP1.3 — sudo argv must not carry secret values (MCB-08 / D9)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mergecraft.mcp import shell as shell_mod
+from mergecraft.utils.secrets import PROVIDER_KEY_ENV_VARS
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP4: sudo --preserve-env by name",
+    strict=False,
+)
+
+_CANARY = "CANARY_PROVIDER_SECRET_VALUE_AP1"
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_sudo_unshare(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "sudo-unshare")
+    monkeypatch.setattr(shell_mod, "network_namespace_available", lambda: False)
+    shell_mod.reset_detection_cache()
+
+
+def _env_with_canaries() -> dict[str, str]:
+    return {name: _CANARY for name in PROVIDER_KEY_ENV_VARS}
+
+
+def _capture_argv(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    captured: list[str] = []
+
+    def _popen(argv: list[str], **_kwargs: Any) -> MagicMock:
+        captured.extend(argv)
+        return MagicMock()
+
+    monkeypatch.setattr(shell_mod.subprocess, "Popen", _popen)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "isolate_network",
+    [False, True],
+    ids=["pid_only", "pid_and_net"],
+)
+def test_no_provider_key_value_appears_in_any_branch_argv(
+    monkeypatch: pytest.MonkeyPatch, isolate_network: bool
+) -> None:
+    for method in ("unshare", "sudo-unshare", "none"):
+        monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
+        if method == "unshare":
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "unshare")
+        elif method == "sudo-unshare":
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "sudo-unshare")
+        else:
+            monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")
+        captured = _capture_argv(monkeypatch)
+        shell_mod._spawn_shell(
+            "echo ok",
+            env=_env_with_canaries(),
+            cwd="/tmp",
+            stdout=MagicMock(),
+            stderr=MagicMock(),
+            isolate_network=isolate_network,
+        )
+        joined = " ".join(captured)
+        assert _CANARY not in joined, f"secret leaked in argv for method={method}"
+
+
+def test_sudo_branch_uses_preserve_env_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture_argv(monkeypatch)
+    env = {"ANTHROPIC_API_KEY": "sekret", "PATH": "/usr/bin"}
+    shell_mod._spawn_shell(
+        "echo ok",
+        env=env,
+        cwd="/tmp",
+        stdout=MagicMock(),
+        stderr=MagicMock(),
+    )
+    assert any(arg.startswith("--preserve-env=") for arg in captured)
+    assert not any("=sekret" in arg for arg in captured)

--- a/tests/prep/test_prep_env.py
+++ b/tests/prep/test_prep_env.py
@@ -1,0 +1,23 @@
+"""Lane A AP1.6 — prep environment allowlist (MCB-22)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: _prep_env allowlist",
+    strict=False,
+)
+
+
+def test_prep_env_is_a_real_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.prep.python import _prep_env
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sekret")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_sekret")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", "/tmp")
+    env = _prep_env()
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert env.get("PATH") == "/usr/bin"

--- a/tests/prep/test_prep_env.py
+++ b/tests/prep/test_prep_env.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: _prep_env allowlist",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_prep_env_is_a_real_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/prep/test_prep_fail_closed.py
+++ b/tests/prep/test_prep_fail_closed.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
+import pytest
 from tests.support.run_main_harness import FakeAgent, run_main_for_test
 
 from mergecraft.agents.shared import AgentResult
@@ -37,7 +38,19 @@ from mergecraft.utils.github import GitHubClient
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
+
+@pytest.fixture(autouse=True)
+def _uid_independent_privilege_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCB-24 — prep fail-closed cases must not depend on ambient uid (AP1.4b)."""
+
+    def _noop_prepare_workspace_for_agent(_workspace: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "mergecraft.main.prepare_workspace_for_agent",
+        _noop_prepare_workspace_for_agent,
+    )
+
 
 _SKIP_ISSUE = (
     "skipped: python dependency installation can execute arbitrary code "

--- a/tests/prep/test_prep_selection.py
+++ b/tests/prep/test_prep_selection.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-
-import pytest
+from typing import TYPE_CHECKING
 
 from mergecraft.prep.python import _config_applies
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: uv.lock wins over requirements.txt",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_uv_lock_wins_over_a_stray_requirements_txt(tmp_path: Path) -> None:

--- a/tests/prep/test_prep_selection.py
+++ b/tests/prep/test_prep_selection.py
@@ -1,0 +1,39 @@
+"""Lane A AP1.6 — prep lockfile selection order (MCB-22)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mergecraft.prep.python import _config_applies
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: uv.lock wins over requirements.txt",
+    strict=False,
+)
+
+
+def test_uv_lock_wins_over_a_stray_requirements_txt(tmp_path: Path) -> None:
+    from mergecraft.prep import python as prep_python
+
+    (tmp_path / "requirements.txt").write_text("httpx==0.1\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    chosen = next(c for c in prep_python._PYTHON_CONFIGS if _config_applies(c, tmp_path))
+    assert chosen.file == "uv.lock"
+
+
+def test_cwd_is_threaded_not_read_twice(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from mergecraft.prep.python import InstallPythonDependencies
+
+    calls = 0
+
+    def _cwd() -> Path:
+        nonlocal calls
+        calls += 1
+        return tmp_path
+
+    monkeypatch.setattr("mergecraft.prep.python.Path.cwd", _cwd)
+    inst = InstallPythonDependencies()
+    _ = inst.should_run()
+    assert calls == 1, "should_run must read cwd once; run receives explicit cwd after AP7"

--- a/tests/prep/test_prep_uv_lock.py
+++ b/tests/prep/test_prep_uv_lock.py
@@ -1,0 +1,61 @@
+"""Lane A AP1.6 — uv.lock prep must not touch checkout ``.venv`` (MCB-22)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_uv_lock_sync_targets_prep_venv_not_checkout_dot_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mergecraft.prep.python import (
+        InstallPythonDependencies,
+        _prep_venv_bin,
+        _prep_venv_dir,
+        _prep_venv_python,
+    )
+    from mergecraft.prep.types import PrepOptions
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.1.0"\nrequires-python = ">=3.11"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "uv.lock").write_text("# uv lock\n", encoding="utf-8")
+    checkout_venv = tmp_path / ".venv"
+    checkout_venv.mkdir()
+    (checkout_venv / "marker").write_text("untouched", encoding="utf-8")
+    before_mtime = (checkout_venv / "marker").stat().st_mtime_ns
+
+    monkeypatch.chdir(tmp_path)
+    captured_envs: list[dict[str, str]] = []
+
+    async def _fake_run(cmd: str, args: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
+        from mergecraft.prep.python import _prep_env
+
+        captured_envs.append(_prep_env(cwd))
+        if len(args) >= 3 and args[0] == "-m" and args[1] == "venv":
+            venv = Path(args[2])
+            for name in ("python", "pip", "uv"):
+                bin_path = (
+                    _prep_venv_python(venv) if name == "python" else _prep_venv_bin(venv, name)
+                )
+                bin_path.parent.mkdir(parents=True, exist_ok=True)
+                bin_path.touch()
+        return 0, ""
+
+    import mergecraft.prep.python as prep_python
+
+    prep_python._run_cmd = _fake_run  # type: ignore[method-assign]
+    inst = InstallPythonDependencies()
+    result = await inst.run(PrepOptions(ignore_scripts=False))
+
+    assert result.dependencies_installed is True
+    assert result.package_manager == "uv"
+    assert result.config_file == "uv.lock"
+    assert captured_envs, "prep subprocesses must receive an isolated env"
+    assert captured_envs[-1]["UV_PROJECT_ENVIRONMENT"] == ".mergecraft/prep-scratch/prep-venv"
+    assert (checkout_venv / "marker").stat().st_mtime_ns == before_mtime
+    assert _prep_venv_dir(tmp_path) == tmp_path / ".mergecraft" / "prep-scratch" / "prep-venv"

--- a/tests/prep/test_prep_venv.py
+++ b/tests/prep/test_prep_venv.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.6 — prep installs into a dedicated virtualenv (MCB-22 / D12)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP7: dedicated prep-venv target",
+    strict=False,
+)
+
+
+@pytest.mark.asyncio
+async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
+    from mergecraft.prep.python import InstallPythonDependencies
+    from mergecraft.prep.types import PrepOptions
+
+    (tmp_path / "requirements.txt").write_text("httpx==0.28.1\n", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    async def _fake_run(cmd: str, args: list[str]) -> tuple[int, str]:
+        captured.append([cmd, *args])
+        return 0, ""
+
+    import mergecraft.prep.python as prep_python
+
+    prep_python._run_cmd = _fake_run  # type: ignore[method-assign]
+    inst = InstallPythonDependencies()
+    result = await inst.run(PrepOptions(ignore_scripts=False))
+    assert result.dependencies_installed is True
+    joined = " ".join(" ".join(c) for c in captured)
+    assert "prep-venv" in joined or ".venv" in joined

--- a/tests/prep/test_prep_venv.py
+++ b/tests/prep/test_prep_venv.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP7: dedicated prep-venv target",
-    strict=False,
-)
-
 
 @pytest.mark.asyncio
 async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
@@ -20,7 +15,7 @@ async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
     (tmp_path / "requirements.txt").write_text("httpx==0.28.1\n", encoding="utf-8")
     captured: list[list[str]] = []
 
-    async def _fake_run(cmd: str, args: list[str]) -> tuple[int, str]:
+    async def _fake_run(cmd: str, args: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
         captured.append([cmd, *args])
         return 0, ""
 

--- a/tests/prep/test_prep_venv.py
+++ b/tests/prep/test_prep_venv.py
@@ -8,15 +8,39 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
-    from mergecraft.prep.python import InstallPythonDependencies
+async def test_install_targets_a_dedicated_virtualenv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mergecraft.prep.python import (
+        InstallPythonDependencies,
+        _prep_venv_bin,
+        _prep_venv_dir,
+        _prep_venv_python,
+    )
     from mergecraft.prep.types import PrepOptions
 
     (tmp_path / "requirements.txt").write_text("httpx==0.28.1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
     captured: list[list[str]] = []
 
     async def _fake_run(cmd: str, args: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
         captured.append([cmd, *args])
+        if len(args) >= 3 and args[0] == "-m" and args[1] == "venv":
+            venv = Path(args[2])
+            for name in ("python", "pip"):
+                bin_path = (
+                    _prep_venv_python(venv) if name == "python" else _prep_venv_bin(venv, name)
+                )
+                bin_path.parent.mkdir(parents=True, exist_ok=True)
+                bin_path.touch()
+        elif "install" in args:
+            venv = _prep_venv_dir(tmp_path)
+            for tool in ("uv", "poetry", "pipenv"):
+                if tool in args:
+                    tool_bin = _prep_venv_bin(venv, tool)
+                    tool_bin.parent.mkdir(parents=True, exist_ok=True)
+                    tool_bin.touch()
+                    break
         return 0, ""
 
     import mergecraft.prep.python as prep_python
@@ -25,5 +49,12 @@ async def test_install_targets_a_dedicated_virtualenv(tmp_path: Path) -> None:
     inst = InstallPythonDependencies()
     result = await inst.run(PrepOptions(ignore_scripts=False))
     assert result.dependencies_installed is True
+    assert result.package_manager == "pip"
+    assert result.config_file == "requirements.txt"
     joined = " ".join(" ".join(c) for c in captured)
-    assert "prep-venv" in joined or ".venv" in joined
+    assert "prep-venv" in joined
+    venv = _prep_venv_dir(tmp_path)
+    prep_pip = str(_prep_venv_bin(venv, "pip"))
+    assert any(prep_pip in " ".join(c) for c in captured), (
+        "dependency install must use pip from the prep virtualenv"
+    )

--- a/tests/runtime/test_budgets.py
+++ b/tests/runtime/test_budgets.py
@@ -86,6 +86,29 @@ def test_record_agent_usage_charges_token_and_cost_budgets() -> None:
     assert exc_info.value.kind == "token"
 
 
+def test_record_agent_usage_does_not_double_count_cached_input() -> None:
+    """OpenAI-style cached input is already in ``input_tokens`` (D16 / #273)."""
+    from mergecraft.agents.shared import AgentUsage
+
+    tracker = BudgetTracker(_tight_bounds())
+    record_agent_usage(
+        tracker,
+        AgentUsage(
+            agent="test",
+            input_tokens=90,
+            output_tokens=5,
+            cache_read_tokens=40,
+        ),
+    )
+    assert tracker.tokens_used == 95
+    with pytest.raises(BudgetExhausted) as exc_info:
+        record_agent_usage(
+            tracker,
+            AgentUsage(agent="test", input_tokens=6, output_tokens=0, cache_read_tokens=40),
+        )
+    assert exc_info.value.kind == "token"
+
+
 def test_tracker_records_last_exhausted_for_orchestrator_drain() -> None:
     """``BudgetTracker`` records the ``BudgetExhausted`` it raises.
 

--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -126,10 +126,11 @@ def make_agent_run_ctx(tmp_path: Path):
 
 @pytest.fixture
 def no_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force ``detect_sandbox_method`` off the CI-required unshare path.
-
-    Also resets the module-level detection cache so host runs always take the
-    plain ``bash -c`` spawn path regardless of test ordering.
-    """
+    """Reset sandbox detection cache and use unsandboxed shell for host runs."""
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("MERGECRAFT_ALLOW_UNSANDBOXED_SHELL", "1")
     monkeypatch.setattr("mergecraft.mcp.shell._detected_sandbox", None)
+    monkeypatch.setattr("mergecraft.mcp.shell._detected_netns", None)
+    from mergecraft.mcp import shell as shell_mod
+
+    monkeypatch.setattr(shell_mod, "detect_sandbox_method", lambda: "none")

--- a/tests/security/fixtures/build_hostile_repo.sh
+++ b/tests/security/fixtures/build_hostile_repo.sh
@@ -72,4 +72,14 @@ ln -s "${OUTSIDE}" "${REPO}/home-escape"
 git add home-escape
 git commit -m "attack: add workspace escape symlink"
 
+# MCB-01 vectors for lane A AP1.4b — hostile .git/config entries.
+cat >>"${REPO}/.git/config" <<CFG
+
+[core]
+	fsmonitor = /bin/false
+	diff.external = /bin/false
+[url "https://attacker.example/"]
+	insteadOf = https://github.com/
+CFG
+
 echo "built ${REPO}"

--- a/tests/security/fixtures/build_hostile_repo.sh
+++ b/tests/security/fixtures/build_hostile_repo.sh
@@ -73,13 +73,20 @@ git add home-escape
 git commit -m "attack: add workspace escape symlink"
 
 # MCB-01 vectors for lane A AP1.4b — hostile .git/config entries.
-cat >>"${REPO}/.git/config" <<CFG
-
-[core]
-	fsmonitor = /bin/false
-	diff.external = /bin/false
-[url "https://attacker.example/"]
-	insteadOf = https://github.com/
-CFG
+evil_fsmonitor="${ROOT}/evil-fsmonitor.sh"
+cat >"${evil_fsmonitor}" <<'SH'
+#!/bin/sh
+touch /tmp/mergecraft-hostile-fsmonitor-pwned
+SH
+chmod +x "${evil_fsmonitor}"
+evil_diff="${ROOT}/evil-diff.sh"
+cat >"${evil_diff}" <<'SH'
+#!/bin/sh
+touch /tmp/mergecraft-hostile-diff-external-pwned
+SH
+chmod +x "${evil_diff}"
+git config core.fsmonitor "${evil_fsmonitor}"
+git config diff.external "${evil_diff}"
+git config url.https://attacker.example/.insteadOf https://github.com/
 
 echo "built ${REPO}"

--- a/tests/security/hostile_git_fixtures.py
+++ b/tests/security/hostile_git_fixtures.py
@@ -1,0 +1,79 @@
+"""Shared helpers for hostile ``.git/config`` RED tests (lane A / AP1)."""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class HostileGitRepo:
+    """Real git checkout with attacker-controlled ``.git/config`` entries."""
+
+    root: Path
+    fsmonitor_sentinel: Path
+    diff_external_sentinel: Path
+    insteadof_leak_path: Path
+
+
+def _git(repo: Path, *args: str) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+
+
+def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
+    """Create a throwaway repo whose ``.git/config`` models MCB-01 vectors."""
+    repo = tmp_path / "hostile-git"
+    repo.mkdir()
+    fsmonitor_sentinel = tmp_path / "fsmonitor-pwned"
+    diff_external_sentinel = tmp_path / "diff-external-pwned"
+    insteadof_leak_path = tmp_path / "insteadof-leaked.txt"
+
+    evil_fsmonitor = tmp_path / "evil-fsmonitor.sh"
+    evil_fsmonitor.write_text(
+        f"#!/bin/sh\ntouch {fsmonitor_sentinel}\n",
+        encoding="utf-8",
+    )
+    evil_fsmonitor.chmod(evil_fsmonitor.stat().st_mode | stat.S_IXUSR)
+
+    evil_diff = tmp_path / "evil-diff.sh"
+    evil_diff.write_text(
+        f"#!/bin/sh\ntouch {diff_external_sentinel}\n",
+        encoding="utf-8",
+    )
+    evil_diff.chmod(evil_diff.stat().st_mode | stat.S_IXUSR)
+
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "hostile@example.com")
+    _git(repo, "config", "user.name", "hostile")
+    (repo / "README.md").write_text("hostile\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+
+    config_path = repo / ".git" / "config"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + f"""
+[core]
+\tfsmonitor = {evil_fsmonitor}
+\tdiff.external = {evil_diff}
+[url "https://attacker.example/"]
+\tinsteadOf = https://github.com/
+""",
+        encoding="utf-8",
+    )
+
+    return HostileGitRepo(
+        root=repo,
+        fsmonitor_sentinel=fsmonitor_sentinel,
+        diff_external_sentinel=diff_external_sentinel,
+        insteadof_leak_path=insteadof_leak_path,
+    )

--- a/tests/security/hostile_git_fixtures.py
+++ b/tests/security/hostile_git_fixtures.py
@@ -15,6 +15,7 @@ class HostileGitRepo:
     root: Path
     fsmonitor_sentinel: Path
     diff_external_sentinel: Path
+    textconv_sentinel: Path
     insteadof_leak_path: Path
 
 
@@ -35,6 +36,7 @@ def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
     repo.mkdir()
     fsmonitor_sentinel = tmp_path / "fsmonitor-pwned"
     diff_external_sentinel = tmp_path / "diff-external-pwned"
+    textconv_sentinel = tmp_path / "textconv-pwned"
     insteadof_leak_path = tmp_path / "insteadof-leaked.txt"
 
     evil_fsmonitor = tmp_path / "evil-fsmonitor.sh"
@@ -51,6 +53,13 @@ def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
     )
     evil_diff.chmod(evil_diff.stat().st_mode | stat.S_IXUSR)
 
+    evil_textconv = tmp_path / "evil-textconv.sh"
+    evil_textconv.write_text(
+        f"#!/bin/sh\ntouch {textconv_sentinel}\n",
+        encoding="utf-8",
+    )
+    evil_textconv.chmod(evil_textconv.stat().st_mode | stat.S_IXUSR)
+
     _git(repo, "init", "-b", "main")
     _git(repo, "config", "user.email", "hostile@example.com")
     _git(repo, "config", "user.name", "hostile")
@@ -66,15 +75,19 @@ def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
 \tfsmonitor = {evil_fsmonitor}
 [diff]
 \texternal = {evil_diff}
+[diff "hostile"]
+\ttextconv = {evil_textconv}
 [url "https://attacker.example/"]
 \tinsteadOf = https://github.com/
 """,
         encoding="utf-8",
     )
+    (repo / ".gitattributes").write_text("* diff=hostile\n", encoding="utf-8")
 
     return HostileGitRepo(
         root=repo,
         fsmonitor_sentinel=fsmonitor_sentinel,
         diff_external_sentinel=diff_external_sentinel,
+        textconv_sentinel=textconv_sentinel,
         insteadof_leak_path=insteadof_leak_path,
     )

--- a/tests/security/hostile_git_fixtures.py
+++ b/tests/security/hostile_git_fixtures.py
@@ -64,7 +64,8 @@ def build_hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
         + f"""
 [core]
 \tfsmonitor = {evil_fsmonitor}
-\tdiff.external = {evil_diff}
+[diff]
+\texternal = {evil_diff}
 [url "https://attacker.example/"]
 \tinsteadOf = https://github.com/
 """,

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -80,8 +80,65 @@ def test_insteadof_rewrite_does_not_leak_git_config_value_0(
         check=False,
     )
     combined = f"{completed.stdout}\n{completed.stderr}"
-    assert "evil.example" not in combined
+    assert "attacker.example" not in combined
     assert not hostile_git_repo.insteadof_leak_path.exists()
+
+
+def test_insteadof_guard_matches_actions_checkout_origin_without_git_suffix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identity pins must cover origin URLs stored without a ``.git`` suffix."""
+    from mergecraft.mcp.git import _run_authenticated_git
+    from mergecraft.utils.git_hardening import git_authenticated_argv, read_remote_origin_url
+
+    repo = tmp_path / "checkout-shape"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    remote = "https://github.com/acme/demo"
+    subprocess.run(
+        ["git", "remote", "add", "origin", remote],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    config_path = repo / ".git" / "config"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + """
+[url "https://attacker.example/"]
+\tinsteadOf = https://github.com/
+""",
+        encoding="utf-8",
+    )
+
+    trusted = "https://github.com/acme/demo.git"
+    assert read_remote_origin_url(str(repo)) == remote
+
+    fetch_argv = git_authenticated_argv(["fetch", "--no-tags", "origin"], remote_url=remote)
+    argv_text = " ".join(fetch_argv)
+    assert f"url.{remote}.insteadOf={remote}" in argv_text
+    assert f"url.{trusted}.insteadOf={trusted}" in argv_text
+
+    captured: dict[str, str] = {}
+
+    def _capture_env(token: str, *, remote_url: str = "") -> dict[str, str]:
+        captured["remote_url"] = remote_url
+        return {"GIT_TERMINAL_PROMPT": "0"}
+
+    import mergecraft.mcp.git as git_mod
+
+    monkeypatch.setattr(git_mod, "_git_env", _capture_env)
+    monkeypatch.setattr(git_mod, "_run_git", lambda *_a, **_k: "")
+
+    _run_authenticated_git(
+        ["fetch", "--no-tags", "origin"],
+        cwd=str(repo),
+        token="ghs_secret",
+        trusted_remote_url=trusted,
+    )
+
+    assert captured["remote_url"] == trusted
 
 
 def test_hostile_insteadof_fetch_scopes_auth_to_trusted_push_url(

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -18,7 +18,10 @@ def test_root_side_status_does_not_execute_fsmonitor(hostile_git_repo: HostileGi
 
 
 def test_root_side_diff_does_not_execute_diff_external(hostile_git_repo: HostileGitRepo) -> None:
-    _run_git(["diff", "HEAD"], cwd=str(hostile_git_repo.root))
+    (hostile_git_repo.root / "README.md").write_text("changed\n", encoding="utf-8")
+    output = _run_git(["diff", "README.md"], cwd=str(hostile_git_repo.root))
+    assert "README.md" in output
+    assert "changed" in output
     assert not hostile_git_repo.diff_external_sentinel.exists()
 
 

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -42,16 +42,29 @@ def test_commit_path_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo
 def test_insteadof_rewrite_does_not_leak_git_config_value_0(
     hostile_git_repo: HostileGitRepo,
 ) -> None:
+    from mergecraft.utils.git_hardening import git_authenticated_argv
+    from mergecraft.utils.git_setup import git_env_for_token
+
+    remote = "https://github.com/acme/demo.git"
+    _run_git(["remote", "add", "origin", remote], cwd=str(hostile_git_repo.root))
+    fetch_argv = git_authenticated_argv(["fetch", "--no-tags", "origin"], remote_url=remote)
+    assert f"url.{remote}.insteadOf={remote}" in " ".join(fetch_argv)
+
+    env = git_env_for_token("ghs_secret_token", remote_url=remote)
+    assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
+    assert "http.extraHeader" not in env.values()
+
     completed = subprocess.run(
-        ["git", "config", "--get", "url.https://attacker.example/.insteadof"],
+        fetch_argv,
         cwd=hostile_git_repo.root,
+        env=env,
         capture_output=True,
         text=True,
         check=False,
     )
-    assert completed.stdout.strip() == "https://github.com/"
-    _run_git(["status"], cwd=str(hostile_git_repo.root))
-    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert "evil.example" not in combined
+    assert not hostile_git_repo.insteadof_leak_path.exists()
 
 
 def test_xrepo_checkout_is_equally_protected(hostile_git_repo: HostileGitRepo) -> None:

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -1,0 +1,61 @@
+"""Lane A AP1.1 — root-side git must not execute hostile ``.git/config`` (MCB-01)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mergecraft.mcp.git import _run_git
+from mergecraft.xrepo.review import _rev_parse_commit
+from tests.security.hostile_git_fixtures import HostileGitRepo, build_hostile_git_repo
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: git_hardening routes every root-side git call",
+    strict=False,
+)
+
+
+def test_root_side_status_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
+    _run_git(["status", "--porcelain"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_root_side_diff_does_not_execute_diff_external(hostile_git_repo: HostileGitRepo) -> None:
+    _run_git(["diff", "HEAD"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.diff_external_sentinel.exists()
+
+
+def test_commit_path_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
+    """``commit_changes`` path must pin safe git config (hooksPath alone is insufficient)."""
+    (hostile_git_repo.root / "tracked.txt").write_text("x\n", encoding="utf-8")
+    _run_git(["add", "tracked.txt"], cwd=str(hostile_git_repo.root))
+    _run_git(["commit", "-m", "test"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_insteadof_rewrite_does_not_leak_git_config_value_0(
+    hostile_git_repo: HostileGitRepo,
+) -> None:
+    completed = subprocess.run(
+        ["git", "config", "--get", "url.https://attacker.example/.insteadof"],
+        cwd=hostile_git_repo.root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.stdout.strip() == "https://github.com/"
+    _run_git(["status"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+def test_xrepo_checkout_is_equally_protected(hostile_git_repo: HostileGitRepo) -> None:
+    """H-7: xrepo ``_rev_parse_commit`` must use hardened git argv."""
+    _rev_parse_commit(hostile_git_repo.root, "HEAD")
+    assert not hostile_git_repo.fsmonitor_sentinel.exists()
+
+
+@pytest.fixture
+def hostile_git_repo(tmp_path: Path) -> HostileGitRepo:
+    return build_hostile_git_repo(tmp_path)

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -42,17 +42,34 @@ def test_commit_path_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo
 def test_insteadof_rewrite_does_not_leak_git_config_value_0(
     hostile_git_repo: HostileGitRepo,
 ) -> None:
-    from mergecraft.utils.git_hardening import git_authenticated_argv
+    from mergecraft.mcp.git import _origin_remote_url, _run_git
+    from mergecraft.utils.git_hardening import git_authenticated_argv, read_remote_origin_url
     from mergecraft.utils.git_setup import git_env_for_token
 
     remote = "https://github.com/acme/demo.git"
     _run_git(["remote", "add", "origin", remote], cwd=str(hostile_git_repo.root))
+
+    expanded = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=hostile_git_repo.root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert "attacker.example" in expanded, "fixture must model insteadOf expansion"
+
+    raw = read_remote_origin_url(str(hostile_git_repo.root))
+    assert raw == remote
+    assert _origin_remote_url(str(hostile_git_repo.root)) == remote
+    assert "attacker.example" not in raw
+
     fetch_argv = git_authenticated_argv(["fetch", "--no-tags", "origin"], remote_url=remote)
     assert f"url.{remote}.insteadOf={remote}" in " ".join(fetch_argv)
 
     env = git_env_for_token("ghs_secret_token", remote_url=remote)
     assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
     assert "http.extraHeader" not in env.values()
+    assert "attacker.example" not in env.values()
 
     completed = subprocess.run(
         fetch_argv,
@@ -65,6 +82,41 @@ def test_insteadof_rewrite_does_not_leak_git_config_value_0(
     combined = f"{completed.stdout}\n{completed.stderr}"
     assert "evil.example" not in combined
     assert not hostile_git_repo.insteadof_leak_path.exists()
+
+
+def test_hostile_insteadof_fetch_scopes_auth_to_trusted_push_url(
+    hostile_git_repo: HostileGitRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authenticated fetch must bind bearer auth to trusted push_url, not expanded origin."""
+    from mergecraft.mcp.git import _run_authenticated_git
+
+    remote = "https://github.com/acme/demo.git"
+    trusted = "https://github.com/trusted-owner/trusted-repo.git"
+    _run_git(["remote", "add", "origin", remote], cwd=str(hostile_git_repo.root))
+
+    captured: dict[str, str] = {}
+
+    def _capture_env(token: str, *, remote_url: str = "") -> dict[str, str]:
+        captured["remote_url"] = remote_url
+        return git_setup_mod.git_env_for_token(token, remote_url=remote_url)
+
+    import mergecraft.utils.git_setup as git_setup_mod
+
+    monkeypatch.setattr("mergecraft.mcp.git._git_env", _capture_env)
+    monkeypatch.setattr(
+        "mergecraft.mcp.git._run_git",
+        lambda *_a, **_k: "",
+    )
+
+    _run_authenticated_git(
+        ["fetch", "--no-tags", "origin"],
+        cwd=str(hostile_git_repo.root),
+        token="ghs_secret",
+        trusted_remote_url=trusted,
+    )
+    assert captured["remote_url"] == trusted
+    assert "attacker.example" not in captured["remote_url"]
 
 
 def test_xrepo_checkout_is_equally_protected(hostile_git_repo: HostileGitRepo) -> None:

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -11,11 +11,6 @@ from mergecraft.mcp.git import _run_git
 from mergecraft.xrepo.review import _rev_parse_commit
 from tests.security.hostile_git_fixtures import HostileGitRepo, build_hostile_git_repo
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: git_hardening routes every root-side git call",
-    strict=False,
-)
-
 
 def test_root_side_status_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
     _run_git(["status", "--porcelain"], cwd=str(hostile_git_repo.root))

--- a/tests/security/test_hostile_git_config.py
+++ b/tests/security/test_hostile_git_config.py
@@ -25,6 +25,12 @@ def test_root_side_diff_does_not_execute_diff_external(hostile_git_repo: Hostile
     assert not hostile_git_repo.diff_external_sentinel.exists()
 
 
+def test_root_side_diff_does_not_execute_textconv(hostile_git_repo: HostileGitRepo) -> None:
+    (hostile_git_repo.root / "README.md").write_text("changed\n", encoding="utf-8")
+    _run_git(["diff", "README.md"], cwd=str(hostile_git_repo.root))
+    assert not hostile_git_repo.textconv_sentinel.exists()
+
+
 def test_commit_path_does_not_execute_fsmonitor(hostile_git_repo: HostileGitRepo) -> None:
     """``commit_changes`` path must pin safe git config (hooksPath alone is insufficient)."""
     (hostile_git_repo.root / "tracked.txt").write_text("x\n", encoding="utf-8")

--- a/tests/security/test_privilege_fail_closed.py
+++ b/tests/security/test_privilege_fail_closed.py
@@ -49,6 +49,8 @@ def _force_root(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every branch in ``wrap_agent_command``/``prepare_workspace_for_agent``
     see the action-image root path, regardless of the host's real uid."""
     monkeypatch.setattr(os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege, "_in_action_image", lambda: True)
+    monkeypatch.setattr(privilege, "_setpriv_supports_bounding_set", lambda: True)
 
 
 @pytest.fixture(autouse=True)
@@ -123,6 +125,9 @@ def test_root_with_setpriv_and_user_wraps_command(
     # privilege drop contract (the verifier reads uid from inside the child).
     assert wrapped == [
         "setpriv",
+        "--no-new-privs",
+        "--inh-caps=-all",
+        "--bounding-set=-all",
         "--reuid=mergecraft",
         "--regid=mergecraft",
         "--init-groups",
@@ -165,8 +170,8 @@ def test_custom_agent_user_via_env_is_honoured(
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "reviewer")
     monkeypatch.setattr(pwd, "getpwnam", lambda name: _FakePwnam(name))
     wrapped = privilege.wrap_agent_command(["claude", "--help"])
-    assert wrapped[1] == "--reuid=reviewer"
-    assert wrapped[2] == "--regid=reviewer"
+    assert wrapped[4] == "--reuid=reviewer"
+    assert wrapped[5] == "--regid=reviewer"
 
     # Case 2: env var names a user that doesn't exist → fail closed.
     monkeypatch.setattr(pwd, "getpwnam", lambda _name: (_ for _ in ()).throw(KeyError(_name)))
@@ -337,7 +342,7 @@ def test_main_missing_agent_user_fails_closed_as_configuration_error(
     from mergecraft.main import main
 
     # Pretend we're root in the action image with a missing agent user.
-    monkeypatch.setattr(os, "getuid", lambda: 0)
+    _force_root(monkeypatch)
 
     def _raise_keyerror(_name: str) -> _FakePwnam:
         raise KeyError(_name)

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP5: checkout/config integrity helper",
-    strict=False,
-)
-
 _OUTSIDE_CANARY = "MERGECRAFT_OUTSIDE_CHECKOUT_CANARY_AP1"
 _PROVIDER_CANARY = "MERGECRAFT_PROVIDER_KEY_CANARY_AP1"
 

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -64,3 +64,23 @@ def test_hash_tree_does_not_follow_symlink_to_outside_file(tmp_path: Path) -> No
     (checkout / "escape").unlink()
     (checkout / "escape").symlink_to("../outside-secret.txt")
     assert hash_tree(checkout) != before
+
+
+def test_hash_tree_detects_directory_symlink_retarget(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import hash_tree
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    target_a = tmp_path / "target-a"
+    target_b = tmp_path / "target-b"
+    target_a.mkdir()
+    target_b.mkdir()
+    (target_a / "marker.txt").write_text("a\n", encoding="utf-8")
+    (target_b / "marker.txt").write_text("b\n", encoding="utf-8")
+    link = checkout / "linked-dir"
+    link.symlink_to(target_a, target_is_directory=True)
+
+    before = hash_tree(checkout)
+    link.unlink()
+    link.symlink_to(target_b, target_is_directory=True)
+    assert hash_tree(checkout) != before

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -46,3 +46,21 @@ def test_config_yaml_is_unwritable_during_review(tmp_path: Path) -> None:
     config.write_text("review: false\n", encoding="utf-8")
     with pytest.raises(RuntimeError):
         verify_tree_unchanged(checkout, before)
+
+
+def test_hash_tree_does_not_follow_symlink_to_outside_file(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import hash_tree
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    (checkout / "escape").symlink_to(outside)
+
+    before = hash_tree(checkout)
+    outside.write_text("tampered\n", encoding="utf-8")
+    assert hash_tree(checkout) == before
+
+    (checkout / "escape").unlink()
+    (checkout / "escape").symlink_to("../outside-secret.txt")
+    assert hash_tree(checkout) != before

--- a/tests/security/test_review_canary.py
+++ b/tests/security/test_review_canary.py
@@ -1,0 +1,53 @@
+"""Lane A AP1.4 — post-run integrity canaries for review sessions (MCB-06)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP5: checkout/config integrity helper",
+    strict=False,
+)
+
+_OUTSIDE_CANARY = "MERGECRAFT_OUTSIDE_CHECKOUT_CANARY_AP1"
+_PROVIDER_CANARY = "MERGECRAFT_PROVIDER_KEY_CANARY_AP1"
+
+
+def test_outside_checkout_canary_is_unreadable(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import assert_checkout_read_boundary
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    canary = outside / _OUTSIDE_CANARY
+    canary.write_text("secret\n", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        assert_checkout_read_boundary(checkout, [canary])
+
+
+def test_provider_key_canary_does_not_reach_a_local_sink(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import scan_local_sinks_for_secrets
+
+    sink = tmp_path / "sink.log"
+    sink.write_text("benign\n", encoding="utf-8")
+    assert _PROVIDER_CANARY not in scan_local_sinks_for_secrets(
+        tmp_path, secrets=[_PROVIDER_CANARY]
+    )
+
+
+def test_config_yaml_is_unwritable_during_review(tmp_path: Path) -> None:
+    from mergecraft.security.review_integrity import hash_tree, verify_tree_unchanged
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    config_dir = checkout / ".mergecraft"
+    config_dir.mkdir()
+    config = config_dir / "config.yaml"
+    config.write_text("review: true\n", encoding="utf-8")
+    before = hash_tree(checkout)
+    config.write_text("review: false\n", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        verify_tree_unchanged(checkout, before)

--- a/tests/security/test_shell_push_matrix.py
+++ b/tests/security/test_shell_push_matrix.py
@@ -73,6 +73,11 @@ class _RecordingGit:
 def recording_git(monkeypatch: pytest.MonkeyPatch) -> _RecordingGit:
     recorder = _RecordingGit()
     monkeypatch.setattr(git_mod, "_run_git", recorder)
+    monkeypatch.setattr(
+        git_mod,
+        "_origin_remote_url",
+        lambda cwd: "https://github.com/octo/repo.git",
+    )
     return recorder
 
 

--- a/tests/tracing/test_review_env_propagation.py
+++ b/tests/tracing/test_review_env_propagation.py
@@ -123,6 +123,7 @@ def test_privilege_error_still_surfaces_first(
 
     rc = review_context_module
     monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege_module, "_in_action_image", lambda: True)
     monkeypatch.setattr(privilege_module.shutil, "which", lambda _name: None)
 
     with (

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 _EXPECTED_SAFE_KEYS: tuple[str, ...] = (
     "core.fsmonitor=false",
-    "diff.external=",
     "core.hooksPath=/dev/null",
-    "uploadpack.packObjectsHook=",
     "core.sshCommand=ssh",
-    "core.gitProxy=",
     "protocol.ext.allow=never",
     "core.pager=cat",
 )
@@ -25,3 +22,19 @@ def test_git_argv_pins_every_safe_config_key() -> None:
     assert argv[-1] == "status"
     for key in _EXPECTED_SAFE_KEYS:
         assert key.split("=")[0] in flat
+
+
+def test_git_argv_injects_no_ext_diff_for_diff_family() -> None:
+    from mergecraft.utils.git_hardening import git_argv
+
+    diff_argv = git_argv(["diff", "HEAD"])
+    assert diff_argv[diff_argv.index("diff") + 1] == "--no-ext-diff"
+
+    show_argv = git_argv(["-C", "/repo", "show", "HEAD:README.md"])
+    assert show_argv[show_argv.index("show") + 1] == "--no-ext-diff"
+
+    log_argv = git_argv(["log", "-p", "-1"])
+    assert log_argv[log_argv.index("log") + 1] == "--no-ext-diff"
+
+    assert "--no-ext-diff" not in git_argv(["status"])
+    assert "--no-ext-diff" not in git_argv(["log", "-1", "--oneline"])

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 _EXPECTED_SAFE_KEYS: tuple[str, ...] = (
     "core.fsmonitor=false",
     "core.hooksPath=/dev/null",
@@ -66,3 +69,36 @@ def test_git_env_for_token_scopes_bearer_header_to_trusted_host() -> None:
     assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
     assert env["GIT_CONFIG_VALUE_0"] == "Authorization: Bearer ghs_secret"
     assert "http.extraHeader" not in env.values()
+
+
+def test_read_remote_origin_url_ignores_insteadof(tmp_path: Path) -> None:
+    from mergecraft.utils.git_hardening import read_remote_origin_url
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    remote = "https://github.com/acme/demo.git"
+    subprocess.run(
+        ["git", "remote", "add", "origin", remote],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    config_path = repo / ".git" / "config"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + """
+[url "https://attacker.example/"]
+\tinsteadOf = https://github.com/
+""",
+        encoding="utf-8",
+    )
+    expanded = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert "attacker.example" in expanded
+    assert read_remote_origin_url(str(repo)) == remote

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -1,0 +1,34 @@
+"""Lane A AP1.1 — ``git_argv`` pins every safe config key (MCB-01 / D2)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: utils/git_hardening.py lands",
+    strict=False,
+)
+
+_EXPECTED_SAFE_KEYS: tuple[str, ...] = (
+    "core.fsmonitor=false",
+    "diff.external=",
+    "core.hooksPath=/dev/null",
+    "uploadpack.packObjectsHook=",
+    "core.sshCommand=ssh",
+    "core.gitProxy=",
+    "protocol.ext.allow=never",
+    "core.pager=cat",
+)
+
+
+def test_git_argv_pins_every_safe_config_key() -> None:
+    from mergecraft.utils.git_hardening import GIT_SAFE_CONFIG, git_argv
+
+    flat = " ".join(GIT_SAFE_CONFIG)
+    for key in _EXPECTED_SAFE_KEYS:
+        assert key in flat, f"missing safe config pin: {key}"
+    argv = git_argv(["status"])
+    assert argv[0] == "git"
+    assert argv[-1] == "status"
+    for key in _EXPECTED_SAFE_KEYS:
+        assert key.split("=")[0] in flat

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -55,7 +55,22 @@ def test_git_authenticated_argv_pins_identity_rewrite_for_remote_url() -> None:
 
     remote = "https://github.com/acme/demo.git"
     argv = git_authenticated_argv(["fetch", "origin"], remote_url=remote)
-    assert f"url.{remote}.insteadOf={remote}" in " ".join(argv)
+    argv_text = " ".join(argv)
+    assert f"url.{remote}.insteadOf={remote}" in argv_text
+    assert "url.https://github.com/acme/demo.insteadOf=https://github.com/acme/demo" in argv_text
+
+
+def test_git_remote_identity_urls_includes_git_suffix_variants() -> None:
+    from mergecraft.utils.git_hardening import git_remote_identity_urls
+
+    assert git_remote_identity_urls("https://github.com/acme/demo") == (
+        "https://github.com/acme/demo.git",
+        "https://github.com/acme/demo",
+    )
+    assert git_remote_identity_urls("https://github.com/acme/demo.git") == (
+        "https://github.com/acme/demo.git",
+        "https://github.com/acme/demo",
+    )
 
 
 def test_git_env_for_token_scopes_bearer_header_to_trusted_host() -> None:

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -28,13 +28,20 @@ def test_git_argv_injects_no_ext_diff_for_diff_family() -> None:
     from mergecraft.utils.git_hardening import git_argv
 
     diff_argv = git_argv(["diff", "HEAD"])
-    assert diff_argv[diff_argv.index("diff") + 1] == "--no-ext-diff"
+    assert diff_argv[diff_argv.index("diff") + 1 : diff_argv.index("diff") + 3] == [
+        "--no-ext-diff",
+        "--no-textconv",
+    ]
 
     show_argv = git_argv(["-C", "/repo", "show", "HEAD:README.md"])
-    assert show_argv[show_argv.index("show") + 1] == "--no-ext-diff"
+    show_idx = show_argv.index("show")
+    assert show_argv[show_idx + 1 : show_idx + 3] == ["--no-ext-diff", "--no-textconv"]
 
     log_argv = git_argv(["log", "-p", "-1"])
-    assert log_argv[log_argv.index("log") + 1] == "--no-ext-diff"
+    log_idx = log_argv.index("log")
+    assert log_argv[log_idx + 1 : log_idx + 3] == ["--no-ext-diff", "--no-textconv"]
 
     assert "--no-ext-diff" not in git_argv(["status"])
+    assert "--no-textconv" not in git_argv(["status"])
     assert "--no-ext-diff" not in git_argv(["log", "-1", "--oneline"])
+    assert "--no-textconv" not in git_argv(["log", "-1", "--oneline"])

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -45,3 +45,24 @@ def test_git_argv_injects_no_ext_diff_for_diff_family() -> None:
     assert "--no-textconv" not in git_argv(["status"])
     assert "--no-ext-diff" not in git_argv(["log", "-1", "--oneline"])
     assert "--no-textconv" not in git_argv(["log", "-1", "--oneline"])
+
+
+def test_git_authenticated_argv_pins_identity_rewrite_for_remote_url() -> None:
+    from mergecraft.utils.git_hardening import git_authenticated_argv
+
+    remote = "https://github.com/acme/demo.git"
+    argv = git_authenticated_argv(["fetch", "origin"], remote_url=remote)
+    assert f"url.{remote}.insteadOf={remote}" in " ".join(argv)
+
+
+def test_git_env_for_token_scopes_bearer_header_to_trusted_host() -> None:
+    from mergecraft.utils.git_setup import git_env_for_token
+
+    env = git_env_for_token(
+        "ghs_secret",
+        remote_url="https://github.com/acme/demo.git",
+    )
+    assert env["GIT_CONFIG_COUNT"] == "1"
+    assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
+    assert env["GIT_CONFIG_VALUE_0"] == "Authorization: Bearer ghs_secret"
+    assert "http.extraHeader" not in env.values()

--- a/tests/utils/test_git_hardening.py
+++ b/tests/utils/test_git_hardening.py
@@ -2,13 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: utils/git_hardening.py lands",
-    strict=False,
-)
-
 _EXPECTED_SAFE_KEYS: tuple[str, ...] = (
     "core.fsmonitor=false",
     "diff.external=",

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -359,7 +359,7 @@ def test_setup_git_falls_back_to_primary_repo_state(
     )
     assert state.repos  # primary still present
     primary = next(iter(state.repos.values()))
-    assert primary.push_url == "https://github.com/other/elsewhere.git"
+    assert primary.push_url == "https://github.com/other/elsewhere"
 
 
 def test_wipe_preserves_active_temp_and_github_file_commands(

--- a/tests/utils/test_git_setup.py
+++ b/tests/utils/test_git_setup.py
@@ -12,10 +12,12 @@ from unittest.mock import MagicMock
 
 from mergecraft.utils import git_setup as git_setup_mod
 from mergecraft.utils.git_setup import (
+    _auth_header_prefixes,
     _is_under_forbidden_temp,
     _safe_temp_parent,
     cleanup_temp_directory,
     create_temp_directory,
+    git_env_for_token,
     register_created_path,
     setup_git,
     wipe_runner_leak_surface,
@@ -457,3 +459,37 @@ def test_write_askpass_chowns_when_root(monkeypatch: MonkeyPatch, tmp_path: Path
     askpass = write_askpass_script(str(tmp_path), "ghs_root_token")
     assert askpass in chown_targets or str(Path(askpass).parent) in chown_targets
     assert Path(askpass).is_file()
+
+
+def test_auth_header_prefixes_git_ssh_remote() -> None:
+    assert _auth_header_prefixes("git@github.com:acme/demo.git") == ("https://github.com/",)
+
+
+def test_auth_header_prefixes_https_remote() -> None:
+    assert _auth_header_prefixes("https://github.com/acme/demo.git") == ("https://github.com/",)
+    assert _auth_header_prefixes("http://gitlab.example.com/group/repo.git") == (
+        "http://gitlab.example.com/",
+    )
+
+
+def test_auth_header_prefixes_malformed_or_empty_fallback() -> None:
+    fallback = ("https://github.com/", "https://api.github.com/")
+    assert _auth_header_prefixes("") == fallback
+    assert _auth_header_prefixes("   ") == fallback
+    assert _auth_header_prefixes("not-a-url") == fallback
+
+
+def test_git_env_for_token_no_token_skips_config_pairs() -> None:
+    env = git_env_for_token("", remote_url="https://github.com/acme/demo.git")
+    assert env.get("GIT_CONFIG_COUNT") is None
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_git_env_for_token_hostile_rewritten_origin_stays_on_github() -> None:
+    """Bearer must scope to github.com even when checkout rewrites github URLs."""
+    env = git_env_for_token(
+        "ghs_secret",
+        remote_url="https://github.com/acme/demo.git",
+    )
+    assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
+    assert "attacker.example" not in str(env.values())

--- a/tests/utils/test_privilege.py
+++ b/tests/utils/test_privilege.py
@@ -21,6 +21,12 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
 
+def _force_action_image_root(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege, "_in_action_image", lambda: True)
+    monkeypatch.setattr(privilege, "_setpriv_supports_bounding_set", lambda: True)
+
+
 def test_agent_user_name_default(monkeypatch: MonkeyPatch) -> None:
     """Direct ``agent_user_name`` — defaults to ``mergecraft`` when unset/blank."""
     monkeypatch.delenv("MERGECRAFT_AGENT_USER", raising=False)
@@ -59,7 +65,7 @@ def test_wrap_agent_command_prefixes_setpriv_when_root(
     fake_pwd = MagicMock()
     fake_pwd.getpwnam.return_value = _Pw()
     monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setattr(privilege.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     wrapped = wrap_agent_command(["codex", "exec"])
@@ -81,7 +87,7 @@ def test_wrap_agent_command_skips_setpriv_when_missing(
     """
     from mergecraft.main import _ConfigurationError
 
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setattr(privilege.shutil, "which", lambda _name: None)
     with pytest.raises(_ConfigurationError, match="setpriv"):
         wrap_agent_command(["gemini", "run"])
@@ -103,7 +109,7 @@ def test_wrap_agent_subprocess_delegates_to_wrap_agent_command(
     fake_pwd = MagicMock()
     fake_pwd.getpwnam.return_value = _Pw()
     monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setattr(privilege.shutil, "which", lambda name: f"/usr/bin/{name}")
     wrapped = wrap_agent_subprocess(["opencode", "serve"])
     assert wrapped[0] == "setpriv"
@@ -146,7 +152,7 @@ def test_prepare_workspace_for_agent_chowns_when_root(
 
     fake_pwd = MagicMock()
     fake_pwd.getpwnam.return_value = _Pw()
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
     monkeypatch.setattr(privilege.subprocess, "run", _fake_run)
@@ -154,10 +160,10 @@ def test_prepare_workspace_for_agent_chowns_when_root(
     prepare_workspace_for_agent(str(tmp_path))
 
     assert calls, "prepare_workspace_for_agent must chown when root"
-    assert calls[0][0] == "chown"
-    assert calls[0][1] == "-R"
-    assert calls[0][2] == "1001:1001"
-    assert calls[0][3] == str(tmp_path)
+    assert calls[0][0] == "find"
+    assert "chown" in calls[0]
+    assert calls[0][-3] == "1001:1001"
+    assert calls[0][1] == str(tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +213,7 @@ def test_agent_subprocess_env_redirects_inherited_home_when_root(
     the runner's original uid), setpriv drops uid/gid but not HOME, and the
     agent CLI then hits EACCES trying to write dotfiles under it.
     """
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     _install_fake_pwd(monkeypatch, _PwWithHome())
     # /github/home is not owned by uid 1001 in this scenario.
@@ -234,7 +240,7 @@ def test_agent_subprocess_env_preserves_home_already_owned_by_agent_user(
     clobber that back to the passwd home directory, or Gemini's MCP config
     silently stops resolving under the privilege drop.
     """
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     entry = _PwWithHome()
     _install_fake_pwd(monkeypatch, entry)
@@ -251,7 +257,7 @@ def test_agent_subprocess_env_preserves_home_already_owned_by_agent_user(
 
 def test_agent_subprocess_env_fills_missing_home(monkeypatch: MonkeyPatch) -> None:
     """No ``HOME`` key at all → still filled in with the agent user's real home."""
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     _install_fake_pwd(monkeypatch, _PwWithHome())
 
@@ -264,7 +270,7 @@ def test_agent_subprocess_env_missing_user_fails_closed(monkeypatch: MonkeyPatch
     """Same fail-closed contract as ``wrap_agent_command`` — missing agent user raises."""
     from mergecraft.main import _ConfigurationError
 
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
 
     import sys
@@ -285,7 +291,7 @@ def test_agent_subprocess_env_uid_zero_fails_closed(monkeypatch: MonkeyPatch) ->
     """Same fail-closed contract — a user resolving to UID/GID 0 raises, not redirects."""
     from mergecraft.main import _ConfigurationError
 
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
     _install_fake_pwd(monkeypatch, _PwWithHome(uid=0, gid=0))
 
@@ -295,7 +301,7 @@ def test_agent_subprocess_env_uid_zero_fails_closed(monkeypatch: MonkeyPatch) ->
 
 def test_agent_subprocess_env_custom_agent_user_via_env(monkeypatch: MonkeyPatch) -> None:
     """``MERGECRAFT_AGENT_USER`` drives which pwd entry is resolved, same as ``wrap_agent_command``."""
-    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    _force_action_image_root(monkeypatch)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "reviewer")
     _install_fake_pwd(
         monkeypatch, _PwWithHome(name="reviewer", uid=1002, gid=1002, home="/home/reviewer")

--- a/tests/utils/test_privilege_chown.py
+++ b/tests/utils/test_privilege_chown.py
@@ -1,7 +1,8 @@
-"""Lane A AP1.1 — ``prepare_workspace_for_agent`` must not chown ``.git`` (D3)."""
+"""Lane A AP1.1 — ``prepare_workspace_for_agent`` chown safety (D3)."""
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -12,20 +13,7 @@ import mergecraft.utils.privilege as privilege
 from mergecraft.utils.privilege import prepare_workspace_for_agent
 
 
-@pytest.mark.xfail(
-    reason="green after AP2: prune .git from recursive chown",
-    strict=False,
-)
-def test_prepare_workspace_does_not_chown_dot_git(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    repo = tmp_path / "workspace"
-    repo.mkdir()
-    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
-    dot_git = repo / ".git"
-    assert dot_git.exists()
-    before_uid = dot_git.stat().st_uid
-
+def _fake_agent_pwd(monkeypatch: pytest.MonkeyPatch, *, real_chown: bool = False) -> None:
     class _Pw:
         pw_uid = 10001
         pw_gid = 10001
@@ -36,8 +24,67 @@ def test_prepare_workspace_does_not_chown_dot_git(
     monkeypatch.setitem(__import__("sys").modules, "pwd", fake_pwd)
     monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
     monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+    if real_chown:
+        monkeypatch.setenv("MERGECRAFT_ALLOW_ROOT", "1")
+    else:
+        monkeypatch.setattr(privilege, "_in_action_image", lambda: True)
+        monkeypatch.setattr(privilege, "_setpriv_supports_bounding_set", lambda: True)
+
+
+def test_prepare_workspace_does_not_chown_dot_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    dot_git = repo / ".git"
+    assert dot_git.exists()
+    before_uid = dot_git.stat().st_uid
+
+    _fake_agent_pwd(monkeypatch)
 
     prepare_workspace_for_agent(str(repo))
 
     after_uid = dot_git.stat().st_uid
     assert after_uid == before_uid, ".git must not be chowned to the agent user"
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="requires root to chown workspace paths")
+def test_prepare_workspace_does_not_chown_symlink_target_outside_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("keep-owner", encoding="utf-8")
+    before_uid = secret.stat().st_uid
+
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    (repo / "link").symlink_to(secret)
+
+    _fake_agent_pwd(monkeypatch, real_chown=True)
+
+    prepare_workspace_for_agent(str(repo))
+
+    after_uid = secret.stat().st_uid
+    assert after_uid == before_uid, "symlink target outside workspace must keep its owner"
+
+
+def test_prepare_workspace_uses_chown_no_dereference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        calls.append(list(cmd))
+        return MagicMock(returncode=0)
+
+    _fake_agent_pwd(monkeypatch)
+    monkeypatch.setattr(privilege.subprocess, "run", _fake_run)
+
+    prepare_workspace_for_agent(str(tmp_path))
+
+    assert calls, "prepare_workspace_for_agent must invoke chown when root"
+    chown_idx = calls[0].index("chown")
+    assert calls[0][chown_idx + 1] == "-h", "chown must use -h to avoid following symlinks"

--- a/tests/utils/test_privilege_chown.py
+++ b/tests/utils/test_privilege_chown.py
@@ -1,0 +1,44 @@
+"""Lane A AP1.1 — ``prepare_workspace_for_agent`` must not chown ``.git`` (D3)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import mergecraft.utils.privilege as privilege
+from mergecraft.utils.privilege import prepare_workspace_for_agent
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: prune .git from recursive chown",
+    strict=False,
+)
+
+
+def test_prepare_workspace_does_not_chown_dot_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    dot_git = repo / ".git"
+    assert dot_git.exists()
+    before_uid = dot_git.stat().st_uid
+
+    class _Pw:
+        pw_uid = 10001
+        pw_gid = 10001
+        pw_name = "mergecraft"
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(__import__("sys").modules, "pwd", fake_pwd)
+    monkeypatch.setattr(privilege.os, "getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_AGENT_USER", "mergecraft")
+
+    prepare_workspace_for_agent(str(repo))
+
+    after_uid = dot_git.stat().st_uid
+    assert after_uid == before_uid, ".git must not be chowned to the agent user"

--- a/tests/utils/test_privilege_chown.py
+++ b/tests/utils/test_privilege_chown.py
@@ -11,12 +11,11 @@ import pytest
 import mergecraft.utils.privilege as privilege
 from mergecraft.utils.privilege import prepare_workspace_for_agent
 
-pytestmark = pytest.mark.xfail(
+
+@pytest.mark.xfail(
     reason="green after AP2: prune .git from recursive chown",
     strict=False,
 )
-
-
 def test_prepare_workspace_does_not_chown_dot_git(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/utils/test_privilege_identity.py
+++ b/tests/utils/test_privilege_identity.py
@@ -43,10 +43,6 @@ def test_in_action_image_detects_is_sandbox_and_opt_dir(monkeypatch: pytest.Monk
     assert _in_action_image() is True
 
 
-@pytest.mark.xfail(
-    reason="green after AP6: image identity gate + hardened setpriv argv",
-    strict=False,
-)
 def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -64,6 +60,10 @@ def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
     monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
     monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: True)
     monkeypatch.setattr("mergecraft.utils.privilege.shutil.which", lambda _n: "/usr/bin/setpriv")
+    monkeypatch.setattr(
+        "mergecraft.utils.privilege._setpriv_supports_bounding_set",
+        lambda: True,
+    )
     argv = wrap_agent_command(["agent"])
     assert "--no-new-privs" in argv
     assert "--inh-caps=-all" in argv

--- a/tests/utils/test_privilege_identity.py
+++ b/tests/utils/test_privilege_identity.py
@@ -1,0 +1,67 @@
+"""Lane A AP1.5 — privilege identity gates (MCB-24 / MCB-32 / D11)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.utils.privilege import wrap_agent_command
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
+
+
+def test_root_outside_action_image_refuses_with_policy_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mergecraft.main import _ConfigurationError
+
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.delenv("MERGECRAFT_ALLOW_ROOT", raising=False)
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: False)
+    with pytest.raises(_ConfigurationError, match=r"policy|action image|MERGECRAFT_ALLOW_ROOT"):
+        wrap_agent_command(["echo", "hi"])
+
+
+def test_allow_root_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.setenv("MERGECRAFT_ALLOW_ROOT", "1")
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: False)
+    monkeypatch.setattr("mergecraft.utils.privilege.shutil.which", lambda _n: "/usr/bin/setpriv")
+    wrapped = wrap_agent_command(["echo", "hi"])
+    assert wrapped[0] == "setpriv"
+
+
+def test_in_action_image_detects_is_sandbox_and_opt_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mergecraft.utils.privilege import _in_action_image
+
+    monkeypatch.setenv("IS_SANDBOX", "1")
+    monkeypatch.setattr(
+        "mergecraft.utils.privilege.Path.is_dir",
+        lambda self: str(self).endswith("/opt/mergecraft"),
+    )
+    assert _in_action_image() is True
+
+
+def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    from unittest.mock import MagicMock
+
+    class _Pw:
+        pw_uid = 10001
+        pw_gid = 10001
+        pw_name = "mergecraft"
+
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _Pw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+    monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
+    monkeypatch.setattr("mergecraft.utils.privilege._in_action_image", lambda: True)
+    monkeypatch.setattr("mergecraft.utils.privilege.shutil.which", lambda _n: "/usr/bin/setpriv")
+    argv = wrap_agent_command(["agent"])
+    assert "--no-new-privs" in argv
+    assert "--inh-caps=-all" in argv
+    assert "--bounding-set=-all" in argv

--- a/tests/utils/test_privilege_identity.py
+++ b/tests/utils/test_privilege_identity.py
@@ -6,11 +6,6 @@ import pytest
 
 from mergecraft.utils.privilege import wrap_agent_command
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP6: image identity gate + hardened setpriv argv",
-    strict=False,
-)
-
 
 def test_root_outside_action_image_refuses_with_policy_message(
     monkeypatch: pytest.MonkeyPatch,
@@ -24,6 +19,10 @@ def test_root_outside_action_image_refuses_with_policy_message(
         wrap_agent_command(["echo", "hi"])
 
 
+@pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
 def test_allow_root_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("mergecraft.utils.privilege.os.getuid", lambda: 0)
     monkeypatch.setenv("MERGECRAFT_ALLOW_ROOT", "1")
@@ -44,6 +43,10 @@ def test_in_action_image_detects_is_sandbox_and_opt_dir(monkeypatch: pytest.Monk
     assert _in_action_image() is True
 
 
+@pytest.mark.xfail(
+    reason="green after AP6: image identity gate + hardened setpriv argv",
+    strict=False,
+)
 def test_setpriv_argv_carries_no_new_privs_and_cleared_caps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -1,0 +1,55 @@
+"""Lane A AP1.1 — manifest / xrepo rev guards (MCB-33)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mergecraft.xrepo.review import _rev_parse_commit
+
+pytestmark = pytest.mark.xfail(
+    reason="green after AP2: reject_if_leading_dash + --end-of-options in _rev_parse_commit",
+    strict=False,
+)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "linked"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    (repo / "f").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "f"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def test_leading_dash_rev_is_rejected(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    with pytest.raises(ValueError, match=r"dash|ref|rev"):
+        _rev_parse_commit(repo, "-evil")
+
+
+def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert _rev_parse_commit(repo, sha) == sha

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -9,11 +9,6 @@ import pytest
 
 from mergecraft.xrepo.review import _rev_parse_commit
 
-pytestmark = pytest.mark.xfail(
-    reason="green after AP2: reject_if_leading_dash + --end-of-options in _rev_parse_commit",
-    strict=False,
-)
-
 
 def _init_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "linked"

--- a/tests/xrepo/test_rev_parse_guards.py
+++ b/tests/xrepo/test_rev_parse_guards.py
@@ -43,9 +43,17 @@ def test_leading_dash_rev_is_rejected(tmp_path: Path) -> None:
         _rev_parse_commit(repo, "-evil")
 
 
-def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
+def test_rev_parse_passes_end_of_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _init_repo(tmp_path)
-    sha = subprocess.run(
+    seen: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _record_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.append(list(cmd))
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(subprocess, "run", _record_run)
+    sha = real_run(
         ["git", "rev-parse", "HEAD"],
         cwd=repo,
         capture_output=True,
@@ -53,3 +61,4 @@ def test_rev_parse_passes_end_of_options(tmp_path: Path) -> None:
         check=True,
     ).stdout.strip()
     assert _rev_parse_commit(repo, sha) == sha
+    assert any("--end-of-options" in argv for argv in seen)


### PR DESCRIPTION
## What?

Promotes the staged work on pre-0.0.1 to the default branch, and refreshes the self-review Action pin so the reviewer actually runs it. Three things land together.

- Lane A privilege and execution boundary remediation (#519): sandboxed review sessions lose webfetch and unscoped reads, the checkout is hashed before and after review and fails closed on mutation, the privilege drop gates on action-image identity rather than uid alone, and root-side git calls route through a hardened argv builder.
- Logfire tracing reaches CI reviews (#531): the review workflow passes its tracing settings, the Action image carries the tracing dependencies, and workflow wiring can target a data region.
- The Action pin on both review steps moves to the tip being promoted.

## Why?

Reviews run on the default branch definition, so nothing staged here affects an actual review until it lands. Both lanes are inert on pre-0.0.1.

The tracing lane exists to answer questions an operator currently cannot: a review that runs long, chooses the wrong model, or blocks a merge leaves no record of which tools it called or where the time went, because the runner is gone by the time anyone asks.

The pin refresh is what makes any of it take effect. The previous pin dated to 23 August and sat 107 commits behind on product code, so every review since then executed a build that stale. Two costs were already paid for it. That build runs its dependency sync without the tracing extra, so the wiring above would have resolved to a no-op sink and exported nothing while reporting success. And analyzer defects fixed weeks ago kept surfacing in Action logs, which is how #527 came to be filed against bugs that no longer existed in the tree.

## Note

The pin moves to `b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5`, the pre-0.0.1 tip this PR promotes, verified to carry both the image change and the lane A hardening. This follows how #456 and #463 handled promotion.

Merging advances the reviewer 107 commits in one step. `mergecraft review` is a required check, so a regression in the reviewer itself blocks every open PR. The alternative was leaving the drift in place, which is not neutral: it is what produced the two costs above.

`make action-pin-check` currently reports the inverse condition on this branch, that main still pins the old SHA and is 268 commits behind. That is the guard asking for exactly this merge, and it clears once both branches carry the same pin.

The guard staying silent through 107 commits of drift is its own defect, tracked in #532: the target is absent from `ci-static` and `CI_STEPS`, which carry the similarly named `pins-check`, and its one invocation downgrades failure to a warning annotation on a green job.

The `LOGFIRE_TOKEN` secret and `LOGFIRE_PROJECT` variable are already configured on this repository.

## Test plan

- [x] `make lint`, `make typecheck`, `make docs-check` clean on the merged tree
- [x] `tests/action` and `tests/cli/test_workflow_cmd.py` pass after the pin bump
- [x] Workflow re-parses and both review steps resolve to the new pin
- [ ] After merge: confirm a review emits spans to Logfire and reports `ran=True` from the analyzer pipeline

## Related PR(s)/Issue(s)

Promotes #519 and #531.
Follow-up: #532, #526, #528, #529, #530.
