### PR TITLE
perf(ci): resolve PR number on workflow_dispatch

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -351,17 +351,39 @@ jobs:
             echo "::notice title=mergecraft skipped::Configure CODEX_AUTH_JSON (mergecraft auth codex), OPENAI_API_KEY, or NOUS_API_KEY to enable mergeCraft reviews."
           fi
 
+      - name: Resolve PR for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: dispatch_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Same-repo dispatch: the ref is the head branch. An empty number is a
+          # real outcome (no open PR) — Compose then falls back to the bare
+          # string rather than failing the job (#529).
+          pr_json="$(gh pr list --repo "${{ github.repository }}" \
+                --head "${{ github.ref_name }}" --state open \
+                --json number,baseRefName --jq '.[0] // {}')"
+          n="$(printf '%s' "${pr_json}" | jq -r '.number // ""')"
+          base="$(printf '%s' "${pr_json}" | jq -r '.baseRefName // ""')"
+          {
+            echo "number=${n}"
+            echo "base_ref=${base}"
+          } >> "${GITHUB_OUTPUT}"
+
       # Composed in a step rather than inline in `with:` so the CI-context clause
       # stays readable. Every interpolated value is repo-controlled (PR number,
       # base ref, our own wait-job outputs) — no PR-authored free text reaches the
-      # prompt.
+      # prompt. pull_request_target and workflow_dispatch share one prompt shape
+      # (#529): an explicit inputs.prompt stays verbatim; a resolved PR number
+      # gets the checkout_pr + CI-context text; no matching PR falls back to the
+      # bare string.
       - name: Compose review prompt
         id: prompt
         if: env.HAS_AUTH == 'true'
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.dispatch_pr.outputs.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || steps.dispatch_pr.outputs.base_ref }}
           DISPATCH_PROMPT: ${{ inputs.prompt }}
           CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
           CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
@@ -369,8 +391,11 @@ jobs:
           CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
-            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          if [ -n "${DISPATCH_PROMPT:-}" ]; then
+            # Operator override: pass through unchanged (#529).
+            text="${DISPATCH_PROMPT}"
+          elif [ -z "${PR_NUMBER:-}" ]; then
+            text="Review the current pull request."
           else
             # Codex presents mergeCraft MCP tools as mergecraft_. Naming the
             # bare tool (checkout_pr) makes Codex request a GitHub *plugin* that is
@@ -379,7 +404,8 @@ jobs:
             text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
             # The Action runs with `shell: disabled`, so the reviewer cannot run
             # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
-            # check_suite id, because no MCP tool can discover one.
+            # check_suite id, because no MCP tool can discover one. wait-for-ci
+            # outputs are available on workflow_dispatch too (#529).
             case "${CI_STATE}" in
               complete)
                 if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ evals/results/structural-replay-convergence-*.json
 # `git worktree remove`, this just keeps them out of `git status`/`find`).
 /mergecraft-*/
 
+# Isolated git worktrees (local operator checkouts)
+.worktrees/
+
 # mergeCraft's own runtime cache/scratch state, provisioned into <repo>/.mergecraft/
 # on every self-review run (analyzer-cache/, analyzer-scratch/, analyzer-runs/,
 # analyzers.lock, .provision.lock, traces/) — regenerated every run, never source

--- a/src/mergecraft/mcp/git_guards.py
+++ b/src/mergecraft/mcp/git_guards.py
@@ -55,16 +55,19 @@ _READONLY_SUBCOMMANDS: frozenset[str] = frozenset(
         "cat-file",
         "rev-list",
         "branch",
+        "grep",
     }
 )
-# Rejected verbs that have a dedicated tool. Not an auth gate — a redirect
-# table, consulted before the allowlist so the agent is told where to go rather
-# than only that it cannot go here.
+# Rejected verbs that have a dedicated tool or a clear alternative. Not an
+# auth gate — a redirect table, consulted before the allowlist so the agent
+# is told where to go rather than only that it cannot go here.
 _REDIRECT_TO_TOOL: dict[str, str] = {
     "push": "use push_branch instead",
     "fetch": "use git_fetch instead",
     "pull": "use git_fetch then git merge",
     "clone": "use checkout_repo / checkout_pr",
+    "remote": "use git branch --remotes instead",
+    "config": "use git rev-parse for repository paths and refs",
 }
 # Flags that enable arbitrary code execution via git alias expansion.
 # Rejected unconditionally regardless of payload.shell (#257 / D7).
