### PR TITLE
feat(skills): add grok-bot harness for mergeCraft Grok Bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,28 @@ Use this when asked to add AI PR review to another repository.
    **`mergecraft review`** (not `diff-review`, which is a deprecated alias that
    emits one stderr warning per invocation).
 
+## Setup with Grok Bot
+
+Use this when a Grok Bot (including the in-account **mergeCraft** bot) is
+asked to add mergeCraft to another repository.
+
+Grok Bot does **not** read `.agents/skills/` in a consumer repo. Install the
+generated skill from [`skills/grok-bot/mergecraft/SKILL.md`](skills/grok-bot/mergecraft/SKILL.md)
+as a Grok Bot user skill (Settings → Plugins → Yours; enable it for the Bot).
+
+Follow the same consumer flow as other agents:
+
+1. **`uv tool install`** the CLI (see above).
+2. In the **consumer repo root** (never in the mergeCraft source tree), run
+   **`mergecraft init`**.
+3. **STOP for authentication.** Ask the human to run exactly one
+   `mergecraft auth …` command. **Never** invent, paste, or commit credentials,
+   tokens, secrets, or `.env` files.
+4. After the human confirms the GitHub Actions secret is stored, you may run
+   **`mergecraft doctor`** and **`mergecraft review`** as needed.
+5. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`
+   on a new branch in the consumer repo.
+
 ## Working on this repo (development)
 
 mergeCraft itself: Python **3.11+**, managed with uv, recurring commands via **Make**

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ config keys, exit codes, and failure modes.
    your agent reads. Examples:
 
      skills/cursor/mergecraft/     -> Cursor
+     skills/grok-bot/mergecraft/   -> Grok Bot (user skill; not .agents/skills/)
      skills/opencode/mergecraft/   -> OpenCode
      skills/codex/mergecraft/      -> Codex CLI
      skills/gemini-cli/mergecraft/ -> Gemini CLI
@@ -133,7 +134,7 @@ config keys, exit codes, and failure modes.
 ```
 
 <details>
-<summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
+<summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Grok Bot, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
 
 **Claude Code** — the only *packaged* install. Skill + slash commands in one step:
 
@@ -154,6 +155,22 @@ open a PR with the workflow. Print the `mergecraft auth <provider>` command for
 me to run myself — never touch credentials. Then copy
 skills/cursor/mergecraft/ into .agents/skills/mergecraft/ so you keep the
 knowledge.
+```
+
+**Grok Bot** — install the generated skill as a user skill (Settings → Plugins);
+Grok Bot does not read `.agents/skills/` in consumer repos. The in-account
+**mergeCraft** bot follows this same recipe:
+
+```text
+Read https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md and set
+mergeCraft up in this repo. Install the CLI with uv (uv fetches its own Python —
+do not install Python), run `mergecraft init` in the consumer repo (never in the
+mergeCraft source tree), wire .mergecraft/config.yaml, and open a PR with the
+workflow. Print the `mergecraft auth <provider>` command for me to run myself —
+never touch credentials. After I confirm the secret is stored, run
+`mergecraft doctor` as needed. Install the generated skill from
+skills/grok-bot/mergecraft/ as a Grok Bot user skill (Settings → Plugins → Yours;
+enable it for this Bot) so you keep the knowledge.
 ```
 
 **Codex CLI / ChatGPT cloud agent:**
@@ -244,7 +261,7 @@ Everything else — install, scaffold, config, commit, PR — is unattended.
 
 | Surface | What it gives an agent |
 |---|---|
-| [`AGENTS.md`](AGENTS.md) | Cross-vendor setup + contribution guidance, read natively by Codex, Cursor, OpenCode, Gemini CLI and Copilot |
+| [`AGENTS.md`](AGENTS.md) | Cross-vendor setup + contribution guidance, read natively by Codex, Cursor, Grok Bot, OpenCode, Gemini CLI and Copilot |
 | [`skills/mergecraft/SKILL.md`](skills/mergecraft/SKILL.md) | Agent-Skills package: setup checklist, CLI map, config keys, troubleshooting |
 | [`llms.txt`](llms.txt) · [`llms-full.txt`](llms-full.txt) | Curated doc map, and the full corpus in one file |
 | [`.claude-plugin/`](.claude-plugin/plugin.json) · [`commands/`](commands/) | Claude plugin manifest and `/mergecraft-setup` · `/mergecraft-review` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,6 +109,7 @@ config keys, exit codes, and failure modes.
    your agent reads. Examples:
 
      skills/cursor/mergecraft/     -> Cursor
+     skills/grok-bot/mergecraft/   -> Grok Bot (user skill; not .agents/skills/)
      skills/opencode/mergecraft/   -> OpenCode
      skills/codex/mergecraft/      -> Codex CLI
      skills/gemini-cli/mergecraft/ -> Gemini CLI
@@ -137,7 +138,7 @@ config keys, exit codes, and failure modes.
 ```
 
 <details>
