### PR TITLE
ci: stop persisting the checkout token into git config

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -319,13 +319,21 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
-          # Persist the checkout token so the mergeCraft action's own git layer
-          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
-          # fail and the action marks its `mergecraft` self-status check red even
-          # though the review completes via the GitHub API. Read-only escalation
-          # only: the action already sets ``push: disabled`` / ``shell: disabled``
-          # below, so a persisted token cannot be used to push.
-          persist-credentials: true
+          # MUST stay false. actions/checkout persists its token as
+          # `http.https://github.com/.extraheader = AUTHORIZATION: basic ...` in
+          # .git/config, and mergeCraft's git layer adds its own
+          # `Authorization: Bearer ...` (utils/git_setup.py:208, lane A D5).
+          # `extraHeader` is multi-valued in git, so the second does not replace
+          # the first — both go on the same request and GitHub answers
+          # 400 "Duplicate header: Authorization". checkout_pr then fails, review
+          # scope is never established, and every terminal verdict is rejected.
+          #
+          # The old comment here claimed persistence was required for
+          # checkout_pr / git_fetch to authenticate. That stopped being true when
+          # lane A gave those tools header-based auth of their own: checkout.py
+          # passes `env=_git_env(ctx.git_token)`, so the action authenticates
+          # from its `token:` input and needs nothing in .git/config.
+          persist-credentials: false
 
       - name: Ensure PR base ref exists locally
         if: github.event_name == 'pull_request_target'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `actions/checkout` no longer persists its token in the review workflow, the
+  shipped hardened example, its template, or the dogfood artifact. A persisted
+  `extraheader = AUTHORIZATION: basic ...` collided with the `Authorization:
+  Bearer ...` that mergeCraft's own git layer adds, and `extraHeader` is
+  multi-valued in git, so both headers went on one request and GitHub answered
+  `400 Duplicate header: "Authorization"`. `checkout_pr` failed, review scope
+  was never established, and every terminal verdict was rejected — a review
+  that found 45 issues posted none of them and burned 9.4M tokens against a 5M
+  budget before failing closed. The action authenticates from its own `token:`
+  input, so nothing needs persisting; the comment that claimed otherwise
+  predated lane A giving those tools header auth of their own
+
+
 ### Changed
 
 - The self-review Action pin on both review steps moves to `b34e9f25`. The

--- a/docs/artifacts/dogfood-mergecraft.yml
+++ b/docs/artifacts/dogfood-mergecraft.yml
@@ -219,13 +219,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Persist the checkout token so mergeCraft's own git layer
-          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
-          # fail and the action marks its `mergecraft` self-status red even though
-          # the review completes via the API. Read-only escalation only: the
-          # action runs with push/shell disabled, so a persisted token cannot be
-          # used to push.
-          persist-credentials: true
+          # MUST stay false. actions/checkout persists its token as an
+          # `extraheader = AUTHORIZATION: basic ...` entry in .git/config, and the
+          # mergeCraft action adds its own `Authorization: Bearer ...`. git treats
+          # `extraHeader` as multi-valued, so both land on one request and GitHub
+          # answers 400 "Duplicate header: Authorization" — checkout_pr fails and
+          # the review never reaches a verdict. The action authenticates from its
+          # own `token:` input and needs nothing persisted here.
+          persist-credentials: false
 
       - name: Ensure PR base ref exists locally
         if: github.event_name == 'pull_request_target'

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -237,13 +237,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Persist the checkout token so mergeCraft's own git layer
-          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
-          # fail and the action marks its `mergecraft` self-status red even though
-          # the review completes via the API. Read-only escalation only: the
-          # action runs with push/shell disabled, so a persisted token cannot be
-          # used to push.
-          persist-credentials: true
+          # MUST stay false. actions/checkout persists its token as an
+          # `extraheader = AUTHORIZATION: basic ...` entry in .git/config, and the
+          # mergeCraft action adds its own `Authorization: Bearer ...`. git treats
+          # `extraHeader` as multi-valued, so both land on one request and GitHub
+          # answers 400 "Duplicate header: Authorization" — checkout_pr fails and
+          # the review never reaches a verdict. The action authenticates from its
+          # own `token:` input and needs nothing persisted here.
+          persist-credentials: false
 
       - name: Ensure PR base ref exists locally
         if: github.event_name == 'pull_request_target'

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -237,13 +237,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Persist the checkout token so mergeCraft's own git layer
-          # (checkout_pr / git_fetch) can authenticate. Without it those git ops
-          # fail and the action marks its `mergecraft` self-status red even though
-          # the review completes via the API. Read-only escalation only: the
-          # action runs with push/shell disabled, so a persisted token cannot be
-          # used to push.
-          persist-credentials: true
+          # MUST stay false. actions/checkout persists its token as an
+          # `extraheader = AUTHORIZATION: basic ...` entry in .git/config, and the
+          # mergeCraft action adds its own `Authorization: Bearer ...`. git treats
+          # `extraHeader` as multi-valued, so both land on one request and GitHub
+          # answers 400 "Duplicate header: Authorization" — checkout_pr fails and
+          # the review never reaches a verdict. The action authenticates from its
+          # own `token:` input and needs nothing persisted here.
+          persist-credentials: false
 
       - name: Ensure PR base ref exists locally
         if: github.event_name == 'pull_request_target'

