### PR TITLE
ci: bump the reviewer action pin to the promotion merge

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -546,7 +546,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -694,7 +694,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -805,7 +805,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@a5651edacbf700a54212f6d0572f6a772aee66ba # main (PR #548)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Moves the three reviewer Action pins from `a5651eda` to `16ce0441`, the merge commit from #558.

## Why?

The review workflow runs the Action at a pinned SHA resolved from the default branch, so everything promoted in #558 is inert until that pin moves. Right now a review still runs the image built before any of it landed.

What starts taking effect with this bump:

- A Claude run that parses no events reports its exit code, stderr tail and retryability instead of `claude CLI produced no events` (#557)
- Enforcement modes and the approval gate agree on what blocks (#559)
- git auth failures are recognised from the status forms git actually emits (#548)
- Trace payloads are redacted before serialization, not after (#522)
- Egress failover tries every pinned address (#522)
- One shared definition of what counts as a passing check (#523)

## Note

Self-referential, like #545 and #546 before it: this PR is reviewed by the pin it replaces, so its own review still runs the old image. The new pin takes effect for the next review after merge.

## Related PR(s)/Issue(s)

Depends on #558
