### PR TITLE
perf(ci): resolve the PR number on workflow_dispatch

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -379,17 +379,39 @@ jobs:
             echo "::notice title=mergecraft skipped::Configure CODEX_AUTH_JSON (mergecraft auth codex), OPENAI_API_KEY, NOUS_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN (mergecraft auth claude) to enable mergeCraft reviews."
           fi
 
+      - name: Resolve PR for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: dispatch_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Same-repo dispatch: the ref is the head branch. An empty number is a
+          # real outcome (no open PR) — Compose then falls back to the bare
+          # string rather than failing the job (#529).
+          pr_json="$(gh pr list --repo "${{ github.repository }}" \
+                --head "${{ github.ref_name }}" --state open \
+                --json number,baseRefName --jq '.[0] // {}')"
+          n="$(printf '%s' "${pr_json}" | jq -r '.number // ""')"
+          base="$(printf '%s' "${pr_json}" | jq -r '.baseRefName // ""')"
+          {
+            echo "number=${n}"
+            echo "base_ref=${base}"
+          } >> "${GITHUB_OUTPUT}"
+
       # Composed in a step rather than inline in `with:` so the CI-context clause
       # stays readable. Every interpolated value is repo-controlled (PR number,
       # base ref, our own wait-job outputs) — no PR-authored free text reaches the
-      # prompt.
+      # prompt. pull_request_target and workflow_dispatch share one prompt shape
+      # (#529): an explicit inputs.prompt stays verbatim; a resolved PR number
+      # gets the checkout_pr + CI-context text; no matching PR falls back to the
+      # bare string.
       - name: Compose review prompt
         id: prompt
         if: env.HAS_AUTH == 'true'
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.dispatch_pr.outputs.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || steps.dispatch_pr.outputs.base_ref }}
           DISPATCH_PROMPT: ${{ inputs.prompt }}
           CI_STATE: ${{ needs.wait-for-ci.outputs.state }}
           CI_FAILED_COUNT: ${{ needs.wait-for-ci.outputs.failed_count }}
@@ -397,8 +419,11 @@ jobs:
           CI_CHECK_SUITE_ID: ${{ needs.wait-for-ci.outputs.check_suite_id }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" != "pull_request_target" ]; then
-            text="${DISPATCH_PROMPT:-Review the current pull request.}"
+          if [ -n "${DISPATCH_PROMPT:-}" ]; then
+            # Operator override: pass through unchanged (#529).
+            text="${DISPATCH_PROMPT}"
+          elif [ -z "${PR_NUMBER:-}" ]; then
+            text="Review the current pull request."
           else
             # Codex presents mergeCraft MCP tools as mergecraft_. Naming the
             # bare tool (checkout_pr) makes Codex request a GitHub *plugin* that is
@@ -407,7 +432,8 @@ jobs:
             text="Review pull request #${PR_NUMBER}. First call the mergecraft MCP tool mergecraft_checkout_pr (the checkout_pr tool on the mergecraft MCP server — already configured). Do NOT install, request, or wait for any GitHub plugin. For base-side file reads use origin/${BASE_REF}:path, not bare branch names. If prior mergeCraft threads are resolved and the latest commits address them, submit approved:true with a short summary. Focus on correctness, security, regressions, missing tests, and maintainability. Leave concise, actionable comments only for issues that should be addressed before merge."
             # The Action runs with `shell: disabled`, so the reviewer cannot run
             # lint/typecheck/tests itself. Hand it the CI outcome instead — and the
-            # check_suite id, because no MCP tool can discover one.
+            # check_suite id, because no MCP tool can discover one. wait-for-ci
+            # outputs are available on workflow_dispatch too (#529).
             case "${CI_STATE}" in
               complete)
                 if [ "${CI_FAILED_COUNT}" -gt 0 ] 2>/dev/null && [ -n "${CI_CHECK_SUITE_ID}" ]; then

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -384,13 +384,19 @@ jobs:
         id: dispatch_pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Never interpolate these into the script body. A branch name is
