### PR TITLE
ci: promote pin 7 to main (7f0ef988)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb"
+  MERGECRAFT_ACTION_SHA: "7f0ef988613a12f1c3e2d53f616420cb6416132a"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@7fcdc6c2d3b6dd9b6e1ddf38abe0783cb82ef4eb # env.MERGECRAFT_ACTION_SHA / digest commit / pin 6
+        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:77822e1af04d2778701c3bc20b27022a16d88c6e8cbcb1fdd013928ba537b274"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Promotion of `pre-0.0.1` to `main` for **pin 7**. `pull_request_target` reads the workflow from `main`, so the pin is inert until this lands.

## What lands

- `MERGECRAFT_ACTION_SHA` → `7f0ef988613a12f1c3e2d53f616420cb6416132a` and the three mirrored `uses:` lines
- `action.yml` `runs.image` → `sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06` (tracing extra verified present)

Trial-merged locally: clean, two parents, and only those two files change.

## Read this before assuming pin 7 deploys the fixes it names

It does not, and that is a pre-existing procedure defect rather than a fault in these commits — see the discussion on #633.

`uses: owner/repo@<sha>` reads `action.yml` from `<sha>`'s tree and runs the image named **there**. The digest commit always lands *after* the commit being pinned, so it never applies to it. Verified: `action.yml` at pin-6 SHA `7fcdc6c2` names `e14a5e2d`, and `e14a5e2d` is exactly the image #628's review ran. The `runs.image` history shows the same pattern across eight cycles.

**Pinning to SHA_N deploys the image built for SHA_N−1.**

So:

| Pin | Deploys |
|-----|---------|
| Pin 6 (`7fcdc6c2`) | pin 5's code — **#623 was never live**, which is why the `Agent sandbox` line never rendered |
| **Pin 7 (`7f0ef988`)** | **#623's code, at last** |
| Pin 8 (next) | #622, #631, #632 |

This promotion is still a strict improvement: it advances the deployed image by one cycle and finally ships #623. **Pin 8 follows immediately** to deploy the event-loop and confirmed-findings fixes.

`check_action_image_digest.py` and `check_action_pin_freshness.py` both pass on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM