### PR TITLE
refactor(analyzers): dedupe diff-tool constants, drop dead registry API

### DIFF
--- a/src/mergecraft/analyzers/adapters.py
+++ b/src/mergecraft/analyzers/adapters.py
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
 
 TrustTier = Literal["trusted", "untrusted"]
 
-DIFFERENTIAL_CONTRACT_TOOLS: frozenset[str] = frozenset({"oasdiff", "squawk", "buf"})
-SUPPLY_CHAIN_DIFF_TOOLS: frozenset[str] = frozenset({"osv-scanner", "trivy"})
-
 
 @dataclass(frozen=True, slots=True)
 class AdapterRunResult:
@@ -354,7 +351,11 @@ def run_adapter(
         logger.info("{}", egress_reason)
         return AdapterRunResult(findings=[], skipped=True, skip_reason=egress_reason)
 
-    from mergecraft.analyzers.contracts import resolve_analyzer_base_ref, run_differential_adapter
+    from mergecraft.analyzers.contracts import (
+        DIFFERENTIAL_CONTRACT_TOOLS,
+        resolve_analyzer_base_ref,
+        run_differential_adapter,
+    )
 
     if tool_id in DIFFERENTIAL_CONTRACT_TOOLS:
         resolved_base = resolve_analyzer_base_ref(
@@ -371,9 +372,12 @@ def run_adapter(
             allow_repo_binaries=allow_repo_binaries,
         )
 
-    if tool_id in SUPPLY_CHAIN_DIFF_TOOLS:
-        from mergecraft.analyzers.supply_chain import run_supply_chain_adapter
+    from mergecraft.analyzers.supply_chain import (
+        SUPPLY_CHAIN_DIFF_TOOLS,
+        run_supply_chain_adapter,
+    )
 
+    if tool_id in SUPPLY_CHAIN_DIFF_TOOLS:
         resolved_base = resolve_analyzer_base_ref(
             repo_root,
             base_ref=base_ref,
@@ -587,8 +591,6 @@ def run_adapter(
 
 
 __all__ = [
-    "DIFFERENTIAL_CONTRACT_TOOLS",
-    "SUPPLY_CHAIN_DIFF_TOOLS",
     "AdapterRunResult",
     "run_adapter",
 ]

--- a/src/mergecraft/analyzers/registry.py
+++ b/src/mergecraft/analyzers/registry.py
@@ -6,8 +6,6 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from loguru import logger
-
 from mergecraft.analyzers.detect import (
     detect_js_linter_intent,
     has_basedpyright_config,
@@ -332,16 +330,6 @@ def known_analyzer_ids() -> frozenset[str]:
     return frozenset(m.id for m in load_catalog())
 
 
-def warn_unknown_analyzer_overrides(settings: dict[str, Any]) -> None:
-    """Log a warning for override keys that do not match a catalog id."""
-    analyzers = settings.get("analyzers") or {}
-    overrides = analyzers.get("overrides") or {}
-    known = known_analyzer_ids()
-    for analyzer_id in overrides:
-        if analyzer_id not in known:
-            logger.warning("unknown analyzer id in config overrides: {}", analyzer_id)
-
-
 __all__ = [
     "detect_enabled",
     "filter_changed_files_for_manifest",
@@ -350,5 +338,4 @@ __all__ = [
     "known_analyzer_ids",
     "load_catalog",
     "select_enabled_analyzers",
-    "warn_unknown_analyzer_overrides",
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Nightly audit cleanup D2 — subtract duplicate differential-tool constants and remove an unused registry export.

- **`DIFFERENTIAL_CONTRACT_TOOLS`** — canonical definition stays in `contracts.py`; `adapters.py` lazy-imports it for dispatch (avoids circular import with `AdapterRunResult`).
- **`SUPPLY_CHAIN_DIFF_TOOLS`** — canonical definition stays in `supply_chain.py`; same lazy-import pattern in `adapters.py`.
- Dropped both constants from `adapters.__all__` (no external importers).
- Deleted unused `registry.warn_unknown_analyzer_overrides` (zero callers). Left `settings._warn_unknown_analyzer_overrides` on its private catalog-glob helper to avoid pulling in `mergecraft.analyzers` (loguru re-init).

Net: **−11 lines**. No adapter split, no `differential_base.py` extraction.

## Why?

Single source of truth for differential dispatch sets; remove dead API surface from the registry module.

## Test plan

- [x] `rg` shows one definition site per constant (`contracts.py`, `supply_chain.py`)
- [x] Targeted analyzer tests green (`test_adapters_contract`, `test_adapters_supply_chain`, `test_registry`, `test_adapters_parse` — 27 passed)
- [x] `ruff check` / `ruff format --check` clean on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9de6c118-a46b-4a76-a149-c1d56328eec4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9de6c118-a46b-4a76-a149-c1d56328eec4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

