### PR TITLE
fix(evidence): read confirmed findings into the approval gate

### DIFF
--- a/src/mergecraft/evidence/findings.py
+++ b/src/mergecraft/evidence/findings.py
@@ -53,6 +53,19 @@ def load_run_findings_with_drops(
     """
     state = ctx.tool_state
     raw: list[Any] = list(state.agent_findings)
+    # Judge-confirmed rows live in ``confirmed_findings``, a list distinct from
+    # ``agent_findings`` (``mcp/tool_state.py``). ``verify_agent_findings`` ->
+    # ``record_finding_verdict`` appends the confirmed row there and nowhere
+    # else, so reading only ``agent_findings`` made a confirmed agent blocker
+    # invisible to ``decide_approval`` — which is by contract "a pure function
+    # of typed findings". ``ToolState.iter_finding_rows`` already reads both,
+    # which is why such a finding still reached the review body a human reads
+    # while the packet and the gate recorded ``success``. Observed on PR #631:
+    # one queued finding, judge verdict ``confirm``, zero agent rows on the
+    # packet, ``verdict: success``. Deduplicated downstream by
+    # ``merge_findings`` on fingerprint, so a row present in both lanes is
+    # counted once.
+    raw.extend(state.confirmed_findings)
     run_state = state.analyzer_run
     if run_state is not None:
         raw.extend(list(run_state.findings))

--- a/tests/agents/test_cov_opencode_paths.py
+++ b/tests/agents/test_cov_opencode_paths.py
@@ -471,6 +471,19 @@ class _FakeBytesStream:
     def read(self) -> bytes:
         return self._data
 
+    def readline(self) -> bytes:
+        """Terminate ``opencode._drain`` instead of raising in its thread.
+
+        ``_drain`` consumes this stream with ``iter(stream.readline, b"")`` on a
+        background thread. Without ``readline`` that thread died with an
+        ``AttributeError`` *after* the owning test had finished, and the
+        traceback was printed to whatever ``sys.stderr`` happened to be current
+        — inside another test's Click ``CliRunner`` capture, where it broke an
+        unrelated assertion (``tests/cli/test_doctor.py``). Returning ``b""``
+        ends the drain loop cleanly.
+        """
+        return b""
+
 
 class _FakeClock:
     """Deterministic stand-in for the ``time`` module inside opencode."""

--- a/tests/evidence/test_confirmed_findings_reach_gate.py
+++ b/tests/evidence/test_confirmed_findings_reach_gate.py
@@ -1,0 +1,124 @@
+"""A judge-confirmed agent finding must reach the packet and block the gate.
+
+Observed on PR #631. The reviewing agent raised one finding, it passed through
+``verify_agent_findings``, and the judge returned ``confirm``:
+
+    agent-finding verification: 1 queued, 0 already withdrawn, 0 over budget
+    judge verdict: confirm on <...> | provider=codex ... lane=medium
+
+The published review said "Request changes" and GitHub recorded
+``CHANGES_REQUESTED`` — yet the evidence packet carried 13 findings, every one
+``source: "ci"``, and ``decision.verdict`` was ``success``.
+
+Cause: ``record_finding_verdict`` appends the confirmed row to
+``ToolState.confirmed_findings``, a list distinct from ``ToolState.agent_findings``.
+``load_run_findings`` read only the latter, so ``decide_approval`` — "a pure
+function of typed findings" — was handed a set with no agent blocker in it.
+``iter_finding_rows`` reads both, which is why the finding still reached the
+review body a human reads while the gate approved.
+
+This is not the #623 validation-drop bug. That fix works: a row that fails
+``Finding`` validation increments the drop count and emits run-health evidence.
+Nothing was dropped here, because the row was never in the list being read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mergecraft.agents.gates import decide_approval
+from mergecraft.analyzers.finding import make_finding
+from mergecraft.evidence.findings import load_run_findings, load_run_findings_with_drops
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import AnalyzerRunState, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    tool_state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    tool_state.analyzer_run = AnalyzerRunState(ran=True, findings=[])
+    return ToolContext(
+        agent_id="codex",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="pull_request", issue_number=631, is_pr=True),
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("codex"),
+        tool_state=tool_state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+
+
+def _confirmed_blocker(fingerprint: str = "a1b2c3d4e5f60718") -> dict[str, Any]:
+    """A Major agent finding shaped as ``record_finding_verdict`` stores it."""
+    return make_finding(
+        tool="agent",
+        rule_id="correctness",
+        category="Functional Correctness",
+        severity="Major",
+        confidence="certain",
+        message="removes a live seam without migrating its callers",
+        path="src/mergecraft/utils/github.py",
+        start_line=188,
+        end_line=188,
+        source="agent",
+        introduced_by_pr="true",
+        fingerprint=fingerprint,
+    ).model_dump()
+
+
+def test_confirmed_finding_reaches_the_packet(tmp_path: Path) -> None:
+    """The regression: confirmed-only rows were invisible to the packet."""
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.confirmed_findings.append(_confirmed_blocker())
+    assert ctx.tool_state.agent_findings == [], "the #631 shape: confirmed but not in agent lane"
+
+    findings = load_run_findings(ctx)
+
+    assert [f.rule_id for f in findings] == ["correctness"]
+    assert findings[0].severity == "Major"
+
+
+def test_confirmed_blocker_fails_the_approval_gate(tmp_path: Path) -> None:
+    """The consequence that actually mattered: the gate said ``success``."""
+    ctx = _ctx(tmp_path)
+    ctx.tool_state.confirmed_findings.append(_confirmed_blocker())
+
+    verdict = decide_approval(
+        load_run_findings(ctx),
+        run_succeeded=True,
+        tier="trusted",
+    )
+
+    assert verdict == "failure", "a judge-confirmed Major finding must block"
+
+
+def test_row_in_both_lanes_is_counted_once(tmp_path: Path) -> None:
+    """``merge_findings`` dedupes on fingerprint, so the fix cannot double-count."""
+    ctx = _ctx(tmp_path)
+    row = _confirmed_blocker()
+    ctx.tool_state.agent_findings.append(dict(row))
+    ctx.tool_state.confirmed_findings.append(dict(row))
+
+    findings, dropped = load_run_findings_with_drops(ctx)
+
+    assert len(findings) == 1
+    assert dropped == 0
+
+
+def test_no_confirmed_rows_still_approves(tmp_path: Path) -> None:
+    """The fix must not invent blockers on a clean run."""
+    ctx = _ctx(tmp_path)
+
+    assert load_run_findings(ctx) == []
+    # An empty finding set is ``neutral``, not ``success`` — absence of evidence
+    # is not evidence of approval. The point here is only that the fix adds no
+    # blocker of its own.
+    assert decide_approval([], run_succeeded=True, tier="trusted") != "failure"

--- a/tests/utils/test_github_client_event_loops.py
+++ b/tests/utils/test_github_client_event_loops.py
@@ -47,6 +47,27 @@ class _Handler(BaseHTTPRequestHandler):
         """Silence the stdlib access log."""
 
 
+class _QuietServer(ThreadingHTTPServer):
+    """A loopback server that cannot leak into another test's output.
+
+    Two hardenings, both learned from a real CI failure. ``socketserver``
+    writes "Exception occurred during processing of request ..." plus a
+    traceback straight to ``sys.stderr``; when an unrelated test is running
+    under a Click/Typer ``CliRunner``, that lands inside the runner's captured
+    output and fails *its* assertions (``tests/cli/test_doctor.py``). And
+    ``ThreadingHTTPServer`` defaults to ``daemon_threads = True``, which makes
+    ``block_on_close`` False, so ``server_close()`` returns while per-connection
+    handler threads are still alive — the keep-alive connection this module
+    needs guarantees at least one is parked in ``rfile.readline()``.
+    """
+
+    daemon_threads = False  # so block_on_close is True and server_close() joins
+    allow_reuse_address = True
+
+    def handle_error(self, request: object, client_address: object) -> None:
+        """Swallow handler errors instead of printing them to stderr."""
+
+
 @pytest.fixture
 def api_base_url() -> Iterator[str]:
     """A real loopback HTTP server, so the httpx connection pool is exercised.
@@ -54,7 +75,7 @@ def api_base_url() -> Iterator[str]:
     A mock or ASGI transport would not do: those bypass the pool, and the pool
     is precisely what carries the loop-bound primitives this test is about.
     """
-    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    server = _QuietServer(("127.0.0.1", 0), _Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:


### PR DESCRIPTION
## A judge-confirmed agent finding could not block a merge

On PR #631 the reviewing agent raised one finding, it passed through `verify_agent_findings`, and the judge confirmed it:

```
agent-finding verification: 1 queued, 0 already withdrawn, 0 over budget
judge verdict: confirm on <...> | provider=codex ... lane=medium
```

The published review said *"Request changes"* and GitHub recorded `CHANGES_REQUESTED`. The evidence packet still carried 13 findings — **every one `source: "ci"`** — and:

```json
"decision": {"verdict": "success", "reason": "success: derived from typed findings and run state"}
```

The agent's blocker was correct (it caught a real removed seam). It simply never reached the gate.

## Cause: two lists

```
mcp/tool_state.py:461   confirmed_findings: list[dict]   ← record_finding_verdict appends HERE
mcp/tool_state.py:462   agent_findings:     list[dict]
```

`load_run_findings` (`evidence/findings.py`) read only `agent_findings`, so `decide_approval` — by contract *"a pure function of typed findings"* — received a set containing no agent blocker.

`ToolState.iter_finding_rows` reads **both**. That asymmetry is the whole bug: the finding reached the review body a human reads, but not the packet or the gate.

**This is not the #623 validation-drop bug.** That fix works — a row failing `Finding` validation increments the drop count and emits run-health evidence. No drop row appeared here, because the row was never in the list being read.

## Fix

`load_run_findings_with_drops` now also reads `confirmed_findings`. `merge_findings` already dedupes on fingerprint, so a row present in both lanes is counted once.

## Testing

`tests/evidence/test_confirmed_findings_reach_gate.py` — 4 tests:

- a confirmed-only row reaches the packet
- a confirmed `Major` finding makes `decide_approval` return `failure`
- a row in both lanes is counted once, with zero drops
- a clean run gains no blocker

**Verified by reverting the fix:** both behavioural tests fail, and the gate test reproduces the production symptom — a judge-confirmed `Major` finding yields a non-blocking verdict instead of `failure`.

- `make lint`, `make typecheck` (533 files), `make ci-static` — clean
- `tests/evidence`, `tests/mcp`, `tests/agents` — 1968 passed, 0 failed

## Note

Intended for **pin 7** alongside #622 and #631. Until this ships in a pinned image, an agent blocker cannot fail the approval gate.

Refs #631, #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM