### PR TITLE
ci: bump the reviewer action pin to 3f48d9fe (pin 8)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "7f0ef988613a12f1c3e2d53f616420cb6416132a"
+  MERGECRAFT_ACTION_SHA: "3f48d9fe8d4a46a726278fc7fc06553e7e718129"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:8afe41b9946c740e8d0fa03dc4c99476bb80f79e13c579013f05a8b751030782"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
**This is the pin that actually deploys #622, #631 and #632.**

Pin SHA: `3f48d9fe8d4a46a726278fc7fc06553e7e718129` — the `main` → `pre-0.0.1` sync merge.

## Why this one deploys the fixes and pin 7 did not

`uses: owner/repo@<sha>` reads `action.yml` from `<sha>`'s tree and runs the image named **there**. The digest commit always lands *after* the commit being pinned, so **pinning to SHA_N deploys the image built for SHA_N−1** — confirmed across eight cycles in the #633 discussion, and proven by `action.yml` at pin-6's `7fcdc6c2` naming `e14a5e2d`, exactly the image #628's review ran.

`action.yml` at `3f48d9fe` names **`sha256:ecc18ddd…`**, the image built for pin 7's `7f0ef988`. That image carries:

| PR | Fix |
|----|-----|
| **#622** | D7 fork-YAML export-cap bypass |
| **#631** | One GitHub HTTP transport per event loop — stops `report_status_checks` silently losing every check-run, including `mergecraft-approval`, which failed the merge gate closed on approved reviews |
| **#632** | Judge-confirmed agent findings reach `decide_approval`, so an agent blocker can actually block |

## Two commits

- **Commit 1 (this one):** `env.MERGECRAFT_ACTION_SHA` plus the three mirrored `uses:` lines, relabelled pin 7 → pin 8.
- **Commit 2 (to follow):** `action.yml`'s `runs.image` digest for the image `action-slim-bootstrap` builds for this SHA. Note that digest governs **pin 9**, not this pin — which is the defect itself, not a mistake in this PR.

**Do not merge after commit 1 alone** (#562).

## Still outstanding

The underlying procedure defect — every pin ships one cycle stale — is not fixed here. It needs a design change to the pin/digest ordering and to `check_action_image_digest.py`, whose current invariant (`action.yml` digest == digest of the image tagged `MERGECRAFT_ACTION_SHA`) is one the pinned tree can never satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM