### PR TITLE
ci-gate: fix coverage delta and add provider status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Lane C — CI gate correctness & operator surface
+
+#### Added
+
+- `mergecraft provider status` shows what CI will run — each reviewer agent's
+  `pN` slots, credential and workflow-wiring state, dispatch level, and skipped
+  slots — with `--json` for scripting and optional `--github` to report repo
+  secret presence without printing values (#520)
+
+#### Fixed
+
+- Coverage delta on pull requests no longer fails when the merge-base branch
+  cannot measure coverage; the PR checkout still runs `make coverage-gate` and
+  the skip is surfaced as an Actions warning and job-summary line naming the
+  base ref and reason (#536)
+- Base-branch coverage measurement reads that worktree's
+  `.mergecraft/config.yaml` instead of the PR head's — a PR that adds a config
+  key and its schema field no longer fails the base run (#573)
+
 ### Added
 
 - `mergecraft agent` and `mergecraft agent-local` author the agent roster —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,46 @@ merge-base **lowering guard** that blocks undeclared ``fail_under`` drops runs
 only on pull requests, because on ``push`` / ``workflow_dispatch`` the
 merge-base comparison is self-referential.
 
+### Config path resolution (#573)
+
+``load_repo_settings()`` resolves ``.mergecraft/config.yaml`` through this
+ladder (first hit wins):
+
+1. explicit ``root=`` argument
+2. ``MERGECRAFT_CONFIG`` when the file exists
+3. ``<workspace-root>/.mergecraft/config.yaml``
+
+**Workspace root** (the base for step 3 when no explicit path is set):
+
+| Situation | Root used |
+|-----------|-----------|
+| No ``GITHUB_WORKSPACE`` | process ``cwd`` |
+| ``cwd`` inside ``GITHUB_WORKSPACE`` (normal CI) | ``GITHUB_WORKSPACE`` |
+| ``cwd`` in a **sibling git worktree** of the same repo | the **cwd** worktree (#573 / D2) |
+| otherwise | ``GITHUB_WORKSPACE`` |
+
+The coverage gate's base measurement runs inside a detached worktree and
+**re-exports ``GITHUB_WORKSPACE`` at that worktree** before calling
+``make coverage-measure`` (D1). Each tree therefore reads its own config even
+when Actions still has the PR checkout as the outer workspace.
+
+### Coverage gate contract (#432 / #536)
+
+On ``pull_request``, ``scripts/ci_coverage_delta_gate.sh``:
+
+1. measures coverage on the merge-base worktree (signal only)
+2. runs ``make coverage-gate`` on the **PR checkout** (hard gate — always)
+3. compares head vs base when ``coverage-base.json`` exists
+
+| Step | On failure |
+|------|------------|
+| Base measurement | **No** ``coverage-base.json``; delta **skipped** with an Actions ``::warning::`` and a job-summary line naming ``GITHUB_BASE_REF`` and the reason (D4/D6) |
+| Head ``make coverage-gate`` | Run **fails** — the ratchet stays on (D5) |
+| Delta comparison | Runs only when base measurement succeeded |
+
+On ``push`` / ``workflow_dispatch`` the script runs the head gate only (no
+merge-base worktree).
+
 To run the live slice (requires provider secrets such as `ANTHROPIC_API_KEY`):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Everything else — install, scaffold, config, commit, PR — is unattended.
 | `mergecraft review --json out.json` | Structured findings on disk |
 | [`docs/EXIT-CODES.md`](docs/EXIT-CODES.md) | Contractual exit codes — branch on them instead of parsing text |
 | `mergecraft doctor` | Self-diagnosis of git, providers, analyzers, auth, config and MCP wiring |
+| `mergecraft provider status` | Roster inspection — what CI will run, credential and wiring state, optional `--github` secret check |
 | [`docs/mcp.md`](docs/mcp.md) | **Public MCP install** — six review-only tools over stdio for Cursor, Claude Desktop, Codex, Gemini CLI, OpenCode |
 | `mergecraft mcp serve` | The reviewer's **in-run** MCP tool surface at `/mcp/reviewer`, Bearer-authenticated (not the public stdio profile) |
 
@@ -447,6 +448,7 @@ When `harness:` is unset, mergeCraft infers the runtime from the model slug — 
 | [`docs/glossary.md`](docs/glossary.md) | Plain-language definitions for landing-page terms |
 | [`docs/install.md`](docs/install.md) | Action vs CLI vs Docker install paths |
 | [`docs/authentication.md`](docs/authentication.md) | Providers, custom gateways, model fallback chains |
+| [`docs/agent-roster.md`](docs/agent-roster.md) | Agent roster, `provider status`, multi-reviewer merge, trust snapshot |
 | [`docs/workflows.md`](docs/workflows.md) | Examples 2–6, trust tiers, `pull_request_target` gotchas |
 | [`docs/cli.md`](docs/cli.md) | Full `mergecraft` command reference |
 | [`docs/action-reference.md`](docs/action-reference.md) | Every Action `with:` input and output |

--- a/docs/agent-roster.md
+++ b/docs/agent-roster.md
@@ -13,6 +13,8 @@ mergecraft agent create       reviewer2 --role reviewer          # a second revi
 mergecraft agent create       reviewer3 --role reviewer --after reviewer2
 mergecraft agent-local assign-model reviewer p0 openai/gpt-codex  # local-only override
 mergecraft workflow sync --check   # fail when roster models lack CI credentials
+mergecraft provider status         # what CI will run — roster, credentials, wiring
+mergecraft provider status --github   # also check repo secret presence
 ```
 
 Full command reference: [`docs/cli.md`](cli.md).
@@ -118,6 +120,33 @@ model reviews that PR.
 Implementation: `src/mergecraft/config/settings_snapshot.py` (AG2 / MCB-19).
 Roster helpers in `src/mergecraft/config/agent_roster.py` import the snapshot
 primitives — do not duplicate snapshot logic elsewhere.
+
+## Inspecting what CI will run
+
+`mergecraft provider status` is the read-only inspection command for the
+question *"what will CI actually run?"* It projects the committed roster onto
+credential presence, workflow auth wiring, dispatch levels, and per-slot skip
+reasons — without calling a model or mutating config.
+
+```bash
+mergecraft provider status              # offline view from config + workflow
+mergecraft provider status --github     # also query repo secret presence
+mergecraft provider status --json       # machine-readable output (schema v1)
+```
+
+| State | Meaning | Typical remedy |
+|-------|---------|----------------|
+| credential missing | env var absent locally (or secret absent with `--github`) | `mergecraft provider auth <label>` |
+| not wired | provider absent from `mergecraft.yml` auth manifest | `mergecraft workflow sync --apply` |
+| disabled | credentials cleared via `provider disable` | `mergecraft provider enable <label>` |
+
+``--github`` needs a token with ``repo`` scope (``gh auth token`` or
+``GITHUB_TOKEN``). Without one every remote field is ``unknown`` and the command
+still exits 0. Secrets are reported as present/absent only — values are never
+printed (#520 / D11).
+
+``--cwd`` selects every target — config path, git resolution, workflow file,
+and registry — the same rule as `provider disable` (#521).
 
 ## Workflow sync
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,6 +121,7 @@ Pass `--help` to any invocation below for its full flag set.
 | `mergecraft provider harnesses` | List supported agent harnesses (generated from code). |
 | `mergecraft provider list` | List registered provider labels. |
 | `mergecraft provider migrate` | Migrate legacy `*_API_KEY` env vars into indexed provider registry layout (D2 / #483). |
+| `mergecraft provider status` | Show the reviewer roster, credentials, wiring, and dispatch order. |
 | `mergecraft replay` | Replay a stored review run from local traces (read-only). |
 | `mergecraft requirements explain <requirement-id>` | Explain one requirement by id; unknown ids are an error. |
 | `mergecraft requirements inspect` | List ingested requirements and their states. |

--- a/docs/test-plans/16-ci-gate-operator-surface.md
+++ b/docs/test-plans/16-ci-gate-operator-surface.md
@@ -1,0 +1,72 @@
+# CI gate operator surface — test plan
+
+Maps **W1 RED** contracts for wave plan 16 to the test suite.
+Source plan: `.ignorelocal/waves/16-ci-gate-operator-surface-wave-plan.md`.
+
+All cross-wave reds use `@pytest.mark.xfail(..., strict=True)` per the lane plan —
+`scripts/check_xpass.py` fails non-strict xfails that pass.
+
+## W1.1 — settings root → W2
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `load_repo_settings(root=<base>)` reads base config with `GITHUB_WORKSPACE` at head (#573 guard) | `tests/config/test_ci_gate_settings_root.py::test_load_repo_settings_root_reads_base_with_github_workspace_at_head` | unit |
+| cwd in sibling worktree wins over `GITHUB_WORKSPACE` (D2) | `…::test_cwd_worktree_wins_over_github_workspace` | unit |
+| cwd inside `GITHUB_WORKSPACE` unchanged (normal CI) | `…::test_cwd_inside_github_workspace_unchanged` | unit |
+| `MERGECRAFT_CONFIG` wins (D3) | `…::test_mergecraft_config_wins_over_workspace_and_cwd` | unit |
+| explicit `root=` wins over `GITHUB_WORKSPACE` | `…::test_explicit_root_wins_over_github_workspace` | unit |
+| outside git repo, no `GITHUB_WORKSPACE` → cwd fallback | `…::test_outside_git_repo_falls_back_to_cwd` | unit |
+| base tree validates when head config has unknown key (#573 e2e) | `…::test_base_tree_validates_cleanly_when_head_config_has_unknown_key` | integration |
+
+Shared helpers: `tests/config/support_ci_gate_settings.py`.
+
+Pinned API: `mergecraft.config.settings.load_repo_settings`, `_workspace_root` (W2).
+
+## W1.2 — coverage gate → W3
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| `BASE_WORKTREE_MEASURE_BLOCK` markers parseable (D7) | `tests/ci/test_ci_gate_coverage_delta.py::test_base_measure_block_markers_remain_parseable` | structural |
+| `UV_PROJECT_ENVIRONMENT` export survives | `…::test_base_measure_block_exports_uv_project_environment` | structural |
+| pre-TH inline measure fallback survives | `…::test_base_measure_block_keeps_pre_th_inline_fallback` | structural |
+| head `make coverage-gate` stays hard (D5) | `…::test_head_coverage_gate_stays_unguarded_outside_subshell` | structural |
+| broken base → no `coverage-base.json`, exit 0 (D4) | `…::test_broken_base_measurement_exits_zero_without_base_json` | integration |
+| skipped delta emits warning with reason (D6) | `…::test_skipped_delta_emits_warning_with_reason` | integration |
+| healthy base still runs delta comparison | `…::test_successful_base_measurement_still_runs_delta_comparison` | structural |
+| worktree cleaned up when measurement fails | `…::test_worktree_cleaned_up_when_base_measurement_fails` | integration |
+| head regression still fails when base skips (D5) | `…::test_head_coverage_regression_still_fails_when_base_skips` | integration |
+
+Existing wrapper guard: `tests/ci/test_coverage_delta_wrapper.py` (D7 base block must not run `make coverage-gate`).
+
+Shared helpers: `tests/ci/support_ci_gate_coverage.py`.
+
+Pinned script: `scripts/ci_coverage_delta_gate.sh`.
+
+## W1.3 — `provider status --github` → W4
+
+| Contract | Tests | Layer |
+| --- | --- | --- |
+| every reviewer + `pN` slot + provider (D8) | `tests/cli/test_provider_status_cmd.py::test_provider_status_renders_every_reviewer_slot_and_provider` | E2E |
+| no credential → not available + env var name (D11) | `…::test_provider_status_missing_credential_reports_env_var_not_value` | E2E |
+| unwired ≠ no credential (D10) | `…::test_provider_status_unwired_is_distinct_from_missing_credential` | E2E |
+| `after:` / dispatch level rendered | `…::test_provider_status_renders_dispatch_level_and_after_ordering` | E2E |
+| disabled provider renders disabled (#521) | `…::test_provider_status_disabled_provider_renders_disabled` | E2E |
+| `--github` no token → unknown, exit 0 (D9) | `…::test_provider_status_github_without_token_is_unknown_exit_zero` | E2E |
+| `--github` with token → secret presence only (D11) | `…::test_provider_status_github_with_token_reports_secret_presence` | E2E |
+| `--json` stable documented schema | `…::test_provider_status_json_matches_documented_schema` | E2E |
+| `--cwd` selects every target | `…::test_provider_status_cwd_selects_config_workflow_and_registry_targets` | E2E |
+| read-only (D9) | `…::test_provider_status_is_read_only` | E2E |
+
+Shared helpers: `tests/cli/support_provider_status.py`.
+
+Pinned modules (W4): `mergecraft.cli.provider_status` (`STATUS_JSON_SCHEMA`), roster sources `resolve_roles` / `resolve_role_levels`, `parse_auth_manifest`, `credential_status_for_slug` adapter.
+
+## xfail reconciliation
+
+| Wave | Marker reason prefix | Files |
+| --- | --- | --- |
+| W2 | `green after W2: settings-root worktree resolution` | `tests/config/test_ci_gate_settings_root.py` |
+| W3 | `green after W3: base measurement signal not gate` | `tests/ci/test_ci_gate_coverage_delta.py` |
+| W4 | `green after W4: provider status roster view` | `tests/cli/test_provider_status_cmd.py` |
+
+Guard tests (no xfail) must stay green through W2–W4 implementation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -256,6 +256,7 @@ Everything else — install, scaffold, config, commit, PR — is unattended.
 | `mergecraft review --json out.json` | Structured findings on disk |
 | [`docs/EXIT-CODES.md`](docs/EXIT-CODES.md) | Contractual exit codes — branch on them instead of parsing text |
 | `mergecraft doctor` | Self-diagnosis of git, providers, analyzers, auth, config and MCP wiring |
+| `mergecraft provider status` | Roster inspection — what CI will run, credential and wiring state, optional `--github` secret check |
 | [`docs/mcp.md`](docs/mcp.md) | **Public MCP install** — six review-only tools over stdio for Cursor, Claude Desktop, Codex, Gemini CLI, OpenCode |
 | `mergecraft mcp serve` | The reviewer's **in-run** MCP tool surface at `/mcp/reviewer`, Bearer-authenticated (not the public stdio profile) |
 
@@ -451,6 +452,7 @@ When `harness:` is unset, mergeCraft infers the runtime from the model slug — 
 | [`docs/glossary.md`](docs/glossary.md) | Plain-language definitions for landing-page terms |
 | [`docs/install.md`](docs/install.md) | Action vs CLI vs Docker install paths |
 | [`docs/authentication.md`](docs/authentication.md) | Providers, custom gateways, model fallback chains |
+| [`docs/agent-roster.md`](docs/agent-roster.md) | Agent roster, `provider status`, multi-reviewer merge, trust snapshot |
 | [`docs/workflows.md`](docs/workflows.md) | Examples 2–6, trust tiers, `pull_request_target` gotchas |
 | [`docs/cli.md`](docs/cli.md) | Full `mergecraft` command reference |
 | [`docs/action-reference.md`](docs/action-reference.md) | Every Action `with:` input and output |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,12 @@ markers = [
 [tool.coverage.run]
 source = ["mergecraft"]
 branch = true
-omit = ["*/tests/*"]
+omit = [
+    "*/tests/*",
+    "*/pytest-of-*/*",
+    "*/scratch/*",
+    "*/.ci-mergecraft-base-coverage/*",
+]
 
 [tool.coverage.report]
 fail_under = 82

--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -25,9 +25,11 @@ git worktree prune 2>/dev/null || true
 
 git fetch origin "${GITHUB_BASE_REF}"
 git worktree add "$worktree" "$base_ref"
+orig_workspace="$GITHUB_WORKSPACE"
 # BASE_WORKTREE_MEASURE_BLOCK — parsed by tests/ci/test_coverage_delta_wrapper.py (D10).
 (
   cd "$worktree"
+  export GITHUB_WORKSPACE="$worktree"  # #573: base tree reads its own config, not head's
   # The base worktree gets its own fresh venv. `dev` is a
   # [project.optional-dependencies] extra, which `uv run` does not install, so
   # `make coverage-measure` died with "Failed to spawn: pytest" before measuring
@@ -56,7 +58,7 @@ git worktree add "$worktree" "$base_ref"
       --randomly-seed="${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}" \
       -rX
   fi
-  cp coverage.json "${GITHUB_WORKSPACE}/coverage-base.json"
+  cp coverage.json "${orig_workspace}/coverage-base.json"
 )
 make coverage-gate
 if [[ -f coverage-base.json ]]; then

--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -2,6 +2,11 @@
 # Coverage ratchet for integration CI — base worktree + delta gate (#432 / D6).
 set -euo pipefail
 
+# Nested ``make coverage-measure`` / pytest must not inherit the parent CI
+# session's coverage subprocess hooks (wave-16 integration tests spawn this
+# script while pytest-cov is active on the outer gate).
+unset COVERAGE_PROCESS_START COVERAGE_PROCESS_CONFIG COVERAGE_FILE COVERAGE_RCFILE
+
 if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
   make coverage-gate
   exit 0

--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -37,6 +37,7 @@ orig_workspace="$GITHUB_WORKSPACE"
 : >"$base_measure_log"
 # BASE_WORKTREE_MEASURE_BLOCK — parsed by tests/ci/test_coverage_delta_wrapper.py (D10).
 (
+  set +e
   cd "$worktree"
   export GITHUB_WORKSPACE="$worktree"  # #573: base tree reads its own config, not head's
   # The base worktree gets its own fresh venv. `dev` is a
@@ -53,36 +54,51 @@ orig_workspace="$GITHUB_WORKSPACE"
   # Makefile defers to it — so this also works against an older base tree whose
   # Makefile predates MCB-23 and would otherwise default to `.venv`.
   export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-$PWD/.venv-dev}"
-  "${UV:-uv}" sync --extra dev --extra tracing
+  measure_ok=true
+  if ! "${UV:-uv}" sync --extra dev --extra tracing >>"$base_measure_log" 2>&1; then
+    measure_ok=false
+  fi
   # Repo-native analyzer tests (#427) require tools/node_modules/.bin; bootstrap
   # only runs on the PR checkout, not this detached base worktree.
-  make setup-local-analyzers
-  measure_ok=true
-  if grep -q '^coverage-measure:' Makefile; then
-    if ! make coverage-measure >>"$base_measure_log" 2>&1; then
-      measure_ok=false
-    fi
-  else
-    # Pre-TH base trees only ship ``coverage-gate``; inline the measure recipe
-    # so the delta gate can compare against the merge base before TH lands.
-    if ! "${UV:-uv}" run pytest tests -q --tb=short --strict-markers -m "not integration" \
-      --cov=mergecraft --cov-branch --cov-report=term --cov-report=json:coverage.json \
-      --randomly-seed="${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}" \
-      -rX >>"$base_measure_log" 2>&1; then
+  if [[ "$measure_ok" == true ]]; then
+    if ! make setup-local-analyzers >>"$base_measure_log" 2>&1; then
       measure_ok=false
     fi
   fi
   if [[ "$measure_ok" == true ]]; then
-    cp coverage.json "${orig_workspace}/coverage-base.json"
+    if grep -q '^coverage-measure:' Makefile; then
+      if ! make coverage-measure >>"$base_measure_log" 2>&1; then
+        measure_ok=false
+      fi
+    else
+      # Pre-TH base trees only ship ``coverage-gate``; inline the measure recipe
+      # so the delta gate can compare against the merge base before TH lands.
+      if ! "${UV:-uv}" run pytest tests -q --tb=short --strict-markers -m "not integration" \
+        --cov=mergecraft --cov-branch --cov-report=term --cov-report=json:coverage.json \
+        --randomly-seed="${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}" \
+        -rX >>"$base_measure_log" 2>&1; then
+        measure_ok=false
+      fi
+    fi
   fi
+  if [[ "$measure_ok" == true ]]; then
+    if ! cp coverage.json "${orig_workspace}/coverage-base.json" 2>>"$base_measure_log"; then
+      measure_ok=false
+    fi
+  fi
+  exit 0
 )
 if [[ ! -f coverage-base.json ]]; then
-  base_reason="base coverage measurement failed"
+  base_detail=""
   if [[ -s "$base_measure_log" ]]; then
-    base_reason="$(tail -n 5 "$base_measure_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //;s/ $//')"
+    base_detail="$(tail -n 5 "$base_measure_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //;s/ $//')"
+    base_detail="${base_detail//::/}"
   fi
-  skip_msg="Coverage delta skipped: base ref ${GITHUB_BASE_REF} could not be measured (${base_reason})."
+  skip_msg="Coverage delta skipped: base ref ${GITHUB_BASE_REF} could not be measured (see .ci-base-measure.log)."
   echo "warning: ${skip_msg}" >&2
+  if [[ -n "$base_detail" ]]; then
+    echo "warning: base measurement tail: ${base_detail}" >&2
+  fi
   if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
     escaped_msg="${skip_msg//'%'/'%25'}"
     escaped_msg="${escaped_msg//$'\r'/'%0D'}"
@@ -93,6 +109,10 @@ if [[ ! -f coverage-base.json ]]; then
     {
       echo "### Coverage delta skipped"
       echo "${skip_msg}"
+      if [[ -n "$base_detail" ]]; then
+        echo ""
+        echo "Base measurement tail: ${base_detail}"
+      fi
     } >>"$GITHUB_STEP_SUMMARY"
   fi
 fi

--- a/scripts/ci_coverage_delta_gate.sh
+++ b/scripts/ci_coverage_delta_gate.sh
@@ -13,8 +13,11 @@ fi
 base_ref="origin/${GITHUB_BASE_REF}"
 worktree="${GITHUB_WORKSPACE}/.ci-mergecraft-base-coverage"
 
+base_measure_log="${GITHUB_WORKSPACE}/.ci-base-measure.log"
+
 cleanup() {
   rm -f "${GITHUB_WORKSPACE}/coverage-base.json" 2>/dev/null || true
+  rm -f "$base_measure_log" 2>/dev/null || true
   git worktree remove "$worktree" --force 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
@@ -26,6 +29,7 @@ git worktree prune 2>/dev/null || true
 git fetch origin "${GITHUB_BASE_REF}"
 git worktree add "$worktree" "$base_ref"
 orig_workspace="$GITHUB_WORKSPACE"
+: >"$base_measure_log"
 # BASE_WORKTREE_MEASURE_BLOCK — parsed by tests/ci/test_coverage_delta_wrapper.py (D10).
 (
   cd "$worktree"
@@ -48,18 +52,45 @@ orig_workspace="$GITHUB_WORKSPACE"
   # Repo-native analyzer tests (#427) require tools/node_modules/.bin; bootstrap
   # only runs on the PR checkout, not this detached base worktree.
   make setup-local-analyzers
+  measure_ok=true
   if grep -q '^coverage-measure:' Makefile; then
-    make coverage-measure
+    if ! make coverage-measure >>"$base_measure_log" 2>&1; then
+      measure_ok=false
+    fi
   else
     # Pre-TH base trees only ship ``coverage-gate``; inline the measure recipe
     # so the delta gate can compare against the merge base before TH lands.
-    "${UV:-uv}" run pytest tests -q --tb=short --strict-markers -m "not integration" \
+    if ! "${UV:-uv}" run pytest tests -q --tb=short --strict-markers -m "not integration" \
       --cov=mergecraft --cov-branch --cov-report=term --cov-report=json:coverage.json \
       --randomly-seed="${MERGECRAFT_PYTEST_RANDOM_SEED:-424242}" \
-      -rX
+      -rX >>"$base_measure_log" 2>&1; then
+      measure_ok=false
+    fi
   fi
-  cp coverage.json "${orig_workspace}/coverage-base.json"
+  if [[ "$measure_ok" == true ]]; then
+    cp coverage.json "${orig_workspace}/coverage-base.json"
+  fi
 )
+if [[ ! -f coverage-base.json ]]; then
+  base_reason="base coverage measurement failed"
+  if [[ -s "$base_measure_log" ]]; then
+    base_reason="$(tail -n 5 "$base_measure_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //;s/ $//')"
+  fi
+  skip_msg="Coverage delta skipped: base ref ${GITHUB_BASE_REF} could not be measured (${base_reason})."
+  echo "warning: ${skip_msg}" >&2
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    escaped_msg="${skip_msg//'%'/'%25'}"
+    escaped_msg="${escaped_msg//$'\r'/'%0D'}"
+    escaped_msg="${escaped_msg//$'\n'/'%0A'}"
+    echo "::warning title=Coverage delta skipped::${escaped_msg}" >&2
+  fi
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Coverage delta skipped"
+      echo "${skip_msg}"
+    } >>"$GITHUB_STEP_SUMMARY"
+  fi
+fi
 make coverage-gate
 if [[ -f coverage-base.json ]]; then
   uv run python scripts/check_coverage_delta.py coverage.json --base coverage-base.json

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -1254,9 +1254,11 @@ def provider_auth_cmd(
 # ``provider enable|disable`` (#520) live in their own module to keep this one
 # from growing further; they are attached here so they appear under the same
 # ``mergecraft provider`` app as ``auth``/``add``/``delete``.
+from mergecraft.cli.provider_status import register as _register_status  # noqa: E402
 from mergecraft.cli.provider_toggle import register as _register_toggle  # noqa: E402
 
 _register_toggle(app)
+_register_status(app)
 
 
 __all__ = [

--- a/src/mergecraft/cli/provider_status.py
+++ b/src/mergecraft/cli/provider_status.py
@@ -277,6 +277,15 @@ def _collect_github_secrets(
         }
 
     repo_slug = _resolve_repo_slug(cwd)
+    if repo_slug == "local/unknown":
+        return {
+            "status": "unknown",
+            "message": (
+                "GitHub secret presence unknown — could not resolve owner/repo from "
+                f"git origin at {cwd.resolve()}"
+            ),
+        }
+
     present_names = set(list_repo_secrets(repo_slug))
     provider_registry = load_provider_registry(_config_path(cwd))
     provider_entry_by_label = {
@@ -300,10 +309,7 @@ def _collect_github_secrets(
                     seen.add(name)
                     required.append(name)
 
-    secret_rows = [
-        {"name": name, "present": name in present_names or secret_is_present(repo_slug, name)}
-        for name in sorted(required)
-    ]
+    secret_rows = [{"name": name, "present": name in present_names} for name in sorted(required)]
     return {"status": "ok", "repo": repo_slug, "secrets": secret_rows}
 
 
@@ -326,11 +332,11 @@ def build_status_payload(
 
     reviewers_payload: list[dict[str, Any]] = []
     skipped: list[dict[str, str]] = []
+    provider_entry_by_label = {
+        str(row.get("label", "")).lower(): row for row in provider_registry.entries
+    }
 
     for binding in registry.resolve_roles(AgentRole.reviewer):
-        provider_entry_by_label = {
-            str(row.get("label", "")).lower(): row for row in provider_registry.entries
-        }
         slots_payload: list[dict[str, Any]] = []
         agent_enabled = True
 

--- a/src/mergecraft/cli/provider_status.py
+++ b/src/mergecraft/cli/provider_status.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 from rich.panel import Panel
@@ -23,13 +23,6 @@ from mergecraft.agents.registry import AgentRole, RegistryValidationError, load_
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
-from mergecraft.cli.provider_cmd import (
-    _config_path,
-    _env_path,
-    _read_env_map,
-    load_provider_registry,
-    resolve_indexed_credential,
-)
 from mergecraft.cli.provider_toggle import resolve_provider_secrets
 from mergecraft.cli.target_dir import target_dir as resolve_target_dir
 from mergecraft.config.runtime_provider_registry import (
@@ -44,6 +37,17 @@ from mergecraft.workflow.auth_manifest import (
     flat_credential_env_keys,
     parse_auth_manifest,
 )
+
+if TYPE_CHECKING:
+    from mergecraft.config.settings import RepoSettings
+
+
+def _provider_cmd() -> Any:
+    """Lazy import to avoid a circular import with ``provider_cmd.register``."""
+    from mergecraft.cli import provider_cmd as mod
+
+    return mod
+
 
 STATUS_JSON_SCHEMA_VERSION = 1
 
@@ -78,7 +82,25 @@ STATUS_JSON_SCHEMA: dict[str, Any] = {
                         "type": "array",
                         "items": {
                             "type": "object",
-                            "required": ["slot", "model", "provider", "credential", "wired"],
+                            "required": [
+                                "slot",
+                                "model",
+                                "provider",
+                                "credential",
+                                "wired",
+                                "disabled",
+                            ],
+                            "properties": {
+                                "slot": {"type": "string"},
+                                "model": {"type": "string"},
+                                "provider": {"type": "string"},
+                                "wired": {"type": "boolean"},
+                                "disabled": {"type": "boolean"},
+                                "credential": {
+                                    "type": "object",
+                                    "required": ["available", "looked_for", "source"],
+                                },
+                            },
                         },
                     },
                 },
@@ -89,6 +111,7 @@ STATUS_JSON_SCHEMA: dict[str, Any] = {
             "properties": {
                 "status": {"type": "string"},
                 "message": {"type": "string"},
+                "repo": {"type": "string"},
                 "secrets": {
                     "type": "array",
                     "items": {
@@ -114,7 +137,7 @@ class CredentialStatus:
 def credential_status_for_slug(
     slug: str,
     *,
-    settings: Any,
+    settings: RepoSettings,
     cwd: Path,
     wired: bool,
 ) -> CredentialStatus:
@@ -144,23 +167,24 @@ def credential_status_for_slug(
 def _local_credential_status(
     slug: str,
     *,
-    settings: Any,
+    settings: RepoSettings,
     cwd: Path,
     wired: bool,
 ) -> CredentialStatus:
     del wired  # unwired slots still report which env var would be consulted
+    provider_cmd = _provider_cmd()
     try:
         provider, _model_id = parse_model(slug)
     except ValueError:
         return CredentialStatus(available=False, source="unknown", looked_for="")
 
     provider_key = provider.lower()
-    env_map = _read_env_map(_env_path(cwd))
+    env_map = provider_cmd._read_env_map(provider_cmd._env_path(cwd))
     entry = lookup_registry_entry(settings, provider_key)
     keys: tuple[str, ...]
     if entry is not None:
         keys = credential_env_keys_for_entry(entry)
-        if resolve_indexed_credential(
+        if provider_cmd.resolve_indexed_credential(
             {
                 "label": entry.label,
                 "envIndex": entry.env_index,
@@ -171,9 +195,6 @@ def _local_credential_status(
             primary = keys[0] if keys else f"LLM_PROVIDER_{entry.env_index}_API_KEY"
             return CredentialStatus(available=True, source="env", looked_for=primary)
     else:
-        keys = flat_credential_env_keys(provider_key)
-
-    if not keys:
         keys = flat_credential_env_keys(provider_key)
 
     for key in keys:
@@ -188,11 +209,9 @@ def _provider_disabled(label: str, entry: dict[str, Any] | None, *, cwd: Path) -
     secrets = resolve_provider_secrets(label, entry)
     if not secrets.local:
         return False
-    env_map = _read_env_map(_env_path(cwd))
+    env_map = _provider_cmd()._read_env_map(_provider_cmd()._env_path(cwd))
     has_blank = any(key in env_map and not env_map[key].strip() for key in secrets.local)
-    has_value = any(
-        env_map.get(key, "").strip() or os.environ.get(key, "").strip() for key in secrets.local
-    )
+    has_value = any(env_map.get(key, "").strip() for key in secrets.local)
     return has_blank and not has_value
 
 
@@ -222,8 +241,8 @@ def _github_token() -> str | None:
     return None
 
 
-def list_repo_secrets(repo_slug: str) -> list[str]:
-    """Return Actions secret names on *repo_slug* (empty when ``gh`` is unavailable)."""
+def list_repo_secrets(repo_slug: str) -> list[str] | None:
+    """Return Actions secret names on *repo_slug*, or ``None`` when ``gh`` fails."""
     try:
         completed = subprocess.run(  # nosec B603 B607 — fixed argv, gh binary
             ["gh", "secret", "list", "--repo", repo_slug, "--json", "name", "-q", ".[].name"],
@@ -232,32 +251,81 @@ def list_repo_secrets(repo_slug: str) -> list[str]:
             check=False,
         )
     except FileNotFoundError:
-        return []
+        return None
     if completed.returncode != 0:
-        return []
+        return None
     return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
 
 
-def secret_is_present(repo_slug: str, name: str) -> bool:
+def secret_is_present(
+    repo_slug: str,
+    name: str,
+    *,
+    present_names: set[str] | None = None,
+) -> bool:
     """Return whether *name* exists as an Actions secret on *repo_slug*."""
-    return name in list_repo_secrets(repo_slug)
+    if present_names is not None:
+        return name in present_names
+    names = list_repo_secrets(repo_slug)
+    return False if names is None else name in names
 
 
 def _resolve_repo_slug(cwd: Path) -> str:
     """Return ``owner/repo`` for *cwd*, or a placeholder when origin is unreadable."""
-    import re
+    from mergecraft.cli.provider_toggle import resolve_repo_slug
 
-    from mergecraft.utils.git_hardening import read_remote_origin_url
-
-    resolved = cwd.resolve()
     try:
-        url = read_remote_origin_url(str(resolved))
-    except (RuntimeError, OSError):
+        return resolve_repo_slug(cwd)
+    except typer.Exit:
         return "local/unknown"
-    match = re.search(r"github\.com(?::\d+)?[:/]+([^/]+)/(.+?)(?:\.git)?(?:/)?$", url)
-    if not match:
-        return "local/unknown"
-    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _remote_credential_available(
+    provider_key: str,
+    registry_entry: dict[str, Any] | None,
+    *,
+    present_github_secrets: set[str] | None,
+) -> bool:
+    """Return whether any Actions secret for *provider_key* is present on the repo."""
+    if present_github_secrets is None:
+        return False
+    secrets = resolve_provider_secrets(provider_key, registry_entry)
+    if not secrets.github:
+        return False
+    return any(name in present_github_secrets for name in secrets.github)
+
+
+def _reviewer_agent_entries(registry: Any) -> list[tuple[str, Any]]:
+    """Return ``(config_key, binding)`` pairs for reviewer agents in dispatch order."""
+    return list(registry._ordered_role_entries(AgentRole.reviewer))
+
+
+def _present_github_secret_names(github_block: dict[str, Any] | None) -> set[str] | None:
+    if github_block is None or github_block.get("status") != "ok":
+        return None
+    return {
+        str(row["name"])
+        for row in github_block.get("secrets", [])
+        if isinstance(row, dict) and row.get("present")
+    }
+
+
+def _credential_payload(
+    credential: CredentialStatus,
+    *,
+    remote_available: bool,
+) -> dict[str, str | bool]:
+    if remote_available and not credential.available:
+        return {
+            "available": True,
+            "looked_for": credential.looked_for,
+            "source": "github",
+        }
+    return {
+        "available": credential.available,
+        "looked_for": credential.looked_for,
+        "source": credential.source,
+    }
 
 
 def _collect_github_secrets(
@@ -286,14 +354,25 @@ def _collect_github_secrets(
             ),
         }
 
-    present_names = set(list_repo_secrets(repo_slug))
-    provider_registry = load_provider_registry(_config_path(cwd))
+    secret_names = list_repo_secrets(repo_slug)
+    if secret_names is None:
+        return {
+            "status": "unknown",
+            "message": (
+                "GitHub secret presence unknown — `gh secret list` failed or `gh` is "
+                "unavailable (needs repo scope: read:repo or admin:repo_hook)"
+            ),
+        }
+
+    present_names = set(secret_names)
+    provider_cmd = _provider_cmd()
+    provider_registry = provider_cmd.load_provider_registry(provider_cmd._config_path(cwd))
     provider_entry_by_label = {
         str(row.get("label", "")).lower(): row for row in provider_registry.entries
     }
     required: list[str] = []
     seen: set[str] = set()
-    for binding in registry_data.resolve_roles(AgentRole.reviewer):
+    for _agent_key, binding in _reviewer_agent_entries(registry_data):
         for slug in binding.model_chain:
             try:
                 provider, _ = parse_model(slug)
@@ -320,15 +399,23 @@ def build_status_payload(
 ) -> dict[str, Any]:
     target = resolve_target_dir(cwd)
     settings = load_repo_settings(root=target, load_learnings_files=False)
-    try:
-        registry = load_registry(settings=settings, repo_root=target)
-    except RegistryValidationError as exc:
-        cli_bail(str(exc))
+    registry = load_registry(settings=settings, repo_root=target)
 
     workflow_path = target / DEFAULT_WORKFLOW_RELATIVE_PATH
     wired = _wired_providers(workflow_path)
-    provider_registry = load_provider_registry(_config_path(target))
+    provider_cmd = _provider_cmd()
+    provider_registry = provider_cmd.load_provider_registry(provider_cmd._config_path(target))
     dispatch_levels = _dispatch_level_map(registry)
+
+    github_block: dict[str, Any] | None = None
+    present_github_secrets: set[str] | None = None
+    if github:
+        github_block = _collect_github_secrets(
+            cwd=target,
+            registry_data=registry,
+            wired=wired,
+        )
+        present_github_secrets = _present_github_secret_names(github_block)
 
     reviewers_payload: list[dict[str, Any]] = []
     skipped: list[dict[str, str]] = []
@@ -336,7 +423,7 @@ def build_status_payload(
         str(row.get("label", "")).lower(): row for row in provider_registry.entries
     }
 
-    for binding in registry.resolve_roles(AgentRole.reviewer):
+    for agent_key, binding in _reviewer_agent_entries(registry):
         slots_payload: list[dict[str, Any]] = []
         agent_enabled = True
 
@@ -358,16 +445,21 @@ def build_status_payload(
                 cwd=target,
                 wired=is_wired,
             )
+            remote_available = _remote_credential_available(
+                provider_key,
+                registry_entry,
+                present_github_secrets=present_github_secrets,
+            )
+            effective_available = credential.available or remote_available
             slot_payload = {
                 "slot": slot_name,
                 "model": slug,
                 "provider": provider_key,
                 "wired": is_wired,
-                "credential": {
-                    "available": credential.available,
-                    "looked_for": credential.looked_for,
-                    "source": credential.source,
-                },
+                "credential": _credential_payload(
+                    credential,
+                    remote_available=remote_available,
+                ),
                 "disabled": disabled,
             }
             slots_payload.append(slot_payload)
@@ -375,7 +467,7 @@ def build_status_payload(
             if disabled:
                 skipped.append(
                     {
-                        "agentId": binding.agent_id,
+                        "agentId": agent_key,
                         "slot": slot_name,
                         "reason": f"provider {provider_key!r} is disabled",
                     }
@@ -383,15 +475,15 @@ def build_status_payload(
             elif not is_wired:
                 skipped.append(
                     {
-                        "agentId": binding.agent_id,
+                        "agentId": agent_key,
                         "slot": slot_name,
                         "reason": f"provider {provider_key!r} is not wired in mergecraft.yml",
                     }
                 )
-            elif not credential.available:
+            elif not effective_available:
                 skipped.append(
                     {
-                        "agentId": binding.agent_id,
+                        "agentId": agent_key,
                         "slot": slot_name,
                         "reason": (f"credential not available (consult {credential.looked_for})"),
                     }
@@ -399,7 +491,7 @@ def build_status_payload(
 
         reviewers_payload.append(
             {
-                "agentId": binding.agent_id,
+                "agentId": agent_key,
                 "after": binding.after,
                 "dispatchLevel": dispatch_levels.get(binding.agent_id, 0),
                 "enabled": agent_enabled,
@@ -413,11 +505,15 @@ def build_status_payload(
         for row in reviewer["slots"]
         if row["wired"] and row["credential"]["available"] and not row.get("disabled")
     ]
-    headline = (
-        f"{len(runnable)} slot(s) will run in CI"
-        if runnable
-        else "no roster slots are fully runnable in CI"
-    )
+    if github and present_github_secrets is not None:
+        headline = f"{len(runnable)} slot(s) runnable in CI"
+    elif runnable:
+        headline = f"{len(runnable)} slot(s) runnable with local credentials"
+    else:
+        headline = (
+            "no roster slots are fully runnable with local credentials "
+            "(use --github to check remote Actions secrets)"
+        )
 
     payload: dict[str, Any] = {
         "schemaVersion": STATUS_JSON_SCHEMA_VERSION,
@@ -425,12 +521,8 @@ def build_status_payload(
         "skipped": skipped,
         "reviewers": reviewers_payload,
     }
-    if github:
-        payload["github"] = _collect_github_secrets(
-            cwd=target,
-            registry_data=registry,
-            wired=wired,
-        )
+    if github_block is not None:
+        payload["github"] = github_block
     return payload
 
 
@@ -478,7 +570,10 @@ def _render_text(payload: dict[str, Any]) -> None:
 
             wired_label = "wired" if slot["wired"] else "not wired"
             if cred["available"]:
-                cred_label = "available"
+                if cred.get("source") == "github":
+                    cred_label = "available (Actions secret)"
+                else:
+                    cred_label = "available"
             else:
                 cred_label = f"not available ({cred['looked_for']})"
 
@@ -518,7 +613,10 @@ def provider_status_cmd(
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Show the reviewer roster, credentials, wiring, and dispatch order."""
-    payload = build_status_payload(cwd=cwd, github=github)
+    try:
+        payload = build_status_payload(cwd=cwd, github=github)
+    except RegistryValidationError as exc:
+        cli_bail(str(exc))
     if json_output:
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
         raise typer.Exit(CLI_SUCCESS_EXIT_CODE)

--- a/src/mergecraft/cli/provider_status.py
+++ b/src/mergecraft/cli/provider_status.py
@@ -1,0 +1,537 @@
+"""``mergecraft provider status`` — roster credential and wiring inspection (#520).
+
+Read-only operator view of what CI will run: per-reviewer ``modelChain`` slots,
+credential presence, workflow wiring, dispatch levels, and optional GitHub
+secret presence via ``--github``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from mergecraft.agents.registry import AgentRole, RegistryValidationError, load_registry
+from mergecraft.cli.consoles import err_console as console
+from mergecraft.cli.errors import cli_bail
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+from mergecraft.cli.provider_cmd import (
+    _config_path,
+    _env_path,
+    _read_env_map,
+    load_provider_registry,
+    resolve_indexed_credential,
+)
+from mergecraft.cli.provider_toggle import resolve_provider_secrets
+from mergecraft.cli.target_dir import target_dir as resolve_target_dir
+from mergecraft.config.runtime_provider_registry import (
+    credential_env_keys_for_entry,
+    lookup_registry_entry,
+)
+from mergecraft.config.settings import load_repo_settings
+from mergecraft.models import parse_model
+from mergecraft.workflow.auth_manifest import (
+    DEFAULT_WORKFLOW_RELATIVE_PATH,
+    WorkflowAuthManifestError,
+    flat_credential_env_keys,
+    parse_auth_manifest,
+)
+
+STATUS_JSON_SCHEMA_VERSION = 1
+
+STATUS_JSON_SCHEMA: dict[str, Any] = {
+    "version": STATUS_JSON_SCHEMA_VERSION,
+    "description": (
+        "Roster view of reviewer agents, modelChain slots, credential presence, "
+        "workflow wiring, dispatch levels, and optional GitHub secret presence."
+    ),
+    "required": ["schemaVersion", "reviewers"],
+    "properties": {
+        "schemaVersion": {"type": "integer", "const": STATUS_JSON_SCHEMA_VERSION},
+        "headline": {"type": "string"},
+        "skipped": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["agentId", "slot", "reason"],
+            },
+        },
+        "reviewers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["agentId", "slots"],
+                "properties": {
+                    "agentId": {"type": "string"},
+                    "after": {"type": ["string", "null"]},
+                    "dispatchLevel": {"type": "integer"},
+                    "enabled": {"type": "boolean"},
+                    "slots": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["slot", "model", "provider", "credential", "wired"],
+                        },
+                    },
+                },
+            },
+        },
+        "github": {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "message": {"type": "string"},
+                "secrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "present"],
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialStatus:
+    """Credential probe result for one model slug (lane B adapter surface)."""
+
+    available: bool
+    source: str
+    looked_for: str
+
+
+def credential_status_for_slug(
+    slug: str,
+    *,
+    settings: Any,
+    cwd: Path,
+    wired: bool,
+) -> CredentialStatus:
+    """Return credential presence for *slug* without printing secret material."""
+    import importlib
+
+    try:
+        lane_b_module = importlib.import_module("mergecraft.utils.agent_resolve")
+        lane_b_status = getattr(lane_b_module, "credential_status_for_slug", None)
+    except ImportError:
+        lane_b_status = None
+    if lane_b_status is not None:
+        try:
+            status = lane_b_status(slug, settings=settings, cwd=cwd, wired=wired)
+        except TypeError:
+            pass
+        else:
+            return CredentialStatus(
+                available=bool(status.available),
+                source=str(status.source),
+                looked_for=str(status.looked_for),
+            )
+
+    return _local_credential_status(slug, settings=settings, cwd=cwd, wired=wired)
+
+
+def _local_credential_status(
+    slug: str,
+    *,
+    settings: Any,
+    cwd: Path,
+    wired: bool,
+) -> CredentialStatus:
+    del wired  # unwired slots still report which env var would be consulted
+    try:
+        provider, _model_id = parse_model(slug)
+    except ValueError:
+        return CredentialStatus(available=False, source="unknown", looked_for="")
+
+    provider_key = provider.lower()
+    env_map = _read_env_map(_env_path(cwd))
+    entry = lookup_registry_entry(settings, provider_key)
+    keys: tuple[str, ...]
+    if entry is not None:
+        keys = credential_env_keys_for_entry(entry)
+        if resolve_indexed_credential(
+            {
+                "label": entry.label,
+                "envIndex": entry.env_index,
+                "authKind": entry.auth_kind,
+            },
+            cwd=cwd,
+        ):
+            primary = keys[0] if keys else f"LLM_PROVIDER_{entry.env_index}_API_KEY"
+            return CredentialStatus(available=True, source="env", looked_for=primary)
+    else:
+        keys = flat_credential_env_keys(provider_key)
+
+    if not keys:
+        keys = flat_credential_env_keys(provider_key)
+
+    for key in keys:
+        if env_map.get(key, "").strip() or os.environ.get(key, "").strip():
+            return CredentialStatus(available=True, source="env", looked_for=key)
+
+    looked_for = keys[0] if keys else f"{provider_key.upper()}_API_KEY"
+    return CredentialStatus(available=False, source="env", looked_for=looked_for)
+
+
+def _provider_disabled(label: str, entry: dict[str, Any] | None, *, cwd: Path) -> bool:
+    secrets = resolve_provider_secrets(label, entry)
+    if not secrets.local:
+        return False
+    env_map = _read_env_map(_env_path(cwd))
+    has_blank = any(key in env_map and not env_map[key].strip() for key in secrets.local)
+    has_value = any(
+        env_map.get(key, "").strip() or os.environ.get(key, "").strip() for key in secrets.local
+    )
+    return has_blank and not has_value
+
+
+def _wired_providers(workflow_path: Path) -> frozenset[str]:
+    if not workflow_path.is_file():
+        return frozenset()
+    try:
+        return parse_auth_manifest(workflow_path)
+    except WorkflowAuthManifestError:
+        return frozenset()
+
+
+def _dispatch_level_map(registry: Any) -> dict[str, int]:
+    levels = registry.resolve_role_levels(AgentRole.reviewer)
+    mapping: dict[str, int] = {}
+    for level_index, batch in enumerate(levels):
+        for binding in batch:
+            mapping[binding.agent_id] = level_index
+    return mapping
+
+
+def _github_token() -> str | None:
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return None
+
+
+def list_repo_secrets(repo_slug: str) -> list[str]:
+    """Return Actions secret names on *repo_slug* (empty when ``gh`` is unavailable)."""
+    try:
+        completed = subprocess.run(  # nosec B603 B607 — fixed argv, gh binary
+            ["gh", "secret", "list", "--repo", repo_slug, "--json", "name", "-q", ".[].name"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if completed.returncode != 0:
+        return []
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def secret_is_present(repo_slug: str, name: str) -> bool:
+    """Return whether *name* exists as an Actions secret on *repo_slug*."""
+    return name in list_repo_secrets(repo_slug)
+
+
+def _resolve_repo_slug(cwd: Path) -> str:
+    """Return ``owner/repo`` for *cwd*, or a placeholder when origin is unreadable."""
+    import re
+
+    from mergecraft.utils.git_hardening import read_remote_origin_url
+
+    resolved = cwd.resolve()
+    try:
+        url = read_remote_origin_url(str(resolved))
+    except (RuntimeError, OSError):
+        return "local/unknown"
+    match = re.search(r"github\.com(?::\d+)?[:/]+([^/]+)/(.+?)(?:\.git)?(?:/)?$", url)
+    if not match:
+        return "local/unknown"
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _collect_github_secrets(
+    *,
+    cwd: Path,
+    registry_data: Any,
+    wired: frozenset[str],
+) -> dict[str, Any]:
+    token = _github_token()
+    if token is None:
+        return {
+            "status": "unknown",
+            "message": (
+                "GitHub secret presence unknown — set GH_TOKEN or GITHUB_TOKEN "
+                "(repo scope: read:repo or admin:repo_hook) and re-run with --github"
+            ),
+        }
+
+    repo_slug = _resolve_repo_slug(cwd)
+    present_names = set(list_repo_secrets(repo_slug))
+    provider_registry = load_provider_registry(_config_path(cwd))
+    provider_entry_by_label = {
+        str(row.get("label", "")).lower(): row for row in provider_registry.entries
+    }
+    required: list[str] = []
+    seen: set[str] = set()
+    for binding in registry_data.resolve_roles(AgentRole.reviewer):
+        for slug in binding.model_chain:
+            try:
+                provider, _ = parse_model(slug)
+            except ValueError:
+                continue
+            provider_key = provider.lower()
+            if provider_key not in wired:
+                continue
+            registry_entry = provider_entry_by_label.get(provider_key)
+            secrets = resolve_provider_secrets(provider_key, registry_entry)
+            for name in secrets.github:
+                if name not in seen:
+                    seen.add(name)
+                    required.append(name)
+
+    secret_rows = [
+        {"name": name, "present": name in present_names or secret_is_present(repo_slug, name)}
+        for name in sorted(required)
+    ]
+    return {"status": "ok", "repo": repo_slug, "secrets": secret_rows}
+
+
+def build_status_payload(
+    *,
+    cwd: Path,
+    github: bool = False,
+) -> dict[str, Any]:
+    target = resolve_target_dir(cwd)
+    settings = load_repo_settings(root=target, load_learnings_files=False)
+    try:
+        registry = load_registry(settings=settings, repo_root=target)
+    except RegistryValidationError as exc:
+        cli_bail(str(exc))
+
+    workflow_path = target / DEFAULT_WORKFLOW_RELATIVE_PATH
+    wired = _wired_providers(workflow_path)
+    provider_registry = load_provider_registry(_config_path(target))
+    dispatch_levels = _dispatch_level_map(registry)
+
+    reviewers_payload: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+
+    for binding in registry.resolve_roles(AgentRole.reviewer):
+        provider_entry_by_label = {
+            str(row.get("label", "")).lower(): row for row in provider_registry.entries
+        }
+        slots_payload: list[dict[str, Any]] = []
+        agent_enabled = True
+
+        for index, slug in enumerate(binding.model_chain):
+            slot_name = f"p{index}"
+            try:
+                provider, _model_id = parse_model(slug)
+            except ValueError:
+                provider = "unknown"
+            provider_key = provider.lower()
+            registry_entry = provider_entry_by_label.get(provider_key)
+            disabled = _provider_disabled(provider_key, registry_entry, cwd=target)
+            if disabled:
+                agent_enabled = False
+            is_wired = provider_key in wired
+            credential = credential_status_for_slug(
+                slug,
+                settings=settings,
+                cwd=target,
+                wired=is_wired,
+            )
+            slot_payload = {
+                "slot": slot_name,
+                "model": slug,
+                "provider": provider_key,
+                "wired": is_wired,
+                "credential": {
+                    "available": credential.available,
+                    "looked_for": credential.looked_for,
+                    "source": credential.source,
+                },
+                "disabled": disabled,
+            }
+            slots_payload.append(slot_payload)
+
+            if disabled:
+                skipped.append(
+                    {
+                        "agentId": binding.agent_id,
+                        "slot": slot_name,
+                        "reason": f"provider {provider_key!r} is disabled",
+                    }
+                )
+            elif not is_wired:
+                skipped.append(
+                    {
+                        "agentId": binding.agent_id,
+                        "slot": slot_name,
+                        "reason": f"provider {provider_key!r} is not wired in mergecraft.yml",
+                    }
+                )
+            elif not credential.available:
+                skipped.append(
+                    {
+                        "agentId": binding.agent_id,
+                        "slot": slot_name,
+                        "reason": (f"credential not available (consult {credential.looked_for})"),
+                    }
+                )
+
+        reviewers_payload.append(
+            {
+                "agentId": binding.agent_id,
+                "after": binding.after,
+                "dispatchLevel": dispatch_levels.get(binding.agent_id, 0),
+                "enabled": agent_enabled,
+                "slots": slots_payload,
+            }
+        )
+
+    runnable = [
+        row
+        for reviewer in reviewers_payload
+        for row in reviewer["slots"]
+        if row["wired"] and row["credential"]["available"] and not row.get("disabled")
+    ]
+    headline = (
+        f"{len(runnable)} slot(s) will run in CI"
+        if runnable
+        else "no roster slots are fully runnable in CI"
+    )
+
+    payload: dict[str, Any] = {
+        "schemaVersion": STATUS_JSON_SCHEMA_VERSION,
+        "headline": headline,
+        "skipped": skipped,
+        "reviewers": reviewers_payload,
+    }
+    if github:
+        payload["github"] = _collect_github_secrets(
+            cwd=target,
+            registry_data=registry,
+            wired=wired,
+        )
+    return payload
+
+
+def _render_text(payload: dict[str, Any]) -> None:
+    headline = payload.get("headline", "")
+    console.print(Panel(Text(headline, style="bold"), title="What will CI run?"))
+
+    skipped = payload.get("skipped") or []
+    if skipped:
+        skip_table = Table(title="Skipped slots", show_header=True, header_style="bold")
+        skip_table.add_column("agent")
+        skip_table.add_column("slot")
+        skip_table.add_column("reason")
+        for row in skipped:
+            skip_table.add_row(row["agentId"], row["slot"], row["reason"])
+        console.print(skip_table)
+
+    for reviewer in payload.get("reviewers", []):
+        agent_id = reviewer["agentId"]
+        after = reviewer.get("after")
+        level = reviewer.get("dispatchLevel", 0)
+        title = f"{agent_id} (dispatch level {level}"
+        if after:
+            title += f", after {after}"
+        title += ")"
+
+        table = Table(title=title, show_header=True, header_style="bold")
+        table.add_column("slot")
+        table.add_column("model")
+        table.add_column("provider")
+        table.add_column("wired")
+        table.add_column("credential")
+        table.add_column("state")
+
+        for slot in reviewer.get("slots", []):
+            cred = slot["credential"]
+            if slot.get("disabled"):
+                state = "disabled"
+            elif not slot["wired"]:
+                state = "not wired"
+            elif cred["available"]:
+                state = "ready"
+            else:
+                state = "not available"
+
+            wired_label = "wired" if slot["wired"] else "not wired"
+            if cred["available"]:
+                cred_label = "available"
+            else:
+                cred_label = f"not available ({cred['looked_for']})"
+
+            table.add_row(
+                slot["slot"],
+                slot["model"],
+                slot["provider"],
+                wired_label,
+                cred_label,
+                state,
+            )
+        console.print(table)
+
+    github = payload.get("github")
+    if github is not None:
+        status = github.get("status", "unknown")
+        if status == "unknown":
+            console.print(f"[yellow]GitHub secrets: unknown[/yellow] — {github.get('message', '')}")
+        else:
+            secret_table = Table(title="GitHub Actions secrets", show_header=True)
+            secret_table.add_column("secret")
+            secret_table.add_column("present")
+            for row in github.get("secrets", []):
+                present = row.get("present")
+                label = "present" if present else "absent"
+                secret_table.add_row(row.get("name", ""), label)
+            console.print(secret_table)
+
+
+def provider_status_cmd(
+    cwd: Path = typer.Option(Path("."), "--cwd", help="Repository root."),
+    github: bool = typer.Option(
+        False,
+        "--github",
+        help="Also report whether required Actions secrets exist on the repo.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Show the reviewer roster, credentials, wiring, and dispatch order."""
+    payload = build_status_payload(cwd=cwd, github=github)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        raise typer.Exit(CLI_SUCCESS_EXIT_CODE)
+    _render_text(payload)
+
+
+def register(provider_app: typer.Typer) -> None:
+    """Attach ``status`` to the ``provider`` Typer app."""
+    provider_app.command("status")(provider_status_cmd)
+
+
+__all__ = [
+    "STATUS_JSON_SCHEMA",
+    "STATUS_JSON_SCHEMA_VERSION",
+    "CredentialStatus",
+    "build_status_payload",
+    "credential_status_for_slug",
+    "list_repo_secrets",
+    "provider_status_cmd",
+    "register",
+    "secret_is_present",
+]

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import re
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
@@ -23,6 +22,7 @@ from mergecraft.classify import RuleSet
 from mergecraft.config.compat import CONFIG_SCHEMA_VERSION, migrate_config
 from mergecraft.enterprise.controls import EnterpriseSettings
 from mergecraft.types import PushPermission, ShellPermission  # noqa: TC001
+from mergecraft.utils.source_resolve import is_registered_git_worktree, resolve_git_common_dir
 
 AccountPlan = Literal["none", "payg"]
 HeadingDepth = Literal[1, 2, 3, 4, 5, 6]
@@ -751,44 +751,6 @@ def parse_learnings_headings(body: str | None) -> list[LearningsHeading]:
     return result
 
 
-def _git_worktree_root(path: Path) -> Path | None:
-    """Return the git worktree root containing *path*, or ``None`` if not in a repo."""
-    try:
-        current = path.resolve()
-    except OSError:
-        return None
-    for candidate in (current, *current.parents):
-        if (candidate / ".git").exists():
-            return candidate
-    return None
-
-
-@lru_cache(maxsize=32)
-def _git_common_dir(worktree_root: str) -> str | None:
-    """Resolve the git common directory for *worktree_root* without subprocess (#573 / D2)."""
-    root = Path(worktree_root)
-    git_entry = root / ".git"
-    if not git_entry.exists():
-        return None
-    if git_entry.is_dir():
-        return str(git_entry.resolve())
-    if not git_entry.is_file():
-        return None
-    try:
-        first_line = git_entry.read_text(encoding="utf-8").splitlines()[0].strip()
-    except (OSError, IndexError):
-        return None
-    if not first_line.startswith("gitdir:"):
-        return None
-    gitdir = Path(first_line.removeprefix("gitdir:").strip())
-    gitdir = (root / gitdir).resolve() if not gitdir.is_absolute() else gitdir.resolve()
-    parts = gitdir.parts
-    if "worktrees" not in parts:
-        return None
-    common = Path(*parts[: parts.index("worktrees")])
-    return str(common) if common.is_dir() else None
-
-
 def _path_is_inside(child: Path, parent: Path) -> bool:
     try:
         child.resolve().relative_to(parent.resolve())
@@ -820,13 +782,15 @@ def _workspace_root(explicit: Path | None = None) -> Path:
         return workspace
     if _path_is_inside(cwd, workspace) or cwd_resolved == workspace_resolved:
         return workspace
-    cwd_root = _git_worktree_root(cwd)
-    ws_root = _git_worktree_root(workspace)
-    if cwd_root is not None and ws_root is not None and cwd_root.resolve() != ws_root.resolve():
-        cwd_common = _git_common_dir(str(cwd_root.resolve()))
-        ws_common = _git_common_dir(str(ws_root.resolve()))
-        if cwd_common is not None and cwd_common == ws_common:
-            return cwd_root
+    cwd_common = resolve_git_common_dir(cwd_resolved)
+    ws_common = resolve_git_common_dir(workspace_resolved)
+    if (
+        cwd_common is not None
+        and ws_common is not None
+        and cwd_common == ws_common
+        and is_registered_git_worktree(cwd_resolved)
+    ):
+        return cwd_resolved
     return workspace
 
 

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -22,7 +22,6 @@ from mergecraft.classify import RuleSet
 from mergecraft.config.compat import CONFIG_SCHEMA_VERSION, migrate_config
 from mergecraft.enterprise.controls import EnterpriseSettings
 from mergecraft.types import PushPermission, ShellPermission  # noqa: TC001
-from mergecraft.utils.source_resolve import is_registered_git_worktree, resolve_git_common_dir
 
 AccountPlan = Literal["none", "payg"]
 HeadingDepth = Literal[1, 2, 3, 4, 5, 6]
@@ -782,6 +781,9 @@ def _workspace_root(explicit: Path | None = None) -> Path:
         return workspace
     if _path_is_inside(cwd, workspace) or cwd_resolved == workspace_resolved:
         return workspace
+    # Lazy import: source_resolve → analyzers.trust → settings at module load.
+    from mergecraft.utils.source_resolve import is_registered_git_worktree, resolve_git_common_dir
+
     cwd_common = resolve_git_common_dir(cwd_resolved)
     ws_common = resolve_git_common_dir(workspace_resolved)
     if (

--- a/src/mergecraft/config/settings.py
+++ b/src/mergecraft/config/settings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
@@ -750,13 +751,83 @@ def parse_learnings_headings(body: str | None) -> list[LearningsHeading]:
     return result
 
 
+def _git_worktree_root(path: Path) -> Path | None:
+    """Return the git worktree root containing *path*, or ``None`` if not in a repo."""
+    try:
+        current = path.resolve()
+    except OSError:
+        return None
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+@lru_cache(maxsize=32)
+def _git_common_dir(worktree_root: str) -> str | None:
+    """Resolve the git common directory for *worktree_root* without subprocess (#573 / D2)."""
+    root = Path(worktree_root)
+    git_entry = root / ".git"
+    if not git_entry.exists():
+        return None
+    if git_entry.is_dir():
+        return str(git_entry.resolve())
+    if not git_entry.is_file():
+        return None
+    try:
+        first_line = git_entry.read_text(encoding="utf-8").splitlines()[0].strip()
+    except (OSError, IndexError):
+        return None
+    if not first_line.startswith("gitdir:"):
+        return None
+    gitdir = Path(first_line.removeprefix("gitdir:").strip())
+    gitdir = (root / gitdir).resolve() if not gitdir.is_absolute() else gitdir.resolve()
+    parts = gitdir.parts
+    if "worktrees" not in parts:
+        return None
+    common = Path(*parts[: parts.index("worktrees")])
+    return str(common) if common.is_dir() else None
+
+
+def _path_is_inside(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except (OSError, ValueError):
+        return False
+    else:
+        return True
+
+
 def _workspace_root(explicit: Path | None = None) -> Path:
+    """Resolve the repo root for config and learnings paths.
+
+    #573: the coverage gate re-points ``GITHUB_WORKSPACE`` at the base worktree
+    it is measuring. When settings load from a *different* linked worktree of the
+    same repo (cwd in the base tree, ``GITHUB_WORKSPACE`` at the head checkout),
+    prefer the cwd worktree so each tree reads its own ``.mergecraft/config``.
+    """
     if explicit is not None:
         return explicit
-    workspace = os.environ.get("GITHUB_WORKSPACE")
-    if workspace:
-        return Path(workspace)
-    return Path.cwd()
+    cwd = Path.cwd()
+    workspace_env = os.environ.get("GITHUB_WORKSPACE")
+    if not workspace_env:
+        return cwd
+    workspace = Path(workspace_env)
+    try:
+        workspace_resolved = workspace.resolve()
+        cwd_resolved = cwd.resolve()
+    except OSError:
+        return workspace
+    if _path_is_inside(cwd, workspace) or cwd_resolved == workspace_resolved:
+        return workspace
+    cwd_root = _git_worktree_root(cwd)
+    ws_root = _git_worktree_root(workspace)
+    if cwd_root is not None and ws_root is not None and cwd_root.resolve() != ws_root.resolve():
+        cwd_common = _git_common_dir(str(cwd_root.resolve()))
+        ws_common = _git_common_dir(str(ws_root.resolve()))
+        if cwd_common is not None and cwd_common == ws_common:
+            return cwd_root
+    return workspace
 
 
 def _read_text(path: Path) -> str | None:

--- a/tests/ci/support_ci_gate_coverage.py
+++ b/tests/ci/support_ci_gate_coverage.py
@@ -77,6 +77,33 @@ def git(cwd: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def resolve_push_branch(scratch: Path, *, fallback: str = "ci-gate-test-head") -> str:
+    """Return a branch name suitable for ``git push`` from *scratch*.
+
+    Detached HEAD (common on Actions) yields the literal ``HEAD`` from
+    ``rev-parse --abbrev-ref``; resolve via symbolic-ref, ``GITHUB_HEAD_REF``,
+    or a named branch created from the current commit.
+    """
+    sym = subprocess.run(
+        ["git", "symbolic-ref", "-q", "--short", "HEAD"],
+        cwd=scratch,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if sym.returncode == 0:
+        name = sym.stdout.strip()
+        if name and name != "HEAD":
+            return name
+
+    gh_head = os.environ.get("GITHUB_HEAD_REF", "").strip()
+    if gh_head:
+        return gh_head
+
+    git(scratch, "checkout", "-B", fallback)
+    return fallback
+
+
 def install_bare_origin(scratch: Path, tmp_path: Path) -> None:
     """Point *scratch*'s ``origin`` at a local bare repo with current branches."""
     bare = tmp_path / "origin.git"
@@ -87,7 +114,7 @@ def install_bare_origin(scratch: Path, tmp_path: Path) -> None:
         text=True,
     )
     git(scratch, "remote", "set-url", "origin", str(bare))
-    branch = git(scratch, "rev-parse", "--abbrev-ref", "HEAD")
+    branch = resolve_push_branch(scratch)
     git(scratch, "push", "-u", "origin", branch)
 
 
@@ -177,6 +204,7 @@ __all__ = [
     "git",
     "install_bare_origin",
     "noop_coverage_measure",
+    "resolve_push_branch",
     "run_coverage_delta_gate",
     "script_text",
     "seed_passing_coverage_json",

--- a/tests/ci/support_ci_gate_coverage.py
+++ b/tests/ci/support_ci_gate_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -12,6 +13,20 @@ from tests.ci.workflow_support import REPO_ROOT
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+_MODULE_FLOORS = (
+    "utils/token.py",
+    "utils/git_setup.py",
+    "main.py",
+)
+_PREFIX_NEEDLES = (
+    "/mcp/",
+    "/action/",
+    "/security/",
+    "/analyzers/",
+    "/agents/",
+    "/review/",
+)
 
 _BASE_MEASURE_MARKER = "BASE_WORKTREE_MEASURE_BLOCK"
 _BASE_MEASURE_BLOCK_RE = re.compile(
@@ -89,6 +104,43 @@ def break_coverage_measure(makefile: Path) -> None:
     makefile.write_text(patched, encoding="utf-8")
 
 
+def noop_coverage_measure(makefile: Path) -> None:
+    """Replace ``coverage-measure`` with a no-op so a pre-seeded ``coverage.json`` survives."""
+    text = makefile.read_text(encoding="utf-8")
+    match = re.search(r"^(coverage-measure:.*\n)((?:\t.*\n)+)", text, flags=re.MULTILINE)
+    if match is None:
+        msg = "Makefile is missing a coverage-measure target"
+        raise AssertionError(msg)
+    replacement = f"{match.group(1)}\t@:\n"
+    patched = text[: match.start()] + replacement + text[match.end() :]
+    makefile.write_text(patched, encoding="utf-8")
+
+
+def seed_passing_coverage_json(path: Path) -> None:
+    """Write a ``coverage.json`` that satisfies the head ratchet and floor checks."""
+    summary = {
+        "percent_covered": 100.0,
+        "num_statements": 100,
+        "covered_lines": 100,
+        "num_branches": 100,
+        "covered_branches": 100,
+    }
+    files: dict[str, dict[str, dict[str, float | int]]] = {}
+    for suffix in _MODULE_FLOORS:
+        files[f"src/mergecraft/{suffix}"] = {"summary": summary}
+    for needle in _PREFIX_NEEDLES:
+        files[f"src/mergecraft{needle}module.py"] = {"summary": summary}
+    payload = {
+        "totals": {
+            "percent_covered": 100.0,
+            "num_statements": 100,
+            "covered_lines": 100,
+        },
+        "files": files,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def run_coverage_delta_gate(
     repo_root: Path,
     *,
@@ -124,7 +176,9 @@ __all__ = [
     "clone_local_repo",
     "git",
     "install_bare_origin",
+    "noop_coverage_measure",
     "run_coverage_delta_gate",
     "script_text",
+    "seed_passing_coverage_json",
     "worktree_path",
 ]

--- a/tests/ci/support_ci_gate_coverage.py
+++ b/tests/ci/support_ci_gate_coverage.py
@@ -63,6 +63,8 @@ def clone_local_repo(tmp_path: Path) -> Path:
         capture_output=True,
         text=True,
     )
+    git(dest, "config", "user.email", "ci-gate@test.local")
+    git(dest, "config", "user.name", "CI Gate Test")
     return dest
 
 

--- a/tests/ci/support_ci_gate_coverage.py
+++ b/tests/ci/support_ci_gate_coverage.py
@@ -1,0 +1,130 @@
+"""Shared helpers for wave 16 — coverage delta gate contracts."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.ci.workflow_support import REPO_ROOT
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_BASE_MEASURE_MARKER = "BASE_WORKTREE_MEASURE_BLOCK"
+_BASE_MEASURE_BLOCK_RE = re.compile(
+    rf"#.*{re.escape(_BASE_MEASURE_MARKER)}.*\n\(\s*\n(.*?)^\)",
+    re.MULTILINE | re.DOTALL,
+)
+_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci_coverage_delta_gate.sh"
+_WORKTREE_SUFFIX = ".ci-mergecraft-base-coverage"
+
+
+def script_text() -> str:
+    return _SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def base_measure_block(text: str | None = None) -> str:
+    source = text if text is not None else script_text()
+    match = _BASE_MEASURE_BLOCK_RE.search(source)
+    if match is None:
+        msg = f"{_BASE_MEASURE_MARKER} block missing from ci_coverage_delta_gate.sh"
+        raise AssertionError(msg)
+    return match.group(1)
+
+
+def worktree_path(repo_root: Path) -> Path:
+    return repo_root / _WORKTREE_SUFFIX
+
+
+def clone_local_repo(tmp_path: Path) -> Path:
+    """Clone the checkout under test into an isolated scratch repo."""
+    dest = tmp_path / "scratch"
+    subprocess.run(
+        ["git", "clone", "--local", str(REPO_ROOT), str(dest)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return dest
+
+
+def git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def install_bare_origin(scratch: Path, tmp_path: Path) -> None:
+    """Point *scratch*'s ``origin`` at a local bare repo with current branches."""
+    bare = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(scratch), str(bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    git(scratch, "remote", "set-url", "origin", str(bare))
+    branch = git(scratch, "rev-parse", "--abbrev-ref", "HEAD")
+    git(scratch, "push", "-u", "origin", branch)
+
+
+def break_coverage_measure(makefile: Path) -> None:
+    text = makefile.read_text(encoding="utf-8")
+    if "ci-gate-break-measure" in text:
+        return
+    match = re.search(r"^(coverage-measure:.*\n)((?:\t.*\n)+)", text, flags=re.MULTILINE)
+    if match is None:
+        msg = "Makefile is missing a coverage-measure target"
+        raise AssertionError(msg)
+    replacement = f"{match.group(1)}\t@echo ci-gate-break-measure >&2\n\t@exit 1\n"
+    patched = text[: match.start()] + replacement + text[match.end() :]
+    makefile.write_text(patched, encoding="utf-8")
+
+
+def run_coverage_delta_gate(
+    repo_root: Path,
+    *,
+    base_ref: str,
+    extra_env: Mapping[str, str] | None = None,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_BASE_REF": base_ref,
+            "GITHUB_WORKSPACE": str(repo_root),
+            "CI": "true",
+        }
+    )
+    if extra_env:
+        env.update(dict(extra_env))
+    return subprocess.run(
+        ["bash", str(_SCRIPT_PATH)],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+__all__ = [
+    "base_measure_block",
+    "break_coverage_measure",
+    "clone_local_repo",
+    "git",
+    "install_bare_origin",
+    "run_coverage_delta_gate",
+    "script_text",
+    "worktree_path",
+]

--- a/tests/ci/support_ci_gate_coverage.py
+++ b/tests/ci/support_ci_gate_coverage.py
@@ -80,9 +80,9 @@ def git(cwd: Path, *args: str) -> str:
 def resolve_push_branch(scratch: Path, *, fallback: str = "ci-gate-test-head") -> str:
     """Return a branch name suitable for ``git push`` from *scratch*.
 
-    Detached HEAD (common on Actions) yields the literal ``HEAD`` from
-    ``rev-parse --abbrev-ref``; resolve via symbolic-ref, ``GITHUB_HEAD_REF``,
-    or a named branch created from the current commit.
+    Named checkouts (local dev) resolve via ``symbolic-ref``. Detached HEAD
+    (common on Actions) must not use ``GITHUB_HEAD_REF`` — create a synthetic
+    local branch so ``install_bare_origin`` never pushes the real PR branch.
     """
     sym = subprocess.run(
         ["git", "symbolic-ref", "-q", "--short", "HEAD"],
@@ -95,10 +95,6 @@ def resolve_push_branch(scratch: Path, *, fallback: str = "ci-gate-test-head") -
         name = sym.stdout.strip()
         if name and name != "HEAD":
             return name
-
-    gh_head = os.environ.get("GITHUB_HEAD_REF", "").strip()
-    if gh_head:
-        return gh_head
 
     git(scratch, "checkout", "-B", fallback)
     return fallback

--- a/tests/ci/test_ci_gate_coverage_delta.py
+++ b/tests/ci/test_ci_gate_coverage_delta.py
@@ -6,16 +6,16 @@ import json
 import re
 from typing import TYPE_CHECKING
 
-import pytest
-
 from tests.ci.support_ci_gate_coverage import (
     base_measure_block,
     break_coverage_measure,
     clone_local_repo,
     git,
     install_bare_origin,
+    noop_coverage_measure,
     run_coverage_delta_gate,
     script_text,
+    seed_passing_coverage_json,
     worktree_path,
 )
 from tests.ci.test_coverage_delta_wrapper import (
@@ -26,7 +26,6 @@ from tests.ci.test_coverage_delta_wrapper import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-W3_XFAIL = pytest.mark.xfail(reason="green after W3: base measurement signal not gate", strict=True)
 _INTEGRATION_TIMEOUT = 180
 
 
@@ -38,6 +37,11 @@ def _bootstrap_broken_base(scratch: Path, tmp_path: Path, base_ref: str = "broke
     git(scratch, "commit", "-m", "break base coverage-measure")
     git(scratch, "push", "-u", "origin", base_ref)
     git(scratch, "checkout", "-b", "feature-head")
+    git(scratch, "checkout", f"{base_ref}^", "--", "Makefile")
+    noop_coverage_measure(scratch / "Makefile")
+    seed_passing_coverage_json(scratch / "coverage.json")
+    git(scratch, "add", "Makefile")
+    git(scratch, "commit", "-m", "fast head coverage gate for integration tests")
     git(scratch, "push", "-u", "origin", "feature-head")
 
 
@@ -90,7 +94,6 @@ def test_worktree_cleaned_up_when_base_measurement_fails(tmp_path: Path) -> None
     assert not wt.exists()
 
 
-@W3_XFAIL
 def test_broken_base_measurement_exits_zero_without_base_json(tmp_path: Path) -> None:
     """D4 — a red base is a signal, not a script-killing pre-gate."""
     scratch = clone_local_repo(tmp_path)
@@ -102,7 +105,6 @@ def test_broken_base_measurement_exits_zero_without_base_json(tmp_path: Path) ->
     assert not (scratch / "coverage-base.json").is_file()
 
 
-@W3_XFAIL
 def test_skipped_delta_emits_warning_with_reason(tmp_path: Path) -> None:
     """D6 — a skipped delta must be visible, not silent."""
     scratch = clone_local_repo(tmp_path)
@@ -117,7 +119,6 @@ def test_skipped_delta_emits_warning_with_reason(tmp_path: Path) -> None:
     assert "measure" in combined or "coverage" in combined
 
 
-@W3_XFAIL
 def test_head_coverage_regression_still_fails_when_base_skips(tmp_path: Path) -> None:
     """D5 — relaxing only the base must not disable the head ratchet."""
     scratch = clone_local_repo(tmp_path)

--- a/tests/ci/test_ci_gate_coverage_delta.py
+++ b/tests/ci/test_ci_gate_coverage_delta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,7 @@ from tests.ci.support_ci_gate_coverage import (
     git,
     install_bare_origin,
     noop_coverage_measure,
+    resolve_push_branch,
     run_coverage_delta_gate,
     script_text,
     seed_passing_coverage_json,
@@ -117,6 +119,62 @@ def test_skipped_delta_emits_warning_with_reason(tmp_path: Path) -> None:
     assert "warn" in combined or "::warning" in combined
     assert "base" in combined or "broken-base" in combined
     assert "measure" in combined or "coverage" in combined
+
+
+def test_base_measure_block_tolerates_setup_failures() -> None:
+    """Regression guard — uv sync / setup-local-analyzers failures must not abort the gate."""
+    block = base_measure_block()
+    assert "set +e" in block
+    assert "measure_ok=false" in block
+    assert "uv}" in block or "${UV:-uv}" in block
+    assert "setup-local-analyzers" in block
+
+
+def test_install_bare_origin_pushes_from_detached_head(tmp_path: Path) -> None:
+    """Detached HEAD must not push the literal branch name ``HEAD``."""
+    scratch = clone_local_repo(tmp_path)
+    install_bare_origin(scratch, tmp_path)
+    git(scratch, "checkout", "--detach", "HEAD")
+    branch = resolve_push_branch(scratch, fallback="detached-ci-gate-head")
+    assert branch == "detached-ci-gate-head"
+    git(scratch, "push", "-u", "origin", branch)
+
+
+def test_base_uv_sync_failure_still_warns_and_skips_delta(tmp_path: Path) -> None:
+    """Base ``uv sync`` failure must reach the warn-and-skip path, not abort under set -e."""
+    import shutil
+
+    real_uv = shutil.which("uv")
+    assert real_uv is not None, "uv must be on PATH for this integration test"
+    wrapper = tmp_path / "uv"
+    wrapper.write_text(
+        f"""#!/usr/bin/env bash
+case "$PWD" in
+  *".ci-mergecraft-base-coverage"*)
+    echo "uv sync failed (test)" >&2
+    exit 1
+    ;;
+esac
+exec {real_uv} "$@"
+""",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    scratch = clone_local_repo(tmp_path)
+    _bootstrap_broken_base(scratch, tmp_path)
+
+    result = run_coverage_delta_gate(
+        scratch,
+        base_ref="broken-base",
+        extra_env={"UV": str(wrapper), "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}"},
+        timeout=_INTEGRATION_TIMEOUT,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined
+    assert not (scratch / "coverage-base.json").is_file()
+    assert "warn" in combined.lower() or "::warning" in combined.lower()
 
 
 def test_head_coverage_regression_still_fails_when_base_skips(tmp_path: Path) -> None:

--- a/tests/ci/test_ci_gate_coverage_delta.py
+++ b/tests/ci/test_ci_gate_coverage_delta.py
@@ -1,0 +1,136 @@
+"""W1.2 — coverage delta gate contracts (wave 16, green after W3)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.ci.support_ci_gate_coverage import (
+    base_measure_block,
+    break_coverage_measure,
+    clone_local_repo,
+    git,
+    install_bare_origin,
+    run_coverage_delta_gate,
+    script_text,
+    worktree_path,
+)
+from tests.ci.test_coverage_delta_wrapper import (
+    _BASE_MEASURE_MARKER,
+    _base_worktree_block,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+W3_XFAIL = pytest.mark.xfail(reason="green after W3: base measurement signal not gate", strict=True)
+_INTEGRATION_TIMEOUT = 180
+
+
+def _bootstrap_broken_base(scratch: Path, tmp_path: Path, base_ref: str = "broken-base") -> None:
+    install_bare_origin(scratch, tmp_path)
+    break_coverage_measure(scratch / "Makefile")
+    git(scratch, "checkout", "-b", base_ref)
+    git(scratch, "add", "Makefile")
+    git(scratch, "commit", "-m", "break base coverage-measure")
+    git(scratch, "push", "-u", "origin", base_ref)
+    git(scratch, "checkout", "-b", "feature-head")
+    git(scratch, "push", "-u", "origin", "feature-head")
+
+
+def test_base_measure_block_markers_remain_parseable() -> None:
+    """D7 — ``BASE_WORKTREE_MEASURE_BLOCK`` stays where the wrapper test expects."""
+    block = _base_worktree_block(script_text())
+    assert "make coverage-measure" in block or "coverage-gate:" in block
+    assert _BASE_MEASURE_MARKER in script_text()
+
+
+def test_base_measure_block_exports_uv_project_environment() -> None:
+    """Regression guard — ``UV_PROJECT_ENVIRONMENT`` export must survive W3 edits."""
+    block = base_measure_block()
+    assert "UV_PROJECT_ENVIRONMENT" in block
+    assert "export UV_PROJECT_ENVIRONMENT" in block
+
+
+def test_base_measure_block_keeps_pre_th_inline_fallback() -> None:
+    """Regression guard — pre-TH inline measure fallback must survive W3 edits."""
+    block = base_measure_block()
+    assert "grep -q '^coverage-measure:' Makefile" in block
+    assert "--cov-report=json:coverage.json" in block
+
+
+def test_head_coverage_gate_stays_unguarded_outside_subshell() -> None:
+    """D5 guard — head ``make coverage-gate`` must not be wrapped in a tolerant guard."""
+    text = script_text()
+    tail = text.split(")\n", 1)[-1]
+    assert re.search(r"^make coverage-gate\s*$", tail, re.MULTILINE), (
+        "head make coverage-gate must remain a hard gate after the subshell"
+    )
+    assert "make coverage-gate ||" not in tail
+
+
+def test_successful_base_measurement_still_runs_delta_comparison() -> None:
+    """Regression guard — a healthy base must still reach the delta comparison tail."""
+    text = script_text()
+    assert "if [[ -f coverage-base.json ]]; then" in text
+    assert "check_coverage_delta.py" in text
+
+
+def test_worktree_cleaned_up_when_base_measurement_fails(tmp_path: Path) -> None:
+    """The trap must remove the base worktree even when measurement fails."""
+    scratch = clone_local_repo(tmp_path)
+    _bootstrap_broken_base(scratch, tmp_path)
+    wt = worktree_path(scratch)
+
+    run_coverage_delta_gate(scratch, base_ref="broken-base", timeout=_INTEGRATION_TIMEOUT)
+
+    assert not wt.exists()
+
+
+@W3_XFAIL
+def test_broken_base_measurement_exits_zero_without_base_json(tmp_path: Path) -> None:
+    """D4 — a red base is a signal, not a script-killing pre-gate."""
+    scratch = clone_local_repo(tmp_path)
+    _bootstrap_broken_base(scratch, tmp_path)
+
+    result = run_coverage_delta_gate(scratch, base_ref="broken-base", timeout=_INTEGRATION_TIMEOUT)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not (scratch / "coverage-base.json").is_file()
+
+
+@W3_XFAIL
+def test_skipped_delta_emits_warning_with_reason(tmp_path: Path) -> None:
+    """D6 — a skipped delta must be visible, not silent."""
+    scratch = clone_local_repo(tmp_path)
+    _bootstrap_broken_base(scratch, tmp_path)
+
+    result = run_coverage_delta_gate(scratch, base_ref="broken-base", timeout=_INTEGRATION_TIMEOUT)
+    combined = (result.stdout + result.stderr).lower()
+
+    assert result.returncode == 0, combined
+    assert "warn" in combined or "::warning" in combined
+    assert "base" in combined or "broken-base" in combined
+    assert "measure" in combined or "coverage" in combined
+
+
+@W3_XFAIL
+def test_head_coverage_regression_still_fails_when_base_skips(tmp_path: Path) -> None:
+    """D5 — relaxing only the base must not disable the head ratchet."""
+    scratch = clone_local_repo(tmp_path)
+    _bootstrap_broken_base(scratch, tmp_path)
+    bad = {
+        "totals": {"percent_covered": 0.0, "num_statements": 100, "covered_lines": 0},
+        "files": {},
+    }
+    (scratch / "coverage.json").write_text(json.dumps(bad), encoding="utf-8")
+
+    result = run_coverage_delta_gate(scratch, base_ref="broken-base", timeout=_INTEGRATION_TIMEOUT)
+    combined = (result.stdout + result.stderr).lower()
+
+    assert result.returncode != 0, "head coverage regression must still fail the gate"
+    assert not (scratch / "coverage-base.json").is_file()
+    assert "coverage-gate" in combined or "ratchet" in combined or "fail_under" in combined

--- a/tests/cli/support_provider_status.py
+++ b/tests/cli/support_provider_status.py
@@ -1,0 +1,216 @@
+"""Shared helpers for wave 16 — ``provider status`` roster view."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.cli.support_agent_roster import (
+    WORKFLOW_INDEXED_STEP,
+    plain_cli_output,
+    two_reviewer_config,
+    write_config,
+)
+from tests.cli.support_provider_registry import (
+    NOUS_BASE_URL,
+    NOUS_TENCENT_HY3,
+    format_model_slug,
+    scaffold_mergecraft_home,
+    scaffold_workflow_file,
+    stub_mergecraft_env,
+    write_provider_entry,
+)
+
+PROVIDER_STATUS_MODULE = "mergecraft.cli.provider_status"
+STATUS_JSON_SCHEMA_VERSION = 1
+
+STATUS_JSON_REQUIRED_TOP = frozenset({"schemaVersion", "reviewers"})
+STATUS_SLOT_REQUIRED = frozenset({"slot", "model", "provider", "credential", "wired"})
+STATUS_CREDENTIAL_REQUIRED = frozenset({"available", "looked_for"})
+
+WORKFLOW_UNWIRED_STEP = """\
+name: mergecraft
+on:
+  pull_request_target:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mergeCraft PR review (anthropic only)
+        uses: alexhawat/mergeCraft@pre-0.0.1
+        with:
+          model: anthropic/claude-sonnet
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+"""
+
+CHAIN_REVIEWER_CONFIG = """
+models:
+  - anthropic/claude-sonnet
+  - openai/gpt-5.3-codex
+agents:
+  reviewer:
+    modelChain:
+      - anthropic/claude-sonnet
+      - openai/gpt-5.3-codex
+  reviewer2:
+    role: reviewer
+    after: reviewer
+    modelChain:
+      - openai/gpt-5.3-codex
+"""
+
+
+def import_provider_status() -> Any:
+    try:
+        return importlib.import_module(PROVIDER_STATUS_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{PROVIDER_STATUS_MODULE} is not implemented: {exc}")
+
+
+def require_status_json_schema() -> Any:
+    module = import_provider_status()
+    schema = getattr(module, "STATUS_JSON_SCHEMA", None)
+    if schema is None:
+        pytest.fail(f"{PROVIDER_STATUS_MODULE}.STATUS_JSON_SCHEMA is not defined")
+    return schema
+
+
+def bootstrap_status_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config_body: str = CHAIN_REVIEWER_CONFIG,
+    workflow_body: str = WORKFLOW_INDEXED_STEP,
+    cwd: Path | None = None,
+) -> Path:
+    """Minimal repo with roster, workflow, and provider registry."""
+    root = cwd or tmp_path
+    scaffold_mergecraft_home(root, config_body=config_body.strip())
+    stub_mergecraft_env(monkeypatch, root)
+    scaffold_workflow_file(root, workflow_body)
+    monkeypatch.chdir(root)
+    return root
+
+
+def register_chain_providers(tmp_path: Path, invoke: Any) -> tuple[str, str]:
+    anthropic = invoke(
+        "provider",
+        "add",
+        "--label",
+        "anthropic",
+        "--harness",
+        "claude",
+        "--cwd",
+        str(tmp_path),
+    )
+    assert anthropic.exit_code == 0, anthropic.stdout + anthropic.stderr
+    openai = invoke(
+        "provider",
+        "add",
+        "--label",
+        "openai",
+        "--harness",
+        "codex",
+        "--cwd",
+        str(tmp_path),
+    )
+    assert openai.exit_code == 0, openai.stdout + openai.stderr
+    nous = invoke(
+        "provider",
+        "add",
+        "--label",
+        "nous",
+        "--url",
+        NOUS_BASE_URL,
+        "--harness",
+        "opencode",
+        "--cwd",
+        str(tmp_path),
+    )
+    assert nous.exit_code == 0, nous.stdout + nous.stderr
+    add_model = invoke(
+        "model",
+        "add",
+        "--provider",
+        "nous",
+        NOUS_TENCENT_HY3,
+        "--cwd",
+        str(tmp_path),
+    )
+    assert add_model.exit_code == 0, add_model.stdout + add_model.stderr
+    return format_model_slug("anthropic", "claude-sonnet"), format_model_slug(
+        "openai", "gpt-5.3-codex"
+    )
+
+
+def parse_status_json(payload: str) -> dict[str, Any]:
+    data = json.loads(payload)
+    assert isinstance(data, dict), "status --json must emit a JSON object"
+    return data
+
+
+def validate_status_payload(data: dict[str, Any]) -> None:
+    missing_top = STATUS_JSON_REQUIRED_TOP - set(data)
+    assert not missing_top, f"status JSON missing keys: {sorted(missing_top)}"
+    assert data["schemaVersion"] == STATUS_JSON_SCHEMA_VERSION
+    reviewers = data["reviewers"]
+    assert isinstance(reviewers, list), "reviewers must be a list"
+    assert reviewers, "reviewers must be a non-empty list"
+    for reviewer in reviewers:
+        assert isinstance(reviewer, dict)
+        slots = reviewer.get("slots")
+        assert isinstance(slots, list), "each reviewer needs slots list"
+        assert slots, "each reviewer needs slots"
+        for slot in slots:
+            assert isinstance(slot, dict)
+            missing_slot = STATUS_SLOT_REQUIRED - set(slot)
+            assert not missing_slot, f"slot missing keys: {sorted(missing_slot)}"
+            assert re.fullmatch(r"p\d+", str(slot["slot"])), slot["slot"]
+            credential = slot["credential"]
+            assert isinstance(credential, dict)
+            missing_cred = STATUS_CREDENTIAL_REQUIRED - set(credential)
+            assert not missing_cred, f"credential missing keys: {sorted(missing_cred)}"
+
+
+def assert_no_secret_material(text: str, *, secrets: tuple[str, ...] = ()) -> None:
+    for secret in secrets:
+        assert secret not in text, "status output leaked a credential value"
+    assert "sk-" not in text
+    assert "sha256:" not in text.lower()
+    assert "fingerprint" not in text.lower()
+
+
+def snapshot_paths(repo: Path) -> dict[str, float]:
+    watched = [
+        repo / ".mergecraft" / "config.yaml",
+        repo / ".mergecraft" / "config.local.yaml",
+        repo / ".env",
+        repo / ".github" / "workflows" / "mergecraft.yml",
+    ]
+    return {str(path): path.stat().st_mtime for path in watched if path.is_file()}
+
+
+__all__ = [
+    "CHAIN_REVIEWER_CONFIG",
+    "PROVIDER_STATUS_MODULE",
+    "STATUS_JSON_REQUIRED_TOP",
+    "STATUS_JSON_SCHEMA_VERSION",
+    "WORKFLOW_UNWIRED_STEP",
+    "assert_no_secret_material",
+    "bootstrap_status_repo",
+    "import_provider_status",
+    "parse_status_json",
+    "plain_cli_output",
+    "register_chain_providers",
+    "require_status_json_schema",
+    "snapshot_paths",
+    "two_reviewer_config",
+    "validate_status_payload",
+    "write_config",
+    "write_provider_entry",
+]

--- a/tests/cli/test_provider_status_cmd.py
+++ b/tests/cli/test_provider_status_cmd.py
@@ -168,21 +168,16 @@ def test_provider_status_github_with_token_reports_secret_presence(
     present: set[str] = set()
 
     def _list_secrets(repo_slug: str) -> list[str]:
-        assert repo_slug
+        assert repo_slug == "acme/demo"
         return sorted(present)
 
-    def _probe(repo_slug: str, name: str) -> bool:
-        assert repo_slug
-        return name in present
-
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status._resolve_repo_slug",
+        lambda _cwd: "acme/demo",
+    )
     monkeypatch.setattr(
         "mergecraft.cli.provider_status.list_repo_secrets",
         _list_secrets,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "mergecraft.cli.provider_status.secret_is_present",
-        _probe,
         raising=False,
     )
     present.update({"ANTHROPIC_API_KEY", "OPENAI_API_KEY"})

--- a/tests/cli/test_provider_status_cmd.py
+++ b/tests/cli/test_provider_status_cmd.py
@@ -202,6 +202,98 @@ def test_provider_status_github_with_token_reports_secret_presence(
     assert_no_secret_material(result.stdout, secrets=("test-token",))
 
 
+def test_provider_status_github_secret_makes_slot_runnable_without_local_key(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Remote-only credentials must participate in CI slot/headline state with --github."""
+    _require_status_subcommand()
+    single_reviewer = """
+models:
+  - anthropic/claude-sonnet
+agents:
+  reviewer:
+    modelChain:
+      - anthropic/claude-sonnet
+"""
+    bootstrap_status_repo(
+        tmp_path,
+        monkeypatch,
+        config_body=single_reviewer,
+        workflow_body=WORKFLOW_UNWIRED_STEP,
+    )
+    register_chain_providers(tmp_path, _invoke)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    present = {"ANTHROPIC_API_KEY"}
+
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status._resolve_repo_slug",
+        lambda _cwd: "acme/demo",
+    )
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status.list_repo_secrets",
+        lambda _repo: sorted(present),
+    )
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    result = _invoke(
+        "provider",
+        "status",
+        "--github",
+        "--json",
+        "--cwd",
+        str(tmp_path),
+        env={"GH_TOKEN": "test-token"},
+    )
+    payload = parse_status_json(result.stdout)
+    validate_status_payload(payload)
+
+    assert "runnable in ci" in payload.get("headline", "").lower()
+    skipped_slots = {(row["agentId"], row["slot"]) for row in payload.get("skipped", [])}
+    reviewer_id = payload["reviewers"][0]["agentId"]
+    assert (reviewer_id, "p0") not in skipped_slots
+    anthropic_slot = payload["reviewers"][0]["slots"][0]
+    assert anthropic_slot["credential"]["available"] is True
+    assert anthropic_slot["credential"]["source"] == "github"
+
+
+def test_provider_status_github_gh_failure_reports_unknown_not_ok(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``gh`` failures must not masquerade as an empty secret list with status ok."""
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status._resolve_repo_slug",
+        lambda _cwd: "acme/demo",
+    )
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status.list_repo_secrets",
+        lambda _repo: None,
+    )
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    result = _invoke(
+        "provider",
+        "status",
+        "--github",
+        "--json",
+        "--cwd",
+        str(tmp_path),
+        env={"GH_TOKEN": "test-token"},
+    )
+    payload = parse_status_json(result.stdout)
+    github = payload.get("github") or {}
+
+    assert github.get("status") == "unknown"
+    assert "unknown" in github.get("message", "").lower()
+    assert "runnable in ci" not in payload.get("headline", "").lower()
+
+
 def test_provider_status_json_matches_documented_schema(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:

--- a/tests/cli/test_provider_status_cmd.py
+++ b/tests/cli/test_provider_status_cmd.py
@@ -1,0 +1,276 @@
+"""W1.3 — ``mergecraft provider status`` roster view (wave 16, green after W4)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.cli.support_provider_registry import stub_mergecraft_env
+from tests.cli.support_provider_status import (
+    CHAIN_REVIEWER_CONFIG,
+    WORKFLOW_UNWIRED_STEP,
+    assert_no_secret_material,
+    bootstrap_status_repo,
+    parse_status_json,
+    plain_cli_output,
+    register_chain_providers,
+    require_status_json_schema,
+    snapshot_paths,
+    two_reviewer_config,
+    validate_status_payload,
+    write_config,
+    write_provider_entry,
+)
+from typer.testing import CliRunner
+
+from mergecraft.cli.app import app
+from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+runner = CliRunner()
+_DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
+W4_XFAIL = pytest.mark.xfail(reason="green after W4: provider status roster view", strict=True)
+
+
+def _invoke(*argv: str, env: dict[str, str] | None = None) -> Any:
+    merged = dict(_DUMB_ENV)
+    if env:
+        merged.update(env)
+    return runner.invoke(app, list(argv), env=merged)
+
+
+def _require_status_subcommand() -> None:
+    result = _invoke("provider", "--help")
+    output = plain_cli_output(result.stdout + result.stderr).lower()
+    if result.exit_code != CLI_SUCCESS_EXIT_CODE or "status" not in output:
+        pytest.fail("mergecraft provider status is not registered yet")
+
+
+@W4_XFAIL
+def test_provider_status_renders_every_reviewer_slot_and_provider(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch, config_body=CHAIN_REVIEWER_CONFIG)
+    register_chain_providers(tmp_path, _invoke)
+
+    result = _invoke("provider", "status", "--cwd", str(tmp_path))
+    output = plain_cli_output(result.stdout + result.stderr)
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    for token in ("reviewer", "reviewer2", "p0", "p1", "anthropic", "openai"):
+        assert token in output.lower(), f"expected {token!r} in status output"
+
+
+@W4_XFAIL
+def test_provider_status_missing_credential_reports_env_var_not_value(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER_1_API_KEY", raising=False)
+
+    result = _invoke("provider", "status", "--cwd", str(tmp_path))
+    output = plain_cli_output(result.stdout + result.stderr)
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "not available" in output.lower() or "unavailable" in output.lower()
+    assert "ANTHROPIC_API_KEY" in output or "LLM_PROVIDER" in output
+    assert_no_secret_material(output, secrets=("super-secret-value",))
+
+
+@W4_XFAIL
+def test_provider_status_unwired_is_distinct_from_missing_credential(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(
+        tmp_path,
+        monkeypatch,
+        config_body=two_reviewer_config(),
+        workflow_body=WORKFLOW_UNWIRED_STEP,
+    )
+    write_provider_entry(tmp_path, label="nous", env_index=3)
+
+    result = _invoke("provider", "status", "--cwd", str(tmp_path))
+    output = plain_cli_output(result.stdout + result.stderr).lower()
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "not wired" in output
+    assert "not available" in output or "unavailable" in output
+    missing_label = "not available" if "not available" in output else "unavailable"
+    assert missing_label != "not wired"
+
+
+@W4_XFAIL
+def test_provider_status_renders_dispatch_level_and_after_ordering(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch, config_body=CHAIN_REVIEWER_CONFIG)
+    register_chain_providers(tmp_path, _invoke)
+
+    result = _invoke("provider", "status", "--json", "--cwd", str(tmp_path))
+    payload = parse_status_json(result.stdout)
+    validate_status_payload(payload)
+
+    levels = {row.get("dispatchLevel") for row in payload["reviewers"]}
+    assert len(levels) >= 2, "after: reviewer2 must render on a later dispatch level"
+    after_agents = [row.get("after") for row in payload["reviewers"] if row.get("after")]
+    assert after_agents, "after: ordering must be visible in JSON"
+
+
+@W4_XFAIL
+def test_provider_status_disabled_provider_renders_disabled(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+    disable = _invoke(
+        "provider", "disable", "anthropic", "--scope", "local", "--cwd", str(tmp_path)
+    )
+    assert disable.exit_code == CLI_SUCCESS_EXIT_CODE, disable.stdout + disable.stderr
+
+    result = _invoke("provider", "status", "--cwd", str(tmp_path))
+    output = plain_cli_output(result.stdout + result.stderr).lower()
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "disabled" in output
+    assert "anthropic" in output
+
+
+@W4_XFAIL
+def test_provider_status_github_without_token_is_unknown_exit_zero(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    result = _invoke("provider", "status", "--github", "--cwd", str(tmp_path))
+    output = plain_cli_output(result.stdout + result.stderr).lower()
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, output
+    assert "unknown" in output
+    assert "token" in output or "gh_token" in output or "github_token" in output
+
+
+@W4_XFAIL
+def test_provider_status_github_with_token_reports_secret_presence(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+
+    present: set[str] = set()
+
+    def _list_secrets(repo_slug: str) -> list[str]:
+        assert repo_slug
+        return sorted(present)
+
+    def _probe(repo_slug: str, name: str) -> bool:
+        assert repo_slug
+        return name in present
+
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status.list_repo_secrets",
+        _list_secrets,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "mergecraft.cli.provider_status.secret_is_present",
+        _probe,
+        raising=False,
+    )
+    present.update({"ANTHROPIC_API_KEY", "OPENAI_API_KEY"})
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    result = _invoke(
+        "provider",
+        "status",
+        "--github",
+        "--json",
+        "--cwd",
+        str(tmp_path),
+        env={"GH_TOKEN": "test-token"},
+    )
+    payload = parse_status_json(result.stdout)
+    github = payload.get("github") or {}
+    secrets = github.get("secrets") or github.get("remoteSecrets") or []
+    assert isinstance(secrets, (list, dict))
+    rendered = json.dumps(secrets).lower()
+    assert "anthropic_api_key" in rendered
+    assert "present" in rendered or "true" in rendered
+    assert_no_secret_material(result.stdout, secrets=("test-token",))
+
+
+@W4_XFAIL
+def test_provider_status_json_matches_documented_schema(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch, config_body=CHAIN_REVIEWER_CONFIG)
+    register_chain_providers(tmp_path, _invoke)
+    schema = require_status_json_schema()
+
+    result = _invoke("provider", "status", "--json", "--cwd", str(tmp_path))
+    payload = parse_status_json(result.stdout)
+    validate_status_payload(payload)
+    assert schema["version"] == payload["schemaVersion"]
+
+
+@W4_XFAIL
+def test_provider_status_cwd_selects_config_workflow_and_registry_targets(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    _require_status_subcommand()
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    bootstrap_status_repo(repo_a, monkeypatch, config_body=CHAIN_REVIEWER_CONFIG)
+    write_config(repo_b, two_reviewer_config())
+    stub_mergecraft_env(monkeypatch, repo_b)
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke("provider", "status", "--json", "--cwd", str(repo_b))
+    payload = parse_status_json(result.stdout)
+
+    reviewer_ids = {row.get("agentId") or row.get("agent_id") for row in payload["reviewers"]}
+    assert "reviewer2" in reviewer_ids
+    assert all(
+        "reviewer2" not in str(slot.get("model", "")) for slot in payload["reviewers"][0]["slots"]
+    )
+
+
+@W4_XFAIL
+def test_provider_status_is_read_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _require_status_subcommand()
+    bootstrap_status_repo(tmp_path, monkeypatch)
+    register_chain_providers(tmp_path, _invoke)
+    before = snapshot_paths(tmp_path)
+
+    result = _invoke(
+        "provider",
+        "status",
+        "--github",
+        "--json",
+        "--cwd",
+        str(tmp_path),
+        env={"GH_TOKEN": "read-only-token"},
+    )
+
+    assert result.exit_code == CLI_SUCCESS_EXIT_CODE, result.stdout + result.stderr
+    after = snapshot_paths(tmp_path)
+    assert before == after, "status must not mutate config, env, or workflow files"

--- a/tests/cli/test_provider_status_cmd.py
+++ b/tests/cli/test_provider_status_cmd.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
 
 runner = CliRunner()
 _DUMB_ENV = {"TERM": "dumb", "NO_COLOR": "1"}
-W4_XFAIL = pytest.mark.xfail(reason="green after W4: provider status roster view", strict=True)
 
 
 def _invoke(*argv: str, env: dict[str, str] | None = None) -> Any:
@@ -51,7 +50,6 @@ def _require_status_subcommand() -> None:
         pytest.fail("mergecraft provider status is not registered yet")
 
 
-@W4_XFAIL
 def test_provider_status_renders_every_reviewer_slot_and_provider(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -67,7 +65,6 @@ def test_provider_status_renders_every_reviewer_slot_and_provider(
         assert token in output.lower(), f"expected {token!r} in status output"
 
 
-@W4_XFAIL
 def test_provider_status_missing_credential_reports_env_var_not_value(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -86,7 +83,6 @@ def test_provider_status_missing_credential_reports_env_var_not_value(
     assert_no_secret_material(output, secrets=("super-secret-value",))
 
 
-@W4_XFAIL
 def test_provider_status_unwired_is_distinct_from_missing_credential(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -109,7 +105,6 @@ def test_provider_status_unwired_is_distinct_from_missing_credential(
     assert missing_label != "not wired"
 
 
-@W4_XFAIL
 def test_provider_status_renders_dispatch_level_and_after_ordering(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -127,7 +122,6 @@ def test_provider_status_renders_dispatch_level_and_after_ordering(
     assert after_agents, "after: ordering must be visible in JSON"
 
 
-@W4_XFAIL
 def test_provider_status_disabled_provider_renders_disabled(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -147,7 +141,6 @@ def test_provider_status_disabled_provider_renders_disabled(
     assert "anthropic" in output
 
 
-@W4_XFAIL
 def test_provider_status_github_without_token_is_unknown_exit_zero(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -165,7 +158,6 @@ def test_provider_status_github_without_token_is_unknown_exit_zero(
     assert "token" in output or "gh_token" in output or "github_token" in output
 
 
-@W4_XFAIL
 def test_provider_status_github_with_token_reports_secret_presence(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -215,7 +207,6 @@ def test_provider_status_github_with_token_reports_secret_presence(
     assert_no_secret_material(result.stdout, secrets=("test-token",))
 
 
-@W4_XFAIL
 def test_provider_status_json_matches_documented_schema(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -230,7 +221,6 @@ def test_provider_status_json_matches_documented_schema(
     assert schema["version"] == payload["schemaVersion"]
 
 
-@W4_XFAIL
 def test_provider_status_cwd_selects_config_workflow_and_registry_targets(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -254,7 +244,6 @@ def test_provider_status_cwd_selects_config_workflow_and_registry_targets(
     )
 
 
-@W4_XFAIL
 def test_provider_status_is_read_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     _require_status_subcommand()
     bootstrap_status_repo(tmp_path, monkeypatch)

--- a/tests/config/support_ci_gate_settings.py
+++ b/tests/config/support_ci_gate_settings.py
@@ -1,0 +1,98 @@
+"""Shared helpers for wave 16 — CI gate settings-root contracts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def init_repo_with_worktrees(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a primary repo and a sibling linked worktree.
+
+    Returns ``(head_worktree, base_worktree)`` where *head* is the primary
+    checkout and *base* is a detached sibling worktree of the same repo.
+    """
+    head = tmp_path / "head"
+    head.mkdir()
+    git(tmp_path, "init", str(head))
+    git(head, "config", "user.email", "ci-gate@test.local")
+    git(head, "config", "user.name", "CI Gate Test")
+    (head / "README.md").write_text("ci-gate fixture\n", encoding="utf-8")
+    git(head, "add", ".")
+    git(head, "commit", "-m", "init")
+
+    base = tmp_path / "base"
+    git(head, "worktree", "add", str(base), "--detach")
+    return head, base
+
+
+def write_mergecraft_config(repo_root: Path, body: str) -> Path:
+    cfg_dir = repo_root / ".mergecraft"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    path = cfg_dir / "config.yaml"
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def commit_config(repo_root: Path, message: str) -> None:
+    git(repo_root, "add", ".mergecraft/config.yaml")
+    git(repo_root, "commit", "-m", message)
+
+
+HEAD_MODEL = "openai/head-only-model"
+BASE_MODEL = "anthropic/base-only-model"
+
+
+def seed_head_and_base_configs(head: Path, base: Path) -> None:
+    """Distinct model values so mis-resolution is observable."""
+    write_mergecraft_config(head, f"model: {HEAD_MODEL}\npush: restricted\nshell: restricted\n")
+    commit_config(head, "head config")
+    write_mergecraft_config(
+        base,
+        f"model: {BASE_MODEL}\npush: restricted\nshell: restricted\n",
+    )
+    commit_config(base, "base config")
+
+
+def apply_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    github_workspace: str | None = None,
+    mergecraft_config: str | None = None,
+    clear_github_workspace: bool = False,
+) -> None:
+    if clear_github_workspace:
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    if github_workspace is not None:
+        monkeypatch.setenv("GITHUB_WORKSPACE", github_workspace)
+    if mergecraft_config is not None:
+        monkeypatch.setenv("MERGECRAFT_CONFIG", mergecraft_config)
+    elif mergecraft_config is None and not clear_github_workspace:
+        monkeypatch.delenv("MERGECRAFT_CONFIG", raising=False)
+
+
+__all__ = [
+    "BASE_MODEL",
+    "HEAD_MODEL",
+    "apply_env",
+    "commit_config",
+    "git",
+    "init_repo_with_worktrees",
+    "seed_head_and_base_configs",
+    "write_mergecraft_config",
+]

--- a/tests/config/test_ci_gate_settings_root.py
+++ b/tests/config/test_ci_gate_settings_root.py
@@ -1,0 +1,130 @@
+"""W1.1 — settings-root resolution (wave 16, green after W2)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from mergecraft.config.settings import load_repo_settings
+from tests.config.support_ci_gate_settings import (
+    BASE_MODEL,
+    HEAD_MODEL,
+    apply_env,
+    init_repo_with_worktrees,
+    seed_head_and_base_configs,
+    write_mergecraft_config,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+W2_XFAIL = pytest.mark.xfail(
+    reason="green after W2: settings-root worktree resolution", strict=True
+)
+
+
+def test_load_repo_settings_root_reads_base_with_github_workspace_at_head(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """#573 guard — explicit ``root=`` must load the base worktree config."""
+    head, base = init_repo_with_worktrees(tmp_path)
+    seed_head_and_base_configs(head, base)
+    apply_env(monkeypatch, github_workspace=str(head))
+
+    settings = load_repo_settings(root=base, load_learnings_files=False)
+    assert settings.model == BASE_MODEL
+
+
+@W2_XFAIL
+def test_cwd_worktree_wins_over_github_workspace(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """D2 — cwd in a sibling worktree must not inherit head's ``GITHUB_WORKSPACE``."""
+    head, base = init_repo_with_worktrees(tmp_path)
+    seed_head_and_base_configs(head, base)
+    apply_env(monkeypatch, github_workspace=str(head))
+    monkeypatch.chdir(base)
+
+    settings = load_repo_settings(load_learnings_files=False)
+    assert settings.model == BASE_MODEL
+
+
+def test_cwd_inside_github_workspace_unchanged(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Normal CI case — cwd under ``GITHUB_WORKSPACE`` keeps today's behaviour."""
+    repo = tmp_path / "workspace"
+    nested = repo / "nested"
+    nested.mkdir(parents=True)
+    write_mergecraft_config(
+        repo,
+        f"model: {HEAD_MODEL}\npush: restricted\nshell: restricted\n",
+    )
+    apply_env(monkeypatch, github_workspace=str(repo))
+    monkeypatch.chdir(nested)
+
+    settings = load_repo_settings(load_learnings_files=False)
+    assert settings.model == HEAD_MODEL
+
+
+def test_mergecraft_config_wins_over_workspace_and_cwd(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """D3 — ``MERGECRAFT_CONFIG`` keeps precedence over workspace and cwd."""
+    head, base = init_repo_with_worktrees(tmp_path)
+    seed_head_and_base_configs(head, base)
+    override = tmp_path / "override.yaml"
+    override.write_text("model: custom/override\npush: restricted\nshell: restricted\n")
+    apply_env(monkeypatch, github_workspace=str(head), mergecraft_config=str(override))
+    monkeypatch.chdir(base)
+
+    settings = load_repo_settings(load_learnings_files=False)
+    assert settings.model == "custom/override"
+
+
+def test_explicit_root_wins_over_github_workspace(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Guard — ``root=`` still beats ``GITHUB_WORKSPACE``."""
+    head, base = init_repo_with_worktrees(tmp_path)
+    seed_head_and_base_configs(head, base)
+    apply_env(monkeypatch, github_workspace=str(head))
+
+    settings = load_repo_settings(root=base, load_learnings_files=False)
+    assert settings.model == BASE_MODEL
+
+
+def test_outside_git_repo_falls_back_to_cwd(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Guard — non-repo cwd with no ``GITHUB_WORKSPACE`` resolves to cwd."""
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    write_mergecraft_config(
+        repo,
+        f"model: {BASE_MODEL}\npush: restricted\nshell: restricted\n",
+    )
+    apply_env(monkeypatch, clear_github_workspace=True)
+    monkeypatch.chdir(repo)
+
+    settings = load_repo_settings(load_learnings_files=False)
+    assert settings.model == BASE_MODEL
+
+
+@W2_XFAIL
+def test_base_tree_validates_cleanly_when_head_config_has_unknown_key(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """End-to-end #573 shape — base load must not parse head's invalid config."""
+    head, base = init_repo_with_worktrees(tmp_path)
+    seed_head_and_base_configs(head, base)
+    write_mergecraft_config(
+        head,
+        f"model: {HEAD_MODEL}\nw0TestFlag: true\npush: restricted\nshell: restricted\n",
+    )
+    apply_env(monkeypatch, github_workspace=str(head))
+    monkeypatch.chdir(base)
+
+    settings = load_repo_settings(load_learnings_files=False)
+    assert settings.model == BASE_MODEL
+
+    with pytest.raises(ValidationError):
+        load_repo_settings(root=head, load_learnings_files=False)

--- a/tests/config/test_ci_gate_settings_root.py
+++ b/tests/config/test_ci_gate_settings_root.py
@@ -22,10 +22,6 @@ if TYPE_CHECKING:
 
     from _pytest.monkeypatch import MonkeyPatch
 
-W2_XFAIL = pytest.mark.xfail(
-    reason="green after W2: settings-root worktree resolution", strict=True
-)
-
 
 def test_load_repo_settings_root_reads_base_with_github_workspace_at_head(
     tmp_path: Path,
@@ -40,7 +36,6 @@ def test_load_repo_settings_root_reads_base_with_github_workspace_at_head(
     assert settings.model == BASE_MODEL
 
 
-@W2_XFAIL
 def test_cwd_worktree_wins_over_github_workspace(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """D2 — cwd in a sibling worktree must not inherit head's ``GITHUB_WORKSPACE``."""
     head, base = init_repo_with_worktrees(tmp_path)
@@ -108,7 +103,6 @@ def test_outside_git_repo_falls_back_to_cwd(tmp_path: Path, monkeypatch: MonkeyP
     assert settings.model == BASE_MODEL
 
 
-@W2_XFAIL
 def test_base_tree_validates_cleanly_when_head_config_has_unknown_key(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## What?

Fixes the coverage delta gate so pull requests stop failing for base-branch problems unrelated to their own changes, and adds a roster-aware provider status command that shows what CI will actually run.

- Base-branch coverage measurement reads that worktree's config instead of the head checkout's.
- When the base branch cannot measure coverage, the delta is skipped with a loud warning while the head gate still runs.
- mergecraft provider status reports each reviewer slot's model, credential state, workflow wiring, dispatch level, and enabled state, with optional GitHub secret presence via --github and machine-readable output via --json.

## Why?

Every pull request was paying a tax when the merge-base branch could not measure coverage or when a new config key made the base parse the head's schema. That blocked fixes to the base itself and made config-touching work in other lanes harder to land.

Operators also had no single offline command to answer what will CI run against the multi-reviewer roster. The enable/disable half of #520 shipped in #521; the remaining half needed a roster projection, not a single-provider summary.

## Note

Merging this lane does not change the live reviewer. pull_request_target resolves the workflow and action pin from the default branch, so these fixes reach real reviews only when a pin bump carries them to main.

#520 should be retitled to reflect the roster-scoped status view; the enable/disable half already shipped in #521.

## Test plan

- [x] make ci-resume green on the lane branch (all 16 steps, 82.85% coverage)
- [x] make ci-static
- [x] uv run pytest tests/ci tests/cli -q (lane C RED suite and provider status commands)
- [x] make docs && make llms

## Related PR(s)/Issue(s)

Refs #573
Refs #536
Refs #520
