### PR TITLE
ci: bump the reviewer action pin to the lane E promotion

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "4182fd45a103a9b5a213feb1aee684bf34fe7759"
+  MERGECRAFT_ACTION_SHA: "4ab87265015624cf64fc000643781bb3d778d414"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -588,7 +588,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -779,7 +779,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -926,7 +926,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The self-review Action pin on all three review rungs moves to `4ab87265`,
+  pin 3 of 3 — lane E agent credential broker (#594). Reviews run the loopback
+  broker, pinned egress, and Codex routing fixes instead of the lane B pin
+  (`4182fd45`)
 - The self-review Action pin on all three review rungs moves to `3ed2c798`,
   the lane A/C sync on `pre-0.0.1` (#582). Reviews run publication attribution,
   the token-budget band, and the coverage-gate work instead of the #575 pin

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:91ccb73894e0bf18a120118617083397909d494619d359d8116870e009c79b51"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:7f92717edf826dba6bb3c724a6d924712e15622fcb8e9c78098c9ec2eec91144"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Pin 3 of 3 in `.ignorelocal/waves/19-integration-and-pin-wave-plan.md`.

## What?

Moves the self-review Action pin to `4ab87265` so dogfood reviews can run lane E (agent credential broker, #594) once this reaches `main`.

## Why?

Lane E is merged into `pre-0.0.1`, but `pull_request_target` resolves the action pin from the default branch. Until this lands on `main`, every review still runs the lane B image (`4182fd45`) without the loopback credential broker, pinned egress, or Codex broker routing from #594.

## The SHA

`4ab87265` is the merge of #594 into `pre-0.0.1` — it contains lane E and has `main`'s current pin `4182fd45` as an ancestor, which `check_action_pin_freshness.py` requires.

## Two commits, deliberately

1. this one — `MERGECRAFT_ACTION_SHA` plus the three mirrored `uses:` lines
2. `action.yml`'s `runs.image` digest, once `action-slim-bootstrap` has published the image for this SHA

GHCR has no slim tag for `4ab87265` yet (`action-image-digest-check` skips until it appears). **The PR is not mergeable until commit 2 lands** — splitting the pin from the digest turned five checks red on #562.

## Next

Once this merges to `pre-0.0.1`, open or refresh the promotion PR (`pre-0.0.1` → `main`) so the reviewer actually picks up the pin.

Refs #553
