### PR TITLE
ci: bump the reviewer action pin to e3a0cc27 (pin 9)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "3f48d9fe8d4a46a726278fc7fc06553e7e718129"
+  MERGECRAFT_ACTION_SHA: "e3a0cc27f8212c7abe4060847d5810d2fba31f9d"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:8afe41b9946c740e8d0fa03dc4c99476bb80f79e13c579013f05a8b751030782"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:d7ed9a04f22072934ca7adb07e0b53b243c931c36a5bdd797ed1484960193cfa"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
Bumps `MERGECRAFT_ACTION_SHA` (and the three `uses: alexhawat/mergeCraft@…` pins) to `e3a0cc27f8212c7abe4060847d5810d2fba31f9d`, the current tip of `main`.

`scripts/check_action_pin_freshness.py`'s staleness check started failing repo-wide today: today's merges (#626, #627, #636, #638, #628, #637, #643, #644 — 8 commits touching `src/mergecraft/`) pushed the pin's product-code lag past `MAX_PRODUCT_LAG=5`. That in turn breaks `Verify (static + build)` — a required status check — on every PR rebased onto current `main`, and it also breaks `main`'s own post-merge `ci-cd.yml` (which runs `make ci` including this same check), so no new slim image can publish through the normal path either.

This PR relies on `action-slim-bootstrap` (gated to PRs against `pre-0.0.1`) to build and push `ghcr.io/alexhawat/mergecraft:e3a0cc27f8212c7abe4060847d5810d2fba31f9d` since no image exists yet for this commit. A follow-up commit will update `action.yml`'s digest pin once that image is published, matching the #640/#633/#624 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)