### PR TITLE
ci: bump the reviewer action pin to the lane D promotion

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "4ab87265015624cf64fc000643781bb3d778d414"
+  MERGECRAFT_ACTION_SHA: "e5f9ed5f799d8d352fd850724ceaca333dedb1ce"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
+        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
+        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@4ab87265015624cf64fc000643781bb3d778d414 # env.MERGECRAFT_ACTION_SHA / lane E promotion / pin 3
+        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The self-review Action pin on all three review rungs moves to `e5f9ed5f`,
+  the lane D sync on `pre-0.0.1` (#601). Reviews run the selfReview catalog,
+  Claude backstop, green-CI SARIF ingest, and `agentSandbox: same-repo`
+  instead of the lane E pin (`4ab87265`)
 - Dogfood `trust.selfReview` / `trust.agentSandbox` knobs apply after merge to
   the default branch — `pull_request_target` reads the base config snapshot, not
   the PR head

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:7f92717edf826dba6bb3c724a6d924712e15622fcb8e9c78098c9ec2eec91144"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:d258e83a69ef69fb0d4bbe2f09ce322dbf782ad81fb55a98879ff0589da32201"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Pin 4 in the 14–19 runbook. Pin 3 was spent on lane E (#598); this is the bump that carries lane D.

## What?

Moves the self-review Action pin to `e5f9ed5f` so dogfood reviews can run lane D (catalog participation, Claude backstop, green-CI SARIF ingest, `agentSandbox: same-repo`) once this reaches `main`.

## Why?

Lane D is merged into `pre-0.0.1` (#601), but `pull_request_target` resolves the action pin from the default branch. Until this lands on `main`, every review still runs the lane E image (`4ab87265`) with `selfReview` off, Claude still firing after a Codex `neutral` verdict, and no green-CI SARIF ingest.

## The SHA

`e5f9ed5f` is the sync of `main` into `pre-0.0.1` after #601. It contains lane D and has `main`'s current pin `4ab87265` as an ancestor, which `check_action_pin_freshness.py` requires. The sync also brought #602 (grok-bot harness) onto `pre-0.0.1` so the promotion does not fight those files.

## Two commits, deliberately

1. this one — `MERGECRAFT_ACTION_SHA` plus the three mirrored `uses:` lines
2. `action.yml`'s `runs.image` digest, once `action-slim-bootstrap` has published the image for this SHA

GHCR has no slim tag for `e5f9ed5f` yet (`action-image-digest-check` skips until it appears). **The PR is not mergeable until commit 2 lands** — splitting the pin from the digest turned five checks red on #562.

## Next

Once this merges to `pre-0.0.1`, refresh the promotion PR (`pre-0.0.1` → `main`) so the reviewer actually picks up the pin.

Refs #600
