### PR TITLE
ci: bump the reviewer action pin to 7f0ef988 (pin 7)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb"
+  MERGECRAFT_ACTION_SHA: "7f0ef988613a12f1c3e2d53f616420cb6416132a"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:77822e1af04d2778701c3bc20b27022a16d88c6e8cbcb1fdd013928ba537b274"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Pin 7. Base is `pre-0.0.1` because `action-slim-bootstrap` (`ci.yml`) is the only job that publishes an image, and it is gated on `pull_request` with `base.ref == 'pre-0.0.1'`. A pin PR against `main` never triggers a build.

Pin SHA: `7f0ef988613a12f1c3e2d53f616420cb6416132a` — the `main` → `pre-0.0.1` sync merge, so it both contains the lane work and descends from `main`'s current pin.

## What pin 7 carries that pin 6 does not

| PR | Fix |
|----|-----|
| **#622** | D7 fork-YAML export-cap bypass — decided from snapshot provenance instead of an ambient `GITHUB_EVENT_NAME` read |
| **#631** | One GitHub HTTP transport per event loop |
| **#632** | Judge-confirmed agent findings now reach the approval gate |

**Why #631 matters.** `ToolContext.scm` wrapped one `httpx.AsyncClient` driven from two event loops — the main loop and the MCP server's loop in a daemon thread. httpx binds its pool primitives to whichever loop sends first, so the publish path raised `<asyncio.locks.Event ...> is bound to a different event loop`, `report_status_checks` swallowed it, and **no check-runs were posted at all** — including `mergecraft-approval`. The gate then failed closed on an approved review. Seen on #628 and again on #631 itself.

**Why #632 matters.** A judge-confirmed agent blocker landed only in `ToolState.confirmed_findings`, which `load_run_findings` never read. `decide_approval` — by contract "a pure function of typed findings" — saw no agent blocker and returned `success`, while the published review said *"Request changes"*. Under pin 6, an agent cannot block a merge.

## Two commits, in order

- **Commit 1 (this one):** `env.MERGECRAFT_ACTION_SHA` plus all three mirrored `uses: alexhawat/mergeCraft@…` lines, relabelled pin 6 → pin 7. GitHub cannot interpolate `env.` into `uses:`, so the duplication is required; `make action-pin-check` gates it.
- **Commit 2 (to follow):** `action.yml`'s `runs.image` digest, once `action-slim-bootstrap` has built and pushed the image for this SHA. The digest does not exist until that finishes.

**Do not merge after commit 1 alone** — splitting the pin from the digest turned five checks red on #562.

`check_action_pin_freshness.py` passes on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM