### PR TITLE
ci: post review check-runs from the job token, not a PAT

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -705,15 +705,6 @@ jobs:
           model: openai/gpt-codex
           push: disabled
           shell: disabled
-          # Codex's Linux platform sandbox is bubblewrap + Landlock, and the
-          # action runs inside a Docker container action — already namespaced —
-          # so bwrap cannot create a nested user namespace and every shell call
-          # dies with "No permissions to create a new namespace" before doing
-          # work. Run 33167090906 lost every command_execution to it.
-          # action.yml documents this exact remedy (#70): the runner IS the
-          # ephemeral isolated container the input asks about. mergeCraft's own
-          # shell (disabled above) and push controls are unaffected either way.
-          codex_sandbox: danger-full-access
           status_checks: enabled
           # Job token, not the PAT — see the matching comment on the Nous step.
           token: ${{ github.token }}

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -325,13 +325,15 @@ jobs:
       # `env` expression). Adding a provider here without updating that copy
       # fails the required gate OPEN — see the comment there.
       HAS_AUTH: ${{ (secrets.CODEX_AUTH_JSON != '' || secrets.OPENAI_API_KEY != '' || secrets.NOUS_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
-      # The default github.token cannot submit an "Approve" review — GitHub
-      # silently downgrades any attempt to a comment (a documented platform
-      # restriction, independent of PR author). A PAT from a genuinely
+      # MERGECRAFT_REVIEWER_PAT is deliberately absent from this job. The
+      # default github.token cannot submit an "Approve" review — GitHub
+      # silently downgrades any attempt to a comment — and a PAT from a
       # distinct account (sevn-one, a collaborator + CODEOWNERS entry) can.
-      # Only used for same-repo runs — fork PRs still rely purely on the
-      # review's findings, never on an approval identity to route around.
-      HAS_BOT_TOKEN: ${{ secrets.MERGECRAFT_REVIEWER_PAT != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      # But a PAT also cannot create the check-run the approval gate reads, so
+      # handing it to the review steps disabled the gate and the approval both.
+      # The approve lane lives in mergecraft-approve.yml, which holds its own
+      # copy of the PAT and never re-reads PR content — see the review steps'
+      # `token:` comment and PR #200.
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -544,7 +546,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
+        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -559,9 +561,23 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
-          # See HAS_BOT_TOKEN above — falls back to github.token when the PAT
-          # isn't configured (e.g. a fork of this repo without the secret).
-          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          # The workflow job token, NOT MERGECRAFT_REVIEWER_PAT. mergeCraft
+          # posts the `mergecraft` / `mergecraft-approval` check-runs from this
+          # input, and `POST /repos/{owner}/{repo}/check-runs` answers any
+          # classic or OAuth user token with `403 You must authenticate via a
+          # GitHub App` — no scope unlocks it. GITHUB_TOKEN *is* an App
+          # installation token, and this job already grants checks: write.
+          #
+          # Under the PAT neither check-run had EVER posted (verified across
+          # #519, #524, #533, #534, #542, #545, #546, #548), so `mergecraft
+          # review` failed closed on every PR AND mergecraft-approve.yml, which
+          # gates on reading that conclusion, could never submit its approval.
+          # The PAT bought only the comment byline; it cost the whole gate.
+          #
+          # MERGECRAFT_REVIEWER_PAT stays where it works: mergecraft-approve.yml
+          # holds its own copy and submits the sevn-one APPROVE from there.
+          # Restoring a distinct byline here needs a GitHub App, not a PAT.
+          token: ${{ github.token }}
           tracing: "true"
           tracing-to: logfire
           logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
@@ -678,7 +694,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
+        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -689,9 +705,18 @@ jobs:
           model: openai/gpt-codex
           push: disabled
           shell: disabled
+          # Codex's Linux platform sandbox is bubblewrap + Landlock, and the
+          # action runs inside a Docker container action — already namespaced —
+          # so bwrap cannot create a nested user namespace and every shell call
+          # dies with "No permissions to create a new namespace" before doing
+          # work. Run 33167090906 lost every command_execution to it.
+          # action.yml documents this exact remedy (#70): the runner IS the
+          # ephemeral isolated container the input asks about. mergeCraft's own
+          # shell (disabled above) and push controls are unaffected either way.
+          codex_sandbox: danger-full-access
           status_checks: enabled
-          # See the matching comment on the Nous step above.
-          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          # Job token, not the PAT — see the matching comment on the Nous step.
+          token: ${{ github.token }}
           tracing: "true"
           tracing-to: logfire
           logfire-token: ${{ secrets.LOGFIRE_TOKEN }}
@@ -789,7 +814,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@b3638ea760dad4e42cc75cbfd0de3bac1a207297 # main (PR #545)
+        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -797,8 +822,8 @@ jobs:
           push: disabled
           shell: disabled
           status_checks: enabled
-          # See the matching comment on the Nous step above.
-          token: ${{ env.HAS_BOT_TOKEN == 'true' && secrets.MERGECRAFT_REVIEWER_PAT || github.token }}
+          # Job token, not the PAT — see the matching comment on the Nous step.
+          token: ${{ github.token }}
           tracing: "true"
           tracing-to: logfire
           logfire-token: ${{ secrets.LOGFIRE_TOKEN }}


### PR DESCRIPTION
## What?

The `mergecraft` and `mergecraft-approval` check-runs post again, so the required review gate can pass and the sevn-one approval can fire.

- Review steps authenticate with the workflow job token instead of a personal access token.
- All three rungs move to `a5651eda`, which carries the auth-marker fix from #548.

## Why?

Neither check-run has ever posted. Verified absent on every recent head: #519, #524, #533, #534, #542, #545, #546, #548. `mergecraft review` is a required check that fails closed when no approval check exists, so every pull request has been red on it and every merge has needed an override.

mergeCraft posts those check-runs from its `token:` input, and the create-check-run endpoint answers a classic or OAuth user token with `403 You must authenticate via a GitHub App`. No scope unlocks that. The job token is an App installation token, and this job already grants `checks: write`.

The cost compounded rather than stopping at a missing check. `mergecraft-approve.yml` gates on reading that same conclusion, so the approval as sevn-one could never fire either. One credential choice disabled the check-run, the merge gate, and the approval identity the token existed to provide. What it actually bought on these steps was the review comment byline.

## Note

`MERGECRAFT_REVIEWER_PAT` is unchanged and still lives in `mergecraft-approve.yml`, which holds its own copy, never re-reads pull request content, and resolves its definition from the default branch. That separation is from #200 and is not touched here.

Review comments will now be authored by `github-actions[bot]` rather than sevn-one. Restoring a distinct byline needs a GitHub App rather than a user token, since only an App can do both. Tracked separately.

`HAS_BOT_TOKEN` had no remaining reader and is dropped.

A `codex_sandbox: danger-full-access` change was pushed here and then removed after review. It is not a convenience question: `shell: disabled` gates mergeCraft's own MCP shell, not Codex's native one, so bubblewrap is the only thing stopping shell execution over PR-authored content on a target run — and both the injected `OPENAI_API_KEY` and the chowned `$CODEX_HOME/auth.json` sit inside that blast radius. Tracked separately with the viable options.

## Test plan

- `make action-pin-check`
- `uv run pytest tests/ci` (345 passed)
- `scripts/check_action_yml_hygiene.py` on `action.yml` and the workflow
- Probed the endpoint directly to confirm the class of refusal rather than infer it: an empty-body POST to the create-check-run endpoint returns `403 You must authenticate via a GitHub App`
- This pull request's own review is the acceptance check: `mergecraft-approval` should appear on its head

## Related PR(s)/Issue(s)

Follows #548
Refs #70
