### PR TITLE
fix(scm): bind one GitHub HTTP transport per event loop

### DIFF
--- a/src/mergecraft/utils/github.py
+++ b/src/mergecraft/utils/github.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any, Final
 
@@ -185,15 +187,63 @@ class GitHubClient:
         }
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-        self._client = client or httpx.AsyncClient(
+        self._headers = headers
+        self._timeout = timeout
+        self._injected_client = client
+        # One transport per event loop. A single ``httpx.AsyncClient`` binds its
+        # connection-pool primitives (``asyncio.Event``/locks) to whichever loop
+        # first drives a request through it, so sharing one client across loops
+        # raises "bound to a different event loop" on the second loop. This run
+        # has two: the main loop and the MCP HTTP server's own loop in a daemon
+        # thread (``mcp/server.py::_serve_in_thread``). Binding lazily *per loop*
+        # keeps every caller on the same ``ScmProvider`` while giving each loop a
+        # transport it owns. See PR #628, where the publish path lost both
+        # check-runs — including ``mergecraft-approval`` — to exactly this.
+        self._clients: dict[asyncio.AbstractEventLoop, httpx.AsyncClient] = {}
+
+    def _new_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
             base_url=self.base_url,
-            headers=headers,
-            timeout=timeout,
+            headers=dict(self._headers),
+            timeout=self._timeout,
         )
 
