### PR TITLE
ci: bump the reviewer action pin to 7fcdc6c2 (pin 6)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "93a7897c1e7fecabb094759d5d05b3b20e23708a"
+  MERGECRAFT_ACTION_SHA: "7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
+        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
+        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@93a7897c1e7fecabb094759d5d05b3b20e23708a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 5
+        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:e14a5e2d753db4785ecd7e44e758e016d7e23b3c790d5e753b62fe719a994cc5"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:77822e1af04d2778701c3bc20b27022a16d88c6e8cbcb1fdd013928ba537b274"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Pin 6 — bumps the reviewer action pin from `93a7897c` (pin 5) to `7fcdc6c2`, the `pre-0.0.1` sync merge of `main`.

## Why?

`check_action_pin_freshness.py` went red on every branch built on `main`:

```
pin 93a7897c1e7f lags main by 6 commits touching src/mergecraft/ (max 5).
The reviewer is not running the product code on main, so anything merged
since the pin is absent from every review. Bump the pin.
```

The check is right, and the second sentence is the real cost. #623 fixed the approval gate — agent findings never reached the merge-evidence packet, a `request_changes` verdict could not block a structural `success`, a run whose review never published still reported `passed` — and none of it is live. Every review since, including the reviews of #622 and #623 themselves, ran the pre-fix image.

`7fcdc6c2` both contains that work and descends from pin 5, which the freshness checker requires.

## What this pin carries

- **#623** — agent findings reach the approval gate; one-way `request_changes` ratchet; fail-closed on an unpublished terminal review; 422 payload logging + `event=COMMENT` fallback + body truncation; mode prompts speaking the real `verdict`/`summary`/`findings` vocabulary; `git grep`/`ls-tree` behind pager-exec and content-filter guards; `trust.sandboxTrustedAuthors`; the pre-push author guard.
- Dependabot bumps already on `pre-0.0.1` (#608, #610).

**Not** carried: #622 (D7 export-cap provenance) — it cannot merge until this pin makes `action-pin-check` pass again, so it rides pin 7.

## Sequence

Two commits, per the runbook:

1. `env.MERGECRAFT_ACTION_SHA` + the three mirrored `uses:` lines (this commit). Opening the PR is what triggers `action-slim-bootstrap` to build and push the image for this SHA — the digest cannot be computed before that finishes.
2. `action.yml`'s `runs.image` digest.

**Do not merge after commit 1 alone** — that leaves `action.yml` pointing at the old image and turned five checks red on #562.

## Test plan

- [x] `check_action_pin_freshness.py` → `action-pin-check OK: 1 workflow(s) pin this action`
- [ ] `action-slim-bootstrap` builds and pushes the image for `7fcdc6c2`
- [ ] `check_action_image_digest.py` green, `tracing extra` is `True`
- [ ] Both checkers green from the PR tree before commit 2 is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsKpJMQ1yby9gYCowKqRc6
