### PR TITLE
review-record: findings scope, checks, and action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,70 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: make coverage-gate
 
+  action-slim-bootstrap:
+    name: Bootstrap slim GHCR image for Action SHA pin
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'pre-0.0.1' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Resolve self-review Action SHA pin
+        id: pin
+        run: |
+          set -euo pipefail
+          SHA=$(grep -E '^\s*MERGECRAFT_ACTION_SHA:\s*"' .github/workflows/mergecraft.yml | head -1 | sed -E 's/.*"([0-9a-f]{40})".*/\1/')
+          test -n "${SHA}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check whether slim image tag already exists on GHCR
+        id: tag
+        env:
+          SHA: ${{ steps.pin.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if docker manifest inspect "ghcr.io/alexhawat/mergecraft:${SHA}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Slim image tag already published — skipping bootstrap rebuild"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Slim image tag missing — will build and push"
+          fi
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.tag.outputs.exists != 'true'
+        with:
+          ref: ${{ steps.pin.outputs.sha }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        if: steps.tag.outputs.exists != 'true'
+      - name: Build and push slim image for pinned Action SHA
+        if: steps.tag.outputs.exists != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/alexhawat/mergecraft:${{ steps.pin.outputs.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.pin.outputs.sha }}
+          cache-from: type=gha,scope=mergeCraft-slim-bootstrap
+          cache-to: type=gha,mode=max,scope=mergeCraft-slim-bootstrap
+
   static:
     name: Verify (static + build py${{ matrix.python }})
+    needs: action-slim-bootstrap
+    if: >-
+      always() &&
+      (needs.action-slim-bootstrap.result == 'success' ||
+       needs.action-slim-bootstrap.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -115,12 +177,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Static, typecheck, build tier
         run: make ci-static
-      # Reports self-review Action-pin drift (#450). Advisory on purpose: the
-      # stale pin lives on the default branch, so it is not a defect in the PR
-      # being checked, and failing here would block every unrelated change
-      # until someone bumps main. The annotation is what makes the skew
-      # visible instead of silent -- which is how it reached 687 commits.
-      - name: Action pin freshness (advisory)
+      - name: Action pin freshness
         if: matrix.python == '3.14'
         run: |
           # No --depth here. A depth-limited fetch marks origin/main as a
@@ -130,13 +187,7 @@ jobs:
           # runs it. The checkout above is fetch-depth: 0, so the objects are
           # already local and a full fetch is near-free.
           git fetch --no-tags origin main:refs/remotes/origin/main || true
-          if out="$(make action-pin-check 2>&1)"; then
-            echo "$out"
-          else
-            echo "$out"
-            detail="$(printf '%s' "$out" | grep -m1 -- '  - ' | sed 's/^  - //')"
-            echo "::warning title=mergecraft action pin drift::${detail:-see log}"
-          fi
+          make action-pin-check
       # First-wave CI SARIF for mergeCraft ingest (#464 / D8). Upload even when
       # the static tier failed so the review still sees the tool's findings.
       - name: Emit ruff and mypy SARIF

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "16ce04413932eb74957d394d2aa376b2af39f0b8"
+  MERGECRAFT_ACTION_SHA: "5526931955df8974ed2cbc72c3810a6d3a9ff5d9"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
+        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -757,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
+        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -894,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
+        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "5526931955df8974ed2cbc72c3810a6d3a9ff5d9"
+  MERGECRAFT_ACTION_SHA: "2a943ce9724e454944dabf695f2eab2c676b3dcb"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -757,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -894,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@5526931955df8974ed2cbc72c3810a6d3a9ff5d9 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -155,6 +155,10 @@ env:
   # review job timeout-minutes derive from this — do not shorten per-attempt for
   # retry headroom.
   MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES: "25"
+  # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
+  # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
+  # `make action-pin-check`.
+  MERGECRAFT_ACTION_SHA: "16ce04413932eb74957d394d2aa376b2af39f0b8"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -242,7 +246,7 @@ jobs:
               state="timeout"
               break
             fi
-            sleep 20
+            sleep 10
           done
 
           {
@@ -578,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -753,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -890,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # env.MERGECRAFT_ACTION_SHA / main (PR #558)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -619,6 +619,21 @@ jobs:
           MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
           MERGECRAFT_TRACING_REGION: eu
 
+      - name: Persist evidence packet (Nous)
+        if: always()
+        env:
+          PACKET: ${{ steps.mergecraft_nous.outputs.evidence_packet }}
+        run: printf '%s' "$PACKET" > packet-nous.json
+
+      - name: Upload packet artifact (Nous)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mergecraft-evidence-nous
+          path: packet-nous.json
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Decide Codex fallback after Nous
         id: fallback
         # Deliberately NOT gated on steps.mergecraft_nous.outcome. The failure
@@ -637,10 +652,22 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASELINE_ID: ${{ steps.approval_baseline.outputs.id }}
           NOUS_OUTCOME: ${{ steps.mergecraft_nous.outcome }}
+          NOUS_PACKET: ${{ steps.mergecraft_nous.outputs.evidence_packet }}
         run: |
           set -euo pipefail
           need="false"
-          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+          if [ -n "${NOUS_PACKET:-}" ]; then
+            verdict="$(printf '%s' "$NOUS_PACKET" | jq -r '.decision.verdict // empty')"
+            case "${verdict}" in
+              failure|success)
+                echo "packet decision.verdict=${verdict} — Nous review posted a verdict; not falling back to Codex."
+                ;;
+              *)
+                need="true"
+                echo "::notice title=mergecraft Codex fallback::Nous review posted no verdict in evidence packet (action outcome: ${NOUS_OUTCOME}); retrying with openai/gpt-codex."
+                ;;
+            esac
+          elif [ "${EVENT_NAME}" = "pull_request_target" ]; then
             latest=""
             for attempt in $(seq 1 3); do
               if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
@@ -749,6 +776,21 @@ jobs:
           MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
           MERGECRAFT_TRACING_REGION: eu
 
+      - name: Persist evidence packet (Codex)
+        if: always()
+        env:
+          PACKET: ${{ steps.mergecraft_codex.outputs.evidence_packet }}
+        run: printf '%s' "$PACKET" > packet-codex.json
+
+      - name: Upload packet artifact (Codex)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mergecraft-evidence-codex
+          path: packet-codex.json
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Decide Claude backstop after the provider cascade
         id: claude_fallback
         # Gated on a RETRYABLE provider failure, not on "no verdict posted".
@@ -784,10 +826,21 @@ jobs:
           BASELINE_ID: ${{ steps.approval_baseline.outputs.id }}
           NOUS_OUTCOME: ${{ steps.mergecraft_nous.outcome }}
           CODEX_OUTCOME: ${{ steps.mergecraft_codex.outcome }}
+          NOUS_PACKET: ${{ steps.mergecraft_nous.outputs.evidence_packet }}
+          CODEX_PACKET: ${{ steps.mergecraft_codex.outputs.evidence_packet }}
         run: |
           set -euo pipefail
           need="true"
-          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+          packet="${CODEX_PACKET:-${NOUS_PACKET:-}}"
+          if [ -n "${packet}" ]; then
+            verdict="$(printf '%s' "$packet" | jq -r '.decision.verdict // empty')"
+            case "${verdict}" in
+              failure|success)
+                need="false"
+                echo "packet decision.verdict=${verdict} — a rung posted a verdict despite failing later; not spending the Claude backstop."
+                ;;
+            esac
+          elif [ "${EVENT_NAME}" = "pull_request_target" ]; then
             latest=""
             for attempt in $(seq 1 3); do
               if latest="$(gh api "/repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
@@ -855,6 +908,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
           MERGECRAFT_TRACING_REGION: eu
+
+      - name: Persist evidence packet (Claude)
+        if: always()
+        env:
+          PACKET: ${{ steps.mergecraft_claude.outputs.evidence_packet }}
+        run: printf '%s' "$PACKET" > packet-claude.json
+
+      - name: Upload packet artifact (Claude)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mergecraft-evidence-claude
+          path: packet-claude.json
+          retention-days: 30
+          if-no-files-found: ignore
 
       - name: mergeCraft review incomplete (non-fatal)
         if: >-

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "2a943ce9724e454944dabf695f2eab2c676b3dcb"
+  MERGECRAFT_ACTION_SHA: "fcb64c11d839d8ff4cf18bb925362080873df067"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -757,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -894,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@2a943ce9724e454944dabf695f2eab2c676b3dcb # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/.mergecraft/config.yaml
+++ b/.mergecraft/config.yaml
@@ -6,8 +6,9 @@
 # approved=true AND ctx.trust_tier == "trusted", which derive_trust_tier()
 # (src/mergecraft/analyzers/trust.py) only grants to a genuine non-fork
 # `pull_request` event or workflow_dispatch — never to pull_request_target,
-# regardless of fork status. See the mergecraft.yml trigger comment for how the
-# workflow now earns that "trusted" tier for same-repo PRs.
+# regardless of fork status. mergecraft.yml deliberately stays on
+# pull_request_target only (see PR #200); the PAT-backed APPROVE lane lives in
+# mergecraft-approve.yml.
 #
 # recallPass dogfood resumes after this PR merges to pre-0.0.1: pull_request_target
 # runs the workflow + action pin from the base branch, so self-review PRs cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Every review run that resolves a pull request number posts a deterministic run
+  record — a sticky progress comment and a mandatory review-body preamble rendered
+  from the same function, so a green review that says nothing is no longer
+  indistinguishable from a review that never ran (#546 post-mortem)
+- The merge-evidence packet gains a `run_health` section (schema `1.11.0`) for
+  run-scoped findings partitioned out of the top-level `findings` list; change
+  findings and run observations now have separate audiences and surfaces
+- `Finding.scope` (`change` | `run`, default `change`) and `FindingSource`
+  `"trajectory"` so trajectory auditor rows are attributed as process evidence,
+  not PR defects
+- Job step summary (`GITHUB_STEP_SUMMARY`) written from `_publish` with outcome,
+  pre-merge rows, and findings — capped at GitHub's 1 MiB with the header intact
+- Evidence packet persisted to a workflow artifact on every review rung
+  (`if: always()`, 30-day retention) so the packet survives runner teardown
+- `MERGECRAFT_ACTION_SHA` workflow variable — one pin definition shared by all
+  three review rungs, with `make action-pin-check` enforcing staleness and
+  rung parity (#532)
+- Action image digest pin gate (`action-image-digest-check`) and halved
+  `wait-for-ci` poll cadence (20s → 10s, #528)
+
 ### Fixed
+
+- Trajectory findings no longer block merge: `blocking_findings()` is the single
+  predicate shared by the terminal-verdict gate, packet gate, and approval check;
+  run-scoped rows are dropped before severity grading (D2/D3)
+- A review whose inline anchors are all invalid still lands its body and verdict
+  — anchors are pre-validated against the diff, 422 on non-APPROVE reviews is
+  recovered server-side, and a total anchor failure posts zero inline comments
+  instead of losing the review (#530)
+- Trajectory auditor classifies tool failures before counting them, so
+  self-corrected schema slips, policy refusals, and environment faults no
+  longer masquerade as ignored errors that block the PR
+- Status-check summaries are derived from the evidence packet they report — no
+  hardcoded prose that the packet can contradict; failed check posts log at
+  WARNING with a matching `::warning::` annotation (#546 post-mortem)
+- Codex fallback routing reads `decision.verdict` from the in-process evidence
+  packet instead of racing the check-runs API
+
+### Changed
 
 - Enforcement modes and the approval gate now agree on what blocks. The
   gate-facing severity is the single authority, so ``contributes_blocker`` is

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SHELL := /bin/bash
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check mcp-server-json mcp-server-json-check reference-docs reference-docs-check bench-review eval-gate eval-replay eval-convergence \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-measure coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check pins-check action-pin-check
+	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -79,6 +79,7 @@ lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-
 	$(UV) run python scripts/check_cli_consoles.py
 	$(MAKE) action-yml-hygiene-check
 	$(MAKE) hook-pins-check
+	$(MAKE) action-image-digest-check
 	$(UV) run python scripts/check_privilege_drop_chown.py
 	$(UV) run python scripts/check_type_ignores.py
 	$(UV) run python scripts/check_called_workflow_permissions.py
@@ -96,6 +97,9 @@ hook-pins-check: ## Fail when .pre-commit-config.yaml hook revs drift from pypro
 
 action-pin-check: ## Fail when the default branch's self-review Action pin drifts too far behind (#450)
 	$(UV) run python scripts/check_action_pin_freshness.py
+
+action-image-digest-check: ## Fail when action.yml slim digest drifts from GHCR for the Action SHA (#526)
+	$(UV) run python scripts/check_action_image_digest.py
 
 lint-ruff-advisory: ## Ruff advisory families (non-blocking CI; #146)
 	$(RUFF) check src tests scripts --select $(RUFF_ADVISORY_FAMILIES)
@@ -251,11 +255,11 @@ reference-docs: docs ## Regenerate the README action + CLI reference tables (ali
 
 reference-docs-check: docs-check ## Fail when README reference tables drift (alias)
 
-ci-static: lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check ## Static/build tier
+ci-static: lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check action-pin-check ## Static/build tier
 	@echo "ci-static OK"
 
 # Ordered expansion of `make ci`, consumed by the resumable runner (scripts/ci_resume.sh).
-CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check security coverage-gate mcp-server-json-check
+CI_STEPS := lockcheck lint typecheck pyright catalog-check agents-check build example-workflows-check agent-packages-check cli-examples-check docs-check pins-check action-pin-check security coverage-gate mcp-server-json-check
 
 ci-steps: ## Print the ordered `make ci` step list (consumed by ci-resume)
 	@echo $(CI_STEPS)

--- a/REVIEW-CHECKS.md
+++ b/REVIEW-CHECKS.md
@@ -23,6 +23,8 @@ A quick orientation before the lists:
 7. [Memory across runs](#7-memory-across-runs)
 8. [Output shape](#8-output-shape)
 9. [Address-reviews checks](#9-address-reviews-checks)
+10. [Trajectory checks](#10-trajectory-checks-43-49)
+11. [Deterministic run record](#11-deterministic-run-record-plan-12)
 
 ---
 
@@ -37,8 +39,10 @@ verdict; everything else is advisory. Concretely:
   `mergecraft.analyzers.finding`, `extra="forbid"`). Each finding carries
   `tool`, `rule_id`, `category`, `severity`, `confidence`, `path`,
   `start_line`/`end_line`, `fingerprint`, `evidence: list[str]`,
-  `introduced_by_pr`, `source`, `cluster_id`. Findings are the
-  authoritative structural input to `decide_approval()`.
+  `introduced_by_pr`, `source`, `scope`, `cluster_id`. Findings are the
+  authoritative structural input to `decide_approval()`. Only `scope="change"`
+  findings can block; `scope="run"` rows are advisory and partition into the
+  packet's `run_health` section at assembly time (plan 12).
 - **`DeterministicCheck` rows** — one per declared `staticChecks` or
   discovered Makefile target. Status is one of five: `passed`, `failed`,
   `timed_out`, `unavailable`, `declared-but-cannot-run`. **Only
@@ -407,13 +411,48 @@ gated on the record carrying that signal at all: `changed-unread-file` needs
 `read_coverage`, `missing-completion-signal` needs at least one recorded call. A
 check that fires on every run is noise, not a gate.
 
-**No second gate.** These are ordinary findings in the packet's finding list, so
-`decide_approval()` weighs them exactly like any other evidence — a `Critical`
-`unresolved-failure` blocks for the same reason a `Critical` analyzer finding
-does. There is no separate trajectory verdict.
+**Run-scoped, never blocking (D2).** Trajectory checks stamp `scope="run"`,
+`source="trajectory"`, and `introduced_by_pr="false"`. They partition into the
+packet's `run_health` section and render under a separate collapsed heading in
+the deterministic run record. `blocking_findings()` drops them before severity
+grading — no severity, and no future check, makes a run-scoped finding fail a
+PR. There is no separate trajectory verdict and no second required check-run
+(D14).
 
 **They never crowd out code findings.** Inline slots go to code findings first;
-trajectory findings take only what is left and otherwise report in the body.
+trajectory findings take only what is left and otherwise report in the body or
+the run-health section.
+
+## 11. Deterministic run record (plan 12)
+
+Every run that resolves a PR number leaves exactly one authoritative sticky
+progress comment, whether the agent published a review, posted no verdict, or
+failed mid-run (D6). Re-runs edit the same comment in place via the existing
+sticky marker — they do not append a second one.
+
+The comment and the published review body both render from
+`render_deterministic_review_block()` in `findings/ledger.py` (D7), so the two
+surfaces cannot drift. The agent cannot suppress the block by supplying its own
+copy of the markers — dedupe keeps the server's version.
+
+The block always contains, in order:
+
+1. **Run header** — outcome, verdict diagnostic, decision verdict and reason,
+   model actually used, attempt count, token summary, run URL, reviewed SHA.
+2. **Pre-merge checks** — analyzers (dispatched lenses or packet summary),
+   static checks from `deterministic_checks`, CI intelligence pointer, trust
+   tier.
+3. **Change-scoped findings** — typed packet rows (`scope="change"`); `_No
+   change-scoped findings recorded._` when empty.
+4. **Run health** — collapsed `<details>` with `scope="run"` findings when
+   present; omitted when none.
+5. **Agent summary or rejection** — when a verdict exists, the agent's summary
+   quoted beneath the deterministic rows; when it does not, an explicit
+   `No verdict recorded — reason: <typed rejection>` line.
+
+The same block is merged into the review body as a mandatory preamble through
+`merge_deterministic_preamble_into_review_body` in `mcp/review.py`, applied
+last so nothing can be appended above it.
 
 ## 9. Address-reviews checks
 

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:fc150a9427ce4e72de27282e04c0447a2964194e833028673b85c63cdf05b6e9"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:abc741b5f493af4f2b7eee7b9f149e46926562d33d4462455ecc2a895b88f858"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:f139c08a08d5e7b6b36050605dc87e8b9200c62a2eeb1cb796b1cbcf65c826f2"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:fc150a9427ce4e72de27282e04c0447a2964194e833028673b85c63cdf05b6e9"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:2195c850f6553ac078c547e1d362d957d869aa5395f003087a4660c86c7067d3"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:f139c08a08d5e7b6b36050605dc87e8b9200c62a2eeb1cb796b1cbcf65c826f2"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,10 @@ outputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
+  # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
+  # build-images push for the workflow Action SHA (#526).
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:2195c850f6553ac078c547e1d362d957d869aa5395f003087a4660c86c7067d3"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:abc741b5f493af4f2b7eee7b9f149e46926562d33d4462455ecc2a895b88f858"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:1976f3a5069ae417c02d7bed5230bc476a11ff4ac2a5c5de12bdeee00b73e938"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/docs/REVIEW-DOCTRINE.md
+++ b/docs/REVIEW-DOCTRINE.md
@@ -13,6 +13,28 @@ Only a real non-zero exit from an executable gate is evidence. The Action image 
 lands as `unavailable` there unless the repo declares explicit `staticChecks` with binaries
 that exist in the image.
 
+## Finding scope: change vs run (plan 12, D1–D2)
+
+Every `Finding` carries a `scope` axis: `change` or `run`. The default is `change`, so
+existing producers keep their meaning without silent reclassification.
+
+- **`change`** — a claim about the diff under review. These are the findings that can
+  block merge after causality policy and severity grading.
+- **`run`** — a claim about how the review executed (trajectory auditor rows, environment
+  observations, and similar process evidence). These are **advisory only** and can never
+  block (D2). Run health is reported — in the evidence packet's `run_health` section, the
+  deterministic run record, the `mergecraft` completion check summary, and the job step
+  summary — never enforced as a second merge gate (D14).
+
+`blocking_findings()` in `agents/gates.py` is the single predicate: drop `scope == "run"`,
+apply `apply_causality_policy`, then test `BLOCKING_SEVERITIES`. `_has_blocker`,
+`_packet_has_blockers`, `decide_approval`, and `mcp/verdict.py::_blocks_approve` all route
+through it — two predicates that disagree is a defect class, not a style question (D3).
+
+Trajectory checks stamp `source="trajectory"`, `scope="run"`, and `introduced_by_pr="false"`
+(D4). All three fields matter: `introduced_by_pr` drives causality, `scope` drives gating,
+`source` drives rendering.
+
 ## Makefile discovery, not tool inference
 
 **`DISCOVERABLE_TARGETS` discovers Makefile targets, not tools.** The tuple

--- a/docs/artifacts/dogfood-mergecraft.yml
+++ b/docs/artifacts/dogfood-mergecraft.yml
@@ -173,7 +173,7 @@ jobs:
               state="timeout"
               break
             fi
-            sleep 20
+            sleep 10
           done
 
           {

--- a/docs/evidence-packet.md
+++ b/docs/evidence-packet.md
@@ -88,7 +88,7 @@ to ship a schema change. The rules are:
    a typo) do **not** require a bump. The version is the contract, not
    the prose around it.
 
-The current version is `1.9.0`.
+The current version is `1.11.0`.
 
 Wiring a consumer is **not** a shape change: #96 gave these models their first
 runtime caller without touching a single field, so `PACKET_SCHEMA_VERSION` did
@@ -124,6 +124,8 @@ not move.
   (`success` / `failure` / `neutral`). Gate actions such as `block` live
   on `action`, not `verdict`. Persisted packets that stored `block` as
   `verdict` no longer validate.
+- `1.11.0` — plan 12 W7 adds `run_health`: run-scoped findings and an
+  advisory conclusion, partitioned out of the top-level `findings` list.
 
 ## Top-level fields
 
@@ -166,13 +168,26 @@ is the per-PR evidence record; this list is its scope.
 
 ### `findings` — required (`list[Finding]`)
 
-The re-typed analyzer findings. The packet **composes** the existing
-`Finding` model from `mergecraft.analyzers.finding`, not a parallel
-finding model (D3). The wire shape is governed by the
-[`Finding` schema](ANALYZERS.md); the packet's `findings` field
-inlines that schema entirely into its emitted JSON Schema, so a
-packet consumer never has to look at `$defs` to validate a
-`findings` item.
+Change-scoped findings only. Run-scoped trajectory and environment
+observations live under `run_health` instead (plan 12 W7). The packet
+**composes** the existing `Finding` model from
+`mergecraft.analyzers.finding`, not a parallel finding model (D3). The
+wire shape is governed by the [`Finding` schema](ANALYZERS.md); the
+packet's `findings` field inlines that schema entirely into its emitted
+JSON Schema, so a packet consumer never has to look at `$defs` to validate
+a `findings` item.
+
+### `run_health` — `RunHealth | None` (added in plan 12 W7)
+
+Run-scoped findings and their advisory conclusion. Trajectory auditor rows
+and other `scope="run"` observations are partitioned here at assembly
+time; they never block merge (D2). When no run-scoped findings exist the
+section is omitted (`null`).
+
+| Field | Type | Notes |
+|------|------|-------|
+| `findings` | `list[Finding]` | Run-scoped rows (`scope="run"`). |
+| `conclusion` | `str` | `clean` when empty; `advisory` when observations exist. |
 
 ### `deterministic_checks` — required (`list[DeterministicCheck]`)
 

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -51,6 +51,10 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | **W1.8** `ci.yml` non-zero on stale pin | W8 | `test_w18_action_pin_gate.py::test_ci_yml_fails_on_stale_pin_instead_of_warning_only` |
 | **W1.8** single pin, three rungs | W8 | `test_w18_action_pin_gate.py::test_mergecraft_workflow_three_rungs_share_one_pin_value` |
 | **W1.8** partial bump fails | W8 | `test_w18_action_pin_gate.py::test_partial_pin_bump_fails_action_pin_check` |
+| **W8 / #535** digest guard script | W8 | `test_action_image_digest_check.py` (pre-tracing case stubs workflow SHA when current pin lacks GHCR tag) |
+| **W8 / #535** digest pin in `action.yml` | W8 | `test_action_image_digest_sync.py`, `test_action_yml_contract.py::test_docker_action_pulls_digest_pinned_slim_image` |
+| **W8 / #535** `action-image-digest-check` in `make lint` | W8 | `test_action_image_digest_sync.py::test_action_image_digest_check_runs_via_make_lint` |
+| **W2** `Finding.scope` on CI evidence path | W2 | `test_evidence.py::test_no_new_finding_fields_introduced` |
 
 ## Deliverable symbols
 
@@ -69,6 +73,7 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | `render_step_summary` / `append_step_summary` | `utils/step_summary.py` | `test_w17_packet_artifact_summary.py` |
 | workflow packet `env:` artifact steps | `.github/workflows/mergecraft.yml` | `test_w17_packet_artifact_summary.py` |
 | `action-pin-check` in `ci-static` / `CI_STEPS` | `Makefile` | `test_w18_action_pin_gate.py` |
+| `action-image-digest-check` / `check_action_image_digest.py` | `scripts/`, `Makefile` | `test_action_image_digest_check.py`, `test_action_image_digest_sync.py` |
 
 ## Fixtures
 

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -8,7 +8,7 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 
 | Wave | Test file / test | Reason |
 |------|------------------|--------|
-| **W3** | `test_w13_trajectory_classify.py` (5 xfailed tests, `strict=False`) | classify-before-count + run 33126460925 fixture |
+| **W3** | `test_w13_trajectory_classify.py` (4 xfailed tests, `strict=False`) | classify-before-count + run 33126460925 fixture |
 | — | all other files | bare `assert` / `pytest.fail` / `require_symbol` RED (no xfail) |
 
 ## Contract matrix

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -1,0 +1,95 @@
+# Review record integrity — test plan (W1 RED suite)
+
+Wave plan: `.ignorelocal/waves/12-review-record-integrity-wave-plan.md`
+Worktree: `mergecraft-review-record` @ `wave/review-record`
+Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
+
+## xfail schedule
+
+| Wave | Test file / test | Reason |
+|------|------------------|--------|
+| **W3** | `test_w13_trajectory_classify.py` (5 xfailed tests, `strict=False`) | classify-before-count + run 33126460925 fixture |
+| — | all other files | bare `assert` / `pytest.fail` / `require_symbol` RED (no xfail) |
+
+## Contract matrix
+
+| Contract | Greening wave | Primary test(s) |
+|----------|---------------|-------------------|
+| **W1.1** `Finding.scope` default `change` | W2 | `test_w11_scope_blocking.py::test_finding_defaults_scope_change` |
+| **W1.1** `source="trajectory"` validates | W2 | `test_w11_scope_blocking.py::test_trajectory_source_validates` |
+| **W1.1** `blocking_findings` drops `scope="run"` | W2 | `test_w11_scope_blocking.py::test_blocking_findings_drops_run_scoped_critical` |
+| **W1.1** causality before block test | W2 | `test_w11_scope_blocking.py::test_blocking_findings_applies_causality_policy` |
+| **W1.1** one blocking predicate (#447) | W2 | `test_w11_scope_blocking.py::test_has_blocker_and_blocks_approve_agree_on_mixed_scope_set` |
+| **W1.1** run-only → `success` | W2 | `test_w11_scope_blocking.py::test_decide_approval_success_on_run_only_findings` |
+| **W1.2** trajectory stamp table | W2 | `test_w12_trajectory_attribution.py::test_every_trajectory_check_stamps_scope_source_and_introduced_by_pr` |
+| **W1.2** trajectory-only approval success | W2 | `test_w12_trajectory_attribution.py::test_trajectory_only_run_produces_approval_success` |
+| **W1.2** `unresolved-failure` advisory | W2 | `test_w12_trajectory_attribution.py::test_unresolved_failure_critical_does_not_block` |
+| **W1.3** schema self-correct | W3 | `test_w13_trajectory_classify.py::test_schema_rejection_self_corrected_within_three_calls_produces_no_finding` |
+| **W1.3** guard refusal trivial | W3 | `test_w13_trajectory_classify.py::test_guard_refusal_produces_at_most_trivial_run_scoped_observation` |
+| **W1.3** bubblewrap rollup | W3 | `test_w13_trajectory_classify.py::test_bubblewrap_namespace_failure_produces_one_rolled_up_environment_finding` |
+| **W1.3** git_fetch retry intent | W3 | `test_w13_trajectory_classify.py::test_git_fetch_after_checkout_pr_counts_as_retry_not_ignored_error` |
+| **W1.3** transient ignored-tool-error | W3 | `test_w13_trajectory_classify.py::test_transient_failure_without_retry_fires_ignored_tool_error` |
+| **W1.3** immutable git show not a loop | W3 | `test_w13_trajectory_classify.py::test_repeated_tool_loop_does_not_fire_on_immutable_git_show_with_intervening_work` |
+| **W1.3** adjacent `run_static_checks` loop | W3 | `test_w13_trajectory_classify.py::test_repeated_tool_loop_fires_on_three_adjacent_identical_run_static_checks` |
+| **W1.3** run 33126460925 fixture | W3 | `test_w13_trajectory_classify.py::test_run_33126460925_fixture_zero_blocking_at_most_three_run_scoped` |
+| **W1.4** no false “outstanding feedback” | W4 | `test_w14_status_check_summaries.py::test_zero_change_findings_never_claim_outstanding_feedback` |
+| **W1.4** three summary variants | W4 | `test_w14_status_check_summaries.py::test_three_distinct_summaries_for_outcomes` |
+| **W1.4** run URL + reviewed SHA | W4 | `test_w14_status_check_summaries.py::test_every_summary_carries_run_url_and_reviewed_sha` |
+| **W1.4** failure → warning + `::warning::` | W4 | `test_w14_status_check_summaries.py::test_failed_check_run_post_emits_warning_and_annotation` |
+| **W1.4** success → one INFO line / check | W4 | `test_w14_status_check_summaries.py::test_successful_post_emits_one_info_line_per_check` |
+| **W1.4** post failure non-fatal | W4 | `test_w14_status_check_summaries.py::test_post_failure_does_not_raise_into_run_outcome` |
+| **W1.5** sticky on every verdict path | W5 | `test_w15_deterministic_record.py::test_deterministic_record_posts_on_every_resolved_pr` |
+| **W1.5** zero-finding approve still posts | W5 | `test_w15_deterministic_record.py::test_agent_approved_zero_findings_still_posts_deterministic_record` |
+| **W1.5** idempotent sticky | W5 | `test_w15_deterministic_record.py::test_two_runs_edit_one_sticky_comment_in_place` |
+| **W1.5** mandatory preamble | W5 | `test_w15_deterministic_record.py::test_review_body_contains_preamble_when_agent_body_empty` |
+| **W1.5** agent cannot suppress preamble | W5 | `test_w15_deterministic_record.py::test_agent_cannot_suppress_preamble_by_duplicating_markers` |
+| **W1.5** packet-row findings in preamble | W5 | `test_w15_deterministic_record.py::test_preamble_renders_packet_critical_not_agent_narrative` |
+| **W1.5** run-scoped collapsed heading | W5 | `test_w15_deterministic_record.py::test_run_scoped_findings_render_under_collapsed_heading` |
+| **W1.6** anchor pre-validation | W6 | `test_w16_anchor_422_recovery.py::test_out_of_diff_inline_comment_is_dropped_before_post` |
+| **W1.6** REQUEST_CHANGES 422 swallowed | W6 | `test_w16_anchor_422_recovery.py::test_request_changes_422_does_not_propagate_to_agent` |
+| **W1.6** verdict survives all anchor failures | W6 | `test_w16_anchor_422_recovery.py::test_all_anchors_rejected_still_posts_body_and_verdict` |
+| **W1.6** APPROVE→COMMENT 422 preserved | W6 | `test_w16_anchor_422_recovery.py::test_approve_comment_422_fallback_still_works` |
+| **W1.7** `run_health` + schema bump | W7 | `test_w17_packet_artifact_summary.py::test_packet_run_health_round_trips_and_schema_version_bumps` |
+| **W1.7** step summary all outcomes | W7 | `test_w17_packet_artifact_summary.py::test_step_summary_written_on_success_failure_and_no_verdict` |
+| **W1.7** 1 MiB cap | W7 | `test_w17_packet_artifact_summary.py::test_step_summary_truncates_findings_not_header` |
+| **W1.7** `evidence_packet` output | W7 | `test_w17_packet_artifact_summary.py::test_evidence_packet_output_nonempty_for_pr_run` |
+| **W1.7** workflow artifact via `env:` | W7 | `test_w17_packet_artifact_summary.py::test_mergecraft_workflow_persists_packet_via_env_not_inline_interpolation` |
+| **W1.8** `action-pin-check` in `ci-static` | W8 | `test_w18_action_pin_gate.py::test_make_ci_static_invokes_action_pin_check` |
+| **W1.8** `ci.yml` non-zero on stale pin | W8 | `test_w18_action_pin_gate.py::test_ci_yml_fails_on_stale_pin_instead_of_warning_only` |
+| **W1.8** single pin, three rungs | W8 | `test_w18_action_pin_gate.py::test_mergecraft_workflow_three_rungs_share_one_pin_value` |
+| **W1.8** partial bump fails | W8 | `test_w18_action_pin_gate.py::test_partial_pin_bump_fails_action_pin_check` |
+
+## Deliverable symbols
+
+| Symbol | Module (planned) | Test anchor |
+|--------|----------------|-------------|
+| `FindingScope` | `review_taxonomy.py` | `test_w11_scope_blocking.py` |
+| `Finding.scope` | `analyzers/finding.py` | `test_w11_scope_blocking.py` |
+| `blocking_findings` | `agents/gates.py` | `test_w11_scope_blocking.py`, `test_w12_trajectory_attribution.py`, `test_w13_trajectory_classify.py` |
+| `TRAJECTORY_CHECKS` stamps | `evidence/trajectory_audit.py` | `test_w12_trajectory_attribution.py` |
+| `failure_class` | `evidence/trajectory.py` | `test_w13_trajectory_classify.py` (via auditor behaviour) |
+| `render_deterministic_review_block` | `findings/ledger.py` | `test_w15_deterministic_record.py` |
+| `merge_deterministic_preamble_into_review_body` | `mcp/review.py` | `test_w15_deterministic_record.py` |
+| `publish_deterministic_record` | `main.py` | `test_w15_deterministic_record.py` |
+| anchor pre-validation | `mcp/review.py` / `convergence_runtime.py` | `test_w16_anchor_422_recovery.py` |
+| `run_health` | `evidence/packet.py` | `test_w17_packet_artifact_summary.py` |
+| `render_step_summary` / `append_step_summary` | `utils/step_summary.py` | `test_w17_packet_artifact_summary.py` |
+| workflow packet `env:` artifact steps | `.github/workflows/mergecraft.yml` | `test_w17_packet_artifact_summary.py` |
+| `action-pin-check` in `ci-static` / `CI_STEPS` | `Makefile` | `test_w18_action_pin_gate.py` |
+
+## Fixtures
+
+| Fixture | Path |
+|---------|------|
+| Run 33126460925 trajectory replay | `tests/review_record/fixtures/run_33126460925_trajectory.json` |
+
+## Verification
+
+```bash
+export UV_PROJECT_ENVIRONMENT="$PWD/.venv-dev"
+make lint && make typecheck
+uv run pytest --collect-only -q tests/review_record
+uv run pytest tests/review_record -q
+```
+
+Expect RED: failures/errors dominate; W3-marked cases xfail; `test_approve_comment_422_fallback_still_works` passes today (regression pin).

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -1,4 +1,4 @@
-# Review record integrity — test plan (W1 RED suite)
+# Review record integrity — test plan
 
 Wave plan: `.ignorelocal/waves/12-review-record-integrity-wave-plan.md`
 Worktree: `mergecraft-review-record` @ `wave/review-record`
@@ -55,6 +55,7 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | **W8 / #535** digest pin in `action.yml` | W8 | `test_action_image_digest_sync.py`, `test_action_yml_contract.py::test_docker_action_pulls_digest_pinned_slim_image` |
 | **W8 / #535** `action-image-digest-check` in `make lint` | W8 | `test_action_image_digest_sync.py::test_action_image_digest_check_runs_via_make_lint` |
 | **W2** `Finding.scope` on CI evidence path | W2 | `test_evidence.py::test_no_new_finding_fields_introduced` |
+| **cd6ff87c** cached packet re-finalizes on outcome | — | `test_run_packet.py::test_resolve_prepared_run_packet_refinalizes_on_outcome_change` |
 
 ## Deliverable symbols
 
@@ -70,6 +71,7 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | `publish_deterministic_record` | `main.py` | `test_w15_deterministic_record.py` |
 | anchor pre-validation | `mcp/review.py` / `convergence_runtime.py` | `test_w16_anchor_422_recovery.py` |
 | `run_health` | `evidence/packet.py` | `test_w17_packet_artifact_summary.py` |
+| `resolve_prepared_run_packet` | `evidence/run_packet.py` | `test_run_packet.py::test_resolve_prepared_run_packet_refinalizes_on_outcome_change` |
 | `render_step_summary` / `append_step_summary` | `utils/step_summary.py` | `test_w17_packet_artifact_summary.py` |
 | workflow packet `env:` artifact steps | `.github/workflows/mergecraft.yml` | `test_w17_packet_artifact_summary.py` |
 | `action-pin-check` in `ci-static` / `CI_STEPS` | `Makefile` | `test_w18_action_pin_gate.py` |
@@ -86,8 +88,6 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 ```bash
 export UV_PROJECT_ENVIRONMENT="$PWD/.venv-dev"
 make lint && make typecheck
-uv run pytest --collect-only -q tests/review_record
-uv run pytest tests/review_record -q
+uv run pytest --collect-only -q tests/review_record tests/evidence/test_run_packet.py
+uv run pytest tests/review_record tests/evidence/test_run_packet.py::test_resolve_prepared_run_packet_refinalizes_on_outcome_change -q
 ```
-
-Expect RED: failures/errors dominate; W3-marked cases xfail; `test_approve_comment_422_fallback_still_works` passes today (regression pin).

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -4,13 +4,6 @@ Wave plan: `.ignorelocal/waves/12-review-record-integrity-wave-plan.md`
 Worktree: `mergecraft-review-record` @ `wave/review-record`
 Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 
-## xfail schedule
-
-| Wave | Test file / test | Reason |
-|------|------------------|--------|
-| **W3** | `test_w13_trajectory_classify.py` (4 xfailed tests, `strict=False`) | classify-before-count + run 33126460925 fixture |
-| — | all other files | bare `assert` / `pytest.fail` / `require_symbol` RED (no xfail) |
-
 ## Contract matrix
 
 | Contract | Greening wave | Primary test(s) |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -246,6 +246,45 @@ head branch — the base moved, say — because nothing then re-triggers the run
 A conflicted PR is unmergeable on its own account anyway, so weigh this against
 running with secrets in scope rather than treating it as decisive.
 
+## Action pin and evidence artifacts
+
+The shipped `.github/workflows/mergecraft.yml` hoists the review Action SHA to a
+single workflow-level variable:
+
+```yaml
+env:
+  MERGECRAFT_ACTION_SHA: "<40-char-sha>"
+```
+
+All three review rungs (`uses: alexhawat/mergeCraft@…`) derive from that value,
+with a `# env.MERGECRAFT_ACTION_SHA` comment suffix on each line. A bump is one
+edit; `make action-pin-check` (wired into `make ci-static`) fails when the pin
+drifts from the default branch or when the three rungs disagree (#532).
+
+After each review rung, the workflow persists the `evidence_packet` action output
+to disk and uploads it as an artifact (`if: always()`):
+
+```yaml
+- name: Persist evidence packet
+  if: always()
+  env:
+    PACKET: ${{ steps.mergecraft_codex.outputs.evidence_packet }}
+  run: printf '%s' "$PACKET" > packet-codex.json
+
+- uses: actions/upload-artifact@<full-sha>
+  if: always()
+  with:
+    name: mergecraft-evidence-codex
+    path: packet-codex.json
+    retention-days: 30
+    if-no-files-found: ignore
+```
+
+The `env:` indirection is mandatory — interpolating the packet directly into a
+`run:` body puts it in the process table and re-renders it into the log. The
+packet is also written to `$GITHUB_OUTPUT` by the Action and consumed in-process
+for fallback routing; the artifact is what survives after the runner is recycled.
+
 If you pin the action SHA in more than one place, gate the copies against each
 other in CI — and read the workflow side from the **default branch**
 (`git show origin/main:.github/workflows/mergecraft.yml`), not the working tree.

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -184,7 +184,7 @@ jobs:
               state="timeout"
               break
             fi
-            sleep 20
+            sleep 10
           done
 
           {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -595,6 +595,8 @@ A quick orientation before the lists:
 7. [Memory across runs](#7-memory-across-runs)
 8. [Output shape](#8-output-shape)
 9. [Address-reviews checks](#9-address-reviews-checks)
+10. [Trajectory checks](#10-trajectory-checks-43-49)
+11. [Deterministic run record](#11-deterministic-run-record-plan-12)
 
 ---
 
@@ -609,8 +611,10 @@ verdict; everything else is advisory. Concretely:
   `mergecraft.analyzers.finding`, `extra="forbid"`). Each finding carries
   `tool`, `rule_id`, `category`, `severity`, `confidence`, `path`,
   `start_line`/`end_line`, `fingerprint`, `evidence: list[str]`,
-  `introduced_by_pr`, `source`, `cluster_id`. Findings are the
-  authoritative structural input to `decide_approval()`.
+  `introduced_by_pr`, `source`, `scope`, `cluster_id`. Findings are the
+  authoritative structural input to `decide_approval()`. Only `scope="change"`
+  findings can block; `scope="run"` rows are advisory and partition into the
+  packet's `run_health` section at assembly time (plan 12).
 - **`DeterministicCheck` rows** — one per declared `staticChecks` or
   discovered Makefile target. Status is one of five: `passed`, `failed`,
   `timed_out`, `unavailable`, `declared-but-cannot-run`. **Only
@@ -979,13 +983,48 @@ gated on the record carrying that signal at all: `changed-unread-file` needs
 `read_coverage`, `missing-completion-signal` needs at least one recorded call. A
 check that fires on every run is noise, not a gate.
 
-**No second gate.** These are ordinary findings in the packet's finding list, so
-`decide_approval()` weighs them exactly like any other evidence — a `Critical`
-`unresolved-failure` blocks for the same reason a `Critical` analyzer finding
-does. There is no separate trajectory verdict.
+**Run-scoped, never blocking (D2).** Trajectory checks stamp `scope="run"`,
+`source="trajectory"`, and `introduced_by_pr="false"`. They partition into the
+packet's `run_health` section and render under a separate collapsed heading in
+the deterministic run record. `blocking_findings()` drops them before severity
+grading — no severity, and no future check, makes a run-scoped finding fail a
+PR. There is no separate trajectory verdict and no second required check-run
+(D14).
 
 **They never crowd out code findings.** Inline slots go to code findings first;
-trajectory findings take only what is left and otherwise report in the body.
+trajectory findings take only what is left and otherwise report in the body or
+the run-health section.
+
+## 11. Deterministic run record (plan 12)
+
+Every run that resolves a PR number leaves exactly one authoritative sticky
+progress comment, whether the agent published a review, posted no verdict, or
+failed mid-run (D6). Re-runs edit the same comment in place via the existing
+sticky marker — they do not append a second one.
+
+The comment and the published review body both render from
+`render_deterministic_review_block()` in `findings/ledger.py` (D7), so the two
+surfaces cannot drift. The agent cannot suppress the block by supplying its own
+copy of the markers — dedupe keeps the server's version.
+
+The block always contains, in order:
+
+1. **Run header** — outcome, verdict diagnostic, decision verdict and reason,
+   model actually used, attempt count, token summary, run URL, reviewed SHA.
+2. **Pre-merge checks** — analyzers (dispatched lenses or packet summary),
+   static checks from `deterministic_checks`, CI intelligence pointer, trust
+   tier.
+3. **Change-scoped findings** — typed packet rows (`scope="change"`); `_No
+   change-scoped findings recorded._` when empty.
+4. **Run health** — collapsed `<details>` with `scope="run"` findings when
+   present; omitted when none.
+5. **Agent summary or rejection** — when a verdict exists, the agent's summary
+   quoted beneath the deterministic rows; when it does not, an explicit
+   `No verdict recorded — reason: <typed rejection>` line.
+
+The same block is merged into the review body as a mandatory preamble through
+`merge_deterministic_preamble_into_review_body` in `mcp/review.py`, applied
+last so nothing can be appended above it.
 
 ## 9. Address-reviews checks
 
@@ -1259,6 +1298,28 @@ Only a real non-zero exit from an executable gate is evidence. The Action image 
 `git`, `gh`, `jq`, `node`, and `npm` — not `make` — so every Makefile-discovered target
 lands as `unavailable` there unless the repo declares explicit `staticChecks` with binaries
 that exist in the image.
+
+## Finding scope: change vs run (plan 12, D1–D2)
+
+Every `Finding` carries a `scope` axis: `change` or `run`. The default is `change`, so
+existing producers keep their meaning without silent reclassification.
+
+- **`change`** — a claim about the diff under review. These are the findings that can
+  block merge after causality policy and severity grading.
+- **`run`** — a claim about how the review executed (trajectory auditor rows, environment
+  observations, and similar process evidence). These are **advisory only** and can never
+  block (D2). Run health is reported — in the evidence packet's `run_health` section, the
+  deterministic run record, the `mergecraft` completion check summary, and the job step
+  summary — never enforced as a second merge gate (D14).
+
+`blocking_findings()` in `agents/gates.py` is the single predicate: drop `scope == "run"`,
+apply `apply_causality_policy`, then test `BLOCKING_SEVERITIES`. `_has_blocker`,
+`_packet_has_blockers`, `decide_approval`, and `mcp/verdict.py::_blocks_approve` all route
+through it — two predicates that disagree is a defect class, not a style question (D3).
+
+Trajectory checks stamp `source="trajectory"`, `scope="run"`, and `introduced_by_pr="false"`
+(D4). All three fields matter: `introduced_by_pr` drives causality, `scope` drives gating,
+`source` drives rendering.
 
 ## Makefile discovery, not tool inference
 

--- a/scripts/check_action_image_digest.py
+++ b/scripts/check_action_image_digest.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Guard: ``action.yml`` slim image digest must match GHCR for the workflow Action SHA.
+
+The published Docker action must pull a digest-pinned ``ghcr.io/alexhawat/mergecraft``
+image instead of rebuilding from ``Dockerfile`` on every run (#526). When CI/CD
+has published a slim image for the self-review workflow's Action SHA pin, this
+script compares that registry digest to ``action.yml``'s ``runs.image`` pin and
+verifies the image was built with ``--extra tracing`` (#531).
+
+Registry outcomes are handled separately:
+- reachable + tag present → digest must match ``action.yml``
+- reachable + tag missing → **fail** (chicken-and-egg blocks a stale digest)
+- unreachable → skip with a notice (offline / local ``make lint``)
+
+Module: scripts.check_action_image_digest
+Depends: json, re, sys, urllib.error, urllib.request, pathlib, yaml
+
+Exports:
+    main — CLI entry; compares action.yml digest vs published GHCR slim image.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+ACTION_YML = REPO / "action.yml"
+SELF_REVIEW_WORKFLOW = REPO / ".github" / "workflows" / "mergecraft.yml"
+
+SLIM_IMAGE_REPO = "alexhawat/mergecraft"
+SLIM_IMAGE = f"ghcr.io/{SLIM_IMAGE_REPO}"
+GHCR_MANIFEST_ACCEPT = (
+    "application/vnd.oci.image.index.v1+json, "
+    "application/vnd.oci.image.manifest.v1+json, "
+    "application/vnd.docker.distribution.manifest.list.v2+json, "
+    "application/vnd.docker.distribution.manifest.v2+json"
+)
+OCI_REVISION_LABEL = "org.opencontainers.image.revision"
+
+_ENV_SHA_RE = re.compile(
+    r"^\s*MERGECRAFT_ACTION_SHA:\s*[\"']?(?P<sha>[0-9a-f]{40})[\"']?\s*$",
+    re.MULTILINE,
+)
+_ACTION_PIN_RE = re.compile(r"uses:\s*alexhawat/mergeCraft@(?P<sha>[0-9a-f]{40})")
+_DIGEST_IMAGE_RE = re.compile(rf"^docker://{re.escape(SLIM_IMAGE)}@sha256:([a-f0-9]{{64}})$")
+
+
+class TagLookupStatus(Enum):
+    FOUND = "found"
+    MISSING = "missing"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class TagLookupResult:
+    status: TagLookupStatus
+    digest: str | None = None
+
+
+def _pins_in(text: str) -> list[str]:
+    return [match.group("sha") for match in _ACTION_PIN_RE.finditer(text)]
+
+
+def _read_action_image() -> str | None:
+    if not ACTION_YML.is_file():
+        return None
+    payload = ACTION_YML.read_text(encoding="utf-8")
+    data = __import__("yaml").safe_load(payload)
+    runs = data.get("runs") if isinstance(data, dict) else None
+    if not isinstance(runs, dict):
+        return None
+    image = runs.get("image")
+    return image if isinstance(image, str) else None
+
+
+def _ghcr_pull_token() -> str | None:
+    """Return a registry pull token (anonymous for public packages, or via env)."""
+    auth_header: str | None = None
+    gh_token = __import__("os").environ.get("GITHUB_TOKEN") or __import__("os").environ.get(
+        "GH_TOKEN"
+    )
+    if gh_token:
+        auth_header = f"Bearer {gh_token}"
+    url = f"https://ghcr.io/token?service=ghcr.io&scope=repository:{SLIM_IMAGE_REPO}:pull"
+    try:
+        request = urllib.request.Request(url)
+        if auth_header:
+            request.add_header("Authorization", auth_header)
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        return None
+    token = payload.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def _registry_reachable() -> bool:
+    return _ghcr_pull_token() is not None
+
+
+def _ghcr_digest_for_tag(tag: str) -> TagLookupResult:
+    """Resolve the slim image digest for ``tag``, distinguishing missing vs errors."""
+    token = _ghcr_pull_token()
+    if token is None:
+        return TagLookupResult(status=TagLookupStatus.ERROR)
+    url = f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/manifests/{tag}"
+    request = urllib.request.Request(url, method="HEAD")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", GHCR_MANIFEST_ACCEPT)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            digest = response.headers.get("docker-content-digest")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return TagLookupResult(status=TagLookupStatus.MISSING)
+        return TagLookupResult(status=TagLookupStatus.ERROR)
+    except OSError:
+        return TagLookupResult(status=TagLookupStatus.ERROR)
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        return TagLookupResult(status=TagLookupStatus.ERROR)
+    return TagLookupResult(status=TagLookupStatus.FOUND, digest=digest)
+
+
+def _fetch_oci_config_for_tag(tag: str) -> dict[str, Any] | None:
+    """Return the OCI image config JSON for a published slim image tag."""
+    token = _ghcr_pull_token()
+    if token is None:
+        return None
+    request = urllib.request.Request(
+        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/manifests/{tag}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": GHCR_MANIFEST_ACCEPT,
+        },
+    )
+    try:
+        index = json.loads(urllib.request.urlopen(request, timeout=30).read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        return None
+    manifests = index.get("manifests")
+    if not isinstance(manifests, list) or not manifests:
+        return None
+    platform = manifests[0]
+    if not isinstance(platform, dict):
+        return None
+    manifest_digest = platform.get("digest")
+    if not isinstance(manifest_digest, str):
+        return None
+    request_manifest = urllib.request.Request(
+        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/manifests/{manifest_digest}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": GHCR_MANIFEST_ACCEPT,
+        },
+    )
+    try:
+        manifest = json.loads(
+            urllib.request.urlopen(request_manifest, timeout=30).read().decode("utf-8")
+        )
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        return None
+    config = manifest.get("config")
+    if not isinstance(config, dict):
+        return None
+    config_digest = config.get("digest")
+    if not isinstance(config_digest, str):
+        return None
+    request_config = urllib.request.Request(
+        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/blobs/{config_digest}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        payload = json.loads(
+            urllib.request.urlopen(request_config, timeout=30).read().decode("utf-8")
+        )
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _image_has_tracing_extra(config: dict[str, Any]) -> bool:
+    """Return whether the slim image ``uv sync`` layer includes ``--extra tracing``."""
+    history = config.get("history")
+    if not isinstance(history, list):
+        return False
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        created_by = entry.get("created_by")
+        if isinstance(created_by, str) and "uv sync" in created_by:
+            return "--extra tracing" in created_by
+    return False
+
+
+def _revision_from_config(config: dict[str, Any]) -> str | None:
+    labels = config.get("config", {}).get("Labels")
+    if not isinstance(labels, dict):
+        return None
+    revision = labels.get(OCI_REVISION_LABEL)
+    return revision if isinstance(revision, str) and revision else None
+
+
+def _self_review_action_sha() -> str | None:
+    if not SELF_REVIEW_WORKFLOW.is_file():
+        return None
+    text = SELF_REVIEW_WORKFLOW.read_text(encoding="utf-8")
+    env_match = _ENV_SHA_RE.search(text)
+    if env_match is not None:
+        return env_match.group("sha")
+    pins = _pins_in(text)
+    if not pins:
+        return None
+    distinct = set(pins)
+    if len(distinct) != 1:
+        return None
+    return pins[0]
+
+
+def main() -> int:
+    """Validate action.yml image contract and GHCR parity."""
+    image = _read_action_image()
+    if image is None:
+        print("action-image-digest-check: action.yml missing runs.image", file=sys.stderr)
+        return 1
+
+    if image == "Dockerfile" or image.endswith("/Dockerfile"):
+        print(
+            "action-image-digest-check FAILED: action.yml still builds from Dockerfile — "
+            "pin docker://ghcr.io/alexhawat/mergecraft@sha256:<digest> (#526)",
+            file=sys.stderr,
+        )
+        return 1
+
+    match = _DIGEST_IMAGE_RE.match(image)
+    if match is None:
+        print(
+            f"action-image-digest-check FAILED: runs.image must be digest-pinned slim image "
+            f"docker://{SLIM_IMAGE}@sha256:<64-hex> — got {image!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pinned = f"sha256:{match.group(1)}"
+    if "analyzers" in image:
+        print(
+            "action-image-digest-check FAILED: Action must use the slim image, not analyzers",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not _registry_reachable():
+        print(
+            "action-image-digest-check: skipped GHCR parity — registry unreachable "
+            f"(action.yml pins {pinned[:19]}…)"
+        )
+        return 0
+
+    action_sha = _self_review_action_sha()
+    if action_sha is None:
+        print(
+            "action-image-digest-check OK: digest-pinned slim image "
+            f"({pinned[:19]}…) — no self-review Action SHA to compare"
+        )
+        return 0
+
+    lookup = _ghcr_digest_for_tag(action_sha)
+    if lookup.status is TagLookupStatus.ERROR:
+        print(
+            "action-image-digest-check: skipped GHCR parity — registry error while "
+            f"resolving {SLIM_IMAGE}:{action_sha[:12]} (action.yml pins {pinned[:19]}…)"
+        )
+        return 0
+
+    if lookup.status is TagLookupStatus.MISSING:
+        if not __import__("os").environ.get("GITHUB_ACTIONS"):
+            print(
+                "action-image-digest-check: skipped GHCR parity — slim image tag "
+                f"{SLIM_IMAGE}:{action_sha} not published yet (action.yml pins "
+                f"{pinned[:19]}…). The action-slim-bootstrap job or ci-cd "
+                "build-images must publish it first."
+            )
+            return 0
+        print("action-image-digest-check FAILED:", file=sys.stderr)
+        print(
+            f"  no published slim image for Action SHA {action_sha} "
+            f"(expected tag {SLIM_IMAGE}:{action_sha})",
+            file=sys.stderr,
+        )
+        print(
+            f"  action.yml pins {pinned} — run ci-cd build-images on pre-0.0.1, "
+            "then bump runs.image to that digest",
+            file=sys.stderr,
+        )
+        return 1
+
+    published = lookup.digest
+    assert published is not None
+    if published != pinned:
+        print("action-image-digest-check FAILED:", file=sys.stderr)
+        print(f"  action.yml pins {pinned}", file=sys.stderr)
+        print(f"  GHCR {SLIM_IMAGE}:{action_sha[:12]} publishes {published}", file=sys.stderr)
+        print(
+            "  Update action.yml runs.image to the published slim digest for this Action SHA.",
+            file=sys.stderr,
+        )
+        return 1
+
+    published_config = _fetch_oci_config_for_tag(action_sha)
+    if published_config is None:
+        print(
+            "action-image-digest-check FAILED: could not read OCI config for "
+            f"{SLIM_IMAGE}:{action_sha}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not _image_has_tracing_extra(published_config):
+        print(
+            "action-image-digest-check FAILED: published slim image was built without "
+            "`uv sync --extra tracing` — Logfire/OTEL sinks degrade to NullSink (#531). "
+            f"Do not pin pre-#531 digests such as {pinned[:19]}…",
+            file=sys.stderr,
+        )
+        return 1
+
+    published_revision = _revision_from_config(published_config)
+    if published_revision is not None and published_revision != action_sha:
+        print("action-image-digest-check FAILED:", file=sys.stderr)
+        print(
+            f"  GHCR tag {action_sha} ({OCI_REVISION_LABEL}={published_revision})",
+            file=sys.stderr,
+        )
+        print(
+            f"  mergecraft.yml Action SHA is {action_sha}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"action-image-digest-check OK: action.yml matches GHCR slim digest for "
+        f"Action SHA {action_sha[:12]} (tracing extra present)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_action_image_digest.py
+++ b/scripts/check_action_image_digest.py
@@ -22,8 +22,10 @@ Exports:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -106,8 +108,33 @@ def _registry_reachable() -> bool:
     return _ghcr_pull_token() is not None
 
 
+# A tag pushed by action-slim-bootstrap is not always visible on the very next
+# read: GHCR settles a moment behind the push, and the gates start seconds after
+# it. Retry only MISSING, and only a few times — a genuinely unpublished SHA
+# must still fail rather than stall the job.
+_MISSING_RETRIES = int(os.environ.get("MERGECRAFT_GHCR_MISSING_RETRIES", "3"))
+_MISSING_BACKOFF_SECONDS = float(os.environ.get("MERGECRAFT_GHCR_MISSING_BACKOFF", "3"))
+
+
 def _ghcr_digest_for_tag(tag: str) -> TagLookupResult:
-    """Resolve the slim image digest for ``tag``, distinguishing missing vs errors."""
+    """Resolve the slim image digest for ``tag``, retrying a not-yet-visible push.
+
+    ``MISSING`` is retried because it is the one status that is routinely
+    transient right after a push. ``ERROR`` is not: a registry fault or a bad
+    token will not resolve itself inside a few seconds, and retrying it would
+    only delay a failure the caller already treats as non-fatal.
+    """
+    result = _ghcr_digest_for_tag_once(tag)
+    attempts = 0
+    while result.status is TagLookupStatus.MISSING and attempts < _MISSING_RETRIES:
+        time.sleep(_MISSING_BACKOFF_SECONDS)
+        attempts += 1
+        result = _ghcr_digest_for_tag_once(tag)
+    return result
+
+
+def _ghcr_digest_for_tag_once(tag: str) -> TagLookupResult:
+    """One HEAD against the registry, distinguishing missing from errors."""
     token = _ghcr_pull_token()
     if token is None:
         return TagLookupResult(status=TagLookupStatus.ERROR)

--- a/scripts/check_action_pin_freshness.py
+++ b/scripts/check_action_pin_freshness.py
@@ -50,6 +50,10 @@ WORKFLOW_DIR = REPO / ".github" / "workflows"
 
 # The action pins itself here; a consumer's own pin is their business.
 _PIN_RE = re.compile(r"uses:\s*alexhawat/mergeCraft@(?P<sha>[0-9a-f]{40})")
+_ENV_SHA_RE = re.compile(
+    r"^\s*MERGECRAFT_ACTION_SHA:\s*[\"']?(?P<sha>[0-9a-f]{40})[\"']?\s*$",
+    re.MULTILINE,
+)
 
 DEFAULT_BRANCH = os.environ.get("MERGECRAFT_DEFAULT_BRANCH", "main")
 
@@ -116,6 +120,23 @@ def _check_self_consistency(rel_path: str, pins: list[tuple[int, str]]) -> list[
         f"{rel_path}: {len(distinct)} different Action pins in one file "
         f"({locations}). A one-sided bump leaves the review and fallback steps "
         f"on different code."
+    ]
+
+
+def _check_env_parity(rel_path: str, text: str, pins: list[tuple[int, str]]) -> list[str]:
+    """Every rung pin must match the hoisted ``env.MERGECRAFT_ACTION_SHA``."""
+    env_match = _ENV_SHA_RE.search(text)
+    if env_match is None:
+        return []
+    env_sha = env_match.group("sha")
+    mismatched = [(line, sha) for line, sha in pins if sha != env_sha]
+    if not mismatched:
+        return []
+    locations = ", ".join(f"line {line}: {sha[:12]}" for line, sha in mismatched)
+    return [
+        f"{rel_path}: uses: pin(s) disagree with env.MERGECRAFT_ACTION_SHA "
+        f"({env_sha[:12]}): {locations}. Bump env.MERGECRAFT_ACTION_SHA only "
+        f"and mirror to every rung."
     ]
 
 
@@ -200,6 +221,7 @@ def main() -> int:
         checked += 1
         rel_path = path.relative_to(REPO).as_posix()
         failures.extend(_check_self_consistency(rel_path, pins))
+        failures.extend(_check_env_parity(rel_path, text, pins))
         failures.extend(_check_freshness(rel_path, pins[0][1]))
         failures.extend(_check_staleness(rel_path, pins[0][1]))
 

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -184,7 +184,7 @@ jobs:
               state="timeout"
               break
             fi
-            sleep 20
+            sleep 10
           done
 
           {

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -768,6 +768,7 @@ def _run_claude_once(
     cmd = [
         cli,
         "--print",
+        "--verbose",
         "--output-format",
         "stream-json",
         "--mcp-config",

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -159,6 +159,14 @@ def _packet_has_blockers(packet: MergeEvidencePacket) -> bool:
     return _has_blocker(packet.findings)
 
 
+def _packet_attested_findings(packet: MergeEvidencePacket) -> list[Finding]:
+    """Return all findings that attest the review ran, including run-health rows."""
+    attested = list(packet.findings)
+    if packet.run_health is not None:
+        attested.extend(packet.run_health.findings)
+    return attested
+
+
 def _trusted_positive_decision(packet: MergeEvidencePacket) -> bool:
     """True when the packet carries a trusted structural success verdict with no blockers."""
     decision = packet.decision
@@ -336,7 +344,7 @@ def _decide_approval_from_packet(
         return packet.decision
 
     conclusion = _decide_approval_from_findings(
-        packet.findings, run_succeeded=run_succeeded, tier=tier
+        _packet_attested_findings(packet), run_succeeded=run_succeeded, tier=tier
     )
     return PacketDecision(
         verdict=conclusion,
@@ -364,7 +372,7 @@ def _packet_decision_reason(
             f"{conclusion}: structural evidence — agent's self_assessment.approved=true "
             "is advisory only and did not override the verdict"
         )
-    if not packet.findings:
+    if not _packet_attested_findings(packet):
         return f"{conclusion}: no typed findings to attest to the review"
     return f"{conclusion}: derived from typed findings and run state"
 

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -155,7 +155,10 @@ def _has_blocker(findings: list[Finding]) -> bool:
 
 
 def _packet_has_blockers(packet: MergeEvidencePacket) -> bool:
-    """True iff ``packet`` carries any blocking finding."""
+    """True iff ``packet.findings`` carries a change-scoped blocking row (D2).
+
+    ``run_health`` findings are advisory-only and are excluded here.
+    """
     return _has_blocker(packet.findings)
 
 
@@ -248,8 +251,9 @@ def decide_approval(
       explicit ``Decision``, that row is honoured only when ``decided_by`` is
       the trusted decider and the verdict is consistent with typed findings
       (D9 / LR-1 — forged or permissive rows are refused). Otherwise the same
-      monotone blocker logic runs against ``packet.findings`` and the result is
-      wrapped in a :class:`Decision`.
+      monotone blocker logic runs against attested findings (change-scoped rows
+      from ``packet.findings`` plus run-health rows for attestation only) and
+      the result is wrapped in a :class:`Decision`.
 
     The decision is monotone in blockers:
 
@@ -320,7 +324,8 @@ def _decide_approval_from_packet(
     ``decided_by`` matches :data:`TRUSTED_PACKET_DECIDED_BY` and the verdict
     is consistent with typed findings; otherwise a :class:`ValueError` is
     raised. When the packet does not carry an explicit verdict, the legacy
-    blocker logic runs against ``packet.findings`` and the ``Conclusion``
+    blocker logic runs against :func:`_packet_attested_findings` (change-scoped
+    rows block; ``run_health`` rows attest only per D2) and the ``Conclusion``
     literal is wrapped in a ``Decision`` with a stable ``decided_by`` and a
     reason that names the signal the verdict came from.
 
@@ -456,25 +461,17 @@ def log_decision(
 # recorder is the only caller that *records* it (shadow mode).
 
 
-def _combined_packet_findings(packet: MergeEvidencePacket) -> list[Finding]:
-    """Change-scoped plus run-health rows (trajectory lives in ``run_health`` since W7)."""
-    combined = list(packet.findings)
-    if packet.run_health is not None:
-        combined.extend(packet.run_health.findings)
-    return combined
-
-
 def _has_changed_unread_file(packet: MergeEvidencePacket) -> bool:
     """A trajectory finding flagged a file modified but never read."""
     return any(
-        finding.rule_id == "changed-unread-file" for finding in _combined_packet_findings(packet)
+        finding.rule_id == "changed-unread-file" for finding in _packet_attested_findings(packet)
     )
 
 
 def _has_tool_loop(packet: MergeEvidencePacket) -> bool:
     """A trajectory finding flagged a repeated call loop."""
     return any(
-        finding.rule_id == "repeated-tool-loop" for finding in _combined_packet_findings(packet)
+        finding.rule_id == "repeated-tool-loop" for finding in _packet_attested_findings(packet)
     )
 
 

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -384,9 +384,13 @@ def approval_decision_inputs(
     ``decide_approval`` decision from the stored summary without re-running the
     analysis path.
     """
+    change_findings = [f for f in findings if f.scope != "run"]
+    run_findings = [f for f in findings if f.scope == "run"]
     severities = sorted({f.severity for f in findings})
     return {
         "findings_count": len(findings),
+        "change_findings_count": len(change_findings),
+        "run_findings_count": len(run_findings),
         "severities": severities,
         "has_blocker": _has_blocker(findings),
         "run_succeeded": run_succeeded,
@@ -396,17 +400,17 @@ def approval_decision_inputs(
 
 def decision_summary_lines(inputs: dict[str, object]) -> list[str]:
     """Render ``approval_decision_inputs`` as human-readable check-run summary lines (W8.6)."""
-    findings_count_raw = inputs.get("findings_count", 0)
-    findings_count = int(findings_count_raw) if isinstance(findings_count_raw, (int, float)) else 0
-    severities_raw = inputs.get("severities") or []
-    severities = [str(item) for item in severities_raw] if isinstance(severities_raw, list) else []
+    change_count_raw = inputs.get("change_findings_count", inputs.get("findings_count", 0))
+    run_count_raw = inputs.get("run_findings_count", 0)
+    change_count = int(change_count_raw) if isinstance(change_count_raw, (int, float)) else 0
+    run_count = int(run_count_raw) if isinstance(run_count_raw, (int, float)) else 0
     tier_raw = inputs.get("tier", "trusted")
     tier = str(tier_raw) if tier_raw is not None else "trusted"
     run_succeeded = bool(inputs.get("run_succeeded"))
     has_blocker = bool(inputs.get("has_blocker"))
-    severities_text = ", ".join(severities) if severities else "(none)"
     return [
-        f"- Findings: {findings_count} (severities: {severities_text})",
+        f"- Change findings: {change_count}",
+        f"- Run-health findings: {run_count}",
         f"- Run succeeded: {run_succeeded}",
         f"- Trust tier: {tier}",
         f"- Has blocker: {has_blocker}",

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -135,9 +135,23 @@ def build_opencode_native_fs_permission() -> dict[str, object]:
     }
 
 
+def blocking_findings(findings: list[Finding]) -> list[Finding]:
+    """Return change-scoped findings that block after causality policy (D3)."""
+    from mergecraft.findings.causality import apply_causality_policy
+
+    blockers: list[Finding] = []
+    for finding in findings:
+        if finding.scope == "run":
+            continue
+        adjusted = apply_causality_policy(finding)
+        if adjusted.severity in BLOCKING_SEVERITIES:
+            blockers.append(adjusted)
+    return blockers
+
+
 def _has_blocker(findings: list[Finding]) -> bool:
     """True iff any finding carries a severity the gate treats as blocking."""
-    return any(f.severity in BLOCKING_SEVERITIES for f in findings)
+    return bool(blocking_findings(findings))
 
 
 def _packet_has_blockers(packet: MergeEvidencePacket) -> bool:
@@ -581,6 +595,7 @@ __all__ = [
     "BLOCKING_SEVERITIES",
     "GateAction",
     "approval_decision_inputs",
+    "blocking_findings",
     "build_claude_native_fs_denies",
     "build_opencode_native_fs_permission",
     "decide_action",

--- a/src/mergecraft/agents/gates.py
+++ b/src/mergecraft/agents/gates.py
@@ -456,14 +456,26 @@ def log_decision(
 # recorder is the only caller that *records* it (shadow mode).
 
 
+def _combined_packet_findings(packet: MergeEvidencePacket) -> list[Finding]:
+    """Change-scoped plus run-health rows (trajectory lives in ``run_health`` since W7)."""
+    combined = list(packet.findings)
+    if packet.run_health is not None:
+        combined.extend(packet.run_health.findings)
+    return combined
+
+
 def _has_changed_unread_file(packet: MergeEvidencePacket) -> bool:
     """A trajectory finding flagged a file modified but never read."""
-    return any(finding.rule_id == "changed-unread-file" for finding in packet.findings)
+    return any(
+        finding.rule_id == "changed-unread-file" for finding in _combined_packet_findings(packet)
+    )
 
 
 def _has_tool_loop(packet: MergeEvidencePacket) -> bool:
     """A trajectory finding flagged a repeated call loop."""
-    return any(finding.rule_id == "repeated-tool-loop" for finding in packet.findings)
+    return any(
+        finding.rule_id == "repeated-tool-loop" for finding in _combined_packet_findings(packet)
+    )
 
 
 def _is_high_risk_migration(packet: MergeEvidencePacket) -> bool:

--- a/src/mergecraft/analyzers/execution.py
+++ b/src/mergecraft/analyzers/execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import platform
 import sys
+import time
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
 TrustTier = Literal["trusted", "untrusted"]
 
 _NO_LINT_TARGETS_REASON = "no source files to lint after dropping enablement markers"
+_PROVISION_MAX_ATTEMPTS = 3
+_PROVISION_RETRY_DELAY_S = 1.0
 
 
 def marker_only_lint_skip_reason(manifest: AnalyzerManifest) -> str:
@@ -145,15 +148,33 @@ def provision_managed_argv(
     platform_key = provision_platform_key()
     cache_dir = repo_root / ".mergecraft" / "analyzer-cache"
     lock_path = repo_root / ".mergecraft" / "analyzers.lock"
-    try:
-        result = resolve_with_lock(
-            manifest=manifest,
-            lock_path=lock_path,
-            cache_dir=cache_dir,
-            platform=platform_key,
-        )
-    except ProvisionError as exc:
-        logger.info("{}", exc)
+    last_error: ProvisionError | None = None
+    for attempt in range(1, _PROVISION_MAX_ATTEMPTS + 1):
+        try:
+            result = resolve_with_lock(
+                manifest=manifest,
+                lock_path=lock_path,
+                cache_dir=cache_dir,
+                platform=platform_key,
+            )
+            break
+        except ProvisionError as exc:
+            last_error = exc
+            logger.warning(
+                "{}: provisioning failed on attempt {}/{}: {}",
+                manifest.id,
+                attempt,
+                _PROVISION_MAX_ATTEMPTS,
+                exc,
+            )
+            if attempt < _PROVISION_MAX_ATTEMPTS:
+                time.sleep(_PROVISION_RETRY_DELAY_S)
+                continue
+            logger.info("{}", exc)
+            return None
+    else:
+        assert last_error is not None
+        logger.info("{}", last_error)
         return None
 
     argv = list(plan.argv)

--- a/src/mergecraft/analyzers/finding.py
+++ b/src/mergecraft/analyzers/finding.py
@@ -18,6 +18,7 @@ from mergecraft.review_taxonomy import (
     FINDING_CATEGORIES,
     FINDING_CONFIDENCES,
     FINDING_SEVERITIES,
+    FindingScope,
     FindingSource,
     finding_fingerprint,
 )
@@ -63,6 +64,7 @@ class Finding(BaseModel):
     autofix: str | None
     introduced_by_pr: IntroducedByPr
     source: FindingSource
+    scope: FindingScope = "change"
     cluster_id: str | None
     lens: str | None = None
     collateral: list[str] = Field(default_factory=list)
@@ -114,6 +116,7 @@ def make_finding(
     remediation: str | None = None,
     autofix: str | None = None,
     introduced_by_pr: IntroducedByPr = "unknown",
+    scope: FindingScope = "change",
     cluster_id: str | None = None,
     fingerprint: str | None = None,
     lens: str | None = None,
@@ -141,6 +144,7 @@ def make_finding(
             autofix=autofix,
             introduced_by_pr=introduced_by_pr,
             source=source,
+            scope=scope,
             cluster_id=cluster_id,
             lens=lens,
             collateral=collateral or [],

--- a/src/mergecraft/analyzers/supply_chain.py
+++ b/src/mergecraft/analyzers/supply_chain.py
@@ -583,6 +583,12 @@ def run_differential_scan(
             skip_reason=f"skipped {tool_id}: no head manifest paths",
         )
 
+    if head_files == base_files:
+        # Head and base resolve to the same manifest paths (e.g. scanning an
+        # unchanged ``*.base`` lockfile). The CVE delta is empty by definition;
+        # skip duplicate network scans that can flake under parallel xdist.
+        return AdapterRunResult(findings=[])
+
     head_findings, head_err = _scan_side(
         tool_id,
         manifest=manifest,

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -209,8 +209,9 @@ def _persist_credential(
     ``name``/``value`` are the Actions-secret pair. ``local_entries`` names what
     goes into ``.env`` when that differs from the secret: ``auth logfire``
     writes a runtime-only token env var plus a project label behind a single
-    ``LOGFIRE_TOKEN`` secret. Only the local write is compacted onto one line —
-    an Actions secret has no such constraint, so ``gh`` gets ``value`` verbatim.
+    ``LOGFIRE_TOKEN`` secret. Both the local write and the ``gh secret set``
+    path compact multi-line JSON credentials onto one line so job logs do not
+    redact every ``{`` in the stored secret (ledger B2).
 
     ``github`` (the default) keeps the pre-``--scope`` contract exactly: one
     ``gh secret set``, no ``.env``, and a hard bail when the secret write
@@ -257,7 +258,8 @@ def _persist_credential(
         return
 
     console.print(f"saving [cyan]{name}[/cyan] via gh secret set...")
-    wrote_github = _set_gh_secret(name=name, value=value, repo_slug=target.github.repo_slug)
+    secret_value = _single_line_credential(name=name, value=value)
+    wrote_github = _set_gh_secret(name=name, value=secret_value, repo_slug=target.github.repo_slug)
     secrets_url = f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
     if wrote_github:
         console.print(f"[green]saved {name}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -258,11 +258,7 @@ def _persist_credential(
         return
 
     console.print(f"saving [cyan]{name}[/cyan] via gh secret set...")
-    wrote_github = _set_gh_secret(
-        name=name,
-        value=_single_line_credential(name=name, value=value),
-        repo_slug=target.github.repo_slug,
-    )
+    wrote_github = _set_gh_secret(name=name, value=value, repo_slug=target.github.repo_slug)
     secrets_url = f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
     if wrote_github:
         console.print(f"[green]saved {name}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -258,7 +258,11 @@ def _persist_credential(
         return
 
     console.print(f"saving [cyan]{name}[/cyan] via gh secret set...")
-    wrote_github = _set_gh_secret(name=name, value=value, repo_slug=target.github.repo_slug)
+    wrote_github = _set_gh_secret(
+        name=name,
+        value=_single_line_credential(name=name, value=value),
+        repo_slug=target.github.repo_slug,
+    )
     secrets_url = f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
     if wrote_github:
         console.print(f"[green]saved {name}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -258,8 +258,7 @@ def _persist_credential(
         return
 
     console.print(f"saving [cyan]{name}[/cyan] via gh secret set...")
-    secret_value = _single_line_credential(name=name, value=value)
-    wrote_github = _set_gh_secret(name=name, value=secret_value, repo_slug=target.github.repo_slug)
+    wrote_github = _set_gh_secret(name=name, value=value, repo_slug=target.github.repo_slug)
     secrets_url = f"https://github.com/{target.github.repo_slug}/settings/secrets/actions"
     if wrote_github:
         console.print(f"[green]saved {name}[/green] to GitHub Actions secrets")

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -510,8 +510,9 @@ def _persist_indexed_credentials(
         wrote_any_github = False
         for suffix, raw_value in credential_map.items():
             key = f"LLM_PROVIDER_{env_index}_{suffix}"
+            value = _single_line_credential(name=key, value=raw_value)
             console.print(f"saving [cyan]{key}[/cyan] via gh secret set...")
-            if _set_gh_secret(name=key, value=raw_value, repo_slug=target.github.repo_slug):
+            if _set_gh_secret(name=key, value=value, repo_slug=target.github.repo_slug):
                 console.print(f"[green]saved {key}[/green] to GitHub Actions secrets")
                 wrote_any_github = True
             elif not target.local:

--- a/src/mergecraft/evidence/build.py
+++ b/src/mergecraft/evidence/build.py
@@ -22,6 +22,7 @@ from mergecraft.evidence.packet import (
     DeterministicCheck,
     MergeEvidencePacket,
     ModePromptVersion,
+    RunHealth,
     SelfAssessment,
 )
 from mergecraft.evidence.trajectory import TrajectoryRecord
@@ -139,6 +140,14 @@ def _agent_metadata(
     )
 
 
+def _partition_findings(findings: list[Finding]) -> tuple[list[Finding], RunHealth | None]:
+    """Split change-scoped findings from run-health rows (plan 12 W7)."""
+    change_findings = [finding for finding in findings if finding.scope != "run"]
+    run_findings = [finding for finding in findings if finding.scope == "run"]
+    run_health = RunHealth(findings=run_findings, conclusion="advisory") if run_findings else None
+    return change_findings, run_health
+
+
 def build_packet(
     *,
     change_id: str,
@@ -194,6 +203,7 @@ def build_packet(
     extend their sections.
     """
     coerced_findings = _coerce_findings(findings)
+    change_findings, run_health = _partition_findings(coerced_findings)
     coerced_checks = _coerce_deterministic_checks(deterministic_checks)
     coerced_self_assessment = _coerce_self_assessment(self_assessment)
 
@@ -234,7 +244,8 @@ def build_packet(
             dispatched_lens_ids=dispatched_lens_ids,
         ),
         files_changed=list(files_changed),
-        findings=coerced_findings,
+        findings=change_findings,
+        run_health=run_health,
         deterministic_checks=coerced_checks,
         self_assessment=coerced_self_assessment,
         decision=decision,

--- a/src/mergecraft/evidence/packet.py
+++ b/src/mergecraft/evidence/packet.py
@@ -80,7 +80,9 @@ from mergecraft.evidence.trajectory import TrajectoryRecord
 #   ``decide_action`` runs; untrusted ``decided_by`` values are refused and
 #   a missing or non-success verdict can no longer satisfy ``auto_merge``
 #   (MCB-15 / D7 / D9).
-PACKET_SCHEMA_VERSION = "1.10.0"
+# - 1.11.0 — W7 (plan 12) adds ``run_health``: run-scoped findings and their
+#   advisory conclusion, partitioned out of the top-level ``findings`` list.
+PACKET_SCHEMA_VERSION = "1.11.0"
 
 
 class _PinnedRequiredFieldInfo(FieldInfo):  # type: ignore[misc]  # — FieldInfo.__init_subclass__ is not typed in pydantic stubs; subclassing is intentional
@@ -200,6 +202,19 @@ class SelfAssessment(BaseModel):
     sha: str | None = None
 
 
+class RunHealth(BaseModel):
+    """Run-scoped findings and an advisory conclusion (plan 12 W7).
+
+    Change-scoped findings live on ``findings``; trajectory and environment
+    observations that never block merge land here instead.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    findings: list[Finding]
+    conclusion: Literal["clean", "advisory"]
+
+
 class ModePromptVersion(BaseModel):
     """Identifies the prompt body that produced a run for one mode (#145).
 
@@ -238,6 +253,7 @@ class MergeEvidencePacket(BaseModel):
     agent: AgentMetadata
     files_changed: list[str]
     findings: list[Finding]
+    run_health: RunHealth | None = None
     deterministic_checks: list[DeterministicCheck]
     self_assessment: SelfAssessment | None = None
     decision: Decision | None = None
@@ -276,6 +292,10 @@ def packet_output_schema() -> dict[str, Any]:
     if isinstance(trajectory, dict) and "$ref" in trajectory:
         trajectory.clear()
         trajectory.update(TrajectoryRecord.model_json_schema())
+    run_health = schema.get("properties", {}).get("run_health")
+    if isinstance(run_health, dict) and "$ref" in run_health:
+        run_health.clear()
+        run_health.update(RunHealth.model_json_schema())
     return schema
 
 
@@ -286,6 +306,7 @@ __all__ = [
     "DeterministicCheck",
     "MergeEvidencePacket",
     "ModePromptVersion",
+    "RunHealth",
     "SelfAssessment",
     "packet_output_schema",
 ]

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -15,6 +15,7 @@ only assembles and emits packets for a completed run.
 Exports:
     build_run_packet: Assemble the packet for a completed run (decision included).
     prepare_run_packet: Assemble once with enforce-mode fail-closed fallback.
+    resolve_prepared_run_packet: Return the cached packet snapshot (D7).
     emit_run_packet: Write a pre-assembled packet; never rebuilds.
     resolve_packet_path: Resolve the stable on-disk destination.
 """
@@ -23,7 +24,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 from pydantic import ValidationError
@@ -322,7 +323,7 @@ def build_run_packet(
     # Plan 12 D2/D4: trajectory findings are run-scoped and partition into
     # ``run_health`` at build time. They are advisory-only — never block via
     # ``blocking_findings`` — while gate-policy predicates still read them from
-    # ``run_health.findings`` (see ``agents/gates._combined_packet_findings``).
+    # ``run_health.findings`` (see ``agents/gates._packet_attested_findings``).
     trajectory = build_trajectory_record(state, files_modified=changed_paths)
     trajectory_findings = audit_trajectory(trajectory)
 
@@ -469,6 +470,33 @@ def _fail_closed_assembly_packet(
     )
 
 
+def resolve_prepared_run_packet(
+    ctx: ToolContext,
+    *,
+    run_succeeded: bool,
+    change_id: str | None = None,
+    extra_findings: list[Finding] | None = None,
+) -> MergeEvidencePacket | None:
+    """Return the run's cached packet snapshot, assembling it at most once (D7).
+
+    The review-body preamble and the sticky progress comment must render from
+    the same ``MergeEvidencePacket`` instance so findings and decision rows
+    cannot drift between publish time and finalize.
+    """
+    cached = ctx.tool_state.prepared_run_packet
+    if cached is not None:
+        return cast("MergeEvidencePacket", cached)
+    packet = prepare_run_packet(
+        ctx,
+        run_succeeded=run_succeeded,
+        change_id=change_id,
+        extra_findings=extra_findings,
+    )
+    if packet is not None:
+        ctx.tool_state.prepared_run_packet = packet
+    return packet
+
+
 def prepare_run_packet(
     ctx: ToolContext,
     *,
@@ -596,4 +624,5 @@ __all__ = [
     "emit_run_packet",
     "prepare_run_packet",
     "resolve_packet_path",
+    "resolve_prepared_run_packet",
 ]

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -319,9 +319,10 @@ def build_run_packet(
     from mergecraft.evidence.trajectory_audit import audit_trajectory
 
     changed_paths = changed_paths_from_diff(diff_text)
-    # #43/#49: the record is built from the tool calls mergeCraft mediated, and
-    # its findings join the ordinary finding list rather than a parallel gate —
-    # so `decide_approval` below weighs them exactly like any other evidence.
+    # Plan 12 D2/D4: trajectory findings are run-scoped and partition into
+    # ``run_health`` at build time. They are advisory-only — never block via
+    # ``blocking_findings`` — while gate-policy predicates still read them from
+    # ``run_health.findings`` (see ``agents/gates._combined_packet_findings``).
     trajectory = build_trajectory_record(state, files_modified=changed_paths)
     trajectory_findings = audit_trajectory(trajectory)
 

--- a/src/mergecraft/evidence/run_packet.py
+++ b/src/mergecraft/evidence/run_packet.py
@@ -470,6 +470,13 @@ def _fail_closed_assembly_packet(
     )
 
 
+def _cached_packet_shell(cached: MergeEvidencePacket) -> MergeEvidencePacket:
+    """Return the cached evidence shell without a baked-in decision row."""
+    if cached.decision is None:
+        return cached
+    return cached.model_copy(update={"decision": None})
+
+
 def resolve_prepared_run_packet(
     ctx: ToolContext,
     *,
@@ -480,12 +487,19 @@ def resolve_prepared_run_packet(
     """Return the run's cached packet snapshot, assembling it at most once (D7).
 
     The review-body preamble and the sticky progress comment must render from
-    the same ``MergeEvidencePacket`` instance so findings and decision rows
-    cannot drift between publish time and finalize.
+    the same evidence shell so findings cannot drift between publish time and
+    finalize. The structural decision is re-finalized on every call so a
+    publish-time ``run_succeeded=True`` snapshot does not stick when finalize
+    reports failed, timed_out, or inconclusive.
     """
     cached = ctx.tool_state.prepared_run_packet
     if cached is not None:
-        return cast("MergeEvidencePacket", cached)
+        shell = _cached_packet_shell(
+            cast("MergeEvidencePacket", cached),  # prepared_run_packet is Any on ToolState
+        )
+        if shell is not cached:
+            ctx.tool_state.prepared_run_packet = shell
+        return _finalize_packet_with_gate(shell, ctx=ctx, run_succeeded=run_succeeded)
     packet = prepare_run_packet(
         ctx,
         run_succeeded=run_succeeded,
@@ -493,7 +507,7 @@ def resolve_prepared_run_packet(
         extra_findings=extra_findings,
     )
     if packet is not None:
-        ctx.tool_state.prepared_run_packet = packet
+        ctx.tool_state.prepared_run_packet = _cached_packet_shell(packet)
     return packet
 
 

--- a/src/mergecraft/evidence/trajectory.py
+++ b/src/mergecraft/evidence/trajectory.py
@@ -40,6 +40,7 @@ Exports:
     TrajectoryRecord: The full record, ready for the packet and the auditor.
     build_trajectory_record: Assemble the record from run state (pure).
     classify_tool_intent: Map a tool call onto its trajectory intent.
+    classify_failure_class: Derive a failure class from recorded error text.
     record_tool_call: Append one mediated call to the run's state.
 """
 
@@ -47,9 +48,9 @@ from __future__ import annotations
 
 import hashlib
 import shlex
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from mergecraft.analyzers.redact import redact_secrets
 
@@ -65,6 +66,46 @@ SOURCE_EXTERNAL_TRACE: Final[str] = "external-trace"
 
 Intent = Literal["read", "modify", "verify", "complete", "report", "other"]
 """What a tool call was *for*, as far as the trajectory is concerned."""
+
+FailureClass = Literal["schema", "policy", "environment", "transient", "unknown"]
+"""How a failed tool call should be interpreted by the trajectory auditor."""
+
+# JSON-RPC ``-32602`` and pydantic/jsonschema validation shapes recorded in error
+# text. Classifying here by string match is weaker than inspecting the typed
+# exception at ``mcp/shared.py::execute`` (plan 13's seam) — follow-up:
+# ``classify_failure_at_execute`` should stamp ``failure_class`` at the choke
+# point so this module never re-parses prose.
+_SCHEMA_FAILURE_MARKERS: Final[tuple[str, ...]] = (
+    "-32602",
+    "invalid arguments for",
+    "input validation error",
+    "validation error",
+    "pydantic",
+)
+
+# Guard refusals and mode/policy blocks surfaced as tool errors.
+_POLICY_FAILURE_MARKERS: Final[tuple[str, ...]] = (
+    "invalid git subcommand",
+    "not available through this tool",
+    "invalid parameters for tool",
+    "refused",
+    "mode_not_implemented",
+)
+
+# Network / overload signatures that warrant a retry, not a process indictment.
+_TRANSIENT_FAILURE_MARKERS: Final[tuple[str, ...]] = (
+    "connection reset",
+    "reset by peer",
+    "temporarily unavailable",
+    "timeout",
+    "timed out",
+    "broken pipe",
+    "502",
+    "503",
+    "504",
+    "429",
+    "rate limit",
+)
 
 # Intent by MCP tool name. `shell` and `git` are absent on purpose: both are
 # general-purpose, so their intent is derived from the command (see
@@ -207,8 +248,16 @@ class ToolCallRecord(BaseModel):
     ok: bool
     outcome_ok: bool | None = None
     error: str | None = None
+    failure_class: FailureClass = "unknown"
+    """Classifier for ``ok=False`` rows; derived from ``error`` when unset."""
     command: str | None = None
     paths: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _derive_failure_class(self) -> Self:
+        if not self.ok and self.error and self.failure_class == "unknown":
+            self.failure_class = classify_failure_class(self.error)
+        return self
 
 
 class ExternalTraceRef(BaseModel):
@@ -331,6 +380,38 @@ def _command_intent(tool: str, command: str) -> Intent:
     return "other"
 
 
+def classify_failure_class(error: str | None) -> FailureClass:
+    """Derive a failure class from the error text stored on a tool call.
+
+    String matching on recorded prose is a deliberate trade-off: it lets plan 12
+    classify failures in the auditor without editing ``mcp/shared.py::execute``,
+    which plan 13 owns. The follow-up is to stamp ``failure_class`` from the
+    typed exception at that choke point and treat this function as a fallback
+    for records that predate the seam.
+    """
+    if not error:
+        return "unknown"
+    lowered = error.lower()
+    if any(marker in lowered for marker in _SCHEMA_FAILURE_MARKERS):
+        return "schema"
+    if any(marker in lowered for marker in _POLICY_FAILURE_MARKERS):
+        return "policy"
+    from mergecraft.agents.codex import USER_NAMESPACE_FAILURES, is_user_namespace_failure
+    from mergecraft.mcp.git import _AUTH_FAILURE_MARKERS
+
+    if is_user_namespace_failure(error) or any(
+        marker in error for marker in USER_NAMESPACE_FAILURES
+    ):
+        return "environment"
+    if any(marker in lowered for marker in _AUTH_FAILURE_MARKERS):
+        return "environment"
+    if "newuidmap" in lowered or "bwrap" in lowered:
+        return "environment"
+    if any(marker in lowered for marker in _TRANSIENT_FAILURE_MARKERS):
+        return "transient"
+    return "unknown"
+
+
 def classify_tool_intent(tool: str, arguments: dict[str, Any] | None) -> Intent:
     """Return the trajectory intent of one tool call.
 
@@ -382,6 +463,7 @@ def record_tool_call(
     and surfaced as an Action output.
     """
     command_raw = str((arguments or {}).get("command") or "") or None
+    error_text = _truncate(redact_secrets(error), _MAX_ERROR_CHARS) if error else None
     row = ToolCallRecord(
         sequence=len(state.tool_calls) + 1,
         tool=tool,
@@ -389,7 +471,8 @@ def record_tool_call(
         intent=classify_tool_intent(tool, arguments),
         ok=ok,
         outcome_ok=outcome_ok,
-        error=_truncate(redact_secrets(error), _MAX_ERROR_CHARS) if error else None,
+        error=error_text,
+        failure_class=classify_failure_class(error_text) if not ok and error_text else "unknown",
         command=_truncate(redact_secrets(command_raw), _MAX_COMMAND_CHARS) if command_raw else None,
         paths=_paths_in(arguments),
     )
@@ -517,10 +600,12 @@ __all__ = [
     "SOURCE_RUN_DIFF",
     "TRAJECTORY_SCHEMA_VERSION",
     "ExternalTraceRef",
+    "FailureClass",
     "Intent",
     "ToolCallRecord",
     "TrajectoryRecord",
     "build_trajectory_record",
+    "classify_failure_class",
     "classify_tool_intent",
     "outcome_ok_from_result",
     "record_tool_call",

--- a/src/mergecraft/evidence/trajectory_audit.py
+++ b/src/mergecraft/evidence/trajectory_audit.py
@@ -144,10 +144,11 @@ def _finding(
         path=path,
         start_line=1,
         end_line=1,
-        source="agent",
+        source="trajectory",
+        scope="run",
         evidence=evidence or [],
         remediation=check.recommended_action,
-        introduced_by_pr="true",
+        introduced_by_pr="false",
     )
 
 

--- a/src/mergecraft/evidence/trajectory_audit.py
+++ b/src/mergecraft/evidence/trajectory_audit.py
@@ -25,7 +25,7 @@ Exports:
 
 from __future__ import annotations
 
-from collections import Counter
+import re
 from typing import TYPE_CHECKING, Final
 
 from pydantic import BaseModel, ConfigDict
@@ -50,6 +50,16 @@ BROAD_EDIT_FILE_THRESHOLD: Final[int] = 25
 
 # Two identical calls is a retry. Three is a loop.
 REPEATED_CALL_THRESHOLD: Final[int] = 3
+
+# Schema slips the agent corrects within this window are not process defects.
+SCHEMA_SELF_CORRECT_WINDOW: Final[int] = 3
+
+_PR_COMMAND_RE: Final[re.Pattern[str]] = re.compile(r"pull/(?P<pr>\d+)/|pr-(?P<pr2>\d+)")
+_CHECKOUT_PR_SIGNATURE_RE: Final[re.Pattern[str]] = re.compile(r":(?P<pr>\d+)$")
+_IMMUTABLE_GIT_SHOW_RE: Final[re.Pattern[str]] = re.compile(
+    r"git\s+show\s+[0-9a-f]{4,40}:",
+    re.IGNORECASE,
+)
 
 _TOOL = "trajectory"
 _CATEGORY = "Maintainability & Code Quality"
@@ -126,6 +136,7 @@ def _finding(
     message: str,
     path: str = "",
     evidence: list[str] | None = None,
+    severity: str | None = None,
 ) -> Finding:
     """Build a `Finding` for a named check, carrying its severity and action."""
     check = _BY_ID[rule_id]
@@ -138,7 +149,7 @@ def _finding(
         tool=_TOOL,
         rule_id=rule_id,
         category=_CATEGORY,
-        severity=check.severity,
+        severity=severity or check.severity,
         confidence="certain",
         message=message,
         path=path,
@@ -170,17 +181,142 @@ def _changed_unread_file(record: TrajectoryRecord) -> list[Finding]:
     ]
 
 
+def _pr_target(call: ToolCallRecord) -> str | None:
+    if call.command:
+        match = _PR_COMMAND_RE.search(call.command)
+        if match is not None:
+            return match.group("pr") or match.group("pr2")
+    if call.tool == "checkout_pr" and call.signature:
+        match = _CHECKOUT_PR_SIGNATURE_RE.search(call.signature)
+        if match is not None:
+            return match.group("pr")
+    return None
+
+
+def _call_target(call: ToolCallRecord) -> str:
+    pr = _pr_target(call)
+    if pr is not None:
+        return f"pr:{pr}"
+    if call.intent in {"verify", "modify"} and call.tool not in {"shell", "git"}:
+        return call.tool
+    if call.paths:
+        return f"{call.tool}:path:{','.join(sorted(call.paths))}"
+    if call.command:
+        return f"{call.tool}:cmd:{call.command}"
+    return call.signature
+
+
+def _same_intent_and_target(left: ToolCallRecord, right: ToolCallRecord) -> bool:
+    return left.intent == right.intent and _call_target(left) == _call_target(right)
+
+
+def _was_retried(call: ToolCallRecord, calls: list[ToolCallRecord]) -> bool:
+    return any(
+        later.sequence > call.sequence and _same_intent_and_target(call, later) for later in calls
+    )
+
+
+def _schema_self_corrected(call: ToolCallRecord, calls: list[ToolCallRecord]) -> bool:
+    if call.failure_class != "schema":
+        return False
+    window_end = call.sequence + SCHEMA_SELF_CORRECT_WINDOW
+    for later in calls:
+        if later.sequence <= call.sequence or later.sequence > window_end:
+            continue
+        if later.ok and (later.signature == call.signature or later.tool == call.tool):
+            return True
+    return False
+
+
+def _is_immutable_rev_read(call: ToolCallRecord) -> bool:
+    if call.tool != "git" or not call.command:
+        return False
+    return _IMMUTABLE_GIT_SHOW_RE.search(call.command) is not None
+
+
+def _mutable_target_read(call: ToolCallRecord) -> bool:
+    if call.tool in {"list_check_runs", "get_pull_request"}:
+        return True
+    if call.tool == "git" and call.command:
+        head = call.command.strip().split(maxsplit=2)
+        if len(head) >= 2 and head[0] == "git" and head[1] == "status":
+            return True
+        if head and head[0] == "status":
+            return True
+    return False
+
+
+def _qualifies_for_loop(call: ToolCallRecord) -> bool:
+    if call.intent in {"modify", "verify"}:
+        return True
+    if call.intent != "read":
+        return False
+    if _is_immutable_rev_read(call):
+        return False
+    return _mutable_target_read(call)
+
+
+def _environment_failure_rollup(record: TrajectoryRecord) -> list[Finding]:
+    env_calls = [
+        call for call in record.tool_calls if not call.ok and call.failure_class == "environment"
+    ]
+    if not env_calls:
+        return []
+    namespace = any(
+        "newuidmap" in (call.error or "").lower()
+        or "bwrap" in (call.command or "").lower()
+        or "namespace" in (call.error or "").lower()
+        for call in env_calls
+    )
+    if namespace:
+        from mergecraft.agents.codex import user_namespace_failure_hint
+
+        return [
+            _finding(
+                "ignored-tool-error",
+                message=user_namespace_failure_hint(),
+                evidence=[call.error or call.command or call.tool for call in env_calls[:3]],
+                severity="Major",
+            )
+        ]
+    sample = env_calls[0]
+    return [
+        _finding(
+            "ignored-tool-error",
+            message=f"{sample.tool} failed due to an environment constraint and was not retried",
+            evidence=[sample.error or "environment failure"],
+            severity="Major",
+        )
+    ]
+
+
 def _ignored_tool_error(record: TrajectoryRecord) -> list[Finding]:
-    """A call raised and that tool was never invoked again."""
-    findings: list[Finding] = []
-    for call in record.tool_calls:
+    """A call raised and that intent on that target was never invoked again."""
+    findings: list[Finding] = list(_environment_failure_rollup(record))
+    policy_observed = False
+    calls = list(record.tool_calls)
+    for call in calls:
         if call.ok:
             continue
-        retried = any(
-            later.tool == call.tool and later.sequence > call.sequence
-            for later in record.tool_calls
-        )
-        if retried:
+        if call.failure_class == "schema" and _schema_self_corrected(call, calls):
+            continue
+        if call.failure_class == "policy":
+            if not policy_observed and not _was_retried(call, calls):
+                findings.append(
+                    _finding(
+                        "ignored-tool-error",
+                        message=f"{call.tool} was refused by a guard: {call.error or 'policy refusal'}",
+                        evidence=[call.error or "policy refusal"],
+                        severity="Trivial",
+                    )
+                )
+                policy_observed = True
+            continue
+        if call.failure_class == "environment":
+            continue
+        if call.failure_class not in {"transient", "unknown"}:
+            continue
+        if _was_retried(call, calls):
             continue
         findings.append(
             _finding(
@@ -214,16 +350,33 @@ def _no_post_edit_verification(record: TrajectoryRecord) -> list[Finding]:
 
 
 def _repeated_tool_loop(record: TrajectoryRecord) -> list[Finding]:
-    counts = Counter(call.signature for call in record.tool_calls)
-    return [
-        _finding(
-            "repeated-tool-loop",
-            message=f"the same call was repeated {count} times with identical arguments",
-            evidence=[f"signature={signature!r}"],
-        )
-        for signature, count in sorted(counts.items())
-        if count >= REPEATED_CALL_THRESHOLD
-    ]
+    findings: list[Finding] = []
+    calls = list(record.tool_calls)
+    index = 0
+    while index < len(calls):
+        call = calls[index]
+        if not _qualifies_for_loop(call):
+            index += 1
+            continue
+        signature = call.signature
+        count = 1
+        next_index = index + 1
+        while next_index < len(calls):
+            later = calls[next_index]
+            if not _qualifies_for_loop(later) or later.signature != signature:
+                break
+            count += 1
+            next_index += 1
+        if count >= REPEATED_CALL_THRESHOLD:
+            findings.append(
+                _finding(
+                    "repeated-tool-loop",
+                    message=(f"the same call was repeated {count} times with identical arguments"),
+                    evidence=[f"signature={signature!r}"],
+                )
+            )
+        index = next_index if next_index > index + 1 else index + 1
+    return findings
 
 
 def _unresolved_failure(record: TrajectoryRecord) -> list[Finding]:

--- a/src/mergecraft/evidence/trajectory_audit.py
+++ b/src/mergecraft/evidence/trajectory_audit.py
@@ -13,9 +13,10 @@ is *unknown*, not *unread*. Every check that could fire on missing signal is
 gated on the record carrying that signal at all (``read_coverage``, a non-empty
 ``tool_calls``). A check that fires on every run is noise, not a gate.
 
-**No second gate path.** The checks emit ordinary :class:`Finding` rows that go
-into the packet's finding list, where ``decide_approval()`` — the one gate —
-reads them (D5, W8.2). Nothing here decides anything.
+**No second gate path.** The checks emit ordinary :class:`Finding` rows with
+``scope="run"`` into the packet's ``run_health`` section (D2, W7). They attest
+that the review ran but never block approval. ``decide_approval()`` — the one
+gate — reads change-scoped findings only. Nothing here decides anything.
 
 Exports:
     TrajectoryCheck: One named check's metadata (severity, recommended action).

--- a/src/mergecraft/findings/ledger.py
+++ b/src/mergecraft/findings/ledger.py
@@ -34,10 +34,20 @@ _VIA_MERGECRAFT_MARKER = "*via mergecraft*"
 
 _LEDGER_MARKER_RE = re.compile(r"<!-- mergecraft-ledger:v1:([0-9a-f]+):([a-z-]+)(?::([^>]*?))? -->")
 _LEDGER_MARKER_V2_RE = re.compile(r"<!-- mergecraft-ledger:v2:([0-9a-f]+):([a-z-]+):([^>]+) -->")
+# Agent prose: the block must end at a real terminator. Falling back to ``\Z``
+# here meant a marker the agent merely quoted — plausible in a repo that reviews
+# its own reviewer — swallowed every finding after it. A bare marker with no
+# terminator is removed on its own by the ``replace`` in the stripper below.
 _DETERMINISTIC_RECORD_BLOCK_RE = re.compile(
+    rf"{re.escape(DETERMINISTIC_RECORD_MARKER)}[\s\S]*?"
+    r"(?=\n<!-- mergecraft-ledger:|\n\*via mergecraft\*)",
+)
+# Our own progress comment, where the record legitimately ends the body.
+_DETERMINISTIC_RECORD_BLOCK_EOF_RE = re.compile(
     rf"{re.escape(DETERMINISTIC_RECORD_MARKER)}[\s\S]*?"
     r"(?=\n<!-- mergecraft-ledger:|\n\*via mergecraft\*|\Z)",
 )
+_RECORD_SLOT = "\x00mergecraft-deterministic-record\x00"
 
 _ISSUE_COMMENT_PAGE_SIZE = 100
 # GitHub issue comments are paginated at 100/page; cap total scanned comments
@@ -566,16 +576,29 @@ def _strip_deterministic_record_markers(body: str) -> str:
 
 
 def merge_deterministic_record_into_comment(body: str, *, record_block: str) -> str:
-    """Insert or replace the deterministic record block in a progress comment."""
-    cleaned = _DETERMINISTIC_RECORD_BLOCK_RE.sub("", body).replace(DETERMINISTIC_RECORD_MARKER, "")
-    cleaned = cleaned.strip()
+    """Insert or replace the deterministic record block in a progress comment.
+
+    When the comment already carries a record, the new one replaces it **in
+    place** so any surrounding prose keeps its position. The replacement is
+    staged through a sentinel because the rendered block itself opens with
+    ``DETERMINISTIC_RECORD_MARKER``; substituting it directly would leave the
+    freshly-inserted block matching the same pattern as the stale ones being
+    cleared.
+    """
     block = record_block.strip()
+    if DETERMINISTIC_RECORD_MARKER in body:
+        staged = _DETERMINISTIC_RECORD_BLOCK_EOF_RE.sub(_RECORD_SLOT, body, count=1)
+        staged = _DETERMINISTIC_RECORD_BLOCK_EOF_RE.sub("", staged)
+        staged = staged.replace(DETERMINISTIC_RECORD_MARKER, "")
+        if _PROGRESS_HEADING not in staged:
+            staged = f"{_PROGRESS_HEADING}\n\n{staged.lstrip()}"
+        return f"{staged.replace(_RECORD_SLOT, block).strip()}\n"
+    cleaned = _DETERMINISTIC_RECORD_BLOCK_EOF_RE.sub("", body)
+    cleaned = cleaned.replace(DETERMINISTIC_RECORD_MARKER, "").strip()
     if not cleaned:
         return f"{_PROGRESS_HEADING}\n\n{block}\n"
     if _PROGRESS_HEADING not in cleaned:
         cleaned = f"{_PROGRESS_HEADING}\n\n{cleaned}"
-    if DETERMINISTIC_RECORD_MARKER in cleaned:
-        return f"{_DETERMINISTIC_RECORD_BLOCK_RE.sub(block, cleaned, count=1).rstrip()}\n"
     parts = cleaned.split("\n", 1)
     if parts[0].strip() == _PROGRESS_HEADING:
         tail = parts[1].strip() if len(parts) > 1 else ""

--- a/src/mergecraft/findings/ledger.py
+++ b/src/mergecraft/findings/ledger.py
@@ -612,7 +612,7 @@ def render_deterministic_review_block(
     findings = [
         row if isinstance(row, Finding) else Finding.model_validate(row) for row in findings_raw
     ]
-    change_findings = list(findings)
+    change_findings = [finding for finding in findings if finding.scope != "run"]
     run_health = getattr(packet, "run_health", None)
     if run_health is not None:
         run_findings = [
@@ -620,7 +620,6 @@ def render_deterministic_review_block(
             for row in list(getattr(run_health, "findings", []) or [])
         ]
     else:
-        change_findings = [finding for finding in findings if finding.scope != "run"]
         run_findings = [finding for finding in findings if finding.scope == "run"]
     deterministic_checks = list(getattr(packet, "deterministic_checks", []) or [])
 

--- a/src/mergecraft/findings/ledger.py
+++ b/src/mergecraft/findings/ledger.py
@@ -612,8 +612,16 @@ def render_deterministic_review_block(
     findings = [
         row if isinstance(row, Finding) else Finding.model_validate(row) for row in findings_raw
     ]
-    change_findings = [finding for finding in findings if finding.scope != "run"]
-    run_findings = [finding for finding in findings if finding.scope == "run"]
+    change_findings = list(findings)
+    run_health = getattr(packet, "run_health", None)
+    if run_health is not None:
+        run_findings = [
+            row if isinstance(row, Finding) else Finding.model_validate(row)
+            for row in list(getattr(run_health, "findings", []) or [])
+        ]
+    else:
+        change_findings = [finding for finding in findings if finding.scope != "run"]
+        run_findings = [finding for finding in findings if finding.scope == "run"]
     deterministic_checks = list(getattr(packet, "deterministic_checks", []) or [])
 
     model = ""

--- a/src/mergecraft/findings/ledger.py
+++ b/src/mergecraft/findings/ledger.py
@@ -27,12 +27,17 @@ if TYPE_CHECKING:
 LEDGER_MARKER_PREFIX: str = "<!-- mergecraft-ledger:v1:"
 LEDGER_MARKER_V2_PREFIX: str = "<!-- mergecraft-ledger:v2:"
 LEDGER_SCHEMA_VERSION: str = "v2"
+DETERMINISTIC_RECORD_MARKER: str = "<!-- mergecraft-deterministic-record:v1 -->"
 
 _PROGRESS_HEADING = "## mergeCraft progress"
 _VIA_MERGECRAFT_MARKER = "*via mergecraft*"
 
 _LEDGER_MARKER_RE = re.compile(r"<!-- mergecraft-ledger:v1:([0-9a-f]+):([a-z-]+)(?::([^>]*?))? -->")
 _LEDGER_MARKER_V2_RE = re.compile(r"<!-- mergecraft-ledger:v2:([0-9a-f]+):([a-z-]+):([^>]+) -->")
+_DETERMINISTIC_RECORD_BLOCK_RE = re.compile(
+    rf"{re.escape(DETERMINISTIC_RECORD_MARKER)}[\s\S]*?"
+    r"(?=\n<!-- mergecraft-ledger:|\n\*via mergecraft\*|\Z)",
+)
 
 _ISSUE_COMMENT_PAGE_SIZE = 100
 # GitHub issue comments are paginated at 100/page; cap total scanned comments
@@ -153,7 +158,8 @@ def is_sticky_progress_comment(body: str) -> bool:
     """Return whether ``body`` looks like the mergeCraft sticky progress comment."""
     lowered = body.lower()
     return (
-        LEDGER_MARKER_PREFIX in body
+        DETERMINISTIC_RECORD_MARKER in body
+        or LEDGER_MARKER_PREFIX in body
         or LEDGER_MARKER_V2_PREFIX in body
         or _PROGRESS_HEADING in body
         or _VIA_MERGECRAFT_MARKER in lowered
@@ -553,7 +559,242 @@ async def persist_finding_ledger_to_progress_comment(ctx: ToolContext) -> None:
         logger.info("finding ledger: could not persist progress comment: {}", err)
 
 
+def _strip_deterministic_record_markers(body: str) -> str:
+    """Remove forged or stale deterministic-record markers from agent prose."""
+    without_block = _DETERMINISTIC_RECORD_BLOCK_RE.sub("", body)
+    return without_block.replace(DETERMINISTIC_RECORD_MARKER, "").strip()
+
+
+def merge_deterministic_record_into_comment(body: str, *, record_block: str) -> str:
+    """Insert or replace the deterministic record block in a progress comment."""
+    cleaned = _DETERMINISTIC_RECORD_BLOCK_RE.sub("", body).replace(DETERMINISTIC_RECORD_MARKER, "")
+    cleaned = cleaned.strip()
+    block = record_block.strip()
+    if not cleaned:
+        return f"{_PROGRESS_HEADING}\n\n{block}\n"
+    if _PROGRESS_HEADING not in cleaned:
+        cleaned = f"{_PROGRESS_HEADING}\n\n{cleaned}"
+    if DETERMINISTIC_RECORD_MARKER in cleaned:
+        return f"{_DETERMINISTIC_RECORD_BLOCK_RE.sub(block, cleaned, count=1).rstrip()}\n"
+    parts = cleaned.split("\n", 1)
+    if parts[0].strip() == _PROGRESS_HEADING:
+        tail = parts[1].strip() if len(parts) > 1 else ""
+        if tail:
+            return f"{_PROGRESS_HEADING}\n\n{block}\n\n{tail}\n"
+        return f"{_PROGRESS_HEADING}\n\n{block}\n"
+    return f"{block}\n\n{cleaned}\n"
+
+
+def render_deterministic_review_block(
+    *,
+    packet: Any,
+    rejection_reason: str | None = None,
+    run_url: str | None = None,
+    run_outcome: Any | None = None,
+    verdict_diagnostic: Any | None = None,
+    analyzer_summary: str | None = None,
+    agent_summary: str | None = None,
+    trust_tier: str | None = None,
+    attempt_count: int | None = None,
+    token_summary: str | None = None,
+) -> str:
+    """Render the authoritative deterministic review record (D6/D7).
+
+    Pure leaf: no I/O. Both the sticky progress comment and the review-body
+    preamble render from this single function so the two surfaces cannot drift.
+    """
+    from mergecraft.analyzers.finding import Finding
+
+    decision = getattr(packet, "decision", None)
+    agent_meta = getattr(packet, "agent", None)
+    self_assessment = getattr(packet, "self_assessment", None)
+    findings_raw = list(getattr(packet, "findings", []) or [])
+    findings = [
+        row if isinstance(row, Finding) else Finding.model_validate(row) for row in findings_raw
+    ]
+    change_findings = [finding for finding in findings if finding.scope != "run"]
+    run_findings = [finding for finding in findings if finding.scope == "run"]
+    deterministic_checks = list(getattr(packet, "deterministic_checks", []) or [])
+
+    model = ""
+    if agent_meta is not None:
+        executed = str(getattr(agent_meta, "executed_model", "") or "").strip()
+        model = executed or str(getattr(agent_meta, "model", "") or "").strip()
+
+    reviewed_sha = ""
+    if self_assessment is not None and getattr(self_assessment, "sha", None):
+        reviewed_sha = str(self_assessment.sha)
+
+    header_lines = [
+        DETERMINISTIC_RECORD_MARKER,
+        "### mergeCraft run record",
+        "",
+    ]
+    if run_outcome is not None:
+        header_lines.append(f"- **Outcome:** `{run_outcome}`")
+    if verdict_diagnostic is not None:
+        diagnostic = (
+            verdict_diagnostic.value
+            if hasattr(verdict_diagnostic, "value")
+            else str(verdict_diagnostic)
+        )
+        header_lines.append(f"- **Verdict diagnostic:** `{diagnostic}`")
+    if decision is not None:
+        header_lines.append(f"- **Decision:** `{decision.verdict}` — {decision.reason}")
+    if model:
+        header_lines.append(f"- **Model:** `{model}`")
+    if attempt_count is not None:
+        header_lines.append(f"- **Attempts:** {attempt_count}")
+    if token_summary:
+        header_lines.append(f"- **Tokens:** {token_summary}")
+    if run_url:
+        header_lines.append(f"- **Run:** {run_url}")
+    if reviewed_sha:
+        header_lines.append(f"- **Reviewed SHA:** `{reviewed_sha}`")
+
+    pre_merge_lines = ["", "### Pre-merge checks", ""]
+    if analyzer_summary:
+        pre_merge_lines.append(f"- **Analyzers:** {analyzer_summary}")
+    elif agent_meta is not None and getattr(agent_meta, "dispatched_lens_ids", None):
+        lens_ids = ", ".join(agent_meta.dispatched_lens_ids)
+        pre_merge_lines.append(f"- **Analyzers:** dispatched lenses: {lens_ids}")
+    else:
+        pre_merge_lines.append("- **Analyzers:** not recorded on packet")
+
+    if deterministic_checks:
+        check_bits = [
+            f"{check.name} ({check.status})"
+            for check in deterministic_checks
+            if getattr(check, "name", None)
+        ]
+        pre_merge_lines.append(
+            f"- **Static checks:** {', '.join(check_bits) if check_bits else 'none recorded'}"
+        )
+    else:
+        pre_merge_lines.append("- **Static checks:** none recorded")
+
+    pre_merge_lines.append("- **CI intelligence:** see packet findings")
+    pre_merge_lines.append(f"- **Trust tier:** `{trust_tier or 'unknown'}`")
+
+    finding_lines = ["", "### Change-scoped findings", ""]
+    if change_findings:
+        for finding in change_findings:
+            location = f"`{finding.path}` — " if finding.path else ""
+            finding_lines.append(f"- **{finding.severity}** · {location}{finding.message}")
+    else:
+        finding_lines.append("_No change-scoped findings recorded._")
+
+    run_health_lines: list[str] = []
+    if run_findings:
+        run_health_lines = [
+            "",
+            "<details>",
+            "<summary>Run health</summary>",
+            "",
+        ]
+        for finding in run_findings:
+            run_health_lines.append(f"- **{finding.severity}** · {finding.message}")
+        run_health_lines.append("")
+        run_health_lines.append("</details>")
+
+    verdict_lines: list[str] = []
+    if decision is not None:
+        summary = (agent_summary or "").strip()
+        if summary:
+            verdict_lines = [
+                "",
+                "### Agent summary",
+                "",
+                f"> {summary.replace(chr(10), chr(10) + '> ')}",
+            ]
+    elif rejection_reason:
+        verdict_lines = [
+            "",
+            f"**No verdict recorded — reason:** `{rejection_reason}`",
+        ]
+
+    return (
+        "\n".join(
+            header_lines + pre_merge_lines + finding_lines + run_health_lines + verdict_lines
+        ).rstrip()
+        + "\n"
+    )
+
+
+async def upsert_sticky_progress_comment(ctx: ToolContext, record_block: str) -> None:
+    """Upsert the sticky progress comment with the deterministic record (D6)."""
+    from mergecraft.mcp.comment import add_footer
+    from mergecraft.mcp.tool_state import ProgressComment, primary_repo_state
+    from mergecraft.utils import gha_log
+
+    tool_state = ctx.tool_state
+    if tool_state.progress_comment is False:
+        return
+
+    issue_number = primary_repo_state(tool_state).issue_number or tool_state.pr_number
+    if issue_number is None:
+        return
+
+    try:
+        base_body = str(tool_state.last_progress_body or "").strip()
+        body_with_record = merge_deterministic_record_into_comment(
+            base_body,
+            record_block=record_block,
+        )
+        body_with_footer = add_footer(ctx, body_with_record)
+
+        if isinstance(tool_state.progress_comment, ProgressComment):
+            await ctx.scm.update_issue_comment(
+                ctx.repo.owner,
+                ctx.repo.name,
+                int(tool_state.progress_comment.id),
+                body_with_footer,
+            )
+            tool_state.last_progress_body = body_with_footer
+            return
+
+        sticky = await fetch_sticky_progress_comment(
+            ctx.scm,
+            ctx.repo.owner,
+            ctx.repo.name,
+            int(issue_number),
+        )
+        if sticky is not None:
+            existing_body = str(sticky.get("body") or "")
+            merged = merge_deterministic_record_into_comment(
+                existing_body,
+                record_block=record_block,
+            )
+            body_with_footer = add_footer(ctx, merged)
+            await ctx.scm.update_issue_comment(
+                ctx.repo.owner,
+                ctx.repo.name,
+                int(sticky["id"]),
+                body_with_footer,
+            )
+            tool_state.progress_comment = ProgressComment(
+                id=str(sticky["id"]),
+                type="issue",
+            )
+            tool_state.last_progress_body = body_with_footer
+            return
+
+        result = await ctx.scm.create_issue_comment(
+            ctx.repo.owner,
+            ctx.repo.name,
+            int(issue_number),
+            body_with_footer,
+        )
+        tool_state.progress_comment = ProgressComment(id=str(result["id"]), type="issue")
+        tool_state.last_progress_body = body_with_footer
+    except Exception as err:
+        message = f"deterministic record: could not persist progress comment: {err}"
+        logger.info(message)
+        gha_log.warning(message)
+
+
 __all__ = [
+    "DETERMINISTIC_RECORD_MARKER",
     "LEDGER_MARKER_PREFIX",
     "LEDGER_MARKER_V2_PREFIX",
     "LEDGER_SCHEMA_VERSION",
@@ -564,11 +805,14 @@ __all__ = [
     "hydrate_finding_ledger_from_progress_comment",
     "is_sticky_progress_comment",
     "ledger_round_index",
+    "merge_deterministic_record_into_comment",
     "merge_ledger_into_comment",
     "persist_finding_ledger_to_progress_comment",
     "record_deferred_from_analyzer_run",
     "record_over_budget_verifications",
     "record_published_findings_in_ledger",
     "record_withdrawn_in_ledger",
+    "render_deterministic_review_block",
     "sticky_progress_comment_body",
+    "upsert_sticky_progress_comment",
 ]

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -444,8 +444,10 @@ async def _publish(
         pull_number = tool_context.tool_state.pr_number
         if pull_number is None and tool_context.payload.event.issue_number is not None:
             pull_number = int(tool_context.payload.event.issue_number)
+        rejection_reason = (
+            failure_reason if prepared is not None and prepared.decision is None else None
+        )
         if pull_number is not None and prepared is not None:
-            rejection_reason = failure_reason if prepared.decision is None else None
             await publish_deterministic_record(
                 pull_number=int(pull_number),
                 packet=prepared,
@@ -454,6 +456,28 @@ async def _publish(
                 ctx=tool_context,
                 run_outcome=outcome,
             )
+        if prepared is not None:
+            from mergecraft.utils.status_checks import _run_url
+            from mergecraft.utils.step_summary import append_step_summary, render_step_summary
+
+            submission = tool_context.tool_state.terminal_submission
+            analyzer_run = tool_context.tool_state.analyzer_run
+            outcome_label = (
+                "no_verdict" if prepared.decision is None else ("success" if run_ok else "failure")
+            )
+            summary_body = render_step_summary(
+                packet=prepared,
+                outcome_label=outcome_label,
+                rejection_reason=rejection_reason,
+                run_url=_run_url(tool_context),
+                run_outcome=outcome,
+                analyzer_summary=analyzer_run.pre_merge_summary
+                if analyzer_run is not None
+                else None,
+                agent_summary=submission.summary if submission is not None else None,
+                trust_tier=tool_context.trust_tier,
+            )
+            append_step_summary(summary_body)
 
     if not emit:
         await _learnings_and_status()

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -417,6 +417,7 @@ async def _publish(
     attrs_source: Callable[[], dict[str, Any]] | None = None,
     verdict_prediction: VerdictProtocolPrediction | None = None,
     actual_outcome: str | None = None,
+    verdict_diagnostic: Any | None = None,
     emit: bool = True,
 ) -> str | None:
     """Prepare packet + persist learnings + status checks, then optionally emit.
@@ -455,6 +456,7 @@ async def _publish(
                 tmpdir=tool_context.tmpdir,
                 ctx=tool_context,
                 run_outcome=outcome,
+                verdict_diagnostic=verdict_diagnostic,
             )
         if prepared is not None:
             from mergecraft.utils.status_checks import _run_url
@@ -471,6 +473,7 @@ async def _publish(
                 rejection_reason=rejection_reason,
                 run_url=_run_url(tool_context),
                 run_outcome=outcome,
+                verdict_diagnostic=verdict_diagnostic,
                 analyzer_summary=analyzer_run.pre_merge_summary
                 if analyzer_run is not None
                 else None,
@@ -1501,6 +1504,7 @@ async def _finalize(ctx: RunContext, result: AgentResult | SkipAgentReview) -> M
         attrs_source=lambda: _publish_span_attrs(outcome, selected_mode_obj) | diagnostic_attrs,
         verdict_prediction=verdict_prediction,
         actual_outcome=str(outcome) if verdict_prediction is not None else None,
+        verdict_diagnostic=verdict_diagnostic_code,
     )
 
     # O9 (OB4) — the verdict span at the publish convergence point. Emitted

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -24,7 +24,7 @@ from mergecraft.analyzers.trust import (
     derive_trust_tier,
     resolve_analyzers_mode,
 )
-from mergecraft.evidence.run_packet import emit_run_packet, prepare_run_packet
+from mergecraft.evidence.run_packet import emit_run_packet, resolve_prepared_run_packet
 from mergecraft.main_outcome import (
     _classify_outcome,
     _publish_span_attrs,
@@ -431,7 +431,7 @@ async def _publish(
     if tool_context is None:
         return None
     run_ok = run_succeeded_for_outcome(outcome)
-    prepared = prepare_run_packet(tool_context, run_succeeded=run_ok)
+    prepared = resolve_prepared_run_packet(tool_context, run_succeeded=run_ok)
 
     async def _learnings_and_status() -> None:
         await persist_learnings(tool_context)

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -333,6 +333,82 @@ def _short_circuit_setup_failure(
     return ("continue", None)
 
 
+async def publish_deterministic_record(
+    *,
+    pull_number: int,
+    packet: Any,
+    rejection_reason: str | None = None,
+    tmpdir: str | None = None,
+    ctx: ToolContext | None = None,
+    run_outcome: RunOutcome | None = None,
+    verdict_diagnostic: Any | None = None,
+) -> None:
+    """Publish the deterministic sticky record for a resolved PR (D6, plan 13 A4).
+
+    Plan 13 ``run_post_run_retry_loop`` routes non-retryable rejections here.
+    Stable signature for cross-plan callers::
+
+        publish_deterministic_record(
+            *,
+            pull_number: int,
+            packet: MergeEvidencePacket,
+            rejection_reason: str | None = None,
+            tmpdir: str | None = None,
+            ctx: ToolContext | None = None,
+            run_outcome: RunOutcome | None = None,
+            verdict_diagnostic: VerdictDiagnostic | None = None,
+        ) -> None
+    """
+    from mergecraft.findings.ledger import (
+        render_deterministic_review_block,
+        upsert_sticky_progress_comment,
+    )
+    from mergecraft.scm.github import create_github_scm
+    from mergecraft.utils.status_checks import _run_url
+
+    resolved_ctx = ctx
+    if resolved_ctx is None:
+        tool_state = init_tool_state(owner="local", name="local", dir=tmpdir or ".")
+        tool_state.pr_number = pull_number
+        resolved_ctx = ToolContext(
+            agent_id="claude",
+            repo=RepoIdentity(owner="local", name="local"),
+            payload=ResolvedPayload(
+                event=PayloadEvent(trigger="pull_request", issue_number=pull_number, is_pr=True),
+            ),
+            scm=create_github_scm(""),
+            modes=compute_modes("claude"),
+            tool_state=tool_state,
+            tmpdir=tmpdir or ".",
+        )
+
+    tool_state = resolved_ctx.tool_state
+    submission = tool_state.terminal_submission
+    analyzer_run = tool_state.analyzer_run
+    block = render_deterministic_review_block(
+        packet=packet,
+        rejection_reason=rejection_reason,
+        run_url=_run_url(resolved_ctx),
+        run_outcome=run_outcome,
+        verdict_diagnostic=verdict_diagnostic,
+        analyzer_summary=analyzer_run.pre_merge_summary if analyzer_run is not None else None,
+        agent_summary=submission.summary if submission is not None else None,
+        trust_tier=resolved_ctx.trust_tier,
+        attempt_count=len(tool_state.usage_entries) if tool_state.usage_entries else None,
+        token_summary=_token_summary(tool_state.usage_entries),
+    )
+    await upsert_sticky_progress_comment(resolved_ctx, block)
+
+
+def _token_summary(usage_entries: list[Any]) -> str | None:
+    totals = [
+        str(row.total_tokens)
+        for row in usage_entries
+        if getattr(row, "total_tokens", None) is not None
+    ]
+    return ", ".join(totals) if totals else None
+
+
 async def _publish(
     ctx: RunContext,
     *,
@@ -365,6 +441,19 @@ async def _publish(
             conclusion=RUN_OUTCOME_CONCLUSION[outcome],
             packet=prepared,
         )
+        pull_number = tool_context.tool_state.pr_number
+        if pull_number is None and tool_context.payload.event.issue_number is not None:
+            pull_number = int(tool_context.payload.event.issue_number)
+        if pull_number is not None and prepared is not None:
+            rejection_reason = failure_reason if prepared.decision is None else None
+            await publish_deterministic_record(
+                pull_number=int(pull_number),
+                packet=prepared,
+                rejection_reason=rejection_reason,
+                tmpdir=tool_context.tmpdir,
+                ctx=tool_context,
+                run_outcome=outcome,
+            )
 
     if not emit:
         await _learnings_and_status()
@@ -1568,4 +1657,4 @@ async def main() -> MainResult:
             reset_gateway_settings_cache()
 
 
-__all__ = ["MainResult", "RunOutcome", "main"]
+__all__ = ["MainResult", "RunOutcome", "main", "publish_deterministic_record"]

--- a/src/mergecraft/mcp/inline_anchors.py
+++ b/src/mergecraft/mcp/inline_anchors.py
@@ -218,7 +218,11 @@ def adjust_inline_comment_anchor(
         logger.warning("re-anchoring inline comment on {}:{} → {}:{}", path, line, path, nearest)
         return InlineAnchorAdjustment(comment=adjusted, demoted_body=None, action="reanchored")
 
-    logger.warning("dropping inline comment on {}:{} — path not in diff", path, line)
+    logger.warning(
+        "demoting inline comment on {}:{} — no valid anchor in diff hunk",
+        path,
+        line,
+    )
     return InlineAnchorAdjustment(
         comment=None,
         demoted_body=format_demoted_inline_comment(comment),

--- a/src/mergecraft/mcp/inline_anchors.py
+++ b/src/mergecraft/mcp/inline_anchors.py
@@ -105,8 +105,8 @@ def _nearest_line_in_hunks(
         return None
     ranges = index.hunk_ranges.get(path, {}).get(side) or []
     in_range = any(start <= requested_line <= end for start, end in ranges)
-    if in_range:
-        return min(valid, key=lambda line: (abs(line - requested_line), line))
+    if not in_range:
+        return None
     return min(valid, key=lambda line: (abs(line - requested_line), line))
 
 

--- a/src/mergecraft/mcp/inline_anchors.py
+++ b/src/mergecraft/mcp/inline_anchors.py
@@ -1,0 +1,293 @@
+"""Inline review-comment anchor validation against the checked-out diff (#530, D8)."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_DIFF_FILE_RE = re.compile(r"^diff --git a/(.+?) b/(.+?)$")
+
+
+@dataclass(frozen=True, slots=True)
+class InlineAnchorIndex:
+    """Valid single-line anchors and per-side hunk ranges from a unified diff."""
+
+    anchors: frozenset[tuple[str, int, str]]
+    hunk_ranges: dict[str, dict[str, list[tuple[int, int]]]]
+
+
+@dataclass(frozen=True, slots=True)
+class InlineAnchorAdjustment:
+    """Outcome of validating one inline comment against the diff."""
+
+    comment: dict[str, Any] | None
+    demoted_body: str | None
+    action: Literal["kept", "reanchored", "demoted"]
+
+
+def build_inline_anchor_index(diff_text: str) -> InlineAnchorIndex:
+    """Build the valid ``(path, line, side)`` anchor set from a unified diff."""
+    anchors: set[tuple[str, int, str]] = set()
+    hunk_ranges: dict[str, dict[str, list[tuple[int, int]]]] = defaultdict(
+        lambda: {"LEFT": [], "RIGHT": []}
+    )
+
+    current_path: str | None = None
+    old_line = 0
+    new_line = 0
+
+    for raw_line in diff_text.splitlines():
+        file_match = _DIFF_FILE_RE.match(raw_line)
+        if file_match:
+            current_path = file_match.group(2)
+            continue
+
+        if current_path is None:
+            continue
+
+        hunk_match = _HUNK_RE.match(raw_line)
+        if hunk_match:
+            old_start = int(hunk_match.group(1))
+            old_count = int(hunk_match.group(2) or "1")
+            new_start = int(hunk_match.group(3))
+            new_count = int(hunk_match.group(4) or "1")
+            old_line = old_start
+            new_line = new_start
+            hunk_ranges[current_path]["LEFT"].append((old_start, old_start + max(old_count, 1) - 1))
+            hunk_ranges[current_path]["RIGHT"].append(
+                (new_start, new_start + max(new_count, 1) - 1)
+            )
+            continue
+
+        if raw_line.startswith(("--- ", "+++ ")):
+            continue
+
+        prefix = raw_line[:1]
+        if prefix == " ":
+            anchors.add((current_path, old_line, "LEFT"))
+            anchors.add((current_path, new_line, "RIGHT"))
+            old_line += 1
+            new_line += 1
+        elif prefix == "+":
+            anchors.add((current_path, new_line, "RIGHT"))
+            new_line += 1
+        elif prefix == "-":
+            anchors.add((current_path, old_line, "LEFT"))
+            old_line += 1
+
+    return InlineAnchorIndex(
+        anchors=frozenset(anchors),
+        hunk_ranges={path: dict(sides) for path, sides in hunk_ranges.items()},
+    )
+
+
+def _nearest_line_in_hunks(
+    path: str,
+    *,
+    side: str,
+    requested_line: int,
+    index: InlineAnchorIndex,
+) -> int | None:
+    valid = sorted(
+        line
+        for file_path, line, anchor_side in index.anchors
+        if file_path == path and anchor_side == side
+    )
+    if not valid:
+        return None
+    ranges = index.hunk_ranges.get(path, {}).get(side) or []
+    in_range = any(start <= requested_line <= end for start, end in ranges)
+    if in_range:
+        return min(valid, key=lambda line: (abs(line - requested_line), line))
+    return min(valid, key=lambda line: (abs(line - requested_line), line))
+
+
+def _anchor_points(
+    path: str,
+    line: int | None,
+    side: str,
+    *,
+    start_line: int | None = None,
+    start_side: str | None = None,
+) -> tuple[tuple[str, int, str], ...]:
+    resolved_side = side or "RIGHT"
+    if line is None:
+        return ()
+    if start_line is not None:
+        resolved_start_side = start_side or resolved_side
+        return (
+            (path, int(start_line), resolved_start_side),
+            (path, int(line), resolved_side),
+        )
+    return ((path, int(line), resolved_side),)
+
+
+def format_demoted_inline_comment(comment: Mapping[str, Any]) -> str:
+    path = str(comment.get("path") or "")
+    line = comment.get("line")
+    body = str(comment.get("body") or "").strip()
+    anchor = f"{path}:{line}" if line is not None else path
+    if body:
+        return f"**`{anchor}`** (inline anchor unavailable)\n\n{body}"
+    return f"**`{anchor}`** (inline anchor unavailable)"
+
+
+def adjust_inline_comment_anchor(
+    comment: Mapping[str, Any],
+    *,
+    index: InlineAnchorIndex,
+) -> InlineAnchorAdjustment:
+    """Keep, re-anchor, or demote one inline comment against ``index``."""
+    path = str(comment.get("path") or "").strip()
+    if not path:
+        logger.warning("dropping inline comment — missing path")
+        return InlineAnchorAdjustment(
+            comment=None,
+            demoted_body=format_demoted_inline_comment(comment),
+            action="demoted",
+        )
+
+    line_raw = comment.get("line")
+    line = int(line_raw) if line_raw is not None else None
+    side = str(comment.get("side") or "RIGHT").upper()
+    start_line_raw = comment.get("start_line")
+    start_line = int(start_line_raw) if start_line_raw is not None else None
+    start_side = str(comment.get("start_side")).upper() if comment.get("start_side") else None
+
+    if path not in index.hunk_ranges:
+        logger.warning("dropping inline comment on {}:{} — path not in diff", path, line)
+        return InlineAnchorAdjustment(
+            comment=None,
+            demoted_body=format_demoted_inline_comment(comment),
+            action="demoted",
+        )
+
+    if line is None:
+        nearest = _nearest_line_in_hunks(path, side=side, requested_line=1, index=index)
+        if nearest is None:
+            logger.warning(
+                "dropping inline comment on {} — no valid {} anchors in diff", path, side
+            )
+            return InlineAnchorAdjustment(
+                comment=None,
+                demoted_body=format_demoted_inline_comment(comment),
+                action="demoted",
+            )
+        adjusted = dict(comment)
+        adjusted["line"] = nearest
+        adjusted.setdefault("side", side)
+        logger.warning("re-anchoring inline comment on {}:None → {}:{}", path, path, nearest)
+        return InlineAnchorAdjustment(comment=adjusted, demoted_body=None, action="reanchored")
+
+    anchor_points = _anchor_points(
+        path,
+        line,
+        side,
+        start_line=start_line,
+        start_side=start_side,
+    )
+    if anchor_points and all(point in index.anchors for point in anchor_points):
+        return InlineAnchorAdjustment(comment=dict(comment), demoted_body=None, action="kept")
+
+    nearest = _nearest_line_in_hunks(path, side=side, requested_line=line, index=index)
+    if nearest is not None and (path, nearest, side) in index.anchors:
+        adjusted = dict(comment)
+        adjusted["line"] = nearest
+        adjusted.setdefault("side", side)
+        if start_line is not None:
+            nearest_start = _nearest_line_in_hunks(
+                path,
+                side=start_side or side,
+                requested_line=start_line,
+                index=index,
+            )
+            if nearest_start is not None:
+                adjusted["start_line"] = nearest_start
+                adjusted["start_side"] = start_side or side
+            else:
+                adjusted.pop("start_line", None)
+                adjusted.pop("start_side", None)
+        logger.warning("re-anchoring inline comment on {}:{} → {}:{}", path, line, path, nearest)
+        return InlineAnchorAdjustment(comment=adjusted, demoted_body=None, action="reanchored")
+
+    logger.warning("dropping inline comment on {}:{} — path not in diff", path, line)
+    return InlineAnchorAdjustment(
+        comment=None,
+        demoted_body=format_demoted_inline_comment(comment),
+        action="demoted",
+    )
+
+
+def append_demoted_inline_comments(body: str, demoted_fragments: list[str]) -> str:
+    """Append demoted inline comments into the review body."""
+    if not demoted_fragments:
+        return body
+    snippets = "\n\n".join(fragment.strip() for fragment in demoted_fragments if fragment.strip())
+    if not snippets:
+        return body
+    if body.rstrip():
+        return f"{body.rstrip()}\n\n{snippets}\n"
+    return f"{snippets}\n"
+
+
+def _response_json(response: object) -> dict[str, Any] | None:
+    json_method = getattr(response, "json", None)
+    if not callable(json_method):
+        return None
+    try:
+        payload = json_method()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def parse_comment_422_index(response: object) -> int | None:
+    """Return the failing inline-comment index from a GitHub 422 response, if present."""
+    payload = _response_json(response)
+    if payload is None:
+        return None
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return None
+    for error in errors:
+        if not isinstance(error, dict):
+            continue
+        if error.get("field") != "comments":
+            continue
+        index = error.get("index")
+        if isinstance(index, int):
+            return index
+    return None
+
+
+def is_comments_anchor_422_response(response: object) -> bool:
+    """Return whether a 422 response is about inline comment anchors."""
+    if parse_comment_422_index(response) is not None:
+        return True
+    payload = _response_json(response)
+    if payload is None:
+        return False
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return False
+    return any(isinstance(error, dict) and error.get("field") == "comments" for error in errors)
+
+
+__all__ = [
+    "InlineAnchorAdjustment",
+    "InlineAnchorIndex",
+    "adjust_inline_comment_anchor",
+    "append_demoted_inline_comments",
+    "build_inline_anchor_index",
+    "format_demoted_inline_comment",
+    "is_comments_anchor_422_response",
+    "parse_comment_422_index",
+]

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -85,17 +85,15 @@ def merge_deterministic_preamble_into_review_body(
 def _deterministic_review_block(
     ctx: ToolContext,
     *,
+    packet: Any,
     rejection_reason: str | None = None,
     run_outcome: RunOutcome | None = None,
     verdict_diagnostic: VerdictDiagnostic | str | None = None,
 ) -> str:
-    from mergecraft.evidence.run_packet import prepare_run_packet
     from mergecraft.findings.ledger import render_deterministic_review_block
     from mergecraft.utils.status_checks import _run_url
 
     tool_state = ctx.tool_state
-    run_succeeded = run_outcome is None or str(run_outcome) == "passed"
-    packet = prepare_run_packet(ctx, run_succeeded=run_succeeded)
     analyzer_run = tool_state.analyzer_run
     analyzer_summary = analyzer_run.pre_merge_summary if analyzer_run is not None else None
     submission = tool_state.terminal_submission
@@ -654,7 +652,14 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
         )
 
     payload: dict[str, Any] = {"event": event}
-    deterministic_block = _deterministic_review_block(ctx)
+    from mergecraft.evidence.run_packet import resolve_prepared_run_packet
+
+    run_succeeded = True
+    packet = resolve_prepared_run_packet(ctx, run_succeeded=run_succeeded)
+    deterministic_block = _deterministic_review_block(
+        ctx,
+        packet=packet,
+    )
     await ensure_learnings_review_delta(ctx.tool_state)
     body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, str(body or ""))
     body_with_sections = merge_analyzer_sections_into_review_body(ctx, body_with_delta)

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -49,6 +49,67 @@ from mergecraft.utils.learnings import (
 if TYPE_CHECKING:
     from mergecraft.analyzers.finding import Finding
     from mergecraft.mcp.context import ToolContext
+    from mergecraft.mcp.verdict import VerdictDiagnostic
+    from mergecraft.run_outcome import RunOutcome
+
+
+def merge_deterministic_preamble_into_review_body(
+    *,
+    agent_body: str,
+    deterministic_block: str,
+) -> str:
+    """Prepend the server-owned deterministic record; agent copies cannot win (D7)."""
+    from mergecraft.findings.ledger import (
+        DETERMINISTIC_RECORD_MARKER,
+        _strip_deterministic_record_markers,
+    )
+
+    cleaned_agent = _strip_deterministic_record_markers(agent_body)
+    block = deterministic_block.strip()
+    if not block.startswith(DETERMINISTIC_RECORD_MARKER):
+        block = f"{DETERMINISTIC_RECORD_MARKER}\n{block}"
+    if cleaned_agent:
+        return f"{block.rstrip()}\n\n{cleaned_agent.strip()}\n"
+    return f"{block.rstrip()}\n"
+
+
+def _deterministic_review_block(
+    ctx: ToolContext,
+    *,
+    rejection_reason: str | None = None,
+    run_outcome: RunOutcome | None = None,
+    verdict_diagnostic: VerdictDiagnostic | str | None = None,
+) -> str:
+    from mergecraft.evidence.run_packet import prepare_run_packet
+    from mergecraft.findings.ledger import render_deterministic_review_block
+    from mergecraft.utils.status_checks import _run_url
+
+    tool_state = ctx.tool_state
+    run_succeeded = run_outcome is None or str(run_outcome) == "passed"
+    packet = prepare_run_packet(ctx, run_succeeded=run_succeeded)
+    analyzer_run = tool_state.analyzer_run
+    analyzer_summary = analyzer_run.pre_merge_summary if analyzer_run is not None else None
+    submission = tool_state.terminal_submission
+    agent_summary = submission.summary if submission is not None else None
+    attempt_count = len(tool_state.usage_entries) if tool_state.usage_entries else None
+    token_bits: list[str] = []
+    for usage in tool_state.usage_entries or []:
+        total = getattr(usage, "total_tokens", None)
+        if total:
+            token_bits.append(str(total))
+    token_summary = ", ".join(token_bits) if token_bits else None
+    return render_deterministic_review_block(
+        packet=packet,
+        rejection_reason=rejection_reason,
+        run_url=_run_url(ctx),
+        run_outcome=run_outcome,
+        verdict_diagnostic=verdict_diagnostic,
+        analyzer_summary=analyzer_summary,
+        agent_summary=agent_summary,
+        trust_tier=ctx.trust_tier,
+        attempt_count=attempt_count,
+        token_summary=token_summary,
+    )
 
 
 class PublicationScopeError(ValueError):
@@ -490,20 +551,24 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
         )
 
     payload: dict[str, Any] = {"event": event}
-    if body:
-        await ensure_learnings_review_delta(ctx.tool_state)
-        body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, str(body))
-        body_with_sections = merge_analyzer_sections_into_review_body(ctx, body_with_delta)
-        if ctx.tool_state.dispatched_lens_ids:
-            from mergecraft.modes._pr_summary_format import (
-                merge_dispatched_lenses_into_review_metadata,
-            )
+    deterministic_block = _deterministic_review_block(ctx)
+    await ensure_learnings_review_delta(ctx.tool_state)
+    body_with_delta = merge_learnings_delta_into_review_body(ctx.tool_state, str(body or ""))
+    body_with_sections = merge_analyzer_sections_into_review_body(ctx, body_with_delta)
+    if ctx.tool_state.dispatched_lens_ids:
+        from mergecraft.modes._pr_summary_format import (
+            merge_dispatched_lenses_into_review_metadata,
+        )
 
-            body_with_sections = merge_dispatched_lenses_into_review_metadata(
-                body_with_sections,
-                dispatched_lens_ids=ctx.tool_state.dispatched_lens_ids,
-            )
-        payload["body"] = add_footer(ctx, body_with_sections)
+        body_with_sections = merge_dispatched_lenses_into_review_metadata(
+            body_with_sections,
+            dispatched_lens_ids=ctx.tool_state.dispatched_lens_ids,
+        )
+    body_with_preamble = merge_deterministic_preamble_into_review_body(
+        agent_body=body_with_sections,
+        deterministic_block=deterministic_block,
+    )
+    payload["body"] = add_footer(ctx, body_with_preamble)
     if commit_id:
         payload["commit_id"] = commit_id
 

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -24,6 +24,15 @@ from mergecraft.mcp.deferred_publish import (
     merge_analyzer_sections_into_review_body,
     refresh_analyzer_sections_for_publish,
 )
+from mergecraft.mcp.inline_anchors import (
+    InlineAnchorIndex,
+    adjust_inline_comment_anchor,
+    append_demoted_inline_comments,
+    build_inline_anchor_index,
+    format_demoted_inline_comment,
+    is_comments_anchor_422_response,
+    parse_comment_422_index,
+)
 from mergecraft.mcp.review_comments import fetch_review_threads, resolve_review_thread
 from mergecraft.mcp.shared import ToolClass, execute, tool
 from mergecraft.mcp.tool_state import ApprovalRecord, ReviewRecord, primary_repo_state
@@ -506,6 +515,92 @@ def _assert_publication_scope(
         raise PublicationScopeError(msg)
 
 
+def _load_inline_anchor_index(primary: Any) -> InlineAnchorIndex | None:
+    """Return anchor index from the checkout diff when ``diffPath`` is available."""
+    diff_path = getattr(primary, "diff_path", None)
+    if not diff_path:
+        return None
+    from pathlib import Path
+
+    path = Path(str(diff_path))
+    if not path.is_file():
+        return None
+    return build_inline_anchor_index(path.read_text(encoding="utf-8"))
+
+
+def _demote_inline_comment_from_payload(payload: dict[str, Any], index: int) -> dict[str, Any]:
+    """Move one inline comment into the review body and remove it from the payload."""
+    comments = list(payload.get("comments") or [])
+    if index < 0 or index >= len(comments):
+        return payload
+    comment = comments.pop(index)
+    demoted = format_demoted_inline_comment(comment)
+    updated = dict(payload)
+    updated["body"] = append_demoted_inline_comments(str(payload.get("body") or ""), [demoted])
+    if comments:
+        updated["comments"] = comments
+    else:
+        updated.pop("comments", None)
+    return updated
+
+
+async def _create_github_review_with_anchor_recovery(
+    ctx: ToolContext,
+    *,
+    pull_number: int,
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    """Post a review, recovering APPROVE and inline-anchor 422 rejections (D8, #530)."""
+    scm = ctx.scm
+    current = dict(payload)
+    approve_fallback = False
+
+    while True:
+        try:
+            result = await scm.create_review(
+                ctx.repo.owner,
+                ctx.repo.name,
+                pull_number,
+                **current,
+            )
+            return result, approve_fallback
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 422:
+                raise
+
+            if current.get("comments") and is_comments_anchor_422_response(exc.response):
+                index = parse_comment_422_index(exc.response)
+                if index is None:
+                    logger.warning(
+                        "review comment 422 on PR #{} without index; demoting all inline comments",
+                        pull_number,
+                    )
+                    while current.get("comments"):
+                        current = _demote_inline_comment_from_payload(current, 0)
+                    continue
+
+                logger.warning(
+                    "review comment 422 on PR #{} at index {}; demoting inline comment to body",
+                    pull_number,
+                    index,
+                )
+                current = _demote_inline_comment_from_payload(current, index)
+                continue
+
+            event = str(current.get("event") or "COMMENT")
+            if event == "APPROVE":
+                logger.info(
+                    "APPROVE review rejected with 422 on PR #{}; falling back to COMMENT",
+                    pull_number,
+                )
+                current = dict(current)
+                current["event"] = "COMMENT"
+                approve_fallback = True
+                continue
+
+            raise
+
+
 async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> dict[str, Any]:
     """Post a GitHub review after a validated terminal submission exists (V6)."""
     primary = primary_repo_state(ctx.tool_state)
@@ -581,6 +676,8 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
             incremental_diff_text = Path(incremental_path).read_text(encoding="utf-8")
 
     collateral_map = collateral_by_fingerprint(ctx)
+    anchor_index = _load_inline_anchor_index(primary)
+    demoted_bodies: list[str] = []
 
     inline: list[dict[str, Any]] = []
     for c in comments:
@@ -631,11 +728,26 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
         if "start_line" in c:
             item["start_line"] = int(c["start_line"])
             item["start_side"] = c.get("start_side") or c.get("side") or "RIGHT"
-        inline.append(item)
+        if anchor_index is not None:
+            adjustment = adjust_inline_comment_anchor(item, index=anchor_index)
+            if adjustment.comment is None:
+                if adjustment.demoted_body:
+                    demoted_bodies.append(adjustment.demoted_body)
+                continue
+            inline.append(adjustment.comment)
+        else:
+            inline.append(item)
     if review_settings.recall_pass:
         inline = strip_recall_inline_comments(ctx, inline, publish_sets=publish_sets)
+    if demoted_bodies:
+        payload["body"] = add_footer(
+            ctx,
+            append_demoted_inline_comments(str(payload.get("body") or ""), demoted_bodies),
+        )
     if inline:
         payload["comments"] = inline
+    else:
+        payload.pop("comments", None)
 
     from mergecraft.findings.ledger import (
         persist_finding_ledger_to_progress_comment,
@@ -644,21 +756,11 @@ async def _publish_github_review(ctx: ToolContext, params: dict[str, Any]) -> di
 
     record_published_findings_in_ledger(ctx.tool_state, inline)
 
-    scm = ctx.scm
-    approve_fallback = False
-    try:
-        result = await scm.create_review(ctx.repo.owner, ctx.repo.name, pull_number, **payload)
-    except httpx.HTTPStatusError as exc:
-        if event != "APPROVE" or exc.response.status_code != 422:
-            raise
-        logger.info(
-            "APPROVE review rejected with 422 on PR #{}; falling back to COMMENT",
-            pull_number,
-        )
-        fallback = dict(payload)
-        fallback["event"] = "COMMENT"
-        result = await scm.create_review(ctx.repo.owner, ctx.repo.name, pull_number, **fallback)
-        approve_fallback = True
+    result, approve_fallback = await _create_github_review_with_anchor_recovery(
+        ctx,
+        pull_number=pull_number,
+        payload=payload,
+    )
     review_id = int(result["id"])
     ctx.tool_state.review = ReviewRecord(
         id=review_id,

--- a/src/mergecraft/mcp/review.py
+++ b/src/mergecraft/mcp/review.py
@@ -525,7 +525,15 @@ def _load_inline_anchor_index(primary: Any) -> InlineAnchorIndex | None:
     path = Path(str(diff_path))
     if not path.is_file():
         return None
-    return build_inline_anchor_index(path.read_text(encoding="utf-8"))
+    return _inline_anchor_index_for_diff(path.read_text(encoding="utf-8"))
+
+
+def _inline_anchor_index_for_diff(diff_text: str) -> InlineAnchorIndex | None:
+    """Build an anchor index when the diff carries at least one hunk."""
+    index = build_inline_anchor_index(diff_text)
+    if not index.hunk_ranges:
+        return None
+    return index
 
 
 def _demote_inline_comment_from_payload(payload: dict[str, Any], index: int) -> dict[str, Any]:

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -424,6 +424,9 @@ class ToolState:
     # a CI source is actually read, so a run that consulted no CI records
     # nothing rather than an empty section.
     ci_evidence: CiEvidenceState | None = None
+    # D7 — single evidence-packet snapshot for the review preamble and sticky
+    # record; assembled once via ``resolve_prepared_run_packet`` and reused.
+    prepared_run_packet: Any | None = None
     # True once ``run_static_checks`` has been called this session. Read by the
     # verification tools (D14): an LLM judge may not evaluate a finding before
     # the deterministic checks it is meant to supplement have had their turn.

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -439,8 +439,7 @@ def _blocks_approve(state: ValidationState) -> bool:
         >>> _blocks_approve(build_validation_state())
         False
     """
-    from mergecraft.agents.gates import BLOCKING_SEVERITIES
-    from mergecraft.findings.causality import apply_causality_policy
+    from mergecraft.agents.gates import blocking_findings
 
     if state.ungradable_fingerprints:
         logger.warning(
@@ -449,10 +448,7 @@ def _blocks_approve(state: ValidationState) -> bool:
             ", ".join(state.ungradable_fingerprints),
         )
         return True
-    for finding in (*state.confirmed_findings, *state.unverified_findings):
-        if apply_causality_policy(finding).severity in BLOCKING_SEVERITIES:
-            return True
-    return False
+    return bool(blocking_findings([*state.confirmed_findings, *state.unverified_findings]))
 
 
 def withdrawn_fingerprints_for_state(tool_state: ToolState, *, tmpdir: str | None) -> set[str]:

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -95,7 +95,18 @@ def merge_analyzer_findings_into_result(
     """Fold analyzer findings into structured output used for CLI exit codes."""
     if not extra:
         return result
-    existing = parse_offline_review_findings(result)
+    if result.structured_output:
+        try:
+            existing = [
+                Finding.model_validate(row)
+                for row in parse_findings_payload(result.structured_output)
+            ]
+        except ValueError:
+            # Invalid agent output must fail in finalize — do not mask it with
+            # analyzer rows (tests/cli/test_diff_review_json.py invalid_finding).
+            return result
+    else:
+        existing = []
     seen = {row.fingerprint for row in existing}
     merged = list(existing)
     for finding in extra:

--- a/src/mergecraft/review_taxonomy.py
+++ b/src/mergecraft/review_taxonomy.py
@@ -29,7 +29,9 @@ FINDING_EFFORTS: Final[tuple[str, ...]] = ("Quick win", "Heavy lift", "Low value
 
 FINDING_CONFIDENCES: Final[tuple[str, ...]] = ("certain", "likely", "possible")
 
-FindingSource = Literal["analyzer", "agent", "ci"]
+FindingSource = Literal["analyzer", "agent", "ci", "trajectory"]
+
+FindingScope = Literal["change", "run"]
 
 # A finding at one of these grades never occupies an inline anchor — it belongs
 # in the body's Nitpicks section instead.
@@ -88,6 +90,7 @@ __all__ = [
     "FINDING_SEVERITIES",
     "VERIFY_FIRST_PREAMBLE",
     "WITHDRAWN_FINDINGS_HEADING",
+    "FindingScope",
     "FindingSource",
     "finding_fingerprint",
     "stamp_finding_fingerprint",

--- a/src/mergecraft/utils/gha_log.py
+++ b/src/mergecraft/utils/gha_log.py
@@ -1,0 +1,55 @@
+"""GitHub Actions workflow-command helpers for log groups and annotations."""
+
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _in_github_actions() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _escape_workflow_command(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _write_workflow_command(command: str, message: str) -> None:
+    if not _in_github_actions():
+        return
+    sys.stdout.write(f"::{command}::{_escape_workflow_command(message)}\n")
+    sys.stdout.flush()
+
+
+@contextmanager
+def group(title: str) -> Iterator[None]:
+    """Collapse nested log output under a GitHub Actions log group."""
+    if _in_github_actions():
+        sys.stdout.write(f"::group::{_escape_workflow_command(title)}\n")
+        sys.stdout.flush()
+    try:
+        yield
+    finally:
+        if _in_github_actions():
+            sys.stdout.write("::endgroup::\n")
+            sys.stdout.flush()
+
+
+def notice(message: str) -> None:
+    """Emit a ``::notice::`` workflow annotation."""
+    _write_workflow_command("notice", message)
+
+
+def warning(message: str) -> None:
+    """Emit a ``::warning::`` workflow annotation."""
+    _write_workflow_command("warning", message)
+
+
+def error(message: str) -> None:
+    """Emit a ``::error::`` workflow annotation."""
+    _write_workflow_command("error", message)

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -358,6 +358,8 @@ async def report_status_checks(
             approval_conclusion = packet.decision.verdict
             decision_reason = packet.decision.reason
         findings = list(packet.findings)
+        if packet.run_health is not None:
+            findings.extend(packet.run_health.findings)
         decision_inputs = approval_decision_inputs(
             findings,
             run_succeeded=run_succeeded,

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -282,6 +282,8 @@ async def report_status_checks(
     )
     catalog_banner = _catalog_unavailable_banner(ctx)
     packet_findings = list(packet.findings) if packet is not None else []
+    if packet is not None and packet.run_health is not None:
+        packet_findings.extend(packet.run_health.findings)
     approval = ctx.tool_state.approval
     run_url = _run_url(ctx)
     reviewed_sha = _reviewed_sha(approval, packet)

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -178,6 +178,8 @@ def _build_approval_summary(
     from mergecraft.agents.gates import decision_summary_lines
 
     lines = [_build_approval_lead(approval_conclusion, findings, decision_reason=decision_reason)]
+    if _change_findings(findings) and _run_health_lines(findings):
+        lines.extend(_run_health_lines(findings))
     _append_run_metadata(lines, run_url=run_url, reviewed_sha=reviewed_sha)
     lines.append("Decision inputs:")
     lines.extend(decision_summary_lines(decision_inputs))

--- a/src/mergecraft/utils/status_checks.py
+++ b/src/mergecraft/utils/status_checks.py
@@ -33,15 +33,157 @@ from typing import TYPE_CHECKING, Any, Literal
 from loguru import logger
 
 from mergecraft.run_outcome import CompletionConclusion
+from mergecraft.utils import gha_log
 
 if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding
     from mergecraft.analyzers.manifest import TrustTier
     from mergecraft.evidence.packet import MergeEvidencePacket
     from mergecraft.mcp.context import ToolContext
+    from mergecraft.mcp.tool_state import ApprovalRecord
 
 COMPLETION_CHECK = "mergecraft"
 APPROVAL_CHECK = "mergecraft-approval"
 Conclusion = Literal["success", "failure", "neutral"]
+
+
+def _run_url(ctx: ToolContext) -> str | None:
+    if not ctx.run_id:
+        return None
+    return f"https://github.com/{ctx.repo.owner}/{ctx.repo.name}/actions/runs/{ctx.run_id}"
+
+
+def _reviewed_sha(
+    approval: ApprovalRecord | None,
+    packet: MergeEvidencePacket | None,
+) -> str | None:
+    if approval and approval.sha:
+        return approval.sha
+    if packet is not None and packet.self_assessment is not None and packet.self_assessment.sha:
+        return packet.self_assessment.sha
+    return None
+
+
+def _http_status_from_error(err: BaseException) -> int | None:
+    response = getattr(err, "response", None)
+    status = getattr(response, "status_code", None)
+    return int(status) if isinstance(status, int) else None
+
+
+def _log_check_post_failure(
+    *,
+    check_name: str,
+    head_sha: str,
+    err: BaseException,
+) -> None:
+    status = _http_status_from_error(err)
+    status_text = f" HTTP {status}" if status is not None else ""
+    message = f"status checks: {check_name} post failed on {head_sha[:7]}{status_text}: {err}"
+    logger.warning(message)
+    gha_log.warning(message)
+
+
+def _change_findings(findings: list[Finding]) -> list[Finding]:
+    return [finding for finding in findings if finding.scope != "run"]
+
+
+def _run_health_findings(findings: list[Finding]) -> list[Finding]:
+    return [finding for finding in findings if finding.scope == "run"]
+
+
+def _finding_label(finding: Finding) -> str:
+    return f"{finding.severity} · {finding.tool}/{finding.rule_id}"
+
+
+def _append_run_metadata(
+    lines: list[str],
+    *,
+    run_url: str | None,
+    reviewed_sha: str | None,
+) -> None:
+    if run_url:
+        lines.append(f"Run: {run_url}")
+    if reviewed_sha:
+        lines.append(f"Reviewed commit: {reviewed_sha}")
+
+
+def _run_health_lines(findings: list[Finding]) -> list[str]:
+    run_health = _run_health_findings(findings)
+    if not run_health:
+        return []
+    lines = ["Run-health findings:"]
+    lines.extend(f"- {_finding_label(finding)}: {finding.message}" for finding in run_health)
+    return lines
+
+
+def _build_completion_summary(
+    *,
+    run_succeeded: bool,
+    failure_reason: str | None,
+    findings: list[Finding],
+    catalog_banner: str | None,
+    run_url: str | None,
+    reviewed_sha: str | None,
+) -> str:
+    if run_succeeded:
+        lead = "The mergeCraft run finished successfully."
+    else:
+        lead = (
+            failure_reason
+            or "The mergeCraft run failed or timed out. See the run logs for details."
+        )
+    lines = [lead, *_run_health_lines(findings)]
+    if catalog_banner:
+        lines.append(catalog_banner)
+    _append_run_metadata(lines, run_url=run_url, reviewed_sha=reviewed_sha)
+    return "\n".join(lines)
+
+
+def _build_approval_lead(
+    approval_conclusion: Conclusion,
+    findings: list[Finding],
+    *,
+    decision_reason: str | None,
+) -> str:
+    from mergecraft.agents.gates import blocking_findings
+
+    if approval_conclusion == "success":
+        return "mergeCraft approved this PR."
+    if approval_conclusion == "failure":
+        blockers = blocking_findings(findings)
+        if blockers:
+            names = ", ".join(_finding_label(finding) for finding in blockers)
+            count = len(blockers)
+            noun = "finding" if count == 1 else "findings"
+            return f"mergeCraft found {count} blocking change {noun}: {names}."
+        return "mergeCraft would not approve this PR."
+    reason = decision_reason or "review did not complete"
+    lead = f"The mergeCraft review did not complete: {reason}."
+    run_health = _run_health_lines(findings)
+    if run_health and not _change_findings(findings):
+        return "\n".join([lead, *run_health])
+    return lead
+
+
+def _build_approval_summary(
+    *,
+    approval_conclusion: Conclusion,
+    findings: list[Finding],
+    decision_reason: str | None,
+    decision_inputs: dict[str, object],
+    catalog_banner: str | None,
+    run_url: str | None,
+    reviewed_sha: str | None,
+) -> str:
+    from mergecraft.agents.gates import decision_summary_lines
+
+    lines = [_build_approval_lead(approval_conclusion, findings, decision_reason=decision_reason)]
+    _append_run_metadata(lines, run_url=run_url, reviewed_sha=reviewed_sha)
+    lines.append("Decision inputs:")
+    lines.extend(decision_summary_lines(decision_inputs))
+    if catalog_banner:
+        lines.append(catalog_banner)
+    return "\n".join(lines)
 
 
 async def _create_check_run(
@@ -124,7 +266,12 @@ async def report_status_checks(
         if not head_sha:
             return
     except Exception as err:
-        logger.debug("status checks: failed to resolve PR #{} head sha: {}", pull_number, err)
+        logger.warning(
+            "status checks: failed to resolve PR #{} head sha: {}",
+            pull_number,
+            err,
+        )
+        gha_log.warning(f"status checks: failed to resolve PR #{pull_number} head sha: {err}")
         return
 
     from mergecraft.mcp.tool_state import primary_repo_state
@@ -134,16 +281,18 @@ async def report_status_checks(
         "success" if run_succeeded else "failure"
     )
     catalog_banner = _catalog_unavailable_banner(ctx)
-    completion_summary = (
-        "The mergeCraft run finished successfully."
-        if run_succeeded
-        else (
-            failure_reason
-            or "The mergeCraft run failed or timed out. See the run logs for details."
-        )
+    packet_findings = list(packet.findings) if packet is not None else []
+    approval = ctx.tool_state.approval
+    run_url = _run_url(ctx)
+    reviewed_sha = _reviewed_sha(approval, packet)
+    completion_summary = _build_completion_summary(
+        run_succeeded=run_succeeded,
+        failure_reason=failure_reason,
+        findings=packet_findings,
+        catalog_banner=catalog_banner,
+        run_url=run_url,
+        reviewed_sha=reviewed_sha,
     )
-    if catalog_banner:
-        completion_summary = f"{completion_summary}\n{catalog_banner}"
     try:
         await _create_check_run(
             ctx,
@@ -154,7 +303,11 @@ async def report_status_checks(
             summary=completion_summary,
         )
     except Exception as err:
-        logger.debug("status checks: {} post failed: {}", COMPLETION_CHECK, err)
+        _log_check_post_failure(
+            check_name=COMPLETION_CHECK,
+            head_sha=completion_sha,
+            err=err,
+        )
 
     # --- Approval gate (W8.2): post ``packet.decision.verdict``. -------------
     # The agent's boolean is still in ApprovalRecord.would_approve (W8.3) as an
@@ -162,7 +315,6 @@ async def report_status_checks(
     # ``neutral`` so the check still lands; do not rebuild the packet.
     from mergecraft.agents.gates import (
         approval_decision_inputs,
-        decision_summary_lines,
         log_decision,
     )
 
@@ -171,6 +323,10 @@ async def report_status_checks(
     # Best-effort: never raise after the completion check-run has posted.
     if packet is None:
         logger.debug("status checks: no packet; posting neutral approval")
+        neutral_lines = [
+            "The mergeCraft evidence packet was not assembled, so no approval decision was recorded.",
+        ]
+        _append_run_metadata(neutral_lines, run_url=run_url, reviewed_sha=reviewed_sha)
         try:
             await _create_check_run(
                 ctx,
@@ -178,22 +334,25 @@ async def report_status_checks(
                 head_sha=head_sha,
                 conclusion="neutral",
                 title="mergeCraft review did not complete",
-                summary=(
-                    "The mergeCraft evidence packet was not assembled, so no "
-                    "approval decision was recorded."
-                ),
+                summary="\n".join(neutral_lines),
             )
         except Exception as err:
-            logger.debug("status checks: {} post failed: {}", APPROVAL_CHECK, err)
+            _log_check_post_failure(
+                check_name=APPROVAL_CHECK,
+                head_sha=head_sha,
+                err=err,
+            )
         return
 
     try:
         tier: TrustTier = ctx.trust_tier
+        decision_reason: str | None = None
         if packet.decision is None:
             logger.debug("status checks: packet has no decision; posting neutral approval")
             approval_conclusion: Conclusion = "neutral"
         else:
             approval_conclusion = packet.decision.verdict
+            decision_reason = packet.decision.reason
         findings = list(packet.findings)
         decision_inputs = approval_decision_inputs(
             findings,
@@ -207,28 +366,22 @@ async def report_status_checks(
             conclusion=approval_conclusion,
         )
 
-        approval = ctx.tool_state.approval
         if approval_conclusion == "success":
             approval_title = "mergeCraft would approve"
-            approval_summary = "mergeCraft has no outstanding review feedback on this PR."
         elif approval_conclusion == "failure":
             approval_title = "mergeCraft would not approve"
-            approval_summary = (
-                "mergeCraft has outstanding review feedback or requested changes on this PR."
-            )
         else:
             approval_title = "mergeCraft review did not complete"
-            approval_summary = (
-                "The mergeCraft review did not complete, so no approval decision was recorded."
-            )
 
-        if approval and approval.sha:
-            approval_summary = f"{approval_summary} Reviewed commit: {approval.sha}."
-        approval_summary = f"{approval_summary}\nDecision inputs:\n" + "\n".join(
-            decision_summary_lines(decision_inputs)
+        approval_summary = _build_approval_summary(
+            approval_conclusion=approval_conclusion,
+            findings=findings,
+            decision_reason=decision_reason,
+            decision_inputs=decision_inputs,
+            catalog_banner=catalog_banner,
+            run_url=run_url,
+            reviewed_sha=reviewed_sha,
         )
-        if catalog_banner:
-            approval_summary = f"{approval_summary}\n{catalog_banner}"
 
         await _create_check_run(
             ctx,
@@ -239,7 +392,11 @@ async def report_status_checks(
             summary=approval_summary,
         )
     except Exception as err:
-        logger.debug("status checks: {} post failed: {}", APPROVAL_CHECK, err)
+        _log_check_post_failure(
+            check_name=APPROVAL_CHECK,
+            head_sha=head_sha,
+            err=err,
+        )
 
 
 __all__ = [

--- a/src/mergecraft/utils/step_summary.py
+++ b/src/mergecraft/utils/step_summary.py
@@ -1,0 +1,111 @@
+"""GitHub Actions step summary rendering for mergeCraft runs (plan 12 W7, D11)."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mergecraft.evidence.packet import MergeEvidencePacket
+
+_STEP_SUMMARY_MAX_BYTES = 1_048_576
+
+
+def render_step_summary(
+    *,
+    packet: MergeEvidencePacket,
+    outcome_label: str,
+    rejection_reason: str | None = None,
+    run_url: str | None = None,
+    run_outcome: Any | None = None,
+    verdict_diagnostic: Any | None = None,
+    analyzer_summary: str | None = None,
+    agent_summary: str | None = None,
+    trust_tier: str | None = None,
+) -> str:
+    """Render the step summary body: header table plus the W5 record sections."""
+    from mergecraft.findings.ledger import render_deterministic_review_block
+
+    decision = packet.decision
+    verdict = decision.verdict if decision is not None else "(none)"
+    diagnostic = ""
+    if verdict_diagnostic is not None:
+        diagnostic = (
+            verdict_diagnostic.value
+            if hasattr(verdict_diagnostic, "value")
+            else str(verdict_diagnostic)
+        )
+
+    header_lines = [
+        "# mergeCraft step summary",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Outcome | `{outcome_label}` |",
+    ]
+    if rejection_reason:
+        header_lines.append(f"| Rejection | `{rejection_reason}` |")
+    header_lines.append(f"| Verdict | `{verdict}` |")
+    if diagnostic:
+        header_lines.append(f"| Diagnostic | `{diagnostic}` |")
+    header_lines.append("")
+
+    record = render_deterministic_review_block(
+        packet=packet,
+        rejection_reason=rejection_reason,
+        run_url=run_url,
+        run_outcome=run_outcome,
+        verdict_diagnostic=verdict_diagnostic,
+        analyzer_summary=analyzer_summary,
+        agent_summary=agent_summary,
+        trust_tier=trust_tier,
+    )
+    return _cap_step_summary("\n".join(header_lines) + record)
+
+
+def _cap_step_summary(body: str) -> str:
+    """Enforce GitHub's 1 MiB step-summary limit, truncating findings only."""
+    if len(body.encode("utf-8")) <= _STEP_SUMMARY_MAX_BYTES:
+        return body
+
+    lines = body.splitlines()
+    findings_heading = "### Change-scoped findings"
+    header_end = 0
+    for index, line in enumerate(lines):
+        if line.strip() == findings_heading:
+            header_end = index + 2
+            break
+
+    if header_end == 0:
+        return body.encode("utf-8")[:_STEP_SUMMARY_MAX_BYTES].decode("utf-8", errors="ignore")
+
+    header = "\n".join(lines[:header_end])
+    finding_lines = lines[header_end:]
+    suffix = "\n\n_(Findings truncated to fit the 1 MiB step summary limit.)_\n"
+    budget = _STEP_SUMMARY_MAX_BYTES - len(suffix.encode("utf-8"))
+
+    kept: list[str] = []
+    used = len(header.encode("utf-8"))
+    for line in finding_lines:
+        line_len = len((line + "\n").encode("utf-8"))
+        if used + line_len > budget:
+            break
+        kept.append(line)
+        used += line_len
+
+    return header + "\n" + "\n".join(kept) + suffix
+
+
+def append_step_summary(body: str) -> None:
+    """Append to ``GITHUB_STEP_SUMMARY`` when set; no-op locally."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(body)
+        if not body.endswith("\n"):
+            handle.write("\n")
+        handle.write("\n")
+
+
+__all__ = ["append_step_summary", "render_step_summary"]

--- a/tests/action/test_action_yml_contract.py
+++ b/tests/action/test_action_yml_contract.py
@@ -297,6 +297,13 @@ class TestActionYmlHygiene:
             "delete the value: keys, keep the descriptions"
         )
 
+    def test_docker_action_pulls_digest_pinned_slim_image(self, action_yml: dict[str, Any]) -> None:
+        """#526 — published Action must resolve to a GHCR pull, not a Dockerfile build."""
+        image = action_yml["runs"]["image"]
+        assert image != "Dockerfile"
+        assert image.startswith("docker://ghcr.io/alexhawat/mergecraft@sha256:")
+        assert "analyzers" not in image
+
     def test_every_output_keeps_its_description(self, action_yml: dict[str, Any]) -> None:
         """W8.1 deletes ``value:`` only — the consumer-facing prose must survive."""
         outputs = action_yml.get("outputs") or {}

--- a/tests/ci/test_action_image_digest_check.py
+++ b/tests/ci/test_action_image_digest_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import urllib.error
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -24,24 +25,136 @@ def _load_module() -> Any:
     return module
 
 
-class TestGhcrDigestLookup:
-    def test_published_sha_tag_has_digest(self) -> None:
-        module = _load_module()
-        lookup = module._ghcr_digest_for_tag("b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5")
-        assert lookup.status == module.TagLookupStatus.FOUND
-        assert lookup.digest == (
-            "sha256:3765b55ae73a0974d5fa14842bb73e80a347c2f7d66cb8bbfd5394806b6fae58"
-        )
+def _stub_manifest_head(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    digest: str | None = None,
+    http_error: int | None = None,
+) -> None:
+    """Stub the registry HEAD so status classification is tested, not the network."""
+    monkeypatch.setattr(module, "_ghcr_pull_token", lambda: "stub-token")
 
-    def test_missing_tag_is_not_registry_error(self) -> None:
+    class _Response:
+        def __init__(self) -> None:
+            self.headers = {"docker-content-digest": digest}
+
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+    def _urlopen(request: object, timeout: int = 30) -> _Response:
+        if http_error is not None:
+            raise urllib.error.HTTPError(
+                url="https://ghcr.io", code=http_error, msg="stub", hdrs=None, fp=None
+            )
+        return _Response()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", _urlopen)
+
+
+class TestGhcrDigestLookup:
+    """Status classification, stubbed at the HTTP boundary.
+
+    These once queried GHCR directly and asserted a hardcoded digest. That put
+    an assertion about mutable external state in the unit tier: the jobs running
+    them do not depend on ``action-slim-bootstrap``, so a tag pushed moments
+    earlier read as MISSING and failed the run. What belongs here is the
+    parsing contract; live parity is the checker's own job in CI.
+    """
+
+    def test_a_digest_header_is_reported_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         module = _load_module()
-        lookup = module._ghcr_digest_for_tag("0000000000000000000000000000000000000000")
+        digest = "sha256:" + "a" * 64
+        _stub_manifest_head(module, monkeypatch, digest=digest)
+
+        lookup = module._ghcr_digest_for_tag("b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5")
+
+        assert lookup.status == module.TagLookupStatus.FOUND
+        assert lookup.digest == digest
+
+    def test_404_is_missing_not_a_registry_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MISSING and ERROR drive different outcomes; 404 must not look like a fault."""
+        module = _load_module()
+        _stub_manifest_head(module, monkeypatch, http_error=404)
+        monkeypatch.setattr(module, "_MISSING_RETRIES", 0)
+
+        lookup = module._ghcr_digest_for_tag("0" * 40)
+
         assert lookup.status == module.TagLookupStatus.MISSING
 
-    def test_old_published_digest_lacks_tracing_extra(self) -> None:
+    def test_500_is_a_registry_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         module = _load_module()
-        config = module._fetch_oci_config_for_tag("cfdf38dcd062779aac3e141c51f134213d395b67")
-        assert config is not None
+        _stub_manifest_head(module, monkeypatch, http_error=500)
+
+        lookup = module._ghcr_digest_for_tag("0" * 40)
+
+        assert lookup.status == module.TagLookupStatus.ERROR
+
+    def test_a_missing_tag_is_retried_then_reported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A push GHCR has not surfaced yet must be retried, not failed outright."""
+        module = _load_module()
+        digest = "sha256:" + "b" * 64
+        calls: list[int] = []
+
+        def _flaky(tag: str) -> object:
+            calls.append(1)
+            if len(calls) < 3:
+                return module.TagLookupResult(status=module.TagLookupStatus.MISSING)
+            return module.TagLookupResult(status=module.TagLookupStatus.FOUND, digest=digest)
+
+        monkeypatch.setattr(module, "_ghcr_digest_for_tag_once", _flaky)
+        monkeypatch.setattr(module, "_MISSING_BACKOFF_SECONDS", 0)
+
+        lookup = module._ghcr_digest_for_tag("0" * 40)
+
+        assert lookup.status == module.TagLookupStatus.FOUND
+        assert lookup.digest == digest
+        assert len(calls) == 3
+
+    def test_retries_are_bounded_so_an_unpublished_sha_still_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retry must not turn a genuinely absent image into a stalled job."""
+        module = _load_module()
+        calls: list[int] = []
+
+        def _always_missing(tag: str) -> object:
+            calls.append(1)
+            return module.TagLookupResult(status=module.TagLookupStatus.MISSING)
+
+        monkeypatch.setattr(module, "_ghcr_digest_for_tag_once", _always_missing)
+        monkeypatch.setattr(module, "_MISSING_RETRIES", 2)
+        monkeypatch.setattr(module, "_MISSING_BACKOFF_SECONDS", 0)
+
+        lookup = module._ghcr_digest_for_tag("0" * 40)
+
+        assert lookup.status == module.TagLookupStatus.MISSING
+        assert len(calls) == 3
+
+    def test_a_registry_error_is_not_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ERROR will not resolve itself in seconds; retrying only delays the caller."""
+        module = _load_module()
+        calls: list[int] = []
+
+        def _always_error(tag: str) -> object:
+            calls.append(1)
+            return module.TagLookupResult(status=module.TagLookupStatus.ERROR)
+
+        monkeypatch.setattr(module, "_ghcr_digest_for_tag_once", _always_error)
+        monkeypatch.setattr(module, "_MISSING_BACKOFF_SECONDS", 0)
+
+        lookup = module._ghcr_digest_for_tag("0" * 40)
+
+        assert lookup.status == module.TagLookupStatus.ERROR
+        assert len(calls) == 1
+
+    def test_an_image_without_the_tracing_extra_is_detected(self) -> None:
+        module = _load_module()
+        config = {"config": {"Env": ["PATH=/usr/bin"]}, "history": [{"created_by": "RUN uv sync"}]}
+
         assert module._image_has_tracing_extra(config) is False
 
 

--- a/tests/ci/test_action_image_digest_check.py
+++ b/tests/ci/test_action_image_digest_check.py
@@ -1,0 +1,88 @@
+"""Unit tests for ``scripts/check_action_image_digest.py`` (#526)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tests.ci.workflow_support import REPO_ROOT
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _load_module() -> Any:
+    path = REPO_ROOT / "scripts" / "check_action_image_digest.py"
+    spec = importlib.util.spec_from_file_location("check_action_image_digest", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestGhcrDigestLookup:
+    def test_published_sha_tag_has_digest(self) -> None:
+        module = _load_module()
+        lookup = module._ghcr_digest_for_tag("b34e9f25c5d2dee0e638fa3c62f29733d0fc10c5")
+        assert lookup.status == module.TagLookupStatus.FOUND
+        assert lookup.digest == (
+            "sha256:3765b55ae73a0974d5fa14842bb73e80a347c2f7d66cb8bbfd5394806b6fae58"
+        )
+
+    def test_missing_tag_is_not_registry_error(self) -> None:
+        module = _load_module()
+        lookup = module._ghcr_digest_for_tag("0000000000000000000000000000000000000000")
+        assert lookup.status == module.TagLookupStatus.MISSING
+
+    def test_old_published_digest_lacks_tracing_extra(self) -> None:
+        module = _load_module()
+        config = module._fetch_oci_config_for_tag("cfdf38dcd062779aac3e141c51f134213d395b67")
+        assert config is not None
+        assert module._image_has_tracing_extra(config) is False
+
+
+class TestMain:
+    def test_fails_when_image_is_dockerfile(self, tmp_path: Path) -> None:
+        module = _load_module()
+        action = tmp_path / "action.yml"
+        action.write_text("runs:\n  using: docker\n  image: Dockerfile\n", encoding="utf-8")
+        module.ACTION_YML = action
+        assert module.main() != 0
+
+    def test_fails_on_mutable_tag(self, tmp_path: Path) -> None:
+        module = _load_module()
+        action = tmp_path / "action.yml"
+        action.write_text(
+            "runs:\n  using: docker\n  image: docker://ghcr.io/alexhawat/mergecraft:latest\n",
+            encoding="utf-8",
+        )
+        module.ACTION_YML = action
+        assert module.main() != 0
+
+    def test_fails_on_pre_tracing_digest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned pre-#531 digests must not pass the tracing-extra contract."""
+        module = _load_module()
+        action = tmp_path / "action.yml"
+        action.write_text(
+            "runs:\n  using: docker\n  image: "
+            "docker://ghcr.io/alexhawat/mergecraft@"
+            "sha256:955510ad23e1aa23d564475c2220ec0988236838a914a2a7472ea38220cb1f90\n",
+            encoding="utf-8",
+        )
+        module.ACTION_YML = action
+        monkeypatch.setattr(
+            module,
+            "_self_review_action_sha",
+            lambda: "cfdf38dcd062779aac3e141c51f134213d395b67",
+        )
+        assert module.main() != 0
+
+    def test_passes_on_repo_action_yml(self) -> None:
+        module = _load_module()
+        assert module.main() == 0

--- a/tests/ci/test_evidence.py
+++ b/tests/ci/test_evidence.py
@@ -387,7 +387,7 @@ def test_check_run_finding_evidence_is_redacted() -> None:
 
 
 def test_no_new_finding_fields_introduced(tmp_path: Path) -> None:
-    """CI evidence uses ``evidence`` and ``source``; it adds no field to ``Finding``."""
+    """CI evidence producers must emit only canonical ``Finding`` fields (incl. ``scope``)."""
     expected = {
         "tool",
         "rule_id",
@@ -404,6 +404,7 @@ def test_no_new_finding_fields_introduced(tmp_path: Path) -> None:
         "autofix",
         "introduced_by_pr",
         "source",
+        "scope",
         "cluster_id",
         "lens",
         "collateral",

--- a/tests/evidence/test_run_packet.py
+++ b/tests/evidence/test_run_packet.py
@@ -24,6 +24,7 @@ from mergecraft.evidence.run_packet import (
     emit_run_packet,
     prepare_run_packet,
     resolve_packet_path,
+    resolve_prepared_run_packet,
 )
 from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
 from mergecraft.mcp.tool_state import (
@@ -196,6 +197,26 @@ def test_deterministic_checks_carry_the_catalog_command(tmp_path: Path) -> None:
     assert [check["name"] for check in checks] == ["ruff"]
     assert checks[0]["status"] == "completed"
     assert checks[0]["command"], "command must be recorded, not blank"
+
+
+def test_resolve_prepared_run_packet_refinalizes_on_outcome_change(tmp_path: Path) -> None:
+    """Publish-time success must not stick when finalize reports run failure (cd6ff87c)."""
+    ctx = _make_ctx(tmp_path, diff_text=_TRIVIAL_DIFF)
+
+    first = resolve_prepared_run_packet(ctx, run_succeeded=True)
+    assert first is not None
+    assert first.decision is not None
+    assert first.decision.verdict == "success"
+
+    cached = ctx.tool_state.prepared_run_packet
+    assert cached is not None
+    assert cached.decision is None, "cache must hold the evidence shell without a baked verdict"
+
+    second = resolve_prepared_run_packet(ctx, run_succeeded=False)
+    assert second is not None
+    assert second.decision is not None
+    assert second.decision.verdict != "success"
+    assert second.decision.verdict == "neutral"
 
 
 def test_failed_run_still_emits_a_packet(tmp_path: Path) -> None:

--- a/tests/evidence/test_trajectory.py
+++ b/tests/evidence/test_trajectory.py
@@ -4,8 +4,8 @@ WC-T of the merge-evidence wave plan. Every case here is written against the
 contract W7/W8 must satisfy, not against an implementation:
 
 * **WC-T.1** — one case per named check, each firing on a crafted record.
-* **WC-T.2** — a high-severity trajectory finding blocks auto-merge *through
-  the packet decision* (#43's acceptance criterion), not through a stub.
+* **WC-T.2** — a high-severity trajectory finding reaches the packet but stays
+  advisory (plan 12 D2): run-scoped findings never block auto-merge.
 * **WC-T.3** — the record builds from MCP tool-call state alone (D8): no
   external trace, no tracing sink, no #56.
 * **WC-T.4** — an attached external trace is enrichment; the same record
@@ -369,21 +369,24 @@ def test_every_named_check_has_a_severity_and_a_recommended_action() -> None:
         assert check.recommended_action, f"{check.rule_id} has no recommended action"
 
 
-# ── WC-T.2 — a high-severity finding blocks auto-merge via the packet ─────────
+# ── WC-T.2 — high-severity trajectory findings stay advisory (plan 12 D2) ─────
 
 
-def test_high_severity_trajectory_finding_blocks_auto_merge() -> None:
-    """#43's acceptance criterion, driven through the real decision path.
+def test_high_severity_trajectory_finding_does_not_block_auto_merge() -> None:
+    """Run-scoped trajectory findings reach the packet but never block approval.
 
-    The trajectory finding is not handed to a bespoke gate: it goes into the
-    packet's finding list, and `decide_approval` — the one gate — reads it.
+    Plan 12 D2: even Critical run-health observations are advisory. The
+    trajectory finding rides in the packet's finding list and `decide_approval`
+    — the one gate — must still return success when they are the only findings.
     """
-    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, blocking_findings, decide_approval
     from mergecraft.evidence.build import build_packet
 
     findings = _audit(_record(completion_claims=[], tool_calls=_record().tool_calls[:1]))
-    blockers = [f for f in findings if f.severity in BLOCKING_SEVERITIES]
-    assert blockers, "no trajectory check produces a blocking severity"
+    high_severity = [f for f in findings if f.severity in BLOCKING_SEVERITIES]
+    assert high_severity, "no trajectory check produces a blocking severity"
+    assert all(finding.scope == "run" for finding in high_severity)
+    assert blocking_findings(high_severity) == []
 
     packet = build_packet(
         change_id="acme/demo#1",
@@ -391,13 +394,13 @@ def test_high_severity_trajectory_finding_blocks_auto_merge() -> None:
         agent_version="0.0.1",
         model="claude-sonnet-4-5",
         files_changed=["src/app.py"],
-        findings=blockers,
+        findings=high_severity,
         deterministic_checks=[],
         self_assessment={"would_approve": True, "sha": "cafe"},
     )
     decision = decide_approval(packet, run_succeeded=True, tier="trusted")
-    assert decision.verdict == "failure", (
-        "a blocking trajectory finding must reach the packet verdict, not a side channel"
+    assert decision.verdict == "success", (
+        "run-scoped trajectory findings are advisory and must not block approval"
     )
 
 

--- a/tests/evidence/test_trajectory.py
+++ b/tests/evidence/test_trajectory.py
@@ -190,34 +190,33 @@ def test_no_post_edit_verification_fires() -> None:
 
 
 def test_repeated_tool_loop_fires() -> None:
-    """The same call, with the same arguments, three times over."""
+    """Three adjacent identical verify calls with the same signature."""
     findings = _audit(
         _record(
             tool_calls=[
-                _call(index, "shell", intent="read", command="ls", signature="shell:ls")
-                for index in range(1, 4)
-            ]
-            + [_call(4, "create_pull_request_review", intent="complete")],
+                _call(1, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(2, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(3, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
             files_read=[],
             files_modified=[],
-            retries=2,
         )
     )
     assert "repeated-tool-loop" in _rule_ids(findings)
 
 
 def test_repeated_tool_loop_does_not_fire_below_the_threshold() -> None:
-    """Two identical calls is a retry; the check is about a *loop*."""
+    """Two adjacent identical verify calls is a retry; the check is about a *loop*."""
     findings = _audit(
         _record(
             tool_calls=[
-                _call(index, "shell", intent="read", command="ls", signature="shell:ls")
-                for index in range(1, 3)
-            ]
-            + [_call(3, "create_pull_request_review", intent="complete")],
+                _call(1, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(2, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(3, "create_pull_request_review", intent="complete"),
+            ],
             files_read=[],
             files_modified=[],
-            retries=1,
         )
     )
     assert "repeated-tool-loop" not in _rule_ids(findings)

--- a/tests/pins/test_action_image_digest_sync.py
+++ b/tests/pins/test_action_image_digest_sync.py
@@ -1,0 +1,50 @@
+"""#526 — action.yml slim digest parity gate wiring and contract."""
+
+from __future__ import annotations
+
+import re
+
+from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.docs.support import ci_steps
+
+_TARGET = "action-image-digest-check"
+_ACTION_YML = REPO_ROOT / "action.yml"
+_EXPECTED_PREFIX = "docker://ghcr.io/alexhawat/mergecraft@sha256:"
+
+
+def test_action_yml_pins_slim_image_by_digest() -> None:
+    """action.yml must pull the published slim image, not rebuild from Dockerfile."""
+    text = _ACTION_YML.read_text(encoding="utf-8")
+    assert 'image: "Dockerfile"' not in text
+    match = re.search(
+        r"image:\s*\"(docker://ghcr\.io/alexhawat/mergecraft@sha256:[a-f0-9]{64})\"", text
+    )
+    assert match, "action.yml must declare a digest-pinned ghcr.io/alexhawat/mergecraft slim image"
+    assert "analyzers" not in match.group(1)
+
+
+def test_action_yml_image_contract_documents_pull_not_build() -> None:
+    """Published Action resolves to a registry pull, not a Dockerfile build (#526)."""
+    text = _ACTION_YML.read_text(encoding="utf-8")
+    assert _EXPECTED_PREFIX in text
+    assert (
+        "Dockerfile" not in text.split("runs:", maxsplit=1)[-1].split("entrypoint:", maxsplit=1)[0]
+    )
+
+
+def test_make_action_image_digest_check_target_exists() -> None:
+    makefile = read_text("Makefile")
+    assert re.search(rf"^{re.escape(_TARGET)}:", makefile, re.MULTILINE)
+
+
+def test_action_image_digest_check_runs_via_make_lint() -> None:
+    makefile = read_text("Makefile")
+    lint_body = makefile.split("lint:", maxsplit=1)[1].split("\n\n", maxsplit=1)[0]
+    assert f"$(MAKE) {_TARGET}" in lint_body, (
+        "make lint must invoke action-image-digest-check (#526)"
+    )
+
+
+def test_action_image_digest_check_not_in_ci_steps_as_duplicate() -> None:
+    """Covered by the lint step — avoid a second CI_STEPS entry that re-runs it."""
+    assert _TARGET not in ci_steps()

--- a/tests/review_record/__init__.py
+++ b/tests/review_record/__init__.py
@@ -1,0 +1,1 @@
+"""RED suite for plan 12 — review record integrity."""

--- a/tests/review_record/conftest.py
+++ b/tests/review_record/conftest.py
@@ -65,9 +65,13 @@ def make_scoped_finding(
         kwargs["scope"] = "run"
         kwargs["source"] = "trajectory"
         kwargs["introduced_by_pr"] = "false"
-        kwargs.setdefault("path", "")
+        kwargs["path"] = ""
     else:
         kwargs["scope"] = "change"
+    if "message" not in overrides:
+        rule_id = kwargs.get("rule_id", "RR-FIXTURE")
+        if rule_id != "RR-FIXTURE":
+            kwargs["message"] = f"fixture finding ({rule_id})"
     return make_finding(**kwargs)
 
 

--- a/tests/review_record/conftest.py
+++ b/tests/review_record/conftest.py
@@ -1,0 +1,82 @@
+"""Shared helpers for wave 12 review-record integrity RED suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from mergecraft.analyzers.finding import Finding, make_finding
+from mergecraft.review_taxonomy import FINDING_CATEGORIES
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def require_symbol(module: Any, name: str) -> Any:
+    """Return ``module.name`` or fail with a wave-scoped message."""
+    obj = getattr(module, name, None)
+    if obj is None:
+        pytest.fail(f"{module.__name__}.{name} is not defined (plan 12)")
+    return obj
+
+
+def base_finding_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "tool": "review-record-fixture",
+        "rule_id": "RR-FIXTURE",
+        "category": FINDING_CATEGORIES[-1],
+        "severity": "Major",
+        "confidence": "certain",
+        "message": "fixture finding",
+        "path": "src/example.py",
+        "start_line": 1,
+        "end_line": 1,
+        "source": "analyzer",
+    }
+    base.update(overrides)
+    return base
+
+
+def make_test_finding(**overrides: Any) -> Finding:
+    return make_finding(**base_finding_kwargs(**overrides))
+
+
+def finding_scope_field_available() -> bool:
+    return "scope" in Finding.model_fields
+
+
+def make_scoped_finding(
+    *,
+    scope: Literal["change", "run"],
+    severity: str = "Major",
+    introduced_by_pr: Literal["true", "false", "unknown"] = "unknown",
+    **overrides: Any,
+) -> Finding:
+    if not finding_scope_field_available():
+        pytest.fail("Finding.scope is not defined yet (green after W2)")
+    kwargs = base_finding_kwargs(
+        severity=severity,
+        introduced_by_pr=introduced_by_pr,
+        **overrides,
+    )
+    if scope == "run":
+        kwargs["scope"] = "run"
+        kwargs["source"] = "trajectory"
+        kwargs["introduced_by_pr"] = "false"
+        kwargs.setdefault("path", "")
+    else:
+        kwargs["scope"] = "change"
+    return make_finding(**kwargs)
+
+
+def load_trajectory_fixture(name: str) -> dict[str, Any]:
+    path = _FIXTURES / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def trajectory_record_from_fixture(name: str) -> Any:
+    from mergecraft.evidence.trajectory import TrajectoryRecord
+
+    return TrajectoryRecord.model_validate(load_trajectory_fixture(name))

--- a/tests/review_record/fixtures/run_33126460925_trajectory.json
+++ b/tests/review_record/fixtures/run_33126460925_trajectory.json
@@ -1,0 +1,192 @@
+{
+  "sources": ["mcp-tool-calls"],
+  "tool_calls": [
+    {
+      "sequence": 1,
+      "tool": "checkout_pr",
+      "signature": "checkout_pr:546",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": null,
+      "error": null,
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 2,
+      "tool": "git",
+      "signature": "git:fetch-pr-546",
+      "intent": "read",
+      "ok": false,
+      "outcome_ok": null,
+      "error": "Invalid parameters for tool git: invalid subcommand",
+      "command": "git fetch pull/546/head:pr-546",
+      "paths": []
+    },
+    {
+      "sequence": 3,
+      "tool": "git",
+      "signature": "git:fetch-pr-546-retry",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": "git fetch pull/546/head:pr-546",
+      "paths": []
+    },
+    {
+      "sequence": 4,
+      "tool": "shell",
+      "signature": "shell:bwrap-fail-1",
+      "intent": "verify",
+      "ok": false,
+      "outcome_ok": null,
+      "error": "newuidmap: operation not permitted",
+      "command": "bwrap --unshare-user ...",
+      "paths": []
+    },
+    {
+      "sequence": 5,
+      "tool": "shell",
+      "signature": "shell:bwrap-fail-2",
+      "intent": "verify",
+      "ok": false,
+      "outcome_ok": null,
+      "error": "newuidmap: operation not permitted",
+      "command": "bwrap --unshare-user ...",
+      "paths": []
+    },
+    {
+      "sequence": 6,
+      "tool": "run_static_checks",
+      "signature": "run_static_checks:schema-fail",
+      "intent": "verify",
+      "ok": false,
+      "outcome_ok": null,
+      "error": "Input validation error: '-32602' invalid type",
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 7,
+      "tool": "run_static_checks",
+      "signature": "run_static_checks:schema-ok",
+      "intent": "verify",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 8,
+      "tool": "git",
+      "signature": "git:show:deadbeef:README.md",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": "git show deadbeef:README.md",
+      "paths": ["README.md"]
+    },
+    {
+      "sequence": 9,
+      "tool": "shell",
+      "signature": "shell:intervening",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": "ls",
+      "paths": []
+    },
+    {
+      "sequence": 10,
+      "tool": "git",
+      "signature": "git:show:deadbeef:README.md",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": "git show deadbeef:README.md",
+      "paths": ["README.md"]
+    },
+    {
+      "sequence": 11,
+      "tool": "git",
+      "signature": "git:show:deadbeef:README.md",
+      "intent": "read",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": "git show deadbeef:README.md",
+      "paths": ["README.md"]
+    },
+    {
+      "sequence": 12,
+      "tool": "run_static_checks",
+      "signature": "run_static_checks:loop",
+      "intent": "verify",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 13,
+      "tool": "run_static_checks",
+      "signature": "run_static_checks:loop",
+      "intent": "verify",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 14,
+      "tool": "run_static_checks",
+      "signature": "run_static_checks:loop",
+      "intent": "verify",
+      "ok": true,
+      "outcome_ok": true,
+      "error": null,
+      "command": null,
+      "paths": []
+    },
+    {
+      "sequence": 15,
+      "tool": "shell",
+      "signature": "shell:transient",
+      "intent": "verify",
+      "ok": false,
+      "outcome_ok": null,
+      "error": "connection reset by peer",
+      "command": "curl https://example.test",
+      "paths": []
+    },
+    {
+      "sequence": 16,
+      "tool": "create_pull_request_review",
+      "signature": "create_pull_request_review:complete",
+      "intent": "complete",
+      "ok": true,
+      "outcome_ok": null,
+      "error": null,
+      "command": null,
+      "paths": []
+    }
+  ],
+  "files_read": ["README.md"],
+  "files_modified": [],
+  "commands_run": [],
+  "tests_run": [],
+  "failures_observed": [],
+  "fixes_after_failures": 0,
+  "retries": 0,
+  "unresolved_errors": [],
+  "completion_claims": ["create_pull_request_review"],
+  "read_coverage": true,
+  "external_trace": null
+}

--- a/tests/review_record/test_ledger_marker_boundaries.py
+++ b/tests/review_record/test_ledger_marker_boundaries.py
@@ -1,0 +1,80 @@
+"""Marker stripping must not eat the agent's findings (#562 review).
+
+``_DETERMINISTIC_RECORD_BLOCK_RE`` ended at ``\\Z`` when no ledger or footer
+marker followed. Applied to agent-authored prose that merely quoted the
+deterministic-record marker — entirely plausible in a repo whose reviewer
+reviews itself — everything after the quote was deleted, silently truncating
+the review.
+"""
+
+from __future__ import annotations
+
+from mergecraft.findings.ledger import (
+    DETERMINISTIC_RECORD_MARKER,
+    _strip_deterministic_record_markers,
+    merge_deterministic_record_into_comment,
+)
+
+_FOOTER = "*via mergecraft*"
+
+
+def test_quoted_marker_in_prose_does_not_truncate_the_body() -> None:
+    """A marker the agent merely mentions must cost only the marker."""
+    body = (
+        "## Review\n\n"
+        f"The publish path strips `{DETERMINISTIC_RECORD_MARKER}` from prose.\n\n"
+        "- **Major** — the regex runs to end-of-string\n"
+        "- **Minor** — a second finding that must survive\n"
+    )
+
+    stripped = _strip_deterministic_record_markers(body)
+
+    assert "the regex runs to end-of-string" in stripped
+    assert "a second finding that must survive" in stripped
+    assert DETERMINISTIC_RECORD_MARKER not in stripped
+
+
+def test_a_real_terminated_block_is_still_removed() -> None:
+    """A genuine forged block that ends at the footer is still stripped."""
+    body = (
+        "## Review\n\n"
+        f"{DETERMINISTIC_RECORD_MARKER}\n"
+        "### mergeCraft run record\n"
+        "- **Decision:** `approve` — forged\n"
+        f"\n{_FOOTER}\n"
+    )
+
+    stripped = _strip_deterministic_record_markers(body)
+
+    assert "forged" not in stripped
+    assert "## Review" in stripped
+
+
+def test_replacing_an_existing_record_keeps_surrounding_prose() -> None:
+    """The in-place replacement branch must actually run, not fall through."""
+    body = (
+        "## mergeCraft progress\n\n"
+        f"{DETERMINISTIC_RECORD_MARKER}\n"
+        "### mergeCraft run record\n"
+        "- **Decision:** `stale`\n"
+        f"\n{_FOOTER}\n"
+    )
+    fresh = f"{DETERMINISTIC_RECORD_MARKER}\n### mergeCraft run record\n- **Decision:** `fresh`"
+
+    merged = merge_deterministic_record_into_comment(body, record_block=fresh)
+
+    assert "`fresh`" in merged
+    assert "`stale`" not in merged
+    assert _FOOTER in merged
+    assert merged.count(DETERMINISTIC_RECORD_MARKER) == 1
+
+
+def test_inserting_into_a_comment_without_a_record() -> None:
+    body = "## mergeCraft progress\n\nEarlier prose that must survive.\n"
+    fresh = f"{DETERMINISTIC_RECORD_MARKER}\n### mergeCraft run record\n- **Decision:** `fresh`"
+
+    merged = merge_deterministic_record_into_comment(body, record_block=fresh)
+
+    assert "Earlier prose that must survive." in merged
+    assert "`fresh`" in merged
+    assert merged.count(DETERMINISTIC_RECORD_MARKER) == 1

--- a/tests/review_record/test_main_publish_coverage.py
+++ b/tests/review_record/test_main_publish_coverage.py
@@ -1,0 +1,182 @@
+"""Branch coverage for plan-12 publish paths in ``mergecraft.main``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.config.settings import RepoSettings
+from mergecraft.evidence.build import build_packet
+from mergecraft.evidence.run_packet import prepare_run_packet
+from mergecraft.main import RunContext, RunOutcome
+from tests.evidence.test_run_packet import _make_ctx
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class _UsageRow:
+    total_tokens: int
+
+
+def _publish() -> Any:
+    import mergecraft.main as main_mod
+
+    return main_mod._publish
+
+
+def _token_summary() -> Any:
+    import mergecraft.main as main_mod
+
+    return main_mod._token_summary
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected"),
+    [
+        ([], None),
+        ([_UsageRow(total_tokens=100), _UsageRow(total_tokens=50)], "100, 50"),
+    ],
+)
+def test_token_summary_formats_usage_entries(rows: list[_UsageRow], expected: str | None) -> None:
+    assert _token_summary()(rows) == expected
+
+
+@pytest.mark.asyncio
+async def test_publish_emit_false_writes_deterministic_record_and_step_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_context = _make_ctx(tmp_path)
+    tool_context.tool_state.pr_number = 546
+    prepared = prepare_run_packet(tool_context, run_succeeded=True)
+    assert prepared is not None
+    tool_context.tool_state.prepared_run_packet = prepared
+
+    deterministic_calls: list[dict[str, Any]] = []
+    step_summaries: list[str] = []
+
+    async def _capture_deterministic(**kwargs: Any) -> None:
+        deterministic_calls.append(kwargs)
+
+    def _capture_step_summary(body: str) -> None:
+        step_summaries.append(body)
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    import mergecraft.main as main_mod
+    import mergecraft.utils.step_summary as step_summary_mod
+
+    monkeypatch.setattr(main_mod, "persist_learnings", _noop)
+    monkeypatch.setattr(main_mod, "report_status_checks", _noop)
+    monkeypatch.setattr(main_mod, "publish_deterministic_record", _capture_deterministic)
+    monkeypatch.setattr(step_summary_mod, "append_step_summary", _capture_step_summary)
+
+    run_ctx = RunContext(settings=RepoSettings(), tool_context=tool_context)
+    await _publish()(
+        run_ctx,
+        outcome=RunOutcome.passed,
+        failure_reason=None,
+        emit=False,
+    )
+
+    assert deterministic_calls
+    assert deterministic_calls[0]["pull_number"] == 546
+    assert step_summaries
+
+
+@pytest.mark.asyncio
+async def test_publish_resolves_pull_number_from_issue_number(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_context = _make_ctx(tmp_path)
+    tool_context.tool_state.pr_number = None
+    tool_context.payload.event.issue_number = 99
+    prepared = prepare_run_packet(tool_context, run_succeeded=True)
+    assert prepared is not None
+    tool_context.tool_state.prepared_run_packet = prepared
+
+    deterministic_calls: list[dict[str, Any]] = []
+
+    async def _capture_deterministic(**kwargs: Any) -> None:
+        deterministic_calls.append(kwargs)
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    import mergecraft.main as main_mod
+    import mergecraft.utils.step_summary as step_summary_mod
+
+    monkeypatch.setattr(main_mod, "persist_learnings", _noop)
+    monkeypatch.setattr(main_mod, "report_status_checks", _noop)
+    monkeypatch.setattr(main_mod, "publish_deterministic_record", _capture_deterministic)
+    monkeypatch.setattr(step_summary_mod, "append_step_summary", lambda _body: None)
+
+    run_ctx = RunContext(settings=RepoSettings(), tool_context=tool_context)
+    await _publish()(
+        run_ctx,
+        outcome=RunOutcome.passed,
+        failure_reason=None,
+        emit=False,
+    )
+
+    assert deterministic_calls
+    assert deterministic_calls[0]["pull_number"] == 99
+
+
+@pytest.mark.asyncio
+async def test_publish_passes_rejection_reason_for_no_verdict_packet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_context = _make_ctx(tmp_path)
+    tool_context.tool_state.pr_number = 546
+    packet = build_packet(
+        change_id="acme/demo#546",
+        agent_id="claude",
+        agent_version="0.0.1",
+        model="claude-sonnet-4-5",
+        files_changed=[],
+        findings=[],
+        deterministic_checks=[],
+        self_assessment={"would_approve": False, "sha": "abc"},
+    )
+    tool_context.tool_state.prepared_run_packet = packet
+    no_verdict_packet = packet
+
+    deterministic_calls: list[dict[str, Any]] = []
+
+    async def _capture_deterministic(**kwargs: Any) -> None:
+        deterministic_calls.append(kwargs)
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def _resolve_packet(_ctx: Any, *, run_succeeded: bool) -> Any:
+        assert run_succeeded is False
+        return no_verdict_packet
+
+    import mergecraft.main as main_mod
+    import mergecraft.utils.step_summary as step_summary_mod
+
+    monkeypatch.setattr(main_mod, "resolve_prepared_run_packet", _resolve_packet)
+    monkeypatch.setattr(main_mod, "persist_learnings", _noop)
+    monkeypatch.setattr(main_mod, "report_status_checks", _noop)
+    monkeypatch.setattr(main_mod, "publish_deterministic_record", _capture_deterministic)
+    monkeypatch.setattr(step_summary_mod, "append_step_summary", lambda _body: None)
+
+    run_ctx = RunContext(settings=RepoSettings(), tool_context=tool_context)
+    await _publish()(
+        run_ctx,
+        outcome=RunOutcome.inconclusive,
+        failure_reason="provider_success_without_submission",
+        emit=False,
+    )
+
+    assert deterministic_calls
+    assert deterministic_calls[0]["rejection_reason"] == "provider_success_without_submission"

--- a/tests/review_record/test_w11_scope_blocking.py
+++ b/tests/review_record/test_w11_scope_blocking.py
@@ -1,0 +1,96 @@
+"""W1.1 — scope axis and one blocking predicate (implementation W2)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergecraft.agents import gates
+from mergecraft.analyzers.finding import Finding, FindingValidationError, make_finding
+from mergecraft.mcp.verdict import _blocks_approve, build_validation_state
+from tests.review_record.conftest import (
+    base_finding_kwargs,
+    make_scoped_finding,
+    make_test_finding,
+    require_symbol,
+)
+
+if TYPE_CHECKING:
+    from mergecraft.analyzers.finding import Finding as FindingType
+
+
+def _blocking_findings(findings: list[FindingType]) -> list[FindingType]:
+    return list(require_symbol(gates, "blocking_findings")(findings))
+
+
+def test_finding_defaults_scope_change() -> None:
+    finding = make_test_finding(source="analyzer")
+    assert getattr(finding, "scope", None) == "change"
+
+
+def test_existing_analyzer_row_loads_unchanged_without_scope_in_payload() -> None:
+    payload = make_test_finding(source="analyzer").model_dump()
+    payload.pop("scope", None)
+    loaded = Finding.model_validate(payload)
+    assert loaded.source == "analyzer"
+    assert getattr(loaded, "scope", "change") == "change"
+
+
+def test_trajectory_source_validates() -> None:
+    make_finding(**base_finding_kwargs(source="trajectory", path=""))
+
+
+def test_unknown_source_still_raises() -> None:
+    with pytest.raises((FindingValidationError, ValueError)):
+        make_finding(**base_finding_kwargs(source="not-a-source"))  # type: ignore[arg-type]
+
+
+def test_blocking_findings_drops_run_scoped_critical() -> None:
+    run_critical = make_scoped_finding(
+        scope="run", severity="Critical", rule_id="ignored-tool-error"
+    )
+    assert _blocking_findings([run_critical]) == []
+
+
+def test_blocking_findings_applies_causality_policy() -> None:
+    pre_existing = make_scoped_finding(
+        scope="change",
+        severity="Major",
+        introduced_by_pr="false",
+        rule_id="PRE-EXISTING",
+    )
+    assert _blocking_findings([pre_existing]) == []
+
+
+def test_has_blocker_and_blocks_approve_agree_on_mixed_scope_set() -> None:
+    """#447-shaped regression — one predicate must not disagree with the other."""
+    findings = [
+        make_scoped_finding(scope="run", severity="Critical", rule_id="unresolved-failure"),
+        make_scoped_finding(
+            scope="change",
+            severity="Major",
+            introduced_by_pr="false",
+            rule_id="PRE-EXISTING",
+        ),
+        make_scoped_finding(
+            scope="change",
+            severity="Major",
+            introduced_by_pr="true",
+            rule_id="CHANGE-SCOPED",
+        ),
+    ]
+    state = build_validation_state(analyzer_findings=findings)
+    gates_answer = bool(_blocking_findings(findings))
+    verdict_answer = _blocks_approve(state)
+    has_blocker_answer = gates._has_blocker(findings)
+    assert gates_answer == verdict_answer == has_blocker_answer
+
+
+def test_decide_approval_success_on_run_only_findings() -> None:
+    run_only = [
+        make_scoped_finding(scope="run", severity="Critical", rule_id="ignored-tool-error"),
+        make_scoped_finding(scope="run", severity="Major", rule_id="repeated-tool-loop"),
+    ]
+    conclusion = gates.decide_approval(run_only, run_succeeded=True, tier="trusted")
+    assert conclusion == "success"

--- a/tests/review_record/test_w12_trajectory_attribution.py
+++ b/tests/review_record/test_w12_trajectory_attribution.py
@@ -1,0 +1,146 @@
+"""W1.2 — trajectory attribution stamps and advisory-only run health."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.evidence.build import build_packet
+from mergecraft.evidence.trajectory_audit import TRAJECTORY_CHECKS, audit_trajectory
+from tests.evidence.test_trajectory import _audit, _call, _record
+from tests.review_record.conftest import require_symbol
+
+_TRAJECTORY_FIXTURES: dict[str, dict[str, object]] = {
+    "changed-unread-file": {
+        "files_read": ["src/other.py"],
+        "files_modified": ["src/app.py"],
+    },
+    "ignored-tool-error": {
+        "tool_calls": [
+            _call(1, "run_static_checks", intent="verify", ok=False, error="boom"),
+            _call(2, "create_pull_request_review", intent="complete"),
+        ],
+        "files_read": [],
+        "files_modified": [],
+    },
+    "no-post-edit-verification": {
+        "tool_calls": [
+            _call(1, "shell", intent="verify", command="pytest -q", outcome_ok=True),
+            _call(2, "shell", intent="modify", command="apply patch", paths=["src/app.py"]),
+            _call(3, "create_pull_request_review", intent="complete"),
+        ],
+    },
+    "repeated-tool-loop": {
+        "tool_calls": [
+            _call(index, "run_static_checks", intent="verify", signature="run_static_checks:loop")
+            for index in range(1, 4)
+        ]
+        + [_call(4, "create_pull_request_review", intent="complete")],
+    },
+    "unresolved-failure": {
+        "tool_calls": [
+            _call(
+                1,
+                "run_static_checks",
+                intent="verify",
+                ok=True,
+                outcome_ok=False,
+                command="pytest -q",
+                signature="run_static_checks:pytest",
+            ),
+            _call(2, "create_pull_request_review", intent="complete"),
+        ],
+        "files_read": [],
+        "files_modified": [],
+    },
+    "suspicious-broad-edit": {
+        "files_modified": [f"src/file_{index}.py" for index in range(30)],
+    },
+    "stale-assumption-after-failure": {
+        "tool_calls": [
+            _call(
+                1,
+                "shell",
+                intent="verify",
+                ok=False,
+                error="boom",
+                signature="shell:pytest",
+                command="pytest -q",
+            ),
+            _call(
+                2,
+                "shell",
+                intent="verify",
+                ok=False,
+                error="boom",
+                signature="shell:pytest",
+                command="pytest -q",
+            ),
+            _call(3, "create_pull_request_review", intent="complete"),
+        ],
+    },
+    "missing-completion-signal": {
+        "tool_calls": [_call(1, "shell", intent="read", command="ls")],
+        "completion_claims": [],
+    },
+}
+
+
+@pytest.mark.parametrize("check", TRAJECTORY_CHECKS, ids=lambda check: check.rule_id)
+def test_every_trajectory_check_stamps_scope_source_and_introduced_by_pr(
+    check: object,
+) -> None:
+    overrides = _TRAJECTORY_FIXTURES[check.rule_id]  # type: ignore[attr-defined]
+    findings = audit_trajectory(_record(**overrides))
+    matched = [finding for finding in findings if finding.rule_id == check.rule_id]  # type: ignore[attr-defined]
+    assert matched, f"{check.rule_id} did not fire"  # type: ignore[attr-defined]
+    for finding in matched:
+        assert finding.scope == "run"
+        assert finding.source == "trajectory"
+        assert finding.introduced_by_pr == "false"
+
+
+def test_trajectory_only_run_produces_approval_success() -> None:
+    findings = _audit(_record(completion_claims=[], tool_calls=_record().tool_calls[:1]))
+    assert findings, "fixture must emit at least one trajectory finding"
+    packet = build_packet(
+        change_id="acme/demo#546",
+        agent_id="claude",
+        agent_version="0.0.1",
+        model="claude-sonnet-4-5",
+        files_changed=["src/example.py"],
+        findings=findings,
+        deterministic_checks=[],
+        self_assessment={"would_approve": False, "sha": "abc123"},
+    )
+    decision = decide_approval(packet, run_succeeded=True, tier="trusted")
+    assert decision.verdict == "success"
+
+
+def test_unresolved_failure_critical_does_not_block() -> None:
+    blocking = require_symbol(
+        __import__("mergecraft.agents.gates", fromlist=["blocking_findings"]),
+        "blocking_findings",
+    )
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "run_static_checks",
+                    intent="verify",
+                    ok=True,
+                    outcome_ok=False,
+                    command="pytest -q",
+                    signature="run_static_checks:pytest",
+                ),
+                _call(2, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    critical = [finding for finding in findings if finding.rule_id == "unresolved-failure"]
+    assert critical
+    assert critical[0].severity == "Critical"
+    assert blocking(critical) == []

--- a/tests/review_record/test_w13_trajectory_classify.py
+++ b/tests/review_record/test_w13_trajectory_classify.py
@@ -14,9 +14,6 @@ def _blocking_findings(findings: list[object]) -> list[object]:
     return list(require_symbol(gates, "blocking_findings")(findings))  # type: ignore[arg-type]
 
 
-@pytest.mark.xfail(
-    reason="green after W3: schema slip self-corrects within three calls", strict=False
-)
 def test_schema_rejection_self_corrected_within_three_calls_produces_no_finding() -> None:
     findings = _audit(
         _record(

--- a/tests/review_record/test_w13_trajectory_classify.py
+++ b/tests/review_record/test_w13_trajectory_classify.py
@@ -1,0 +1,244 @@
+"""W1.3 — trajectory auditor classifies before it counts (implementation W3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mergecraft.agents import gates
+from mergecraft.evidence.trajectory_audit import audit_trajectory
+from tests.evidence.test_trajectory import _audit, _call, _record
+from tests.review_record.conftest import require_symbol, trajectory_record_from_fixture
+
+
+def _blocking_findings(findings: list[object]) -> list[object]:
+    return list(require_symbol(gates, "blocking_findings")(findings))  # type: ignore[arg-type]
+
+
+@pytest.mark.xfail(
+    reason="green after W3: schema slip self-corrects within three calls", strict=False
+)
+def test_schema_rejection_self_corrected_within_three_calls_produces_no_finding() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "run_static_checks",
+                    intent="verify",
+                    ok=False,
+                    error="Input validation error: '-32602' invalid type",
+                    signature="run_static_checks:gate",
+                ),
+                _call(
+                    2,
+                    "shell",
+                    intent="read",
+                    command="cat pyproject.toml",
+                    signature="shell:read",
+                ),
+                _call(
+                    3,
+                    "run_static_checks",
+                    intent="verify",
+                    ok=True,
+                    outcome_ok=True,
+                    signature="run_static_checks:gate",
+                ),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "ignored-tool-error" not in {f.rule_id for f in findings}
+
+
+@pytest.mark.xfail(
+    reason="green after W3: guard refusal is at most Trivial run-scoped", strict=False
+)
+def test_guard_refusal_produces_at_most_trivial_run_scoped_observation() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "git",
+                    intent="read",
+                    ok=False,
+                    error="invalid git subcommand",
+                    command="git not-a-real-subcommand",
+                    signature="git:invalid",
+                ),
+                _call(2, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    matched = [
+        f for f in findings if "git" in f.message.lower() or f.rule_id == "ignored-tool-error"
+    ]
+    assert len(matched) <= 1
+    for finding in matched:
+        assert finding.severity == "Trivial"
+        assert getattr(finding, "scope", "change") == "run"
+
+
+@pytest.mark.xfail(reason="green after W3: bubblewrap environment rollup", strict=False)
+def test_bubblewrap_namespace_failure_produces_one_rolled_up_environment_finding() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "shell",
+                    intent="verify",
+                    ok=False,
+                    error="newuidmap: operation not permitted",
+                    command="bwrap --unshare-user",
+                    signature="shell:bwrap",
+                ),
+                _call(
+                    2,
+                    "shell",
+                    intent="verify",
+                    ok=False,
+                    error="newuidmap: operation not permitted",
+                    command="bwrap --unshare-user",
+                    signature="shell:bwrap",
+                ),
+                _call(3, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    env_findings = [
+        f for f in findings if "namespace" in f.message.lower() or "bwrap" in f.message.lower()
+    ]
+    assert len(env_findings) == 1
+
+
+def test_git_fetch_after_checkout_pr_counts_as_retry_not_ignored_error() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "checkout_pr", intent="read", signature="checkout_pr:546"),
+                _call(
+                    2,
+                    "git",
+                    intent="read",
+                    ok=False,
+                    error="fetch failed once",
+                    command="git fetch pull/546/head:pr-546",
+                    signature="git:fetch-pr-546",
+                ),
+                _call(
+                    3,
+                    "git",
+                    intent="read",
+                    ok=True,
+                    outcome_ok=True,
+                    command="git fetch pull/546/head:pr-546",
+                    signature="git:fetch-pr-546",
+                ),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "ignored-tool-error" not in {f.rule_id for f in findings}
+
+
+def test_transient_failure_without_retry_fires_ignored_tool_error() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "shell",
+                    intent="verify",
+                    ok=False,
+                    error="connection reset by peer",
+                    command="curl https://example.test",
+                    signature="shell:transient",
+                ),
+                _call(2, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "ignored-tool-error" in {f.rule_id for f in findings}
+
+
+@pytest.mark.xfail(reason="green after W3: immutable git show repeats are not loops", strict=False)
+def test_repeated_tool_loop_does_not_fire_on_immutable_git_show_with_intervening_work() -> None:
+    signature = "git:show:deadbeef:README.md"
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(
+                    1,
+                    "git",
+                    intent="read",
+                    ok=True,
+                    outcome_ok=True,
+                    command="git show deadbeef:README.md",
+                    signature=signature,
+                ),
+                _call(2, "shell", intent="read", command="ls", signature="shell:ls"),
+                _call(
+                    3,
+                    "git",
+                    intent="read",
+                    ok=True,
+                    outcome_ok=True,
+                    command="git show deadbeef:README.md",
+                    signature=signature,
+                ),
+                _call(
+                    4,
+                    "git",
+                    intent="read",
+                    ok=True,
+                    outcome_ok=True,
+                    command="git show deadbeef:README.md",
+                    signature=signature,
+                ),
+                _call(5, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=["README.md"],
+            files_modified=[],
+        )
+    )
+    assert "repeated-tool-loop" not in {f.rule_id for f in findings}
+
+
+@pytest.mark.xfail(
+    reason="green after W3: adjacent identical run_static_checks loops", strict=False
+)
+def test_repeated_tool_loop_fires_on_three_adjacent_identical_run_static_checks() -> None:
+    findings = _audit(
+        _record(
+            tool_calls=[
+                _call(1, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(2, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(3, "run_static_checks", intent="verify", signature="run_static_checks:loop"),
+                _call(4, "create_pull_request_review", intent="complete"),
+            ],
+            files_read=[],
+            files_modified=[],
+        )
+    )
+    assert "repeated-tool-loop" in {f.rule_id for f in findings}
+
+
+@pytest.mark.xfail(reason="green after W3: run 33126460925 fixture replay", strict=False)
+def test_run_33126460925_fixture_zero_blocking_at_most_three_run_scoped() -> None:
+    record = trajectory_record_from_fixture("run_33126460925_trajectory.json")
+    findings = audit_trajectory(record)
+    assert _blocking_findings(findings) == []
+    run_scoped = [f for f in findings if getattr(f, "scope", "change") == "run"]
+    assert len(run_scoped) <= 3

--- a/tests/review_record/test_w13_trajectory_classify.py
+++ b/tests/review_record/test_w13_trajectory_classify.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from mergecraft.agents import gates
 from mergecraft.evidence.trajectory_audit import audit_trajectory
 from tests.evidence.test_trajectory import _audit, _call, _record
@@ -50,9 +48,6 @@ def test_schema_rejection_self_corrected_within_three_calls_produces_no_finding(
     assert "ignored-tool-error" not in {f.rule_id for f in findings}
 
 
-@pytest.mark.xfail(
-    reason="green after W3: guard refusal is at most Trivial run-scoped", strict=False
-)
 def test_guard_refusal_produces_at_most_trivial_run_scoped_observation() -> None:
     findings = _audit(
         _record(
@@ -81,7 +76,6 @@ def test_guard_refusal_produces_at_most_trivial_run_scoped_observation() -> None
         assert getattr(finding, "scope", "change") == "run"
 
 
-@pytest.mark.xfail(reason="green after W3: bubblewrap environment rollup", strict=False)
 def test_bubblewrap_namespace_failure_produces_one_rolled_up_environment_finding() -> None:
     findings = _audit(
         _record(
@@ -170,7 +164,6 @@ def test_transient_failure_without_retry_fires_ignored_tool_error() -> None:
     assert "ignored-tool-error" in {f.rule_id for f in findings}
 
 
-@pytest.mark.xfail(reason="green after W3: immutable git show repeats are not loops", strict=False)
 def test_repeated_tool_loop_does_not_fire_on_immutable_git_show_with_intervening_work() -> None:
     signature = "git:show:deadbeef:README.md"
     findings = _audit(
@@ -229,7 +222,6 @@ def test_repeated_tool_loop_fires_on_three_adjacent_identical_run_static_checks(
     assert "repeated-tool-loop" in {f.rule_id for f in findings}
 
 
-@pytest.mark.xfail(reason="green after W3: run 33126460925 fixture replay", strict=False)
 def test_run_33126460925_fixture_zero_blocking_at_most_three_run_scoped() -> None:
     record = trajectory_record_from_fixture("run_33126460925_trajectory.json")
     findings = audit_trajectory(record)

--- a/tests/review_record/test_w13_trajectory_classify.py
+++ b/tests/review_record/test_w13_trajectory_classify.py
@@ -216,9 +216,6 @@ def test_repeated_tool_loop_does_not_fire_on_immutable_git_show_with_intervening
     assert "repeated-tool-loop" not in {f.rule_id for f in findings}
 
 
-@pytest.mark.xfail(
-    reason="green after W3: adjacent identical run_static_checks loops", strict=False
-)
 def test_repeated_tool_loop_fires_on_three_adjacent_identical_run_static_checks() -> None:
     findings = _audit(
         _record(

--- a/tests/review_record/test_w14_status_check_summaries.py
+++ b/tests/review_record/test_w14_status_check_summaries.py
@@ -1,0 +1,215 @@
+"""W1.4 — status checks derive truthful summaries (implementation W4)."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from loguru import logger
+
+from mergecraft.agents.gates import TRUSTED_PACKET_DECIDED_BY, decide_approval
+from mergecraft.evidence.build import build_packet
+from mergecraft.evidence.packet import Decision
+from mergecraft.evidence.run_packet import prepare_run_packet
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import ApprovalRecord, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from mergecraft.utils.status_checks import APPROVAL_CHECK, report_status_checks
+from tests.review_record.conftest import make_scoped_finding, make_test_finding
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+RUN_URL = "https://github.com/acme/demo/actions/runs/33126460925"
+REVIEWED_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+PR_HEAD_SHA = "cafebabecafebabecafebabecafebabecafebabe"
+
+
+class _RecordingGitHub(GitHubClient):
+    def __init__(self, *, pr_head_sha: str = PR_HEAD_SHA) -> None:
+        super().__init__(token="test-token")
+        self.pr_head_sha = pr_head_sha
+        self.check_runs: list[dict[str, Any]] = []
+        self.fail_next_approval_post = False
+
+    async def get_pull(self, owner: str, repo: str, pull_number: int) -> dict[str, Any]:
+        return {"head": {"sha": self.pr_head_sha}}
+
+    async def post(self, path: str, **kwargs: Any) -> Any:
+        if path.endswith("/check-runs"):
+            body = kwargs.get("json")
+            if isinstance(body, dict):
+                if body.get("name") == APPROVAL_CHECK and self.fail_next_approval_post:
+                    msg = "simulated check-run post failure"
+                    raise RuntimeError(msg)
+                self.check_runs.append(body)
+        return {}
+
+
+def _ctx(tmp_path: Path, *, github: _RecordingGitHub | None = None) -> ToolContext:
+    gh = github or _RecordingGitHub()
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    tool_state.approval = ApprovalRecord(would_approve=True, sha=REVIEWED_SHA)
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=546, is_pr=True),
+            status_checks=True,
+            shell="restricted",
+        ),
+        github=gh,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        run_id="33126460925",
+    )
+
+
+def _packet_with_findings(
+    findings: list[Any],
+    *,
+    verdict: str,
+    reason: str,
+) -> Any:
+    packet = build_packet(
+        change_id="acme/demo#546",
+        agent_id="claude",
+        agent_version="0.0.1",
+        model="claude-sonnet-4-5",
+        files_changed=["src/example.py"],
+        findings=findings,
+        deterministic_checks=[],
+        self_assessment={"would_approve": verdict == "success", "sha": REVIEWED_SHA},
+    )
+    packet.decision = Decision(
+        verdict=verdict,  # type: ignore[arg-type]
+        reason=reason,
+        decided_by=TRUSTED_PACKET_DECIDED_BY,
+    )
+    return packet
+
+
+def _approval_summary(github: _RecordingGitHub) -> str:
+    approval = next(run for run in github.check_runs if run.get("name") == APPROVAL_CHECK)
+    return str(approval["output"]["summary"])
+
+
+@pytest.mark.asyncio
+async def test_zero_change_findings_never_claim_outstanding_feedback(tmp_path: Path) -> None:
+    run_only = [
+        make_scoped_finding(scope="run", severity="Critical", rule_id="ignored-tool-error"),
+    ]
+    packet = _packet_with_findings(run_only, verdict="success", reason="run health advisory only")
+    ctx = _ctx(tmp_path)
+    await report_status_checks(ctx, run_succeeded=True, packet=packet)
+    summary = _approval_summary(ctx.github)  # type: ignore[arg-type]
+    assert "outstanding review feedback" not in summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_three_distinct_summaries_for_outcomes(tmp_path: Path) -> None:
+    cases = [
+        (
+            "change findings outstanding",
+            [make_scoped_finding(scope="change", severity="Major", introduced_by_pr="true")],
+            "failure",
+            "blocking change finding",
+        ),
+        (
+            "run incomplete",
+            [],
+            "neutral",
+            "review did not complete",
+        ),
+        (
+            "approved",
+            [make_test_finding(severity="Minor", source="agent")],
+            "success",
+            "approved",
+        ),
+    ]
+    summaries: list[str] = []
+    for _label, findings, verdict, reason in cases:
+        if verdict == "success" and findings:
+            decision = decide_approval(findings, run_succeeded=True, tier="trusted")
+            assert decision == "success"
+        packet = _packet_with_findings(findings, verdict=verdict, reason=reason)
+        github = _RecordingGitHub()
+        ctx = _ctx(tmp_path, github=github)
+        await report_status_checks(ctx, run_succeeded=verdict != "neutral", packet=packet)
+        summaries.append(_approval_summary(github))
+    assert len({s.splitlines()[0] for s in summaries}) == 3
+
+
+@pytest.mark.asyncio
+async def test_every_summary_carries_run_url_and_reviewed_sha(tmp_path: Path) -> None:
+    packet = _packet_with_findings([], verdict="success", reason="clean")
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
+    await report_status_checks(ctx, run_succeeded=True, packet=packet)
+    summary = _approval_summary(github)
+    assert RUN_URL in summary
+    assert REVIEWED_SHA in summary
+
+
+@pytest.mark.asyncio
+async def test_failed_check_run_post_emits_warning_and_annotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    warnings: list[str] = []
+    log_warnings: list[str] = []
+
+    import mergecraft.utils.gha_log as gha_log
+
+    monkeypatch.setattr(gha_log, "warning", lambda message: warnings.append(message))
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    github = _RecordingGitHub()
+    github.fail_next_approval_post = True
+    packet = _packet_with_findings([], verdict="success", reason="clean")
+
+    with logger.contextualize():
+        handler_id = logger.add(
+            lambda msg: log_warnings.append(msg.record["message"]), level="WARNING"
+        )
+
+    try:
+        ctx = _ctx(tmp_path, github=github)
+        await report_status_checks(ctx, run_succeeded=True, packet=packet)
+    finally:
+        logger.remove(handler_id)
+
+    captured = capsys.readouterr()
+    assert warnings, "expected ::warning:: annotation on failed approval post"
+    assert any(APPROVAL_CHECK in message for message in log_warnings)
+    assert re.search(r"::warning::", captured.out)
+
+
+@pytest.mark.asyncio
+async def test_successful_post_emits_one_info_line_per_check(tmp_path: Path) -> None:
+    packet = prepare_run_packet(_ctx(tmp_path), run_succeeded=True)
+    ctx = _ctx(tmp_path)
+    info_lines: list[str] = []
+    handler_id = logger.add(lambda msg: info_lines.append(msg.record["message"]), level="INFO")
+    try:
+        await report_status_checks(ctx, run_succeeded=True, packet=packet)
+    finally:
+        logger.remove(handler_id)
+    posted = [line for line in info_lines if "posted" in line and "check" in line]
+    assert len(posted) == 2
+
+
+@pytest.mark.asyncio
+async def test_post_failure_does_not_raise_into_run_outcome(tmp_path: Path) -> None:
+    github = _RecordingGitHub()
+    github.fail_next_approval_post = True
+    ctx = _ctx(tmp_path, github=github)
+    packet = _packet_with_findings([], verdict="success", reason="clean")
+    await report_status_checks(ctx, run_succeeded=True, packet=packet)

--- a/tests/review_record/test_w14_status_check_summaries.py
+++ b/tests/review_record/test_w14_status_check_summaries.py
@@ -107,9 +107,10 @@ async def test_zero_change_findings_never_claim_outstanding_feedback(tmp_path: P
         make_scoped_finding(scope="run", severity="Critical", rule_id="ignored-tool-error"),
     ]
     packet = _packet_with_findings(run_only, verdict="success", reason="run health advisory only")
-    ctx = _ctx(tmp_path)
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github=github)
     await report_status_checks(ctx, run_succeeded=True, packet=packet)
-    summary = _approval_summary(ctx.github)  # type: ignore[arg-type]
+    summary = _approval_summary(github)
     assert "outstanding review feedback" not in summary.lower()
 
 
@@ -168,7 +169,13 @@ async def test_failed_check_run_post_emits_warning_and_annotation(
 
     import mergecraft.utils.gha_log as gha_log
 
-    monkeypatch.setattr(gha_log, "warning", lambda message: warnings.append(message))
+    real_warning = gha_log.warning
+
+    def _spy_warning(message: str) -> None:
+        warnings.append(message)
+        real_warning(message)
+
+    monkeypatch.setattr(gha_log, "warning", _spy_warning)
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
     github = _RecordingGitHub()

--- a/tests/review_record/test_w15_deterministic_record.py
+++ b/tests/review_record/test_w15_deterministic_record.py
@@ -1,0 +1,191 @@
+"""W1.5 — deterministic sticky comment and review preamble (implementation W5)."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mergecraft.agents.gates import TRUSTED_PACKET_DECIDED_BY
+from mergecraft.evidence.build import build_packet
+from mergecraft.evidence.packet import Decision
+from mergecraft.findings import ledger
+from mergecraft.mcp import review as review_mod
+from tests.review_record.conftest import make_scoped_finding, require_symbol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.mcp.context import ToolContext
+
+_PREAMBLE_MARKER = "<!-- mergecraft-deterministic-record:v1 -->"
+
+
+def _renderer() -> Any:
+    return require_symbol(ledger, "render_deterministic_review_block")
+
+
+def _merge_preamble() -> Any:
+    return require_symbol(review_mod, "merge_deterministic_preamble_into_review_body")
+
+
+def _publish_deterministic_record() -> Any:
+    main = importlib.import_module("mergecraft.main")
+    return require_symbol(main, "publish_deterministic_record")
+
+
+def _sample_packet(*, findings: list[Any], verdict: str | None, reason: str) -> Any:
+    packet = build_packet(
+        change_id="acme/demo#546",
+        agent_id="claude",
+        agent_version="0.0.1",
+        model="claude-sonnet-4-5",
+        files_changed=["src/example.py"],
+        findings=findings,
+        deterministic_checks=[],
+        self_assessment={"would_approve": verdict == "success", "sha": "abc123"},
+    )
+    if verdict is not None:
+        packet.decision = Decision(
+            verdict=verdict,  # type: ignore[arg-type]
+            reason=reason,
+            decided_by=TRUSTED_PACKET_DECIDED_BY,
+        )
+    return packet
+
+
+@pytest.mark.parametrize(
+    ("verdict", "reason"),
+    [
+        ("success", "approved"),
+        (None, "provider_success_without_submission"),
+    ],
+    ids=["terminal_verdict", "no_verdict"],
+)
+@pytest.mark.asyncio
+async def test_deterministic_record_posts_on_every_resolved_pr(
+    tmp_path: Path,
+    verdict: str | None,
+    reason: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posts: list[str] = []
+
+    async def _upsert(_ctx: ToolContext, body: str) -> None:
+        posts.append(body)
+
+    monkeypatch.setattr(ledger, "upsert_sticky_progress_comment", _upsert)
+    publish = _publish_deterministic_record()
+    packet = _sample_packet(findings=[], verdict=verdict, reason=reason)
+    await publish(
+        pull_number=546,
+        packet=packet,
+        rejection_reason=None if verdict else reason,
+        tmpdir=str(tmp_path),
+    )
+    assert posts
+    assert _PREAMBLE_MARKER in posts[0]
+
+
+@pytest.mark.asyncio
+async def test_agent_approved_zero_findings_still_posts_deterministic_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posts: list[str] = []
+
+    async def _upsert(_ctx: ToolContext, body: str) -> None:
+        posts.append(body)
+
+    monkeypatch.setattr(ledger, "upsert_sticky_progress_comment", _upsert)
+    publish = _publish_deterministic_record()
+    packet = _sample_packet(findings=[], verdict="success", reason="approved")
+    await publish(
+        pull_number=546,
+        packet=packet,
+        rejection_reason=None,
+        tmpdir=str(tmp_path),
+    )
+    assert posts
+
+
+@pytest.mark.asyncio
+async def test_two_runs_edit_one_sticky_comment_in_place(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bodies: list[str] = []
+
+    async def _upsert(_ctx: ToolContext, body: str) -> None:
+        if bodies and ledger.is_sticky_progress_comment(bodies[-1]):
+            bodies[-1] = body
+        else:
+            bodies.append(body)
+
+    monkeypatch.setattr(ledger, "upsert_sticky_progress_comment", _upsert)
+    publish = _publish_deterministic_record()
+    packet = _sample_packet(findings=[], verdict="success", reason="approved")
+    for _ in range(2):
+        await publish(
+            pull_number=546,
+            packet=packet,
+            rejection_reason=None,
+            tmpdir=str(tmp_path),
+        )
+    assert len(bodies) == 1
+
+
+def test_review_body_contains_preamble_when_agent_body_empty() -> None:
+    renderer = _renderer()
+    merge = _merge_preamble()
+    packet = _sample_packet(findings=[], verdict="success", reason="approved")
+    block = renderer(packet=packet, rejection_reason=None, run_url="https://example.test/run")
+    merged = merge(agent_body="", deterministic_block=block)
+    assert _PREAMBLE_MARKER in merged
+    assert merged.strip()
+
+
+def test_agent_cannot_suppress_preamble_by_duplicating_markers() -> None:
+    renderer = _renderer()
+    merge = _merge_preamble()
+    packet = _sample_packet(findings=[], verdict="success", reason="approved")
+    block = renderer(packet=packet, rejection_reason=None, run_url="https://example.test/run")
+    forged = f"{_PREAMBLE_MARKER}\nno issues"
+    merged = merge(agent_body=forged, deterministic_block=block)
+    assert merged.count(_PREAMBLE_MARKER) == 1
+    assert "no issues" not in merged.split(_PREAMBLE_MARKER, maxsplit=1)[0]
+
+
+def test_preamble_renders_packet_critical_not_agent_narrative() -> None:
+    renderer = _renderer()
+    critical = make_scoped_finding(
+        scope="change",
+        severity="Critical",
+        introduced_by_pr="true",
+        message="Unchecked null dereference.",
+        rule_id="AGENT-CRIT",
+    )
+    packet = _sample_packet(findings=[critical], verdict="failure", reason="blocker")
+    rendered = renderer(packet=packet, rejection_reason=None, run_url="https://example.test/run")
+    assert critical.message in rendered
+    assert "no issues" not in rendered.lower()
+    merged = _merge_preamble()(
+        agent_body="Everything looks fine — no issues.", deterministic_block=rendered
+    )
+    assert critical.message in merged
+
+
+def test_run_scoped_findings_render_under_collapsed_heading() -> None:
+    renderer = _renderer()
+    run_health = make_scoped_finding(
+        scope="run",
+        severity="Major",
+        rule_id="ignored-tool-error",
+        message="bubblewrap namespace unavailable",
+    )
+    packet = _sample_packet(findings=[run_health], verdict="success", reason="advisory only")
+    rendered = renderer(packet=packet, rejection_reason=None, run_url="https://example.test/run")
+    assert "<details>" in rendered
+    assert "run health" in rendered.lower()
+    assert run_health.message in rendered

--- a/tests/review_record/test_w16_anchor_422_recovery.py
+++ b/tests/review_record/test_w16_anchor_422_recovery.py
@@ -24,6 +24,7 @@ class _RecordingGitHub(GitHubClient):
         self, *, reject_all_comments: bool = False, approve_rejected: bool = False
     ) -> None:
         super().__init__(token="test-token")
+        self.review_payload: dict[str, Any] = {}
         self.review_payloads: list[dict[str, Any]] = []
         self.reject_all_comments = reject_all_comments
         self.approve_rejected = approve_rejected
@@ -31,6 +32,7 @@ class _RecordingGitHub(GitHubClient):
     async def create_review(
         self, owner: str, repo: str, pull_number: int, **payload: Any
     ) -> dict[str, Any]:
+        self.review_payload = payload
         self.review_payloads.append(payload)
         if self.approve_rejected and payload.get("event") == "APPROVE":
             request = httpx.Request("POST", "https://api.github.com/reviews")

--- a/tests/review_record/test_w16_anchor_422_recovery.py
+++ b/tests/review_record/test_w16_anchor_422_recovery.py
@@ -1,0 +1,156 @@
+"""W1.6 — inline anchor pre-validation and 422 recovery (#530, implementation W6)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from loguru import logger
+
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.review import create_pull_request_review_tool
+from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+from tests.support.tool_context import bind_review_publication_scope, github_client_from_ctx
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _RecordingGitHub(GitHubClient):
+    def __init__(
+        self, *, reject_all_comments: bool = False, approve_rejected: bool = False
+    ) -> None:
+        super().__init__(token="test-token")
+        self.review_payloads: list[dict[str, Any]] = []
+        self.reject_all_comments = reject_all_comments
+        self.approve_rejected = approve_rejected
+
+    async def create_review(
+        self, owner: str, repo: str, pull_number: int, **payload: Any
+    ) -> dict[str, Any]:
+        self.review_payloads.append(payload)
+        if self.approve_rejected and payload.get("event") == "APPROVE":
+            request = httpx.Request("POST", "https://api.github.com/reviews")
+            response = httpx.Response(422, request=request, json={"message": "Unprocessable"})
+            raise httpx.HTTPStatusError("422", request=request, response=response)
+        if self.reject_all_comments and payload.get("comments"):
+            request = httpx.Request("POST", "https://api.github.com/reviews")
+            response = httpx.Response(
+                422,
+                request=request,
+                json={
+                    "message": "Validation Failed",
+                    "errors": [{"field": "comments", "code": "invalid"}],
+                },
+            )
+            raise httpx.HTTPStatusError("422", request=request, response=response)
+        return {
+            "id": 1,
+            "node_id": "n1",
+            "html_url": "https://x/1",
+            "state": payload.get("event", "COMMENTED"),
+        }
+
+
+def _ctx(tmp_path: Path, github: _RecordingGitHub) -> ToolContext:
+    tool_ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="unknown")),
+        github=github,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        pr_approve_enabled=True,
+    )
+    bind_review_publication_scope(tool_ctx)
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text(
+        "diff --git a/src/in_diff.py b/src/in_diff.py\n@@ -8,3 +8,4 @@\n context\n+added\n",
+        encoding="utf-8",
+    )
+    primary_repo_state(tool_ctx.tool_state).diff_path = str(diff_path)
+    return tool_ctx
+
+
+@pytest.mark.asyncio
+async def test_out_of_diff_inline_comment_is_dropped_before_post(
+    tmp_path: Path,
+) -> None:
+    github = _RecordingGitHub()
+    ctx = _ctx(tmp_path, github)
+    warnings: list[str] = []
+    handler_id = logger.add(lambda msg: warnings.append(msg.record["message"]), level="WARNING")
+    try:
+        spec = create_pull_request_review_tool(ctx)
+        await spec.execute(
+            {
+                "pull_number": 7,
+                "body": "Review body",
+                "comments": [{"path": "src/off_diff.py", "line": 999, "body": "Outside diff."}],
+            }
+        )
+    finally:
+        logger.remove(handler_id)
+    payload = github_client_from_ctx(ctx).review_payload  # type: ignore[attr-defined]
+    comments = list(payload.get("comments") or [])
+    assert comments == []
+    assert warnings, "dropping an invalid anchor must be logged"
+
+
+@pytest.mark.asyncio
+async def test_request_changes_422_does_not_propagate_to_agent(tmp_path: Path) -> None:
+    github = _RecordingGitHub(reject_all_comments=True)
+    ctx = _ctx(tmp_path, github)
+    spec = create_pull_request_review_tool(ctx)
+    result = await spec.execute(
+        {
+            "pull_number": 7,
+            "body": "Please fix.",
+            "approved": False,
+            "request_changes": True,
+            "comments": [{"path": "src/in_diff.py", "line": 10, "body": "Bug."}],
+        }
+    )
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio
+async def test_all_anchors_rejected_still_posts_body_and_verdict(tmp_path: Path) -> None:
+    github = _RecordingGitHub(reject_all_comments=True)
+    ctx = _ctx(tmp_path, github)
+    spec = create_pull_request_review_tool(ctx)
+    await spec.execute(
+        {
+            "pull_number": 7,
+            "body": "Verdict body must survive.",
+            "approved": False,
+            "request_changes": True,
+            "comments": [{"path": "src/in_diff.py", "line": 10, "body": "Bug."}],
+        }
+    )
+    assert github.review_payloads
+    final = github.review_payloads[-1]
+    assert final.get("body")
+    assert final.get("event") == "REQUEST_CHANGES"
+    assert not final.get("comments")
+
+
+@pytest.mark.asyncio
+async def test_approve_comment_422_fallback_still_works(tmp_path: Path) -> None:
+    github = _RecordingGitHub(approve_rejected=True)
+    ctx = _ctx(tmp_path, github)
+    spec = create_pull_request_review_tool(ctx)
+    result = await spec.execute({"pull_number": 7, "body": "Looks good.", "approved": True})
+    assert result.is_error is False
+    assert github.review_payloads[0]["event"] == "APPROVE"
+    assert github.review_payloads[1]["event"] == "COMMENT"
+    assert ctx.tool_state.approval is not None
+    assert ctx.tool_state.approval.would_approve is True

--- a/tests/review_record/test_w17_packet_artifact_summary.py
+++ b/tests/review_record/test_w17_packet_artifact_summary.py
@@ -1,0 +1,146 @@
+"""W1.7 — evidence packet run_health, step summary, workflow artifact (implementation W7)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+from mergecraft.evidence.packet import PACKET_SCHEMA_VERSION, MergeEvidencePacket
+from mergecraft.evidence.run_packet import emit_run_packet, prepare_run_packet
+from mergecraft.main import MainResult
+from tests.ci.workflow_support import read_text
+from tests.evidence.test_run_packet import _make_ctx
+from tests.review_record.conftest import make_scoped_finding, require_symbol
+
+_STEP_SUMMARY_CAP = 1_048_576
+
+
+def _step_summary_module() -> Any:
+    return importlib.import_module("mergecraft.utils.step_summary")
+
+
+def test_packet_run_health_round_trips_and_schema_version_bumps() -> None:
+    run_health = {
+        "findings": [
+            make_scoped_finding(
+                scope="run",
+                severity="Major",
+                rule_id="ignored-tool-error",
+                message="bubblewrap unavailable",
+            ).model_dump()
+        ],
+        "conclusion": "advisory",
+    }
+    payload = {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "change_id": "acme/demo#546",
+        "agent": {
+            "agent_id": "claude",
+            "agent_version": "0.0.1",
+            "model": "claude-sonnet-4-5",
+        },
+        "files_changed": [],
+        "findings": [],
+        "deterministic_checks": [],
+        "run_health": run_health,
+    }
+    packet = MergeEvidencePacket.model_validate(payload)
+    assert packet.run_health is not None
+    assert packet.run_health.findings
+    assert packet.schema_version != "1.10.0"
+
+
+def test_step_summary_written_on_success_failure_and_no_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    step_summary = _step_summary_module()
+    render = require_symbol(step_summary, "render_step_summary")
+    append = require_symbol(step_summary, "append_step_summary")
+    packet = prepare_run_packet(_make_ctx(tmp_path), run_succeeded=True)
+    for label, rejection in [
+        ("success", None),
+        ("failure", "provider_failure"),
+        ("no_verdict", "schema_invalid"),
+    ]:
+        body = render(packet=packet, outcome_label=label, rejection_reason=rejection)
+        append(body)
+    text = summary_path.read_text(encoding="utf-8")
+    assert "success" in text
+    assert "failure" in text
+    assert "schema_invalid" in text
+
+
+def test_step_summary_truncates_findings_not_header(tmp_path: Path) -> None:
+    step_summary = _step_summary_module()
+    render = require_symbol(step_summary, "render_step_summary")
+    findings = [
+        make_scoped_finding(
+            scope="change",
+            severity="Major",
+            introduced_by_pr="true",
+            message=f"finding-{index}",
+            rule_id=f"RULE-{index}",
+        )
+        for index in range(5000)
+    ]
+    packet = prepare_run_packet(_make_ctx(tmp_path), run_succeeded=True)
+    packet.findings.extend(findings)
+    body = render(packet=packet, outcome_label="success", rejection_reason=None)
+    assert len(body.encode("utf-8")) <= _STEP_SUMMARY_CAP
+    assert body.splitlines()[0].startswith("# mergeCraft")
+
+
+def test_evidence_packet_output_nonempty_for_pr_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mergecraft.cli.gha_cmd import _run_main
+
+    output_file = tmp_path / "gh_output"
+    output_file.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    async def _fake_main() -> MainResult:
+        ctx = _make_ctx(tmp_path)
+        packet = prepare_run_packet(ctx, run_succeeded=True)
+        written = emit_run_packet(ctx, packet=packet)
+        return MainResult(success=True, result="ok", evidence_packet_path=str(written))
+
+    import mergecraft.main as main_mod
+
+    monkeypatch.setattr(main_mod, "main", _fake_main)
+    asyncio.run(_run_main())
+    written = output_file.read_text(encoding="utf-8")
+    assert "evidence_packet" in written
+    assert '"schema_version"' in written
+
+
+def test_mergecraft_workflow_persists_packet_via_env_not_inline_interpolation() -> None:
+    workflow = yaml.safe_load(read_text(".github/workflows/mergecraft.yml"))
+    steps = []
+    for job in (workflow.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            name = str(step.get("name") or "")
+            if "Persist evidence packet" in name or "evidence packet" in name.lower():
+                steps.append(step)
+    assert steps, "expected an always() packet persistence step in mergecraft.yml"
+    for step in steps:
+        assert step.get("if") == "always()"
+        env = step.get("env") or {}
+        assert "PACKET" in env
+        assert "${{" in str(env["PACKET"])
+        run_body = str(step.get("run") or "")
+        assert "${{" not in run_body or "$PACKET" in run_body

--- a/tests/review_record/test_w17_packet_artifact_summary.py
+++ b/tests/review_record/test_w17_packet_artifact_summary.py
@@ -43,8 +43,8 @@ def test_packet_run_health_round_trips_and_schema_version_bumps() -> None:
         "schema_version": PACKET_SCHEMA_VERSION,
         "change_id": "acme/demo#546",
         "agent": {
-            "agent_id": "claude",
-            "agent_version": "0.0.1",
+            "id": "claude",
+            "version": "0.0.1",
             "model": "claude-sonnet-4-5",
         },
         "files_changed": [],

--- a/tests/review_record/test_w18_action_pin_gate.py
+++ b/tests/review_record/test_w18_action_pin_gate.py
@@ -1,0 +1,52 @@
+"""W1.8 — action pin gate wired into ci-static (#532, implementation W8)."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.pins.test_action_pin_freshness import _load, _workflow_text
+
+_SHA_A = "0592d72828797005fdc5af1da9e413b0a98bd8a0"
+_SHA_B = "cfa36704cf6c58a6abe895e539a377c4599fa4bd"
+_WORKFLOW = ".github/workflows/mergecraft.yml"
+
+
+def _makefile_text() -> str:
+    return (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+
+def test_make_ci_static_invokes_action_pin_check() -> None:
+    makefile = _makefile_text()
+    ci_static_line = next(line for line in makefile.splitlines() if line.startswith("ci-static:"))
+    assert "action-pin-check" in ci_static_line
+    ci_steps = next(line for line in makefile.splitlines() if line.startswith("CI_STEPS :="))
+    assert "action-pin-check" in ci_steps
+
+
+def test_ci_yml_fails_on_stale_pin_instead_of_warning_only() -> None:
+    ci_yml = read_text(".github/workflows/ci.yml")
+    assert 'echo "::warning title=mergecraft action pin drift::' not in ci_yml
+    assert "make action-pin-check" in ci_yml
+    assert "exit 1" in ci_yml or "exit $?" in ci_yml
+
+
+def test_mergecraft_workflow_three_rungs_share_one_pin_value() -> None:
+    text = read_text(_WORKFLOW)
+    pins = re.findall(r"uses:\s+alexhawat/mergeCraft@([0-9a-f]{40})", text)
+    assert len(pins) >= 3
+    assert len(set(pins)) == 1
+
+
+def test_partial_pin_bump_fails_action_pin_check(tmp_path: Path) -> None:
+    module = _load()
+    drifted = tmp_path / "mergecraft.yml"
+    drifted.write_text(_workflow_text(_SHA_A, _SHA_B), encoding="utf-8")
+    pins = module._pins_in(drifted.read_text(encoding="utf-8"))
+    failures = module._check_self_consistency(_WORKFLOW, pins)
+    assert failures
+    assert "different Action pins" in failures[0]


### PR DESCRIPTION
## What?

Review runs now leave a consistent, auditable record on the pull request and in workflow artifacts, so merge gates and sticky feedback match what actually happened in the run.

- Findings carry an in-scope vs out-of-scope distinction with one shared rule for what blocks merge.
- Trajectory problems are classified before they feed counts that drive the verdict.
- GitHub status checks summarize the bound evidence packet instead of generic placeholders.
- Sticky comments and review preambles are stable across reruns on the same pull request.
- Inline comment anchors that GitHub rejects with 422 are recovered instead of aborting the review.
- Run health, step summaries, and evidence artifacts expose outcome and debugging detail in CI.
- Workflows enforce fresh action version pins and matching image digests.

## Why?

Maintainers decide whether to merge from checks, comment threads, and artifact trails. When blocking counts disagree with the evidence, status text lies about packet state, or a single bad anchor kills the run, those signals cannot be trusted. Unpinned or digest-mismatched Action images let repos drift onto stale review behavior without a visible failure.

## Note

#526 and #528 were handled in wave 8 and are not part of this branch.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/review_record -q`
- [ ] `MERGECRAFT_PYTEST_JOBS=0 uv run pytest tests/ci/test_action_image_digest_check.py tests/pins/test_action_image_digest_sync.py -q`

## Related PR(s)/Issue(s)

Closes #530
Closes #532