+          # attacker-influenced text and can carry shell syntax; expanded by
+          # `${{ }}` it would run as code under this job's write-scoped token.
+          # Passed as env and quoted, it stays one literal argv element.
+          DISPATCH_REPO: ${{ github.repository }}
+          DISPATCH_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           # Same-repo dispatch: the ref is the head branch. An empty number is a
           # real outcome (no open PR) — Compose then falls back to the bare
           # string rather than failing the job (#529).
-          pr_json="$(gh pr list --repo "${{ github.repository }}" \
-                --head "${{ github.ref_name }}" --state open \
+          pr_json="$(gh pr list --repo "${DISPATCH_REPO}" \
+                --head "${DISPATCH_REF}" --state open \
                 --json number,baseRefName --jq '.[0] // {}')"
           n="$(printf '%s' "${pr_json}" | jq -r '.number // ""')"
           base="$(printf '%s' "${pr_json}" | jq -r '.baseRefName // ""')"

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ evals/results/structural-replay-convergence-*.json
 # `git worktree remove`, this just keeps them out of `git status`/`find`).
 /mergecraft-*/
 
+# Isolated git worktrees (local operator checkouts)
+.worktrees/
+
 # mergeCraft's own runtime cache/scratch state, provisioned into <repo>/.mergecraft/
 # on every self-review run (analyzer-cache/, analyzer-scratch/, analyzer-runs/,
 # analyzers.lock, .provision.lock, traces/) — regenerated every run, never source

