### PR TITLE
ci: promote pin 8 to main (3f48d9fe)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "7f0ef988613a12f1c3e2d53f616420cb6416132a"
+  MERGECRAFT_ACTION_SHA: "3f48d9fe8d4a46a726278fc7fc06553e7e718129"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@7f0ef988613a12f1c3e2d53f616420cb6416132a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 7
+        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:8afe41b9946c740e8d0fa03dc4c99476bb80f79e13c579013f05a8b751030782"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Promotion of `pre-0.0.1` to `main` for **pin 8**. `pull_request_target` reads the workflow from `main`, so the pin is inert until this lands.

**This is the promotion that actually deploys #622, #631 and #632.**

## What runs after this merges

`uses: alexhawat/mergeCraft@3f48d9fe` → GitHub reads `action.yml` **at `3f48d9fe`** → runs `sha256:ecc18ddd…`, the image built for pin 7's `7f0ef988`. That image carries:

| PR | Fix |
|----|-----|
| **#622** | D7 fork-YAML export-cap bypass — snapshot provenance instead of an ambient `GITHUB_EVENT_NAME` read |
| **#631** | One GitHub HTTP transport per event loop. Pin 7 and earlier intermittently posted **no check-runs at all**, including `mergecraft-approval`, so the merge gate failed closed on approved reviews (#628, #631) |
| **#632** | Judge-confirmed agent findings reach `decide_approval`, so an agent blocker can actually block a merge |

Verified directly:

```
$ git show 3f48d9fe:action.yml | grep image:
  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:ecc18ddd2f824430fe9a903ed0fa8493834ed9eb05b2d6e3fe558fcc7c11ec06"
```

## Contents

- `MERGECRAFT_ACTION_SHA` → `3f48d9fe8d4a46a726278fc7fc06553e7e718129` and the three mirrored `uses:` lines
- `action.yml` `runs.image` → `sha256:8afe41b9…` (tracing extra verified present)

Trial-merged locally: clean, two parents, only those two files change.

## On the `8afe41b9` digest

That digest governs **pin 9**, not pin 8 — the one-cycle lag documented in #641. It is not a mistake in this PR; it is the defect being tracked. What pin 8 deploys is `ecc18ddd`, as shown above.

#641 carries the proposed fix: pin the *digest commit* rather than the sync commit, and change `check_action_image_digest.py` to resolve `action.yml` at the pinned SHA instead of from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwjHX6zooRWZZVdqUN66xM