### PR TITLE
ci: bump the reviewer action pin to the three-plan promotion

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -627,14 +627,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_nous.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-nous.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-nous.json"
 
       - name: Upload packet artifact (Nous)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-nous
-          path: packet-nous.json
+          path: ${{ runner.temp }}/packet-nous.json
           retention-days: 30
           if-no-files-found: ignore
 
@@ -784,14 +794,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_codex.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-codex.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-codex.json"
 
       - name: Upload packet artifact (Codex)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-codex
-          path: packet-codex.json
+          path: ${{ runner.temp }}/packet-codex.json
           retention-days: 30
           if-no-files-found: ignore
 
@@ -917,14 +937,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_claude.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-claude.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-claude.json"
 
       - name: Upload packet artifact (Claude)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-claude
-          path: packet-claude.json
+          path: ${{ runner.temp }}/packet-claude.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "fcb64c11d839d8ff4cf18bb925362080873df067"
+  MERGECRAFT_ACTION_SHA: "695d34b0979a84f5c3cea53f12c624f9e9f27521"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -757,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -894,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:1976f3a5069ae417c02d7bed5230bc476a11ff4ac2a5c5de12bdeee00b73e938"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:6abb15c12f0c484159dbf7241845118b4c470723700cea7144b488e23bf1ccac"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Bumps the self-review Action pin from `fcb64c11` (plan 12 only) to `695d34b0`, the promotion merge that carries plans 11, 12 and 13.

## Why this is against `pre-0.0.1` and not `main`

`main`'s CI/CD is currently red on the repo's own staleness gate:

```
action-pin-check FAILED:
  pin fcb64c11d839 lags main by 35 commits touching src/mergecraft/ (max 5).
  The reviewer is not running the product code on main. Bump the pin.
```

The gate is correct — after #575 promoted three wave plans, the reviewer runs none of them. But the failure is inside `Full verify`, which gates `Build GHCR images`, so no image was published for `695d34b0`, and without an image the pin cannot be bumped. The gate blocks the job that would satisfy it.

`action-slim-bootstrap` exists for exactly this. It runs on a `pull_request` based on `pre-0.0.1`, *before* `Full verify`, reads `MERGECRAFT_ACTION_SHA` from this branch, and when the tag is missing checks out **that SHA** and builds its `Dockerfile`. The published image therefore corresponds to the pin, not to this branch.

Confirmed missing on GHCR before opening this: `695d34b0`, `63e4d8a8`, `22621515`, `75cec782` — every SHA carrying all three plans. Only `fcb64c11` has an image.

## Sequence

1. **This commit** — `MERGECRAFT_ACTION_SHA` plus all three mirrored `uses:` rungs move to `695d34b0`. `action-slim-bootstrap` publishes the slim image for that SHA.
2. **Follow-up commit on this branch** — `action.yml`'s `runs.image` digest updated to whatever GHCR then serves for `695d34b0`. The digest is unknowable until step 1 has run, which is why the two are split.
3. **After merge** — a small promotion carries the pin to `main`, which is what actually changes reviews and turns `main`'s CI/CD green again.

`check_action_image_digest.py` skips GHCR parity while the tag is unpublished and enforces it once bootstrap has pushed, so this branch is not red in the interim — but it is **not mergeable until step 2 lands**, or the Action would resolve a digest that no longer matches its pin.

## Verified locally

- `check_action_pin_freshness.py` — OK. Self-consistency across all three rungs; `main`'s pin `fcb64c11` is an ancestor of `695d34b0`; staleness lag against `main`'s tip is 0.
- `.github/workflows/mergecraft.yml` parses as YAML.