-<summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
+<summary><b>Per-agent one-liners</b> — Claude Code, Cursor, Grok Bot, Codex, OpenCode, Gemini, Copilot, OpenClaw, Hermes</summary>
 
 **Claude Code** — the only *packaged* install. Skill + slash commands in one step:
 
@@ -158,6 +159,22 @@ open a PR with the workflow. Print the `mergecraft auth <provider>` command for
 me to run myself — never touch credentials. Then copy
 skills/cursor/mergecraft/ into .agents/skills/mergecraft/ so you keep the
 knowledge.
+```
+
+**Grok Bot** — install the generated skill as a user skill (Settings → Plugins);
+Grok Bot does not read `.agents/skills/` in consumer repos. The in-account
+**mergeCraft** bot follows this same recipe:
+
+```text
+Read https://github.com/alexhawat/mergeCraft/blob/main/AGENTS.md and set
+mergeCraft up in this repo. Install the CLI with uv (uv fetches its own Python —
+do not install Python), run `mergecraft init` in the consumer repo (never in the
+mergeCraft source tree), wire .mergecraft/config.yaml, and open a PR with the
+workflow. Print the `mergecraft auth <provider>` command for me to run myself —
+never touch credentials. After I confirm the secret is stored, run
+`mergecraft doctor` as needed. Install the generated skill from
+skills/grok-bot/mergecraft/ as a Grok Bot user skill (Settings → Plugins → Yours;
+enable it for this Bot) so you keep the knowledge.
 ```
 
 **Codex CLI / ChatGPT cloud agent:**
@@ -248,7 +265,7 @@ Everything else — install, scaffold, config, commit, PR — is unattended.
 
 | Surface | What it gives an agent |
 |---|---|
-| [`AGENTS.md`](AGENTS.md) | Cross-vendor setup + contribution guidance, read natively by Codex, Cursor, OpenCode, Gemini CLI and Copilot |
+| [`AGENTS.md`](AGENTS.md) | Cross-vendor setup + contribution guidance, read natively by Codex, Cursor, Grok Bot, OpenCode, Gemini CLI and Copilot |
 | [`skills/mergecraft/SKILL.md`](skills/mergecraft/SKILL.md) | Agent-Skills package: setup checklist, CLI map, config keys, troubleshooting |
 | [`llms.txt`](llms.txt) · [`llms-full.txt`](llms-full.txt) | Curated doc map, and the full corpus in one file |
 | [`.claude-plugin/`](.claude-plugin/plugin.json) · [`commands/`](commands/) | Claude plugin manifest and `/mergecraft-setup` · `/mergecraft-review` |
@@ -530,6 +547,28 @@ Use this when asked to add AI PR review to another repository.
    run the workflow via `workflow_dispatch`. Local/offline review uses
    **`mergecraft review`** (not `diff-review`, which is a deprecated alias that
    emits one stderr warning per invocation).
+
+## Setup with Grok Bot
+
+Use this when a Grok Bot (including the in-account **mergeCraft** bot) is
+asked to add mergeCraft to another repository.
+
+Grok Bot does **not** read `.agents/skills/` in a consumer repo. Install the
+generated skill from [`skills/grok-bot/mergecraft/SKILL.md`](skills/grok-bot/mergecraft/SKILL.md)
+as a Grok Bot user skill (Settings → Plugins → Yours; enable it for the Bot).
+
+Follow the same consumer flow as other agents:
+
+1. **`uv tool install`** the CLI (see above).
+2. In the **consumer repo root** (never in the mergeCraft source tree), run
+   **`mergecraft init`**.
+3. **STOP for authentication.** Ask the human to run exactly one
+   `mergecraft auth …` command. **Never** invent, paste, or commit credentials,
+   tokens, secrets, or `.env` files.
+4. After the human confirms the GitHub Actions secret is stored, you may run
+   **`mergecraft doctor`** and **`mergecraft review`** as needed.
+5. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`
+   on a new branch in the consumer repo.
 
 ## Working on this repo (development)
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,6 +15,7 @@
 - skills/harnesses.yaml — harness manifest (install paths + primary sources)
 - skills/codex/mergecraft/SKILL.md — generated Codex Agent Skills package
 - skills/cursor/mergecraft/SKILL.md — generated Cursor Agent Skills package
