### PR TITLE
trust: enable same-repo self-review APPROVE

### DIFF
--- a/.mergecraft/config.yaml
+++ b/.mergecraft/config.yaml
@@ -16,5 +16,5 @@ ciEvidence:
     - semgrep-sarif
 
 trust:
-  selfReview: "analyzers"
+  selfReview: "full"
   agentSandbox: "same-repo"

--- a/docs/test-plans/self-review-evidence.md
+++ b/docs/test-plans/self-review-evidence.md
@@ -30,9 +30,9 @@ Pinned workflow: `.github/workflows/mergecraft.yml` steps `fallback`, `claude_fa
 
 | Contract | Tests | Layer |
 | --- | --- | --- |
-| Committed `.mergecraft/config.yaml` has quoted `trust.selfReview: "analyzers"` | `tests/config/test_self_review_trust_config_w2.py::test_committed_config_has_self_review_analyzers_quoted` | config |
-| Same-repo `pull_request_target` → execution=trusted, authority=untrusted | `…::test_committed_config_resolves_execution_trusted_on_same_repo_prt` | config |
-| Fork PR stays untrusted on both axes | `…::test_fork_pr_stays_untrusted_on_both_axes_with_analyzers` | unit (guard) |
+| Committed `.mergecraft/config.yaml` has quoted `trust.selfReview: "full"` | `tests/config/test_self_review_trust_config_w2.py::test_committed_config_has_self_review_full_quoted` | config |
+| Same-repo `pull_request_target` → execution=trusted, authority=trusted | `…::test_committed_config_resolves_execution_trusted_on_same_repo_prt` | config |
+| Fork PR stays untrusted on both axes | `…::test_fork_pr_stays_untrusted_on_both_axes_with_analyzers`, `…::test_committed_config_fork_pr_stays_untrusted` | unit (guard) |
 
 Pinned API: `mergecraft.config.trust_policy.resolve_trust_policy`.
 

--- a/tests/config/test_self_review_trust_config_w2.py
+++ b/tests/config/test_self_review_trust_config_w2.py
@@ -25,26 +25,38 @@ def _resolve_policy(**kwargs):
     return resolve_trust_policy(**kwargs)
 
 
-def test_committed_config_has_self_review_analyzers_quoted() -> None:
-    """D6 — dogfood config must carry ``trust.selfReview: \"analyzers\"`` (quoted)."""
+def test_committed_config_has_self_review_full_quoted() -> None:
+    """D6 — dogfood config must carry ``trust.selfReview: \"full\"`` (quoted)."""
     text = _COMMITTED_CONFIG.read_text(encoding="utf-8")
     loaded = yaml.safe_load(text)
     assert isinstance(loaded, dict)
     trust = loaded.get("trust")
     assert isinstance(trust, dict), "committed config must define trust.selfReview"
-    assert trust.get("selfReview") == "analyzers"
-    assert 'selfReview: "analyzers"' in text or "selfReview: 'analyzers'" in text
+    assert trust.get("selfReview") == "full"
+    assert 'selfReview: "full"' in text or "selfReview: 'full'" in text
 
 
 def test_committed_config_resolves_execution_trusted_on_same_repo_prt() -> None:
-    """Plan 13 — committed dogfood config must elevate execution on same-repo PRT."""
+    """Plan 13 — committed dogfood config must elevate execution and authority on same-repo PRT."""
     policy = _resolve_policy(
         event=_SAME_REPO_EVENT,
         config_root=REPO_ROOT,
         event_name="pull_request_target",
     )
-    assert policy.level == "analyzers"
+    assert policy.level == "full"
     assert policy.execution_trust == "trusted"
+    assert policy.authority_trust == "trusted"
+
+
+def test_committed_config_fork_pr_stays_untrusted() -> None:
+    """Fork floor — committed ``full`` must not grant trust on a fork head."""
+    policy = _resolve_policy(
+        event=_FORK_EVENT,
+        config_root=REPO_ROOT,
+        event_name="pull_request_target",
+    )
+    assert policy.level == "full"
+    assert policy.execution_trust == "untrusted"
     assert policy.authority_trust == "untrusted"
 
 


### PR DESCRIPTION
## What?

Same-repo GitHub Actions self-review can APPROVE after this lands on main.

- Dogfood self-review moves from analyzers to full (quoted).
- Agent sandbox stays same-repo.
- Fork heads stay untrusted on both axes.

## Why?

The operator already opted into full locally with the approval-authority confirmation flag. Origin/main is still analyzers, so self-review cannot grant approval authority until the committed base config says full. The CLI refuses to rewrite this comment-heavy file, so the value is hand-edited.

## Note

**Do not start pin 6.** `pull_request_target` reads `.mergecraft/config.yaml` from the **base branch checkout**, not from the Action image. A pin or promote would not make `full` take effect any sooner. If a pin is still wanted after merge, ask.

Fork floor is unchanged: `full` must not apply to fork heads. That stays encoded in trust policy; this change does not touch it.

## Test plan

- [x] Dogfood config tests updated for quoted `full` and same-repo authority=trusted
- [x] New pin that committed `full` still leaves fork PRs untrusted on both axes
- [x] `uv run --extra dev pytest tests/config/test_self_review_trust_config_w2.py tests/config/test_reviewer_resilience_trust_policy.py` (19 passed)
