### PR TITLE
ci: bump the reviewer action pin past the claude CLI fix

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -578,7 +578,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@53a657fbfef0aaaf2a5e2608020cd92b105754b7 # main (PR #564)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -726,7 +726,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@53a657fbfef0aaaf2a5e2608020cd92b105754b7 # main (PR #564)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -837,7 +837,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@16ce04413932eb74957d394d2aa376b2af39f0b8 # main (PR #558)
+        uses: alexhawat/mergeCraft@53a657fbfef0aaaf2a5e2608020cd92b105754b7 # main (PR #564)
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Moves the three reviewer Action pins from `16ce0441` to `53a657fb`.

## Why?

The pin is what decides which image a review actually runs, and the current one predates every fix landed since the last promotion. Three of them change what a review can do:

- The Claude backstop can run at all. Without `--verbose` the CLI rejects `--print --output-format=stream-json` and exits 1 before emitting an event, so the last rung of the model chain has never completed a review (#563)
- A manual dispatch reviews the branch's open PR instead of nothing in particular, and a branch name carrying shell syntax stays data rather than executing under the job's write-scoped token (#561)
- Enforcement modes and the approval gate agree on what blocks, so a `blocking` rule blocks and a `warning` rule does not (#559)

PR #562 shows the cost of leaving it: all three rungs ran, Nous and Codex returned no terminal verdict, the cascade reached Claude, and the approval check went neutral with "review did not complete". Every review that falls through fails the same way until this lands.

## Note

Depends on #564, and must merge after it.

The pin target is #563's merge commit on `pre-0.0.1` rather than #564's future merge commit, which does not exist yet. It carries all four fixes — verified `7cb77881` (#557), `0067ad0a` (#559), `d7646ff1` (#561) and `efcb0d4a` (#563) are all ancestors of it, and the driver at that SHA has the flag. Once #564 fast-forwards `main`, `53a657fb` is an ancestor of the default branch, which is what the pin contract requires.

Self-referential as always: this PR is reviewed by the pin it replaces, so its own review still runs the old image and will still fail at the backstop if it gets that far. The new pin takes effect for the next review after merge.

#564 does not touch `mergecraft.yml`, so this does not conflict with it.

## Test plan

- Diff is 3 lines, one per rung; no other file touched
- Pin target verified to contain #557, #559, #561 and #563 by ancestry, and to carry `--verbose` in the driver

## Related PR(s)/Issue(s)

Depends on #564
