### PR TITLE
ci: switch Codex self-review to openai/gpt-terra

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -748,7 +748,7 @@ jobs:
           # only diagnostic is lost. Job timeout-minutes is composed from the same
           # per-attempt budget (D8) so both attempts can finish before the ceiling.
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
-          model: openai/gpt-codex
+          model: openai/gpt-terra
           push: disabled
           shell: disabled
           status_checks: enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Self-review Codex fallback uses `openai/gpt-terra` (GPT 5.6 Terra) instead of
+  `openai/gpt-codex`
 - The self-review Action pin on all three review rungs moves to `e5f9ed5f`,
   the lane D sync on `pre-0.0.1` (#601). Reviews run the selfReview catalog,
   Claude backstop, green-CI SARIF ingest, and `agentSandbox: same-repo`


### PR DESCRIPTION
## What?

Dogfood Codex self-review now runs GPT 5.6 Terra instead of the previous Codex alias.

## Why?

The operator wanted Terra on live self-review. That swap was pulled out of #607 so the tracing-only change stays tracing-only.

## Note

- Dogfood workflow only. Live `pull_request_target` reviews pick this up once merged to main.
- Independent of #607 (Logfire region). Mergeable to main without those tracing commits.
- Catalog alias `openai/gpt-terra` resolves to `openai/gpt-5.6-terra`.

## Test plan

- [x] Confirmed `openai/gpt-terra` → `openai/gpt-5.6-terra` in `src/mergecraft/models.py`
- [x] `tests/ci/` does not assert the old Codex model on this step
- [x] No Action pin bump

## Related PR(s)

Split from #607. Does not depend on it.
