### PR TITLE
ci: sync soak with main after #615

### DIFF
--- a/.mergecraft/config.yaml
+++ b/.mergecraft/config.yaml
@@ -16,5 +16,5 @@ ciEvidence:
     - semgrep-sarif
 
 trust:
-  selfReview: "analyzers"
+  selfReview: "full"
   agentSandbox: "same-repo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Authentication quick start uses registry labels (`anthropic`, `openai`,
+  `google`) instead of harness names that `provider auth` rejects (#590)
 - GitHub Action Logfire tracing honors `MERGECRAFT_TRACING_REGION`, so an EU
   write token is no longer posted to the US ingest host (#607)
 - Anchor-422 recovery no longer spins on an out-of-range comment index — it

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,7 +7,7 @@ editing:
 
 ```bash
 mergecraft init
-mergecraft provider auth claude    # or codex, gemini, nous, …
+mergecraft provider auth anthropic    # or openai, google, nous, …
 mergecraft review                  # local review works now
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -23,6 +23,9 @@ Commit `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml` after
 auth. Run `mergecraft workflow sync --check` before pushing if you assign roster
 models whose providers are not yet wired in the workflow.
 
+This repository's workflow does not listen for `@mergecraft review` — reviews
+run on `pull_request_target` (opened / synchronize).
+
 ## Provider reference
 
 | Provider | Subscription (recommended) | API key | Recommended model | Inferred harness |

--- a/docs/test-plans/self-review-evidence.md
+++ b/docs/test-plans/self-review-evidence.md
@@ -30,9 +30,9 @@ Pinned workflow: `.github/workflows/mergecraft.yml` steps `fallback`, `claude_fa
 
 | Contract | Tests | Layer |
 | --- | --- | --- |
-| Committed `.mergecraft/config.yaml` has quoted `trust.selfReview: "analyzers"` | `tests/config/test_self_review_trust_config_w2.py::test_committed_config_has_self_review_analyzers_quoted` | config |
-| Same-repo `pull_request_target` → execution=trusted, authority=untrusted | `…::test_committed_config_resolves_execution_trusted_on_same_repo_prt` | config |
-| Fork PR stays untrusted on both axes | `…::test_fork_pr_stays_untrusted_on_both_axes_with_analyzers` | unit (guard) |
+| Committed `.mergecraft/config.yaml` has quoted `trust.selfReview: "full"` | `tests/config/test_self_review_trust_config_w2.py::test_committed_config_has_self_review_full_quoted` | config |
+| Same-repo `pull_request_target` → execution=trusted, authority=trusted | `…::test_committed_config_resolves_execution_trusted_on_same_repo_prt` | config |
+| Fork PR stays untrusted on both axes | `…::test_fork_pr_stays_untrusted_on_both_axes_with_analyzers`, `…::test_committed_config_fork_pr_stays_untrusted` | unit (guard) |
 
 Pinned API: `mergecraft.config.trust_policy.resolve_trust_policy`.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2585,7 +2585,7 @@ editing:
 
 ```bash
 mergecraft init
-mergecraft provider auth claude    # or codex, gemini, nous, …
+mergecraft provider auth anthropic    # or openai, google, nous, …
 mergecraft review                  # local review works now
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2601,6 +2601,9 @@ Commit `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml` after
 auth. Run `mergecraft workflow sync --check` before pushing if you assign roster
 models whose providers are not yet wired in the workflow.
 
+This repository's workflow does not listen for `@mergecraft review` — reviews
+run on `pull_request_target` (opened / synchronize).
+
 ## Provider reference
 
 | Provider | Subscription (recommended) | API key | Recommended model | Inferred harness |

--- a/tests/config/test_self_review_trust_config_w2.py
+++ b/tests/config/test_self_review_trust_config_w2.py
@@ -25,26 +25,38 @@ def _resolve_policy(**kwargs):
     return resolve_trust_policy(**kwargs)
 
 
-def test_committed_config_has_self_review_analyzers_quoted() -> None:
-    """D6 — dogfood config must carry ``trust.selfReview: \"analyzers\"`` (quoted)."""
+def test_committed_config_has_self_review_full_quoted() -> None:
+    """D6 — dogfood config must carry ``trust.selfReview: \"full\"`` (quoted)."""
     text = _COMMITTED_CONFIG.read_text(encoding="utf-8")
     loaded = yaml.safe_load(text)
     assert isinstance(loaded, dict)
     trust = loaded.get("trust")
     assert isinstance(trust, dict), "committed config must define trust.selfReview"
-    assert trust.get("selfReview") == "analyzers"
-    assert 'selfReview: "analyzers"' in text or "selfReview: 'analyzers'" in text
+    assert trust.get("selfReview") == "full"
+    assert 'selfReview: "full"' in text or "selfReview: 'full'" in text
 
 
 def test_committed_config_resolves_execution_trusted_on_same_repo_prt() -> None:
-    """Plan 13 — committed dogfood config must elevate execution on same-repo PRT."""
+    """Plan 13 — committed dogfood config must elevate execution and authority on same-repo PRT."""
     policy = _resolve_policy(
         event=_SAME_REPO_EVENT,
         config_root=REPO_ROOT,
         event_name="pull_request_target",
     )
-    assert policy.level == "analyzers"
+    assert policy.level == "full"
     assert policy.execution_trust == "trusted"
+    assert policy.authority_trust == "trusted"
+
+
+def test_committed_config_fork_pr_stays_untrusted() -> None:
+    """Fork floor — committed ``full`` must not grant trust on a fork head."""
+    policy = _resolve_policy(
+        event=_FORK_EVENT,
+        config_root=REPO_ROOT,
+        event_name="pull_request_target",
+    )
+    assert policy.level == "full"
+    assert policy.execution_trust == "untrusted"
     assert policy.authority_trust == "untrusted"
 
 

--- a/tests/docs/test_auth_reference.py
+++ b/tests/docs/test_auth_reference.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 
 from mergecraft.cli.auth_cmd import app as auth_app
+from mergecraft.models import PROVIDERS
 from tests.ci.workflow_support import REPO_ROOT, read_text
 
 README = REPO_ROOT / "README.md"
@@ -116,6 +117,25 @@ def test_custom_openai_compatible_row_present() -> None:
         "docs/authentication.md must include an OpenAI-compatible custom provider row (A3)"
     )
     assert "docs/authentication.md" in read_text("README.md")
+
+
+def test_quickstart_provider_auth_uses_catalog_labels() -> None:
+    """#590 — ``provider auth`` takes catalog labels, not harness names."""
+    text = _auth_doc_table_text()
+    match = re.search(r"```bash\n(.*?)```", text, re.DOTALL)
+    assert match is not None, "docs/authentication.md missing a bash example"
+    fence = match.group(1)
+    labels = re.findall(r"mergecraft provider auth ([a-z0-9-]+)", fence)
+    or_comment = re.search(r"# or ([^\n]+)", fence)
+    if or_comment is not None:
+        labels.extend(
+            part.strip(" .…") for part in or_comment.group(1).split(",") if part.strip(" .…")
+        )
+    assert labels, "quick start must show mergecraft provider auth <label>"
+    unknown = [label for label in labels if label not in PROVIDERS]
+    assert not unknown, "provider auth takes catalog labels (anthropic, not claude): " + ", ".join(
+        unknown
+    )
 
 
 def test_every_auth_subcommand_has_a_row() -> None:

--- a/tests/security/support_agent_isolation.py
+++ b/tests/security/support_agent_isolation.py
@@ -91,6 +91,17 @@ def _snapshot_request_headers(handler: BaseHTTPRequestHandler) -> dict[str, str]
     return {name: value for name, value in handler.headers.items()}
 
 
+def _consume_request_body(handler: BaseHTTPRequestHandler) -> None:
+    """Drain the request body so HTTP/1.1 keep-alive reuse is not poisoned."""
+    raw_length = handler.headers.get("Content-Length", "0") or "0"
+    try:
+        length = int(raw_length)
+    except ValueError:
+        return
+    if length > 0:
+        handler.rfile.read(length)
+
+
 class MockModelUpstream:
     """Loopback OpenAI-shaped upstream that records Authorization headers."""
 
@@ -141,6 +152,7 @@ class MockModelUpstream:
 
             def do_POST(self) -> None:
                 self._record_request()
+                _consume_request_body(self)
                 if redirect_to is not None:
                     self.send_response(HTTPStatus.FOUND)
                     self.send_header("Location", redirect_to)
@@ -170,6 +182,7 @@ class MockModelUpstream:
 
             def do_GET(self) -> None:
                 self._record_request()
+                _consume_request_body(self)
                 if redirect_to is not None:
                     self.send_response(HTTPStatus.FOUND)
                     self.send_header("Location", redirect_to)
@@ -248,6 +261,7 @@ class SlowModelUpstream:
                 with upstream._lock:
                     upstream.authorization_headers.append(self.headers.get("Authorization", ""))
                     upstream.request_header_maps.append(headers)
+                _consume_request_body(self)
                 time.sleep(delay_seconds)
                 body = json.dumps(
                     {
@@ -338,6 +352,7 @@ class StreamingSSEUpstream:
                 with upstream._lock:
                     upstream.authorization_headers.append(self.headers.get("Authorization", ""))
                     upstream.request_header_maps.append(headers)
+                _consume_request_body(self)
                 self.send_response(HTTPStatus.OK)
                 self.send_header("Content-Type", "text/event-stream")
                 self.send_header("Cache-Control", "no-cache")

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -334,7 +334,8 @@ async def test_concurrent_requests_with_same_bearer() -> None:
                 client.post(MODEL_PATH, json=payload, headers=headers),
                 client.post(MODEL_PATH, json=payload, headers=headers),
             )
-        assert all(response.status_code == 200 for response in responses)
+        codes = [response.status_code for response in responses]
+        assert codes == [200, 200], codes
 
 
 def test_resolve_codex_broker_posture_no_credentials(


### PR DESCRIPTION
## What?

Fast-forwards soak to main so it includes the provider-auth docs and same-repo APPROVE trust change that landed after pin 5.

## Why?

Soak fell behind after #615 and #617. Later soak-base work cannot rebase until soak catches main.

## Note

Fast-forward only. No pin bump: pin 5 (`93a7897c`) is already on both branches.

Included from main:

- #617 same-repo self-review APPROVE
- #615 provider-auth catalog labels
- pin 5 promotion to main
- keep-alive mock drain test and `pull_request_target` docs note

## Test plan

- CI on this branch vs `pre-0.0.1` (no pin, no image publish)
