### PR TITLE
fix(ci): pin the base worktree venv in the coverage delta gate

### DIFF
--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -28,10 +28,20 @@ git worktree add "$worktree" "$base_ref"
 # BASE_WORKTREE_MEASURE_BLOCK — parsed by tests/ci/test_coverage_delta_wrapper.py (D10).
 (
   cd "$worktree"
-  # The base worktree gets its own fresh .venv. `dev` is a
+  # The base worktree gets its own fresh venv. `dev` is a
   # [project.optional-dependencies] extra, which `uv run` does not install, so
   # `make coverage-measure` died with "Failed to spawn: pytest" before measuring
   # anything. Sync the extra explicitly.
+  #
+  # Pin which venv that is, because this sync and the `make` below disagreed
+  # otherwise. MCB-23 made the Makefile export
+  # `UV_PROJECT_ENVIRONMENT ?= $(CURDIR)/.venv-dev`; this sync runs in a bare
+  # shell, so it filled `.venv` while `make coverage-measure` then looked in
+  # `.venv-dev` and hit the same "Failed to spawn: pytest" by a new route.
+  # Exporting it here settles both halves on one path, and `?=` means the
+  # Makefile defers to it — so this also works against an older base tree whose
+  # Makefile predates MCB-23 and would otherwise default to `.venv`.
+  export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-$PWD/.venv-dev}"
   "${UV:-uv}" sync --extra dev --extra tracing
   # Repo-native analyzer tests (#427) require tools/node_modules/.bin; bootstrap
   # only runs on the PR checkout, not this detached base worktree.


### PR DESCRIPTION
## What?

Pull requests targeting `pre-0.0.1` can pass CI again. The coverage delta gate measures the base branch instead of dying before it starts.

## Why?

Every PR based on the current `pre-0.0.1` fails `Integration (PR / mocked + self-skip)` at the Coverage ratchet step:

```
error: Failed to spawn: `pytest`
  Caused by: No such file or directory (os error 2)
make: *** [Makefile:151: coverage-measure] Error 2
```

It shows up on unrelated branches — `feat/520-provider-disable` (#521) and `test/enforcement-gate-divergence` (#555) — which is what marks it as base breakage rather than a defect in either.

MCB-23 made the Makefile export `UV_PROJECT_ENVIRONMENT` to a separate dev environment so the test suite stops mutating the project virtualenv. The delta gate syncs the base worktree's dependencies from a bare shell, where that export does not apply, so the sync populated one virtualenv and the `make coverage-measure` that follows looked in another.

Exporting the path before the sync settles both halves on the same environment. Because the Makefile assigns it with `?=`, it defers to the exported value, which also keeps this working against an older base tree whose Makefile predates MCB-23.

## Note

This is the same symptom the block's existing comment already records, reached by a different route. The comment now carries both, so the next person to touch it sees why the sync target is pinned rather than inferred.

Nothing else changes. No source, no test expectations.

## Test plan

- `bash -n scripts/ci_coverage_delta_gate.sh`
- `uv run pytest tests/ci/test_coverage_delta_wrapper.py` — the `BASE_WORKTREE_MEASURE_BLOCK` contract still parses
- Confirmed the exported value reaches `make`: with it set, `make -n coverage-measure` resolves against the pinned environment
- The real proof is CI on this pull request and on #521 / #555 once they pick it up

## Related PR(s)/Issue(s)

Refs #536
Unblocks #521
Unblocks #555