+- skills/grok-bot/mergecraft/SKILL.md — generated Grok Bot user skill package
 - skills/opencode/mergecraft/SKILL.md — generated OpenCode Agent Skills package
 - skills/gemini-cli/mergecraft/SKILL.md — generated Gemini CLI Agent Skills package
 - skills/openclaw/mergecraft/SKILL.md — generated OpenClaw Agent Skills package

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -84,6 +84,12 @@
       "sourceType": "local",
       "skillPath": "skills/claude-code/mergecraft/SKILL.md",
       "computedHash": "1bf6eca6cb64b636e0bf6f929796c95eafdb4eeefb038761f7d0d6a6299bc7f7"
+    },
+    "mergecraft-grok-bot": {
+      "source": "alexhawat/mergeCraft",
+      "sourceType": "local",
+      "skillPath": "skills/grok-bot/mergecraft/SKILL.md",
+      "computedHash": "1bf6eca6cb64b636e0bf6f929796c95eafdb4eeefb038761f7d0d6a6299bc7f7"
     }
   }
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -38,6 +38,7 @@ provider credentials securely — never paste secrets into the skill body.
 | --- | --- | --- |
 | Codex | https://learn.chatgpt.com/docs/build-skills | 2026-08-21 |
 | Cursor | https://cursor.com/docs/skills | 2026-08-21 |
+| Grok Bot | https://docs.x.ai/grok-bot/skills-routines-and-automations | 2026-09-01 |
 | OpenCode | https://opencode.ai/docs/skills | 2026-08-21 |
 | Gemini CLI | https://geminicli.com/docs/cli/skills | 2026-08-21 |
 | OpenClaw | https://docs.openclaw.ai/tools/skills | 2026-08-21 |

--- a/skills/grok-bot/mergecraft/SKILL.md
+++ b/skills/grok-bot/mergecraft/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: mergecraft
+description: Set up, run, and troubleshoot mergeCraft — the BYOK AI PR review GitHub
+  Action and CLI. Use when the user asks to install or configure mergeCraft, add AI
+  PR review to a repo, run a local review, interpret mergecraft-approval status or
+  findings, configure models in .mergecraft/config.yaml, use mergecraft mcp serve,
+  or debug a failing mergeCraft workflow.
+compatibility: Requires uv; gh CLI optional
+---
+# mergeCraft
+
+mergeCraft is an AI-powered PR reviewer: a GitHub Action plus a Python CLI
+(`mergecraft`). BYOK — the user's Claude/ChatGPT subscription or API key; no
+SaaS backend. Deterministic analyzers run first, then an LLM review agent, then
+a read-only verifier; typed findings drive inline comments and the
+`mergecraft-approval` commit status.
+
+## Setup checklist (new consumer repo)
+
+1. **Prereqs:** Python **3.11+**, uv, authenticated `gh` CLI. If no Python 3.11+
+   locally → use the Docker Action only ([`docs/install.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/install.md)).
+2. **Install:**
+
+   ```bash
+   uv tool install "merge-craft @ git+https://github.com/alexhawat/mergeCraft"
+   mergecraft init
+   ```
+
+3. **Authentication — STOP and ask the user** to run one of:
+   - `mergecraft auth claude` (Claude Pro/Max)
+   - `mergecraft auth codex` (ChatGPT Plus/Pro/Team/Enterprise)
+   - `mergecraft auth cursor` / `mergecraft auth gemini` / API-key providers
+
+   Never handle raw credentials; never commit secrets. Each auth command stores
+   a GitHub Actions secret via `gh secret set`.
+4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
+   push, open a PR (or comment `@mergecraft review`).
+
+## CLI quick reference
+
+| Command | Purpose |
+|---------|---------|
+| `mergecraft init` | Scaffold config + workflow |
+| `mergecraft review` | Review local diff / branch changes (primary local review command) |
+| `mergecraft review --dry-run` | Print prompt, no LLM call |
+| `mergecraft review --json out.json` | Machine-readable findings |
+| `mergecraft auth …` | Interactive provider login → `gh secret set` |
+| `mergecraft models list\|show\|set` | Inspect/configure model chains |
+| `mergecraft analyzers list\|detect\|run\|explain` | Deterministic analyzers |
+| `mergecraft learnings active\|staging` | Inspect learnings memory |
+| `mergecraft findings export` | Export unresolved findings |
+| `mergecraft eval replay-bank` | Eval bank replay |
+| `mergecraft mcp serve` | Start MCP HTTP server (Bearer token required) |
+| `mergecraft mcp list` | List MCP tool surface for a role |
+
+`diff-review` is a **deprecated alias** for `mergecraft review` (one stderr
+warning per invocation) — teach `mergecraft review` instead.
+
+## MCP
+
+Two profiles — do not confuse them:
+
+| Profile | Command | Transport | Auth |
+|---------|---------|-----------|------|
+| **Public product** | `mergecraft mcp serve --role public --transport stdio` | stdio JSON-RPC | None (local OS user) |
+| **Runtime harness** | `mergecraft mcp serve` (default `--role reviewer`) | HTTP on ephemeral port | Per-serve Bearer required |
+
+**Public install (Cursor, Claude Desktop, Codex, Gemini CLI, OpenCode):** see
+[`docs/mcp.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/mcp.md) for copy-paste `mcpServers` JSON. Six tools only
+(`review_change`, `get_review`, `inspect_finding`, `explain_finding`,
+`get_capabilities`, `get_policy`). Registry: `mcp-name: io.github.alexhawat/mergecraft`.
+
+**Runtime harness HTTP:** default `mergecraft mcp serve` mints a Bearer token on an
+ephemeral port; omitting `Authorization: Bearer …` returns HTTP 401 / JSON-RPC
+`-32600`. Reviewer tools live at `/mcp/reviewer`. Startup prints
+`MERGECRAFT_MCP_BEARER=<token>` to stderr — pass that token on every HTTP request.
+Optional HTTP public (`--role public` without `--transport stdio`) also requires Bearer.
+
+## Configuration essentials (`.mergecraft/config.yaml`)
+
+- **`models:`** ordered fallback chain, e.g.
+  `["anthropic/claude-sonnet", "openai/gpt-5.3-codex"]`. Uncredentialed providers
+  are skipped; transient failures fall through. `model_pin: enabled` opts out.
+- **`prApproveEnabled: true`** lets trusted-tier runs submit a real APPROVE.
+- **Trust tiers** are fail-closed: fork PRs and `pull_request_target` run with
+  no secrets/network — do not "fix" this.
+- **Learnings** in `.mergecraft/learnings.md`: new entries land in `## Staging`;
+  only maintainer-associated authors promote to `## Active`.
+
+## Troubleshooting
+
+- **`mergecraft-approval` failing/neutral** — pure function of typed findings;
+  run `mergecraft findings export` and read blocking items. Prose verdict cannot
+  override a blocker.
+- **Workflow did not trigger on comment** — only OWNER/MEMBER/COLLABORATOR
+  commenters are authorized; authorization reads `author_association` from the
+  event payload, never the comment body.
+- **Model skipped** — no credential for that provider; run `mergecraft models list`.
+- **Full docs:** [`README.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/README.md), [`AGENTS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/AGENTS.md),
+  [`REVIEW-CHECKS.md`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/REVIEW-CHECKS.md), [`docs/`](https://github.com/alexhawat/mergeCraft/blob/v0.1.0a1/docs/README.md).

--- a/skills/harnesses.yaml
+++ b/skills/harnesses.yaml
@@ -20,6 +20,10 @@ harnesses:
     alt_paths: [.cursor/skills/mergecraft/]
     source: https://cursor.com/docs/skills
     verified: 2026-08-21
+  - id: grok-bot
+    alt_paths: []
+    source: https://docs.x.ai/grok-bot/skills-routines-and-automations
+    verified: 2026-09-01
   - id: opencode
     alt_paths: [.opencode/skills/mergecraft/, .claude/skills/mergecraft/]
     source: https://opencode.ai/docs/skills


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `grok-bot` harness so mergeCraft can be set up and managed from Grok Bot the same way as Cursor and Claude, using the existing source skill without changes to review doctrine.

- Declares `grok-bot` in `skills/harnesses.yaml` (primary source: xAI Grok Bot skills docs, verified 2026-09-01)
- Generates `skills/grok-bot/mergecraft/SKILL.md` via `make agent-packages`
- Documents Grok Bot setup in `AGENTS.md` and `README.md`, including the in-account **mergeCraft** bot (repo skill only; no share URL invented)
- Updates `skills/README.md` primary-sources table and `llms.txt`

## Grok Bot install model

Grok Bot does not read `.agents/skills/` in consumer repos. The generated package is installed as a Grok Bot user skill (Settings → Plugins). Setup flow matches other agents: `uv tool install`, `mergecraft init` in the consumer repo, STOP for `mergecraft auth`, then `doctor` / `review` after the human confirms the secret.

## Verification

- `make agent-packages-check` — clean
- `tests/docs/test_agent_packages.py` — pass
- `tests/docs/test_readme_harness_copy_prompts.py` — pass
- `tests/docs/test_agent_surfaces.py` — pass
- `tests/docs/test_docs_gate.py::test_llms_full_matches_generator` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-488cfd22-f46e-49fd-a2df-b4198a2eff0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-488cfd22-f46e-49fd-a2df-b4198a2eff0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

