### PR TITLE
ci: bump the reviewer action pin to the lane B promotion

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "3ed2c798c0e487f44a737fcecb49ab632ed4bad5"
+  MERGECRAFT_ACTION_SHA: "4182fd45a103a9b5a213feb1aee684bf34fe7759"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -588,7 +588,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
+        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -779,7 +779,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
+        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -926,7 +926,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@3ed2c798c0e487f44a737fcecb49ab632ed4bad5 # env.MERGECRAFT_ACTION_SHA / lane A+C promotion
+        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:17909d3c66f6d13ee85c3e6461cbe693ccd3b9491fd5dda912e3cd5933b0cbdd"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:91ccb73894e0bf18a120118617083397909d494619d359d8116870e009c79b51"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Pin 2 of 3 in `.ignorelocal/waves/19-integration-and-pin-wave-plan.md`.

## What this carries

Lane B (#586, trust credentials) is merged into `pre-0.0.1`, but **merging does not change the reviewer** — `pull_request_target` resolves the action pin from the default branch, so every review still runs the image pinned on `main`.

Until this lands on `main`, every PR is reviewed by a reviewer that still lacks:

- the `trust.agentSandbox` schema (`TrustSettings` is `extra="forbid"` — writing that key while the pinned image does not know it raises `ValidationError` and breaks every review)
- credential posture alignment, egress policy wiring, and fork credential hardening from lane B

That schema gap is what blocks lane D, so this pin is a hard prerequisite for slot 5.

## The SHA

`4182fd45` is the merge of #586 into `pre-0.0.1` — it contains lane B and has `main`'s current pin `3ed2c798` as an ancestor, which `check_action_pin_freshness.py` requires.

- workflow verified against `main`'s: 3 × `token: ${{ github.token }}`, zero non-comment `MERGECRAFT_REVIEWER_PAT`

## Two commits, deliberately

1. this one — `MERGECRAFT_ACTION_SHA` plus the three mirrored `uses:` lines
2. `action.yml`'s `runs.image` digest, once `action-slim-bootstrap` has published the image for this SHA

The digest cannot be computed before the image exists, and the bootstrap job builds whatever SHA this branch declares. **The PR is not mergeable until commit 2 lands** — splitting the pin from the digest turned five checks red on #562.

## Next

Once this merges, a promotion PR carries `pre-0.0.1` → `main` so the reviewer actually picks it up. Lane D starts after that.

Refs #552 #551 #537 — these close on the promotion to `main`, not here.