@@ -122,6 +125,9 @@ _SUBCOMMAND_SHORT_FLAGS: dict[str, frozenset[str]] = {
     # write letter — ``d``/``D``/``m``/``M``/``c``/``C`` — is absent, which is
     # what keeps the bundled write forms refused.
     "branch": frozenset("arvi"),
+    # git grep: -c is --count (not git's config flag), -C is context lines
+    # (not chdir; see _SUBCOMMAND_OWNS_DASH_C), and -o is --only-matching.
+    "grep": frozenset("aABCcEefFGHhiIlLmnoPpqrvWwz"),
 }
 
 # ---------------------------------------------------------------------------
@@ -129,10 +135,13 @@ _SUBCOMMAND_SHORT_FLAGS: dict[str, frozenset[str]] = {
 # ---------------------------------------------------------------------------
 # Subcommands that define ``-C`` themselves, where it is not git's chdir option
 # and must not be pulled into the global slot. It means find-copies to ``diff``,
-# ``log`` and ``show``, whitespace-insensitive blame to ``blame``, and
-# copy-force to ``branch`` — a write, which ``_reject_branch_writes`` refuses on
-# its own; what matters here is only that none of them is the chdir option.
-_SUBCOMMAND_OWNS_DASH_C: frozenset[str] = frozenset({"diff", "log", "show", "blame", "branch"})
+# ``log`` and ``show``, whitespace-insensitive blame to ``blame``, context
+# lines to ``grep``, and copy-force to ``branch`` — a write, which
+# ``_reject_branch_writes`` refuses on its own; what matters here is only that
+# none of them is the chdir option.
+_SUBCOMMAND_OWNS_DASH_C: frozenset[str] = frozenset(
+    {"diff", "log", "show", "blame", "branch", "grep"}
+)
 
 # ---------------------------------------------------------------------------
 # Q4 — Which ``--output``-family flags write a file?

--- a/tests/ci/test_mergecraft_dispatch_prompt.py
+++ b/tests/ci/test_mergecraft_dispatch_prompt.py
@@ -1,0 +1,239 @@
+"""#529 — workflow_dispatch must share the pull_request_target review prompt.
+
+A dispatch run with no ``prompt`` input used to hand the agent
+``Review the current pull request.`` — no PR number, no
+``mergecraft_checkout_pr`` instruction. The agent then spent ~48 turns
+discovering the PR. Both event paths now build the same prompt from one
+script; an explicit ``inputs.prompt`` still passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.ci.workflow_support import job, load_workflow
+
+_WORKFLOW = "mergecraft.yml"
+_REVIEW_JOB = "review"
+_RESOLVE_STEP = "Resolve PR for workflow_dispatch"
+_COMPOSE_STEP = "Compose review prompt"
+_CHECKOUT_PR = "mergecraft_checkout_pr"
+_BARE_FALLBACK = "Review the current pull request."
+
+
+def _review_steps() -> list[dict[str, Any]]:
+    steps = job(load_workflow(_WORKFLOW), _REVIEW_JOB).get("steps")
+    assert isinstance(steps, list), "review job steps must be a list"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _review_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"review job is missing step {name!r}")
+
+
+def _compose_script() -> str:
+    run = _step(_COMPOSE_STEP).get("run")
+    assert isinstance(run, str), "Compose review prompt has no run script"
+    assert run.strip(), "Compose review prompt run script is empty"
+    return run
+
+
+def _prompt_from_github_output(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    start = "text<<MERGECRAFT_PROMPT_EOF\n"
+    end = "\nMERGECRAFT_PROMPT_EOF\n"
+    assert start in text, f"GITHUB_OUTPUT missing prompt delimiter: {text!r}"
+    after = text.split(start, 1)[1]
+    assert end in after or after.endswith("\nMERGECRAFT_PROMPT_EOF"), text
+    body = after.rsplit("MERGECRAFT_PROMPT_EOF", 1)[0]
+    return body.rstrip("\n")
+
+
+def _run_compose(
+    tmp_path: Path,
+    *,
+    env: dict[str, str],
+) -> str:
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    script_env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "GITHUB_OUTPUT": str(output),
+        "HOME": str(tmp_path),
+    }
+    script_env.update(env)
+    completed = subprocess.run(
+        ["bash", "-c", _compose_script()],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=script_env,
+    )
+    assert completed.returncode == 0, (
+        f"compose script failed ({completed.returncode}): "
+        f"stdout={completed.stdout!r} stderr={completed.stderr!r}"
+    )
+    return _prompt_from_github_output(output)
+
+
+class TestDispatchResolveStep:
+    """The dispatch job must resolve an open PR for the ref without failing closed."""
+
+    def test_resolve_step_is_dispatch_only(self) -> None:
+        step = _step(_RESOLVE_STEP)
+        assert step.get("if") == "github.event_name == 'workflow_dispatch'"
+        assert step.get("id") == "dispatch_pr"
+
+    def test_resolve_step_lists_open_prs_for_the_head_ref(self) -> None:
+        run = _step(_RESOLVE_STEP).get("run")
+        assert isinstance(run, str)
+        assert "gh pr list" in run
+        assert "--state open" in run
+        assert "github.ref_name" in run
+        assert "number=" in run
+
+    def test_resolve_step_does_not_fail_the_job_on_empty_match(self) -> None:
+        run = _step(_RESOLVE_STEP).get("run")
+        assert isinstance(run, str)
+        assert '.number // ""' in run or ".number // empty" in run
+
+
+class TestComposePromptShape:
+    """Both events build the prompt from one script, not two event branches."""
+
+    def test_compose_script_does_not_branch_on_event_name(self) -> None:
+        script = _compose_script()
+        assert "EVENT_NAME" not in script
+        assert "pull_request_target" not in script
+
+    def test_compose_keeps_the_dispatch_prompt_override(self) -> None:
+        env = _step(_COMPOSE_STEP).get("env")
+        assert isinstance(env, dict)
+        assert env.get("DISPATCH_PROMPT") == "${{ inputs.prompt }}"
+        assert "DISPATCH_PROMPT" in _compose_script()
+
+    def test_compose_reads_the_resolved_dispatch_pr_number(self) -> None:
+        env = _step(_COMPOSE_STEP).get("env")
+        assert isinstance(env, dict)
+        pr_number = env.get("PR_NUMBER")
+        assert isinstance(pr_number, str)
+        assert "steps.dispatch_pr.outputs.number" in pr_number
+        assert "github.event.pull_request.number" in pr_number
+
+    def test_shared_path_names_checkout_pr(self) -> None:
+        script = _compose_script()
+        assert _CHECKOUT_PR in script
+        assert script.count(_CHECKOUT_PR) == 1
+
+    def test_shared_path_wires_ci_context(self) -> None:
+        script = _compose_script()
+        assert "CI_STATE" in script
+        assert "mergecraft_get_check_suite_logs" in script
+
+
+class TestComposePromptBehaviour:
+    """Execute the real compose script — the YAML is the code under test."""
+
+    def test_dispatch_without_prompt_names_the_pr_number(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "skipped",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert "Review pull request #529." in prompt
+        assert _CHECKOUT_PR in prompt
+        assert "origin/pre-0.0.1:path" in prompt
+        assert "wait state: skipped" in prompt
+
+    def test_pull_request_target_uses_the_same_shape(self, tmp_path: Path) -> None:
+        dispatch = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        target = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert dispatch == target
+        assert "CI has finished green" in target
+
+    def test_explicit_prompt_input_passes_through_unchanged(self, tmp_path: Path) -> None:
+        override = "Review only the security findings on #12."
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "DISPATCH_PROMPT": override,
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "2",
+                "CI_FAILED_NAMES": "Verify (lint)",
+                "CI_CHECK_SUITE_ID": "99",
+            },
+        )
+        assert prompt == override
+        assert _CHECKOUT_PR not in prompt
+
+    def test_missing_pr_number_falls_back_to_the_bare_string(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "",
+                "BASE_REF": "",
+                "CI_STATE": "skipped",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert prompt == _BARE_FALLBACK
+        assert _CHECKOUT_PR not in prompt
+
+    def test_failed_ci_clause_is_attached_when_a_pr_is_resolved(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "main",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "1",
+                "CI_FAILED_NAMES": "Verify (typecheck)",
+                "CI_CHECK_SUITE_ID": "12345",
+            },
+        )
+        assert "Review pull request #529." in prompt
+        assert "1 job(s) FAILED (Verify (typecheck))" in prompt
+        assert "check_suite_id 12345" in prompt
+
+
+@pytest.mark.parametrize("name", [_RESOLVE_STEP, _COMPOSE_STEP])
+def test_required_review_steps_exist(name: str) -> None:
+    _step(name)

--- a/tests/mcp/test_git_tool.py
+++ b/tests/mcp/test_git_tool.py
@@ -394,6 +394,10 @@ SUBCOMMAND_SCOPED_READONLY = [
     pytest.param("branch", ["-ar"], id="branch-bundled-all-remotes"),
     pytest.param("branch", ["-vvv"], id="branch-repeated-verbose"),
     pytest.param("branch", ["--list", "topic/*"], id="branch-list-pattern"),
+    pytest.param("grep", ["-n", "TODO"], id="grep-line-numbers"),
+    pytest.param("grep", ["-c", "TODO"], id="grep-count"),
+    pytest.param("grep", ["-C", "2", "TODO"], id="grep-context"),
+    pytest.param("grep", ["-ci", "TODO"], id="grep-bundled-count-ignore-case"),
 ]
 
 
@@ -422,6 +426,7 @@ SUBCOMMAND_SCOPED_STILL_BLOCKED = [
     pytest.param("branch", ["-aD"], id="branch-bundled-with-delete"),
     pytest.param("branch", ["-vd", "topic"], id="branch-bundled-with-lowercase-delete"),
     pytest.param("branch", ["topic"], id="branch-bare-creation-without-list"),
+    pytest.param("grep", ["-calias.x=!true"], id="glued-config-on-grep"),
 ]
 
 
@@ -516,6 +521,29 @@ async def test_auth_requiring_subcommands_name_their_dedicated_tool(
     assert any(name in text for name in ("push_branch", "git_fetch", "checkout_repo"))
 
 
+@pytest.mark.parametrize(
+    ("subcommand", "hint"),
+    [
+        ("remote", "git branch --remotes"),
+        ("config", "git rev-parse"),
+    ],
+)
+async def test_remote_and_config_name_an_alternative(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, subcommand: str, hint: str
+) -> None:
+    """#529 — refuse remote/config with a clear alternative, not a dead allowlist error."""
+    recorder = _RunGitRecorder()
+    monkeypatch.setattr("mergecraft.mcp.git._run_git", recorder)
+
+    result = await git_tool(_ctx(tmp_path)).execute({"command": subcommand})
+    assert result.is_error is True
+    assert recorder.calls == []
+    text = result.content[0]["text"]
+    assert "read-only allowlist" not in text
+    assert hint in text
+    assert "use" in text
+
+
 async def test_relative_c_is_resolved_against_the_repo_checkout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -589,6 +617,7 @@ async def test_a_registered_cross_repo_checkout_is_reachable(
         "cat-file",
         "rev-list",
         "branch",
+        "grep",
     ],
 )
 async def test_readonly_subcommands_allowed(


### PR DESCRIPTION
## Summary

- On `workflow_dispatch`, resolve the open PR for the branch and build the same `#N` + `checkout_pr` prompt as `pull_request_target`.
- An explicit `inputs.prompt` still passes through unchanged.
- No matching PR falls back to `Review the current pull request.` without failing the job.
- Admit `git grep` on the read-only git allowlist; redirect `git remote` / `git config` to safe substitutes.

Fixes #529

## Test plan

- [x] `uv run pytest tests/ci/test_mergecraft_dispatch_prompt.py tests/mcp/test_git_tool.py tests/mcp/test_git_guards_module.py -n 0` (200 passed)
- [x] ruff check/format on touched Python files
- [ ] CI on this PR

## Follow-up

Mirror `sleep`/prompt shape to `sevn-bot/sevn` consumer workflow when that can be edited.