### PR TITLE
ci: bump the reviewer action pin to the lane A+C promotion

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "695d34b0979a84f5c3cea53f12c624f9e9f27521"
+  MERGECRAFT_ACTION_SHA: "3ed2c798c0e487f44a737fcecb49ab632ed4bad5"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -582,7 +582,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
+        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -767,7 +767,7 @@ jobs:
         # closed with no mergecraft-approval check at all. Fixed in #545
         # (utils/git_setup.py — basic auth on the documented `x-access-token`
         # username). b3638ea7 is #545's merge commit.
-        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
+        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -914,7 +914,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now b3638ea7 (#545).
-        uses: alexhawat/mergeCraft@695d34b0979a84f5c3cea53f12c624f9e9f27521 # env.MERGECRAFT_ACTION_SHA / PR #575 promotion
+        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:6abb15c12f0c484159dbf7241845118b4c470723700cea7144b488e23bf1ccac"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:17909d3c66f6d13ee85c3e6461cbe693ccd3b9491fd5dda912e3cd5933b0cbdd"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Pin 1 of 3 in `.ignorelocal/waves/19-integration-and-pin-wave-plan.md`.

## What this carries

Lane A (#580, publication & attribution) and lane C (#581, CI gate & operator surface) are merged into `pre-0.0.1`, but **merging does not change the reviewer** — `pull_request_target` resolves the action pin from the default branch, so every review still runs the image pinned on `main`.

Until this lands, every PR is reviewed by a reviewer that still has:

- the 5M token cliff that killed #567 at 7.3% over (**#571**)
- the out-of-range 422 recovery loop (**#570**)
- the probe-string review body (**#572**)
- the publication guard that refuses any PR touching `.mergecraft/config.yaml`

That last one is what blocks lane D, so this pin is a hard prerequisite for the rest of the sequence.

## The SHA

`3ed2c798` is the sync merge of `main` into `pre-0.0.1` — it contains both lanes and has `main`'s current pin `695d34b0` as an ancestor, which `check_action_pin_freshness.py` requires.

- freshness: ancestor ✅, drift 34 of max 100
- workflow verified against `main`'s: 3 × `token: ${{ github.token }}`, zero non-comment `MERGECRAFT_REVIEWER_PAT`

## Two commits, deliberately

1. this one — `MERGECRAFT_ACTION_SHA` plus the three mirrored `uses:` lines
2. `action.yml`'s `runs.image` digest, once `action-slim-bootstrap` has published the image for this SHA

The digest cannot be computed before the image exists, and the bootstrap job builds whatever SHA this branch declares. **The PR is not mergeable until commit 2 lands** — splitting the pin from the digest turned five checks red on #562.

## Next

Once this merges, a promotion PR carries `pre-0.0.1` → `main` so the reviewer actually picks it up. Lane B and lane E start after that.

Refs #570 #571 #572 #574 #573 #536 #520 — these close on the promotion to `main`, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLQwHrdSZruBt83xEPQD9B