### PR TITLE
ci: promote pin 9 to main (e3a0cc27)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "3f48d9fe8d4a46a726278fc7fc06553e7e718129"
+  MERGECRAFT_ACTION_SHA: "e3a0cc27f8212c7abe4060847d5810d2fba31f9d"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@3f48d9fe8d4a46a726278fc7fc06553e7e718129 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 8
+        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:8afe41b9946c740e8d0fa03dc4c99476bb80f79e13c579013f05a8b751030782"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:d7ed9a04f22072934ca7adb07e0b53b243c931c36a5bdd797ed1484960193cfa"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"

--- a/tests/analyzers/test_entropy_redaction_sweep.py
+++ b/tests/analyzers/test_entropy_redaction_sweep.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from mergecraft.analyzers.redact import redact_secrets
+from mergecraft.analyzers.redact import _entropy_threshold, _shannon_entropy, redact_secrets
 from mergecraft.redaction_sentinel import REDACTION_SENTINEL
 from tests.analyzers.support import FIXTURES_DIR, REDACTION_ANALYZER_IDS
 
@@ -31,8 +31,22 @@ class RedactionHit:
 
 
 def _high_entropy_secret(length: int = 32) -> str:
+    """Draw a token that actually clears the redactor's own entropy floor.
+
+    A single ``secrets.choice`` draw occasionally lands below
+    ``_entropy_threshold`` by chance (character repeats collapse the measured
+    Shannon entropy), which flakes this fail-closed guard on a token the
+    redactor was never guaranteed to treat as high-entropy. Resample until the
+    draw actually satisfies the precondition the test means to exercise.
+    """
     alphabet = string.ascii_letters + string.digits + "+/=_-"
-    return "".join(secrets.choice(alphabet) for _ in range(length))
+    threshold = _entropy_threshold(length)
+    for _ in range(100):
+        candidate = "".join(secrets.choice(alphabet) for _ in range(length))
+        if _shannon_entropy(candidate) >= threshold:
+            return candidate
+    msg = f"could not draw a token clearing the entropy threshold ({threshold}) in 100 attempts"
+    raise AssertionError(msg)
 
 
 def _fixture_paths_for_analyzer(analyzer_id: str) -> list[Path]:


### PR DESCRIPTION
Promotes `pre-0.0.1` into `main` to land the pin 9 bump (#648): `MERGECRAFT_ACTION_SHA` → `e3a0cc27f8212c7abe4060847d5810d2fba31f9d`, with `action.yml`'s digest matched to the GHCR image the bootstrap job published for it.

Same pattern as #642 (pin 8), #634 (pin 7), #625 (pin 6). This clears the `action-pin-check` failure that's been blocking `Verify (static + build)` — a required status check — on every PR rebased onto `main` since today's merge wave (8 commits touching `src/mergecraft/` pushed the pin past its 5-commit staleness ceiling), and also unblocks `main`'s own post-merge `ci-cd.yml` (which was failing on the same check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)