### PR TITLE
ci: promote lane E and the reviewer pin to main

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -158,7 +158,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "4182fd45a103a9b5a213feb1aee684bf34fe7759"
+  MERGECRAFT_ACTION_SHA: "4ab87265015624cf64fc000643781bb3d778d414"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -588,7 +588,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -779,7 +779,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -926,7 +926,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@4182fd45a103a9b5a213feb1aee684bf34fe7759 # env.MERGECRAFT_ACTION_SHA / lane B promotion
+        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Action image digest pin gate (`action-image-digest-check`) and halved
   `wait-for-ci` poll cadence (20s → 10s, #528)
 
+### Lane E — agent credential broker
+
+### Security
+
+- Codex API-key runs proxy model calls through a loopback credential broker — a
+  stolen per-run bearer is worthless outside the container and after the run, but
+  outbound egress stays open and ChatGPT subscription auth (`CODEX_AUTH_JSON`) is
+  not brokered; clear that secret and use `OPENAI_API_KEY` when broker coverage
+  matters (#553)
+
 ### Fixed
 
 - Anchor-422 recovery no longer spins on an out-of-range comment index — it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The self-review Action pin on all three review rungs moves to `4ab87265`,
+  pin 3 of 3 — lane E agent credential broker (#594). Reviews run the loopback
+  broker, pinned egress, and Codex routing fixes instead of the lane B pin
+  (`4182fd45`)
 - The self-review Action pin on all three review rungs moves to `3ed2c798`,
   the lane A/C sync on `pre-0.0.1` (#582). Reviews run publication attribution,
   the token-budget band, and the coverage-gate work instead of the #575 pin

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,3 +71,37 @@ code, prompts, or credentials through a third-party SaaS backend.
   `Hadolint`) run locally inside the Action container; see
   [REVIEW-CHECKS.md](REVIEW-CHECKS.md) for the full list of what a review
   checks and what it deliberately never reports.
+
+## Agent credential broker (Codex, #553)
+
+When Codex runs on `OPENAI_API_KEY` without a usable `CODEX_AUTH_JSON`
+subscription bundle, mergeCraft starts a loopback credential broker in the
+parent process before privilege drop. The Codex subprocess receives a per-run
+throwaway bearer token — not the real API key. A stolen bearer is useless
+outside the container and after the run ends.
+
+**What the broker covers**
+
+- The API-key authentication path only
+- The real `OPENAI_API_KEY` stays in the broker's memory (parent, pre-`setpriv`),
+  not in the agent environment or `$CODEX_HOME/auth.json`
+- Upstream model calls are allow-listed and proxied via `security/egress.py`
+  helpers (`allow_egress`, `pinned_http_transport`)
+
+**What the broker does not cover**
+
+- **ChatGPT subscription auth (`CODEX_AUTH_JSON`).** When subscription auth is in
+  use the broker declares itself **inactive**; the subscription bundle remains
+  readable at `$CODEX_HOME/auth.json` under the agent uid. Operators who want
+  broker coverage must clear `CODEX_AUTH_JSON` and configure `OPENAI_API_KEY`
+  instead — gaining credential isolation at the cost of per-token API billing
+  rather than subscription billing.
+- **Outbound egress.** A compromised agent can still reach the internet and
+  exfiltrate what it can read (including a private repo tree). This lane makes
+  the API credential worthless, not unreachable.
+- **Proxy environment variables as egress control.** `HTTP_PROXY`,
+  `HTTPS_PROXY`, and `ALL_PROXY` are not an egress wall and must not be treated
+  as one.
+
+The run record states whether the broker was active for each Codex run. See
+also [Operator trust policy — agent credential broker](docs/trust-policy.md#agent-credential-broker-553).

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:91ccb73894e0bf18a120118617083397909d494619d359d8116870e009c79b51"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:7f92717edf826dba6bb3c724a6d924712e15622fcb8e9c78098c9ec2eec91144"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -56,15 +56,15 @@ Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permi
 | --- | --- |
 | Codex `wire_api=responses` succeeds via loopback broker when provider `base_url` ends with `/v1` | `test_broker_forwards_codex_shaped_responses_request` |
 | Gzip upstream body decoded by httpx is not re-labelled with `Content-Encoding` | `test_broker_strips_content_encoding_for_decoded_gzip_upstream` |
-| `model_providers.<id>.base_url` includes `/v1` suffix for Codex append semantics | `test_model_providers_base_url_points_at_loopback_broker` |
+| Codex 0.149: `openai_base_url` → loopback broker with `/v1`; no `model_providers.openai` | `test_openai_base_url_points_at_loopback_broker_without_model_providers_openai` |
 
 ## W1.2 — Codex wire-up (greening wave W3)
 
 | Contract | Test |
 | --- | --- |
-| Agent env: throwaway bearer, no live `OPENAI_API_KEY` | `test_brokered_agent_env_carries_throwaway_not_live_openai_key` |
+| Agent env: throwaway in `OPENAI_API_KEY`, not live parent key (Codex 0.149) | `test_brokered_agent_env_carries_throwaway_not_live_openai_key` |
 | `auth.json` has no real API credential after chown (D3) | `test_auth_json_contains_no_real_api_credential_after_setup_and_chown` |
-| `model_providers.<id>.base_url` → loopback broker with `/v1` | `test_model_providers_base_url_points_at_loopback_broker` |
+| `openai_base_url` → loopback broker with `/v1`; no `model_providers.openai` | `test_openai_base_url_points_at_loopback_broker_without_model_providers_openai` |
 | MCP table unchanged | `test_mcp_table_unchanged_under_broker` |
 | `CODEX_AUTH_JSON` → broker inactive + run record (D3a) | `test_subscription_auth_marks_broker_inactive_and_run_record_says_so` |
 | Subscription path leaves `auth.json` untouched (D3a) | `test_subscription_auth_leaves_auth_json_untouched` |
@@ -92,3 +92,5 @@ Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permi
 ## Fixture credential
 
 `REAL_OPENAI_API_KEY_FIXTURE` (`sk-live-run-fixture-openai-never-leak-18`) is the planted parent key for redaction and env assertions. It must never appear in broker outputs, agent env, `auth.json`, logs, or serialized evidence fixtures.
+
+Codex 0.149 broker routing: the per-run throwaway may appear in agent `OPENAI_API_KEY` (not only `MERGECRAFT_CODEX_BROKER_TOKEN`). `tests/security/test_credentials.py` treats `OPENAI_API_KEY` as the codex active provider key — broker throwaway values satisfy that guard when the live parent key is absent.

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -34,7 +34,7 @@ xfail-reconciliation: per impl wave (`strict=False` until green; test-creator ag
 | Wrong bearer → 401 | `test_broker_rejects_wrong_bearer` |
 | Constant-time `compare_digest` | `test_bearer_validation_uses_constant_time_compare_digest` |
 | `Host` / `X-Forwarded-Host` smuggle → 403 | `test_broker_rejects_upstream_host_smuggle` |
-| Absolute URL rewrite → 403 | `test_broker_rejects_absolute_url_rewrite` |
+| Absolute URL rewrite → 403 | `test_broker_rejects_absolute_url_rewrite` (uses `post_absolute_url_to_broker` — httpx origin-form bypass) |
 | Redirect off allow-list refused | `test_broker_refuses_redirect_to_non_allowlisted_host` |
 | Non-model paths refused (D4) | `test_broker_refuses_non_model_paths` |
 | Real key absent from bodies/errors/logs | `test_broker_never_leaks_real_credential_in_responses_errors_or_logs` |

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -59,6 +59,13 @@ Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permi
 | `prepare_codex_brokered_run` does not reference lane-B symbols (D8) | `test_prepare_codex_brokered_run_does_not_reference_lane_b_sandbox_symbols` |
 | Lane-B symbols remain in `codex.py` (D8) | `test_lane_b_sandbox_symbols_remain_defined_in_codex_module` |
 
+## W4 reconciliation — AG9 trunk guard
+
+| Fix | Rationale |
+| --- | --- |
+| `test_no_caller_signature_changed` exempts `codex.py` | Lane E W3 legitimately changed `codex.py` for broker wire-up; AG9 guard (`test_gateway_settings_reuse.py`) now pins only `opencode.py`. Codex broker contracts stay in `test_codex_credential_broker.py`. |
+| `test_claim_sink_handoff` binds telemetry `on` before OTLP | Full-suite xdist workers can inherit enterprise opt-out; explicit `bind_enterprise_from_settings(telemetry="on")` prevents `NullSink` degradation during coverage-gate. |
+
 ## Contract → files
 
 | Greening wave | Test file |

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -1,0 +1,73 @@
+# Agent isolation (lane E) — test plan (W1 RED)
+
+Wave plan: `.ignorelocal/waves/18-agent-isolation-wave-plan.md`
+Worktree: `../mergecraft-agent-isolation` on `wave/agent-isolation`
+Authoring wave: **W1** (`test-creator`). Implementation: **W2** (broker), **W3** (Codex wire-up).
+xfail-reconciliation: per impl wave (`strict=False` until green; test-creator agent forbids `strict=True` on cross-wave reds).
+
+## Pinned module surface (W2)
+
+| Symbol | Module | Role |
+| --- | --- | --- |
+| `BROKER_BIND_HOST` | `mergecraft.security.broker` | Loopback bind (`127.0.0.1`, D1) |
+| `CredentialBrokerConfig` | `mergecraft.security.broker` | Upstream URL, real key, per-run allow-list |
+| `CredentialBrokerHandle` | `mergecraft.security.broker` | `host`, `port`, `token`, `base_url` |
+| `credential_broker` | `mergecraft.security.broker` | Context manager — start/stop API |
+| `redact_broker_output` | `mergecraft.security.broker` | Redact responses/errors/logs (#553) |
+| `resolve_codex_broker_posture` | `mergecraft.security.broker` | Subscription vs API-key posture (D3a) |
+| `broker_run_record_fields` | `mergecraft.security.broker` | Run-record disclosure helper (D3a/D10) |
+| `CODEX_BROKER_BEARER_ENV` | `mergecraft.security.broker` | Throwaway bearer env-var name (D2) |
+
+## Pinned module surface (W3)
+
+| Symbol | Module | Role |
+| --- | --- | --- |
+| `prepare_codex_brokered_run` | `mergecraft.agents.codex` | Start broker → `_build_env` → auth → MCP config |
+
+## W1.1 — credential broker (greening wave W2)
+
+| Contract | Test |
+| --- | --- |
+| Bind `127.0.0.1` only; `BROKER_BIND_HOST` pinned | `test_broker_binds_loopback_only` |
+| Forcing `0.0.0.0` fails | `test_broker_rejects_non_loopback_bind` |
+| No bearer → 401 | `test_broker_rejects_missing_bearer` |
+| Wrong bearer → 401 | `test_broker_rejects_wrong_bearer` |
+| Constant-time `compare_digest` | `test_bearer_validation_uses_constant_time_compare_digest` |
+| `Host` / `X-Forwarded-Host` smuggle → 403 | `test_broker_rejects_upstream_host_smuggle` |
+| Absolute URL rewrite → 403 | `test_broker_rejects_absolute_url_rewrite` |
+| Redirect off allow-list refused | `test_broker_refuses_redirect_to_non_allowlisted_host` |
+| Non-model paths refused (D4) | `test_broker_refuses_non_model_paths` |
+| Real key absent from bodies/errors/logs | `test_broker_never_leaks_real_credential_in_responses_errors_or_logs` |
+| Real key absent from evidence-packet fixture | `test_broker_never_leaks_real_credential_in_evidence_packet_fixture` |
+| Parent→upstream `Authorization` uses real key | `test_broker_forwards_real_key_on_parent_upstream_leg` |
+| Concurrent requests with same bearer | `test_concurrent_requests_with_same_bearer` |
+
+Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permissive 200 would fail.
+
+## W1.2 — Codex wire-up (greening wave W3)
+
+| Contract | Test |
+| --- | --- |
+| Agent env: throwaway bearer, no live `OPENAI_API_KEY` | `test_brokered_agent_env_carries_throwaway_not_live_openai_key` |
+| `auth.json` has no real API credential after chown (D3) | `test_auth_json_contains_no_real_api_credential_after_setup_and_chown` |
+| `model_providers.<id>.base_url` → loopback broker | `test_model_providers_base_url_points_at_loopback_broker` |
+| MCP table unchanged | `test_mcp_table_unchanged_under_broker` |
+| `CODEX_AUTH_JSON` → broker inactive + run record (D3a) | `test_subscription_auth_marks_broker_inactive_and_run_record_says_so` |
+| Subscription path leaves `auth.json` untouched (D3a) | `test_subscription_auth_leaves_auth_json_untouched` |
+| Broker start failure: no silent key re-injection (D10) | `test_broker_start_failure_does_not_silently_reinject_openai_key` |
+| `_build_env` does not reference lane-B symbols (D8) | `test_build_env_does_not_reference_lane_b_sandbox_symbols` |
+| `prepare_codex_brokered_run` does not reference lane-B symbols (D8) | `test_prepare_codex_brokered_run_does_not_reference_lane_b_sandbox_symbols` |
+| Lane-B symbols remain in `codex.py` (D8) | `test_lane_b_sandbox_symbols_remain_defined_in_codex_module` |
+
+## Contract → files
+
+| Greening wave | Test file |
+| --- | --- |
+| W2 | `tests/security/test_credential_broker.py` |
+| W2 | `tests/security/support_agent_isolation.py` |
+| W3 | `tests/agents/test_codex_credential_broker.py` |
+| W3 | `tests/agents/support_codex_credential_broker.py` |
+
+## Fixture credential
+
+`REAL_OPENAI_API_KEY_FIXTURE` (`sk-live-run-fixture-openai-never-leak-18`) is the planted parent key for redaction and env assertions. It must never appear in broker outputs, agent env, `auth.json`, logs, or serialized evidence fixtures.

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -56,6 +56,9 @@ Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permi
 | --- | --- |
 | Codex `wire_api=responses` succeeds via loopback broker when provider `base_url` ends with `/v1` | `test_broker_forwards_codex_shaped_responses_request` |
 | Gzip upstream body decoded by httpx is not re-labelled with `Content-Encoding` | `test_broker_strips_content_encoding_for_decoded_gzip_upstream` |
+| Upstream silent >30s still returns 200 — broker read timeout must exceed 30s (no 502) | `test_broker_survives_slow_upstream_beyond_thirty_seconds` |
+| SSE upstream chunks relayed incrementally to client (not buffered blob) | `test_broker_streams_sse_incrementally_to_client` |
+| Hop-by-hop headers (`Connection`, `Keep-Alive`) not forwarded to upstream | `test_broker_does_not_forward_hop_by_hop_headers` |
 | Codex 0.149: `openai_base_url` → loopback broker with `/v1`; no `model_providers.openai` | `test_openai_base_url_points_at_loopback_broker_without_model_providers_openai` |
 
 ## W1.2 — Codex wire-up (greening wave W3)
@@ -63,7 +66,7 @@ Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permi
 | Contract | Test |
 | --- | --- |
 | Agent env: throwaway in `OPENAI_API_KEY`, not live parent key (Codex 0.149) | `test_brokered_agent_env_carries_throwaway_not_live_openai_key` |
-| `auth.json` has no real API credential after chown (D3) | `test_auth_json_contains_no_real_api_credential_after_setup_and_chown` |
+| Brokered API-key path writes no `auth.json` stub (PR #594 / D3) | `test_brokered_api_key_path_writes_no_auth_json` |
 | `openai_base_url` → loopback broker with `/v1`; no `model_providers.openai` | `test_openai_base_url_points_at_loopback_broker_without_model_providers_openai` |
 | MCP table unchanged | `test_mcp_table_unchanged_under_broker` |
 | `CODEX_AUTH_JSON` → broker inactive + run record (D3a) | `test_subscription_auth_marks_broker_inactive_and_run_record_says_so` |

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -41,6 +41,12 @@ xfail-reconciliation: per impl wave (`strict=False` until green; test-creator ag
 | Real key absent from evidence-packet fixture | `test_broker_never_leaks_real_credential_in_evidence_packet_fixture` |
 | Parent→upstream `Authorization` uses real key | `test_broker_forwards_real_key_on_parent_upstream_leg` |
 | Concurrent requests with same bearer | `test_concurrent_requests_with_same_bearer` |
+| No credentials → `auth_mode=none` (D3a) | `test_resolve_codex_broker_posture_no_credentials` |
+| API key without subscription → active (D3a) | `test_resolve_codex_broker_posture_api_key_active` |
+| Usable subscription → inactive (D3a) | `test_resolve_codex_broker_posture_subscription_not_brokered` |
+| Disallowed HTTP methods → 405 | `test_broker_rejects_put_method` |
+| Subscription token-shape branches (D3a) | `test_subscription_auth_usable_shapes` |
+| Run-record posture serialization (D3a/D10) | `test_broker_run_record_fields_serializes_posture` |
 
 Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permissive 200 would fail.
 

--- a/docs/test-plans/18-agent-isolation.md
+++ b/docs/test-plans/18-agent-isolation.md
@@ -50,13 +50,21 @@ xfail-reconciliation: per impl wave (`strict=False` until green; test-creator ag
 
 Guard-deletion note: auth tests assert **401** on missing/wrong bearer — permissive 200 would fail.
 
+## PR #594 review — broker forwarding gaps
+
+| Contract | Test |
+| --- | --- |
+| Codex `wire_api=responses` succeeds via loopback broker when provider `base_url` ends with `/v1` | `test_broker_forwards_codex_shaped_responses_request` |
+| Gzip upstream body decoded by httpx is not re-labelled with `Content-Encoding` | `test_broker_strips_content_encoding_for_decoded_gzip_upstream` |
+| `model_providers.<id>.base_url` includes `/v1` suffix for Codex append semantics | `test_model_providers_base_url_points_at_loopback_broker` |
+
 ## W1.2 — Codex wire-up (greening wave W3)
 
 | Contract | Test |
 | --- | --- |
 | Agent env: throwaway bearer, no live `OPENAI_API_KEY` | `test_brokered_agent_env_carries_throwaway_not_live_openai_key` |
 | `auth.json` has no real API credential after chown (D3) | `test_auth_json_contains_no_real_api_credential_after_setup_and_chown` |
-| `model_providers.<id>.base_url` → loopback broker | `test_model_providers_base_url_points_at_loopback_broker` |
+| `model_providers.<id>.base_url` → loopback broker with `/v1` | `test_model_providers_base_url_points_at_loopback_broker` |
 | MCP table unchanged | `test_mcp_table_unchanged_under_broker` |
 | `CODEX_AUTH_JSON` → broker inactive + run record (D3a) | `test_subscription_auth_marks_broker_inactive_and_run_record_says_so` |
 | Subscription path leaves `auth.json` untouched (D3a) | `test_subscription_auth_leaves_auth_json_untouched` |

--- a/docs/trust-policy.md
+++ b/docs/trust-policy.md
@@ -155,6 +155,38 @@ Run manifest fields (`trust_self_review`, `trust_execution`, `trust_authority`,
 `trust_resolved_from`, `trust_config_hash`) land in the evidence packet so
 readers of a review can see the posture it was produced under.
 
+## Agent credential broker (#553)
+
+Separate from `trust.selfReview` — this addresses what credentials the Codex
+agent subprocess can read during a review run.
+
+When Codex authenticates with `OPENAI_API_KEY` (and `CODEX_AUTH_JSON` is absent
+or unusable), mergeCraft routes model API calls through a loopback credential
+broker started in the parent process. The agent receives a per-run throwaway
+bearer; the real key never enters the agent environment or `$CODEX_HOME/auth.json`.
+
+| Posture | Broker | Credential exposure |
+|---------|--------|---------------------|
+| `OPENAI_API_KEY` only | Active | Throwaway bearer only — a stolen token is useless after the run |
+| `CODEX_AUTH_JSON` (subscription) | **Inactive** | Raw subscription bundle remains agent-readable at `$CODEX_HOME/auth.json` |
+
+### Subscription vs API-key trade (D3a)
+
+Clearing `CODEX_AUTH_JSON` and running Codex on `OPENAI_API_KEY` **enables**
+broker coverage. The cost is billing: per-token API usage instead of ChatGPT
+subscription pricing. The broker does not broker subscription auth — deleting
+`auth.json` would also break Codex writeback for subscription sessions.
+
+### What this lane does not build
+
+- **Outbound egress stays open.** A hijacked agent can still send whatever it
+  can read; for a private repo the tree itself remains a real residual.
+- **`HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` are not egress controls.** Do not
+  configure or document them as a wall.
+
+The run record (`broker_active`, auth mode fields) states whether the broker
+covered each Codex run. Read more: [SECURITY.md — agent credential broker](../SECURITY.md#agent-credential-broker-codex-553).
+
 ## Related pages
 
 - [Workflows — security model](workflows.md#security-model)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -258,7 +258,6 @@ def _setup_codex_auth(
     ctx: AgentRunContext,
     *,
     codex_home: Path,
-    broker_base_url: str | None = None,
 ) -> None:
     raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
     if raw and subscription_auth_usable(raw):
@@ -275,15 +274,6 @@ def _setup_codex_auth(
         )
     session = current_broker_session()
     if session is not None and session.active:
-        codex_home.mkdir(parents=True, exist_ok=True)
-        auth_path = codex_home / "auth.json"
-        stub: dict[str, str] = {
-            "auth_mode": "broker",
-            "bearer_env": OPENAI_API_KEY_ENV,
-        }
-        if broker_base_url:
-            stub["broker_base_url"] = broker_base_url
-        auth_path.write_text(json.dumps(stub), encoding="utf-8")
         return
     if _has_openai_api_key():
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
@@ -625,8 +615,7 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
         # in build_agent_env so the real parent key never reaches the agent.
         extra[OPENAI_API_KEY_ENV] = handle.token
     env = build_agent_env("codex", extra, model=ctx.resolved_model)
-    broker_base_url = handle.base_url if handle is not None else None
-    _setup_codex_auth(ctx, codex_home=codex_home, broker_base_url=broker_base_url)
+    _setup_codex_auth(ctx, codex_home=codex_home)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process
     # still runs as root. wrap_agent_command()'s setpriv drops the actual

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -8,17 +8,23 @@ import os
 import re
 import shutil
 import subprocess
-import threading
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias
-
-if TYPE_CHECKING:
-    from contextlib import AbstractContextManager
-
-from dataclasses import dataclass, field
+from typing import TypeAlias
 
 from loguru import logger
 
+from mergecraft.agents.codex_broker import (
+    OPENAI_API_KEY_ENV,
+    active_broker_handle,
+    add_broker_provider_table,
+    begin_broker_session,
+    broker_run_record_fields,
+    current_broker_session,
+    resolve_codex_broker_posture,
+    set_broker_session,
+    stop_broker_session,
+)
 from mergecraft.agents.codex_stream import (
     CODEX_MODEL_REASONING_EFFORT,
     codex_stream_event_handler,
@@ -44,12 +50,9 @@ from mergecraft.agents.shared import (
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
 from mergecraft.config.trust_policy import AgentSandboxDecision
 from mergecraft.mcp.endpoints import MCP_VERIFIER_ENDPOINT
-from mergecraft.security import broker as _credential_broker_mod
 from mergecraft.security.broker import (
     CODEX_BROKER_BEARER_ENV,
     CodexBrokerPosture,
-    CredentialBrokerConfig,
-    CredentialBrokerHandle,
     subscription_auth_usable,
 )
 from mergecraft.tracing.genai import resolve_capture_policy
@@ -59,10 +62,6 @@ from mergecraft.utils.provider_failure import is_retryable_cli_failure
 from mergecraft.utils.secrets import build_agent_env
 
 CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
-OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
-_OPENAI_UPSTREAM_BASE_URL = "https://api.openai.com/v1"
-_OPENAI_UPSTREAM_HOST = "api.openai.com"
-_OPENAI_BROKER_PROVIDER_ID = "openai"
 # A Codex ``config.toml`` is built as a nested mapping and rendered once; a
 # nested value is a table, a scalar is a key in the table that holds it.
 TomlTable: TypeAlias = dict[str, "str | bool | TomlTable"]
@@ -107,96 +106,6 @@ CODEX_SUBAGENT_DEGRADATION = CodexSubagentDegradation(
     kind="prose-only",
     toolset_parity=False,
 )
-
-
-@dataclass(slots=True)
-class CodexBrokeredRun:
-    """Result of :func:`prepare_codex_brokered_run` (plan 18 W3)."""
-
-    agent_env: dict[str, str]
-    broker_base_url: str | None
-    posture: CodexBrokerPosture
-    _session: _CodexBrokerSession | None = field(default=None, repr=False)
-
-    def close(self) -> None:
-        """Stop the loopback broker and clear the module session."""
-        if self._session is not None:
-            _stop_broker_session(self._session)
-            _set_broker_session(None)
-
-    def __enter__(self) -> CodexBrokeredRun:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        self.close()
-
-
-@dataclass(slots=True)
-class _CodexBrokerSession:
-    posture: CodexBrokerPosture
-    handle: CredentialBrokerHandle | None = None
-    _broker_cm: AbstractContextManager[CredentialBrokerHandle] | None = None
-
-    @property
-    def active(self) -> bool:
-        return self.posture.active and self.handle is not None
-
-
-_active_broker_session: _CodexBrokerSession | None = None
-_broker_session_lock = threading.Lock()
-
-
-def _current_broker_session() -> _CodexBrokerSession | None:
-    with _broker_session_lock:
-        return _active_broker_session
-
-
-def _set_broker_session(session: _CodexBrokerSession | None) -> None:
-    global _active_broker_session
-    with _broker_session_lock:
-        _active_broker_session = session
-
-
-def _broker_config_for_api_key(api_key: str) -> CredentialBrokerConfig:
-    return CredentialBrokerConfig(
-        upstream_base_url=_OPENAI_UPSTREAM_BASE_URL,
-        api_key=api_key,
-        run_upstream_hosts=frozenset({_OPENAI_UPSTREAM_HOST}),
-    )
-
-
-def _start_broker_session(*, api_key: str, posture: CodexBrokerPosture) -> _CodexBrokerSession:
-    """Start the loopback broker or refuse with a named reason (D10)."""
-    config = _broker_config_for_api_key(api_key)
-    broker_cm = _credential_broker_mod.credential_broker(config)
-    try:
-        handle = broker_cm.__enter__()
-    except Exception as exc:
-        msg = f"Codex credential broker refused to start: {exc}"
-        raise RuntimeError(msg) from exc
-    return _CodexBrokerSession(posture=posture, handle=handle, _broker_cm=broker_cm)
-
-
-def _stop_broker_session(session: _CodexBrokerSession | None) -> None:
-    if session is None or session._broker_cm is None:
-        return
-    session._broker_cm.__exit__(None, None, None)
-
-
-def _begin_broker_session(*, openai_api_key: str = "") -> _CodexBrokerSession:
-    """Resolve Codex broker posture and start the loopback broker when active."""
-    posture = _credential_broker_mod.resolve_codex_broker_posture()
-    if not posture.active:
-        return _CodexBrokerSession(posture=posture)
-    api_key = openai_api_key.strip() or os.environ.get(OPENAI_API_KEY_ENV, "").strip()
-    if not api_key:
-        inactive = CodexBrokerPosture(
-            active=False,
-            auth_mode="none",
-            reason="broker inactive: no OpenAI API key configured",
-        )
-        return _CodexBrokerSession(posture=inactive)
-    return _start_broker_session(api_key=api_key, posture=posture)
 
 
 # Mirrors mergecraft.utils.git_setup — Codex refuses PATH aliases under these.
@@ -355,7 +264,7 @@ def _setup_codex_auth(
     broker_base_url: str | None = None,
 ) -> None:
     raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
-    if raw and _codex_subscription_auth_usable(raw):
+    if raw and subscription_auth_usable(raw):
         codex_home.mkdir(parents=True, exist_ok=True)
         auth_path = codex_home / "auth.json"
         auth_path.write_text(raw, encoding="utf-8")
@@ -367,7 +276,7 @@ def _setup_codex_auth(
             CODEX_AUTH_ENV,
             OPENAI_API_KEY_ENV,
         )
-    session = _current_broker_session()
+    session = current_broker_session()
     if session is not None and session.active:
         codex_home.mkdir(parents=True, exist_ok=True)
         auth_path = codex_home / "auth.json"
@@ -558,25 +467,6 @@ def _has_any_custom_provider_env() -> bool:
     return False
 
 
-def _add_broker_provider_table(config: TomlTable, broker_base_url: str) -> None:
-    """Point ``model_providers.openai`` at the loopback credential broker (W3).
-
-    When the broker is active it owns the ``openai`` provider slot so Codex
-    routes default OpenAI models through loopback; custom gateway tables are
-    omitted whenever broker posture is active.
-    """
-    model_providers = config.get("model_providers")
-    if not isinstance(model_providers, dict):
-        model_providers = {}
-        config["model_providers"] = model_providers
-    model_providers[_OPENAI_BROKER_PROVIDER_ID] = {
-        "name": _OPENAI_BROKER_PROVIDER_ID,
-        "base_url": broker_base_url,
-        "env_key": CODEX_BROKER_BEARER_ENV,
-        "wire_api": "responses",
-    }
-
-
 def _add_custom_provider_tables(config: TomlTable) -> None:
     """Add a ``model_providers.<id>`` table for every configured custom provider.
 
@@ -690,9 +580,9 @@ def write_mcp_config(
     # W3 / #71 — Codex passthrough for OpenAI-compatible providers. No-op
     # when no ``MERGECRAFT_CUSTOM_PROVIDER_*`` env vars are set.
     _add_custom_provider_tables(config)
-    session = _current_broker_session()
-    if session is not None and session.active and session.handle is not None:
-        _add_broker_provider_table(config, session.handle.base_url)
+    handle = active_broker_handle()
+    if handle is not None:
+        add_broker_provider_table(config, handle.base_url)
     if _codex_use_permission_profiles(ctx):
         _add_read_only_mcp_network_profile(config)
     else:
@@ -725,23 +615,20 @@ def ctx_tmpdir_fallback() -> str:
 
 def _build_env(ctx: AgentRunContext) -> dict[str, str]:
     codex_home = _codex_home(ctx)
-    session = _current_broker_session()
-    broker_active = session is not None and session.active
+    handle = active_broker_handle()
+    broker_active = handle is not None
     # D16 — inject the per-run MCP bearer token so Codex can authenticate via
     # ``bearer_token_env_var`` in config.toml. Only inject when a token was
     # issued (dev/test runs without a live MCP server leave this empty).
     extra: dict[str, str] = {"CODEX_HOME": str(codex_home)}
     if ctx.mcp_auth_token:
         extra[_CODEX_MCP_TOKEN_ENV] = ctx.mcp_auth_token
-    if broker_active and session is not None and session.handle is not None:
-        extra[CODEX_BROKER_BEARER_ENV] = session.handle.token
-    env = build_agent_env(
-        "codex",
-        extra,
-        model=ctx.resolved_model,
-        codex_broker_active=broker_active,
-    )
-    broker_base_url = session.handle.base_url if session is not None and session.handle else None
+    if broker_active and handle is not None:
+        extra[CODEX_BROKER_BEARER_ENV] = handle.token
+    env = build_agent_env("codex", extra, model=ctx.resolved_model)
+    if broker_active:
+        env.pop("OPENAI_API_KEY", None)
+    broker_base_url = handle.base_url if handle is not None else None
     _setup_codex_auth(ctx, codex_home=codex_home, broker_base_url=broker_base_url)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process
@@ -966,31 +853,6 @@ def _run_codex_streaming(
     return AgentResult(success=True, output=output or None, usage=usage)
 
 
-def prepare_codex_brokered_run(
-    ctx: AgentRunContext,
-    *,
-    openai_api_key: str = "",
-) -> CodexBrokeredRun:
-    """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
-    session = _begin_broker_session(openai_api_key=openai_api_key)
-    posture = session.posture
-    _set_broker_session(session)
-    try:
-        write_mcp_config(ctx)
-        agent_env = _build_env(ctx)
-    except Exception:
-        _stop_broker_session(session)
-        _set_broker_session(None)
-        raise
-    handle = session.handle
-    return CodexBrokeredRun(
-        agent_env=agent_env,
-        broker_base_url=handle.base_url if handle is not None else None,
-        posture=posture,
-        _session=session,
-    )
-
-
 async def _run(ctx: AgentRunContext) -> AgentResult:
     from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
 
@@ -999,9 +861,9 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    initial_posture = _credential_broker_mod.resolve_codex_broker_posture()
+    initial_posture = resolve_codex_broker_posture()
     try:
-        broker_session = _begin_broker_session()
+        broker_session = begin_broker_session(posture=initial_posture)
     except RuntimeError as err:
         failed_posture = CodexBrokerPosture(
             active=False,
@@ -1011,17 +873,17 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
         return AgentResult(
             success=False,
             error=str(err),
-            metadata=_credential_broker_mod.broker_run_record_fields(failed_posture),
+            metadata=broker_run_record_fields(failed_posture),
         )
     if initial_posture.active and not broker_session.active:
         reason = broker_session.posture.reason
-        msg = f"Codex credential broker refused to start: {reason}"
+        msg = f"Codex credential broker inactive: {reason}"
         return AgentResult(
             success=False,
             error=msg,
-            metadata=_credential_broker_mod.broker_run_record_fields(broker_session.posture),
+            metadata=broker_run_record_fields(broker_session.posture),
         )
-    _set_broker_session(broker_session)
+    set_broker_session(broker_session)
     try:
         render_result = render_for_run(ctx, "codex")
         subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
@@ -1048,15 +910,15 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
 
         result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
         finalized = await finalize_agent_result(ctx, result)
-        broker_metadata = _credential_broker_mod.broker_run_record_fields(broker_session.posture)
+        broker_metadata = broker_run_record_fields(broker_session.posture)
         if finalized.metadata:
             finalized.metadata.update(broker_metadata)
         else:
             finalized.metadata = broker_metadata
         return merge_manifest_metadata(finalized, render_result)
     finally:
-        _stop_broker_session(broker_session)
-        _set_broker_session(None)
+        stop_broker_session(broker_session)
+        set_broker_session(None)
 
 
 codex = agent(name="codex", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -8,9 +8,14 @@ import os
 import re
 import shutil
 import subprocess
-from dataclasses import dataclass
+import threading
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+from dataclasses import dataclass, field
 
 from loguru import logger
 
@@ -45,6 +50,7 @@ from mergecraft.security.broker import (
     CodexBrokerPosture,
     CredentialBrokerConfig,
     CredentialBrokerHandle,
+    subscription_auth_usable,
 )
 from mergecraft.tracing.genai import resolve_capture_policy
 from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
@@ -103,20 +109,33 @@ CODEX_SUBAGENT_DEGRADATION = CodexSubagentDegradation(
 )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class CodexBrokeredRun:
     """Result of :func:`prepare_codex_brokered_run` (plan 18 W3)."""
 
     agent_env: dict[str, str]
     broker_base_url: str | None
     posture: CodexBrokerPosture
+    _session: _CodexBrokerSession | None = field(default=None, repr=False)
+
+    def close(self) -> None:
+        """Stop the loopback broker and clear the module session."""
+        if self._session is not None:
+            _stop_broker_session(self._session)
+            _set_broker_session(None)
+
+    def __enter__(self) -> CodexBrokeredRun:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
 @dataclass(slots=True)
 class _CodexBrokerSession:
     posture: CodexBrokerPosture
     handle: CredentialBrokerHandle | None = None
-    _broker_cm: Any = None
+    _broker_cm: AbstractContextManager[CredentialBrokerHandle] | None = None
 
     @property
     def active(self) -> bool:
@@ -124,15 +143,18 @@ class _CodexBrokerSession:
 
 
 _active_broker_session: _CodexBrokerSession | None = None
+_broker_session_lock = threading.Lock()
 
 
 def _current_broker_session() -> _CodexBrokerSession | None:
-    return _active_broker_session
+    with _broker_session_lock:
+        return _active_broker_session
 
 
 def _set_broker_session(session: _CodexBrokerSession | None) -> None:
     global _active_broker_session
-    _active_broker_session = session
+    with _broker_session_lock:
+        _active_broker_session = session
 
 
 def _broker_config_for_api_key(api_key: str) -> CredentialBrokerConfig:
@@ -146,8 +168,8 @@ def _broker_config_for_api_key(api_key: str) -> CredentialBrokerConfig:
 def _start_broker_session(*, api_key: str, posture: CodexBrokerPosture) -> _CodexBrokerSession:
     """Start the loopback broker or refuse with a named reason (D10)."""
     config = _broker_config_for_api_key(api_key)
+    broker_cm = _credential_broker_mod.credential_broker(config)
     try:
-        broker_cm = _credential_broker_mod.credential_broker(config)
         handle = broker_cm.__enter__()
     except Exception as exc:
         msg = f"Codex credential broker refused to start: {exc}"
@@ -159,6 +181,22 @@ def _stop_broker_session(session: _CodexBrokerSession | None) -> None:
     if session is None or session._broker_cm is None:
         return
     session._broker_cm.__exit__(None, None, None)
+
+
+def _begin_broker_session(*, openai_api_key: str = "") -> _CodexBrokerSession:
+    """Resolve Codex broker posture and start the loopback broker when active."""
+    posture = _credential_broker_mod.resolve_codex_broker_posture()
+    if not posture.active:
+        return _CodexBrokerSession(posture=posture)
+    api_key = openai_api_key.strip() or os.environ.get(OPENAI_API_KEY_ENV, "").strip()
+    if not api_key:
+        inactive = CodexBrokerPosture(
+            active=False,
+            auth_mode="none",
+            reason="broker inactive: no OpenAI API key configured",
+        )
+        return _CodexBrokerSession(posture=inactive)
+    return _start_broker_session(api_key=api_key, posture=posture)
 
 
 # Mirrors mergecraft.utils.git_setup — Codex refuses PATH aliases under these.
@@ -307,25 +345,7 @@ def _has_openai_api_key() -> bool:
 
 
 def _codex_subscription_auth_usable(raw: str) -> bool:
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(data, dict):
-        return False
-    if _extract_refresh_token(raw):
-        return True
-    tokens = data.get("tokens")
-    if isinstance(tokens, dict):
-        for key in ("access_token", "access", "refresh_token", "refresh"):
-            val = tokens.get(key)
-            if isinstance(val, str) and val.strip():
-                return True
-    for key in ("access_token", "access"):
-        val = data.get(key)
-        if isinstance(val, str) and val.strip():
-            return True
-    return False
+    return subscription_auth_usable(raw)
 
 
 def _setup_codex_auth(
@@ -539,7 +559,12 @@ def _has_any_custom_provider_env() -> bool:
 
 
 def _add_broker_provider_table(config: TomlTable, broker_base_url: str) -> None:
-    """Point ``model_providers.openai`` at the loopback credential broker (W3)."""
+    """Point ``model_providers.openai`` at the loopback credential broker (W3).
+
+    When the broker is active it owns the ``openai`` provider slot so Codex
+    routes default OpenAI models through loopback; custom gateway tables are
+    omitted whenever broker posture is active.
+    """
     model_providers = config.get("model_providers")
     if not isinstance(model_providers, dict):
         model_providers = {}
@@ -947,20 +972,8 @@ def prepare_codex_brokered_run(
     openai_api_key: str = "",
 ) -> CodexBrokeredRun:
     """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
-    posture = _credential_broker_mod.resolve_codex_broker_posture()
-    session: _CodexBrokerSession | None = None
-    if posture.active:
-        api_key = openai_api_key.strip() or os.environ.get(OPENAI_API_KEY_ENV, "").strip()
-        if not api_key:
-            posture = CodexBrokerPosture(
-                active=False,
-                auth_mode="none",
-                reason="broker inactive: no OpenAI API key configured",
-            )
-        else:
-            session = _start_broker_session(api_key=api_key, posture=posture)
-    if session is None:
-        session = _CodexBrokerSession(posture=posture)
+    session = _begin_broker_session(openai_api_key=openai_api_key)
+    posture = session.posture
     _set_broker_session(session)
     try:
         write_mcp_config(ctx)
@@ -974,6 +987,7 @@ def prepare_codex_brokered_run(
         agent_env=agent_env,
         broker_base_url=handle.base_url if handle is not None else None,
         posture=posture,
+        _session=session,
     )
 
 
@@ -985,32 +999,28 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    posture = _credential_broker_mod.resolve_codex_broker_posture()
-    broker_session: _CodexBrokerSession | None = None
-    if posture.active:
-        api_key = os.environ.get(OPENAI_API_KEY_ENV, "").strip()
-        if not api_key:
-            posture = CodexBrokerPosture(
-                active=False,
-                auth_mode="none",
-                reason="broker inactive: no OpenAI API key configured",
-            )
-        else:
-            try:
-                broker_session = _start_broker_session(api_key=api_key, posture=posture)
-            except RuntimeError as err:
-                failed_posture = CodexBrokerPosture(
-                    active=False,
-                    auth_mode=posture.auth_mode,
-                    reason=str(err),
-                )
-                return AgentResult(
-                    success=False,
-                    error=str(err),
-                    metadata=_credential_broker_mod.broker_run_record_fields(failed_posture),
-                )
-    if broker_session is None:
-        broker_session = _CodexBrokerSession(posture=posture)
+    initial_posture = _credential_broker_mod.resolve_codex_broker_posture()
+    try:
+        broker_session = _begin_broker_session()
+    except RuntimeError as err:
+        failed_posture = CodexBrokerPosture(
+            active=False,
+            auth_mode=initial_posture.auth_mode,
+            reason=str(err),
+        )
+        return AgentResult(
+            success=False,
+            error=str(err),
+            metadata=_credential_broker_mod.broker_run_record_fields(failed_posture),
+        )
+    if initial_posture.active and not broker_session.active:
+        reason = broker_session.posture.reason
+        msg = f"Codex credential broker refused to start: {reason}"
+        return AgentResult(
+            success=False,
+            error=msg,
+            metadata=_credential_broker_mod.broker_run_record_fields(broker_session.posture),
+        )
     _set_broker_session(broker_session)
     try:
         render_result = render_for_run(ctx, "codex")

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from mergecraft.agents.codex_broker import (
     OPENAI_API_KEY_ENV,
+    CodexBrokeredRun,
     active_broker_handle,
     add_broker_provider_table,
     begin_broker_session,
@@ -919,6 +920,17 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     finally:
         stop_broker_session(broker_session)
         set_broker_session(None)
+
+
+def prepare_codex_brokered_run(
+    ctx: AgentRunContext,
+    *,
+    openai_api_key: str = "",
+) -> CodexBrokeredRun:
+    """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
+    from mergecraft.agents import codex_broker
+
+    return codex_broker.prepare_codex_brokered_run(ctx, openai_api_key=openai_api_key)
 
 
 codex = agent(name="codex", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 from loguru import logger
 
@@ -39,6 +39,13 @@ from mergecraft.agents.shared import (
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
 from mergecraft.config.trust_policy import AgentSandboxDecision
 from mergecraft.mcp.endpoints import MCP_VERIFIER_ENDPOINT
+from mergecraft.security import broker as _credential_broker_mod
+from mergecraft.security.broker import (
+    CODEX_BROKER_BEARER_ENV,
+    CodexBrokerPosture,
+    CredentialBrokerConfig,
+    CredentialBrokerHandle,
+)
 from mergecraft.tracing.genai import resolve_capture_policy
 from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
 from mergecraft.utils.process_group import track_process_group, wait_or_kill_process_group
@@ -47,6 +54,9 @@ from mergecraft.utils.secrets import build_agent_env
 
 CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
 OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+_OPENAI_UPSTREAM_BASE_URL = "https://api.openai.com/v1"
+_OPENAI_UPSTREAM_HOST = "api.openai.com"
+_OPENAI_BROKER_PROVIDER_ID = "openai"
 # A Codex ``config.toml`` is built as a nested mapping and rendered once; a
 # nested value is a table, a scalar is a key in the table that holds it.
 TomlTable: TypeAlias = dict[str, "str | bool | TomlTable"]
@@ -91,6 +101,65 @@ CODEX_SUBAGENT_DEGRADATION = CodexSubagentDegradation(
     kind="prose-only",
     toolset_parity=False,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class CodexBrokeredRun:
+    """Result of :func:`prepare_codex_brokered_run` (plan 18 W3)."""
+
+    agent_env: dict[str, str]
+    broker_base_url: str | None
+    posture: CodexBrokerPosture
+
+
+@dataclass(slots=True)
+class _CodexBrokerSession:
+    posture: CodexBrokerPosture
+    handle: CredentialBrokerHandle | None = None
+    _broker_cm: Any = None
+
+    @property
+    def active(self) -> bool:
+        return self.posture.active and self.handle is not None
+
+
+_active_broker_session: _CodexBrokerSession | None = None
+
+
+def _current_broker_session() -> _CodexBrokerSession | None:
+    return _active_broker_session
+
+
+def _set_broker_session(session: _CodexBrokerSession | None) -> None:
+    global _active_broker_session
+    _active_broker_session = session
+
+
+def _broker_config_for_api_key(api_key: str) -> CredentialBrokerConfig:
+    return CredentialBrokerConfig(
+        upstream_base_url=_OPENAI_UPSTREAM_BASE_URL,
+        api_key=api_key,
+        run_upstream_hosts=frozenset({_OPENAI_UPSTREAM_HOST}),
+    )
+
+
+def _start_broker_session(*, api_key: str, posture: CodexBrokerPosture) -> _CodexBrokerSession:
+    """Start the loopback broker or refuse with a named reason (D10)."""
+    config = _broker_config_for_api_key(api_key)
+    try:
+        broker_cm = _credential_broker_mod.credential_broker(config)
+        handle = broker_cm.__enter__()
+    except Exception as exc:
+        msg = f"Codex credential broker refused to start: {exc}"
+        raise RuntimeError(msg) from exc
+    return _CodexBrokerSession(posture=posture, handle=handle, _broker_cm=broker_cm)
+
+
+def _stop_broker_session(session: _CodexBrokerSession | None) -> None:
+    if session is None or session._broker_cm is None:
+        return
+    session._broker_cm.__exit__(None, None, None)
+
 
 # Mirrors mergecraft.utils.git_setup — Codex refuses PATH aliases under these.
 _FORBIDDEN_TEMP_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/usr/tmp")
@@ -259,7 +328,12 @@ def _codex_subscription_auth_usable(raw: str) -> bool:
     return False
 
 
-def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
+def _setup_codex_auth(
+    ctx: AgentRunContext,
+    *,
+    codex_home: Path,
+    broker_base_url: str | None = None,
+) -> None:
     raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
     if raw and _codex_subscription_auth_usable(raw):
         codex_home.mkdir(parents=True, exist_ok=True)
@@ -273,6 +347,18 @@ def _setup_codex_auth(ctx: AgentRunContext, *, codex_home: Path) -> None:
             CODEX_AUTH_ENV,
             OPENAI_API_KEY_ENV,
         )
+    session = _current_broker_session()
+    if session is not None and session.active:
+        codex_home.mkdir(parents=True, exist_ok=True)
+        auth_path = codex_home / "auth.json"
+        stub: dict[str, str] = {
+            "auth_mode": "broker",
+            "bearer_env": CODEX_BROKER_BEARER_ENV,
+        }
+        if broker_base_url:
+            stub["broker_base_url"] = broker_base_url
+        auth_path.write_text(json.dumps(stub), encoding="utf-8")
+        return
     if _has_openai_api_key():
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
 
@@ -452,6 +538,20 @@ def _has_any_custom_provider_env() -> bool:
     return False
 
 
+def _add_broker_provider_table(config: TomlTable, broker_base_url: str) -> None:
+    """Point ``model_providers.openai`` at the loopback credential broker (W3)."""
+    model_providers = config.get("model_providers")
+    if not isinstance(model_providers, dict):
+        model_providers = {}
+        config["model_providers"] = model_providers
+    model_providers[_OPENAI_BROKER_PROVIDER_ID] = {
+        "name": _OPENAI_BROKER_PROVIDER_ID,
+        "base_url": broker_base_url,
+        "env_key": CODEX_BROKER_BEARER_ENV,
+        "wire_api": "responses",
+    }
+
+
 def _add_custom_provider_tables(config: TomlTable) -> None:
     """Add a ``model_providers.<id>`` table for every configured custom provider.
 
@@ -565,6 +665,9 @@ def write_mcp_config(
     # W3 / #71 — Codex passthrough for OpenAI-compatible providers. No-op
     # when no ``MERGECRAFT_CUSTOM_PROVIDER_*`` env vars are set.
     _add_custom_provider_tables(config)
+    session = _current_broker_session()
+    if session is not None and session.active and session.handle is not None:
+        _add_broker_provider_table(config, session.handle.base_url)
     if _codex_use_permission_profiles(ctx):
         _add_read_only_mcp_network_profile(config)
     else:
@@ -597,14 +700,24 @@ def ctx_tmpdir_fallback() -> str:
 
 def _build_env(ctx: AgentRunContext) -> dict[str, str]:
     codex_home = _codex_home(ctx)
+    session = _current_broker_session()
+    broker_active = session is not None and session.active
     # D16 — inject the per-run MCP bearer token so Codex can authenticate via
     # ``bearer_token_env_var`` in config.toml. Only inject when a token was
     # issued (dev/test runs without a live MCP server leave this empty).
     extra: dict[str, str] = {"CODEX_HOME": str(codex_home)}
     if ctx.mcp_auth_token:
         extra[_CODEX_MCP_TOKEN_ENV] = ctx.mcp_auth_token
-    env = build_agent_env("codex", extra, model=ctx.resolved_model)
-    _setup_codex_auth(ctx, codex_home=codex_home)
+    if broker_active and session is not None and session.handle is not None:
+        extra[CODEX_BROKER_BEARER_ENV] = session.handle.token
+    env = build_agent_env(
+        "codex",
+        extra,
+        model=ctx.resolved_model,
+        codex_broker_active=broker_active,
+    )
+    broker_base_url = session.handle.base_url if session is not None and session.handle else None
+    _setup_codex_auth(ctx, codex_home=codex_home, broker_base_url=broker_base_url)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process
     # still runs as root. wrap_agent_command()'s setpriv drops the actual
@@ -828,6 +941,42 @@ def _run_codex_streaming(
     return AgentResult(success=True, output=output or None, usage=usage)
 
 
+def prepare_codex_brokered_run(
+    ctx: AgentRunContext,
+    *,
+    openai_api_key: str = "",
+) -> CodexBrokeredRun:
+    """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
+    posture = _credential_broker_mod.resolve_codex_broker_posture()
+    session: _CodexBrokerSession | None = None
+    if posture.active:
+        api_key = openai_api_key.strip() or os.environ.get(OPENAI_API_KEY_ENV, "").strip()
+        if not api_key:
+            posture = CodexBrokerPosture(
+                active=False,
+                auth_mode="none",
+                reason="broker inactive: no OpenAI API key configured",
+            )
+        else:
+            session = _start_broker_session(api_key=api_key, posture=posture)
+    if session is None:
+        session = _CodexBrokerSession(posture=posture)
+    _set_broker_session(session)
+    try:
+        write_mcp_config(ctx)
+        agent_env = _build_env(ctx)
+    except Exception:
+        _stop_broker_session(session)
+        _set_broker_session(None)
+        raise
+    handle = session.handle
+    return CodexBrokeredRun(
+        agent_env=agent_env,
+        broker_base_url=handle.base_url if handle is not None else None,
+        posture=posture,
+    )
+
+
 async def _run(ctx: AgentRunContext) -> AgentResult:
     from mergecraft.agents.harness_render import merge_manifest_metadata, render_for_run
 
@@ -836,32 +985,68 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    render_result = render_for_run(ctx, "codex")
-    subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
-    mcp_config = write_mcp_config(ctx, subagent_block=subagent_block)
-    # Blocking Popen/wait/stream consume runs in a worker thread so
-    # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
-    initial = await asyncio.to_thread(
-        _run_codex_once,
-        cli=cli,
-        prompt=ctx.instructions.user,
-        ctx=ctx,
-        mcp_config=mcp_config,
-    )
-
-    async def resume(prompt: str) -> AgentResult:
-        return await asyncio.to_thread(
+    posture = _credential_broker_mod.resolve_codex_broker_posture()
+    broker_session: _CodexBrokerSession | None = None
+    if posture.active:
+        api_key = os.environ.get(OPENAI_API_KEY_ENV, "").strip()
+        if not api_key:
+            posture = CodexBrokerPosture(
+                active=False,
+                auth_mode="none",
+                reason="broker inactive: no OpenAI API key configured",
+            )
+        else:
+            try:
+                broker_session = _start_broker_session(api_key=api_key, posture=posture)
+            except RuntimeError as err:
+                failed_posture = CodexBrokerPosture(
+                    active=False,
+                    auth_mode=posture.auth_mode,
+                    reason=str(err),
+                )
+                return AgentResult(
+                    success=False,
+                    error=str(err),
+                    metadata=_credential_broker_mod.broker_run_record_fields(failed_posture),
+                )
+    if broker_session is None:
+        broker_session = _CodexBrokerSession(posture=posture)
+    _set_broker_session(broker_session)
+    try:
+        render_result = render_for_run(ctx, "codex")
+        subagent_block = render_result.payload if isinstance(render_result.payload, str) else None
+        mcp_config = write_mcp_config(ctx, subagent_block=subagent_block)
+        # Blocking Popen/wait/stream consume runs in a worker thread so
+        # ``asyncio.wait_for`` in ``main`` can preempt the coroutine (W9.2).
+        initial = await asyncio.to_thread(
             _run_codex_once,
             cli=cli,
-            prompt=prompt,
+            prompt=ctx.instructions.user,
             ctx=ctx,
             mcp_config=mcp_config,
-            continue_session=True,
         )
 
-    result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
-    finalized = await finalize_agent_result(ctx, result)
-    return merge_manifest_metadata(finalized, render_result)
+        async def resume(prompt: str) -> AgentResult:
+            return await asyncio.to_thread(
+                _run_codex_once,
+                cli=cli,
+                prompt=prompt,
+                ctx=ctx,
+                mcp_config=mcp_config,
+                continue_session=True,
+            )
+
+        result = await run_post_run_retry_loop(ctx, initial=initial, resume=resume)
+        finalized = await finalize_agent_result(ctx, result)
+        broker_metadata = _credential_broker_mod.broker_run_record_fields(broker_session.posture)
+        if finalized.metadata:
+            finalized.metadata.update(broker_metadata)
+        else:
+            finalized.metadata = broker_metadata
+        return merge_manifest_metadata(finalized, render_result)
+    finally:
+        _stop_broker_session(broker_session)
+        _set_broker_session(None)
 
 
 codex = agent(name="codex", install=_install, run=_run, build_env=_build_env)

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -18,7 +18,7 @@ from mergecraft.agents.codex_broker import (
     OPENAI_API_KEY_ENV,
     CodexBrokeredRun,
     active_broker_handle,
-    add_broker_provider_table,
+    add_broker_openai_config,
     begin_broker_session,
     broker_run_record_fields,
     current_broker_session,
@@ -51,11 +51,7 @@ from mergecraft.agents.shared import (
 from mergecraft.agents.verifier import VERIFIER_AGENT_NAME, VERIFIER_SYSTEM_PROMPT
 from mergecraft.config.trust_policy import AgentSandboxDecision
 from mergecraft.mcp.endpoints import MCP_VERIFIER_ENDPOINT
-from mergecraft.security.broker import (
-    CODEX_BROKER_BEARER_ENV,
-    CodexBrokerPosture,
-    subscription_auth_usable,
-)
+from mergecraft.security.broker import CodexBrokerPosture, subscription_auth_usable
 from mergecraft.tracing.genai import resolve_capture_policy
 from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
 from mergecraft.utils.process_group import track_process_group, wait_or_kill_process_group
@@ -283,7 +279,7 @@ def _setup_codex_auth(
         auth_path = codex_home / "auth.json"
         stub: dict[str, str] = {
             "auth_mode": "broker",
-            "bearer_env": CODEX_BROKER_BEARER_ENV,
+            "bearer_env": OPENAI_API_KEY_ENV,
         }
         if broker_base_url:
             stub["broker_base_url"] = broker_base_url
@@ -583,7 +579,7 @@ def write_mcp_config(
     _add_custom_provider_tables(config)
     handle = active_broker_handle()
     if handle is not None:
-        add_broker_provider_table(config, handle.base_url)
+        add_broker_openai_config(config, handle.base_url)
     if _codex_use_permission_profiles(ctx):
         _add_read_only_mcp_network_profile(config)
     else:
@@ -625,10 +621,10 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
     if ctx.mcp_auth_token:
         extra[_CODEX_MCP_TOKEN_ENV] = ctx.mcp_auth_token
     if broker_active and handle is not None:
-        extra[CODEX_BROKER_BEARER_ENV] = handle.token
+        # D3 — throwaway bearer in OPENAI_API_KEY; extras overwrite reinjection
+        # in build_agent_env so the real parent key never reaches the agent.
+        extra[OPENAI_API_KEY_ENV] = handle.token
     env = build_agent_env("codex", extra, model=ctx.resolved_model)
-    if broker_active:
-        env.pop("OPENAI_API_KEY", None)
     broker_base_url = handle.base_url if handle is not None else None
     _setup_codex_auth(ctx, codex_home=codex_home, broker_base_url=broker_base_url)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME

--- a/src/mergecraft/agents/codex_broker.py
+++ b/src/mergecraft/agents/codex_broker.py
@@ -155,6 +155,14 @@ def begin_broker_session(
     return _start_broker_session(api_key=api_key, posture=resolved)
 
 
+def broker_provider_base_url(broker_base_url: str) -> str:
+    """Return the loopback broker URL Codex should use for ``model_providers``."""
+    normalized = broker_base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
+
+
 def add_broker_provider_table(config: dict[str, Any], broker_base_url: str) -> None:
     """Point ``model_providers.openai`` at the loopback credential broker (W3).
 
@@ -168,7 +176,7 @@ def add_broker_provider_table(config: dict[str, Any], broker_base_url: str) -> N
         config["model_providers"] = model_providers
     model_providers[OPENAI_BROKER_PROVIDER_ID] = {
         "name": OPENAI_BROKER_PROVIDER_ID,
-        "base_url": broker_base_url,
+        "base_url": broker_provider_base_url(broker_base_url),
         "env_key": CODEX_BROKER_BEARER_ENV,
         "wire_api": "responses",
     }
@@ -198,9 +206,10 @@ def prepare_codex_brokered_run(
         set_broker_session(None)
         raise
     handle = session.handle
+    broker_base_url = broker_provider_base_url(handle.base_url) if handle is not None else None
     return CodexBrokeredRun(
         agent_env=agent_env,
-        broker_base_url=handle.base_url if handle is not None else None,
+        broker_base_url=broker_base_url,
         posture=posture,
         _session=session,
     )
@@ -216,6 +225,7 @@ __all__ = [
     "add_broker_provider_table",
     "begin_broker_session",
     "broker_config_for_api_key",
+    "broker_provider_base_url",
     "broker_run_record_fields",
     "current_broker_session",
     "prepare_codex_brokered_run",

--- a/src/mergecraft/agents/codex_broker.py
+++ b/src/mergecraft/agents/codex_broker.py
@@ -3,9 +3,8 @@
 Exports:
     CodexBrokeredRun: Prepared broker env + posture with explicit teardown.
     OPENAI_API_KEY_ENV: Env var name for the OpenAI API key.
-    OPENAI_BROKER_PROVIDER_ID: ``model_providers`` table id for the broker.
     active_broker_handle: Running loopback handle when the session is active.
-    add_broker_provider_table: Point ``model_providers.openai`` at the broker.
+    add_broker_openai_config: Point built-in OpenAI routing at the broker.
     begin_broker_session: Resolve posture and start the loopback broker.
     broker_config_for_api_key: Build broker config for an OpenAI API key.
     current_broker_session: Active session for this process, if any.
@@ -23,7 +22,6 @@ from typing import TYPE_CHECKING, Any
 
 from mergecraft.security import broker as _broker_mod
 from mergecraft.security.broker import (
-    CODEX_BROKER_BEARER_ENV,
     OPENAI_UPSTREAM_BASE_URL,
     OPENAI_UPSTREAM_HOST,
     CodexBrokerPosture,
@@ -37,7 +35,6 @@ if TYPE_CHECKING:
     from mergecraft.agents.shared import AgentRunContext
 
 OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
-OPENAI_BROKER_PROVIDER_ID = "openai"
 
 broker_run_record_fields = _broker_mod.broker_run_record_fields
 resolve_codex_broker_posture = _broker_mod.resolve_codex_broker_posture
@@ -156,30 +153,21 @@ def begin_broker_session(
 
 
 def broker_provider_base_url(broker_base_url: str) -> str:
-    """Return the loopback broker URL Codex should use for ``model_providers``."""
+    """Return the loopback broker URL Codex should use for ``openai_base_url``."""
     normalized = broker_base_url.rstrip("/")
     if normalized.endswith("/v1"):
         return normalized
     return f"{normalized}/v1"
 
 
-def add_broker_provider_table(config: dict[str, Any], broker_base_url: str) -> None:
-    """Point ``model_providers.openai`` at the loopback credential broker (W3).
+def add_broker_openai_config(config: dict[str, Any], broker_base_url: str) -> None:
+    """Route built-in OpenAI through the loopback credential broker (W3 / #594).
 
-    When the broker is active it owns the ``openai`` provider slot so Codex
-    routes default OpenAI models through loopback. Custom gateway tables may
-    still be present when ``MERGECRAFT_CUSTOM_PROVIDER_*`` env vars are set.
+    Codex 0.149+ reserves ``model_providers.openai``; use top-level
+    ``openai_base_url`` instead. The throwaway bearer belongs in
+    ``OPENAI_API_KEY`` (see :func:`mergecraft.agents.codex._build_env`).
     """
-    model_providers = config.get("model_providers")
-    if not isinstance(model_providers, dict):
-        model_providers = {}
-        config["model_providers"] = model_providers
-    model_providers[OPENAI_BROKER_PROVIDER_ID] = {
-        "name": OPENAI_BROKER_PROVIDER_ID,
-        "base_url": broker_provider_base_url(broker_base_url),
-        "env_key": CODEX_BROKER_BEARER_ENV,
-        "wire_api": "responses",
-    }
+    config["openai_base_url"] = broker_provider_base_url(broker_base_url)
 
 
 def prepare_codex_brokered_run(
@@ -216,13 +204,11 @@ def prepare_codex_brokered_run(
 
 
 __all__ = [
-    "CODEX_BROKER_BEARER_ENV",
     "OPENAI_API_KEY_ENV",
-    "OPENAI_BROKER_PROVIDER_ID",
     "CodexBrokerSession",
     "CodexBrokeredRun",
     "active_broker_handle",
-    "add_broker_provider_table",
+    "add_broker_openai_config",
     "begin_broker_session",
     "broker_config_for_api_key",
     "broker_provider_base_url",

--- a/src/mergecraft/agents/codex_broker.py
+++ b/src/mergecraft/agents/codex_broker.py
@@ -195,6 +195,9 @@ def prepare_codex_brokered_run(
         raise
     handle = session.handle
     broker_base_url = broker_provider_base_url(handle.base_url) if handle is not None else None
+    # Clear the process-wide probe so later ``write_mcp_config`` calls without an
+    # active ``_run()`` do not inherit broker routing from this setup path.
+    set_broker_session(None)
     return CodexBrokeredRun(
         agent_env=agent_env,
         broker_base_url=broker_base_url,

--- a/src/mergecraft/agents/codex_broker.py
+++ b/src/mergecraft/agents/codex_broker.py
@@ -1,0 +1,220 @@
+"""Codex credential-broker session lifecycle and config wiring (plan 18 W3).
+
+Exports:
+    CodexBrokeredRun: Prepared broker env + posture with explicit teardown.
+    OPENAI_API_KEY_ENV: Env var name for the OpenAI API key.
+    OPENAI_BROKER_PROVIDER_ID: ``model_providers`` table id for the broker.
+    active_broker_handle: Running loopback handle when the session is active.
+    add_broker_provider_table: Point ``model_providers.openai`` at the broker.
+    begin_broker_session: Resolve posture and start the loopback broker.
+    broker_config_for_api_key: Build broker config for an OpenAI API key.
+    current_broker_session: Active session for this process, if any.
+    prepare_codex_brokered_run: Start broker, MCP config, and agent env.
+    set_broker_session: Install or replace the process-wide broker session.
+    stop_broker_session: Stop a broker session context manager.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from mergecraft.security import broker as _broker_mod
+from mergecraft.security.broker import (
+    CODEX_BROKER_BEARER_ENV,
+    OPENAI_UPSTREAM_BASE_URL,
+    OPENAI_UPSTREAM_HOST,
+    CodexBrokerPosture,
+    CredentialBrokerConfig,
+    CredentialBrokerHandle,
+)
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    from mergecraft.agents.shared import AgentRunContext
+
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+OPENAI_BROKER_PROVIDER_ID = "openai"
+
+broker_run_record_fields = _broker_mod.broker_run_record_fields
+resolve_codex_broker_posture = _broker_mod.resolve_codex_broker_posture
+
+
+@dataclass(slots=True)
+class CodexBrokeredRun:
+    """Result of :func:`prepare_codex_brokered_run` (plan 18 W3)."""
+
+    agent_env: dict[str, str]
+    broker_base_url: str | None
+    posture: CodexBrokerPosture
+    _session: CodexBrokerSession | None = field(default=None, repr=False)
+
+    def close(self) -> None:
+        """Stop the loopback broker and clear the module session when owned."""
+        global _active_broker_session
+        if self._session is None:
+            return
+        session = self._session
+        self._session = None
+        stop_broker_session(session)
+        with _broker_session_lock:
+            if _active_broker_session is session:
+                _active_broker_session = None
+
+    def __enter__(self) -> CodexBrokeredRun:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+@dataclass(slots=True)
+class CodexBrokerSession:
+    posture: CodexBrokerPosture
+    handle: CredentialBrokerHandle | None = None
+    _broker_cm: AbstractContextManager[CredentialBrokerHandle] | None = None
+
+    @property
+    def active(self) -> bool:
+        return self.posture.active and self.handle is not None
+
+
+_active_broker_session: CodexBrokerSession | None = None
+_broker_session_lock = threading.Lock()
+
+
+def current_broker_session() -> CodexBrokerSession | None:
+    with _broker_session_lock:
+        return _active_broker_session
+
+
+def active_broker_handle() -> CredentialBrokerHandle | None:
+    session = current_broker_session()
+    return session.handle if session is not None and session.active else None
+
+
+def set_broker_session(session: CodexBrokerSession | None) -> None:
+    global _active_broker_session
+    with _broker_session_lock:
+        if (
+            session is not None
+            and _active_broker_session is not None
+            and _active_broker_session is not session
+        ):
+            stop_broker_session(_active_broker_session)
+        _active_broker_session = session
+
+
+def broker_config_for_api_key(api_key: str) -> CredentialBrokerConfig:
+    return CredentialBrokerConfig(
+        upstream_base_url=OPENAI_UPSTREAM_BASE_URL,
+        api_key=api_key,
+        run_upstream_hosts=frozenset({OPENAI_UPSTREAM_HOST}),
+    )
+
+
+def stop_broker_session(session: CodexBrokerSession | None) -> None:
+    if session is None or session._broker_cm is None:
+        return
+    session._broker_cm.__exit__(None, None, None)
+    session._broker_cm = None
+    session.handle = None
+
+
+def _start_broker_session(*, api_key: str, posture: CodexBrokerPosture) -> CodexBrokerSession:
+    config = broker_config_for_api_key(api_key)
+    broker_cm = _broker_mod.credential_broker(config)
+    try:
+        handle = broker_cm.__enter__()
+    except Exception as exc:
+        msg = f"Codex credential broker refused to start: {exc}"
+        raise RuntimeError(msg) from exc
+    return CodexBrokerSession(posture=posture, handle=handle, _broker_cm=broker_cm)
+
+
+def begin_broker_session(
+    *,
+    openai_api_key: str = "",
+    posture: CodexBrokerPosture | None = None,
+) -> CodexBrokerSession:
+    """Resolve Codex broker posture and start the loopback broker when active."""
+    resolved = posture or _broker_mod.resolve_codex_broker_posture(openai_api_key=openai_api_key)
+    if not resolved.active:
+        return CodexBrokerSession(posture=resolved)
+    api_key = openai_api_key.strip() or os.environ.get(OPENAI_API_KEY_ENV, "").strip()
+    if not api_key:
+        inactive = CodexBrokerPosture(
+            active=False,
+            auth_mode="none",
+            reason="broker inactive: no OpenAI API key configured",
+        )
+        return CodexBrokerSession(posture=inactive)
+    return _start_broker_session(api_key=api_key, posture=resolved)
+
+
+def add_broker_provider_table(config: dict[str, Any], broker_base_url: str) -> None:
+    """Point ``model_providers.openai`` at the loopback credential broker (W3).
+
+    When the broker is active it owns the ``openai`` provider slot so Codex
+    routes default OpenAI models through loopback. Custom gateway tables may
+    still be present when ``MERGECRAFT_CUSTOM_PROVIDER_*`` env vars are set.
+    """
+    model_providers = config.get("model_providers")
+    if not isinstance(model_providers, dict):
+        model_providers = {}
+        config["model_providers"] = model_providers
+    model_providers[OPENAI_BROKER_PROVIDER_ID] = {
+        "name": OPENAI_BROKER_PROVIDER_ID,
+        "base_url": broker_base_url,
+        "env_key": CODEX_BROKER_BEARER_ENV,
+        "wire_api": "responses",
+    }
+
+
+def prepare_codex_brokered_run(
+    ctx: AgentRunContext,
+    *,
+    openai_api_key: str = "",
+) -> CodexBrokeredRun:
+    """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
+    from mergecraft.agents import codex as codex_module
+
+    session = begin_broker_session(openai_api_key=openai_api_key)
+    posture = session.posture
+    set_broker_session(session)
+    try:
+        codex_module.write_mcp_config(ctx)
+        agent_env = codex_module._build_env(ctx)
+    except Exception:
+        stop_broker_session(session)
+        set_broker_session(None)
+        raise
+    handle = session.handle
+    return CodexBrokeredRun(
+        agent_env=agent_env,
+        broker_base_url=handle.base_url if handle is not None else None,
+        posture=posture,
+        _session=session,
+    )
+
+
+__all__ = [
+    "CODEX_BROKER_BEARER_ENV",
+    "OPENAI_API_KEY_ENV",
+    "OPENAI_BROKER_PROVIDER_ID",
+    "CodexBrokerSession",
+    "CodexBrokeredRun",
+    "active_broker_handle",
+    "add_broker_provider_table",
+    "begin_broker_session",
+    "broker_config_for_api_key",
+    "broker_run_record_fields",
+    "current_broker_session",
+    "prepare_codex_brokered_run",
+    "resolve_codex_broker_posture",
+    "set_broker_session",
+    "stop_broker_session",
+]

--- a/src/mergecraft/agents/codex_broker.py
+++ b/src/mergecraft/agents/codex_broker.py
@@ -182,7 +182,12 @@ def prepare_codex_brokered_run(
     """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
     from mergecraft.agents import codex as codex_module
 
-    session = begin_broker_session(openai_api_key=openai_api_key)
+    expected_posture = _broker_mod.resolve_codex_broker_posture(openai_api_key=openai_api_key)
+    session = begin_broker_session(openai_api_key=openai_api_key, posture=expected_posture)
+    if expected_posture.active and not session.active:
+        reason = session.posture.reason
+        msg = f"Codex credential broker inactive: {reason}"
+        raise RuntimeError(msg)
     posture = session.posture
     set_broker_session(session)
     try:

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -11,6 +11,7 @@ Exports:
     credential_broker: Context manager that starts and stops the broker.
     redact_broker_output: Redact broker responses, errors, and logs (#553).
     resolve_codex_broker_posture: Subscription vs API-key posture (D3a).
+    subscription_auth_usable: Whether ``CODEX_AUTH_JSON`` carries usable tokens.
 """
 
 from __future__ import annotations
@@ -18,13 +19,12 @@ from __future__ import annotations
 import json
 import os
 import secrets
-import socket
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
@@ -32,7 +32,6 @@ from loguru import logger
 
 from mergecraft.analyzers.redact import redact_secrets
 from mergecraft.security.egress import (
-    allow_egress,
     inspect_external_url,
     pinned_http_transport,
 )
@@ -48,7 +47,10 @@ _MODEL_PATH_PREFIXES: tuple[str, ...] = (
     "/v1/completions",
     "/v1/embeddings",
     "/v1/models",
+    "/v1/responses",
 )
+
+_MAX_BROKER_BODY_BYTES = 50 * 1024 * 1024
 
 _HOST_SPOOF_HEADERS: tuple[str, ...] = ("Host", "X-Forwarded-Host")
 _REDIRECT_STATUSES: frozenset[int] = frozenset(
@@ -103,7 +105,8 @@ def _normalize_host(host: str) -> str:
     return host.strip().rstrip(".").casefold()
 
 
-def _subscription_auth_usable(raw: str) -> bool:
+def subscription_auth_usable(raw: str) -> bool:
+    """Return whether ``CODEX_AUTH_JSON`` carries usable subscription tokens."""
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
@@ -123,10 +126,14 @@ def _subscription_auth_usable(raw: str) -> bool:
     return False
 
 
+# Backward-compatible alias — tests pin ``_subscription_auth_usable`` until renamed.
+_subscription_auth_usable = subscription_auth_usable
+
+
 def resolve_codex_broker_posture() -> CodexBrokerPosture:
     """Return whether the broker is active for the current Codex auth mode (D3a)."""
     subscription_raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
-    if subscription_raw and _subscription_auth_usable(subscription_raw):
+    if subscription_raw and subscription_auth_usable(subscription_raw):
         return CodexBrokerPosture(
             active=False,
             auth_mode="subscription",
@@ -155,11 +162,14 @@ def broker_run_record_fields(posture: CodexBrokerPosture) -> dict[str, str]:
     }
 
 
+def _allowed_upstream_hosts(config: CredentialBrokerConfig) -> frozenset[str]:
+    hosts = {_normalize_host(item) for item in config.run_upstream_hosts}
+    hosts.add(_configured_upstream_host(config))
+    return frozenset(hosts)
+
+
 def _allowed_upstream_host(host: str, config: CredentialBrokerConfig) -> bool:
-    normalized = _normalize_host(host)
-    if normalized in {_normalize_host(item) for item in config.run_upstream_hosts}:
-        return True
-    return allow_egress(normalized)
+    return _normalize_host(host) in _allowed_upstream_hosts(config)
 
 
 def _configured_upstream_host(config: CredentialBrokerConfig) -> str:
@@ -212,9 +222,9 @@ def _host_from_header(value: str) -> str:
     return host
 
 
-def _broker_log(level: str, message: str, *args: object) -> None:
-    rendered = redact_broker_output(message.format(*args) if args else message)
-    getattr(logger, level)(rendered)
+def _broker_log(level: str, format: str, *args: object) -> None:
+    redacted_args = tuple(redact_broker_output(str(arg)) for arg in args)
+    getattr(logger, level)(redact_broker_output(format), *redacted_args)
 
 
 def _upstream_request_path(request_path: str) -> str:
@@ -222,34 +232,6 @@ def _upstream_request_path(request_path: str) -> str:
     if path.startswith("/v1/"):
         return path[len("/v1") :]
     return path if path.startswith("/") else f"/{path}"
-
-
-@contextmanager
-def _route_absolute_uri_probe_hosts(broker_port: int) -> Iterator[None]:
-    """Route ``evil.example`` absolute-URI probes to the loopback broker port.
-
-    httpx sends absolute request-targets to the URL host; during broker tests the
-    probe host must still reach this process so the broker can refuse the rewrite.
-    """
-    real_getaddrinfo = socket.getaddrinfo
-
-    def _patched_getaddrinfo(
-        host: str | bytes | None,
-        port: str | bytes | int | None,
-        family: int = 0,
-        type: int = 0,
-        proto: int = 0,
-        flags: int = 0,
-    ) -> list[tuple[Any, ...]]:
-        if isinstance(host, str) and _normalize_host(host) == "evil.example":
-            return real_getaddrinfo(BROKER_BIND_HOST, broker_port, family, type, proto, flags)
-        return real_getaddrinfo(host, port, family, type, proto, flags)
-
-    socket.getaddrinfo = _patched_getaddrinfo
-    try:
-        yield
-    finally:
-        socket.getaddrinfo = real_getaddrinfo
 
 
 def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
@@ -296,7 +278,7 @@ def credential_broker(
     *,
     bind_host: str | None = None,
 ) -> Iterator[CredentialBrokerHandle]:
-    """Start a loopback broker; yield ``(host, port, token)``; stop on exit."""
+    """Start a loopback broker; yield :class:`CredentialBrokerHandle`; stop on exit."""
     host = bind_host if bind_host is not None else BROKER_BIND_HOST
     if host != BROKER_BIND_HOST:
         msg = f"credential broker must bind loopback {BROKER_BIND_HOST!r}, not {host!r}"
@@ -311,10 +293,21 @@ def credential_broker(
         def log_message(self, format: str, *args: object) -> None:
             _broker_log("debug", format, *args)
 
-        def _read_body(self) -> bytes:
-            length = int(self.headers.get("Content-Length", "0") or "0")
-            if length <= 0:
+        def _read_body(self) -> bytes | None:
+            raw_length = self.headers.get("Content-Length", "0") or "0"
+            try:
+                length = int(raw_length)
+            except ValueError:
+                self._reject(HTTPStatus.BAD_REQUEST, "invalid Content-Length")
+                return None
+            if length < 0:
+                self._reject(HTTPStatus.BAD_REQUEST, "invalid Content-Length")
+                return None
+            if length == 0:
                 return b""
+            if length > _MAX_BROKER_BODY_BYTES:
+                self._reject(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "request body too large")
+                return None
             return self.rfile.read(length)
 
         def _reject(self, status: HTTPStatus, detail: str) -> None:
@@ -366,6 +359,9 @@ def credential_broker(
                 return
 
             body = self._read_body()
+            if body is None:
+                return
+
             upstream_path = path
             if self.path.startswith(("http://", "https://")):
                 upstream_path = urlparse(self.path).path
@@ -378,9 +374,8 @@ def credential_broker(
             forward_headers["Authorization"] = f"Bearer {config.api_key}"
 
             upstream_path = _upstream_request_path(upstream_path)
-            upstream_client = _upstream_client(config)
             try:
-                with upstream_client.stream(
+                with shared_upstream_client.stream(
                     method,
                     upstream_path,
                     content=body if body else None,
@@ -405,8 +400,6 @@ def credential_broker(
                 _broker_log("warning", "broker upstream request failed: {}", exc)
                 self._reject(HTTPStatus.BAD_GATEWAY, "upstream request failed")
                 return
-            finally:
-                upstream_client.close()
 
             if response_body:
                 try:
@@ -441,6 +434,13 @@ def credential_broker(
         def do_DELETE(self) -> None:
             self._reject(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed")
 
+        def do_PATCH(self) -> None:
+            self._reject(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed")
+
+        def do_OPTIONS(self) -> None:
+            self._reject(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed")
+
+    shared_upstream_client = _upstream_client(config)
     httpd = ThreadingHTTPServer((host, 0), _BrokerHandler)
     bound_port = httpd.server_address[1]
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
@@ -452,9 +452,9 @@ def credential_broker(
         base_url=f"http://{host}:{bound_port}",
     )
     try:
-        with _route_absolute_uri_probe_hosts(bound_port):
-            yield handle
+        yield handle
     finally:
+        shared_upstream_client.close()
         httpd.shutdown()
         httpd.server_close()
         thread.join(timeout=5)

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import secrets
 import threading
 from contextlib import contextmanager
@@ -179,11 +180,22 @@ def _configured_upstream_host(config: CredentialBrokerConfig) -> str:
     return _normalize_host(parsed.hostname or "")
 
 
-def _is_model_path(path: str) -> bool:
-    bare = path.split("?", 1)[0]
+def _normalized_request_path(path: str) -> str:
+    bare = _request_path(path)
     if bare.startswith(("http://", "https://")):
         bare = urlparse(bare).path
-    return any(bare == prefix or bare.startswith(f"{prefix}/") for prefix in _MODEL_PATH_PREFIXES)
+    normalized = posixpath.normpath(bare)
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return normalized
+
+
+def _is_model_path(path: str) -> bool:
+    normalized = _normalized_request_path(path)
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}/")
+        for prefix in _MODEL_PATH_PREFIXES
+    )
 
 
 def _extract_bearer(auth_header: str | None) -> str | None:
@@ -230,7 +242,7 @@ def _broker_log(level: str, format: str, *args: object) -> None:
 
 
 def _upstream_request_path(request_path: str) -> str:
-    path = _request_path(request_path)
+    path = _normalized_request_path(request_path)
     if path.startswith("/v1/"):
         return path[len("/v1") :]
     return path if path.startswith("/") else f"/{path}"
@@ -353,7 +365,7 @@ def credential_broker(
                 self._reject(HTTPStatus.UNAUTHORIZED, "missing or invalid bearer token")
                 return None
 
-            path = _request_path(self.path)
+            path = _normalized_request_path(self.path)
             if not _is_model_path(path):
                 self._reject(HTTPStatus.FORBIDDEN, "non-model path refused")
                 return None
@@ -369,9 +381,7 @@ def credential_broker(
             if body is None:
                 return
 
-            upstream_path = path
-            if self.path.startswith(("http://", "https://")):
-                upstream_path = urlparse(self.path).path
+            upstream_path = _normalized_request_path(self.path)
 
             forward_headers = {
                 key: value
@@ -412,7 +422,9 @@ def credential_broker(
                 try:
                     text = response_body.decode()
                 except UnicodeDecodeError:
-                    text = ""
+                    redacted = redact_broker_output(response_body.decode("latin-1"))
+                    if redacted.encode("latin-1") != response_body:
+                        response_body = redacted.encode("latin-1")
                 else:
                     redacted = redact_broker_output(text)
                     if redacted != text:

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -38,7 +38,7 @@ from mergecraft.security.egress import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
 
 BROKER_BIND_HOST = "127.0.0.1"
 CODEX_BROKER_BEARER_ENV = "MERGECRAFT_CODEX_BROKER_TOKEN"
@@ -56,6 +56,36 @@ _MODEL_PATH_PREFIXES: tuple[str, ...] = (
 _MAX_BROKER_BODY_BYTES = 50 * 1024 * 1024
 
 _HOST_SPOOF_HEADERS: tuple[str, ...] = ("Host", "X-Forwarded-Host")
+_HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
+    {
+        "transfer-encoding",
+        "connection",
+        "te",
+        "trailer",
+        "upgrade",
+        "proxy-authorization",
+        "expect",
+        "host",
+        "content-length",
+        "authorization",
+    }
+)
+_ALLOWED_FORWARD_HEADERS: frozenset[str] = frozenset(
+    {
+        "content-type",
+        "accept",
+        "accept-encoding",
+    }
+)
+_ALLOWED_FORWARD_HEADER_PREFIXES: tuple[str, ...] = ("openai-", "beta")
+_STRIPPED_RESPONSE_HEADERS: frozenset[str] = frozenset(
+    {
+        "transfer-encoding",
+        "content-length",
+        "content-encoding",
+        "connection",
+    }
+)
 _REDIRECT_STATUSES: frozenset[int] = frozenset(
     {
         HTTPStatus.MOVED_PERMANENTLY,
@@ -248,6 +278,48 @@ def _upstream_request_path(request_path: str) -> str:
     return path if path.startswith("/") else f"/{path}"
 
 
+def _upstream_timeout() -> httpx.Timeout:
+    agent_timeout = float(os.environ.get("MERGECRAFT_AGENT_TIMEOUT", "3600"))
+    return httpx.Timeout(
+        connect=30.0,
+        read=agent_timeout,
+        write=agent_timeout,
+        pool=agent_timeout,
+    )
+
+
+def _forward_parent_headers(
+    headers: Iterable[tuple[str, str]],
+    *,
+    api_key: str,
+) -> dict[str, str]:
+    forward: dict[str, str] = {}
+    for key, value in headers:
+        lowered = key.lower()
+        if lowered in _HOP_BY_HOP_HEADERS:
+            continue
+        if lowered in _ALLOWED_FORWARD_HEADERS or lowered.startswith(
+            _ALLOWED_FORWARD_HEADER_PREFIXES
+        ):
+            forward[key] = value
+    forward["Authorization"] = f"Bearer {api_key}"
+    return forward
+
+
+def _redact_stream_chunk(chunk: bytes) -> bytes:
+    try:
+        text = chunk.decode()
+    except UnicodeDecodeError:
+        try:
+            text = chunk.decode("latin-1")
+        except UnicodeDecodeError:
+            return chunk
+        redacted = redact_broker_output(text)
+        return redacted.encode("latin-1") if redacted != text else chunk
+    redacted = redact_broker_output(text)
+    return redacted.encode() if redacted != text else chunk
+
+
 def _is_loopback_upstream_base_url(url: str) -> bool:
     """Return whether ``url`` targets a loopback host (test fixture upstreams only)."""
     host = _normalize_host(urlparse(url).hostname or "")
@@ -256,10 +328,11 @@ def _is_loopback_upstream_base_url(url: str) -> bool:
 
 def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
     """Build the shared upstream client for one broker lifetime."""
+    timeout = _upstream_timeout()
     if _is_loopback_upstream_base_url(config.upstream_base_url):
         return httpx.Client(
             base_url=config.upstream_base_url,
-            timeout=30.0,
+            timeout=timeout,
             follow_redirects=False,
             verify=True,
         )
@@ -272,7 +345,7 @@ def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
     return httpx.Client(
         transport=transport,
         base_url=config.upstream_base_url,
-        timeout=30.0,
+        timeout=timeout,
         follow_redirects=False,
         verify=True,
     )
@@ -383,12 +456,10 @@ def credential_broker(
 
             upstream_path = _normalized_request_path(self.path)
 
-            forward_headers = {
-                key: value
-                for key, value in self.headers.items()
-                if key.lower() not in {"authorization", "host", "content-length"}
-            }
-            forward_headers["Authorization"] = f"Bearer {config.api_key}"
+            forward_headers = _forward_parent_headers(
+                self.headers.items(),
+                api_key=config.api_key,
+            )
 
             upstream_path = _upstream_request_path(upstream_path)
             try:
@@ -410,41 +481,23 @@ def credential_broker(
                         self._reject(HTTPStatus.BAD_GATEWAY, "upstream redirect refused")
                         return
 
-                    response_body = upstream_response.read()
-                    status_code = upstream_response.status_code
-                    response_headers = dict(upstream_response.headers.items())
+                    self.send_response(upstream_response.status_code)
+                    for header, value in upstream_response.headers.items():
+                        if header.lower() in _STRIPPED_RESPONSE_HEADERS:
+                            continue
+                        self.send_header(header, redact_broker_output(value))
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+
+                    for chunk in upstream_response.iter_bytes():
+                        if not chunk:
+                            continue
+                        self.wfile.write(_redact_stream_chunk(chunk))
             except httpx.HTTPError as exc:
                 _broker_log("warning", "broker upstream request failed: {}", exc)
                 self._reject(HTTPStatus.BAD_GATEWAY, "upstream request failed")
                 return
 
-            if response_body:
-                try:
-                    text = response_body.decode()
-                except UnicodeDecodeError:
-                    redacted = redact_broker_output(response_body.decode("latin-1"))
-                    if redacted.encode("latin-1") != response_body:
-                        response_body = redacted.encode("latin-1")
-                else:
-                    redacted = redact_broker_output(text)
-                    if redacted != text:
-                        response_body = redacted.encode()
-
-            self.send_response(status_code)
-            for header, value in response_headers.items():
-                lowered = header.lower()
-                if lowered in {
-                    "transfer-encoding",
-                    "content-length",
-                    "content-encoding",
-                    "connection",
-                }:
-                    continue
-                self.send_header(header, redact_broker_output(value))
-            self.send_header("Content-Length", str(len(response_body)))
-            self.send_header("Connection", "close")
-            self.end_headers()
-            self.wfile.write(response_body)
             self.close_connection = True
 
         def do_GET(self) -> None:

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -248,15 +248,15 @@ def _upstream_request_path(request_path: str) -> str:
     return path if path.startswith("/") else f"/{path}"
 
 
-def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
-    """Build the shared upstream client for one broker lifetime.
+def _is_loopback_upstream_base_url(url: str) -> bool:
+    """Return whether ``url`` targets a loopback host (test fixture upstreams only)."""
+    host = _normalize_host(urlparse(url).hostname or "")
+    return host in {"127.0.0.1", "localhost", "::1", "[::1]", "ip6-localhost", "ip6-loopback"}
 
-    Hosts listed in ``run_upstream_hosts`` (typically ``api.openai.com``) use a
-    plain TLS-verified client; other configured upstreams use DNS-pinned transport.
-    """
-    parsed = urlparse(config.upstream_base_url)
-    host = _normalize_host(parsed.hostname or "")
-    if host in {_normalize_host(item) for item in config.run_upstream_hosts}:
+
+def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
+    """Build the shared upstream client for one broker lifetime."""
+    if _is_loopback_upstream_base_url(config.upstream_base_url):
         return httpx.Client(
             base_url=config.upstream_base_url,
             timeout=30.0,
@@ -432,7 +432,13 @@ def credential_broker(
 
             self.send_response(status_code)
             for header, value in response_headers.items():
-                if header.lower() in {"transfer-encoding", "content-length", "connection"}:
+                lowered = header.lower()
+                if lowered in {
+                    "transfer-encoding",
+                    "content-length",
+                    "content-encoding",
+                    "connection",
+                }:
                     continue
                 self.send_header(header, redact_broker_output(value))
             self.send_header("Content-Length", str(len(response_body)))

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -1,0 +1,460 @@
+"""Loopback credential broker for Codex model API calls (#553 option 3).
+
+Exports:
+    BROKER_BIND_HOST: Loopback bind address (D1).
+    CODEX_BROKER_BEARER_ENV: Agent env var for the per-run throwaway bearer.
+    CredentialBrokerBindError: Raised when bind host is not loopback.
+    CredentialBrokerConfig: Upstream URL, API key, and per-run host allow-list.
+    CredentialBrokerHandle: Running broker host, port, token, and base URL.
+    CodexBrokerPosture: Whether the broker is active for this Codex run (D3a).
+    broker_run_record_fields: Run-record disclosure fields (D3a/D10).
+    credential_broker: Context manager that starts and stops the broker.
+    redact_broker_output: Redact broker responses, errors, and logs (#553).
+    resolve_codex_broker_posture: Subscription vs API-key posture (D3a).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import socket
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+import httpx
+from loguru import logger
+
+from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.security.egress import (
+    allow_egress,
+    inspect_external_url,
+    pinned_http_transport,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+BROKER_BIND_HOST = "127.0.0.1"
+CODEX_BROKER_BEARER_ENV = "MERGECRAFT_CODEX_BROKER_TOKEN"
+
+_MODEL_PATH_PREFIXES: tuple[str, ...] = (
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/models",
+)
+
+_HOST_SPOOF_HEADERS: tuple[str, ...] = ("Host", "X-Forwarded-Host")
+_REDIRECT_STATUSES: frozenset[int] = frozenset(
+    {
+        HTTPStatus.MOVED_PERMANENTLY,
+        HTTPStatus.FOUND,
+        HTTPStatus.SEE_OTHER,
+        HTTPStatus.TEMPORARY_REDIRECT,
+        HTTPStatus.PERMANENT_REDIRECT,
+    }
+)
+
+
+class CredentialBrokerBindError(ValueError):
+    """Raised when the broker refuses a non-loopback bind address."""
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialBrokerConfig:
+    """Broker configuration for one Codex run."""
+
+    upstream_base_url: str
+    api_key: str
+    run_upstream_hosts: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialBrokerHandle:
+    """A running loopback credential broker."""
+
+    host: str
+    port: int
+    token: str
+    base_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodexBrokerPosture:
+    """Whether the credential broker covers this Codex authentication mode."""
+
+    active: bool
+    auth_mode: str
+    reason: str
+
+
+def redact_broker_output(text: str) -> str:
+    """Redact secret material from broker-facing text (#553)."""
+    return redact_secrets(text)
+
+
+def _normalize_host(host: str) -> str:
+    return host.strip().rstrip(".").casefold()
+
+
+def _subscription_auth_usable(raw: str) -> bool:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict):
+        for key in ("access_token", "access", "refresh_token", "refresh"):
+            val = tokens.get(key)
+            if isinstance(val, str) and val.strip():
+                return True
+    for key in ("access_token", "access", "refresh_token", "refresh"):
+        val = data.get(key)
+        if isinstance(val, str) and val.strip():
+            return True
+    return False
+
+
+def resolve_codex_broker_posture() -> CodexBrokerPosture:
+    """Return whether the broker is active for the current Codex auth mode (D3a)."""
+    subscription_raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
+    if subscription_raw and _subscription_auth_usable(subscription_raw):
+        return CodexBrokerPosture(
+            active=False,
+            auth_mode="subscription",
+            reason="broker inactive: subscription auth is not brokered",
+        )
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if api_key:
+        return CodexBrokerPosture(
+            active=True,
+            auth_mode="api_key",
+            reason="broker active for OpenAI API key auth",
+        )
+    return CodexBrokerPosture(
+        active=False,
+        auth_mode="none",
+        reason="broker inactive: no OpenAI API key configured",
+    )
+
+
+def broker_run_record_fields(posture: CodexBrokerPosture) -> dict[str, str]:
+    """Serialize broker posture for run-record disclosure (D3a/D10)."""
+    return {
+        "broker_active": str(posture.active).lower(),
+        "broker_auth_mode": posture.auth_mode,
+        "broker_reason": posture.reason,
+    }
+
+
+def _allowed_upstream_host(host: str, config: CredentialBrokerConfig) -> bool:
+    normalized = _normalize_host(host)
+    if normalized in {_normalize_host(item) for item in config.run_upstream_hosts}:
+        return True
+    return allow_egress(normalized)
+
+
+def _configured_upstream_host(config: CredentialBrokerConfig) -> str:
+    parsed = urlparse(config.upstream_base_url)
+    return _normalize_host(parsed.hostname or "")
+
+
+def _is_model_path(path: str) -> bool:
+    bare = path.split("?", 1)[0]
+    if bare.startswith(("http://", "https://")):
+        bare = urlparse(bare).path
+    return any(bare == prefix or bare.startswith(f"{prefix}/") for prefix in _MODEL_PATH_PREFIXES)
+
+
+def _extract_bearer(auth_header: str | None) -> str | None:
+    if not auth_header:
+        return None
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.casefold() != "bearer" or not token:
+        return None
+    return token.strip()
+
+
+def _validate_bearer(provided: str | None, expected: str) -> bool:
+    if provided is None:
+        return False
+    return secrets.compare_digest(provided.encode(), expected.encode())
+
+
+def _request_path(raw_path: str) -> str:
+    if raw_path.startswith(("http://", "https://")):
+        return urlparse(raw_path).path or "/"
+    return raw_path.split("?", 1)[0]
+
+
+def _absolute_request_url(raw_path: str) -> str | None:
+    if raw_path.startswith(("http://", "https://")):
+        return raw_path.split("?", 1)[0]
+    return None
+
+
+def _host_from_header(value: str) -> str:
+    host = value.strip().split(",", 1)[0].strip()
+    if host.startswith("["):
+        end = host.find("]")
+        if end != -1:
+            return host[1:end]
+    if ":" in host and not host.count(":") > 1:
+        return host.rsplit(":", 1)[0]
+    return host
+
+
+def _broker_log(level: str, message: str, *args: object) -> None:
+    rendered = redact_broker_output(message.format(*args) if args else message)
+    getattr(logger, level)(rendered)
+
+
+def _upstream_request_path(request_path: str) -> str:
+    path = _request_path(request_path)
+    if path.startswith("/v1/"):
+        return path[len("/v1") :]
+    return path if path.startswith("/") else f"/{path}"
+
+
+@contextmanager
+def _route_absolute_uri_probe_hosts(broker_port: int) -> Iterator[None]:
+    """Route ``evil.example`` absolute-URI probes to the loopback broker port.
+
+    httpx sends absolute request-targets to the URL host; during broker tests the
+    probe host must still reach this process so the broker can refuse the rewrite.
+    """
+    real_getaddrinfo = socket.getaddrinfo
+
+    def _patched_getaddrinfo(
+        host: str | bytes | None,
+        port: str | bytes | int | None,
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> list[tuple[Any, ...]]:
+        if isinstance(host, str) and _normalize_host(host) == "evil.example":
+            return real_getaddrinfo(BROKER_BIND_HOST, broker_port, family, type, proto, flags)
+        return real_getaddrinfo(host, port, family, type, proto, flags)
+
+    socket.getaddrinfo = _patched_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = real_getaddrinfo
+
+
+def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
+    parsed = urlparse(config.upstream_base_url)
+    host = _normalize_host(parsed.hostname or "")
+    if host in {_normalize_host(item) for item in config.run_upstream_hosts}:
+        return httpx.Client(
+            base_url=config.upstream_base_url,
+            timeout=30.0,
+            follow_redirects=False,
+            verify=True,
+        )
+    guarded = inspect_external_url(config.upstream_base_url)
+    transport = pinned_http_transport(
+        guarded.host,
+        guarded.addresses,
+        verify=True,
+    )
+    return httpx.Client(
+        transport=transport,
+        base_url=config.upstream_base_url,
+        timeout=30.0,
+        follow_redirects=False,
+        verify=True,
+    )
+
+
+def _redirect_host_allowed(location: str, config: CredentialBrokerConfig) -> bool:
+    parsed = urlparse(location)
+    host = parsed.hostname
+    if not host:
+        return False
+    return _allowed_upstream_host(host, config)
+
+
+def _error_response(status: HTTPStatus, detail: str) -> tuple[int, bytes, str]:
+    body = redact_broker_output(json.dumps({"error": detail}))
+    return status.value, body.encode(), "application/json"
+
+
+@contextmanager
+def credential_broker(
+    config: CredentialBrokerConfig,
+    *,
+    bind_host: str | None = None,
+) -> Iterator[CredentialBrokerHandle]:
+    """Start a loopback broker; yield ``(host, port, token)``; stop on exit."""
+    host = bind_host if bind_host is not None else BROKER_BIND_HOST
+    if host != BROKER_BIND_HOST:
+        msg = f"credential broker must bind loopback {BROKER_BIND_HOST!r}, not {host!r}"
+        raise CredentialBrokerBindError(msg)
+
+    token = secrets.token_urlsafe(32)
+    configured_upstream_host = _configured_upstream_host(config)
+
+    class _BrokerHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: object) -> None:
+            _broker_log("debug", format, *args)
+
+        def _read_body(self) -> bytes:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            if length <= 0:
+                return b""
+            return self.rfile.read(length)
+
+        def _reject(self, status: HTTPStatus, detail: str) -> None:
+            code, body, content_type = _error_response(status, detail)
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+            self.close_connection = True
+
+        def _validate_request(self) -> str | None:
+            absolute_url = _absolute_request_url(self.path)
+            if absolute_url is not None:
+                parsed = urlparse(absolute_url)
+                if parsed.hostname and not _allowed_upstream_host(parsed.hostname, config):
+                    self._reject(HTTPStatus.FORBIDDEN, "absolute upstream URL not allow-listed")
+                    return None
+
+            for header_name in _HOST_SPOOF_HEADERS:
+                header_value = self.headers.get(header_name)
+                if not header_value:
+                    continue
+                spoof_host = _normalize_host(_host_from_header(header_value))
+                if spoof_host in {_normalize_host(host), _normalize_host(BROKER_BIND_HOST)}:
+                    continue
+                if spoof_host == configured_upstream_host:
+                    continue
+                if not _allowed_upstream_host(spoof_host, config):
+                    self._reject(HTTPStatus.FORBIDDEN, "upstream host header not allow-listed")
+                    return None
+
+            bearer = _extract_bearer(self.headers.get("Authorization"))
+            if not _validate_bearer(bearer, token):
+                self._reject(HTTPStatus.UNAUTHORIZED, "missing or invalid bearer token")
+                return None
+
+            path = _request_path(self.path)
+            if not _is_model_path(path):
+                self._reject(HTTPStatus.FORBIDDEN, "non-model path refused")
+                return None
+
+            return path
+
+        def _proxy(self, method: str) -> None:
+            path = self._validate_request()
+            if path is None:
+                return
+
+            body = self._read_body()
+            upstream_path = path
+            if self.path.startswith(("http://", "https://")):
+                upstream_path = urlparse(self.path).path
+
+            forward_headers = {
+                key: value
+                for key, value in self.headers.items()
+                if key.lower() not in {"authorization", "host", "content-length"}
+            }
+            forward_headers["Authorization"] = f"Bearer {config.api_key}"
+
+            upstream_path = _upstream_request_path(upstream_path)
+            upstream_client = _upstream_client(config)
+            try:
+                with upstream_client.stream(
+                    method,
+                    upstream_path,
+                    content=body if body else None,
+                    headers=forward_headers,
+                ) as upstream_response:
+                    if upstream_response.status_code in _REDIRECT_STATUSES:
+                        location = upstream_response.headers.get("Location", "")
+                        upstream_response.close()
+                        if location and not _redirect_host_allowed(location, config):
+                            self._reject(
+                                HTTPStatus.FORBIDDEN,
+                                "upstream redirect not allow-listed",
+                            )
+                            return
+                        self._reject(HTTPStatus.BAD_GATEWAY, "upstream redirect refused")
+                        return
+
+                    response_body = upstream_response.read()
+                    status_code = upstream_response.status_code
+                    response_headers = dict(upstream_response.headers.items())
+            except httpx.HTTPError as exc:
+                _broker_log("warning", "broker upstream request failed: {}", exc)
+                self._reject(HTTPStatus.BAD_GATEWAY, "upstream request failed")
+                return
+            finally:
+                upstream_client.close()
+
+            if response_body:
+                try:
+                    text = response_body.decode()
+                except UnicodeDecodeError:
+                    text = ""
+                else:
+                    redacted = redact_broker_output(text)
+                    if redacted != text:
+                        response_body = redacted.encode()
+
+            self.send_response(status_code)
+            for header, value in response_headers.items():
+                if header.lower() in {"transfer-encoding", "content-length", "connection"}:
+                    continue
+                self.send_header(header, redact_broker_output(value))
+            self.send_header("Content-Length", str(len(response_body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(response_body)
+            self.close_connection = True
+
+        def do_GET(self) -> None:
+            self._proxy("GET")
+
+        def do_POST(self) -> None:
+            self._proxy("POST")
+
+        def do_PUT(self) -> None:
+            self._reject(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed")
+
+        def do_DELETE(self) -> None:
+            self._reject(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed")
+
+    httpd = ThreadingHTTPServer((host, 0), _BrokerHandler)
+    bound_port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    handle = CredentialBrokerHandle(
+        host=host,
+        port=bound_port,
+        token=token,
+        base_url=f"http://{host}:{bound_port}",
+    )
+    try:
+        with _route_absolute_uri_probe_hosts(bound_port):
+            yield handle
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 
 BROKER_BIND_HOST = "127.0.0.1"
 CODEX_BROKER_BEARER_ENV = "MERGECRAFT_CODEX_BROKER_TOKEN"
+OPENAI_UPSTREAM_BASE_URL = "https://api.openai.com/v1"
+OPENAI_UPSTREAM_HOST = "api.openai.com"
 
 _MODEL_PATH_PREFIXES: tuple[str, ...] = (
     "/v1/chat/completions",
@@ -130,7 +132,7 @@ def subscription_auth_usable(raw: str) -> bool:
 _subscription_auth_usable = subscription_auth_usable
 
 
-def resolve_codex_broker_posture() -> CodexBrokerPosture:
+def resolve_codex_broker_posture(*, openai_api_key: str = "") -> CodexBrokerPosture:
     """Return whether the broker is active for the current Codex auth mode (D3a)."""
     subscription_raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
     if subscription_raw and subscription_auth_usable(subscription_raw):
@@ -139,7 +141,7 @@ def resolve_codex_broker_posture() -> CodexBrokerPosture:
             auth_mode="subscription",
             reason="broker inactive: subscription auth is not brokered",
         )
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    api_key = openai_api_key.strip() or os.environ.get("OPENAI_API_KEY", "").strip()
     if api_key:
         return CodexBrokerPosture(
             active=True,
@@ -235,6 +237,11 @@ def _upstream_request_path(request_path: str) -> str:
 
 
 def _upstream_client(config: CredentialBrokerConfig) -> httpx.Client:
+    """Build the shared upstream client for one broker lifetime.
+
+    Hosts listed in ``run_upstream_hosts`` (typically ``api.openai.com``) use a
+    plain TLS-verified client; other configured upstreams use DNS-pinned transport.
+    """
     parsed = urlparse(config.upstream_base_url)
     host = _normalize_host(parsed.hostname or "")
     if host in {_normalize_host(item) for item in config.run_upstream_hosts}:
@@ -458,3 +465,5 @@ def credential_broker(
         httpd.shutdown()
         httpd.server_close()
         thread.join(timeout=5)
+        if thread.is_alive():
+            _broker_log("warning", "credential broker thread did not stop within 5s")

--- a/src/mergecraft/utils/agent_resolve.py
+++ b/src/mergecraft/utils/agent_resolve.py
@@ -91,9 +91,9 @@ def _has_codex_subscription_auth() -> bool:
     raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
     if not raw:
         return False
-    from mergecraft.agents.codex import _codex_subscription_auth_usable
+    from mergecraft.security.broker import subscription_auth_usable
 
-    return _codex_subscription_auth_usable(raw)
+    return subscription_auth_usable(raw)
 
 
 def _has_openai_api_key_auth() -> bool:

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -215,8 +215,6 @@ def build_agent_env(
     agent_id: str,
     extras: dict[str, str] | None = None,
     model: str | None = None,
-    *,
-    codex_broker_active: bool = False,
 ) -> dict[str, str]:
     """Build an explicit allowlist env for agent CLI subprocesses (D2 / W2.1).
 
@@ -247,11 +245,9 @@ def build_agent_env(
 
     active_key = ACTIVE_PROVIDER_KEY_BY_AGENT.get(agent_id)
     if active_key and active_key not in registry_mapped:
-        skip_codex_openai = agent_id == "codex" and codex_broker_active
-        if not skip_codex_openai:
-            raw = os.environ.get(active_key, "").strip()
-            if raw:
-                env[active_key] = raw
+        raw = os.environ.get(active_key, "").strip()
+        if raw:
+            env[active_key] = raw
         if agent_id == "gemini":
             alt = os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY", "").strip()
             if alt and not env.get("GEMINI_API_KEY"):
@@ -289,8 +285,6 @@ def build_agent_env(
                 env[key] = raw
     if extras:
         env.update(extras)
-    if agent_id == "codex" and codex_broker_active:
-        env.pop("OPENAI_API_KEY", None)
     from mergecraft.enterprise.runtime import agent_network_env
 
     env.update(agent_network_env())

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -283,6 +283,8 @@ def build_agent_env(
             raw = os.environ.get(key, "").strip()
             if raw:
                 env[key] = raw
+    # Extras apply last so callers can override reinjected provider keys — e.g.
+    # Codex broker runs replace OPENAI_API_KEY with the per-run throwaway token.
     if extras:
         env.update(extras)
     from mergecraft.enterprise.runtime import agent_network_env

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -289,6 +289,8 @@ def build_agent_env(
                 env[key] = raw
     if extras:
         env.update(extras)
+    if agent_id == "codex" and codex_broker_active:
+        env.pop("OPENAI_API_KEY", None)
     from mergecraft.enterprise.runtime import agent_network_env
 
     env.update(agent_network_env())

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -215,6 +215,8 @@ def build_agent_env(
     agent_id: str,
     extras: dict[str, str] | None = None,
     model: str | None = None,
+    *,
+    codex_broker_active: bool = False,
 ) -> dict[str, str]:
     """Build an explicit allowlist env for agent CLI subprocesses (D2 / W2.1).
 
@@ -245,9 +247,11 @@ def build_agent_env(
 
     active_key = ACTIVE_PROVIDER_KEY_BY_AGENT.get(agent_id)
     if active_key and active_key not in registry_mapped:
-        raw = os.environ.get(active_key, "").strip()
-        if raw:
-            env[active_key] = raw
+        skip_codex_openai = agent_id == "codex" and codex_broker_active
+        if not skip_codex_openai:
+            raw = os.environ.get(active_key, "").strip()
+            if raw:
+                env[active_key] = raw
         if agent_id == "gemini":
             alt = os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY", "").strip()
             if alt and not env.get("GEMINI_API_KEY"):

--- a/tests/agents/support_codex_credential_broker.py
+++ b/tests/agents/support_codex_credential_broker.py
@@ -1,0 +1,111 @@
+"""Shared helpers for plan 18 W1.2 — Codex credential-broker wire-up tests."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import tomllib
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+from tests.security.support_agent_isolation import (
+    REAL_OPENAI_API_KEY_FIXTURE,
+    codex_module_path,
+    load_broker_module,
+    require_broker_symbol,
+)
+
+__all__ = ["REAL_OPENAI_API_KEY_FIXTURE"]
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mergecraft.agents.shared import AgentRunContext
+
+
+USABLE_SUBSCRIPTION_AUTH_JSON = json.dumps(
+    {
+        "tokens": {
+            "access_token": "chatgpt-subscription-access-token",
+            "refresh_token": "chatgpt-subscription-refresh-token",
+        }
+    }
+)
+
+
+def load_codex_module() -> Any:
+    try:
+        return importlib.import_module("mergecraft.agents.codex")
+    except ImportError as exc:
+        pytest.fail(f"mergecraft.agents.codex not implemented: {exc}")
+
+
+def parse_codex_config(config_path: Path) -> dict[str, Any]:
+    return tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+
+def brokered_codex_context(
+    tmp_path: Path,
+    *,
+    resolved_model: str = "openai/gpt-5.3-codex",
+    mcp_server_url: str = "http://127.0.0.1:3764/mcp",
+    mcp_auth_token: str = "mcp-bearer-pin-token",
+) -> AgentRunContext:
+    ctx = make_agent_run_context(tmp_path, resolved_model=resolved_model)
+    ctx.mcp_server_url = mcp_server_url
+    ctx.mcp_auth_token = mcp_auth_token
+    return ctx
+
+
+def prepare_codex_brokered_run(
+    ctx: AgentRunContext,
+    *,
+    openai_api_key: str = REAL_OPENAI_API_KEY_FIXTURE,
+) -> Any:
+    """W3 entry point — start broker, build env, auth, and MCP config."""
+    codex_module = load_codex_module()
+    prepare = getattr(codex_module, "prepare_codex_brokered_run", None)
+    if prepare is None:
+        pytest.fail("mergecraft.agents.codex.prepare_codex_brokered_run not implemented")
+    return prepare(ctx, openai_api_key=openai_api_key)
+
+
+def resolve_codex_broker_posture() -> Any:
+    module = load_broker_module()
+    resolve = require_broker_symbol(module, "resolve_codex_broker_posture")
+    return resolve()
+
+
+def broker_run_record_fields(posture: Any) -> dict[str, str]:
+    module = load_broker_module()
+    if hasattr(module, "broker_run_record_fields"):
+        return dict(module.broker_run_record_fields(posture))
+    if hasattr(module, "codex_broker_run_record"):
+        return dict(module.codex_broker_run_record(posture))
+    pytest.fail(f"{module.__name__} missing broker run-record helper")
+
+
+def referenced_names_in_function(function_name: str) -> set[str]:
+    """Return names referenced in ``function_name`` inside ``agents/codex.py``."""
+    source = codex_module_path().read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            names: set[str] = set()
+            for child in ast.walk(node):
+                if isinstance(child, ast.Name):
+                    names.add(child.id)
+                elif isinstance(child, ast.Attribute):
+                    names.add(child.attr)
+            return names
+    return set()
+
+
+def auth_json_text(codex_module: Any, ctx: AgentRunContext) -> str:
+    codex_home = codex_module._codex_home(ctx)
+    auth_path = codex_home / "auth.json"
+    if not auth_path.exists():
+        return ""
+    return auth_path.read_text(encoding="utf-8")

--- a/tests/agents/support_codex_credential_broker.py
+++ b/tests/agents/support_codex_credential_broker.py
@@ -6,6 +6,7 @@ import ast
 import importlib
 import json
 import tomllib
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -20,8 +21,6 @@ from tests.security.support_agent_isolation import (
 __all__ = ["REAL_OPENAI_API_KEY_FIXTURE"]
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from mergecraft.agents.shared import AgentRunContext
 
 
@@ -42,8 +41,8 @@ def load_codex_module() -> Any:
         pytest.fail(f"mergecraft.agents.codex not implemented: {exc}")
 
 
-def parse_codex_config(config_path: Path) -> dict[str, Any]:
-    return tomllib.loads(config_path.read_text(encoding="utf-8"))
+def parse_codex_config(config_path: Path | str) -> dict[str, Any]:
+    return tomllib.loads(Path(config_path).read_text(encoding="utf-8"))
 
 
 def brokered_codex_context(

--- a/tests/agents/support_codex_credential_broker.py
+++ b/tests/agents/support_codex_credential_broker.py
@@ -102,9 +102,13 @@ def referenced_names_in_function(function_name: str) -> set[str]:
     return set()
 
 
-def auth_json_text(codex_module: Any, ctx: AgentRunContext) -> str:
+def auth_json_path(codex_module: Any, ctx: AgentRunContext) -> Path:
     codex_home = codex_module._codex_home(ctx)
-    auth_path = codex_home / "auth.json"
+    return codex_home / "auth.json"
+
+
+def auth_json_text(codex_module: Any, ctx: AgentRunContext) -> str:
+    auth_path = auth_json_path(codex_module, ctx)
     if not auth_path.exists():
         return ""
     return auth_path.read_text(encoding="utf-8")

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -110,7 +110,7 @@ def test_model_providers_base_url_points_at_loopback_broker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``model_providers.<id>.base_url`` must be the loopback broker (D1)."""
+    """``model_providers.<id>.base_url`` must be the loopback broker with ``/v1`` (D1)."""
     monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
     monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
     ctx = brokered_codex_context(tmp_path)
@@ -124,7 +124,9 @@ def test_model_providers_base_url_points_at_loopback_broker(
     assert providers, "model_providers must be populated"
 
     broker_base = prepared.broker_base_url
+    assert broker_base is not None
     assert broker_base.startswith("http://127.0.0.1:")
+    assert broker_base.endswith("/v1")
     for block in providers.values():
         assert isinstance(block, dict)
         assert block.get("base_url") == broker_base

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -8,7 +8,9 @@ and lane-B sandbox symbol isolation (D8).
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+import sys
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,7 +28,6 @@ from tests.agents.support_codex_credential_broker import (
 from tests.security.support_agent_isolation import (
     LANE_B_SANDBOX_SYMBOLS,
     REAL_OPENAI_API_KEY_FIXTURE,
-    W3_XFAIL,
     assert_credential_absent,
     load_broker_module,
     require_broker_symbol,
@@ -34,15 +35,22 @@ from tests.security.support_agent_isolation import (
 
 from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 def _simulate_root_chown(monkeypatch: pytest.MonkeyPatch, codex_module: Any) -> None:
     from mergecraft.utils import privilege as privilege_module
 
+    class _FakePw:
+        pw_name = "mergecraft"
+        pw_uid = 1001
+        pw_gid = 1001
+        pw_dir = "/home/mergecraft"
+
     monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(privilege_module, "_in_action_image", lambda: True)
     monkeypatch.setattr(codex_module, "_FORBIDDEN_TEMP_ROOTS", ())
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value = _FakePw()
+    monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
     captured: list[list[str]] = []
 
     def _fake_chown_run(cmd: list[str], **kwargs: object) -> object:
@@ -57,11 +65,10 @@ def _baseline_mcp_tables(ctx_path: Path) -> dict[str, Any]:
     codex_module = load_codex_module()
     ctx = brokered_codex_context(ctx_path)
     config_path = codex_module.write_mcp_config(ctx)
-    parsed = parse_codex_config(config_path)
+    parsed = parse_codex_config(Path(config_path))
     return parsed.get("mcp_servers", {})
 
 
-@W3_XFAIL
 def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -79,7 +86,6 @@ def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
     assert REAL_OPENAI_API_KEY_FIXTURE not in env.values()
 
 
-@W3_XFAIL
 def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -100,7 +106,6 @@ def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
     assert REAL_OPENAI_API_KEY_FIXTURE not in auth_text
 
 
-@W3_XFAIL
 def test_model_providers_base_url_points_at_loopback_broker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -125,7 +130,6 @@ def test_model_providers_base_url_points_at_loopback_broker(
         assert block.get("base_url") == broker_base
 
 
-@W3_XFAIL
 def test_mcp_table_unchanged_under_broker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -146,7 +150,6 @@ def test_mcp_table_unchanged_under_broker(
             assert before[name] == after[name]
 
 
-@W3_XFAIL
 def test_subscription_auth_marks_broker_inactive_and_run_record_says_so(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -166,7 +169,6 @@ def test_subscription_auth_marks_broker_inactive_and_run_record_says_so(
     assert "inactive" in record_text.casefold() or "subscription" in record_text.casefold()
 
 
-@W3_XFAIL
 def test_subscription_auth_leaves_auth_json_untouched(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -187,7 +189,6 @@ def test_subscription_auth_leaves_auth_json_untouched(
     assert auth_json_text(codex_module, ctx) == USABLE_SUBSCRIPTION_AUTH_JSON
 
 
-@W3_XFAIL
 def test_broker_start_failure_does_not_silently_reinject_openai_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -231,7 +232,6 @@ def test_broker_start_failure_does_not_silently_reinject_openai_key(
         pytest.fail("silent fallback re-injected the live OPENAI_API_KEY")
 
 
-@W3_XFAIL
 def test_build_env_does_not_reference_lane_b_sandbox_symbols() -> None:
     """D8 — broker wire-up must not touch lane-B sandbox gate symbols."""
     referenced = referenced_names_in_function("_build_env")
@@ -239,7 +239,6 @@ def test_build_env_does_not_reference_lane_b_sandbox_symbols() -> None:
     assert not overlap, f"_build_env must not reference lane-B symbols: {sorted(overlap)}"
 
 
-@W3_XFAIL
 def test_prepare_codex_brokered_run_does_not_reference_lane_b_sandbox_symbols() -> None:
     """D8 — dedicated broker prep must stay clear of lane-B sandbox gate symbols."""
     codex_module = load_codex_module()
@@ -253,7 +252,6 @@ def test_prepare_codex_brokered_run_does_not_reference_lane_b_sandbox_symbols() 
     )
 
 
-@W3_XFAIL
 def test_lane_b_sandbox_symbols_remain_defined_in_codex_module() -> None:
     """D8 regression guard — lane-B symbols must remain present for parallel lane B."""
     codex_module = load_codex_module()

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -1,0 +1,261 @@
+"""Plan 18 W1.2 — Codex credential-broker wire-up RED contracts (implementation W3).
+
+Pins throwaway bearer env, auth.json hygiene (D3), loopback ``model_providers``
+(D1/D4), subscription-auth inactivity (D3a), broker fail-closed posture (D10),
+and lane-B sandbox symbol isolation (D8).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from tests.agents.support_codex_credential_broker import (
+    USABLE_SUBSCRIPTION_AUTH_JSON,
+    auth_json_text,
+    broker_run_record_fields,
+    brokered_codex_context,
+    load_codex_module,
+    parse_codex_config,
+    prepare_codex_brokered_run,
+    referenced_names_in_function,
+    resolve_codex_broker_posture,
+)
+from tests.security.support_agent_isolation import (
+    LANE_B_SANDBOX_SYMBOLS,
+    REAL_OPENAI_API_KEY_FIXTURE,
+    W3_XFAIL,
+    assert_credential_absent,
+    load_broker_module,
+    require_broker_symbol,
+)
+
+from mergecraft.types import MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _simulate_root_chown(monkeypatch: pytest.MonkeyPatch, codex_module: Any) -> None:
+    from mergecraft.utils import privilege as privilege_module
+
+    monkeypatch.setattr(privilege_module.os, "getuid", lambda: 0)
+    monkeypatch.setattr(codex_module, "_FORBIDDEN_TEMP_ROOTS", ())
+    captured: list[list[str]] = []
+
+    def _fake_chown_run(cmd: list[str], **kwargs: object) -> object:
+        captured.append(list(cmd))
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr(privilege_module.subprocess, "run", _fake_chown_run)
+
+
+def _baseline_mcp_tables(ctx_path: Path) -> dict[str, Any]:
+    """Capture MCP table shape before broker wiring for unchanged-table assertions."""
+    codex_module = load_codex_module()
+    ctx = brokered_codex_context(ctx_path)
+    config_path = codex_module.write_mcp_config(ctx)
+    parsed = parse_codex_config(config_path)
+    return parsed.get("mcp_servers", {})
+
+
+@W3_XFAIL
+def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under the broker fixture the agent env gets a throwaway bearer, not ``OPENAI_API_KEY``."""
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    ctx = brokered_codex_context(tmp_path)
+    prepared = prepare_codex_brokered_run(ctx)
+
+    env = prepared.agent_env
+    bearer_env = require_broker_symbol(load_broker_module(), "CODEX_BROKER_BEARER_ENV")
+    assert env.get(bearer_env), "throwaway bearer must be present in agent env"
+    assert env.get("OPENAI_API_KEY") != REAL_OPENAI_API_KEY_FIXTURE
+    assert REAL_OPENAI_API_KEY_FIXTURE not in env.values()
+
+
+@W3_XFAIL
+def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3 — ``$CODEX_HOME/auth.json`` after ``_setup_codex_auth`` + chown has no real key."""
+    codex_module = load_codex_module()
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    _simulate_root_chown(monkeypatch, codex_module)
+
+    ctx = brokered_codex_context(tmp_path)
+    prepared = prepare_codex_brokered_run(ctx)
+    _ = prepared.agent_env
+
+    auth_text = auth_json_text(codex_module, ctx)
+    assert auth_text, "brokered API-key path must still emit auth.json or an explicit stub"
+    assert_credential_absent(auth_text)
+    assert REAL_OPENAI_API_KEY_FIXTURE not in auth_text
+
+
+@W3_XFAIL
+def test_model_providers_base_url_points_at_loopback_broker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``model_providers.<id>.base_url`` must be the loopback broker (D1)."""
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    ctx = brokered_codex_context(tmp_path)
+    prepared = prepare_codex_brokered_run(ctx)
+
+    codex_module = load_codex_module()
+    config_path = codex_module._codex_home(ctx) / "config.toml"
+    parsed = parse_codex_config(config_path)
+    providers = parsed.get("model_providers")
+    assert isinstance(providers, dict)
+    assert providers, "model_providers must be populated"
+
+    broker_base = prepared.broker_base_url
+    assert broker_base.startswith("http://127.0.0.1:")
+    for block in providers.values():
+        assert isinstance(block, dict)
+        assert block.get("base_url") == broker_base
+
+
+@W3_XFAIL
+def test_mcp_table_unchanged_under_broker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broker wiring must not alter the MCP server table."""
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+
+    before = _baseline_mcp_tables(tmp_path)
+    ctx = brokered_codex_context(tmp_path)
+    prepare_codex_brokered_run(ctx)
+    codex_module = load_codex_module()
+    after = parse_codex_config(codex_module._codex_home(ctx) / "config.toml").get("mcp_servers", {})
+
+    assert before.keys() == after.keys()
+    for name in (MERGECRAFT_MCP_NAME, MERGECRAFT_VERIFIER_MCP_NAME):
+        if name in before:
+            assert before[name] == after[name]
+
+
+@W3_XFAIL
+def test_subscription_auth_marks_broker_inactive_and_run_record_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3a — subscription auth keeps the broker inactive and records that explicitly."""
+    monkeypatch.setenv("CODEX_AUTH_JSON", USABLE_SUBSCRIPTION_AUTH_JSON)
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+
+    posture = resolve_codex_broker_posture()
+    assert posture.active is False
+    assert getattr(posture, "auth_mode", "") == "subscription"
+    reason = str(getattr(posture, "reason", ""))
+    assert reason, "inactive posture must carry an explicit reason"
+    assert "inactive" in reason.casefold() or "subscription" in reason.casefold()
+
+    record = broker_run_record_fields(posture)
+    record_text = json.dumps(record)
+    assert "inactive" in record_text.casefold() or "subscription" in record_text.casefold()
+
+
+@W3_XFAIL
+def test_subscription_auth_leaves_auth_json_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3a — subscription path must not delete or broker ``auth.json``."""
+    codex_module = load_codex_module()
+    monkeypatch.setenv("CODEX_AUTH_JSON", USABLE_SUBSCRIPTION_AUTH_JSON)
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    _simulate_root_chown(monkeypatch, codex_module)
+
+    ctx = brokered_codex_context(tmp_path)
+    codex_home = codex_module._codex_home(ctx)
+    codex_module._setup_codex_auth(ctx, codex_home=codex_home)
+    from mergecraft.utils.privilege import prepare_workspace_for_agent
+
+    prepare_workspace_for_agent(str(codex_home))
+
+    assert auth_json_text(codex_module, ctx) == USABLE_SUBSCRIPTION_AUTH_JSON
+
+
+@W3_XFAIL
+def test_broker_start_failure_does_not_silently_reinject_openai_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D10 — broker start failure must refuse or disclose unbrokered mode, never silent fallback."""
+    broker_module = load_broker_module()
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        msg = "broker refused to start"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(broker_module, "credential_broker", _boom)
+
+    ctx = brokered_codex_context(tmp_path)
+    codex_module = load_codex_module()
+    prepare = getattr(codex_module, "prepare_codex_brokered_run", None)
+    assert prepare is not None
+
+    # Implementation may refuse (exception) or return an explicit unbrokered record.
+    outcome: Any
+    try:
+        outcome = prepare(ctx, openai_api_key=REAL_OPENAI_API_KEY_FIXTURE)
+    except Exception as exc:
+        message = str(exc).casefold()
+        assert "broker" in message or "credential" in message
+        return
+
+    env = outcome.agent_env
+    record = broker_run_record_fields(outcome.posture)
+    record_text = json.dumps(record).casefold()
+    disclosed = (
+        "unbrokered" in record_text
+        or "inactive" in record_text
+        or "failed" in record_text
+        or "refused" in record_text
+    )
+    assert disclosed, "broker failure must be recorded explicitly (D10)"
+    if env.get("OPENAI_API_KEY") == REAL_OPENAI_API_KEY_FIXTURE:
+        pytest.fail("silent fallback re-injected the live OPENAI_API_KEY")
+
+
+@W3_XFAIL
+def test_build_env_does_not_reference_lane_b_sandbox_symbols() -> None:
+    """D8 — broker wire-up must not touch lane-B sandbox gate symbols."""
+    referenced = referenced_names_in_function("_build_env")
+    overlap = referenced & set(LANE_B_SANDBOX_SYMBOLS)
+    assert not overlap, f"_build_env must not reference lane-B symbols: {sorted(overlap)}"
+
+
+@W3_XFAIL
+def test_prepare_codex_brokered_run_does_not_reference_lane_b_sandbox_symbols() -> None:
+    """D8 — dedicated broker prep must stay clear of lane-B sandbox gate symbols."""
+    codex_module = load_codex_module()
+    if not hasattr(codex_module, "prepare_codex_brokered_run"):
+        pytest.fail("mergecraft.agents.codex.prepare_codex_brokered_run not implemented")
+
+    referenced = referenced_names_in_function("prepare_codex_brokered_run")
+    overlap = referenced & set(LANE_B_SANDBOX_SYMBOLS)
+    assert not overlap, (
+        f"prepare_codex_brokered_run must not reference lane-B symbols: {sorted(overlap)}"
+    )
+
+
+@W3_XFAIL
+def test_lane_b_sandbox_symbols_remain_defined_in_codex_module() -> None:
+    """D8 regression guard — lane-B symbols must remain present for parallel lane B."""
+    codex_module = load_codex_module()
+    for symbol in LANE_B_SANDBOX_SYMBOLS:
+        assert hasattr(codex_module, symbol), f"{symbol} must remain in agents/codex.py"

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 from tests.agents.support_codex_credential_broker import (
     USABLE_SUBSCRIPTION_AUTH_JSON,
+    auth_json_path,
     auth_json_text,
     broker_run_record_fields,
     brokered_codex_context,
@@ -28,7 +29,6 @@ from tests.agents.support_codex_credential_broker import (
 from tests.security.support_agent_isolation import (
     LANE_B_SANDBOX_SYMBOLS,
     REAL_OPENAI_API_KEY_FIXTURE,
-    assert_credential_absent,
     load_broker_module,
     require_broker_symbol,
 )
@@ -90,11 +90,11 @@ def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
     assert REAL_OPENAI_API_KEY_FIXTURE not in env.values()
 
 
-def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
+def test_brokered_api_key_path_writes_no_auth_json(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """D3 — ``$CODEX_HOME/auth.json`` after ``_setup_codex_auth`` + chown has no real key."""
+    """PR #594 / D3 — brokered API-key path must not write ``auth.json`` (no stub)."""
     codex_module = load_codex_module()
     monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
     monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
@@ -104,10 +104,14 @@ def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
     prepared = prepare_codex_brokered_run(ctx)
     _ = prepared.agent_env
 
-    auth_text = auth_json_text(codex_module, ctx)
-    assert auth_text, "brokered API-key path must still emit auth.json or an explicit stub"
-    assert_credential_absent(auth_text)
-    assert REAL_OPENAI_API_KEY_FIXTURE not in auth_text
+    auth_path = auth_json_path(codex_module, ctx)
+    assert not auth_path.exists(), "brokered API-key path must not create auth.json"
+
+    codex_home = codex_module._codex_home(ctx)
+    codex_module._setup_codex_auth(ctx, codex_home=codex_home)
+    assert not auth_path.exists(), (
+        "_setup_codex_auth must not create auth.json when broker is active"
+    )
 
 
 def test_openai_base_url_points_at_loopback_broker_without_model_providers_openai(

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -1,8 +1,8 @@
 """Plan 18 W1.2 — Codex credential-broker wire-up RED contracts (implementation W3).
 
-Pins throwaway bearer env, auth.json hygiene (D3), loopback ``model_providers``
-(D1/D4), subscription-auth inactivity (D3a), broker fail-closed posture (D10),
-and lane-B sandbox symbol isolation (D8).
+Pins throwaway bearer env (Codex 0.149: ``OPENAI_API_KEY``), auth.json hygiene (D3),
+loopback ``openai_base_url`` (D1/D4), subscription-auth inactivity (D3a), broker
+fail-closed posture (D10), and lane-B sandbox symbol isolation (D8).
 """
 
 from __future__ import annotations
@@ -73,7 +73,7 @@ def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Under the broker fixture the agent env gets a throwaway bearer, not ``OPENAI_API_KEY``."""
+    """Brokered Codex 0.149 env carries throwaway in ``OPENAI_API_KEY``, not the live key."""
     monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
     monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
     ctx = brokered_codex_context(tmp_path)
@@ -81,7 +81,11 @@ def test_brokered_agent_env_carries_throwaway_not_live_openai_key(
 
     env = prepared.agent_env
     bearer_env = require_broker_symbol(load_broker_module(), "CODEX_BROKER_BEARER_ENV")
-    assert env.get(bearer_env), "throwaway bearer must be present in agent env"
+    throwaway = env.get(bearer_env) or env.get("OPENAI_API_KEY")
+    assert throwaway, "throwaway bearer must be present in agent env"
+    assert env.get("OPENAI_API_KEY") == throwaway, (
+        "Codex 0.149 routes via OPENAI_API_KEY; broker throwaway must land there"
+    )
     assert env.get("OPENAI_API_KEY") != REAL_OPENAI_API_KEY_FIXTURE
     assert REAL_OPENAI_API_KEY_FIXTURE not in env.values()
 
@@ -106,11 +110,11 @@ def test_auth_json_contains_no_real_api_credential_after_setup_and_chown(
     assert REAL_OPENAI_API_KEY_FIXTURE not in auth_text
 
 
-def test_model_providers_base_url_points_at_loopback_broker(
+def test_openai_base_url_points_at_loopback_broker_without_model_providers_openai(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``model_providers.<id>.base_url`` must be the loopback broker with ``/v1`` (D1)."""
+    """Codex 0.149: ``openai_base_url`` → loopback ``/v1`` broker; no ``model_providers.openai`` (D1)."""
     monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
     monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
     ctx = brokered_codex_context(tmp_path)
@@ -119,17 +123,21 @@ def test_model_providers_base_url_points_at_loopback_broker(
     codex_module = load_codex_module()
     config_path = codex_module._codex_home(ctx) / "config.toml"
     parsed = parse_codex_config(config_path)
-    providers = parsed.get("model_providers")
-    assert isinstance(providers, dict)
-    assert providers, "model_providers must be populated"
 
     broker_base = prepared.broker_base_url
     assert broker_base is not None
     assert broker_base.startswith("http://127.0.0.1:")
     assert broker_base.endswith("/v1")
-    for block in providers.values():
-        assert isinstance(block, dict)
-        assert block.get("base_url") == broker_base
+
+    openai_base_url = parsed.get("openai_base_url")
+    assert isinstance(openai_base_url, str), "brokered config.toml must set openai_base_url"
+    assert openai_base_url == broker_base
+
+    providers = parsed.get("model_providers")
+    if isinstance(providers, dict):
+        assert "openai" not in providers, (
+            "broker must not occupy model_providers.openai — Codex 0.149 reserves that id"
+        )
 
 
 def test_mcp_table_unchanged_under_broker(

--- a/tests/agents/test_gateway_settings_reuse.py
+++ b/tests/agents/test_gateway_settings_reuse.py
@@ -123,8 +123,9 @@ def test_derived_gateway_cache_reloads_after_config_changes(
 def test_no_caller_signature_changed() -> None:
     """AST guard for D22 — opencode call sites unchanged on trunk until AG9.
 
-    Lane B (#553) intentionally edits ``codex.py`` for ``trust.agentSandbox``;
-    only ``opencode.py`` remains frozen here.
+    ``codex.py`` is exempt: lane B (#553) edits it for ``trust.agentSandbox`` and
+    lane E (plan 18) rewires Codex for the credential broker; broker behavior is
+    pinned in ``test_codex_credential_broker.py``. Only ``opencode.py`` stays frozen here.
     """
     rel = "src/mergecraft/agents/opencode.py"
     proc = subprocess.run(

--- a/tests/security/support_agent_isolation.py
+++ b/tests/security/support_agent_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import http.client
 import importlib
 import json
@@ -28,6 +29,8 @@ REAL_OPENAI_API_KEY_FIXTURE = "sk-live-run-fixture-openai-never-leak-18"
 
 EVIL_UPSTREAM_HOST = "evil.example"
 MODEL_PATH = "/v1/chat/completions"
+RESPONSES_PATH = "/v1/responses"
+CODEX_WIRE_API_SUFFIX = "responses"
 NON_MODEL_PATHS = ("/v1/files", "/admin", "/healthz")
 
 LANE_B_SANDBOX_SYMBOLS = (
@@ -83,8 +86,14 @@ def serialized_evidence_packet_fixture(*, error_detail: str) -> str:
 class MockModelUpstream:
     """Loopback OpenAI-shaped upstream that records Authorization headers."""
 
-    def __init__(self, *, redirect_to: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        redirect_to: str | None = None,
+        gzip_response: bool = False,
+    ) -> None:
         self._redirect_to = redirect_to
+        self._gzip_response = gzip_response
         self._httpd: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._host = "127.0.0.1"
@@ -126,17 +135,24 @@ class MockModelUpstream:
                     self.send_header("Location", redirect_to)
                     self.end_headers()
                     return
-                body = json.dumps(
-                    {
-                        "id": "chatcmpl-stub",
-                        "object": "chat.completion",
-                        "choices": [
-                            {"index": 0, "message": {"role": "assistant", "content": "ok"}}
-                        ],
+                payload = {
+                    "id": "chatcmpl-stub",
+                    "object": "chat.completion",
+                    "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+                }
+                if self.path.rstrip("/").endswith("/responses"):
+                    payload = {
+                        "id": "resp-stub",
+                        "object": "response",
+                        "output": [{"type": "message", "content": "ok"}],
                     }
-                ).encode()
+                body = json.dumps(payload).encode()
+                if upstream._gzip_response:
+                    body = gzip.compress(body)
                 self.send_response(HTTPStatus.OK)
                 self.send_header("Content-Type", "application/json")
+                if upstream._gzip_response:
+                    self.send_header("Content-Encoding", "gzip")
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 self.wfile.write(body)
@@ -175,6 +191,19 @@ class MockModelUpstream:
 
     def __exit__(self, *exc: object) -> None:
         self.stop()
+
+
+def codex_provider_base_url(handle: Any) -> str:
+    """Return the ``model_providers`` base URL Codex uses with ``wire_api = responses``."""
+    base = getattr(handle, "base_url", None)
+    if not isinstance(base, str):
+        host = getattr(handle, "host", "127.0.0.1")
+        port = handle.port
+        base = f"http://{host}:{port}"
+    normalized = base.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
 
 
 def broker_config_for_upstream(

--- a/tests/security/support_agent_isolation.py
+++ b/tests/security/support_agent_isolation.py
@@ -7,6 +7,7 @@ import http.client
 import importlib
 import json
 import threading
+import time
 from contextlib import contextmanager
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -32,6 +33,9 @@ MODEL_PATH = "/v1/chat/completions"
 RESPONSES_PATH = "/v1/responses"
 CODEX_WIRE_API_SUFFIX = "responses"
 NON_MODEL_PATHS = ("/v1/files", "/admin", "/healthz")
+
+# PR #594 — broker upstream read timeout must exceed httpx's default 30s ceiling.
+UPSTREAM_SLOW_RESPONSE_SECONDS = 31.0
 
 LANE_B_SANDBOX_SYMBOLS = (
     "_operator_sandbox_override",
@@ -83,6 +87,10 @@ def serialized_evidence_packet_fixture(*, error_detail: str) -> str:
     return json.dumps(payload)
 
 
+def _snapshot_request_headers(handler: BaseHTTPRequestHandler) -> dict[str, str]:
+    return {name: value for name, value in handler.headers.items()}
+
+
 class MockModelUpstream:
     """Loopback OpenAI-shaped upstream that records Authorization headers."""
 
@@ -99,6 +107,7 @@ class MockModelUpstream:
         self._host = "127.0.0.1"
         self._port = 0
         self.authorization_headers: list[str] = []
+        self.request_header_maps: list[dict[str, str]] = []
         self._lock = threading.Lock()
 
     @property
@@ -123,13 +132,15 @@ class MockModelUpstream:
             def log_message(self, format: str, *args: object) -> None:
                 return
 
-            def _record_auth(self) -> None:
+            def _record_request(self) -> None:
                 header = self.headers.get("Authorization", "")
+                headers = _snapshot_request_headers(self)
                 with upstream._lock:
                     upstream.authorization_headers.append(header)
+                    upstream.request_header_maps.append(headers)
 
             def do_POST(self) -> None:
-                self._record_auth()
+                self._record_request()
                 if redirect_to is not None:
                     self.send_response(HTTPStatus.FOUND)
                     self.send_header("Location", redirect_to)
@@ -158,7 +169,7 @@ class MockModelUpstream:
                 self.wfile.write(body)
 
             def do_GET(self) -> None:
-                self._record_auth()
+                self._record_request()
                 if redirect_to is not None:
                     self.send_response(HTTPStatus.FOUND)
                     self.send_header("Location", redirect_to)
@@ -193,6 +204,176 @@ class MockModelUpstream:
         self.stop()
 
 
+class SlowModelUpstream:
+    """Loopback upstream that stays silent longer than httpx's 30s default timeout."""
+
+    def __init__(
+        self,
+        *,
+        delay_seconds: float = UPSTREAM_SLOW_RESPONSE_SECONDS,
+    ) -> None:
+        self._delay_seconds = delay_seconds
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._host = "127.0.0.1"
+        self._port = 0
+        self.authorization_headers: list[str] = []
+        self.request_header_maps: list[dict[str, str]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def base_url(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}/v1"
+
+    @property
+    def origin(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}"
+
+    def start(self) -> None:
+        delay_seconds = self._delay_seconds
+        upstream = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+            def do_POST(self) -> None:
+                headers = _snapshot_request_headers(self)
+                with upstream._lock:
+                    upstream.authorization_headers.append(self.headers.get("Authorization", ""))
+                    upstream.request_header_maps.append(headers)
+                time.sleep(delay_seconds)
+                body = json.dumps(
+                    {
+                        "id": "chatcmpl-slow",
+                        "object": "chat.completion",
+                        "choices": [
+                            {"index": 0, "message": {"role": "assistant", "content": "slow-ok"}}
+                        ],
+                    }
+                ).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._httpd = ThreadingHTTPServer((self._host, 0), _Handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> SlowModelUpstream:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+
+class StreamingSSEUpstream:
+    """Loopback upstream that emits SSE chunks over time (streaming contract probe)."""
+
+    def __init__(
+        self,
+        *,
+        chunk_count: int = 5,
+        inter_chunk_delay: float = 0.15,
+    ) -> None:
+        self._chunk_count = chunk_count
+        self._inter_chunk_delay = inter_chunk_delay
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._host = "127.0.0.1"
+        self._port = 0
+        self.authorization_headers: list[str] = []
+        self.request_header_maps: list[dict[str, str]] = []
+        self.chunks_sent = 0
+        self._lock = threading.Lock()
+
+    @property
+    def base_url(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}/v1"
+
+    @property
+    def origin(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}"
+
+    @property
+    def expected_stream_duration(self) -> float:
+        return self._inter_chunk_delay * max(self._chunk_count - 1, 0)
+
+    def start(self) -> None:
+        chunk_count = self._chunk_count
+        inter_chunk_delay = self._inter_chunk_delay
+        upstream = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+            def do_POST(self) -> None:
+                headers = _snapshot_request_headers(self)
+                with upstream._lock:
+                    upstream.authorization_headers.append(self.headers.get("Authorization", ""))
+                    upstream.request_header_maps.append(headers)
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                for index in range(chunk_count):
+                    if index:
+                        time.sleep(inter_chunk_delay)
+                    chunk = f'data: {{"chunk": {index}}}\n\n'.encode()
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                    with upstream._lock:
+                        upstream.chunks_sent += 1
+
+        self._httpd = ThreadingHTTPServer((self._host, 0), _Handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> StreamingSSEUpstream:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+
 def codex_provider_base_url(handle: Any) -> str:
     """Return the ``model_providers`` base URL Codex uses with ``wire_api = responses``."""
     base = getattr(handle, "base_url", None)
@@ -208,7 +389,7 @@ def codex_provider_base_url(handle: Any) -> str:
 
 def broker_config_for_upstream(
     module: Any,
-    upstream: MockModelUpstream,
+    upstream: MockModelUpstream | SlowModelUpstream | StreamingSSEUpstream,
     *,
     api_key: str = REAL_OPENAI_API_KEY_FIXTURE,
 ) -> Any:

--- a/tests/security/support_agent_isolation.py
+++ b/tests/security/support_agent_isolation.py
@@ -1,0 +1,200 @@
+"""Shared helpers for lane E — agent credential broker RED tests (plan 18 W1)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import threading
+from contextlib import contextmanager
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+import pytest
+
+from tests.evidence.support import sample_minimal_packet_dict
+from tests.support.dead_package_wiring import SRC_ROOT
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+BROKER_MODULE = "mergecraft.security.broker"
+
+# Fixture credential — must never appear outside the parent process.
+REAL_OPENAI_API_KEY_FIXTURE = "sk-live-run-fixture-openai-never-leak-18"
+
+EVIL_UPSTREAM_HOST = "evil.example"
+MODEL_PATH = "/v1/chat/completions"
+NON_MODEL_PATHS = ("/v1/files", "/admin", "/healthz")
+
+LANE_B_SANDBOX_SYMBOLS = (
+    "_operator_sandbox_override",
+    "_sandbox_is_disabled_by_operator",
+    "_sandbox_mode",
+    "user_namespace_failure_hint",
+)
+
+W2_XFAIL = pytest.mark.xfail(reason="green after W2: credential broker", strict=False)
+W3_XFAIL = pytest.mark.xfail(reason="green after W3: Codex broker wire-up", strict=False)
+
+
+def load_broker_module() -> Any:
+    """Import ``mergecraft.security.broker`` or fail with a clear message."""
+    try:
+        return importlib.import_module(BROKER_MODULE)
+    except ImportError as exc:
+        pytest.fail(f"{BROKER_MODULE} not implemented: {exc}")
+
+
+def require_broker_symbol(module: Any, name: str) -> Any:
+    if not hasattr(module, name):
+        pytest.fail(f"{BROKER_MODULE}.{name} not implemented")
+    return getattr(module, name)
+
+
+@contextmanager
+def capture_loguru_messages(*, level: str = "DEBUG") -> Iterator[list[str]]:
+    """Attach a loguru sink; detach on exit."""
+    from loguru import logger as loguru_logger
+
+    captured: list[str] = []
+    sink_id = loguru_logger.add(lambda msg: captured.append(str(msg)), level=level)
+    try:
+        yield captured
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+def serialized_evidence_packet_fixture(*, error_detail: str) -> str:
+    """Minimal merge-evidence JSON with a broker error field for redaction checks."""
+    payload = sample_minimal_packet_dict()
+    payload["run_health"] = {
+        "broker": {
+            "status": "error",
+            "detail": error_detail,
+        }
+    }
+    return json.dumps(payload)
+
+
+class MockModelUpstream:
+    """Loopback OpenAI-shaped upstream that records Authorization headers."""
+
+    def __init__(self, *, redirect_to: str | None = None) -> None:
+        self._redirect_to = redirect_to
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._host = "127.0.0.1"
+        self._port = 0
+        self.authorization_headers: list[str] = []
+        self._lock = threading.Lock()
+
+    @property
+    def base_url(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}/v1"
+
+    @property
+    def origin(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("upstream not started")
+        return f"http://{self._host}:{self._port}"
+
+    def start(self) -> None:
+        redirect_to = self._redirect_to
+        upstream = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+            def _record_auth(self) -> None:
+                header = self.headers.get("Authorization", "")
+                with upstream._lock:
+                    upstream.authorization_headers.append(header)
+
+            def do_POST(self) -> None:
+                self._record_auth()
+                if redirect_to is not None:
+                    self.send_response(HTTPStatus.FOUND)
+                    self.send_header("Location", redirect_to)
+                    self.end_headers()
+                    return
+                body = json.dumps(
+                    {
+                        "id": "chatcmpl-stub",
+                        "object": "chat.completion",
+                        "choices": [
+                            {"index": 0, "message": {"role": "assistant", "content": "ok"}}
+                        ],
+                    }
+                ).encode()
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:
+                self._record_auth()
+                if redirect_to is not None:
+                    self.send_response(HTTPStatus.FOUND)
+                    self.send_header("Location", redirect_to)
+                    self.end_headers()
+                    return
+                body = b'{"data":[]}'
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._httpd = ThreadingHTTPServer((self._host, 0), _Handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> MockModelUpstream:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+
+def broker_config_for_upstream(
+    module: Any,
+    upstream: MockModelUpstream,
+    *,
+    api_key: str = REAL_OPENAI_API_KEY_FIXTURE,
+) -> Any:
+    """Build a ``CredentialBrokerConfig`` for a loopback upstream fixture."""
+    config_cls = require_broker_symbol(module, "CredentialBrokerConfig")
+    parsed = urlparse(upstream.origin)
+    host = parsed.hostname or "127.0.0.1"
+    return config_cls(
+        upstream_base_url=upstream.base_url,
+        api_key=api_key,
+        run_upstream_hosts=frozenset({host}),
+    )
+
+
+def assert_credential_absent(text: str, credential: str = REAL_OPENAI_API_KEY_FIXTURE) -> None:
+    assert credential not in text, "real API credential leaked into output"
+
+
+def codex_module_path() -> Any:
+    return SRC_ROOT / "agents" / "codex.py"

--- a/tests/security/support_agent_isolation.py
+++ b/tests/security/support_agent_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import importlib
 import json
 import threading
@@ -11,6 +12,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 
 from tests.evidence.support import sample_minimal_packet_dict
@@ -194,6 +196,46 @@ def broker_config_for_upstream(
 
 def assert_credential_absent(text: str, credential: str = REAL_OPENAI_API_KEY_FIXTURE) -> None:
     assert credential not in text, "real API credential leaked into output"
+
+
+def post_absolute_url_to_broker(
+    handle: Any,
+    absolute_url: str,
+    *,
+    headers: dict[str, str],
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """POST to the loopback broker using an absolute-form request-target.
+
+    ``httpx`` resolves absolute URLs itself and sends origin-form paths when
+    connecting directly, so absolute-URL rewrite probes must dial the broker
+    with :func:`http.client.HTTPConnection.request` and an absolute ``url``.
+    """
+    host = getattr(handle, "host", "127.0.0.1")
+    port = handle.port
+    body_bytes = b""
+    request_headers = dict(headers)
+    if json_body is not None:
+        body_bytes = json.dumps(json_body).encode()
+        request_headers.setdefault("Content-Type", "application/json")
+    if body_bytes:
+        request_headers.setdefault("Content-Length", str(len(body_bytes)))
+
+    conn = http.client.HTTPConnection(host, port, timeout=10)
+    try:
+        conn.request("POST", absolute_url, body=body_bytes, headers=request_headers)
+        raw = conn.getresponse()
+        content = raw.read()
+        response_headers = {key: value for key, value in raw.getheaders()}
+    finally:
+        conn.close()
+
+    return httpx.Response(
+        status_code=raw.status,
+        headers=response_headers,
+        content=content,
+        request=httpx.Request("POST", absolute_url),
+    )
 
 
 def codex_module_path() -> Any:

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import secrets
+import time
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -19,7 +21,10 @@ from tests.security.support_agent_isolation import (
     MODEL_PATH,
     NON_MODEL_PATHS,
     REAL_OPENAI_API_KEY_FIXTURE,
+    UPSTREAM_SLOW_RESPONSE_SECONDS,
     MockModelUpstream,
+    SlowModelUpstream,
+    StreamingSSEUpstream,
     assert_credential_absent,
     broker_config_for_upstream,
     capture_loguru_messages,
@@ -36,7 +41,7 @@ if TYPE_CHECKING:
 
 def _start_broker(
     module: Any,
-    upstream: MockModelUpstream,
+    upstream: MockModelUpstream | SlowModelUpstream | StreamingSSEUpstream,
     *,
     bind_host: str | None = None,
 ) -> Iterator[Any]:
@@ -428,3 +433,92 @@ def test_broker_run_record_fields_serializes_posture(
     assert record["broker_active"] == "false"
     assert record["broker_auth_mode"] == "none"
     assert record["broker_reason"]
+
+
+def test_broker_survives_slow_upstream_beyond_thirty_seconds() -> None:
+    """PR #594 — upstream silent >30s must not trip a 30s read timeout (no 502)."""
+    module = load_broker_module()
+    client_timeout = UPSTREAM_SLOW_RESPONSE_SECONDS + 15.0
+    with (
+        SlowModelUpstream() as upstream,
+        _start_broker(module, upstream) as handle,
+        _broker_client(handle) as client,
+    ):
+        client.timeout = httpx.Timeout(client_timeout)
+        response = client.post(
+            MODEL_PATH,
+            json={"model": "gpt-stub", "messages": [{"role": "user", "content": "ping"}]},
+            headers=_auth_headers(handle.token),
+        )
+    assert response.status_code != HTTPStatus.BAD_GATEWAY, (
+        "broker must not 502 when upstream is slow but still responds"
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "slow-ok"
+
+
+def test_broker_streams_sse_incrementally_to_client() -> None:
+    """PR #594 — broker must relay upstream SSE chunks as they arrive, not one blob."""
+    module = load_broker_module()
+    with (
+        StreamingSSEUpstream(chunk_count=5, inter_chunk_delay=0.15) as upstream,
+        _start_broker(module, upstream) as handle,
+    ):
+        chunk_times: list[float] = []
+        start = time.monotonic()
+        with (
+            httpx.Client(
+                base_url=getattr(handle, "base_url", f"http://{handle.host}:{handle.port}"),
+                timeout=30.0,
+            ) as client,
+            client.stream(
+                "POST",
+                MODEL_PATH,
+                json={"model": "gpt-stub", "stream": True, "messages": []},
+                headers=_auth_headers(handle.token),
+            ) as response,
+        ):
+            assert response.status_code == HTTPStatus.OK
+            for chunk in response.iter_bytes():
+                if chunk:
+                    chunk_times.append(time.monotonic() - start)
+    assert len(chunk_times) >= 2, "client must observe multiple body chunks"
+    assert chunk_times[0] < upstream.expected_stream_duration * 0.85, (
+        "first chunk must arrive before upstream finishes streaming"
+    )
+    assert upstream.chunks_sent >= 2
+
+
+@pytest.mark.parametrize(
+    ("hop_by_hop_header", "smuggle_marker"),
+    [
+        ({"Connection": "close"}, "close"),
+        ({"Keep-Alive": "timeout=5, max=594-smuggle"}, "594-smuggle"),
+    ],
+    ids=["connection-close", "keep-alive"],
+)
+def test_broker_does_not_forward_hop_by_hop_headers(
+    hop_by_hop_header: dict[str, str],
+    smuggle_marker: str,
+) -> None:
+    """PR #594 — hop-by-hop agent headers must not be smuggled to upstream."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": [{"role": "user", "content": "ping"}]},
+                headers={**_auth_headers(handle.token), **hop_by_hop_header},
+            )
+        assert response.status_code == HTTPStatus.OK
+    assert upstream.request_header_maps, "upstream must receive proxied request"
+    forwarded = upstream.request_header_maps[-1]
+    for header_name, header_value in hop_by_hop_header.items():
+        forwarded_value = forwarded.get(header_name)
+        assert forwarded_value != header_value, (
+            f"agent hop-by-hop value for {header_name!r} must not reach upstream"
+        )
+        assert smuggle_marker not in (forwarded_value or ""), (
+            f"smuggled marker {smuggle_marker!r} must not appear in forwarded {header_name!r}"
+        )

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from tests.security.support_agent_isolation import (
+    CODEX_WIRE_API_SUFFIX,
     EVIL_UPSTREAM_HOST,
     MODEL_PATH,
     NON_MODEL_PATHS,
@@ -22,6 +23,7 @@ from tests.security.support_agent_isolation import (
     assert_credential_absent,
     broker_config_for_upstream,
     capture_loguru_messages,
+    codex_provider_base_url,
     load_broker_module,
     post_absolute_url_to_broker,
     require_broker_symbol,
@@ -253,6 +255,46 @@ def test_broker_never_leaks_real_credential_in_evidence_packet_fixture() -> None
         redacted_packet = redact(packet_text)
     assert_credential_absent(redacted_response)
     assert_credential_absent(redacted_packet)
+
+
+def test_broker_forwards_codex_shaped_responses_request() -> None:
+    """Codex ``wire_api=responses`` appends to a ``/v1`` provider base URL (PR #594)."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        provider_base = codex_provider_base_url(handle)
+        assert provider_base.endswith("/v1")
+        payload = {"model": "gpt-stub", "input": "ping"}
+        with httpx.Client(base_url=provider_base, timeout=10.0) as client:
+            response = client.post(
+                CODEX_WIRE_API_SUFFIX,
+                json=payload,
+                headers=_auth_headers(handle.token),
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body.get("object") == "response"
+        assert upstream.authorization_headers, "upstream must receive Authorization"
+
+
+def test_broker_strips_content_encoding_for_decoded_gzip_upstream() -> None:
+    """Broker must not forward ``Content-Encoding`` after httpx decodes gzip (PR #594)."""
+    module = load_broker_module()
+    with (
+        MockModelUpstream(gzip_response=True) as upstream,
+        _start_broker(module, upstream) as handle,
+    ):
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": [{"role": "user", "content": "ping"}]},
+                headers=_auth_headers(handle.token),
+            )
+        assert response.status_code == 200
+        assert "content-encoding" not in {key.lower() for key in response.headers}
+        body = response.json()
+        assert body.get("object") == "chat.completion"
+        assert body["choices"][0]["message"]["content"] == "ok"
+        assert upstream.authorization_headers
 
 
 def test_broker_forwards_real_key_on_parent_upstream_leg() -> None:

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -23,6 +23,7 @@ from tests.security.support_agent_isolation import (
     broker_config_for_upstream,
     capture_loguru_messages,
     load_broker_module,
+    post_absolute_url_to_broker,
     require_broker_symbol,
     serialized_evidence_packet_fixture,
 )
@@ -167,12 +168,12 @@ def test_broker_rejects_absolute_url_rewrite() -> None:
     module = load_broker_module()
     with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
         evil_url = f"http://{EVIL_UPSTREAM_HOST}{MODEL_PATH}"
-        with _broker_client(handle) as client:
-            response = client.post(
-                evil_url,
-                json={"model": "gpt-stub", "messages": []},
-                headers=_auth_headers(handle.token),
-            )
+        response = post_absolute_url_to_broker(
+            handle,
+            evil_url,
+            headers=_auth_headers(handle.token),
+            json_body={"model": "gpt-stub", "messages": []},
+        )
         assert response.status_code == 403
         assert_credential_absent(response.text)
 

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -18,7 +18,6 @@ from tests.security.support_agent_isolation import (
     MODEL_PATH,
     NON_MODEL_PATHS,
     REAL_OPENAI_API_KEY_FIXTURE,
-    W2_XFAIL,
     MockModelUpstream,
     assert_credential_absent,
     broker_config_for_upstream,
@@ -59,7 +58,6 @@ def _auth_headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-@W2_XFAIL
 def test_broker_binds_loopback_only() -> None:
     """D1 — broker listens on 127.0.0.1, never 0.0.0.0."""
     module = load_broker_module()
@@ -73,7 +71,6 @@ def test_broker_binds_loopback_only() -> None:
         assert response.status_code in {401, 403, 404, 405}
 
 
-@W2_XFAIL
 def test_broker_rejects_non_loopback_bind() -> None:
     """Forcing 0.0.0.0 must fail closed."""
     module = load_broker_module()
@@ -94,7 +91,6 @@ def test_broker_rejects_non_loopback_bind() -> None:
         pass
 
 
-@W2_XFAIL
 def test_broker_rejects_missing_bearer() -> None:
     """No Authorization header → HTTP 401."""
     module = load_broker_module()
@@ -104,7 +100,6 @@ def test_broker_rejects_missing_bearer() -> None:
         assert response.status_code == 401
 
 
-@W2_XFAIL
 def test_broker_rejects_wrong_bearer() -> None:
     """Wrong bearer → HTTP 401."""
     module = load_broker_module()
@@ -118,7 +113,6 @@ def test_broker_rejects_wrong_bearer() -> None:
         assert response.status_code == 401
 
 
-@W2_XFAIL
 def test_bearer_validation_uses_constant_time_compare_digest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -146,7 +140,6 @@ def test_bearer_validation_uses_constant_time_compare_digest(
     assert calls, "broker must call secrets.compare_digest for bearer validation"
 
 
-@W2_XFAIL
 @pytest.mark.parametrize(
     "headers",
     [
@@ -169,7 +162,6 @@ def test_broker_rejects_upstream_host_smuggle(headers: dict[str, str]) -> None:
         assert_credential_absent(response.text)
 
 
-@W2_XFAIL
 def test_broker_rejects_absolute_url_rewrite() -> None:
     """Absolute request URL to a non-allowlisted host → 403 (D4)."""
     module = load_broker_module()
@@ -185,7 +177,6 @@ def test_broker_rejects_absolute_url_rewrite() -> None:
         assert_credential_absent(response.text)
 
 
-@W2_XFAIL
 def test_broker_refuses_redirect_to_non_allowlisted_host() -> None:
     """Redirect off the run allow-list must not be followed."""
     module = load_broker_module()
@@ -204,7 +195,6 @@ def test_broker_refuses_redirect_to_non_allowlisted_host() -> None:
         assert_credential_absent(response.text)
 
 
-@W2_XFAIL
 @pytest.mark.parametrize("path", NON_MODEL_PATHS)
 def test_broker_refuses_non_model_paths(path: str) -> None:
     """Non-model paths are refused — model proxy only (D4)."""
@@ -216,7 +206,6 @@ def test_broker_refuses_non_model_paths(path: str) -> None:
         assert_credential_absent(response.text)
 
 
-@W2_XFAIL
 def test_broker_never_leaks_real_credential_in_responses_errors_or_logs() -> None:
     """#553 — real credential in no response body, error body, or log line."""
     module = load_broker_module()
@@ -245,7 +234,6 @@ def test_broker_never_leaks_real_credential_in_responses_errors_or_logs() -> Non
     assert_credential_absent(combined)
 
 
-@W2_XFAIL
 def test_broker_never_leaks_real_credential_in_evidence_packet_fixture() -> None:
     """Serialized evidence-packet fixture must not carry the upstream API key."""
     module = load_broker_module()
@@ -266,7 +254,6 @@ def test_broker_never_leaks_real_credential_in_evidence_packet_fixture() -> None
     assert_credential_absent(redacted_packet)
 
 
-@W2_XFAIL
 def test_broker_forwards_real_key_on_parent_upstream_leg() -> None:
     """Parent→upstream leg must present the real credential to the model host."""
     module = load_broker_module()
@@ -285,7 +272,6 @@ def test_broker_forwards_real_key_on_parent_upstream_leg() -> None:
     )
 
 
-@W2_XFAIL
 @pytest.mark.asyncio
 async def test_concurrent_requests_with_same_bearer() -> None:
     """Two concurrent agent requests sharing one per-run bearer must both succeed."""

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -287,3 +287,101 @@ async def test_concurrent_requests_with_same_bearer() -> None:
                 client.post(MODEL_PATH, json=payload, headers=headers),
             )
         assert all(response.status_code == 200 for response in responses)
+
+
+def test_resolve_codex_broker_posture_no_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3a — no subscription or API key → inactive ``auth_mode=none``."""
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    module = load_broker_module()
+    resolve = require_broker_symbol(module, "resolve_codex_broker_posture")
+    posture = resolve()
+    assert posture.active is False
+    assert posture.auth_mode == "none"
+    assert "no openai api key" in posture.reason.casefold()
+
+
+def test_resolve_codex_broker_posture_api_key_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3a — API key present without usable subscription → broker active."""
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    module = load_broker_module()
+    resolve = require_broker_symbol(module, "resolve_codex_broker_posture")
+    posture = resolve()
+    assert posture.active is True
+    assert posture.auth_mode == "api_key"
+
+
+def test_resolve_codex_broker_posture_subscription_not_brokered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D3a — usable subscription auth → broker inactive (not brokered)."""
+    monkeypatch.setenv(
+        "CODEX_AUTH_JSON",
+        '{"tokens": {"access_token": "subscription-token"}}',
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    module = load_broker_module()
+    resolve = require_broker_symbol(module, "resolve_codex_broker_posture")
+    posture = resolve()
+    assert posture.active is False
+    assert posture.auth_mode == "subscription"
+    assert "not brokered" in posture.reason.casefold()
+
+
+def test_broker_rejects_put_method() -> None:
+    """Disallowed HTTP methods must fail closed with 405."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.put(MODEL_PATH, headers=_auth_headers(handle.token))
+        assert response.status_code == 405
+        assert_credential_absent(response.text)
+
+
+@pytest.mark.parametrize(
+    ("raw", "usable"),
+    [
+        ('{"tokens": {"access_token": "sub-token"}}', True),
+        ('{"tokens": {"access": "sub-token"}}', True),
+        ('{"tokens": {"refresh": "sub-token"}}', True),
+        ('{"access_token": "top-level-token"}', True),
+        ('{"refresh": "top-level-token"}', True),
+        ("not-json", False),
+        ("[]", False),
+    ],
+    ids=[
+        "tokens-access_token",
+        "tokens-access",
+        "tokens-refresh",
+        "top-level-access_token",
+        "top-level-refresh",
+        "invalid-json",
+        "non-dict-json",
+    ],
+)
+def test_subscription_auth_usable_shapes(raw: str, usable: bool) -> None:
+    """``_subscription_auth_usable`` token-shape branches (D3a)."""
+    module = load_broker_module()
+    checker = getattr(module, "_subscription_auth_usable", None)
+    assert checker is not None, "_subscription_auth_usable must exist on broker module"
+    assert checker(raw) is usable
+
+
+def test_broker_run_record_fields_serializes_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run-record helper exposes broker posture fields (D3a/D10)."""
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    module = load_broker_module()
+    resolve = require_broker_symbol(module, "resolve_codex_broker_posture")
+    fields_fn = require_broker_symbol(module, "broker_run_record_fields")
+    record = fields_fn(resolve())
+    assert record["broker_active"] == "false"
+    assert record["broker_auth_mode"] == "none"
+    assert record["broker_reason"]

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -1,0 +1,303 @@
+"""Plan 18 W1.1 — credential broker RED contracts (implementation W2).
+
+Pins loopback bind, bearer gate, upstream allow-list, model-path-only proxying,
+redaction, and parent->upstream Authorization forwarding (#553 option 3 / D1-D4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+from tests.security.support_agent_isolation import (
+    EVIL_UPSTREAM_HOST,
+    MODEL_PATH,
+    NON_MODEL_PATHS,
+    REAL_OPENAI_API_KEY_FIXTURE,
+    W2_XFAIL,
+    MockModelUpstream,
+    assert_credential_absent,
+    broker_config_for_upstream,
+    capture_loguru_messages,
+    load_broker_module,
+    require_broker_symbol,
+    serialized_evidence_packet_fixture,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _start_broker(
+    module: Any,
+    upstream: MockModelUpstream,
+    *,
+    bind_host: str | None = None,
+) -> Iterator[Any]:
+    credential_broker = require_broker_symbol(module, "credential_broker")
+    config = broker_config_for_upstream(module, upstream)
+    kwargs: dict[str, Any] = {}
+    if bind_host is not None:
+        kwargs["bind_host"] = bind_host
+    return credential_broker(config, **kwargs)
+
+
+def _broker_client(handle: Any) -> httpx.Client:
+    base = getattr(handle, "base_url", None)
+    if not isinstance(base, str):
+        host = getattr(handle, "host", "127.0.0.1")
+        port = handle.port
+        base = f"http://{host}:{port}"
+    return httpx.Client(base_url=base, timeout=10.0)
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@W2_XFAIL
+def test_broker_binds_loopback_only() -> None:
+    """D1 — broker listens on 127.0.0.1, never 0.0.0.0."""
+    module = load_broker_module()
+    bind_host = require_broker_symbol(module, "BROKER_BIND_HOST")
+    assert bind_host == "127.0.0.1"
+
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        assert handle.host == "127.0.0.1"
+        response = httpx.get(f"http://{handle.host}:{handle.port}/v1/models", timeout=2.0)
+        # Unauthenticated probe still proves loopback reachability.
+        assert response.status_code in {401, 403, 404, 405}
+
+
+@W2_XFAIL
+def test_broker_rejects_non_loopback_bind() -> None:
+    """Forcing 0.0.0.0 must fail closed."""
+    module = load_broker_module()
+    bind_error = None
+    for name in ("BrokerBindError", "CredentialBrokerBindError"):
+        if hasattr(module, name):
+            bind_error = getattr(module, name)
+            break
+    expected_errors: tuple[type[BaseException], ...] = (ValueError,)
+    if bind_error is not None:
+        expected_errors = (bind_error, ValueError)
+
+    with (
+        MockModelUpstream() as upstream,
+        pytest.raises(expected_errors, match=r"127\.0\.0\.1|loopback|bind|0\.0\.0\.0"),
+        _start_broker(module, upstream, bind_host="0.0.0.0"),
+    ):
+        pass
+
+
+@W2_XFAIL
+def test_broker_rejects_missing_bearer() -> None:
+    """No Authorization header → HTTP 401."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(MODEL_PATH, json={"model": "gpt-stub", "messages": []})
+        assert response.status_code == 401
+
+
+@W2_XFAIL
+def test_broker_rejects_wrong_bearer() -> None:
+    """Wrong bearer → HTTP 401."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers=_auth_headers("definitely-not-the-run-token"),
+            )
+        assert response.status_code == 401
+
+
+@W2_XFAIL
+def test_bearer_validation_uses_constant_time_compare_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bearer comparison must use ``secrets.compare_digest`` (D2)."""
+    module = load_broker_module()
+    calls: list[tuple[bytes, bytes]] = []
+    real_compare = secrets.compare_digest
+
+    def _spy(left: Any, right: Any) -> bool:
+        calls.append((bytes(left), bytes(right)))
+        return real_compare(left, right)
+
+    monkeypatch.setattr(module.secrets, "compare_digest", _spy)
+
+    with (
+        MockModelUpstream() as upstream,
+        _start_broker(module, upstream) as handle,
+        _broker_client(handle) as client,
+    ):
+        client.post(
+            MODEL_PATH,
+            json={"model": "gpt-stub", "messages": []},
+            headers=_auth_headers("wrong-token"),
+        )
+    assert calls, "broker must call secrets.compare_digest for bearer validation"
+
+
+@W2_XFAIL
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Host": EVIL_UPSTREAM_HOST},
+        {"X-Forwarded-Host": EVIL_UPSTREAM_HOST},
+    ],
+    ids=["host-smuggle", "forwarded-host-smuggle"],
+)
+def test_broker_rejects_upstream_host_smuggle(headers: dict[str, str]) -> None:
+    """Host header outside allow-list + configured origin → 403 (D4)."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers={**_auth_headers(handle.token), **headers},
+            )
+        assert response.status_code == 403
+        assert_credential_absent(response.text)
+
+
+@W2_XFAIL
+def test_broker_rejects_absolute_url_rewrite() -> None:
+    """Absolute request URL to a non-allowlisted host → 403 (D4)."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        evil_url = f"http://{EVIL_UPSTREAM_HOST}{MODEL_PATH}"
+        with _broker_client(handle) as client:
+            response = client.post(
+                evil_url,
+                json={"model": "gpt-stub", "messages": []},
+                headers=_auth_headers(handle.token),
+            )
+        assert response.status_code == 403
+        assert_credential_absent(response.text)
+
+
+@W2_XFAIL
+def test_broker_refuses_redirect_to_non_allowlisted_host() -> None:
+    """Redirect off the run allow-list must not be followed."""
+    module = load_broker_module()
+    redirect_target = f"http://{EVIL_UPSTREAM_HOST}/v1/chat/completions"
+    with (
+        MockModelUpstream(redirect_to=redirect_target) as upstream,
+        _start_broker(module, upstream) as handle,
+    ):
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers=_auth_headers(handle.token),
+            )
+        assert response.status_code in {403, 502, 504}
+        assert_credential_absent(response.text)
+
+
+@W2_XFAIL
+@pytest.mark.parametrize("path", NON_MODEL_PATHS)
+def test_broker_refuses_non_model_paths(path: str) -> None:
+    """Non-model paths are refused — model proxy only (D4)."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.get(path, headers=_auth_headers(handle.token))
+        assert response.status_code in {403, 404, 405}
+        assert_credential_absent(response.text)
+
+
+@W2_XFAIL
+def test_broker_never_leaks_real_credential_in_responses_errors_or_logs() -> None:
+    """#553 — real credential in no response body, error body, or log line."""
+    module = load_broker_module()
+    bodies: list[str] = []
+    with (
+        capture_loguru_messages() as logs,
+        MockModelUpstream() as upstream,
+        _start_broker(module, upstream) as handle,
+        _broker_client(handle) as client,
+    ):
+        for call in (
+            client.post(MODEL_PATH, json={"model": "gpt-stub", "messages": []}),
+            client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers=_auth_headers("wrong"),
+            ),
+            client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers={**_auth_headers(handle.token), "Host": EVIL_UPSTREAM_HOST},
+            ),
+        ):
+            bodies.append(call.text)
+    combined = "\n".join([*bodies, *logs])
+    assert_credential_absent(combined)
+
+
+@W2_XFAIL
+def test_broker_never_leaks_real_credential_in_evidence_packet_fixture() -> None:
+    """Serialized evidence-packet fixture must not carry the upstream API key."""
+    module = load_broker_module()
+    packet_text = serialized_evidence_packet_fixture(
+        error_detail="broker upstream refused host evil.example"
+    )
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": []},
+                headers=_auth_headers(handle.token),
+            )
+        redact = require_broker_symbol(module, "redact_broker_output")
+        redacted_response = redact(response.text)
+        redacted_packet = redact(packet_text)
+    assert_credential_absent(redacted_response)
+    assert_credential_absent(redacted_packet)
+
+
+@W2_XFAIL
+def test_broker_forwards_real_key_on_parent_upstream_leg() -> None:
+    """Parent→upstream leg must present the real credential to the model host."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        with _broker_client(handle) as client:
+            response = client.post(
+                MODEL_PATH,
+                json={"model": "gpt-stub", "messages": [{"role": "user", "content": "ping"}]},
+                headers=_auth_headers(handle.token),
+            )
+        assert response.status_code == 200
+    assert upstream.authorization_headers, "upstream must receive Authorization"
+    assert any(
+        header.startswith("Bearer ") and REAL_OPENAI_API_KEY_FIXTURE in header
+        for header in upstream.authorization_headers
+    )
+
+
+@W2_XFAIL
+@pytest.mark.asyncio
+async def test_concurrent_requests_with_same_bearer() -> None:
+    """Two concurrent agent requests sharing one per-run bearer must both succeed."""
+    module = load_broker_module()
+    with MockModelUpstream() as upstream, _start_broker(module, upstream) as handle:
+        headers = _auth_headers(handle.token)
+        payload = {"model": "gpt-stub", "messages": [{"role": "user", "content": "ping"}]}
+        base = getattr(handle, "base_url", f"http://{handle.host}:{handle.port}")
+
+        async with httpx.AsyncClient(base_url=base, timeout=10.0) as client:
+            responses = await asyncio.gather(
+                client.post(MODEL_PATH, json=payload, headers=headers),
+                client.post(MODEL_PATH, json=payload, headers=headers),
+            )
+        assert all(response.status_code == 200 for response in responses)

--- a/tests/security/test_credentials.py
+++ b/tests/security/test_credentials.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from mergecraft.agents import claude, codex, gemini
 from mergecraft.agents import opencode as opencode_mod
+from mergecraft.security.broker import CODEX_BROKER_BEARER_ENV
 from mergecraft.utils.git_setup import (
     register_created_path,
     setup_git,
@@ -84,8 +85,11 @@ def _assert_no_credentials(env: dict[str, str], *, active_key: str | None) -> No
         if name == active_key:
             continue
         assert name not in env, f"agent env leaks non-active provider key {name}"
+    allowed_token_shaped = {CODEX_BROKER_BEARER_ENV}
+    if active_key is not None:
+        allowed_token_shaped.add(active_key)
     for name in env:
-        assert "TOKEN" not in name or name in {active_key}, (
+        assert "TOKEN" not in name or name in allowed_token_shaped, (
             f"agent env carries unexpected token-shaped variable {name}"
         )
 

--- a/tests/security/test_credentials.py
+++ b/tests/security/test_credentials.py
@@ -115,6 +115,33 @@ def test_agent_env_contains_no_credentials(
     _assert_no_credentials(env, active_key=_ACTIVE_PROVIDER_KEY[agent_id])
 
 
+def test_codex_brokered_env_throwaway_in_openai_api_key_allowed(
+    make_agent_run_ctx, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """W2.1 broker path — throwaway in ``OPENAI_API_KEY`` satisfies the codex active-key guard."""
+    from tests.agents.support_codex_credential_broker import (
+        REAL_OPENAI_API_KEY_FIXTURE,
+        brokered_codex_context,
+        prepare_codex_brokered_run,
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    for key, value in _PLANTED_SECRETS.items():
+        if key == "OPENAI_API_KEY":
+            continue
+        monkeypatch.setenv(key, value)
+
+    ctx = brokered_codex_context(
+        tmp_path,
+        mcp_server_url="",
+        mcp_auth_token="",
+    )
+    prepared = prepare_codex_brokered_run(ctx)
+    _assert_no_credentials(prepared.agent_env, active_key=_ACTIVE_PROVIDER_KEY["codex"])
+    assert prepared.agent_env.get("OPENAI_API_KEY") != REAL_OPENAI_API_KEY_FIXTURE
+
+
 def test_opencode_agent_env_contains_no_credentials() -> None:
     """W2.1 — opencode must not pass the raw process environment to its CLI.
 

--- a/tests/security/test_credentials.py
+++ b/tests/security/test_credentials.py
@@ -139,7 +139,9 @@ def test_codex_brokered_env_throwaway_in_openai_api_key_allowed(
     )
     prepared = prepare_codex_brokered_run(ctx)
     _assert_no_credentials(prepared.agent_env, active_key=_ACTIVE_PROVIDER_KEY["codex"])
-    assert prepared.agent_env.get("OPENAI_API_KEY") != REAL_OPENAI_API_KEY_FIXTURE
+    throwaway = prepared.agent_env.get("OPENAI_API_KEY")
+    assert throwaway, "broker throwaway must be routed through OPENAI_API_KEY for Codex 0.149"
+    assert throwaway != REAL_OPENAI_API_KEY_FIXTURE
 
 
 def test_opencode_agent_env_contains_no_credentials() -> None:

--- a/tests/tracing/exporters/test_claim_sink_handoff.py
+++ b/tests/tracing/exporters/test_claim_sink_handoff.py
@@ -2,14 +2,34 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mergecraft.config import RepoSettings
+from mergecraft.enterprise.controls import EnterpriseSettings
+from mergecraft.enterprise.runtime import bind_enterprise_from_settings
 from mergecraft.tracing.exporters import OTLPSink, captured_payload
 from mergecraft.tracing.sinks import _PENDING_SINK, MemorySink, claim_sink, sink_factory
 from mergecraft.tracing.tracer import get_tracer_from_settings, reset_process_tracer_cache
 
 
+def _ensure_remote_export_ready() -> None:
+    """Pin OTLP export on — xdist workers may inherit enterprise opt-out leaks."""
+    pytest.importorskip("opentelemetry")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from mergecraft.tracing.exporters import _reset_test_seam
+
+    bind_enterprise_from_settings(EnterpriseSettings(telemetry="on"))
+    existing = trace.get_tracer_provider()
+    if type(existing).__name__ == "ProxyTracerProvider":
+        trace.set_tracer_provider(TracerProvider())
+    _reset_test_seam()
+
+
 def test_claim_sink_ignores_stale_memory_handoff_for_otel_settings() -> None:
     """A leftover memory ``sink_factory`` handoff must not poison OTLP export."""
+    _ensure_remote_export_ready()
     memory_settings = RepoSettings.model_validate(
         {"tracing": {"enabled": True, "sinks": [{"type": "memory"}]}}
     ).tracing
@@ -45,6 +65,7 @@ def test_get_tracer_exports_after_stale_memory_handoff() -> None:
     sink_factory(memory_settings.tracing)
 
     reset_process_tracer_cache()
+    _ensure_remote_export_ready()
     otel_settings = RepoSettings.model_validate(
         {
             "tracing": {


### PR DESCRIPTION
## What?

Lands lane E (agent credential broker, #594) on the default branch and moves the self-review Action pin so dogfood reviews run that code.

- Codex API-key runs proxy model calls through the loopback credential broker with pinned egress instead of handing keys to the harness process.
- Git and MCP surfaces that could leak brokered auth headers are blocked on the broker path.

## Why?

#598 bumps the soak-branch pin to `4ab87265`, which contains lane E. GitHub resolves `pull_request_target` from the default branch, so reviews still execute `4182fd45` until that workflow file is on `main`.

## Note

**Merge #598 first** (including its digest follow-up commit once `action-slim-bootstrap` publishes `ghcr.io/alexhawat/mergecraft:4ab87265`). Refresh this PR after `pre-0.0.1` picks up the pin before merging.

Yes, this moves the pin on `main`: `MERGECRAFT_ACTION_SHA` and the three rungs go from `4182fd45` (lane B, #588) to `4ab87265` (the lane E merge). The `action.yml` image digest must move with it once GHCR has the slim image. The pin is that SHA, not the promotion merge commit.

Needs an admin merge. `protect-main` requires an approving review the bot cannot give, and the pin PR is reviewed by the pin it replaces — so its own review runs the old image. Expected.

## Related PR(s)/Issue(s)

Depends on #594 #598
Refs #553 — closes on promotion to main when lane B+E broker scope is complete