+    def _active_client(self) -> httpx.AsyncClient:
+        """Return the transport bound to the running loop, creating it on first use.
+
+        An injected client is returned as-is: the caller owns its lifecycle and
+        its loop affinity, and test seams depend on getting back the exact
+        object they passed in.
+        """
+        if self._injected_client is not None:
+            return self._injected_client
+        loop = asyncio.get_running_loop()
+        transport = self._clients.get(loop)
+        if transport is None:
+            transport = self._new_client()
+            self._clients[loop] = transport
+        return transport
+
     async def aclose(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        """Close every per-loop transport this client created.
+
+        Only the transport belonging to the running loop can be closed cleanly;
+        the rest are closed best-effort, since awaiting another loop's pool
+        raises the very error this class exists to avoid. At most one such
+        transport is ever left over, and the process exits at the end of a run.
+        """
+        if not self._owns_client:
+            return
+        running = None
+        with contextlib.suppress(RuntimeError):
+            running = asyncio.get_running_loop()
+        for loop, transport in list(self._clients.items()):
+            if loop is running:
+                await transport.aclose()
+            else:
+                with contextlib.suppress(Exception):
+                    await transport.aclose()
+        self._clients.clear()
 
     async def __aenter__(self) -> GitHubClient:
         return self
@@ -221,7 +271,7 @@ class GitHubClient:
         if not self.token:
             msg = "GitHub token is missing; cannot call the GitHub API"
             raise ValueError(msg)
-        response = await self._client.request(
+        response = await self._active_client().request(
             method,
             path,
             params=params,

--- a/tests/utils/test_empty_github_bearer_469.py
+++ b/tests/utils/test_empty_github_bearer_469.py
@@ -28,7 +28,7 @@ _EMPTY_TOKENS = ("", "   ", "\t", "\n")
 
 
 def _authorization(client: GitHubClient) -> str | None:
-    return client._client.headers.get("Authorization")
+    return client._active_client().headers.get("Authorization")
 
 
 def _result_text(result: ToolResult) -> str:
@@ -81,7 +81,7 @@ async def test_get_commit_info_without_token_reports_unavailable_naming_token(
         msg = "GitHub HTTP must not run without a token"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(github._client, "request", _spy)
+    monkeypatch.setattr(github._active_client(), "request", _spy)
     try:
         ctx = _tool_context(tmp_path, github)
         result = await get_commit_info_tool(ctx).execute({"sha": "abc1234deadbeef"})
@@ -111,7 +111,7 @@ async def test_download_artifact_zip_fail_closed_without_token(
         msg = "GitHub HTTP must not run without a token"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(github._client, "request", _spy)
+    monkeypatch.setattr(github._active_client(), "request", _spy)
     try:
         with pytest.raises(ValueError, match="token"):
             await github.download_artifact_zip("acme", "demo", 1)
@@ -132,7 +132,7 @@ async def test_download_workflow_run_logs_fail_closed_without_token(
         msg = "GitHub HTTP must not run without a token"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(github._client, "request", _spy)
+    monkeypatch.setattr(github._active_client(), "request", _spy)
     try:
         with pytest.raises(ValueError, match="token"):
             await github.download_workflow_run_logs("acme", "demo", 1)

--- a/tests/utils/test_github_client_event_loops.py
+++ b/tests/utils/test_github_client_event_loops.py
@@ -1,0 +1,165 @@
+"""One ``GitHubClient`` must survive being driven from more than one event loop.
+
+PR #628 published its review and then lost *both* check-runs — including
+``mergecraft-approval``, the one the merge gate reads — to a single warning:
+
+    status checks: failed to resolve PR #628 head sha:
+    <asyncio.locks.Event object ...> is bound to a different event loop
+
+``ToolContext.scm`` wraps one ``httpx.AsyncClient``, and a run drives it from
+two loops: the main loop and the MCP HTTP server's own loop in a daemon thread
+(``mcp/server.py::_serve_in_thread``). httpx binds its connection-pool
+primitives to whichever loop first sends a request, so the second loop raised,
+``report_status_checks`` swallowed it, and the gate failed closed on an
+approved review. The binding is lazy, which is why this was intermittent — the
+same code approved #623 cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Coroutine, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from mergecraft.utils.github import GitHubClient
+
+
+class _Handler(BaseHTTPRequestHandler):
+    # Keep-alive is the whole point: the bug needs a pooled connection that
+    # outlives the loop that opened it. HTTP/1.0 would close after each
+    # response, leave the pool empty, and the second loop would never touch
+    # the first loop's primitives.
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:
+        body = b'{"head": {"sha": "deadbeef"}}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_: object) -> None:
+        """Silence the stdlib access log."""
+
+
+@pytest.fixture
+def api_base_url() -> Iterator[str]:
+    """A real loopback HTTP server, so the httpx connection pool is exercised.
+
+    A mock or ASGI transport would not do: those bypass the pool, and the pool
+    is precisely what carries the loop-bound primitives this test is about.
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class _BackgroundLoop:
+    """A live event loop in a daemon thread — ``mcp/server.py::_serve_in_thread``.
+
+    The loop must stay *running* for the whole test, not be spun up and torn
+    down per call. A closed loop produces a different error ("Event loop is
+    closed"); the production failure needs the first loop still alive, holding
+    the pooled connection's primitives, when the second loop reaches for it.
+    """
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, name="mcp-like-loop", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def run(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=30)
+
+    def close(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=5)
+
+
+@pytest.fixture
+def mcp_loop() -> Iterator[_BackgroundLoop]:
+    background = _BackgroundLoop()
+    try:
+        yield background
+    finally:
+        background.close()
+
+
+async def test_client_serves_a_second_event_loop_after_the_first(
+    api_base_url: str, mcp_loop: _BackgroundLoop
+) -> None:
+    """The MCP loop goes first, then the publish path on the main loop must work.
+
+    This is the #628 ordering exactly: MCP tools (``submit_review_verdict``,
+    ``list_check_runs``) bind the client, then ``report_status_checks`` calls
+    ``get_pull`` on the main loop.
+    """
+    client = GitHubClient("token", base_url=api_base_url)
+    try:
+        assert mcp_loop.run(client.get("/anything")) == {"head": {"sha": "deadbeef"}}
+        # Before the per-loop fix this raised
+        # "... is bound to a different event loop".
+        assert await client.get("/anything") == {"head": {"sha": "deadbeef"}}
+    finally:
+        await client.aclose()
+
+
+async def test_each_loop_gets_its_own_transport_and_reuses_it(
+    api_base_url: str, mcp_loop: _BackgroundLoop
+) -> None:
+    """Per-loop binding, not per-request: the transport is cached by loop."""
+    client = GitHubClient("token", base_url=api_base_url)
+    try:
+        await client.get("/anything")
+        main_transport = client._active_client()
+        assert client._active_client() is main_transport
+
+        mcp_loop.run(client.get("/anything"))
+        assert len(client._clients) == 2
+        assert client._active_client() is main_transport
+    finally:
+        await client.aclose()
+
+
+async def test_injected_client_is_returned_unchanged(
+    api_base_url: str, mcp_loop: _BackgroundLoop
+) -> None:
+    """An injected transport keeps its caller-owned lifecycle and loop affinity."""
+    import httpx
+
+    injected = httpx.AsyncClient(base_url=api_base_url)
+    client = GitHubClient("token", base_url=api_base_url, client=injected)
+    try:
+        assert client._active_client() is injected
+        await client.aclose()
+        # ``aclose`` is a no-op for an injected client — still usable.
+        assert await client.get("/anything") == {"head": {"sha": "deadbeef"}}
+    finally:
+        await injected.aclose()
+
+
+async def test_aclose_releases_every_per_loop_transport(
+    api_base_url: str, mcp_loop: _BackgroundLoop
+) -> None:
+    """Closing must not leave another loop's pool behind."""
+    client = GitHubClient("token", base_url=api_base_url)
+    await client.get("/anything")
+    mcp_loop.run(client.get("/anything"))
+    assert len(client._clients) == 2
+    await client.aclose()
+    assert client._clients == {}

--- a/tests/utils/test_retry_policy.py
+++ b/tests/utils/test_retry_policy.py
@@ -73,7 +73,7 @@ class TestRetryBehavior:
         """W9.3 — a retryable GET is retried, but bounded (never a hot loop)."""
         client = GitHubClient(token="x")
         flaky = _FlakyTransport(500)
-        monkeypatch.setattr(client._client, "request", flaky)
+        monkeypatch.setattr(client._active_client(), "request", flaky)
         with pytest.raises(httpx.HTTPStatusError):
             await client.get("/repos/acme/demo")
         assert 2 <= flaky.calls <= 5, f"GET attempts unbounded or absent: {flaky.calls}"
@@ -84,7 +84,7 @@ class TestRetryBehavior:
         """W9.3 — a 422 is not retried (classification, not blanket retry)."""
         client = GitHubClient(token="x")
         flaky = _FlakyTransport(422)
-        monkeypatch.setattr(client._client, "request", flaky)
+        monkeypatch.setattr(client._active_client(), "request", flaky)
         with pytest.raises(httpx.HTTPStatusError):
             await client.get("/repos/acme/demo")
         assert flaky.calls == 1
@@ -97,7 +97,7 @@ class TestRetryBehavior:
         """
         client = GitHubClient(token="x")
         flaky = _FlakyTransport(500)
-        monkeypatch.setattr(client._client, "request", flaky)
+        monkeypatch.setattr(client._active_client(), "request", flaky)
         with pytest.raises(httpx.HTTPStatusError):
             await client.post("/repos/acme/demo/issues", json={"title": "x"})
         assert flaky.calls == 1, f"mutation retried {flaky.calls - 1} extra time(s)"


### PR DESCRIPTION
## What broke

PR #628 published its review, reached `verdict: success`, and then posted **no check-runs at all** — including `mergecraft-approval`, the one the merge gate reads. The gate failed closed on an approved review. The only trace was one warning in the `publish` group of [run 33855337279](https://github.com/alexhawat/mergeCraft/actions/runs/33855337279):

```
status checks: failed to resolve PR #628 head sha:
<asyncio.locks.Event object at 0x7fde91147a70 [unset]> is bound to a different event loop
```

`report_status_checks` (`utils/status_checks.py:264-278`) catches that and returns early, so both the `mergecraft` completion check and `mergecraft-approval` vanished without an error.

Confirmed by API: #623's head SHA carries both check-runs at `success`; #628's head carries neither.

## Why

`ToolContext.scm` wraps one `httpx.AsyncClient` (`mcp/context.py:70`, `utils/github.py`), and a run drives it from **two** event loops:

- the **main loop**, which runs the publish path, and
- the **MCP HTTP server's own loop**, in a daemon thread (`mcp/server.py::_serve_in_thread`).

httpx binds its connection-pool primitives to whichever loop first sends a request through the pool. The MCP tools (`submit_review_verdict`, `list_check_runs`) got there first, so the main loop's `get_pull` raised on the pooled connection they left behind.

The binding is lazy and only bites on a **reused** connection — which is why this is intermittent, and why the same code approved #623 cleanly.

## The fix

`GitHubClient` keeps one transport **per event loop**, created lazily at the single chokepoint every REST and GraphQL call already funnels through (`_send`).

- An injected client is returned unchanged, so test seams that pass one keep their caller-owned lifecycle and loop affinity.
- `aclose()` releases each per-loop transport — cleanly for the running loop, best-effort for the others, since awaiting another loop's pool raises the very error this change exists to avoid.
- At most two loops exist in a run, so the map stays tiny.

## Testing

Two details in the regression test are load-bearing, and I got both wrong before getting them right:

1. **A real keep-alive loopback server.** A mock or ASGI transport bypasses the connection pool — and the pool is exactly what carries the loop-bound primitives. My first attempt used HTTP/1.0, pooled nothing, and **passed against unfixed code**.
2. **A live background loop** mirroring `_serve_in_thread`. Tearing the first loop down raises `Event loop is closed`, a different failure; production needs the first loop still alive.

With both, the test reproduces the production error verbatim. Verified by reverting the fix:

```
RuntimeError: <asyncio.locks.Event object at 0x107050af0 [unset]> is bound to a different event loop
```

- `tests/utils/test_github_client_event_loops.py` — 4 tests; 3 fail without the fix
- `make lint`, `make typecheck` (533 files), `make ci-static` — all clean
- `tests/utils`, `tests/scm` — green

## Note

This is intended to ride into **pin 7** alongside #622. The gate is currently unreliable for every PR, so this should land first.

Refs #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM