### PR TITLE
ci: bump the self-review Action pin to b3638ea7

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -533,9 +533,18 @@ jobs:
         # #459 still appeared in Action logs, which is how #527 came to be filed
         # against bugs that no longer existed. `make action-pin-check` detects this
         # correctly but is wired into no gate — see #532, which fixes the guard.
-        # b34e9f25 is the pre-0.0.1 tip this PR promotes; it carries the Dockerfile
-        # `--extra tracing` line and the lane A hardening from #519.
-        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
+        # b34e9f25 was the pre-0.0.1 tip promoted by #533; it carried the
+        # Dockerfile `--extra tracing` line and the lane A hardening from #519.
+        # 2026-08-28 (eleventh bump, PR #546): re-bumped to b3638ea7 so the
+        # reviewer can authenticate at all. Every rung at b34e9f25 brokered the
+        # GitHub token to git as `Authorization: Bearer`, which GitHub's git
+        # transport rejects, so `checkout_pr` failed on every review and the
+        # scope guard then refused the terminal verdict — a review that reached
+        # "approve" on PR #545 could not publish it, and the approval gate failed
+        # closed with no mergecraft-approval check at all. Fixed in #545
+        # (utils/git_setup.py — basic auth on the documented `x-access-token`
+        # username). b3638ea7 is #545's merge commit.
+        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -658,9 +667,18 @@ jobs:
         # #459 still appeared in Action logs, which is how #527 came to be filed
         # against bugs that no longer existed. `make action-pin-check` detects this
         # correctly but is wired into no gate — see #532, which fixes the guard.
-        # b34e9f25 is the pre-0.0.1 tip this PR promotes; it carries the Dockerfile
-        # `--extra tracing` line and the lane A hardening from #519.
-        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
+        # b34e9f25 was the pre-0.0.1 tip promoted by #533; it carried the
+        # Dockerfile `--extra tracing` line and the lane A hardening from #519.
+        # 2026-08-28 (eleventh bump, PR #546): re-bumped to b3638ea7 so the
+        # reviewer can authenticate at all. Every rung at b34e9f25 brokered the
+        # GitHub token to git as `Authorization: Bearer`, which GitHub's git
+        # transport rejects, so `checkout_pr` failed on every review and the
+        # scope guard then refused the terminal verdict — a review that reached
+        # "approve" on PR #545 could not publish it, and the approval gate failed
+        # closed with no mergecraft-approval check at all. Fixed in #545
+        # (utils/git_setup.py — basic auth on the documented `x-access-token`
+        # username). b3638ea7 is #545's merge commit.
+        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -769,9 +787,9 @@ jobs:
         continue-on-error: true
         # Same mandatory full-SHA pin as the rungs above — keep all three in
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
-        # was authored against the pre-#533 pin; carried to b34e9f25 on the merge
-        # so all three rungs run the same product code (#532).
-        uses: alexhawat/mergeCraft@b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5 # pre-0.0.1 (PR #533)
+        # was authored against the pre-#533 pin; carried forward on each bump so
+        # all three rungs run the same product code (#532). Now b3638ea7 (#545).
+        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The self-review Action pin on both review steps moves to `b34e9f25`. The
+- The self-review Action pin on all three review rungs moves to `b3638ea7`,
+  the merge commit of #545. Every rung at the previous pin sent git the token
+  as `Authorization: Bearer`, which GitHub's git transport rejects, so
+  `checkout_pr` failed on every review and the scope guard then refused the
+  terminal verdict. A review that reached "approve" on #545 could not publish
+  it and the approval gate failed closed with no `mergecraft-approval` check at
+  all. `pull_request_target` resolves this workflow from the default branch, so
+  a self-review PR cannot consume its own fix; the bump has to follow the merge
+- The self-review Action pin on both review steps moved to `b34e9f25`. The
   previous pin (`5b9ded9f`, 23 August) had drifted 107 commits on
   `src/mergecraft/`, so every review since then ran product code that stale.
   The image at that pin carries no `[tracing]` extra, which would have left


### PR DESCRIPTION
## What?

The self-review workflow runs a reviewer that can authenticate. All three rungs move to `b3638ea7`, the merge commit of #545.

## Why?

Every rung ran `b34e9f25`, which sends git the token as `Authorization: Bearer`. GitHub's git transport rejects that scheme, so `checkout_pr` failed on every review, and the scope guard then refused the terminal verdict. The review of #545 is the clean illustration: Codex read the diff, concluded approve, and could not publish it. No `mergecraft-approval` check was posted at all, and the gate failed closed.

`pull_request_target` resolves this workflow and its pin from the default branch, not the PR head, so #545 could not consume its own fix. The bump has to follow the merge.

## Note

This PR's own review still runs the old pin, for the same reason, so expect the approval gate to fail closed once more here. Every PR after this one gets the working reviewer.

Two things left open, worth their own issues. The Nous rung died instantly on run 33124897883 with `no runnable model slug in chain — configure credentials for at least one entry`, which is what pushed the cascade to Codex in the first place. And `make action-pin-check` passes on drift it should catch: it reports "1 workflow(s) pin this action" and nothing about staleness, which is #532's territory.

The header comment on the workflow asks for edits to be mirrored to the sevn-side copy. That lives in another repo and is not touched here.

## Test plan

- `make action-pin-check`
- `make ci-static`
- `uv run pytest tests/ci` (345 passed)

## Related PR(s)/Issue(s)

Follows #545
