### PR TITLE
tracing: honor MERGECRAFT_TRACING_REGION on Action Logfire

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -634,7 +634,7 @@ jobs:
         env:
           MERGECRAFT_CUSTOM_PROVIDER_BASE_URL: https://inference-api.nousresearch.com/v1
           MERGECRAFT_CUSTOM_PROVIDER_API_KEY: ${{ secrets.NOUS_API_KEY }}
-          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_PROJECT: mergecraft-dev
           MERGECRAFT_TRACING_REGION: eu
 
       - name: Persist evidence packet (Nous)
@@ -760,7 +760,7 @@ jobs:
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_PROJECT: mergecraft-dev
           MERGECRAFT_TRACING_REGION: eu
 
       - name: Persist evidence packet (Codex)
@@ -861,7 +861,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MERGECRAFT_TRACING_PROJECT: ${{ vars.LOGFIRE_PROJECT }}
+          MERGECRAFT_TRACING_PROJECT: mergecraft-dev
           MERGECRAFT_TRACING_REGION: eu
 
       - name: Persist evidence packet (Claude)

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -748,7 +748,7 @@ jobs:
           # only diagnostic is lost. Job timeout-minutes is composed from the same
           # per-attempt budget (D8) so both attempts can finish before the ceiling.
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
-          model: openai/gpt-codex
+          model: openai/gpt-terra
           push: disabled
           shell: disabled
           status_checks: enabled

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -748,7 +748,7 @@ jobs:
           # only diagnostic is lost. Job timeout-minutes is composed from the same
           # per-attempt budget (D8) so both attempts can finish before the ceiling.
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
-          model: openai/gpt-terra
+          model: openai/gpt-codex
           push: disabled
           shell: disabled
           status_checks: enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GitHub Action Logfire tracing honors `MERGECRAFT_TRACING_REGION`, so an EU write token is no longer posted to the US ingest host
 - Anchor-422 recovery no longer spins on an out-of-range comment index — it
   demotes all inline comments and posts once (#570)
 - The published GitHub review body always matches the terminal submission;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- GitHub Action Logfire tracing honors `MERGECRAFT_TRACING_REGION`, so an EU write token is no longer posted to the US ingest host
+- GitHub Action Logfire tracing honors `MERGECRAFT_TRACING_REGION`, so an EU
+  write token is no longer posted to the US ingest host (#607)
 - Anchor-422 recovery no longer spins on an out-of-range comment index — it
   demotes all inline comments and posts once (#570)
 - The published GitHub review body always matches the terminal submission;

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -85,6 +85,8 @@ US one:
 | Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
 | Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`). The Action applies that env onto the logfire sink even when tracing is enabled via the `tracing` input rather than `MERGECRAFT_TRACING` |
 
+There is no `tracing-region` Action input, so GitHub never injects `INPUT_TRACING_REGION`. If both `INPUT_TRACING_REGION` and `MERGECRAFT_TRACING_REGION` are set, the Action input wins — it is more specific than the job `env:`.
+
 Both paths converge on the same precedence layer
 (`cli/tracing_precedence.py`) and the same resolver
 (`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -83,7 +83,7 @@ US one:
 | Surface | How |
 | ------- | --- |
 | Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
-| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`). The Action applies that env onto the logfire sink even when tracing is enabled via the `tracing` input rather than `MERGECRAFT_TRACING` |
 
 Both paths converge on the same precedence layer
 (`cli/tracing_precedence.py`) and the same resolver

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1851,7 +1851,9 @@ US one:
 | Surface | How |
 | ------- | --- |
 | Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
-| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`) |
+| Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`). The Action applies that env onto the logfire sink even when tracing is enabled via the `tracing` input rather than `MERGECRAFT_TRACING` |
+
+There is no `tracing-region` Action input, so GitHub never injects `INPUT_TRACING_REGION`. If both `INPUT_TRACING_REGION` and `MERGECRAFT_TRACING_REGION` are set, the Action input wins — it is more specific than the job `env:`.
 
 Both paths converge on the same precedence layer
 (`cli/tracing_precedence.py`) and the same resolver

--- a/scripts/workflow_lint.sh
+++ b/scripts/workflow_lint.sh
@@ -33,7 +33,7 @@ if [[ ! -x "${ACTIONLINT_BIN}" ]]; then
   fi
   tmp="$(mktemp -d)"
   trap 'rm -rf "${tmp}"' EXIT
-  curl -fsSL -o "${tmp}/actionlint.tar.gz" \
+  curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o "${tmp}/actionlint.tar.gz" \
     "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${arch_norm}.tar.gz"
   echo "${ACTIONLINT_SHA256}  ${tmp}/actionlint.tar.gz" | sha256sum -c -
   tar -xzf "${tmp}/actionlint.tar.gz" -C "${tmp}" actionlint
@@ -45,7 +45,7 @@ if [[ ! -x "${ZIZMOR_BIN}" ]]; then
     exit 0
   fi
   tmp="${tmp:-$(mktemp -d)}"
-  curl -fsSL -o "${tmp}/zizmor.tar.gz" \
+  curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o "${tmp}/zizmor.tar.gz" \
     "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${zizmor_arch}-unknown-linux-gnu.tar.gz"
   # ARM64 digest differs from the amd64 pin in Dockerfile.analyzers — SARIF emit
   # runs on ubuntu-latest amd64 only; arm64 installs trust the release HTTPS path.

--- a/src/mergecraft/action/inputs.py
+++ b/src/mergecraft/action/inputs.py
@@ -58,6 +58,25 @@ def _read_input(name: str) -> str | None:
     return value
 
 
+def _read_logfire_region() -> Literal["us", "eu"] | None:
+    """Return a valid Logfire region from Action input or ``MERGECRAFT_TRACING_REGION``.
+
+    ``INPUT_TRACING_REGION`` (if a consumer sets it) beats
+    ``MERGECRAFT_TRACING_REGION``. Invalid or unset values return ``None`` so
+    the sink keeps the US default.
+    """
+    for name in ("INPUT_TRACING_REGION", "MERGECRAFT_TRACING_REGION"):
+        raw = os.environ.get(name)
+        if raw is None or raw == "":
+            continue
+        region = raw.strip().lower()
+        if region == "us":
+            return "us"
+        if region == "eu":
+            return "eu"
+    return None
+
+
 def _parse_bool(value: str | None) -> bool | None:
     """Parse a tri-state bool string (true / false / unset-or-garbage → None).
 
@@ -114,7 +133,11 @@ def resolve_tracing_from_action_inputs() -> dict[str, Any]:
         if tracing_to == "local_files":
             sinks.append({"type": "jsonl_file", "path": _resolve_local_path(None)})
         elif tracing_to == "logfire":
-            sinks.append({"type": "logfire"})
+            logfire_entry: dict[str, Any] = {"type": "logfire"}
+            region = _read_logfire_region()
+            if region is not None:
+                logfire_entry["region"] = region
+            sinks.append(logfire_entry)
         elif tracing_to == "otel":
             entry: dict[str, Any] = {"type": "otel"}
             if otel_endpoint:

--- a/src/mergecraft/cli/tracing_precedence.py
+++ b/src/mergecraft/cli/tracing_precedence.py
@@ -129,6 +129,13 @@ def _resolve_env_layer(env: dict[str, str]) -> dict[str, Any]:
         region = env["MERGECRAFT_TRACING_REGION"].strip().lower()
         if region in {"us", "eu"}:
             out["region"] = region
+    # Action input is more specific than job ``env:``. There is currently no
+    # ``tracing-region`` Action input, so GitHub never injects this var; if
+    # both are set, ``INPUT_TRACING_REGION`` still wins.
+    if "INPUT_TRACING_REGION" in env:
+        region = env["INPUT_TRACING_REGION"].strip().lower()
+        if region in {"us", "eu"}:
+            out["region"] = region
     return out
 
 

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -15,7 +15,6 @@ Exports:
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Any, Literal
 
 from mergecraft.cli.tracing_precedence import resolve_tracing_settings
@@ -79,20 +78,15 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
 def _overlay_logfire_region(
     sinks: list[TraceSinkEntry],
     merged: dict[str, Any],
-    env: dict[str, str] | None = None,
 ) -> list[TraceSinkEntry]:
-    """Apply env/CLI ``region`` onto adopted logfire sinks, if present.
+    """Apply the resolved ``region`` onto adopted logfire sinks, if present.
 
-    ``INPUT_TRACING_REGION`` beats ``MERGECRAFT_TRACING_REGION`` (and the
-    merged env-layer ``region``) because a GitHub Action input is more
-    specific than the job ``env:``.
+    ``merged["region"]`` already encodes CLI ``--region`` over the env layer,
+    and the env layer already prefers ``INPUT_TRACING_REGION`` over
+    ``MERGECRAFT_TRACING_REGION``. Re-reading the Action input here would
+    invert that stack when ``cli_args`` set ``--region``.
     """
-    source = env if env is not None else os.environ
-    raw_input = source.get("INPUT_TRACING_REGION")
-    if isinstance(raw_input, str) and raw_input.strip().lower() in ("us", "eu"):
-        raw_region: Any = raw_input.strip().lower()
-    else:
-        raw_region = merged.get("region")
+    raw_region = merged.get("region")
     if raw_region not in ("us", "eu"):
         return sinks
     region: Literal["us", "eu"] = raw_region
@@ -165,13 +159,13 @@ def resolve_active_tracing(
         #
         # Region is special: Action enablement arrives via ``INPUT_TRACING``,
         # so ``MERGECRAFT_TRACING`` is often unset even when tracing is on.
-        # Overlay ``INPUT_TRACING_REGION`` (if set) over
-        # ``MERGECRAFT_TRACING_REGION`` onto logfire sinks so an EU write
-        # token is not posted to the US OTLP host, and a more-specific Action
-        # input is not clobbered by the job env.
+        # Overlay the resolved region onto logfire sinks so an EU write
+        # token is not posted to the US OTLP host. ``merged["region"]``
+        # already prefers ``INPUT_TRACING_REGION`` over job env, and CLI
+        # ``--region`` over both.
         return TracingSettings(
             enabled=bool(config.enabled),
-            sinks=_overlay_logfire_region(list(config.sinks), merged, env),
+            sinks=_overlay_logfire_region(list(config.sinks), merged),
         )
     return TracingSettings(
         enabled=bool(merged.get("enabled")),

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -75,6 +75,20 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
     return [TraceSinkEntry(type="jsonl_file", path=path)]
 
 
+def _overlay_logfire_region(
+    sinks: list[TraceSinkEntry], merged: dict[str, Any]
+) -> list[TraceSinkEntry]:
+    """Apply env/CLI ``region`` onto adopted logfire sinks, if present."""
+    raw_region = merged.get("region")
+    if raw_region not in ("us", "eu"):
+        return sinks
+    region: Literal["us", "eu"] = raw_region
+    return [
+        sink.model_copy(update={"region": region}) if sink.type == "logfire" else sink
+        for sink in sinks
+    ]
+
+
 def resolve_active_tracing(
     *,
     cli_args: list[str] | None = None,
@@ -135,7 +149,15 @@ def resolve_active_tracing(
         # sinks so a settings-driven run emits. Env/CLI override takes
         # precedence: when ``merged["enabled"]`` is already True/False from a
         # higher layer, that decision stands and ``_build_sinks`` applies.
-        return TracingSettings(enabled=bool(config.enabled), sinks=list(config.sinks))
+        #
+        # Region is special: Action enablement arrives via ``INPUT_TRACING``,
+        # so ``MERGECRAFT_TRACING`` is often unset even when tracing is on.
+        # Still overlay ``MERGECRAFT_TRACING_REGION`` onto logfire sinks so an
+        # EU write token is not posted to the US OTLP host.
+        return TracingSettings(
+            enabled=bool(config.enabled),
+            sinks=_overlay_logfire_region(list(config.sinks), merged),
+        )
     return TracingSettings(
         enabled=bool(merged.get("enabled")),
         sinks=_build_sinks(merged),

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -15,6 +15,7 @@ Exports:
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any, Literal
 
 from mergecraft.cli.tracing_precedence import resolve_tracing_settings
@@ -76,10 +77,22 @@ def _build_sinks(merged: dict[str, Any]) -> list[TraceSinkEntry]:
 
 
 def _overlay_logfire_region(
-    sinks: list[TraceSinkEntry], merged: dict[str, Any]
+    sinks: list[TraceSinkEntry],
+    merged: dict[str, Any],
+    env: dict[str, str] | None = None,
 ) -> list[TraceSinkEntry]:
-    """Apply env/CLI ``region`` onto adopted logfire sinks, if present."""
-    raw_region = merged.get("region")
+    """Apply env/CLI ``region`` onto adopted logfire sinks, if present.
+
+    ``INPUT_TRACING_REGION`` beats ``MERGECRAFT_TRACING_REGION`` (and the
+    merged env-layer ``region``) because a GitHub Action input is more
+    specific than the job ``env:``.
+    """
+    source = env if env is not None else os.environ
+    raw_input = source.get("INPUT_TRACING_REGION")
+    if isinstance(raw_input, str) and raw_input.strip().lower() in ("us", "eu"):
+        raw_region: Any = raw_input.strip().lower()
+    else:
+        raw_region = merged.get("region")
     if raw_region not in ("us", "eu"):
         return sinks
     region: Literal["us", "eu"] = raw_region
@@ -152,11 +165,13 @@ def resolve_active_tracing(
         #
         # Region is special: Action enablement arrives via ``INPUT_TRACING``,
         # so ``MERGECRAFT_TRACING`` is often unset even when tracing is on.
-        # Still overlay ``MERGECRAFT_TRACING_REGION`` onto logfire sinks so an
-        # EU write token is not posted to the US OTLP host.
+        # Overlay ``INPUT_TRACING_REGION`` (if set) over
+        # ``MERGECRAFT_TRACING_REGION`` onto logfire sinks so an EU write
+        # token is not posted to the US OTLP host, and a more-specific Action
+        # input is not clobbered by the job env.
         return TracingSettings(
             enabled=bool(config.enabled),
-            sinks=_overlay_logfire_region(list(config.sinks), merged),
+            sinks=_overlay_logfire_region(list(config.sinks), merged, env),
         )
     return TracingSettings(
         enabled=bool(merged.get("enabled")),

--- a/tests/ci/test_mergecraft_workflow_tracing.py
+++ b/tests/ci/test_mergecraft_workflow_tracing.py
@@ -1,0 +1,33 @@
+"""Dogfood ``mergecraft.yml`` tracing env must match this repo's Logfire project."""
+
+from __future__ import annotations
+
+from tests.ci.workflow_support import load_workflow
+
+_WORKFLOW = "mergecraft.yml"
+_DOGFOOD_PROJECT = "mergecraft-dev"
+
+
+def test_dogfood_review_steps_label_traces_mergecraft_dev() -> None:
+    """Every review rung sets ``MERGECRAFT_TRACING_PROJECT`` to ``mergecraft-dev``.
+
+    Routing is still in the write token; the project label must match the
+    token's project. ``vars.LOGFIRE_PROJECT`` previously resolved to
+    ``mergecraft-ci`` and mislabeled this repo's traces.
+    """
+    jobs = load_workflow(_WORKFLOW).get("jobs") or {}
+    labeled: list[str] = []
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            env = step.get("env") or {}
+            if not isinstance(env, dict) or "MERGECRAFT_TRACING_PROJECT" not in env:
+                continue
+            labeled.append(f"{job_name}/{step.get('name', '<unnamed>')}")
+            assert env["MERGECRAFT_TRACING_PROJECT"] == _DOGFOOD_PROJECT, (
+                f"{labeled[-1]} MERGECRAFT_TRACING_PROJECT={env['MERGECRAFT_TRACING_PROJECT']!r}"
+            )
+    assert labeled, "expected at least one review step to set MERGECRAFT_TRACING_PROJECT"

--- a/tests/ci/test_mergecraft_workflow_tracing.py
+++ b/tests/ci/test_mergecraft_workflow_tracing.py
@@ -6,14 +6,16 @@ from tests.ci.workflow_support import load_workflow
 
 _WORKFLOW = "mergecraft.yml"
 _DOGFOOD_PROJECT = "mergecraft-dev"
+_DOGFOOD_REGION = "eu"
 
 
 def test_dogfood_review_steps_label_traces_mergecraft_dev() -> None:
-    """Every review rung sets ``MERGECRAFT_TRACING_PROJECT`` to ``mergecraft-dev``.
+    """Every review rung sets dogfood project and EU region on tracing env.
 
     Routing is still in the write token; the project label must match the
     token's project. ``vars.LOGFIRE_PROJECT`` previously resolved to
-    ``mergecraft-ci`` and mislabeled this repo's traces.
+    ``mergecraft-ci`` and mislabeled this repo's traces. Region must stay
+    ``eu``: dropping it would post an EU write token to the US ingest host.
     """
     jobs = load_workflow(_WORKFLOW).get("jobs") or {}
     labeled: list[str] = []
@@ -29,5 +31,8 @@ def test_dogfood_review_steps_label_traces_mergecraft_dev() -> None:
             labeled.append(f"{job_name}/{step.get('name', '<unnamed>')}")
             assert env["MERGECRAFT_TRACING_PROJECT"] == _DOGFOOD_PROJECT, (
                 f"{labeled[-1]} MERGECRAFT_TRACING_PROJECT={env['MERGECRAFT_TRACING_PROJECT']!r}"
+            )
+            assert env.get("MERGECRAFT_TRACING_REGION") == _DOGFOOD_REGION, (
+                f"{labeled[-1]} MERGECRAFT_TRACING_REGION={env.get('MERGECRAFT_TRACING_REGION')!r}"
             )
     assert labeled, "expected at least one review step to set MERGECRAFT_TRACING_PROJECT"

--- a/tests/ci/test_workflow_lint_sarif.py
+++ b/tests/ci/test_workflow_lint_sarif.py
@@ -29,6 +29,12 @@ def test_workflow_lint_script_uses_catalog_actionlint_sarif_template() -> None:
     assert _ACTIONLINT_TEMPLATE.is_file()
 
 
+def test_workflow_lint_script_retries_github_release_downloads() -> None:
+    """CI SARIF emit must retry GitHub-releases curl (exit 35 RST is otherwise fatal)."""
+    script = (REPO_ROOT / "scripts" / "workflow_lint.sh").read_text(encoding="utf-8")
+    assert script.count("curl --retry 5 --retry-delay 2 --retry-all-errors") == 2
+
+
 @pytest.mark.skipif(
     sys.platform != "linux", reason="actionlint bootstrap is linux-only in workflow_lint.sh"
 )

--- a/tests/tracing/exporters/test_action_inputs.py
+++ b/tests/tracing/exporters/test_action_inputs.py
@@ -192,3 +192,64 @@ def test_action_inputs_are_dropped_into_github_workspace(
         settings["sinks"][0]["path"].endswith("traces")
         or ".mergecraft" in settings["sinks"][0]["path"]
     )
+
+
+def _clear_action_tracing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "INPUT_TRACING",
+        "INPUT_TRACING_TO",
+        "INPUT_TRACING_REGION",
+        "INPUT_LOGFIRE_TOKEN",
+        "INPUT_OTEL_ENDPOINT",
+        "MERGECRAFT_TRACING",
+        "MERGECRAFT_TRACING_REGION",
+        "GITHUB_WORKSPACE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_action_logfire_shorthand_honors_tracing_region_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``MERGECRAFT_TRACING_REGION=eu`` lands on the Action logfire sink."""
+    _clear_action_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "eu")
+
+    from mergecraft.action.inputs import resolve_tracing_from_action_inputs
+
+    resolved = resolve_tracing_from_action_inputs()
+    assert resolved["sinks"][0]["type"] == "logfire"
+    assert resolved["sinks"][0]["region"] == "eu"
+    assert resolved["settings"].sinks[0].region == "eu"
+
+
+def test_action_logfire_shorthand_honors_tracing_region_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``INPUT_TRACING_REGION`` wins over ``MERGECRAFT_TRACING_REGION``."""
+    _clear_action_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+    monkeypatch.setenv("INPUT_TRACING_REGION", "eu")
+    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "us")
+
+    from mergecraft.action.inputs import resolve_tracing_from_action_inputs
+
+    resolved = resolve_tracing_from_action_inputs()
+    assert resolved["settings"].sinks[0].region == "eu"
+
+
+def test_action_logfire_region_defaults_us_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset region env keeps the US OTLP host default for other consumers."""
+    _clear_action_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+
+    from mergecraft.action.inputs import resolve_tracing_from_action_inputs
+
+    resolved = resolve_tracing_from_action_inputs()
+    assert resolved["settings"].sinks[0].region == "us"

--- a/tests/tracing/test_tracing_resolution.py
+++ b/tests/tracing/test_tracing_resolution.py
@@ -254,3 +254,31 @@ def test_action_input_region_wins_over_conflicting_env_region(
     assert active.enabled is True
     assert active.sinks[0].type == "logfire"
     assert active.sinks[0].region == "eu"
+
+
+def test_cli_region_wins_over_action_input_on_adopt_config_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI ``--region`` beats ``INPUT_TRACING_REGION`` when overlaying config sinks.
+
+    The adopt-config path used to re-read the Action input from the env dict
+    and invert the documented CLI > env stack. Overlay must use the already
+    merged region so ``--region`` still wins.
+    """
+    _clear_tracing_env(monkeypatch)
+
+    from mergecraft.config.settings import TraceSinkEntry, TracingSettings
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    config = TracingSettings(
+        enabled=True,
+        sinks=[TraceSinkEntry(type="logfire", region="us")],
+    )
+    active = resolve_active_tracing(
+        cli_args=["--region", "eu"],
+        env={"INPUT_TRACING_REGION": "us"},
+        config=config,
+    )
+    assert active.enabled is True
+    assert active.sinks[0].type == "logfire"
+    assert active.sinks[0].region == "eu"

--- a/tests/tracing/test_tracing_resolution.py
+++ b/tests/tracing/test_tracing_resolution.py
@@ -32,6 +32,10 @@ _LOG_KEYS = (
     "MERGECRAFT_LOGFIRE_TOKEN",
     "MERGECRAFT_OTEL_ENDPOINT",
     "MERGECRAFT_TRACING_PROJECT",
+    "MERGECRAFT_TRACING_REGION",
+    "INPUT_TRACING",
+    "INPUT_TRACING_TO",
+    "INPUT_TRACING_REGION",
 )
 
 
@@ -179,3 +183,46 @@ def test_diff_review_forwards_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert settings.enabled is True
     assert settings.sinks[0].type == "logfire"
+
+
+def test_action_enablement_without_tracing_env_applies_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Action ``INPUT_TRACING`` must not drop ``MERGECRAFT_TRACING_REGION``.
+
+    Enablement on the GitHub Action path comes from ``INPUT_TRACING``, not
+    ``MERGECRAFT_TRACING``. The resolver used to keep the Action shorthand
+    sinks (region default ``us``) and ignore the env, so an EU write token
+    was posted to ``logfire-us.pydantic.dev``.
+    """
+    _clear_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "eu")
+
+    from mergecraft.action.inputs import apply_tracing_overrides
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = apply_tracing_overrides(RepoSettings())
+    active = resolve_active_tracing(config=settings.tracing)
+    assert active.enabled is True
+    assert active.sinks[0].type == "logfire"
+    assert active.sinks[0].region == "eu"
+
+
+def test_action_enablement_without_tracing_env_defaults_region_us(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset region env keeps the US default when Action inputs enable Logfire."""
+    _clear_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+
+    from mergecraft.action.inputs import apply_tracing_overrides
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = apply_tracing_overrides(RepoSettings())
+    active = resolve_active_tracing(config=settings.tracing)
+    assert active.sinks[0].region == "us"

--- a/tests/tracing/test_tracing_resolution.py
+++ b/tests/tracing/test_tracing_resolution.py
@@ -226,3 +226,31 @@ def test_action_enablement_without_tracing_env_defaults_region_us(
     settings = apply_tracing_overrides(RepoSettings())
     active = resolve_active_tracing(config=settings.tracing)
     assert active.sinks[0].region == "us"
+
+
+def test_action_input_region_wins_over_conflicting_env_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``INPUT_TRACING_REGION`` beats ``MERGECRAFT_TRACING_REGION`` end to end.
+
+    ``apply_tracing_overrides`` stamps Action shorthand sinks onto
+    ``RepoSettings``; ``resolve_active_tracing`` then overlays region. When
+    both vars are set to conflicting values, the Action input wins — it is
+    more specific than job env. GitHub does not declare a ``tracing-region``
+    input today, so this is the contract if ``INPUT_TRACING_REGION`` is set.
+    """
+    _clear_tracing_env(monkeypatch)
+    monkeypatch.setenv("INPUT_TRACING", "true")
+    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
+    monkeypatch.setenv("INPUT_TRACING_REGION", "eu")
+    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "us")
+
+    from mergecraft.action.inputs import apply_tracing_overrides
+    from mergecraft.config.settings import RepoSettings
+    from mergecraft.tracing.resolve import resolve_active_tracing
+
+    settings = apply_tracing_overrides(RepoSettings())
+    active = resolve_active_tracing(config=settings.tracing)
+    assert active.enabled is True
+    assert active.sinks[0].type == "logfire"
+    assert active.sinks[0].region == "eu"


### PR DESCRIPTION
## What?

GitHub Action Logfire tracing now sends spans to the EU ingest host when MERGECRAFT_TRACING_REGION is eu, instead of posting an EU write token to the US host (HTTP 401). This repo's review workflow labels traces mergecraft-dev to match the token's project.

## Why?

Self-review tracing was wired and then failed export: an EU token hit logfire-us.pydantic.dev because Action enablement comes from the tracing input, not MERGECRAFT_TRACING, and the logfire shorthand kept the US default. The GitHub variable LOGFIRE_PROJECT was mergecraft-ci, which does not match this repo's write token.

## Note

**Pin vs workflow env (when this takes effect):**

- `MERGECRAFT_TRACING_PROJECT` / `MERGECRAFT_TRACING_REGION` in `.github/workflows/mergecraft.yml` take effect once this workflow file is on `main` (`pull_request_target` reads `main`'s workflow).
- The Python sink/region fix runs inside the Action container. Live `mergecraft.yml` reviews **need a pin** before they stop 401ing. The pin is not bumped here (`MERGECRAFT_ACTION_SHA` / `action.yml` digest stay as they are).

Lane B's `INPUT_LOGFIRE_TOKEN` → `MERGECRAFT_LOGFIRE_TOKEN` copy is unchanged. Consumers that unset the region env still default to `us`.

The repo Actions variable `LOGFIRE_PROJECT` is now `mergecraft-dev` (was `mergecraft-ci`), so live `main` reviews that still interpolate `vars.LOGFIRE_PROJECT` pick up the matching project label before this workflow file lands.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make pyright`
- [x] scoped pytest: `tests/tracing/exporters/test_action_inputs.py`, `tests/tracing/test_tracing_resolution.py`, `tests/ci/test_mergecraft_workflow_tracing.py`, `tests/cli/test_tracing_region_env.py`, `tests/config/test_tracing_tri_state.py`

## Related PR(s)/Issue(s)

Does not mix with #585, #605, #606, or #578.