--- a/tests/ci/test_mergecraft_dispatch_prompt.py
+++ b/tests/ci/test_mergecraft_dispatch_prompt.py
@@ -1,0 +1,239 @@
+"""#529 — workflow_dispatch must share the pull_request_target review prompt.
+
+A dispatch run with no ``prompt`` input used to hand the agent
+``Review the current pull request.`` — no PR number, no
+``mergecraft_checkout_pr`` instruction. The agent then spent ~48 turns
+discovering the PR. Both event paths now build the same prompt from one
+script; an explicit ``inputs.prompt`` still passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.ci.workflow_support import job, load_workflow
+
+_WORKFLOW = "mergecraft.yml"
+_REVIEW_JOB = "review"
+_RESOLVE_STEP = "Resolve PR for workflow_dispatch"
+_COMPOSE_STEP = "Compose review prompt"
+_CHECKOUT_PR = "mergecraft_checkout_pr"
+_BARE_FALLBACK = "Review the current pull request."
+
+
+def _review_steps() -> list[dict[str, Any]]:
+    steps = job(load_workflow(_WORKFLOW), _REVIEW_JOB).get("steps")
+    assert isinstance(steps, list), "review job steps must be a list"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _review_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"review job is missing step {name!r}")
+
+
+def _compose_script() -> str:
+    run = _step(_COMPOSE_STEP).get("run")
+    assert isinstance(run, str), "Compose review prompt has no run script"
+    assert run.strip(), "Compose review prompt run script is empty"
+    return run
+
+
+def _prompt_from_github_output(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    start = "text<<MERGECRAFT_PROMPT_EOF\n"
+    end = "\nMERGECRAFT_PROMPT_EOF\n"
+    assert start in text, f"GITHUB_OUTPUT missing prompt delimiter: {text!r}"
+    after = text.split(start, 1)[1]
+    assert end in after or after.endswith("\nMERGECRAFT_PROMPT_EOF"), text
+    body = after.rsplit("MERGECRAFT_PROMPT_EOF", 1)[0]
+    return body.rstrip("\n")
+
+
+def _run_compose(
+    tmp_path: Path,
+    *,
+    env: dict[str, str],
+) -> str:
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    script_env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "GITHUB_OUTPUT": str(output),
+        "HOME": str(tmp_path),
+    }
+    script_env.update(env)
+    completed = subprocess.run(
+        ["bash", "-c", _compose_script()],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=script_env,
+    )
+    assert completed.returncode == 0, (
+        f"compose script failed ({completed.returncode}): "
+        f"stdout={completed.stdout!r} stderr={completed.stderr!r}"
+    )
+    return _prompt_from_github_output(output)
+
+
+class TestDispatchResolveStep:
+    """The dispatch job must resolve an open PR for the ref without failing closed."""
+
+    def test_resolve_step_is_dispatch_only(self) -> None:
+        step = _step(_RESOLVE_STEP)
+        assert step.get("if") == "github.event_name == 'workflow_dispatch'"
+        assert step.get("id") == "dispatch_pr"
+
+    def test_resolve_step_lists_open_prs_for_the_head_ref(self) -> None:
+        run = _step(_RESOLVE_STEP).get("run")
+        assert isinstance(run, str)
+        assert "gh pr list" in run
+        assert "--state open" in run
+        assert "github.ref_name" in run
+        assert "number=" in run
+
+    def test_resolve_step_does_not_fail_the_job_on_empty_match(self) -> None:
+        run = _step(_RESOLVE_STEP).get("run")
+        assert isinstance(run, str)
+        assert '.number // ""' in run or ".number // empty" in run
+
+
+class TestComposePromptShape:
+    """Both events build the prompt from one script, not two event branches."""
+
+    def test_compose_script_does_not_branch_on_event_name(self) -> None:
+        script = _compose_script()
+        assert "EVENT_NAME" not in script
+        assert "pull_request_target" not in script
+
+    def test_compose_keeps_the_dispatch_prompt_override(self) -> None:
+        env = _step(_COMPOSE_STEP).get("env")
+        assert isinstance(env, dict)
+        assert env.get("DISPATCH_PROMPT") == "${{ inputs.prompt }}"
+        assert "DISPATCH_PROMPT" in _compose_script()
+
+    def test_compose_reads_the_resolved_dispatch_pr_number(self) -> None:
+        env = _step(_COMPOSE_STEP).get("env")
+        assert isinstance(env, dict)
+        pr_number = env.get("PR_NUMBER")
+        assert isinstance(pr_number, str)
+        assert "steps.dispatch_pr.outputs.number" in pr_number
+        assert "github.event.pull_request.number" in pr_number
+
+    def test_shared_path_names_checkout_pr(self) -> None:
+        script = _compose_script()
+        assert _CHECKOUT_PR in script
+        assert script.count(_CHECKOUT_PR) == 1
+
+    def test_shared_path_wires_ci_context(self) -> None:
+        script = _compose_script()
+        assert "CI_STATE" in script
+        assert "mergecraft_get_check_suite_logs" in script
+
+
+class TestComposePromptBehaviour:
+    """Execute the real compose script — the YAML is the code under test."""
+
+    def test_dispatch_without_prompt_names_the_pr_number(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "skipped",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert "Review pull request #529." in prompt
+        assert _CHECKOUT_PR in prompt
+        assert "origin/pre-0.0.1:path" in prompt
+        assert "wait state: skipped" in prompt
+
+    def test_pull_request_target_uses_the_same_shape(self, tmp_path: Path) -> None:
+        dispatch = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        target = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert dispatch == target
+        assert "CI has finished green" in target
+
+    def test_explicit_prompt_input_passes_through_unchanged(self, tmp_path: Path) -> None:
+        override = "Review only the security findings on #12."
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "DISPATCH_PROMPT": override,
+                "PR_NUMBER": "529",
+                "BASE_REF": "pre-0.0.1",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "2",
+                "CI_FAILED_NAMES": "Verify (lint)",
+                "CI_CHECK_SUITE_ID": "99",
+            },
+        )
+        assert prompt == override
+        assert _CHECKOUT_PR not in prompt
+
+    def test_missing_pr_number_falls_back_to_the_bare_string(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "",
+                "BASE_REF": "",
+                "CI_STATE": "skipped",
+                "CI_FAILED_COUNT": "0",
+                "CI_FAILED_NAMES": "",
+                "CI_CHECK_SUITE_ID": "",
+            },
+        )
+        assert prompt == _BARE_FALLBACK
+        assert _CHECKOUT_PR not in prompt
+
+    def test_failed_ci_clause_is_attached_when_a_pr_is_resolved(self, tmp_path: Path) -> None:
+        prompt = _run_compose(
+            tmp_path,
+            env={
+                "PR_NUMBER": "529",
+                "BASE_REF": "main",
+                "CI_STATE": "complete",
+                "CI_FAILED_COUNT": "1",
+                "CI_FAILED_NAMES": "Verify (typecheck)",
+                "CI_CHECK_SUITE_ID": "12345",
+            },
+        )
+        assert "Review pull request #529." in prompt
+        assert "1 job(s) FAILED (Verify (typecheck))" in prompt
+        assert "check_suite_id 12345" in prompt
+
+
+@pytest.mark.parametrize("name", [_RESOLVE_STEP, _COMPOSE_STEP])
+def test_required_review_steps_exist(name: str) -> None:
+    _step(name)

--- a/tests/ci/test_mergecraft_dispatch_prompt.py
+++ b/tests/ci/test_mergecraft_dispatch_prompt.py
@@ -97,8 +97,30 @@ class TestDispatchResolveStep:
         assert isinstance(run, str)
         assert "gh pr list" in run
         assert "--state open" in run
-        assert "github.ref_name" in run
         assert "number=" in run
+
+    def test_resolve_step_takes_ref_and_repo_from_env_not_interpolation(self) -> None:
+        """The ref must reach the script as data, never as expanded template text."""
+        step = _step(_RESOLVE_STEP)
+        env = step.get("env")
+        assert isinstance(env, dict), "resolve step must declare env"
+        assert env.get("DISPATCH_REF") == "${{ github.ref_name }}"
+        assert env.get("DISPATCH_REPO") == "${{ github.repository }}"
+
+        run = step.get("run")
+        assert isinstance(run, str)
+        assert "${DISPATCH_REF}" in run
+        assert "${DISPATCH_REPO}" in run
+
+    def test_resolve_step_interpolates_nothing_into_its_script(self) -> None:
+        """zizmor template-injection: no ``${{ }}`` may appear in the run body.
+
+        A branch name is attacker-influenced text. Expanded by ``${{ }}`` into
+        bash it executes under this job's write-scoped token.
+        """
+        run = _step(_RESOLVE_STEP).get("run")
+        assert isinstance(run, str)
+        assert "${{" not in run, f"template expansion in run body: {run!r}"
 
     def test_resolve_step_does_not_fail_the_job_on_empty_match(self) -> None:
         run = _step(_RESOLVE_STEP).get("run")
@@ -237,3 +259,86 @@ class TestComposePromptBehaviour:
 @pytest.mark.parametrize("name", [_RESOLVE_STEP, _COMPOSE_STEP])
 def test_required_review_steps_exist(name: str) -> None:
     _step(name)
+
+
+_HOSTILE_REFS: tuple[str, ...] = (
+    'evil"; touch INJECTED; echo "',
+    "evil'; touch INJECTED; echo '",
+    "evil$(touch INJECTED)",
+    "evil`touch INJECTED`",
+    "evil; touch INJECTED",
+    "evil && touch INJECTED",
+    "evil | touch INJECTED",
+    "evil\ntouch INJECTED",
+)
+
+
+def _resolve_script() -> str:
+    run = _step(_RESOLVE_STEP).get("run")
+    assert isinstance(run, str), "resolve step has no run script"
+    return run
+
+
+def _run_resolve(tmp_path: Path, *, ref: str) -> tuple[Path, Path]:
+    """Execute the real resolve script with a stub ``gh``; return argv log and cwd."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_log = tmp_path / "gh_argv.txt"
+    stub = bin_dir / "gh"
+    stub.write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$@" >> {argv_log}\nprintf "%s" "{{}}"\n',
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    script_env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "GITHUB_OUTPUT": str(output),
+        "HOME": str(tmp_path),
+        "DISPATCH_REPO": "acme/demo",
+        "DISPATCH_REF": ref,
+    }
+    completed = subprocess.run(
+        ["bash", "-c", _resolve_script()],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=script_env,
+    )
+    assert completed.returncode == 0, (
+        f"resolve script failed ({completed.returncode}): "
+        f"stdout={completed.stdout!r} stderr={completed.stderr!r}"
+    )
+    return argv_log, tmp_path
+
+
+@pytest.mark.parametrize("ref", _HOSTILE_REFS)
+def test_shell_metacharacters_in_a_branch_name_do_not_execute(
+    tmp_path: Path,
+    ref: str,
+) -> None:
+    """A branch name carrying shell syntax must stay data (#529 injection review).
+
+    ``workflow_dispatch`` runs with a write-scoped token, so a ref expanded into
+    the script body would execute with it.
+    """
+    argv_log, workdir = _run_resolve(tmp_path, ref=ref)
+
+    assert not (workdir / "INJECTED").exists(), f"branch name executed as code: {ref!r}"
+    logged = argv_log.read_text(encoding="utf-8").splitlines()
+    assert ref.splitlines()[0] in "\n".join(logged), (
+        f"gh never received the ref as an argument: {logged!r}"
+    )
+
+
+def test_a_plain_branch_name_still_reaches_gh_unchanged(tmp_path: Path) -> None:
+    """The hardening must not mangle an ordinary ref."""
+    argv_log, _ = _run_resolve(tmp_path, ref="feat/plain-branch")
+
+    logged = argv_log.read_text(encoding="utf-8").splitlines()
+    assert "feat/plain-branch" in logged
+    assert "--state" in logged
+    assert "open" in logged


