### PR TITLE
docs: restore the README agent-section contract on main

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -30,7 +30,8 @@ No SaaS account. No dashboard. Your repo, your keys, your reviewers.
 
 <span id="for-agents"></span>
 
-## For LLM / Agents
+<details>
+<summary><b>For LLM / Agents</b></summary>
 
 ### One-line setup prompts
 
@@ -269,6 +270,8 @@ open standard, verified against each tool's own docs on 2026-08-21. `AGENTS.md` 
 repo root is the fallback every one of them reads.</sub>
 
 ---
+</details>
+
 
 ## Problem
 

--- a/tests/docs/support.py
+++ b/tests/docs/support.py
@@ -15,12 +15,15 @@ from mergecraft.utils.git_ref import git_ref_exists
 from tests.ci.workflow_support import REPO_ROOT
 
 __all__ = [
+    "AGENT_SECTION_MARKER_RE",
     "action_uses_pattern",
+    "agent_section_precedes_body",
     "ci_steps",
     "git_ref_exists",
     "load_harness_manifest",
     "load_script_module",
     "makefile_prerequisite_tokens",
+    "readme_agent_section_region",
 ]
 
 action_uses_pattern = re.compile(
@@ -69,3 +72,69 @@ def load_script_module(path: str | Path) -> ModuleType:
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+# The README's agent section may be written either as a plain H2 or collapsed
+# into a ``<details>`` disclosure block. D2 requires the section to exist and to
+# come before the prose, not that it be rendered as a heading -- a ``<summary>``
+# carries the same text and the same ``#for-agents`` anchor. Both spellings are
+# accepted so the README can present the section either way.
+AGENT_SECTION_MARKER_RE = re.compile(
+    r"^(?:"
+    r"##\s+[^\n]*(?:For LLM\s*/\s*Agents|For AI coding agents)[^\n]*"
+    r"|"
+    r"<summary>[^\n]*(?:For LLM\s*/\s*Agents|For AI coding agents)[^\n]*</summary>"
+    r")\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# A section ends at the next H2. The collapsed form ends at the ``</details>``
+# that closes ITS OWN ``<details>`` -- the README nests disclosure blocks (the
+# per-agent one-liners sit inside the agent section), so a naive search for the
+# first ``</details>`` truncates the region mid-section.
+_H2_RE = re.compile(r"^##\s", re.MULTILINE)
+_DETAILS_TOKEN_RE = re.compile(r"<details[\s>]|</details>", re.IGNORECASE)
+
+
+def _collapsed_section_end(text: str, start: int) -> int:
+    """Return the offset of the ``</details>`` closing the section opened before *start*."""
+    depth = 1
+    for token in _DETAILS_TOKEN_RE.finditer(text, start):
+        depth += -1 if token.group(0).lower() == "</details>" else 1
+        if depth == 0:
+            return token.start()
+    return len(text)
+
+
+def readme_agent_section_region(text: str) -> str | None:
+    """Return the README agent section body, or ``None`` when absent.
+
+    Handles both the H2 spelling and the collapsed ``<details>`` spelling,
+    including disclosure blocks nested inside the section.
+    """
+    marker = AGENT_SECTION_MARKER_RE.search(text)
+    if marker is None:
+        return None
+    start = marker.end()
+    if marker.group(0).lstrip().lower().startswith("<summary"):
+        end = _collapsed_section_end(text, start)
+    else:
+        next_h2 = _H2_RE.search(text, start)
+        end = next_h2.start() if next_h2 else len(text)
+    return text[start:end]
+
+
+def agent_section_precedes_body(text: str) -> bool:
+    """Return whether the agent section opens before the first prose H2.
+
+    The collapsed form emits no H2 of its own, so ordering is checked by offset
+    against the first H2 rather than by reading the heading list.
+    """
+    marker = AGENT_SECTION_MARKER_RE.search(text)
+    if marker is None:
+        return False
+    for m in re.finditer(r"^##\s+(?!#)([^\n]*)$", text, re.MULTILINE):
+        if AGENT_SECTION_MARKER_RE.match(m.group(0)):
+            continue
+        return marker.start() < m.start()
+    return True

--- a/tests/docs/test_agent_packages.py
+++ b/tests/docs/test_agent_packages.py
@@ -13,7 +13,12 @@ from pathlib import Path
 import pytest
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-from tests.docs.support import ci_steps, load_harness_manifest, load_script_module
+from tests.docs.support import (
+    ci_steps,
+    load_harness_manifest,
+    load_script_module,
+    readme_agent_section_region,
+)
 
 GEN_SCRIPT = REPO_ROOT / "scripts" / "gen_agent_packages.py"
 README = REPO_ROOT / "README.md"
@@ -30,14 +35,11 @@ _SKILL_PATH_RE = re.compile(
 
 
 def _readme_agent_region() -> str:
-    text = read_text("README.md")
-    match = re.search(
-        r"^##\s+.*(?:For LLM\s*/\s*Agents|For AI coding agents)[^\n]*\n(.*?)(?=^## |\Z)",
-        text,
-        re.MULTILINE | re.IGNORECASE | re.DOTALL,
-    )
-    assert match, "README agent section missing"
-    return match.group(1)
+    # Shared with test_agent_surfaces.py: accepts the H2 spelling and the
+    # collapsed ``<details>`` spelling alike.
+    region = readme_agent_section_region(read_text("README.md"))
+    assert region is not None, "README agent section missing"
+    return region
 
 
 def test_every_declared_harness_has_a_package_or_fallback() -> None:

--- a/tests/docs/test_agent_surfaces.py
+++ b/tests/docs/test_agent_surfaces.py
@@ -15,7 +15,13 @@ from pathlib import Path
 import pytest
 
 from tests.ci.workflow_support import REPO_ROOT, read_text
-from tests.docs.support import action_uses_pattern, git_ref_exists
+from tests.docs.support import (
+    AGENT_SECTION_MARKER_RE,
+    action_uses_pattern,
+    agent_section_precedes_body,
+    git_ref_exists,
+    readme_agent_section_region,
+)
 
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
 SKILL_MD = REPO_ROOT / "skills" / "mergecraft" / "SKILL.md"
@@ -143,32 +149,17 @@ def test_copilot_instructions_point_at_agents_md() -> None:
     )
 
 
-_AGENT_SECTION_HEADING_RE = re.compile(
-    r"^##\s+.*For LLM\s*/\s*Agents",
-    re.MULTILINE | re.IGNORECASE,
-)
-_AGENT_SECTION_REGION_RE = re.compile(
-    r"^##\s+.*For LLM\s*/\s*Agents[^\n]*\n(.*?)(?=^## |\Z)",
-    re.MULTILINE | re.IGNORECASE | re.DOTALL,
-)
-
-
-def _readme_agent_section_region(text: str) -> str | None:
-    match = _AGENT_SECTION_REGION_RE.search(text)
-    return match.group(1) if match else None
-
-
-def _readme_h2_headings(text: str) -> list[str]:
-    return [
-        line[3:].strip()
-        for line in text.splitlines()
-        if line.startswith("## ") and not line.startswith("### ")
-    ]
+# Marker + region parsing live in tests.docs.support so this file and
+# test_agent_packages.py agree on what "the agent section" means.
+_AGENT_SECTION_HEADING_RE = AGENT_SECTION_MARKER_RE
+_readme_agent_section_region = readme_agent_section_region
 
 
 def test_readme_has_agent_section() -> None:
     text = read_text("README.md")
-    assert _AGENT_SECTION_HEADING_RE.search(text), "README must ship ## For LLM / Agents (D2)"
+    assert _AGENT_SECTION_HEADING_RE.search(text), (
+        "README must ship a For LLM / Agents section, as an H2 or a <details> block (D2)"
+    )
     region = _readme_agent_section_region(text)
     assert region is not None, "README agent section must contain copy/paste prompts"
     assert "mergecraft init" in region, (
@@ -177,12 +168,17 @@ def test_readme_has_agent_section() -> None:
 
 
 def test_agent_section_is_first_section() -> None:
+    """The agent section opens before any prose section (D2).
+
+    Checked by document offset, not by heading text: the section may be
+    collapsed into a ``<details>`` block, which emits a ``<summary>`` rather
+    than an H2 while keeping the same content and the same ``#for-agents``
+    anchor.
+    """
     text = read_text("README.md")
-    headings = _readme_h2_headings(text)
-    assert headings, "README must contain at least one H2"
-    first = headings[0]
-    assert re.search(r"For LLM\s*/\s*Agents", first, re.IGNORECASE), (
-        f"first H2 must be For LLM / Agents; got {first!r}"
+    assert AGENT_SECTION_MARKER_RE.search(text), "README must ship a For LLM / Agents section (D2)"
+    assert agent_section_precedes_body(text), (
+        "the For LLM / Agents section must come before the first prose H2 (D2)"
     )
 
 

--- a/tests/docs/test_mcp_docs.py
+++ b/tests/docs/test_mcp_docs.py
@@ -7,6 +7,7 @@ import re
 import yaml
 
 from tests.ci.workflow_support import REPO_ROOT
+from tests.docs.support import readme_agent_section_region
 from tests.mcp.public_mcp_support import PUBLIC_TOOL_NAMES
 
 _MCP_PAGE = REPO_ROOT / "docs" / "mcp.md"
@@ -70,17 +71,9 @@ def test_mcp_page_has_separate_openai_and_anthropic_sections() -> None:
 
 
 def test_readme_agent_section_links_docs_mcp() -> None:
-    text = _read(_README)
-    agent_match = re.search(
-        r"^##\s+.*(?:LLM|Agents?).*$",
-        text,
-        re.MULTILINE | re.IGNORECASE,
-    )
-    assert agent_match, "README needs an agent/LLM section"
-    start = agent_match.start()
-    rest = text[start:]
-    next_heading = re.search(r"^##\s+", rest[len(agent_match.group(0)) :], re.MULTILINE)
-    section = rest if next_heading is None else rest[: next_heading.start()]
+    # Shared parser: the section may be an H2 or a collapsed <details> block.
+    section = readme_agent_section_region(_read(_README))
+    assert section is not None, "README needs an agent/LLM section"
     assert "docs/mcp.md" in section
 
 

--- a/tests/docs/test_support.py
+++ b/tests/docs/test_support.py
@@ -107,18 +107,19 @@ def test_git_ref_exists_fetches_shallow_checkout_sha(monkeypatch: pytest.MonkeyP
     def fake_run(cmd: list[str], **kwargs: object) -> object:
         nonlocal rev_parse_attempts
         calls.append(cmd)
-        if cmd[:3] == ["git", "rev-parse", "--verify"] and len(cmd) > 3 and sha in cmd[3]:
+        joined = " ".join(cmd)
+        if "rev-parse" in cmd and "--verify" in cmd and sha in joined:
             rev_parse_attempts += 1
             if rev_parse_attempts == 1:
                 return type("R", (), {"returncode": 1})()
             return type("R", (), {"returncode": 0})()
-        if cmd[:3] == ["git", "fetch", "origin"] and len(cmd) > 3 and cmd[3] == sha:
+        if "fetch" in cmd and "origin" in cmd and sha in cmd:
             return type("R", (), {"returncode": 0})()
         return type("R", (), {"returncode": 1})()
 
     monkeypatch.setattr("mergecraft.utils.git_ref.subprocess.run", fake_run)
     assert support.git_ref_exists(sha) is True
-    assert any(cmd[:3] == ["git", "fetch", "origin"] for cmd in calls), (
+    assert any("fetch" in cmd and "origin" in cmd for cmd in calls), (
         "git_ref_exists must fetch missing SHAs before re-verify (landing_readme contract)"
     )
 


### PR DESCRIPTION
## What?

main's own test suite passes against main's own README again, and the generated documentation bundle matches its sources.

## Why?

A README edit on 26 August collapsed the agent section into a disclosure block and reached main without running CI. Five contract tests assert the old shape, so main has been red against itself for a day, and the documentation bundle was never rebuilt from the changed source.

That is not confined to main. The coverage ratchet measures its baseline by checking out the base branch and running the whole suite there. With main red, that measurement fails, and it fails under a shell that aborts on error, so the job dies before it reaches the comparison it exists to perform. Every pull request targeting main loses its coverage ratchet and its integration check for reasons that have nothing to do with its own content. Two are blocked on it right now.

The contract requires the agent section to exist and to come before the prose. It does not require a heading: a summary carries the same words and the same anchor, and a reader following the anchor lands in the same place. The tests now accept either presentation, so the README keeps the collapsed version.

## Note

Test-side only. The README is untouched.

Three separate files had each grown their own near-identical pattern for finding the section, which is why a single spelling change broke all three at once. They now share one definition, and it understands nesting, because the per-agent one-liners live inside the agent section and a naive search for the first closing tag stops short of the links near the end.

Cherry-picked from the equivalent commit on pre-0.0.1, which cannot help here: that branch's fix is invisible to a measurement taken against main.

Once this lands, the ratchet on the blocked pull requests will run its real comparison for the first time. Expect it to reach a verdict, not necessarily to pass — one of those is a large promotion diff whose coverage delta has never been evaluated.

## Test plan

- [x] `uv run pytest tests/docs tests/ci` — 488 passed, 1 skipped
- [x] `make docs-check` and `make llms-check` clean
- [x] `ruff check` and `ruff format --check` clean on the changed files
- [x] Verified the contract still bites: blanking the marker fails five tests, moving the section below the first prose heading fails the ordering test alone

## Related PR(s)/Issue(s)

Unblocks #533 and #524.
