### PR TITLE
chore(agents): nightly audit cleanup C1 — remove dead lens stubs

### DIFF
--- a/scripts/check_type_ignores.py
+++ b/scripts/check_type_ignores.py
@@ -37,7 +37,6 @@ D6_SRC_PATHS: frozenset[str] = frozenset(
     {
         "src/mergecraft/agents/_stream_consumer.py",
         "src/mergecraft/agents/codex.py",
-        "src/mergecraft/agents/ensemble.py",
         "src/mergecraft/agents/structured_handoff.py",
         "src/mergecraft/analyzers/adapters.py",
         "src/mergecraft/analyzers/parsers/osv_json.py",

--- a/src/mergecraft/agents/lenses/api-compatibility.py
+++ b/src/mergecraft/agents/lenses/api-compatibility.py
@@ -1,5 +1,0 @@
-"""Bundled lens: api-compatibility (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["api-compatibility"]

--- a/src/mergecraft/agents/lenses/concurrency.py
+++ b/src/mergecraft/agents/lenses/concurrency.py
@@ -1,5 +1,0 @@
-"""Bundled lens: concurrency (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["concurrency"]

--- a/src/mergecraft/agents/lenses/copy-vs-code.py
+++ b/src/mergecraft/agents/lenses/copy-vs-code.py
@@ -1,5 +1,0 @@
-"""Bundled lens: copy-vs-code (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["copy-vs-code"]

--- a/src/mergecraft/agents/lenses/correctness.py
+++ b/src/mergecraft/agents/lenses/correctness.py
@@ -1,5 +1,0 @@
-"""Bundled lens: correctness (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["correctness"]

--- a/src/mergecraft/agents/lenses/cross-repo.py
+++ b/src/mergecraft/agents/lenses/cross-repo.py
@@ -1,5 +1,0 @@
-"""Bundled lens: cross-repo (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["cross-repo"]

--- a/src/mergecraft/agents/lenses/data-integrity.py
+++ b/src/mergecraft/agents/lenses/data-integrity.py
@@ -1,5 +1,0 @@
-"""Bundled lens: data-integrity (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["data-integrity"]

--- a/src/mergecraft/agents/lenses/dependency-build.py
+++ b/src/mergecraft/agents/lenses/dependency-build.py
@@ -1,5 +1,0 @@
-"""Bundled lens: dependency-build (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["dependency-build"]

--- a/src/mergecraft/agents/lenses/holistic.py
+++ b/src/mergecraft/agents/lenses/holistic.py
@@ -1,5 +1,0 @@
-"""Bundled lens: holistic (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["holistic"]

--- a/src/mergecraft/agents/lenses/impact.py
+++ b/src/mergecraft/agents/lenses/impact.py
@@ -1,5 +1,0 @@
-"""Bundled lens: impact (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["impact"]

--- a/src/mergecraft/agents/lenses/integration.py
+++ b/src/mergecraft/agents/lenses/integration.py
@@ -1,5 +1,0 @@
-"""Bundled lens: integration (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["integration"]

--- a/src/mergecraft/agents/lenses/operational-readiness.py
+++ b/src/mergecraft/agents/lenses/operational-readiness.py
@@ -1,5 +1,0 @@
-"""Bundled lens: operational-readiness (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["operational-readiness"]

--- a/src/mergecraft/agents/lenses/performance.py
+++ b/src/mergecraft/agents/lenses/performance.py
@@ -1,5 +1,0 @@
-"""Bundled lens: performance (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["performance"]

--- a/src/mergecraft/agents/lenses/policy.py
+++ b/src/mergecraft/agents/lenses/policy.py
@@ -1,5 +1,0 @@
-"""Bundled lens: policy (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["policy"]

--- a/src/mergecraft/agents/lenses/privilege-drop-ordering.py
+++ b/src/mergecraft/agents/lenses/privilege-drop-ordering.py
@@ -1,5 +1,0 @@
-"""Bundled lens: privilege-drop-ordering (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["privilege-drop-ordering"]

--- a/src/mergecraft/agents/lenses/requirements.py
+++ b/src/mergecraft/agents/lenses/requirements.py
@@ -1,5 +1,0 @@
-"""Bundled lens: requirements (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["requirements"]

--- a/src/mergecraft/agents/lenses/research-validated-assumptions.py
+++ b/src/mergecraft/agents/lenses/research-validated-assumptions.py
@@ -1,5 +1,0 @@
-"""Bundled lens: research-validated-assumptions (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["research-validated-assumptions"]

--- a/src/mergecraft/agents/lenses/schema-migration.py
+++ b/src/mergecraft/agents/lenses/schema-migration.py
@@ -1,5 +1,0 @@
-"""Bundled lens: schema-migration (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["schema-migration"]

--- a/src/mergecraft/agents/lenses/security.py
+++ b/src/mergecraft/agents/lenses/security.py
@@ -1,5 +1,0 @@
-"""Bundled lens: security (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["security"]

--- a/src/mergecraft/agents/lenses/test-integrity.py
+++ b/src/mergecraft/agents/lenses/test-integrity.py
@@ -1,5 +1,0 @@
-"""Bundled lens: test-integrity (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["test-integrity"]

--- a/src/mergecraft/agents/lenses/user-journey.py
+++ b/src/mergecraft/agents/lenses/user-journey.py
@@ -1,5 +1,0 @@
-"""Bundled lens: user-journey (AP5)."""
-
-from mergecraft.agents.lenses._definitions import LENS_DEFINITIONS
-
-LENS = LENS_DEFINITIONS["user-journey"]

--- a/src/mergecraft/agents/structured_handoff.py
+++ b/src/mergecraft/agents/structured_handoff.py
@@ -18,8 +18,6 @@ from mergecraft.agents.verifier import AgentFinding, plan_agent_verifications
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from mergecraft.agents.registry import AgentBinding
-
 _TYPED_FINDINGS_MARKER: Final[str] = "---typed-findings---"
 # Matched against the original text so the offsets stay byte-for-byte valid:
 # ``casefold()`` is not length-preserving (``ß`` → ``ss``), and the reasoning
@@ -79,9 +77,8 @@ def parse_specialist_handoff(raw: str) -> SpecialistHandoff:
     return SpecialistHandoff(reasoning=reasoning, findings=tuple(findings))
 
 
-def build_specialist_dispatch_prompt(binding: AgentBinding) -> str:
+def build_specialist_dispatch_prompt() -> str:
     """Discovery dispatch brief — no finding schema pre-shapes output (D6)."""
-    del binding
     return (
         "Review the dispatched scope using read-only tools. Reason in free-form "
         "prose while you investigate — do not pre-format findings as JSON during "

--- a/src/mergecraft/agents/verifier.py
+++ b/src/mergecraft/agents/verifier.py
@@ -594,8 +594,3 @@ def record_verifier_verdict(
         escalated_to_human=False,
         reason=verdict.reason,
     )
-
-
-def withdrawn_fingerprint_for_reason(reason: str) -> str:
-    """Stable fingerprint input for a withdrawn-finding bullet."""
-    return finding_fingerprint(path="", body=reason)

--- a/tests/agents/test_multi_reviewer_execution.py
+++ b/tests/agents/test_multi_reviewer_execution.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from tests.cli.support_agent_roster import (
-    import_reviewer_merge,
+    import_terminal_submission,
     two_reviewer_config,
     write_config,
 )
@@ -51,7 +51,7 @@ def test_default_subagent_selection_returns_every_reviewer_plus_verifier(
 
 
 def test_merge_dedupes_identical_path_body_line() -> None:
-    mod = import_reviewer_merge()
+    mod = import_terminal_submission()
     left = [_finding(path="a.py", body="bug", line=10)]
     right = [_finding(path="a.py", body="bug", line=10)]
     merged = mod.merge_reviewer_findings([("reviewer", left), ("reviewer2", right)])
@@ -60,7 +60,7 @@ def test_merge_dedupes_identical_path_body_line() -> None:
 
 
 def test_merge_preserves_critical_findings_at_different_lines() -> None:
-    mod = import_reviewer_merge()
+    mod = import_terminal_submission()
     left = [_finding(path="a.py", body="bug one", line=10)]
     right = [_finding(path="a.py", body="bug two", line=20)]
     merged = mod.merge_reviewer_findings([("reviewer", left), ("reviewer2", right)])
@@ -69,7 +69,7 @@ def test_merge_preserves_critical_findings_at_different_lines() -> None:
 
 
 def test_merged_findings_yield_one_verdict_and_one_terminal_submission() -> None:
-    mod = import_reviewer_merge()
+    mod = import_terminal_submission()
     findings = mod.merge_reviewer_findings(
         [
             ("reviewer", [_finding(path="a.py", body="warn", line=1, severity="warning")]),
@@ -88,7 +88,7 @@ def test_merged_findings_yield_one_verdict_and_one_terminal_submission() -> None
 
 
 def test_critical_from_reviewer2_blocks_when_reviewer_approves() -> None:
-    mod = import_reviewer_merge()
+    mod = import_terminal_submission()
     findings = mod.merge_reviewer_findings(
         [
             ("reviewer", []),
@@ -100,7 +100,7 @@ def test_critical_from_reviewer2_blocks_when_reviewer_approves() -> None:
 
 
 def test_one_reviewer_failing_does_not_void_other_findings() -> None:
-    mod = import_reviewer_merge()
+    mod = import_terminal_submission()
     surviving = [_finding(path="a.py", body="still here", line=3)]
     merged = mod.merge_reviewer_findings(
         [

--- a/tests/agents/test_structured_handoff.py
+++ b/tests/agents/test_structured_handoff.py
@@ -80,13 +80,9 @@ def test_specialist_returns_typed_findings(tmp_path: Path) -> None:
 
 def test_free_form_discovery_is_not_constrained(tmp_path: Path) -> None:
     """Discovery dispatch must not pre-shape output with a finding schema (D6)."""
-    from mergecraft.agents.registry import AgentRole
     from mergecraft.agents.structured_handoff import build_specialist_dispatch_prompt
 
-    _write_config(tmp_path, _DEFAULT_MODELS_YAML)
-    registry = _load_registry(tmp_path)
-    reviewer = registry.resolve_role(AgentRole.reviewer)
-    prompt = build_specialist_dispatch_prompt(reviewer)
+    prompt = build_specialist_dispatch_prompt()
     lowered = prompt.casefold()
     assert "json schema" not in lowered
     assert "output_schema" not in lowered

--- a/tests/cli/support_agent_roster.py
+++ b/tests/cli/support_agent_roster.py
@@ -98,7 +98,7 @@ def import_agent_local_cmd() -> Any:
     return import_module_or_fail(AGENT_LOCAL_CMD_MODULE)
 
 
-def import_reviewer_merge() -> Any:
+def import_terminal_submission() -> Any:
     return import_module_or_fail(REVIEWER_TERMINAL_MODULE)
 
 
@@ -258,7 +258,7 @@ __all__ = [
     "import_agent_cmd",
     "import_agent_local_cmd",
     "import_agent_roster",
-    "import_reviewer_merge",
+    "import_terminal_submission",
     "init_git_repo",
     "local_config_path",
     "local_config_text",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Subtract post-#627 dead surface from `agents/lenses` and a few tiny related stubs:

- Delete 20 unused lens stub modules (each only set `LENS = LENS_DEFINITIONS[id]` with zero importers). Kept `_definitions.py`, `_bindings.py`, `_base.py`, `_menu.py`, `__init__.py`.
- Remove dead `withdrawn_fingerprint_for_reason` from `verifier.py` (zero callers).
- Drop stale `agents/ensemble.py` entry from `scripts/check_type_ignores.py` `D6_SRC_PATHS` (file deleted in #627).
- Rename test helper `import_reviewer_merge()` → `import_terminal_submission()` (imports `review.terminal_submission`).
- Drop unused `binding` param on `build_specialist_dispatch_prompt()` (was `del binding`).

Net: **−113 lines** across 26 files.

## Why?

Nightly audit cleanup C1 (2026-09-06). Confirmed residual dead code after the lens registry consolidation in #627. No lens runtime redesign; no dispatch/settings changes.

## Test plan

- [x] ripgrep: no imports of deleted lens stub modules
- [x] `uv run pytest tests/agents/test_multi_reviewer_execution.py tests/agents/test_structured_handoff.py` — 40 passed
- [x] `uv run ruff format` + `ruff check` on touched paths — clean
- [ ] `make ci` (CI gate on merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9840b2b-4871-474c-9791-2a5e14e3f7e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9840b2b-4871-474c-9791-2a5e14e3f7e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