### PR DESCRIPTION
## What?

Running the reviewer manually now reviews the branch's open PR instead of nothing in particular.

A `workflow_dispatch` run resolves the open PR for the branch and builds the same `#N` plus `checkout_pr` prompt that `pull_request_target` already builds. An explicit prompt input still passes through untouched, and a branch with no open PR falls back to the bare instruction rather than failing the job.

## Why?

Manual dispatch was the one entry point that gave the reviewer no PR to hold onto. It produced a prompt with no number and no checkout instruction, so the agent had nothing to fetch and no diff to score, and the run burned tokens arriving at a verdict about nothing. Re-running a review by hand is exactly what an operator reaches for when an automatic run fails, which is when it needs to work.

## Note

This carries only the dispatch half of #539. That PR also widened the read-only git allowlist in `mcp/git_guards.py`, admitting `grep` and redirecting `config` and `remote` to substitutes. Those changes are deliberately left out.

The reviewer-resilience plan's W2 and W3 own that file, and W3 takes the opposite approach to the same verbs: it admits `show-ref`, `ls-remote`, `for-each-ref` and `config --get` rather than refusing them, because the ergonomics gap is what motivated the `--no-index` containment bypass in the first place. Landing both would leave two designs fighting over one allowlist while W2's confinement work lands in the same file. Splitting here lets the uncontested half ship now and leaves the allowlist to the wave that owns it.

Rebuilt on current `main` rather than rebased: #539's branch was 137 commits behind.

## Test plan

- `uv run pytest tests/ci/test_mergecraft_dispatch_prompt.py` (15 passed)
- Action pins deliberately untouched, so #560 remains the only pin change in flight
- `make workflow-lint` is linux-only and runs in CI

## Related PR(s)/Issue(s)

Fixes #529
Supersedes #539
