### PR TITLE
fix(agents): pass --verbose so claude accepts stream-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Claude driver: pass ``--verbose`` alongside ``--print
+  --output-format=stream-json``. The CLI refuses that pair without it and exits
+  1 before emitting a single event, so the Claude backstop failed on every run
+  it was ever asked to handle; the failure only became legible once zero-event
+  runs began reporting their stderr (#557)
 - Enforcement modes and the approval gate now agree on what blocks. The
   gate-facing severity is the single authority, so ``contributes_blocker`` is
   read off it rather than computed beside it. ``blocking`` floors a

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -768,6 +768,11 @@ def _run_claude_once(
     cmd = [
         cli,
         "--print",
+        # The CLI refuses `--print --output-format=stream-json` without
+        # `--verbose` ("requires --verbose") and exits 1 before emitting a
+        # single event, so the whole run reads as "no events". Keep these
+        # three together; dropping --verbose silently kills the backstop.
+        "--verbose",
         "--output-format",
         "stream-json",
         "--mcp-config",

--- a/tests/agents/test_claude_cli_flag_contract.py
+++ b/tests/agents/test_claude_cli_flag_contract.py
@@ -1,0 +1,129 @@
+"""The claude CLI refuses ``--print --output-format=stream-json`` without ``--verbose``.
+
+Reproduced against claude-code 2.1.251::
+
+    $ claude --print --output-format stream-json
+    Error: When using --print, --output-format=stream-json requires --verbose
+
+The CLI exits 1 before emitting a single event, so the driver saw an empty
+stream and the run read as "produced no events". The flag had never been
+passed, which means the Claude backstop had never worked; run 33260176539
+(PR #562) is the first one to say so out loud, because the zero-event
+diagnostics landed first and surfaced the stderr.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.agents.claude import _run_claude_once
+from mergecraft.agents.shared import AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import PayloadEvent, ResolvedPayload
+from mergecraft.mcp.tool_state import init_tool_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _run_ctx(tmp_path: Path) -> AgentRunContext:
+    return AgentRunContext(
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request")),
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(user="review this diff"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        resolved_model="anthropic/claude-sonnet-5",
+    )
+
+
+class _EmptyProcess:
+    def __init__(self) -> None:
+        self.stdout = iter(())
+        self.stderr = _Reader("")
+        self.pid = 4242
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+    def poll(self) -> int:
+        return 0
+
+    def kill(self) -> None:  # pragma: no cover - not reached
+        return None
+
+
+class _Reader:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+def _noop_ctx(*_a: Any, **_k: Any) -> Any:
+    from contextlib import nullcontext
+
+    return nullcontext()
+
+
+def _captured_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Run the driver against a stub CLI and return the argv it actually built."""
+    module = importlib.import_module("mergecraft.agents.claude")
+    seen: list[list[str]] = []
+
+    def _spawn(cmd: list[str], **_k: Any) -> _EmptyProcess:
+        seen.append(list(cmd))
+        return _EmptyProcess()
+
+    monkeypatch.setattr(module, "spawn_agent_cli", _spawn)
+    monkeypatch.setattr(module, "track_process_group", _noop_ctx)
+    monkeypatch.setattr(module, "wait_or_kill_process_group", lambda proc, timeout: proc.wait())
+
+    _run_claude_once(
+        cli="/usr/bin/claude",
+        prompt="review this diff",
+        ctx=_run_ctx(tmp_path),
+        mcp_config=str(tmp_path / "mcp.json"),
+    )
+    assert seen, "driver never spawned the CLI"
+    return seen[0]
+
+
+def test_stream_json_invocation_passes_verbose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without this flag the CLI exits 1 and the backstop is dead on arrival."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    assert "--print" in argv
+    assert "stream-json" in argv
+    assert "--verbose" in argv, (
+        "claude refuses --print with --output-format=stream-json unless --verbose "
+        f"is present; argv was {argv!r}"
+    )
+
+
+def test_output_format_is_still_stream_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--verbose must be added beside stream-json, not instead of it."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+
+
+def test_verbose_never_ships_without_the_flags_that_require_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three flags are one contract: whenever the pair appears, so does --verbose."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    requires_verbose = "--print" in argv and "stream-json" in argv
+    assert requires_verbose is ("--verbose" in argv)


### PR DESCRIPTION
## What?

The Claude backstop can now actually run a review. It passes `--verbose`, which the CLI requires whenever `--print` and `--output-format=stream-json` are used together.

## Why?

The last rung of the model chain has never completed a review. The CLI rejects that flag combination and exits 1 before emitting a single event, so the driver read an empty stream and reported `claude CLI produced no events`. Every fallback that reached Claude died instantly, and the run ended with no verdict rather than a degraded one.

Reproduced directly against claude-code 2.1.251:

```
$ claude --print --output-format stream-json
Error: When using --print, --output-format=stream-json requires --verbose

$ claude --print --output-format stream-json --verbose
{"type":"system","subtype":"init",...}
```

`git log -S'--verbose'` on the driver returns nothing: the flag was never there. This is not a regression from the recent CLI bump to 2.1.240 — PR #525's run 33208727218 failed with the same empty-stream signature back when the driver still discarded the exit code.

It only became diagnosable now. #557 taught zero-event runs to report their exit code and stderr tail, and the pin moved to `16ce0441`; the very next run to reach the backstop, 33260176539 on #562, printed the real cause instead of the symptom.

## Note

Three tests pin the flag as one contract rather than asserting a literal argv: `--verbose` must be present whenever `--print` and `stream-json` both are, `--output-format` must still be `stream-json`, and the two must move together. They capture the argv the driver really builds by stubbing `spawn_agent_cli`, so a refactor that drops the flag fails rather than silently killing the backstop again.

`gemini.py` also emits `stream-json`, but that is a different CLI with its own flag rules and is deliberately untouched.

This is product code behind the pinned Action, so it changes nothing for CI until it reaches the default branch and the pin moves — the same chain #557 needed. Until then every review that falls through to Claude keeps failing, including #562.

## Test plan

- `uv run pytest tests/agents tests/tracing/streaming` (780 passed)
- 2 of the 3 new tests fail against the unfixed driver
- `ruff check`, `ruff format --check`, `mypy` clean on the touched files

## Related PR(s)/Issue(s)

Refs #557
