### PR TITLE
refactor(mcp): remove process_state shim and git_askpass_path bookkeeping

### DIFF
--- a/src/mergecraft/mcp/process_state.py
+++ b/src/mergecraft/mcp/process_state.py
@@ -1,7 +1,0 @@
-"""Process-wide MCP state that must not leak across tests under xdist (#421 / D4)."""
-
-from __future__ import annotations
-
-from mergecraft.mcp.shared import reset_mcp_process_state
-
-__all__ = ["reset_mcp_process_state"]

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -397,9 +397,6 @@ class ToolState:
     # ``main.py`` can wire it into the agent prompt at both call sites and
     # into the outcome resolution path. Empty string = no failure.
     setup_hook_failure: str = ""
-    # Former askpass path retained for bookkeeping only — ``setup_git`` shreds
-    # the on-disk helper immediately (auth is MCP ``http.extraHeader``; W2.2).
-    git_askpass_path: str | None = None
     xrepo_learnings_file_path: str | None = None
     xrepo_learnings_seed: str | None = None
     xrepo_learnings_persist_attempted: bool = False

--- a/src/mergecraft/utils/git_setup.py
+++ b/src/mergecraft/utils/git_setup.py
@@ -372,7 +372,6 @@ def setup_git(
     # surface for root-UID MCP ``shell=restricted`` (Thermos Final). Auth is
     # brokered per-op via MCP git ``http.extraHeader`` — never ``GIT_ASKPASS``.
     askpass = write_askpass_script(temp, git_token)
-    tool_state.git_askpass_path = askpass
     askpass_path = Path(askpass)
     if askpass_path.is_file():
         _secure_overwrite_file(askpass_path)

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from mergecraft.mcp.process_state import reset_mcp_process_state
+from mergecraft.mcp.shared import reset_mcp_process_state
 
 
 @pytest.fixture(autouse=True)

--- a/tests/mcp/test_xdist_isolation.py
+++ b/tests/mcp/test_xdist_isolation.py
@@ -71,7 +71,7 @@ def _tool_ctx(tmp_path: Path) -> ToolContext:
 
 def _find_reset_mcp_process_state() -> Callable[[], object] | None:
     for module_name in (
-        "mergecraft.mcp.process_state",
+        "mergecraft.mcp.shared",
         "mergecraft.mcp.isolation",
         "mergecraft.mcp.server",
     ):
@@ -117,7 +117,7 @@ def test_reset_mcp_process_state_is_public_api() -> None:
     """D4 — module-level MCP caches must expose a process reset hook."""
     reset = _find_reset_mcp_process_state()
     assert reset is not None, (
-        "export reset_mcp_process_state() from mergecraft.mcp.{process_state,isolation,server}"
+        "export reset_mcp_process_state() from mergecraft.mcp.{shared,isolation,server}"
     )
     reset()
 

--- a/tests/security/test_credentials.py
+++ b/tests/security/test_credentials.py
@@ -26,6 +26,7 @@ from mergecraft.agents import opencode as opencode_mod
 from mergecraft.security.broker import CODEX_BROKER_BEARER_ENV
 from mergecraft.utils.git_setup import (
     register_created_path,
+    reviewer_askpass_credentials_dir,
     setup_git,
     wipe_runner_leak_surface,
     write_askpass_script,
@@ -224,8 +225,8 @@ def test_agent_cannot_locate_askpass_script(
         shell="restricted",
         tmpdir=str(tmp_path),
     )
-    askpass_path = state.git_askpass_path
-    assert askpass_path is not None
+    askpass_path = str(reviewer_askpass_credentials_dir(str(tmp_path)) / "git-askpass.sh")
+    assert not Path(askpass_path).exists(), "askpass helper must be shredded after setup_git"
     env = claude._build_env(make_agent_run_ctx())
     assert "GIT_ASKPASS" not in env
     assert askpass_path not in env.values()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Nightly audit cleanup B2 — subtract dead MCP bookkeeping with no behavior change:

1. **Delete `process_state.py`** — thin re-export of `reset_mcp_process_state` from `shared.py`. Importers now use `mergecraft.mcp.shared` directly (`tests/mcp/conftest.py`, `test_xdist_isolation.py` module search list updated).
2. **Remove `ToolState.git_askpass_path`** — ripgrep confirmed set-only in `git_setup.py`, read only in one security test. No runtime consumer after askpass shred. `test_agent_cannot_locate_askpass_script` now asserts via `reviewer_askpass_credentials_dir` + filesystem (file absent, path not in agent env).

Net: **−10 lines** (6 files).

## Why?

Confirmed dead re-export shim and bookkeeping-only field from nightly audit B2 (2026-09-05). No redesigns; B1 perf (#635), review.py splits, and ToolState nesting refactors explicitly out of scope.

## Skipped

- **`git_askpass_path` runtime reader check:** ripgrep found no reader outside tests — field removed (not skipped).
- **`review.py` split / ToolState nesting:** out of scope per audit charter.

## Test plan

- [x] ripgrep clean for deleted module (`process_state.py`) and field (`git_askpass_path`)
- [x] `pytest tests/mcp/test_xdist_isolation.py tests/security/test_credentials.py::test_agent_cannot_locate_askpass_script tests/security/test_credentials.py::test_setup_git_does_not_export_askpass_to_shared_env -q` — 10 passed
- [x] `ruff format` + `ruff check` on touched paths — clean
- [ ] Full `tests/mcp/` suite — 934 passed locally; 6 pre-existing failures unrelated to this diff (missing `.venv/bin/mergecraft` CLI for stdio integration tests, static-checks env issues)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4fe85fb-66b5-4da2-b06c-4494357403a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4fe85fb-66b5-4da2-b06c-4494357403a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

