### PR TITLE
test(policy): pin the enforcement-mode vs approval-gate divergence

### DIFF
--- a/tests/policy/test_enforcement.py
+++ b/tests/policy/test_enforcement.py
@@ -6,6 +6,8 @@ Implementation: **DG5.2** — advisory/warning/required/blocking enforcement.
 
 from __future__ import annotations
 
+import pytest
+
 from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
 
 
@@ -63,3 +65,72 @@ def test_advisory_mode_caps_critical_declared_severity_to_non_blocker() -> None:
     assert result.finding is not None
     assert result.finding.severity not in BLOCKING_SEVERITIES
     assert decide_approval([result.finding], run_succeeded=True, tier="trusted") == "success"
+
+
+# --- Enforcement mode vs. the gate it feeds -------------------------------
+#
+# ``EnforcementResult.contributes_blocker`` records what a mode *means*, and
+# ``decide_approval`` decides from ``Finding.severity``. Nothing reads the
+# flag: it appears nowhere in ``src`` outside ``policy/enforcement.py``, and
+# ``evaluate_enforcement`` has no production caller, so no policy violation
+# reaches the gate by any path today. The two representations therefore
+# disagree in two cells without any runtime consequence yet.
+#
+# These pin the disagreement rather than assert a resolution, because the
+# resolution is a design fork (see the follow-up issue): either the gate
+# learns about the flag, or severity becomes authoritative and the modes cap
+# and floor accordingly. Both cells flip to green under either branch, so
+# ``strict=True`` — an xpass means the fork was taken and these become real
+# assertions rather than quietly passing pins.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="blocking + Minor sets contributes_blocker=True, but the gate reads "
+    "severity and Minor is not blocking. MCB-12 removed the Minor->Major "
+    "promotion that used to make this block; the intent moved to a flag "
+    "nothing consumes.",
+)
+def test_blocking_mode_blocks_even_at_minor_severity() -> None:
+    from mergecraft.policy.enforcement import evaluate_enforcement
+
+    violation = {
+        "rule_id": "no-hardcoded-secrets",
+        "path": "src/config.py",
+        "message": "token",
+        "severity": "Minor",
+    }
+    result = evaluate_enforcement(mode="blocking", violation=violation)
+    assert result.contributes_blocker is True
+    assert result.finding is not None
+
+    conclusion = decide_approval([result.finding], run_succeeded=True, tier="trusted")
+    assert conclusion == "failure", (
+        "a blocking rule that contributes a blocker must block the gate it feeds"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="warning + Major sets contributes_blocker=False, but the declared "
+    "severity is preserved and the gate blocks on it. 'warning never blocks' "
+    "and 'warning preserves declared severity' cannot both hold while the "
+    "gate decides from severity.",
+)
+def test_warning_mode_does_not_block_at_major_severity() -> None:
+    from mergecraft.policy.enforcement import evaluate_enforcement
+
+    violation = {
+        "rule_id": "prefer-structured-logging",
+        "path": "src/app.py",
+        "message": "print()",
+        "severity": "Major",
+    }
+    result = evaluate_enforcement(mode="warning", violation=violation)
+    assert result.contributes_blocker is False
+    assert result.finding is not None
+
+    conclusion = decide_approval([result.finding], run_succeeded=True, tier="trusted")
+    assert conclusion != "failure", (
+        "a warning rule that contributes no blocker must not block the gate it feeds"
+    )


### PR DESCRIPTION
## What?

The two cells where an enforcement mode and the approval gate disagree are now pinned, so neither can change silently.

## Why?

`EnforcementResult.contributes_blocker` records what a mode means; `decide_approval` decides from `Finding.severity`. Nothing connects them, so `blocking` at `Minor` severity sets the flag and passes the gate, while `warning` at `Major` clears the flag and blocks it.

Nothing consumes that flag today — it appears nowhere in `src` outside `policy/enforcement.py`, `evaluate_enforcement` has no production caller, and no policy violation reaches the gate by any path. So this is latent, and resolving it is a design fork rather than a patch: either the gate learns about the flag, or severity becomes authoritative and the modes cap and floor accordingly. The second reverts a change that shipped deliberately in #523 with its own test.

That decision belongs with whoever wires enforcement into the packet. Until then the disagreement should be visible rather than discoverable.

## Note

`strict=True` on both, so the fork cannot be taken quietly: whichever cell flips green fails the suite until these become real assertions. That matches `scripts/check_xpass.py`, which already treats a non-strict xfail that passes as a leftover RED marker.

Worth recording why the existing suite missed this. `test_mode_by_severity_truth_table` asserts only that a severity comes back and is a taxonomy member, and `test_mode_distinguishability` keys on the `(contributes_blocker, severity)` pair — it pins the pairs as distinct without asserting either half is what the gate honours.

No source change.

## Test plan

- `uv run pytest tests/policy` — 2 xfailed, existing coverage unchanged
- `uv run ruff check` and `ruff format --check` on the touched file

## Related PR(s)/Issue(s)

Refs #554
Follows #523
