### PR TITLE
chore: promote the claude CLI fix to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,7 +93,7 @@ jobs:
       analyzers_ref: ${{ steps.meta.outputs.analyzers_ref }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -137,7 +137,7 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -212,7 +212,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -354,8 +354,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Build action image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Build slim
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build production image (PR artifact)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build production image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Claude driver: pass ``--verbose`` alongside ``--print
+  --output-format=stream-json``. The CLI refuses that pair without it and exits
+  1 before emitting a single event, so the Claude backstop failed on every run
+  it was ever asked to handle; the failure only became legible once zero-event
+  runs began reporting their stderr (#557)
 - Enforcement modes and the approval gate now agree on what blocks. The
   gate-facing severity is the single authority, so ``contributes_blocker`` is
   read off it rather than computed beside it. ``blocking`` floors a

--- a/src/mergecraft/agents/claude.py
+++ b/src/mergecraft/agents/claude.py
@@ -768,6 +768,11 @@ def _run_claude_once(
     cmd = [
         cli,
         "--print",
+        # The CLI refuses `--print --output-format=stream-json` without
+        # `--verbose` ("requires --verbose") and exits 1 before emitting a
+        # single event, so the whole run reads as "no events". Keep these
+        # three together; dropping --verbose silently kills the backstop.
+        "--verbose",
         "--output-format",
         "stream-json",
         "--mcp-config",

--- a/tests/agents/test_claude_cli_flag_contract.py
+++ b/tests/agents/test_claude_cli_flag_contract.py
@@ -1,0 +1,129 @@
+"""The claude CLI refuses ``--print --output-format=stream-json`` without ``--verbose``.
+
+Reproduced against claude-code 2.1.251::
+
+    $ claude --print --output-format stream-json
+    Error: When using --print, --output-format=stream-json requires --verbose
+
+The CLI exits 1 before emitting a single event, so the driver saw an empty
+stream and the run read as "produced no events". The flag had never been
+passed, which means the Claude backstop had never worked; run 33260176539
+(PR #562) is the first one to say so out loud, because the zero-event
+diagnostics landed first and surfaced the stderr.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.agents.claude import _run_claude_once
+from mergecraft.agents.shared import AgentRunContext, ResolvedInstructions
+from mergecraft.mcp.context import PayloadEvent, ResolvedPayload
+from mergecraft.mcp.tool_state import init_tool_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _run_ctx(tmp_path: Path) -> AgentRunContext:
+    return AgentRunContext(
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request")),
+        mcp_server_url="http://127.0.0.1:0/mcp",
+        tmpdir=str(tmp_path),
+        subagent_denied_tools=(),
+        instructions=ResolvedInstructions(user="review this diff"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        resolved_model="anthropic/claude-sonnet-5",
+    )
+
+
+class _EmptyProcess:
+    def __init__(self) -> None:
+        self.stdout = iter(())
+        self.stderr = _Reader("")
+        self.pid = 4242
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+    def poll(self) -> int:
+        return 0
+
+    def kill(self) -> None:  # pragma: no cover - not reached
+        return None
+
+
+class _Reader:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+def _noop_ctx(*_a: Any, **_k: Any) -> Any:
+    from contextlib import nullcontext
+
+    return nullcontext()
+
+
+def _captured_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Run the driver against a stub CLI and return the argv it actually built."""
+    module = importlib.import_module("mergecraft.agents.claude")
+    seen: list[list[str]] = []
+
+    def _spawn(cmd: list[str], **_k: Any) -> _EmptyProcess:
+        seen.append(list(cmd))
+        return _EmptyProcess()
+
+    monkeypatch.setattr(module, "spawn_agent_cli", _spawn)
+    monkeypatch.setattr(module, "track_process_group", _noop_ctx)
+    monkeypatch.setattr(module, "wait_or_kill_process_group", lambda proc, timeout: proc.wait())
+
+    _run_claude_once(
+        cli="/usr/bin/claude",
+        prompt="review this diff",
+        ctx=_run_ctx(tmp_path),
+        mcp_config=str(tmp_path / "mcp.json"),
+    )
+    assert seen, "driver never spawned the CLI"
+    return seen[0]
+
+
+def test_stream_json_invocation_passes_verbose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without this flag the CLI exits 1 and the backstop is dead on arrival."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    assert "--print" in argv
+    assert "stream-json" in argv
+    assert "--verbose" in argv, (
+        "claude refuses --print with --output-format=stream-json unless --verbose "
+        f"is present; argv was {argv!r}"
+    )
+
+
+def test_output_format_is_still_stream_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--verbose must be added beside stream-json, not instead of it."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+
+
+def test_verbose_never_ships_without_the_flags_that_require_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three flags are one contract: whenever the pair appears, so does --verbose."""
+    argv = _captured_argv(tmp_path, monkeypatch)
+
+    requires_verbose = "--print" in argv and "stream-json" in argv
+    assert requires_verbose is ("--verbose" in argv)


### PR DESCRIPTION
## What?

Promotes the Claude CLI fix (#563) and the GitHub Actions bumps (#511) to the default branch.

`main` is an ancestor of `pre-0.0.1`, so this is a fast-forward with nothing to resolve.

## Why?

The Claude backstop has never completed a review. The CLI rejects `--print --output-format=stream-json` unless `--verbose` is passed, and exits 1 before emitting any event, so every fallback that reached the last rung of the model chain died instantly and the run finished with no verdict rather than a degraded one. That fix is on the integration branch and cannot affect a single review until it reaches the default branch, because the workflow resolves the Action from a pin here.

PR #562 is the current cost: all three rungs ran, Nous and Codex produced no terminal verdict, the cascade reached Claude, and the approval check went neutral with "review did not complete". Every review that falls through keeps failing the same way until this lands and the pin moves.

## Note

The pin still reads `16ce0441`, which predates #560, #561 and now #563. It needs a bump to this merge afterwards or nothing here takes effect — the same self-referential follow-up every promotion in this sequence has needed.

Verified before opening: `mergecraft.yml` keeps the job-token check-run posts (3 occurrences, no reviewer PAT), keeps the `workflow_dispatch` PR resolution with the ref passed through step env rather than template expansion, and the driver on this head carries the `--verbose` flag. #511 touches `ci-cd.yml`, `ci.yml`, `docker.yml` and `e2e.yml` only — mechanical action-SHA bumps, nothing in the review workflow.

## Related PR(s)/Issue(s)

Depends on #563
