### PR TITLE
refactor(analyzers): nightly audit cleanup A1 — remove dead surface

### DIFF
--- a/src/mergecraft/analyzers/__init__.py
+++ b/src/mergecraft/analyzers/__init__.py
@@ -1,5 +1,7 @@
 """Analyzer platform — manifests, registry, resolution, and execution."""
 
+from __future__ import annotations
+
 from mergecraft.analyzers.finding import Finding, FindingValidationError, make_finding
 from mergecraft.analyzers.manifest import (
     AnalyzerManifest,

--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -61,14 +61,12 @@ def _scan_agentsec_in_process(
     *,
     repo_root: Path,
     scoped: list[str],
-    tier: TrustTier,
 ) -> _NativeScanOutcome:
     from mergecraft.analyzers.agentsec import scan_manifests
 
     agentsec_result = scan_manifests(
         repo_root=repo_root,
         changed_files=scoped,
-        tier=tier,
     )
     return _NativeScanOutcome(
         findings=agentsec_result.findings,
@@ -81,9 +79,7 @@ def _scan_antislop_in_process(
     *,
     repo_root: Path,
     scoped: list[str],
-    tier: TrustTier,
 ) -> _NativeScanOutcome:
-    _ = tier
     from mergecraft.analyzers.antislop import scan_changed_files
 
     antislop_result = scan_changed_files(repo_root=repo_root, changed_files=scoped)
@@ -105,13 +101,12 @@ def _run_in_process_scan(
     *,
     repo_root: Path,
     scoped: list[str],
-    tier: TrustTier,
 ) -> _NativeScanOutcome:
     scanner = _IN_PROCESS_SCANNERS.get(tool_id)
     if scanner is None:
         msg = f"unsupported in-process analyzer {tool_id!r}"
         raise ValueError(msg)
-    return scanner(repo_root=repo_root, scoped=scoped, tier=tier)
+    return scanner(repo_root=repo_root, scoped=scoped)
 
 
 def _run_in_process_native_adapter(
@@ -132,7 +127,6 @@ def _run_in_process_native_adapter(
         tool_id,
         repo_root=repo_root,
         scoped=scoped_files,
-        tier=tier,
     )
     version_note = IN_PROCESS_VERSION_NOTES[tool_id]
     if outcome.skipped:
@@ -366,7 +360,6 @@ def run_adapter(
         resolved_base = resolve_analyzer_base_ref(
             repo_root,
             base_ref=base_ref,
-            offline=offline,
             changed_files=changed_files,
         )
         return run_differential_adapter(
@@ -384,7 +377,6 @@ def run_adapter(
         resolved_base = resolve_analyzer_base_ref(
             repo_root,
             base_ref=base_ref,
-            offline=offline,
             changed_files=changed_files,
         )
         return run_supply_chain_adapter(

--- a/src/mergecraft/analyzers/agentsec/__init__.py
+++ b/src/mergecraft/analyzers/agentsec/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from mergecraft.analyzers.agentsec.mcp_manifest import discover_mcp_documents
 from mergecraft.analyzers.agentsec.policy import (
@@ -20,7 +20,6 @@ from mergecraft.analyzers.finding import Finding, make_finding
 if TYPE_CHECKING:
     from pathlib import Path
 
-TrustTier = Literal["trusted", "untrusted"]
 _TOOL = "agentsec"
 _CATEGORY = "Security & Privacy"
 
@@ -38,10 +37,8 @@ def scan_manifests(
     *,
     repo_root: Path,
     changed_files: list[str],
-    tier: TrustTier = "trusted",
 ) -> AgentSecScanResult:
     """Scan changed MCP and skill manifests with native YAML rules."""
-    _ = tier
     repo_root = repo_root.resolve()
     scoped = [path for path in changed_files if path.strip()]
     if not scoped:

--- a/src/mergecraft/analyzers/baseline_suppression.py
+++ b/src/mergecraft/analyzers/baseline_suppression.py
@@ -121,7 +121,6 @@ def collect_base_analyzer_findings(
     resolved = resolve_analyzer_base_ref(
         repo_root,
         base_ref=base_ref,
-        offline=offline,
         changed_files=changed_files,
     )
     if not resolved:

--- a/src/mergecraft/analyzers/config.py
+++ b/src/mergecraft/analyzers/config.py
@@ -23,7 +23,6 @@ def trufflehog_verify_enabled(
     *,
     repo_root: Path,
     tier: TrustTier,
-    event: dict[str, Any] | None = None,
 ) -> bool:
     """Return whether TruffleHog live verification may run (C2 / D7).
 
@@ -31,7 +30,6 @@ def trufflehog_verify_enabled(
     pull_request_target). Trusted repos must opt in via
     ``analyzers.trufflehog.verify: true``.
     """
-    _ = event
     if tier != "trusted":
         return False
     trufflehog = raw_analyzers_block(repo_root).get("trufflehog")

--- a/src/mergecraft/analyzers/contracts.py
+++ b/src/mergecraft/analyzers/contracts.py
@@ -422,16 +422,10 @@ def run_differential_adapter(
     raise ValueError(msg)
 
 
-def requires_base_run(tool_id: str) -> bool:
-    """Return whether this adapter always needs a base revision (D6)."""
-    return tool_id in DIFFERENTIAL_CONTRACT_TOOLS
-
-
 def resolve_analyzer_base_ref(
     repo_root: Path,
     *,
     base_ref: str | None,
-    offline: bool = False,
     changed_files: list[str] | None = None,
 ) -> str | None:
     """Resolve the base revision for differential contract adapters (D6).
@@ -440,7 +434,6 @@ def resolve_analyzer_base_ref(
     by ``tests/analyzers/fixtures/repo``, then a git-detectable merge base for
     offline diff-review and PR checkouts.
     """
-    _ = offline
     if base_ref:
         return base_ref
     for head_rel in changed_files or []:
@@ -459,7 +452,6 @@ def resolve_analyzer_base_ref(
 
 __all__ = [
     "DIFFERENTIAL_CONTRACT_TOOLS",
-    "requires_base_run",
     "resolve_analyzer_base_ref",
     "run_differential_adapter",
 ]

--- a/src/mergecraft/analyzers/execution.py
+++ b/src/mergecraft/analyzers/execution.py
@@ -72,7 +72,7 @@ def finalize_plan(
     argv = list(expand_analyzer_argv(plan.argv, repo_root=repo_root, changed_files=scoped_files))
     if manifest.id == "trufflehog":
         argv = _trufflehog_argv(argv, repo_root=repo_root, tier=tier, event=event)
-    env = build_analyzer_env(tier=tier, event=event, repo_env=None)
+    env = build_analyzer_env(tier=tier, repo_env=None)
     if plan.env:
         env = {**env, **plan.env}
     return replace(plan, argv=tuple(argv), cwd=repo_root, env=env)
@@ -98,7 +98,7 @@ def _trufflehog_argv(
     # from MCP callers that assemble their own arguments (see ``run_argv``).
     if TRUFFLEHOG_NO_UPDATE_FLAG not in filtered:
         filtered.append(TRUFFLEHOG_NO_UPDATE_FLAG)
-    if trufflehog_verify_enabled(repo_root=repo_root, tier=tier, event=event):
+    if trufflehog_verify_enabled(repo_root=repo_root, tier=tier):
         if "--verification" not in filtered:
             filtered.append("--verification")
     elif "--no-verification" not in filtered:

--- a/src/mergecraft/analyzers/impact.py
+++ b/src/mergecraft/analyzers/impact.py
@@ -133,7 +133,7 @@ def _run_ast_grep(
         msg = sandbox_decision.skip_reason or f"ast-grep sandbox unavailable ({rule_path.name})"
         raise _ExtractionFailed(msg)
 
-    env = build_analyzer_env(tier=tier, event=None)
+    env = build_analyzer_env(tier=tier)
     plan = AnalyzerPlan(
         manifest_id="ast-grep-impact",
         mode="managed",

--- a/src/mergecraft/analyzers/parse.py
+++ b/src/mergecraft/analyzers/parse.py
@@ -46,7 +46,7 @@ def persist_analyzer_output(raw: str, *, tmpdir: Path, tool_id: str) -> Path:
     return path
 
 
-def read_output_file(path: Path) -> str:
+def _read_output_file(path: Path) -> str:
     """Read analyzer output from disk without an 8 KB cap."""
     return path.read_text(encoding="utf-8")
 
@@ -58,9 +58,9 @@ def parse_output_file(
     repo_root: Path,
 ) -> list[Finding]:
     """Parse normalized findings from a persisted analyzer output file."""
-    raw = read_output_file(path)
+    raw = _read_output_file(path)
     findings = parse_output(raw, manifest=manifest, repo_root=repo_root)
     return _redact_findings(findings, tool_id=manifest.id)
 
 
-__all__ = ["parse_output_file", "persist_analyzer_output", "read_output_file"]
+__all__ = ["parse_output_file", "persist_analyzer_output"]

--- a/src/mergecraft/analyzers/paths.py
+++ b/src/mergecraft/analyzers/paths.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mergecraft.review_policy.paths import normalize_repo_path
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -22,4 +20,4 @@ def safe_repo_relative_path(repo_root: Path, rel: str) -> Path | None:
     return None
 
 
-__all__ = ["normalize_repo_path", "safe_repo_relative_path"]
+__all__ = ["safe_repo_relative_path"]

--- a/src/mergecraft/analyzers/run.py
+++ b/src/mergecraft/analyzers/run.py
@@ -47,7 +47,7 @@ so a new status cannot be added without deciding here whether it passes.
 
 Two readers disagreed before this existed: ``AnalyzerOutcome.passed`` accepted
 ``satisfied-by-ci`` while the approval gate's own allowlist did not, so a repo
-whose ``ciEvidence`` proved a gate green had its terminal approve rejected. The
+whose ``ciEvidence`` proved a gate green had its terminal approve rejected.
 If a new status is added to ``CheckStatus``, decide here whether it passes and
 both readers follow.
 """

--- a/src/mergecraft/analyzers/trust.py
+++ b/src/mergecraft/analyzers/trust.py
@@ -228,16 +228,10 @@ def derive_trust_tier(
 
 def build_analyzer_env(
     *,
-    event: dict[str, Any] | None,
     tier: TrustTier,
     repo_env: dict[str, str] | None = None,
-    network_allowlist: list[str] | None = None,
 ) -> dict[str, str]:
     """Build analyzer subprocess env; untrusted tier strips secrets (D7)."""
-    _ = event
-    # ``network_allowlist`` is enforced in ``sandbox.py`` (egress policy / argv
-    # construction) — not applied to subprocess env (D5/D6).
-    _ = network_allowlist
     base = dict(repo_env or os.environ)
     if tier == "trusted":
         return filter_env(base)

--- a/tests/analyzers/support.py
+++ b/tests/analyzers/support.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import json
 from pathlib import Path
 from typing import Any
 
@@ -31,9 +30,6 @@ def finding_path_matches(expected: str, actual: str) -> bool:
 
 # W0.2 measured inline cap (D14).
 INLINE_BUDGET = 8
-
-# W6 adapter ids — redaction parametrisation is structurally valid before W6 (W1.12).
-W6_ANALYZER_IDS: tuple[str, ...] = ("actionlint", "zizmor", "shellcheck", "hadolint")
 
 # Catalog expansion (C1-C6) - representative ids checked by test_catalog_docs (C0.7).
 CATALOG_ANALYZER_IDS: tuple[str, ...] = (
@@ -217,7 +213,3 @@ FORK_PULL_REQUEST_EVENT: dict[str, Any] = {
 def import_module(dotted: str) -> Any:
     """Lazy import so collection succeeds before W2 lands ``src/mergecraft/analyzers/``."""
     return importlib.import_module(dotted)
-
-
-def load_json_fixture(name: str) -> Any:
-    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))

--- a/tests/analyzers/test_adapters_supply_chain.py
+++ b/tests/analyzers/test_adapters_supply_chain.py
@@ -157,6 +157,5 @@ def test_trufflehog_verification_off_on_fork(
     verify_enabled = config.trufflehog_verify_enabled(
         repo_root=adapter_fixture_repo,
         tier=tier,
-        event=FORK_PULL_REQUEST_EVENT,
     )
     assert verify_enabled is False, "TruffleHog verification must be off on fork PRs (C2)"

--- a/tests/analyzers/test_agentsec.py
+++ b/tests/analyzers/test_agentsec.py
@@ -12,7 +12,6 @@ def _run_agentsec(repo_root: Path, changed_files: list[str]):
     return agentsec.scan_manifests(
         repo_root=repo_root,
         changed_files=changed_files,
-        tier="trusted",
     )
 
 

--- a/tests/analyzers/test_analyzer_egress_policy.py
+++ b/tests/analyzers/test_analyzer_egress_policy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -153,12 +152,3 @@ def test_egress_skip_reason_names_analyzer_and_hosts(tmp_path: Path) -> None:
     reason = outcome.reason.lower()
     assert "osv-scanner" in reason
     assert "api.osv.dev" in reason or "osv.dev" in reason
-
-
-def test_build_analyzer_env_no_longer_discards_network_allowlist() -> None:
-    """trust.py must not silently discard network_allowlist (the #538 root cause)."""
-    from mergecraft.analyzers import trust as trust_mod
-
-    source = inspect.getsource(trust_mod.build_analyzer_env)
-    assert "_ = event, network_allowlist" not in source
-    assert "network_allowlist" in source

--- a/tests/analyzers/test_shell_disabled_split.py
+++ b/tests/analyzers/test_shell_disabled_split.py
@@ -430,7 +430,6 @@ def test_analyzer_env_still_scrubbed_on_untrusted_runs(
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_shell_split_canary")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk_shell_split_canary")
     env = build_analyzer_env(
-        event=fork_pr_event,
         tier="untrusted",
         repo_env={
             "GITHUB_TOKEN": "ghp_shell_split_canary",

--- a/tests/analyzers/test_trust.py
+++ b/tests/analyzers/test_trust.py
@@ -48,7 +48,7 @@ def test_untrusted_run_strips_secret_env(monkeypatch, fork_pr_event: dict[str, o
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk_secret")
     env = trust.build_analyzer_env(
-        event=fork_pr_event, tier="untrusted", repo_env={"GITHUB_TOKEN": "ghp_secret"}
+        tier="untrusted", repo_env={"GITHUB_TOKEN": "ghp_secret"}
     )
     values = " ".join(f"{k}={v}" for k, v in env.items())
     assert "ghp_secret" not in values

--- a/tests/analyzers/test_trust.py
+++ b/tests/analyzers/test_trust.py
@@ -47,9 +47,7 @@ def test_untrusted_run_strips_secret_env(monkeypatch, fork_pr_event: dict[str, o
     trust = import_module("mergecraft.analyzers.trust")
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk_secret")
-    env = trust.build_analyzer_env(
-        tier="untrusted", repo_env={"GITHUB_TOKEN": "ghp_secret"}
-    )
+    env = trust.build_analyzer_env(tier="untrusted", repo_env={"GITHUB_TOKEN": "ghp_secret"})
     values = " ".join(f"{k}={v}" for k, v in env.items())
     assert "ghp_secret" not in values
     assert "sk_secret" not in values

--- a/tests/security/test_trust_fallthrough.py
+++ b/tests/security/test_trust_fallthrough.py
@@ -242,7 +242,7 @@ def test_every_caller_tolerates_untrusted_default(
     # Analyzer env builder must scrub secrets on the untrusted tier
     # (build_analyzer_env is a pure function: it returns a dict, never raises
     # on the untrusted branch).
-    env = build_analyzer_env(event={"some": "payload"}, tier=tier, repo_env={})
+    env = build_analyzer_env(tier=tier, repo_env={})
     assert isinstance(env, dict)
     assert "GITHUB_TOKEN" not in env
     assert "ANTHROPIC_API_KEY" not in env


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Subtract-only cleanup in `src/mergecraft/analyzers/` — no behavior change.

**Deleted / privatized**
- `requires_base_run` (`contracts.py`) — exported, zero call sites
- `normalize_repo_path` re-export from `paths.py` — callers use `review_policy.paths`
- `read_output_file` → `_read_output_file` (internal to `parse_output_file` only)
- Unused params that were accepted then ignored: `tier` on in-process agentsec/antislop scanners, `event` on `trufflehog_verify_enabled`, `offline` on `resolve_analyzer_base_ref`, `event`/`network_allowlist` on `build_analyzer_env`
- Test-only dead helpers: `W6_ANALYZER_IDS`, `load_json_fixture` (`tests/analyzers/support.py`)
- Structural test pinning removed dead `network_allowlist` param on `build_analyzer_env`

**Fixed**
- Corrupted `PASSING_CHECK_STATUSES` docstring in `run.py`
- Added missing `from __future__ import annotations` to `analyzers/__init__.py`

## Why?

Nightly audit A1: confirmed dead/stale public surface adds maintenance noise and misleading API contracts. All removals verified via ripgrep (no production importers).

## Test plan

- [x] `uv run ruff check` on touched paths — clean
- [x] `uv run pytest tests/analyzers/ -q` — 1551 passed, 3 skipped
- [x] `uv run pytest tests/security/test_trust_fallthrough.py -q` — 21 passed
- [x] ripgrep confirms removed symbols have no remaining production callers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a29f3735-5724-4edd-b78c-6ea72fd5ad1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a29f3735-5724-4edd-b78c-6ea72fd5ad1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

