### PR TITLE
docs: nightly audit B5 — consumer/docs drift cleanup (2026-09-05)

### DIFF
--- a/.github/agents/wave-plan-executor.md
+++ b/.github/agents/wave-plan-executor.md
@@ -96,7 +96,7 @@ ask whether to skip.
   `src/mergecraft/analyzers/pipeline.py`.
 
 ## Step 4 — Execute to project standards
-- Stack is Python 3.14+, package under `src/mergecraft/`, repo config in
+- Stack is Python 3.11+ (CI matrix includes 3.14), package under `src/mergecraft/`, repo config in
   `.mergecraft/config.yaml`, Action inputs in `action.yml`.
 - Loguru only; mypy strict; Pyright; Conventional Commits.
 - **Always use uv**: every Python tool invocation goes through `uv run` / `uv sync`. Never raw

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contributor setup, make targets, and PR expectations for mergeCraft itself.
 make setup
 ```
 
-Requires Python 3.14 and [uv](https://docs.astral.sh/uv/).
+Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/) ([`docs/dev/python-version-floor.md`](docs/dev/python-version-floor.md)).
 
 `make setup` and all Makefile targets use a dedicated project virtualenv at
 `.venv-dev` (via `UV_PROJECT_ENVIRONMENT` in the Makefile). This keeps the dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,9 @@ Map of consumer and contributor pages tracked in [`docs/manifest.yaml`](manifest
 | [EXIT-CODES](EXIT-CODES.md) | consumer | Named CLI exit codes and when mergecraft returns each status. |
 | [docs README](README.md) | contributor | Generated map of every manifest row with audience and purpose. |
 | [REVIEW-DOCTRINE](REVIEW-DOCTRINE.md) | contributor | Review philosophy, lenses, grading, and verifier doctrine for maintainers. |
+| [THREAT-MODEL](THREAT-MODEL.md) | contributor | Threat model — egress allow-list, SSRF guards, and vulnerability gate regression surface (#362). |
 | [TRACING](TRACING.md) | contributor | Tracing sinks, retention, and Logfire/OTLP wiring for operators. |
+| [coding-standards](_standards/coding-standards.md) | contributor | Normative repo-wide coding conventions — style, types, async, testing, security, Git. |
 | [action-reference](action-reference.md) | consumer | Complete action.yml input and output reference for the GitHub Action. |
 | [agent-loop](agent-loop.md) | consumer | Reference workflow for an external coding agent looping with mergecraft review --agent. |
 | [agent-roster](agent-roster.md) | consumer | Agent roster — priority slots, named agents, local overrides, multi-reviewer merge, and trust snapshot (D9). |

--- a/docs/_standards/coding-standards.md
+++ b/docs/_standards/coding-standards.md
@@ -31,7 +31,7 @@ Standards and conventions for all code written in mergeCraft. Follow these consi
 
 ## Language & Runtime
 
-- **Python 3.14+** — use modern syntax (match/case, `X | Y` unions, PEP 695 type params where they help)
+- **Python 3.11+** — install floor in `pyproject.toml`; CI runs 3.11 and 3.14. Use modern syntax where the floor allows (match/case, `X | Y` unions, PEP 695 type params where they help)
 - **Package manager:** uv (not pip directly)
 - **Build system:** hatchling
 - **Source layout:** `src/mergecraft/` (src layout, not flat)

--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -5,8 +5,10 @@ mergeCraft to **review**, **consumes findings**, **decides** what to change
 next, and reviews the new **diff**. This is not a Fix/write loop — mergeCraft
 stays review-only.
 
-Do not put this workflow under `skills/` (harness packages ship later via the
-README v2 program). The machine surface is `mergecraft review --agent`.
+Do not put this workflow under `skills/` — this page is contributor reference,
+not an Agent Skills package. Per-harness packages live under
+`skills/<harness>/mergecraft/` per [`skills/harnesses.yaml`](../skills/harnesses.yaml).
+The machine surface is `mergecraft review --agent`.
 
 ## The five steps
 
@@ -39,9 +41,9 @@ Named exits the loop should handle: `0` (pass), `10` (findings), `11`
 See also: [`docs/cli.md`](cli.md) (`review --agent`),
 [`docs/workflows.md`](workflows.md) (local review examples).
 
-Harness packages for Codex, Gemini CLI, and OpenCode are not authored here.
-Once README v2 RV3 lands, `skills/harnesses.yaml` is the authority this page
-should cite for install paths. Until then, create nothing under `skills/`.
+Per-harness Agent Skills packages ship under `skills/<harness>/mergecraft/`.
+Install paths and alt paths are authoritative in
+[`skills/harnesses.yaml`](../skills/harnesses.yaml).
 
 ## Public MCP (same engine, different wire)
 

--- a/docs/manifest.yaml
+++ b/docs/manifest.yaml
@@ -139,6 +139,18 @@ pages:
     generator: null
     purpose: Tracing sinks, retention, and Logfire/OTLP wiring for operators.
 
+  - path: docs/THREAT-MODEL.md
+    audience: contributor
+    template: contributor
+    generator: null
+    purpose: Threat model — egress allow-list, SSRF guards, and vulnerability gate regression surface (#362).
+
+  - path: docs/_standards/coding-standards.md
+    audience: contributor
+    template: contributor
+    generator: null
+    purpose: Normative repo-wide coding conventions — style, types, async, testing, security, Git.
+
   - path: docs/CONTRIBUTING-ANALYZERS.md
     audience: contributor
     template: contributor

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -21,7 +21,7 @@ notes stay in [compatibility-matrix.md](compatibility-matrix.md).
 | SCM | Role | Status |
 |------|------|------|
 | `github` | Webhook + review ingress | Supported |
-| `gitlab` | Webhook + review ingress | Supported |
+| `gitlab` | Webhook + review ingress | Not supported yet |
 | `bitbucket` | Webhook ingress | Not supported |
 
 ## Languages

--- a/scripts/gen_support_matrix.py
+++ b/scripts/gen_support_matrix.py
@@ -3,7 +3,7 @@
 
 Module: scripts.gen_support_matrix
 Depends: argparse, difflib, pathlib, sys,
-    mergecraft.analyzers.registry, mergecraft.models, mergecraft.scm.webhooks
+    mergecraft.analyzers.registry, mergecraft.models
 
 Builds OS, SCM, language, analyzer, provider, and model tables from live
 catalogs so ``make docs-check`` fails when those sources drift. File 8 RV4
@@ -24,7 +24,6 @@ from pathlib import Path
 
 from mergecraft.analyzers.registry import load_catalog
 from mergecraft.models import PROVIDERS
-from mergecraft.scm.webhooks import SUPPORTED_WEBHOOK_PROVIDERS
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_PATH = REPO_ROOT / "docs" / "support-matrix.md"
@@ -80,11 +79,13 @@ def gen_support_matrix() -> str:
             notes = "preferred" if defn.preferred else "—"
             model_rows.append((f"`{provider_key}/{model_id}`", f"`{provider_key}`", notes))
 
+    # 0.1.0 review ingress is GitHub-only; GitLabScmAdapter raises
+    # UnsupportedScmCapability for all review operations (DG9 stub).
     scm_rows = [
-        (f"`{name}`", "Webhook + review ingress", "Supported")
-        for name in sorted(SUPPORTED_WEBHOOK_PROVIDERS)
+        ("`github`", "Webhook + review ingress", "Supported"),
+        ("`gitlab`", "Webhook + review ingress", "Not supported yet"),
+        ("`bitbucket`", "Webhook ingress", "Not supported"),
     ]
-    scm_rows.append(("`bitbucket`", "Webhook ingress", "Not supported"))
 
     language_rows = [(lang, "Analyzer catalog `languages:`") for lang in languages]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only drift cleanup for the 2026-09-05 nightly audit (B5). Aligns consumer/contributor docs with code-true reality. Net +17 lines across 8 files.

## Fixes (with evidence)

### 1. GitLab support claim

**Problem:** `docs/support-matrix.md` marked `gitlab` as **Supported** for "Webhook + review ingress".

**Code reality:**
- `docs/install.md` and `docs/distribution.md` already state mergeCraft **0.1.0 is GitHub-only**.
- `src/mergecraft/scm/gitlab.py` — `GitLabScmAdapter` is a demand-gated stub; every operation raises `UnsupportedScmCapability` with message `"GitLab support is not available in this release"`.
- Webhook verification for GitLab exists (`src/mergecraft/scm/webhooks.py`), but review ingress via SCM does not.

**Fix:** `scripts/gen_support_matrix.py` now emits `gitlab` → **Not supported yet**; regenerated `docs/support-matrix.md`.

### 2. Python floor (3.11+ vs 3.14 required)

**Canonical floor:** `pyproject.toml` has `requires-python = ">=3.11"`; `AGENTS.md` and `docs/dev/python-version-floor.md` document 3.11+ with CI on 3.11 and 3.14.

**Conflicting docs fixed:**
- `CONTRIBUTING.md` — was "Requires Python 3.14"
- `docs/_standards/coding-standards.md` — was "Python 3.14+"
- `.github/agents/wave-plan-executor.md` — was "Python 3.14+"

Left untouched: `docs/test-plans/` archive (out of scope), CI matrix legs that intentionally run 3.14.

### 3. Manifest gaps

**Problem:** Shipped, linked docs missing from `docs/manifest.yaml`:
- `docs/THREAT-MODEL.md` — linked from `docs/trust-policy.md`
- `docs/_standards/coding-standards.md` — linked from `AGENTS.md`

**Fix:** Added manifest rows; regenerated `docs/README.md` index.

**Skipped:** `docs/dev/local-analyzers.md` — not linked from any manifest/surface page (internal contributor note only).

### 4. Stale agent-loop / README v2 copy

**Problem:** `docs/agent-loop.md` still referenced "README v2 program" / "Once README v2 RV3 lands" and said harness packages were not authored.

**Reality:** `skills/harnesses.yaml` and per-harness packages under `skills/<harness>/mergecraft/` are shipped (8 harness SKILL.md files present).

**Fix:** Cite `skills/harnesses.yaml` as the install-path authority; remove stale RV3 deferral language.

## Out of scope (honoured)

- No changes under `src/mergecraft/`
- No `docs/test-plans/` archive work
- No #630 (`mcp-server-json`, evals/results, generate_c6_catalog) overlap

## Verification

```bash
uv run python scripts/gen_docs.py --check   # green
uv run pytest tests/docs/ -q                # 153 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff2d1a17-75e8-47eb-b1fe-f23d1b8f7ba6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff2d1a17-75e8-47eb-b1fe-f23d1b8f7ba6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

