### PR TITLE
ci: promote the Logfire region pin to main

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "e5f9ed5f799d8d352fd850724ceaca333dedb1ce"
+  MERGECRAFT_ACTION_SHA: "5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
+        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
+        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@e5f9ed5f799d8d352fd850724ceaca333dedb1ce # env.MERGECRAFT_ACTION_SHA / lane D promotion / pin 4
+        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b"
+  MERGECRAFT_ACTION_SHA: "93a7897c1e7fecabb094759d5d05b3b20e23708a"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
+        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
+        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@5d68b56fdc37e6d5981392ee3b6e29b05dd3db4b # env.MERGECRAFT_ACTION_SHA / Logfire region #607 / pin 5
+        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The self-review Action pin on all three review rungs moves to `5d68b56f`,
+  pin 5 — GitHub Action Logfire honors `MERGECRAFT_TRACING_REGION` (#607)
 - Self-review Codex fallback uses `openai/gpt-terra` (GPT 5.6 Terra) instead of
   `openai/gpt-codex`
 - The self-review Action pin on all three review rungs moves to `e5f9ed5f`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The self-review Action pin on all three review rungs moves to `5d68b56f`,
+- The self-review Action pin on all three review rungs moves to `93a7897c`,
   pin 5 — GitHub Action Logfire honors `MERGECRAFT_TRACING_REGION` (#607)
 - Self-review Codex fallback uses `openai/gpt-terra` (GPT 5.6 Terra) instead of
   `openai/gpt-codex`

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:61113dc0a23aa4710c4c97bf61919dc4d357beb98a1eac72167039b6f17bdc5a"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:e14a5e2d753db4785ecd7e44e758e016d7e23b3c790d5e753b62fe719a994cc5"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:d258e83a69ef69fb0d4bbe2f09ce322dbf782ad81fb55a98879ff0589da32201"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:61113dc0a23aa4710c4c97bf61919dc4d357beb98a1eac72167039b6f17bdc5a"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Lands the pin 5 Action bump on the default branch so dogfood reviews honor MERGECRAFT_TRACING_REGION (#607).

- `uses:` points at `93a7897c`, whose `action.yml` already pins `sha256:61113…` (the Logfire-region slim image). GitHub loads that commit's action.yml, not a later tree.
- An EU write token is no longer posted to the US ingest host.

## Why?

#613 is merged. `pre-0.0.1` is at `1dd21701` and pins `93a7897c`. GitHub resolves `pull_request_target` from the default branch, so reviews still execute `e5f9ed5f` / `sha256:d258` until this workflow file is on `main`.

## Note

Pin SHA is `93a7897c` (the digest commit that first wrote `sha256:61113`), not this promotion merge. Soak HEAD `action.yml` also records `sha256:e14a5e2d` for the GHCR tag of that SHA. Trial-merge into `main` is clean: 3 × job token, no live `MERGECRAFT_REVIEWER_PAT`.

Needs an admin merge. `protect-main` requires an approving review the bot cannot give, and `require-ci-on-main` has no bypass. Expected. Same as #604.

## Related PR(s)/Issue(s)

Depends on #613 #607
