### PR TITLE
ci: promote the action pin, image digest, and packet fix to main

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -627,14 +627,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_nous.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-nous.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-nous.json"
 
       - name: Upload packet artifact (Nous)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-nous
-          path: packet-nous.json
+          path: ${{ runner.temp }}/packet-nous.json
           retention-days: 30
           if-no-files-found: ignore
 
@@ -784,14 +794,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_codex.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-codex.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-codex.json"
 
       - name: Upload packet artifact (Codex)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-codex
-          path: packet-codex.json
+          path: ${{ runner.temp }}/packet-codex.json
           retention-days: 30
           if-no-files-found: ignore
 
@@ -917,14 +937,24 @@ jobs:
         if: always()
         env:
           PACKET: ${{ steps.mergecraft_claude.outputs.evidence_packet }}
-        run: printf '%s' "$PACKET" > packet-claude.json
+        run: |
+          # $GITHUB_WORKSPACE is created by the Action container's volume
+          # mount and owned by root — this job never checks out, so no
+          # runner-owned directory exists there. Writing the packet into
+          # the workspace fails with "Permission denied"; $RUNNER_TEMP is
+          # always writable by the runner user.
+          if [ -z "${PACKET:-}" ]; then
+            echo "no evidence packet emitted by this rung; nothing to persist"
+            exit 0
+          fi
+          printf '%s' "$PACKET" > "$RUNNER_TEMP/packet-claude.json"
 
       - name: Upload packet artifact (Claude)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mergecraft-evidence-claude
-          path: packet-claude.json
+          path: ${{ runner.temp }}/packet-claude.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "fcb64c11d839d8ff4cf18bb925362080873df067"
+  MERGECRAFT_ACTION_SHA: "695d34b0979a84f5c3cea53f12c624f9e9f27521"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -757,7 +757,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -894,7 +894,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@fcb64c11d839d8ff4cf18bb925362080873df067 # env.MERGECRAFT_ACTION_SHA / PR #562
+        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:1976f3a5069ae417c02d7bed5230bc476a11ff4ac2a5c5de12bdeee00b73e938"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:6abb15c12f0c484159dbf7241845118b4c470723700cea7144b488e23bf1ccac"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Carries the action pin, its matching image digest, and the evidence-packet fix to `main`. This is the step that makes plans 11, 12 and 13 reach an actual review, and it takes `main`'s CI/CD out of failure.

## Why `main` is currently red

#575 promoted three wave plans, which put the pin 35 `src/mergecraft/` commits behind `main` — past the ceiling of 5 — so `check_action_pin_freshness.py` fails inside `Full verify`:

```
pin fcb64c11d839 lags main by 35 commits touching src/mergecraft/ (max 5).
The reviewer is not running the product code on main. Bump the pin.
```

The gate is right. But it sits above `Build GHCR images`, so no image could be published for the promotion SHA, and without an image the pin could not be bumped — the gate blocked the job that would satisfy it. #576 broke that cycle through `action-slim-bootstrap`, which runs on a `pre-0.0.1`-based PR ahead of `Full verify`.

## What lands

- **Action pin** `fcb64c11` (plan 12 only) → `695d34b0` (all three plans), one `MERGECRAFT_ACTION_SHA` mirrored by three rungs.
- **`action.yml` digest** → `sha256:6abb15c1…`, the image `action-slim-bootstrap` built from `695d34b0` itself. SHA and digest move together; splitting them is what turned five checks red on #562.
- **Evidence packets write to `$RUNNER_TEMP`** instead of the workspace. All three rungs were failing with `packet-nous.json: Permission denied`: the review job never checks out, so the only directory at `$GITHUB_WORKSPACE` is the one the Action container mounted as root, and the `run:` steps execute as the runner user. The step also exits early when a rung emitted no packet, rather than uploading an empty artifact.

## Verified

- `check_action_pin_freshness.py` — OK.
- `check_action_image_digest.py` — OK, digest matches GHCR for `695d34b0979a`, tracing extra present.
- `tests/ci` + `tests/pins` — 431 passed.
- Workflow parses as YAML; all three rungs consistent.
- Staleness after this merge: the four commits touch only `.github/workflows/mergecraft.yml` and `action.yml`, so the src-commit lag stays **0** and the gate that failed on #575 passes here.

## Note

The packet steps could not be tested before now. `pull_request_target` resolves the workflow from the default branch, so plan 12's W7 artifact steps only became executable when #575 put them on `main` — their first run was their first test. The same caveat applies to this PR's own fix: it takes effect for reviews only once this merges.

Needs an admin merge — `protect-main` wants an approving review the reviewer cannot give, since it runs on `github.token`.