--- a/tests/ci/test_checkout_credential_persistence.py
+++ b/tests/ci/test_checkout_credential_persistence.py
@@ -1,0 +1,73 @@
+"""``persist-credentials`` must stay false wherever mergeCraft reviews a PR.
+
+actions/checkout persists its token as
+``http.https://github.com/.extraheader = AUTHORIZATION: basic ...`` in
+``.git/config``. mergeCraft's git layer adds its own ``Authorization: Bearer``
+(``utils/git_setup.py`` ``git_env_for_token``). ``extraHeader`` is multi-valued
+in git, so the second does not replace the first — both go on one request and
+GitHub answers ``400 Duplicate header: "Authorization"``. ``checkout_pr`` then
+fails, review scope is never established, and every terminal verdict is
+rejected with "requires review scope".
+
+Observed on PR #524 (run 33086156079): the agent looped on the unsatisfiable
+error, mergeCraft resumed the whole session once, and the run died at
+9,395,943 tokens against a 5,000,000 budget having posted no review at all.
+
+The action authenticates from its own ``token:`` input, so nothing needs to be
+persisted for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.ci.workflow_support import REPO_ROOT
+
+# Every file that checks out a repo mergeCraft then reviews: our own workflow,
+# the shipped consumer example, the template that generates it, and the
+# dogfood artifact copied into docs.
+_WORKFLOWS = (
+    ".github/workflows/mergecraft.yml",
+    "examples/workflows/mergecraft-hardened.yml",
+    "scripts/example_workflows/hardened.yml.tpl",
+    "docs/artifacts/dogfood-mergecraft.yml",
+)
+
+
+def _checkout_steps(doc: object) -> list[dict[str, object]]:
+    steps: list[dict[str, object]] = []
+    jobs = doc.get("jobs") if isinstance(doc, dict) else None
+    if not isinstance(jobs, dict):
+        return steps
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if isinstance(uses, str) and uses.startswith("actions/checkout@"):
+                steps.append(step)
+    return steps
+
+
+@pytest.mark.parametrize("relpath", _WORKFLOWS)
+def test_checkout_does_not_persist_credentials(relpath: str) -> None:
+    path = Path(REPO_ROOT) / relpath
+    assert path.is_file(), f"missing {relpath}"
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    steps = _checkout_steps(doc)
+    assert steps, f"{relpath} has no actions/checkout step to check"
+    for step in steps:
+        with_block = step.get("with") or {}
+        assert isinstance(with_block, dict)
+        # Accept the bool and the YAML-string spellings alike.
+        persist = str(with_block.get("persist-credentials")).lower()
+        assert persist != "true", (
+            f"{relpath}: actions/checkout must not persist credentials — a persisted "
+            "extraheader collides with mergeCraft's own Authorization header and "
+            "GitHub rejects the fetch with 400 Duplicate header"
+        )


### PR DESCRIPTION
## What?

Reviews reach a verdict again. Every review on this repo, and on any consumer following the shipped hardened example, has been failing to post anything at all.

## Why?

The checkout step persists its token into the repository's git config as an extra HTTP header. The action adds its own authorization header when it fetches. Git treats that setting as a list rather than a single value, so both headers travel on the same request and GitHub rejects it outright.

From there the failure cascades in a way that hides its own cause. The PR checkout fails, so the run never establishes review scope, so every attempt to record the verdict is refused with a message telling the agent to run the checkout — the one step that cannot succeed. The agent does as it is told, repeatedly, and the post-run retry then replays the whole session to discover the same thing a second time.

On #524 that run identified forty-five issues, posted none of them, and spent nearly twice its token budget before failing closed. The gate was right to fail; there was no review to gate on.

The comment on that setting claimed the action needed the persisted token to authenticate. That has not been true since the git tools gained their own header-based authentication: the action authenticates from the token input it is already given. Leaving the stale reasoning in place invites the next reader to turn it back on, so it is corrected rather than just overridden.

## Note

Fixed in all four places this is reachable: the review workflow, the hardened example, the template that generates it, and the dogfood artifact in the docs. A test pins all four; I confirmed it fails when any one is reverted.

This takes effect on merge without an Action pin bump, since the review workflow is resolved from the default branch.

Two related hardening changes are deliberately **not** here, because both live in the action's own code and would therefore need a pin bump — which means shipping changed retry behaviour to every review at once, in an urgent fix, and neither is needed to unblock anything:

- Clearing a persisted header before fetching, for consumers who keep the old setting on workflows they have not updated.
- Failing fast when a precondition cannot be satisfied, instead of inviting the retry loop that spent the budget. The error text currently instructs the agent to retry the broken step by name.

## Test plan

- [x] Reproduced the duplicate header on the wire with `GIT_TRACE_CURL`, and confirmed a single header once the persisted entry is gone
- [x] `uv run pytest tests/docs tests/action tests/ci` — 527 passed, 1 skipped
- [x] `make docs-check` clean; all four files still parse as YAML
- [x] New contract test fails when any of the four is reverted

## Related PR(s)/Issue(s)

Unblocks #524.
