### PR TITLE
fix(policy): one authority for whether a violation blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate-facing severity is the single authority, so ``contributes_blocker`` is
   read off it rather than computed beside it. ``blocking`` floors a
   non-blocking declared severity to ``Major`` and ``warning`` caps blocking
-  severities to ``Minor``; the declared severity is preserved on the finding's
-  ``evidence`` list. **This reverses MCB-12's "blocking no longer promotes
+  severities to ``Minor``, and ``required`` resolves to ``Major`` while declared
+  evidence is outstanding so a ``Minor`` or ``Trivial`` obligation still blocks;
+  the declared severity is preserved on the finding's ``evidence`` list. **This reverses MCB-12's "blocking no longer promotes
   Minor"**, which left the blocking intent in a field ``decide_approval`` never
   read, so a ``blocking`` rule silently passed while a ``warning`` rule blocked
   (#554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Enforcement modes and the approval gate now agree on what blocks. The
+  gate-facing severity is the single authority, so ``contributes_blocker`` is
+  read off it rather than computed beside it. ``blocking`` floors a
+  non-blocking declared severity to ``Major`` and ``warning`` caps blocking
+  severities to ``Minor``; the declared severity is preserved on the finding's
+  ``evidence`` list. **This reverses MCB-12's "blocking no longer promotes
+  Minor"**, which left the blocking intent in a field ``decide_approval`` never
+  read, so a ``blocking`` rule silently passed while a ``warning`` rule blocked
+  (#554)
 - Render path: skip short-id assignment for non-hex fingerprints instead of
   aborting review output; export and explain paths stay strict (#493)
 - Cheat-signature lint: narrow ``getattr_tautology`` to ``object()`` targets so

--- a/src/mergecraft/policy/enforcement.py
+++ b/src/mergecraft/policy/enforcement.py
@@ -69,8 +69,9 @@ def _gate_facing_severity(
     but below the gate. ``required`` preserves the declared value when the rule
     carries no evidence keys, caps blocking severities to ``Trivial`` once
     declared evidence is satisfied so a cleared obligation cannot block, and
-    downgrades ``Critical`` to ``Major`` while evidence is outstanding so the
-    mode stays distinguishable from ``blocking``. ``blocking`` floors a
+    resolves to ``Major`` while evidence is outstanding — flooring a declared
+    ``Minor`` or ``Trivial`` up so the obligation actually blocks, and holding
+    ``Critical`` down so the mode stays distinguishable from ``blocking``. ``blocking`` floors a
     non-blocking declared severity up to ``Major`` so a blocking rule actually
     blocks (#554; reverses MCB-12, which left the intent in an unread flag).
 
@@ -87,7 +88,7 @@ def _gate_facing_severity(
             if _evidence_cleared(violation):
                 if declared in BLOCKING_SEVERITIES:
                     return "Trivial"
-            elif declared == "Critical":
+            else:
                 return "Major"
     if mode == "blocking" and declared not in BLOCKING_SEVERITIES:
         return "Major"
@@ -138,8 +139,8 @@ def evaluate_enforcement(
 
     Blocking intent lives in one place: the gate-facing severity. ``blocking``
     floors a non-blocking declared severity to ``Major`` so the rule blocks.
-    ``required`` consults ``policy.evidence`` and blocks until declared evidence
-    is present. ``warning`` and ``advisory`` never block — ``advisory`` caps
+    ``required`` consults ``policy.evidence`` and blocks at ``Major`` until
+    declared evidence is present, whatever severity the rule declared. ``warning`` and ``advisory`` never block — ``advisory`` caps
     blocking severities to ``Trivial`` and ``warning`` to ``Minor``. The
     declared severity is kept on the finding's ``evidence`` list whenever the
     gate-facing value differs.

--- a/src/mergecraft/policy/enforcement.py
+++ b/src/mergecraft/policy/enforcement.py
@@ -58,19 +58,29 @@ def _gate_facing_severity(
     declared: str,
     violation: dict[str, Any],
 ) -> str:
-    """Map a rule's declared severity to the gate-facing finding severity (D7, D12).
+    """Map a rule's declared severity to the gate-facing finding severity (D7, D12, #554).
 
-    ``advisory`` caps blocking severities visibly to ``Trivial``. ``warning`` and
-    ``required`` preserve the declared value when a required rule carries no
-    evidence keys. ``required`` caps blocking severities to ``Trivial`` once
-    declared evidence is satisfied so ``decide_approval`` cannot block on a
-    cleared obligation. ``required`` downgrades ``Critical`` to ``Major`` when
-    evidence is not cleared so the mode stays distinguishable from ``blocking``
-    at the same declared severity. ``blocking`` preserves declared severity and
-    no longer promotes ``Minor`` to ``Major``.
+    The gate-facing severity is the single authority for whether a violation
+    blocks: ``decide_approval`` reads ``Finding.severity`` and nothing else, so
+    every mode encodes its blocking intent here rather than in a parallel flag.
+
+    ``advisory`` caps blocking severities to ``Trivial``. ``warning`` caps them
+    to ``Minor`` — loud enough to stay visible, and distinct from ``advisory``,
+    but below the gate. ``required`` preserves the declared value when the rule
+    carries no evidence keys, caps blocking severities to ``Trivial`` once
+    declared evidence is satisfied so a cleared obligation cannot block, and
+    downgrades ``Critical`` to ``Major`` while evidence is outstanding so the
+    mode stays distinguishable from ``blocking``. ``blocking`` floors a
+    non-blocking declared severity up to ``Major`` so a blocking rule actually
+    blocks (#554; reverses MCB-12, which left the intent in an unread flag).
+
+    The declared severity is preserved on the finding's ``evidence`` list
+    whenever it differs, so capping never hides what the rule asked for.
     """
     if mode == "advisory" and declared in BLOCKING_SEVERITIES:
         return "Trivial"
+    if mode == "warning" and declared in BLOCKING_SEVERITIES:
+        return "Minor"
     if mode == "required":
         rule = _rule_from_violation(violation)
         if rule is not None and _required_evidence_keys(rule):
@@ -79,6 +89,8 @@ def _gate_facing_severity(
                     return "Trivial"
             elif declared == "Critical":
                 return "Major"
+    if mode == "blocking" and declared not in BLOCKING_SEVERITIES:
+        return "Major"
     return declared
 
 
@@ -88,6 +100,9 @@ def _violation_finding(*, mode: EnforcementMode, violation: dict[str, Any]) -> F
     message = str(violation.get("message", "policy violation"))
     declared = str(violation.get("severity", "Major"))
     severity = _gate_facing_severity(mode=mode, declared=declared, violation=violation)
+    evidence: list[str] | None = None
+    if severity != declared:
+        evidence = [f"declared severity {declared} under {mode} enforcement"]
     return make_finding(
         tool="policy",
         rule_id=rule_id,
@@ -99,15 +114,19 @@ def _violation_finding(*, mode: EnforcementMode, violation: dict[str, Any]) -> F
         start_line=1,
         end_line=1,
         source="analyzer",
+        evidence=evidence,
     )
 
 
 def _contributes_blocker(*, mode: EnforcementMode, violation: dict[str, Any]) -> bool:
-    if mode == "blocking":
-        return True
-    if mode == "required":
-        return not _evidence_cleared(violation)
-    return False
+    """Return whether this violation blocks, read off the one gate-facing authority.
+
+    Derived from the gate-facing severity rather than computed alongside it, so
+    the flag and ``decide_approval`` cannot disagree (#554).
+    """
+    declared = str(violation.get("severity", "Major"))
+    severity = _gate_facing_severity(mode=mode, declared=declared, violation=violation)
+    return severity in BLOCKING_SEVERITIES
 
 
 def evaluate_enforcement(
@@ -115,13 +134,15 @@ def evaluate_enforcement(
     *,
     violation: dict[str, Any],
 ) -> EnforcementResult:
-    """Map a policy violation to a gate-facing enforcement outcome (D7, D12).
+    """Map a policy violation to a gate-facing enforcement outcome (D7, D12, #554).
 
-    ``blocking`` always contributes a blocker at the declared severity (without
-    promoting ``Minor`` to ``Major``). ``required`` consults ``policy.evidence``
-    and contributes a blocker until declared evidence is present. ``warning`` and
-    ``advisory`` never contribute blockers; ``advisory`` caps blocking severities
-    to ``Trivial`` visibly.
+    Blocking intent lives in one place: the gate-facing severity. ``blocking``
+    floors a non-blocking declared severity to ``Major`` so the rule blocks.
+    ``required`` consults ``policy.evidence`` and blocks until declared evidence
+    is present. ``warning`` and ``advisory`` never block — ``advisory`` caps
+    blocking severities to ``Trivial`` and ``warning`` to ``Minor``. The
+    declared severity is kept on the finding's ``evidence`` list whenever the
+    gate-facing value differs.
     """
     finding = _violation_finding(mode=mode, violation=violation)
     contributes_blocker = _contributes_blocker(mode=mode, violation=violation)

--- a/tests/policy/test_enforcement.py
+++ b/tests/policy/test_enforcement.py
@@ -30,8 +30,13 @@ def test_blocking_rule_contributes_a_blocking_finding_not_a_second_gate() -> Non
     assert not hasattr(evaluate_enforcement, "decide_policy_approval")
 
 
-def test_blocking_mode_preserves_minor_declared_severity() -> None:
-    """D12: blocking keeps a declared ``Minor`` finding at ``Minor``."""
+def test_blocking_minor_blocks_at_the_gate() -> None:
+    """#554: a blocking rule must block, so declared ``Minor`` is floored to ``Major``.
+
+    This deliberately reverses MCB-12's "blocking no longer promotes Minor".
+    That change left the blocking intent in ``contributes_blocker``, which
+    ``decide_approval`` never reads, so a blocking rule silently passed.
+    """
     from mergecraft.policy.enforcement import evaluate_enforcement
 
     violation = {
@@ -44,7 +49,43 @@ def test_blocking_mode_preserves_minor_declared_severity() -> None:
 
     assert result.contributes_blocker is True
     assert result.finding is not None
-    assert result.finding.severity == "Minor"
+    assert result.finding.severity == "Major"
+    assert decide_approval([result.finding], run_succeeded=True, tier="trusted") == "failure"
+
+
+def test_blocking_minor_keeps_the_declared_severity_visible() -> None:
+    """Flooring must not hide what the rule actually declared."""
+    from mergecraft.policy.enforcement import evaluate_enforcement
+
+    violation = {
+        "rule_id": "style-block",
+        "path": "src/app.py",
+        "message": "policy violation",
+        "severity": "Minor",
+    }
+    result = evaluate_enforcement(mode="blocking", violation=violation)
+
+    assert result.finding is not None
+    assert any("Minor" in item for item in result.finding.evidence)
+
+
+def test_warning_major_does_not_block_at_the_gate() -> None:
+    """#554: warning never blocks, so a declared blocking severity is capped."""
+    from mergecraft.policy.enforcement import evaluate_enforcement
+
+    violation = {
+        "rule_id": "style-warn",
+        "path": "src/app.py",
+        "message": "policy violation",
+        "severity": "Major",
+    }
+    result = evaluate_enforcement(mode="warning", violation=violation)
+
+    assert result.contributes_blocker is False
+    assert result.finding is not None
+    assert result.finding.severity not in BLOCKING_SEVERITIES
+    assert decide_approval([result.finding], run_succeeded=True, tier="trusted") == "success"
+    assert any("Major" in item for item in result.finding.evidence)
 
 
 def test_advisory_mode_caps_critical_declared_severity_to_non_blocker() -> None:

--- a/tests/policy/test_enforcement_matrix.py
+++ b/tests/policy/test_enforcement_matrix.py
@@ -52,19 +52,47 @@ def test_every_mode_pair_is_distinguishable() -> None:
                 pytest.fail(f"{left_mode!r} and {right_mode!r} are indistinguishable: {left_key!r}")
 
 
+def test_every_mode_agrees_with_the_gate() -> None:
+    """#554 acceptance: contributes_blocker and decide_approval never disagree."""
+    from mergecraft.agents.gates import decide_approval
+
+    rule = {"evidence": {"required": ["contract_schema"]}}
+    for mode in _ENFORCEMENT_MODES:
+        for severity in FINDING_SEVERITIES:
+            result = _evaluate(mode, severity=severity, rule=rule if mode == "required" else None)
+            assert result.finding is not None
+            conclusion = decide_approval([result.finding], run_succeeded=True, tier="trusted")
+            blocked = conclusion == "failure"
+            assert blocked is result.contributes_blocker, (
+                f"{mode}/{severity}: flag={result.contributes_blocker} gate={conclusion}"
+            )
+
+
 @pytest.mark.parametrize("severity", ["Critical", "Major", "Minor"])
-def test_non_blocking_modes_preserve_declared_severity(severity: str) -> None:
-    for mode in ("warning", "required"):
-        rule = {} if mode == "required" else None
-        result = _evaluate(mode, severity=severity, rule=rule)
-        assert result.finding is not None
-        assert result.finding.severity == severity
+def test_required_without_evidence_keys_preserves_declared_severity(severity: str) -> None:
+    result = _evaluate("required", severity=severity, rule={})
+    assert result.finding is not None
+    assert result.finding.severity == severity
 
 
-def test_blocking_does_not_promote_minor_to_major() -> None:
+@pytest.mark.parametrize("severity", ["Critical", "Major", "Minor"])
+def test_warning_never_reaches_a_blocking_severity(severity: str) -> None:
+    """#554: warning is non-blocking by construction, not by an unread flag."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES
+
+    result = _evaluate("warning", severity=severity)
+    assert result.finding is not None
+    assert result.finding.severity not in BLOCKING_SEVERITIES
+    assert result.contributes_blocker is False
+
+
+def test_blocking_floors_minor_to_a_blocking_severity() -> None:
+    """#554: reverses MCB-12 so blocking intent reaches the gate via severity."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES
+
     result = _evaluate("blocking", severity="Minor")
     assert result.finding is not None
-    assert result.finding.severity == "Minor"
+    assert result.finding.severity in BLOCKING_SEVERITIES
 
 
 def test_required_consults_evidence_when_declared() -> None:

--- a/tests/policy/test_enforcement_matrix.py
+++ b/tests/policy/test_enforcement_matrix.py
@@ -107,3 +107,52 @@ def test_required_consults_evidence_when_declared() -> None:
     assert evidence_outcome.status == "inconclusive"
     result = _evaluate("required", severity="Major", rule=rule)
     assert result.contributes_blocker or result.finding.severity == "Major"
+
+
+_EVIDENCE_RULE: dict[str, Any] = {"evidence": {"required": ["contract_schema"]}}
+
+
+def _evaluate_required(*, severity: str, available: dict[str, Any]) -> Any:
+    from mergecraft.policy.enforcement import evaluate_enforcement
+
+    violation = dict(_VIOLATION)
+    violation["severity"] = severity
+    violation["rule"] = _EVIDENCE_RULE
+    violation["available_evidence"] = available
+    return evaluate_enforcement("required", violation=violation)
+
+
+@pytest.mark.parametrize("severity", ["Critical", "Major", "Minor", "Trivial"])
+def test_required_blocks_at_every_declared_severity_while_evidence_is_missing(
+    severity: str,
+) -> None:
+    """#554 follow-up: a low declared severity must not let an obligation pass.
+
+    ``required`` is documented to block until evidence is present, and the
+    schema permits ``Minor`` and ``Trivial``. Deriving the flag from severity
+    alone left those two below the gate, so the obligation silently cleared.
+    """
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+
+    result = _evaluate_required(severity=severity, available={})
+
+    assert result.finding is not None
+    assert result.finding.severity in BLOCKING_SEVERITIES
+    assert result.contributes_blocker is True
+    assert decide_approval([result.finding], run_succeeded=True, tier="trusted") == "failure"
+
+
+@pytest.mark.parametrize("severity", ["Critical", "Major", "Minor", "Trivial"])
+def test_required_stops_blocking_once_evidence_is_satisfied(severity: str) -> None:
+    """A cleared obligation must not block, at any declared severity."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+
+    result = _evaluate_required(
+        severity=severity,
+        available={"contract_schema": "docs/api.yaml"},
+    )
+
+    assert result.finding is not None
+    assert result.finding.severity not in BLOCKING_SEVERITIES
+    assert result.contributes_blocker is False
+    assert decide_approval([result.finding], run_succeeded=True, tier="trusted") == "success"


### PR DESCRIPTION
## What?

Enforcement modes and the approval gate now agree on what blocks. A `blocking` policy rule actually blocks; a `warning` rule does not.

The gate-facing severity becomes the single authority. `contributes_blocker` is read off it rather than computed beside it, so the flag and `decide_approval` cannot drift apart again.

| mode + declared | before | after |
|---|---|---|
| `blocking` + Minor | flag said block, gate passed | blocks |
| `warning` + Major | flag said pass, gate blocked | passes |
| `advisory` + Critical | consistent | unchanged |
| `required` + any | consistent | unchanged |

## Why?

`EnforcementResult.contributes_blocker` recorded what a mode meant. `decide_approval` decided from `Finding.severity`. Nothing connected them, so in two cells the recorded intent and the actual outcome were opposites. An operator writing a `blocking` rule at Minor got a rule that silently passed, and a `warning` rule at Major blocked a merge it was never meant to block.

This is latent rather than live: `evaluate_enforcement` has no production caller today, so no policy violation reaches the gate by any route. The fix lands ahead of that wiring so the semantics are settled before anything depends on them.

`blocking` now floors a non-blocking declared severity to Major. `warning` caps blocking severities to Minor, which keeps it below the gate while staying distinct from `advisory` at Trivial, so the four modes remain mutually distinguishable. The declared severity is preserved on the finding's `evidence` list, so capping never hides what a rule asked for.

`decide_approval` is untouched. It still reads severity and nothing else. That was the deciding factor between the two options in #554: the alternative added a field that lets a finding declare itself unblockable, which is the shape #75 was filed about.

## Note

**This reverses MCB-12's "blocking no longer promotes Minor"** (#523). That change removed the promotion and added `contributes_blocker` in the same commit, moving the blocking intent into a field nothing reads. Its test is updated deliberately rather than deleted, and the reversal is stated in the changelog, per #554's acceptance list.

One correction to #554 itself: its "Already pinned" section claims both divergent cells are pinned as `xfail(strict=True)`. They are not, on any branch. The issue overstated the existing guard. Real assertions replace the pins that were supposed to exist.

`test_every_mode_agrees_with_the_gate` walks the whole mode by severity matrix and asserts `contributes_blocker` equals the real `decide_approval` outcome for every cell, so this class of divergence fails the suite rather than being described in prose.

## Test plan

- `uv run pytest tests/policy tests/agents tests/evidence` — 983 passed, 3 skipped, 2 xfailed
- 7 tests fail against the previous implementation, including both divergent cells end to end
- `ruff check`, `ruff format --check`, `mypy` clean on the touched files

## Related PR(s)/Issue(s)

Closes #554
Refs #523
