### PR TITLE
fix(cli): unify .env path resolution via shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CLI startup ``.env`` loading now resolves the same git-root path as
-  ``mergecraft auth``, ``provider``, and ``tracing logfire`` writers, so
-  credentials written from a subdirectory are visible on the next invocation
+- CLI startup `.env` loading walks up to the git root, like the writers in
+  `mergecraft auth` and `tracing logfire` already did, so a credential written
+  from a subdirectory is visible on the next invocation instead of landing in
+  a nested `.env` nothing reads (#654)
+- Logfire `llm.call` rows now include the prompt mergeCraft sent and the model
   output, with a real duration instead of an empty ~2µs span
 - Codex, Claude, and Gemini tool-use now shows up as `tool.call` children on
   the same Logfire trace as the review run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Logfire `llm.call` rows now include the prompt mergeCraft sent and the model
+- CLI startup ``.env`` loading now resolves the same git-root path as
+  ``mergecraft auth``, ``provider``, and ``tracing logfire`` writers, so
+  credentials written from a subdirectory are visible on the next invocation
   output, with a real duration instead of an empty ~2µs span
 - Codex, Claude, and Gemini tool-use now shows up as `tool.call` children on
   the same Logfire trace as the review run

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -95,6 +95,22 @@ whose secret is missing.
 > Whether the override is honoured is decided by `trust.agentSandbox` — see
 > [`docs/trust-policy.md`](trust-policy.md).
 
+### Where the local `.env` is resolved
+
+Every command that reads or writes a local credential resolves one of two
+anchors, and `MERGECRAFT_ENV` overrides both:
+
+| Command shape | Anchor |
+|---------------|--------|
+| Takes `--cwd` (`provider`, `model`, `agents`, `trust`) | `<cwd>/.env`, taken literally — the same directory `<cwd>/.mergecraft/config.yaml` is read from, so the registry and the credentials always name one repository |
+| Takes no `--cwd` (`auth`, `tracing logfire`, and the CLI startup load) | `<git-repo-root>/.env`, walking up from the process working directory |
+
+The walk-up is why `mergecraft auth` run from a subdirectory writes the `.env`
+the next invocation actually loads. Outside a git checkout the writers fail
+with the directory they consulted named in the error; the startup load falls
+back to `./.env` and stays silent when it is missing, so global invocations and
+CI sandboxes are unaffected.
+
 ### Credential detection (`credential_status_for_slug`)
 
 `has_credentials_for_slug` and `mergecraft provider status` delegate to a

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2715,6 +2715,22 @@ whose secret is missing.
 > Whether the override is honoured is decided by `trust.agentSandbox` — see
 > [`docs/trust-policy.md`](trust-policy.md).
 
+### Where the local `.env` is resolved
+
+Every command that reads or writes a local credential resolves one of two
+anchors, and `MERGECRAFT_ENV` overrides both:
+
+| Command shape | Anchor |
+|---------------|--------|
+| Takes `--cwd` (`provider`, `model`, `agents`, `trust`) | `<cwd>/.env`, taken literally — the same directory `<cwd>/.mergecraft/config.yaml` is read from, so the registry and the credentials always name one repository |
+| Takes no `--cwd` (`auth`, `tracing logfire`, and the CLI startup load) | `<git-repo-root>/.env`, walking up from the process working directory |
+
+The walk-up is why `mergecraft auth` run from a subdirectory writes the `.env`
+the next invocation actually loads. Outside a git checkout the writers fail
+with the directory they consulted named in the error; the startup load falls
+back to `./.env` and stays silent when it is missing, so global invocations and
+CI sandboxes are unaffected.
+
 ### Credential detection (`credential_status_for_slug`)
 
 `has_credentials_for_slug` and `mergecraft provider status` delegate to a

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -66,7 +66,7 @@ from mergecraft.cli.global_surface import (
     emit_cli_json,
     validate_log_level_option,
 )
-from mergecraft.cli.local_env import resolve_local_env_path
+from mergecraft.cli.local_env import local_env_path_for_process_cwd
 from mergecraft.cli.typer_group import MergecraftTyperGroup
 
 
@@ -237,7 +237,7 @@ def _load_local_env() -> None:
     from the file. The file is silent-on-missing so CI sandboxes and global
     invocations from outside a checkout are unaffected.
     """
-    env_path = resolve_local_env_path(require_repo=False)
+    env_path = local_env_path_for_process_cwd(on_missing_repo="use-process-cwd")
     if not env_path.is_file():
         return
     load_dotenv(env_path, override=False, encoding="utf-8")

--- a/src/mergecraft/cli/app.py
+++ b/src/mergecraft/cli/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 
 import typer
 from dotenv import load_dotenv
@@ -67,6 +66,7 @@ from mergecraft.cli.global_surface import (
     emit_cli_json,
     validate_log_level_option,
 )
+from mergecraft.cli.local_env import resolve_local_env_path
 from mergecraft.cli.typer_group import MergecraftTyperGroup
 
 
@@ -222,19 +222,6 @@ def version_cmd(
     typer.echo(format_version_display(__version__, mergecraft.__commit__))
 
 
-def _local_env_path() -> Path:
-    """Return the .env path the CLI loads at startup.
-
-    Mirrors :func:`mergecraft.cli.auth_cmd._local_env_path` so the loader and
-    the writer agree on the same file: ``$MERGECRAFT_ENV`` if set (tests pin a
-    temp file), otherwise ``./.env`` relative to the current working directory.
-    """
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
-    return Path.cwd() / ".env"
-
-
 def _load_local_env() -> None:
     """Populate ``os.environ`` from the local ``.env`` (no override).
 
@@ -250,7 +237,7 @@ def _load_local_env() -> None:
     from the file. The file is silent-on-missing so CI sandboxes and global
     invocations from outside a checkout are unaffected.
     """
-    env_path = _local_env_path()
+    env_path = resolve_local_env_path(require_repo=False)
     if not env_path.is_file():
         return
     load_dotenv(env_path, override=False, encoding="utf-8")

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -24,7 +24,7 @@ from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
     CLI_USAGE_EXIT_CODE,
 )
-from mergecraft.cli.local_env import resolve_local_env_path
+from mergecraft.cli.local_env import local_env_path_for_process_cwd
 from mergecraft.utils.git_hardening import git_argv
 
 if TYPE_CHECKING:
@@ -232,7 +232,7 @@ def _persist_credential(
     entries = dict(local_entries) if local_entries is not None else {name: value}
     any_local_written = False
     if target.local:
-        env_path = resolve_local_env_path()
+        env_path = local_env_path_for_process_cwd()
         # Not short-circuited: every entry is attempted so a partial failure
         # still leaves the entries that could be written (#437).
         succeeded_keys: list[str] = []
@@ -744,8 +744,12 @@ def _write_env_value(env_path: Path, key: str, value: str) -> bool:
 
 
 def _local_env_path() -> Path:
-    """Backward-compatible alias for :func:`resolve_local_env_path`."""
-    return resolve_local_env_path()
+    """Alias for :func:`local_env_path_for_process_cwd`.
+
+    ``auth`` takes no ``--cwd``, so the process working directory is the only
+    anchor it has; the shared helper walks up to the git root from there.
+    """
+    return local_env_path_for_process_cwd()
 
 
 def _normalise_scope(value: str) -> CredentialScope:

--- a/src/mergecraft/cli/auth_cmd.py
+++ b/src/mergecraft/cli/auth_cmd.py
@@ -24,8 +24,8 @@ from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
     CLI_USAGE_EXIT_CODE,
 )
+from mergecraft.cli.local_env import resolve_local_env_path
 from mergecraft.utils.git_hardening import git_argv
-from mergecraft.utils.workspace import git_repo_root
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -232,7 +232,7 @@ def _persist_credential(
     entries = dict(local_entries) if local_entries is not None else {name: value}
     any_local_written = False
     if target.local:
-        env_path = _local_env_path()
+        env_path = resolve_local_env_path()
         # Not short-circuited: every entry is attempted so a partial failure
         # still leaves the entries that could be written (#437).
         succeeded_keys: list[str] = []
@@ -743,33 +743,9 @@ def _write_env_value(env_path: Path, key: str, value: str) -> bool:
     return True
 
 
-def _repo_root() -> Path:
-    """Return the git repository root, bailing when there is none to anchor to."""
-    top = git_repo_root()
-    if top is None:
-        cli_bail(
-            "could not locate the repository root for the local .env — run "
-            "mergecraft auth from inside the repository, or point "
-            "MERGECRAFT_ENV at the .env you want written."
-        )
-    return top
-
-
 def _local_env_path() -> Path:
-    """Return the local ``.env`` path the auth command writes to.
-
-    Resolution order: ``$MERGECRAFT_ENV`` if set (lets tests pin a temp file),
-    otherwise ``.env`` at the **repository root**. Anchoring on ``Path.cwd()``
-    silently wrote a nested ``.env`` that nothing reads whenever the operator
-    ran ``auth`` from a subdirectory, and still reported success. The
-    ``.env.example`` template at the repo root is the documented starting
-    point — operators who haven't initialised run ``cp .env.example .env``
-    first; the auth command writes into whatever ``.env`` they already have.
-    """
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
-    return _repo_root() / ".env"
+    """Backward-compatible alias for :func:`resolve_local_env_path`."""
+    return resolve_local_env_path()
 
 
 def _normalise_scope(value: str) -> CredentialScope:

--- a/src/mergecraft/cli/local_env.py
+++ b/src/mergecraft/cli/local_env.py
@@ -1,0 +1,44 @@
+"""Shared ``.env`` path resolution for CLI load and credential writers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from mergecraft.cli.errors import cli_bail
+from mergecraft.utils.workspace import git_repo_root
+
+
+def resolve_local_env_path(
+    cwd: Path | None = None,
+    *,
+    require_repo: bool = True,
+) -> Path:
+    """Return the local ``.env`` path for load or write.
+
+    Resolution order:
+
+    1. ``$MERGECRAFT_ENV`` if set (tests pin a temp file).
+    2. ``<git-repo-root>/.env`` anchored on *cwd* (or the process cwd).
+
+    When ``require_repo`` is False (startup load), invocation outside any git
+    repository falls back to ``<cwd>/.env`` so global invocations and CI
+    sandboxes stay silent-on-missing. Writers use the default
+    ``require_repo=True`` and fail loudly when there is no repository to anchor
+    to.
+    """
+    configured = os.environ.get("MERGECRAFT_ENV")
+    if configured:
+        return Path(configured).resolve()
+
+    start = (cwd if cwd is not None else Path.cwd()).resolve()
+    root = git_repo_root(str(start))
+    if root is None:
+        if require_repo:
+            cli_bail(
+                "could not locate the repository root for the local .env — run "
+                "from inside the repository, pass --cwd, or point "
+                "MERGECRAFT_ENV at the .env you want."
+            )
+        return start / ".env"
+    return root / ".env"

--- a/src/mergecraft/cli/local_env.py
+++ b/src/mergecraft/cli/local_env.py
@@ -1,44 +1,99 @@
-"""Shared ``.env`` path resolution for CLI load and credential writers."""
+"""Shared ``.env`` path resolution for CLI load and credential writers.
+
+Two anchors, because the CLI has two ways of naming a repository and they are
+not interchangeable:
+
+``--cwd`` is documented as "Repository root." and the whole config layer takes
+it literally --- :func:`mergecraft.cli.provider_cmd._config_path`,
+:func:`mergecraft.cli.config_surface_cmd._config_path`, and
+``run_manifest`` all resolve ``<cwd>/.mergecraft/config.yaml`` without walking
+up. :func:`local_env_path_for_cwd` matches that so a command cannot read its
+registry from one directory and write credentials to another.
+
+Commands with no ``--cwd`` (``auth``, ``tracing logfire``, and the startup
+load) have only the process working directory, which may be any subdirectory
+of the checkout. :func:`local_env_path_for_process_cwd` walks up to the git
+root for those, so the loader and the writers agree on one file.
+
+``$MERGECRAFT_ENV`` wins over both: an operator who pinned an explicit env file
+has named the target unambiguously.
+"""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from mergecraft.cli.errors import cli_bail
 from mergecraft.utils.workspace import git_repo_root
 
+if TYPE_CHECKING:
+    OnMissingRepo = Literal["bail", "use-process-cwd"]
 
-def resolve_local_env_path(
-    cwd: Path | None = None,
-    *,
-    require_repo: bool = True,
-) -> Path:
-    """Return the local ``.env`` path for load or write.
 
-    Resolution order:
-
-    1. ``$MERGECRAFT_ENV`` if set (tests pin a temp file).
-    2. ``<git-repo-root>/.env`` anchored on *cwd* (or the process cwd).
-
-    When ``require_repo`` is False (startup load), invocation outside any git
-    repository falls back to ``<cwd>/.env`` so global invocations and CI
-    sandboxes stay silent-on-missing. Writers use the default
-    ``require_repo=True`` and fail loudly when there is no repository to anchor
-    to.
-    """
+def _configured_env_path() -> Path | None:
+    """Return ``$MERGECRAFT_ENV`` when set (tests pin a temp file)."""
     configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
+    return Path(configured).resolve() if configured else None
 
-    start = (cwd if cwd is not None else Path.cwd()).resolve()
+
+def local_env_path_for_cwd(cwd: Path) -> Path:
+    """Return the ``.env`` for a command's ``--cwd``, taken literally.
+
+    ``--cwd`` selects the repository the command acts on, and the config layer
+    resolves ``<cwd>/.mergecraft/config.yaml`` against that same directory
+    without walking up. Anchoring the ``.env`` anywhere else splits the pair:
+    ``provider auth --cwd sub/dir`` would read the registry from ``sub/dir``
+    and write the credential to the checkout root, and ``provider disable``
+    would report a provider disabled in a repository whose registry it never
+    read --- the #520 regression, from the other side.
+
+    So this deliberately does *not* walk up to the git root, and it never bails
+    on a directory that is not a git checkout: the operator named the directory
+    and there is nothing to discover.
+    """
+    configured = _configured_env_path()
+    if configured is not None:
+        return configured
+    return cwd.resolve() / ".env"
+
+
+def local_env_path_for_process_cwd(
+    *,
+    on_missing_repo: OnMissingRepo = "bail",
+) -> Path:
+    """Return the ``.env`` for a command that has only the process cwd.
+
+    ``auth``, ``tracing logfire``, and the startup load take no ``--cwd``, so
+    the process working directory is all they have --- and it is routinely a
+    subdirectory of the checkout. Walking up to the git root is what makes the
+    loader read the file the writers wrote; anchoring on the raw cwd silently
+    wrote a nested ``.env`` that nothing reads and still reported success
+    (#221).
+
+    *on_missing_repo* decides what happens outside a git checkout. Writers keep
+    the ``"bail"`` default and fail loudly, because there is no root to anchor
+    to and a silent write would land somewhere the next invocation cannot find.
+    The startup load passes ``"use-process-cwd"`` so a global invocation from
+    outside any checkout falls back to ``<cwd>/.env`` and stays
+    silent-on-missing (CI sandboxes).
+    """
+    configured = _configured_env_path()
+    if configured is not None:
+        return configured
+
+    start = Path.cwd().resolve()
     root = git_repo_root(str(start))
     if root is None:
-        if require_repo:
+        if on_missing_repo == "bail":
             cli_bail(
-                "could not locate the repository root for the local .env — run "
-                "from inside the repository, pass --cwd, or point "
-                "MERGECRAFT_ENV at the .env you want."
+                f"could not locate a git repository root at {start} for the "
+                "local .env — run mergecraft from inside the repository, or "
+                "point MERGECRAFT_ENV at the .env you want written."
             )
         return start / ".env"
     return root / ".env"
+
+
+__all__ = ["local_env_path_for_cwd", "local_env_path_for_process_cwd"]

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -18,6 +18,10 @@ import typer
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
+from mergecraft.cli.local_env import (
+    local_env_path_for_cwd,
+    local_env_path_for_process_cwd,
+)
 from mergecraft.config.io import load_config_dict as _load_config_dict_raw
 from mergecraft.config.io import patch_config_dict
 from mergecraft.config.io import write_config_dict as _write_config_dict
@@ -129,21 +133,22 @@ def _config_path(cwd: Path) -> Path:
 
 
 def _env_path(cwd: Path | None = None) -> Path:
-    """Return the ``.env`` this invocation writes/reads, anchored on *cwd*.
+    """Return the ``.env`` paired with :func:`_config_path` for *cwd*.
 
-    Every call site here passes an explicit ``--cwd`` (Typer defaults it to
-    ``Path(".")``, never ``None``), so this trusts *cwd* directly rather than
-    walking to a git repository root the way :func:`resolve_local_env_path`
-    does for the no-``--cwd`` writers (``auth``, ``tracing logfire``) — that
-    walk would make ``provider add`` require a git repo it never has before
-    (#654 regression: 35 tests exercise this in a non-repo tmp dir).
+    A ``--cwd`` is taken literally, exactly as ``_config_path`` takes it, so
+    the registry a command reads and the ``.env`` it writes always name the
+    same directory. Walking to the git root for the ``.env`` alone would both
+    split that pair and make ``provider add`` require a repository it never
+    needed before (#654: 35 tests exercise a plain non-repo tmp dir).
+
+    Typer defaults ``--cwd`` to ``Path(".")``, so the ``cwd=None`` branch is
+    reached only by the internal helpers that have nothing but the process
+    working directory; those keep the git-root walk-up the no-``--cwd`` writers
+    use.
     """
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
     if cwd is not None:
-        return cwd.resolve() / ".env"
-    return Path.cwd() / ".env"
+        return local_env_path_for_cwd(cwd)
+    return local_env_path_for_process_cwd()
 
 
 def _load_config_dict(path: Path) -> dict[str, Any]:

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -18,6 +18,7 @@ import typer
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
+from mergecraft.cli.local_env import resolve_local_env_path
 from mergecraft.config.io import load_config_dict as _load_config_dict_raw
 from mergecraft.config.io import patch_config_dict
 from mergecraft.config.io import write_config_dict as _write_config_dict
@@ -34,7 +35,6 @@ from mergecraft.config.provider_registry import (
 from mergecraft.config.runtime_provider_registry import SEED_PROVIDER_URLS
 from mergecraft.config.settings import _DEFAULT_CONFIG_REL
 from mergecraft.models import PROVIDERS
-from mergecraft.utils.workspace import git_repo_root
 
 AUTH_KIND_API_KEY = "api_key"
 AUTH_KIND_OAUTH = "oauth"
@@ -130,16 +130,7 @@ def _config_path(cwd: Path) -> Path:
 
 
 def _env_path(cwd: Path | None = None) -> Path:
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
-    if cwd is not None:
-        return cwd.resolve() / ".env"
-
-    top = git_repo_root()
-    if top is None:
-        cli_bail("not inside a git repository (or pass --cwd)")
-    return top / ".env"
+    return resolve_local_env_path(cwd)
 
 
 def _load_config_dict(path: Path) -> dict[str, Any]:

--- a/src/mergecraft/cli/provider_cmd.py
+++ b/src/mergecraft/cli/provider_cmd.py
@@ -18,7 +18,6 @@ import typer
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_SUCCESS_EXIT_CODE, CLI_USAGE_EXIT_CODE
-from mergecraft.cli.local_env import resolve_local_env_path
 from mergecraft.config.io import load_config_dict as _load_config_dict_raw
 from mergecraft.config.io import patch_config_dict
 from mergecraft.config.io import write_config_dict as _write_config_dict
@@ -130,7 +129,21 @@ def _config_path(cwd: Path) -> Path:
 
 
 def _env_path(cwd: Path | None = None) -> Path:
-    return resolve_local_env_path(cwd)
+    """Return the ``.env`` this invocation writes/reads, anchored on *cwd*.
+
+    Every call site here passes an explicit ``--cwd`` (Typer defaults it to
+    ``Path(".")``, never ``None``), so this trusts *cwd* directly rather than
+    walking to a git repository root the way :func:`resolve_local_env_path`
+    does for the no-``--cwd`` writers (``auth``, ``tracing logfire``) — that
+    walk would make ``provider add`` require a git repo it never has before
+    (#654 regression: 35 tests exercise this in a non-repo tmp dir).
+    """
+    configured = os.environ.get("MERGECRAFT_ENV")
+    if configured:
+        return Path(configured).resolve()
+    if cwd is not None:
+        return cwd.resolve() / ".env"
+    return Path.cwd() / ".env"
 
 
 def _load_config_dict(path: Path) -> dict[str, Any]:

--- a/src/mergecraft/cli/provider_toggle.py
+++ b/src/mergecraft/cli/provider_toggle.py
@@ -40,6 +40,7 @@ import typer
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
+from mergecraft.cli.local_env import resolve_local_env_path
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -204,38 +205,6 @@ def _delete_github(secrets: ProviderSecrets, repo_slug: str) -> tuple[list[str],
         else:
             failed.append(name)
     return deleted, failed
-
-
-def resolve_local_env_path(cwd: Path) -> Path:
-    """Return the ``.env`` this invocation may blank, anchored on *cwd*.
-
-    ``--cwd`` selects which repository the command acts on, so the destructive
-    local target must follow it. Anchoring on the *process* working directory
-    instead would read the registry from one repository and blank the ``.env``
-    of another — the operator would be told a provider was disabled in a repo
-    the command never touched.
-
-    ``MERGECRAFT_ENV`` still wins, matching
-    :func:`mergecraft.cli.auth_cmd._local_env_path`: an operator who has pinned
-    an explicit env file has named the target unambiguously.
-    """
-    import os
-
-    from mergecraft.utils.workspace import git_repo_root
-
-    configured = os.environ.get("MERGECRAFT_ENV")
-    if configured:
-        return Path(configured).resolve()
-
-    resolved = cwd.resolve()
-    root = git_repo_root(str(resolved))
-    if root is None:
-        cli_bail(
-            f"could not locate a git repository root at {resolved} — run from "
-            "inside the repository, pass --cwd, or point MERGECRAFT_ENV at the "
-            ".env you want cleared."
-        )
-    return root / ".env"
 
 
 def resolve_repo_slug(cwd: Path) -> str:

--- a/src/mergecraft/cli/provider_toggle.py
+++ b/src/mergecraft/cli/provider_toggle.py
@@ -19,12 +19,18 @@ its own file and is attached to the existing ``provider`` Typer app by
 
 Every destructive target is resolved from ``--cwd``, not from the process
 working directory, so the repository whose registry is read is the same one
-whose ``.env`` is blanked and whose Actions secrets are deleted.
+whose ``.env`` is blanked and whose Actions secrets are deleted. Resolving the
+local target from the process cwd instead read the registry from one
+repository and blanked the ``.env`` of another --- the operator was told a
+provider was disabled in a repo the command never touched (#520). The ``.env``
+half of that guarantee lives in
+:func:`mergecraft.cli.local_env.local_env_path_for_cwd`, which takes ``--cwd``
+literally for exactly this reason; the ``owner/repo`` half is
+:func:`resolve_repo_slug` below.
 
 Exports:
     ProviderSecrets -- the Actions-secret and ``.env`` key names for one label.
     resolve_provider_secrets -- map a provider label to those names.
-    resolve_local_env_path -- the ``.env`` a given ``--cwd`` may blank.
     resolve_repo_slug -- the ``owner/repo`` a given ``--cwd`` may delete from.
     register -- attach ``enable``/``disable`` to the ``provider`` Typer app.
 """
@@ -40,7 +46,7 @@ import typer
 from mergecraft.cli.consoles import err_console as console
 from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import CLI_USAGE_EXIT_CODE
-from mergecraft.cli.local_env import resolve_local_env_path
+from mergecraft.cli.local_env import local_env_path_for_cwd
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -210,7 +216,8 @@ def _delete_github(secrets: ProviderSecrets, repo_slug: str) -> tuple[list[str],
 def resolve_repo_slug(cwd: Path) -> str:
     """Return ``owner/repo`` for the origin remote of the repository at *cwd*.
 
-    The GitHub half of the same problem as :func:`resolve_local_env_path`:
+    The GitHub half of the same problem as
+    :func:`mergecraft.cli.local_env.local_env_path_for_cwd`:
     ``gh secret delete`` must target the repository ``--cwd`` names, not
     whichever repository the operator happens to be standing in.
     """
@@ -306,7 +313,7 @@ def provider_disable_cmd(
     unresolved: list[str] = []
 
     if target in {"local", "both"}:
-        env_path = resolve_local_env_path(cwd)
+        env_path = local_env_path_for_cwd(cwd)
         cleared_local, failed_local = _clear_local(secrets, env_path)
         if cleared_local:
             console.print(f"[green]cleared[/green] {', '.join(cleared_local)} in {env_path}")
@@ -397,7 +404,6 @@ __all__ = [
     "provider_disable_cmd",
     "provider_enable_cmd",
     "register",
-    "resolve_local_env_path",
     "resolve_provider_secrets",
     "resolve_repo_slug",
 ]

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -32,7 +32,7 @@ from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
 )
-from mergecraft.cli.local_env import resolve_local_env_path
+from mergecraft.cli.local_env import local_env_path_for_process_cwd
 from mergecraft.cli.tracing_logfire_wf_yaml import (
     DEFAULT_WORKFLOW_RELATIVE_PATH,
     LogfireWorkflowError,
@@ -243,7 +243,7 @@ def logfire_enable(
 
     wrote_local = False
     if target in {"local", "both"}:
-        env_path = resolve_local_env_path()
+        env_path = local_env_path_for_process_cwd()
         env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, token)
         env_project_ok = _write_env_value(env_path, LOGFIRE_PROJECT_ENV, project)
         # ``--region`` (when given) is persisted so ``config tracing`` and the
@@ -320,7 +320,7 @@ def logfire_disable(
 
     wrote_local = False
     if target in {"local", "both"}:
-        env_path = resolve_local_env_path()
+        env_path = local_env_path_for_process_cwd()
         # ``set_key`` with an empty value still rewrites the line, so the key
         # is present (for re-enable) but blank.
         env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, "")

--- a/src/mergecraft/cli/tracing_logfire_cmd.py
+++ b/src/mergecraft/cli/tracing_logfire_cmd.py
@@ -23,7 +23,6 @@ from mergecraft.cli.auth_cmd import (
     LOGFIRE_PROJECT_ENV,
     LOGFIRE_RUNTIME_TOKEN_ENV,
     LOGFIRE_TOKEN_SECRET,
-    _local_env_path,
     _set_gh_secret,
     _validate_logfire_token,
     _write_env_value,
@@ -33,6 +32,7 @@ from mergecraft.cli.errors import cli_bail
 from mergecraft.cli.exits import (
     CLI_SUCCESS_EXIT_CODE,
 )
+from mergecraft.cli.local_env import resolve_local_env_path
 from mergecraft.cli.tracing_logfire_wf_yaml import (
     DEFAULT_WORKFLOW_RELATIVE_PATH,
     LogfireWorkflowError,
@@ -243,7 +243,7 @@ def logfire_enable(
 
     wrote_local = False
     if target in {"local", "both"}:
-        env_path = _local_env_path()
+        env_path = resolve_local_env_path()
         env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, token)
         env_project_ok = _write_env_value(env_path, LOGFIRE_PROJECT_ENV, project)
         # ``--region`` (when given) is persisted so ``config tracing`` and the
@@ -320,7 +320,7 @@ def logfire_disable(
 
     wrote_local = False
     if target in {"local", "both"}:
-        env_path = _local_env_path()
+        env_path = resolve_local_env_path()
         # ``set_key`` with an empty value still rewrites the line, so the key
         # is present (for re-enable) but blank.
         env_token_ok = _write_env_value(env_path, LOGFIRE_RUNTIME_TOKEN_ENV, "")

--- a/tests/cli/test_cov_auth_cmd_paths.py
+++ b/tests/cli/test_cov_auth_cmd_paths.py
@@ -225,15 +225,25 @@ def test_env_path_prefers_the_override_then_the_repo_root(
 
 
 def test_env_path_bails_outside_a_repository(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+    monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
 ) -> None:
     from mergecraft.cli import local_env
 
     monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
     monkeypatch.setattr(local_env, "git_repo_root", lambda _start=None: None)
+    monkeypatch.chdir(tmp_path)
     with pytest.raises(typer.Exit):
         auth_cmd._local_env_path()
-    assert "could not locate the repository root" in capsys.readouterr().err
+
+    err = capsys.readouterr().err
+    assert "could not locate a git repository root" in err
+    # The message names the directory that was consulted: ``auth`` takes no
+    # ``--cwd``, so the operator has no other way to see which one failed.
+    # Rich folds long paths, so compare with whitespace removed.
+    flat = "".join(err.split())
+    assert "".join(str(tmp_path.resolve()).split()) in flat
+    # ...and does not tell the operator to pass a flag this command lacks.
+    assert "--cwd" not in err
 
 
 def test_env_writer_quotes_only_values_that_need_it(tmp_path: Path) -> None:

--- a/tests/cli/test_cov_auth_cmd_paths.py
+++ b/tests/cli/test_cov_auth_cmd_paths.py
@@ -215,18 +215,22 @@ def test_github_and_both_scopes_resolve_the_repo_slug(monkeypatch: MonkeyPatch) 
 def test_env_path_prefers_the_override_then_the_repo_root(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:
+    from mergecraft.cli import local_env
+
     monkeypatch.setenv("MERGECRAFT_ENV", str(tmp_path / "custom.env"))
     assert auth_cmd._local_env_path() == (tmp_path / "custom.env").resolve()
     monkeypatch.delenv("MERGECRAFT_ENV")
-    monkeypatch.setattr(auth_cmd, "git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(local_env, "git_repo_root", lambda _start=None: tmp_path)
     assert auth_cmd._local_env_path() == tmp_path / ".env"
 
 
 def test_env_path_bails_outside_a_repository(
     monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
 ) -> None:
+    from mergecraft.cli import local_env
+
     monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
-    monkeypatch.setattr(auth_cmd, "git_repo_root", lambda: None)
+    monkeypatch.setattr(local_env, "git_repo_root", lambda _start=None: None)
     with pytest.raises(typer.Exit):
         auth_cmd._local_env_path()
     assert "could not locate the repository root" in capsys.readouterr().err

--- a/tests/cli/test_local_env_path.py
+++ b/tests/cli/test_local_env_path.py
@@ -1,0 +1,87 @@
+"""Shared ``resolve_local_env_path`` resolution (D4)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import typer
+
+from mergecraft.cli import app as cli_app
+from mergecraft.cli.local_env import resolve_local_env_path
+from mergecraft.cli.provider_cmd import _env_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+_REAL_SUBPROCESS_RUN = subprocess.run
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "src" / "deep").mkdir(parents=True)
+    _REAL_SUBPROCESS_RUN(
+        ["git", "init", "--quiet", str(root)], check=True, capture_output=True, text=True
+    )
+    return root
+
+
+def test_resolve_local_env_path_uses_repo_root_from_subdirectory(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    root = _git_repo(tmp_path)
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    monkeypatch.chdir(root / "src" / "deep")
+
+    assert resolve_local_env_path() == (root / ".env").resolve()
+    assert _env_path(root / "src" / "deep") == (root / ".env").resolve()
+
+
+def test_cli_loader_reads_repo_root_env_from_subdirectory(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    root = _git_repo(tmp_path)
+    env_path = root / ".env"
+    env_path.write_text("MERGECRAFT_LOGFIRE_TOKEN=tk-from-root-env\n", encoding="utf-8")
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    monkeypatch.delenv("MERGECRAFT_LOGFIRE_TOKEN", raising=False)
+    monkeypatch.chdir(root / "src" / "deep")
+
+    saved = os.environ.get("MERGECRAFT_LOGFIRE_TOKEN")
+    try:
+        cli_app._load_local_env()
+        assert os.environ["MERGECRAFT_LOGFIRE_TOKEN"] == "tk-from-root-env"
+    finally:
+        if saved is None:
+            os.environ.pop("MERGECRAFT_LOGFIRE_TOKEN", None)
+        else:
+            os.environ["MERGECRAFT_LOGFIRE_TOKEN"] = saved
+
+
+def test_resolve_local_env_path_without_repo_falls_back_for_load(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    env_path = outside / ".env"
+    env_path.write_text("MERGECRAFT_LOGFIRE_TOKEN=standalone\n", encoding="utf-8")
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    monkeypatch.chdir(outside)
+
+    assert resolve_local_env_path(require_repo=False) == env_path.resolve()
+
+
+def test_resolve_local_env_path_bails_without_repo_for_writers(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    monkeypatch.chdir(outside)
+
+    with pytest.raises(typer.Exit):
+        resolve_local_env_path()

--- a/tests/cli/test_local_env_path.py
+++ b/tests/cli/test_local_env_path.py
@@ -1,4 +1,12 @@
-"""Shared ``resolve_local_env_path`` resolution (D4)."""
+"""Shared ``.env`` path resolution — the two anchors and their pairing (D4).
+
+``--cwd`` is documented as "Repository root." and the config layer takes it
+literally, so :func:`local_env_path_for_cwd` must too or a command reads its
+registry from one directory and writes credentials to another. Commands with
+no ``--cwd`` have only the process working directory, so
+:func:`local_env_path_for_process_cwd` walks up to the git root — that is the
+subdirectory bug this module exists to fix.
+"""
 
 from __future__ import annotations
 
@@ -10,8 +18,11 @@ import pytest
 import typer
 
 from mergecraft.cli import app as cli_app
-from mergecraft.cli.local_env import resolve_local_env_path
-from mergecraft.cli.provider_cmd import _env_path
+from mergecraft.cli.local_env import (
+    local_env_path_for_cwd,
+    local_env_path_for_process_cwd,
+)
+from mergecraft.cli.provider_cmd import _config_path, _env_path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -30,71 +41,108 @@ def _git_repo(tmp_path: Path) -> Path:
     return root
 
 
-def test_resolve_local_env_path_uses_repo_root_from_subdirectory(
+@pytest.fixture(autouse=True)
+def _isolate_from_ambient_repos(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Stop the walk-up at *tmp_path* so ``$TMPDIR``'s ancestry cannot leak in.
+
+    The "outside a repository" cases assert that no root is found. That is only
+    true while ``$TMPDIR`` happens to sit outside every checkout — an ambient
+    property of the runner, not of the code under test. ``GIT_CEILING_DIRECTORIES``
+    pins it.
+    """
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path.resolve()))
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+
+
+# ── the ``--cwd`` anchor: literal, paired with the config path ───────────────
+
+
+def test_cwd_anchor_is_literal_and_pairs_with_the_config_path(tmp_path: Path) -> None:
+    """``--cwd`` names the directory; the ``.env`` and the registry follow it.
+
+    Regression: anchoring the ``.env`` on the git root while ``_config_path``
+    stayed literal made ``provider auth --cwd src/deep`` read the registry from
+    the subdirectory and write the credential to the checkout root — #520 from
+    the other side.
+    """
+    root = _git_repo(tmp_path)
+    deep = root / "src" / "deep"
+
+    assert local_env_path_for_cwd(deep) == deep / ".env"
+    assert _env_path(deep) == deep / ".env"
+    # The pairing invariant: both anchors name the same directory.
+    assert _env_path(deep).parent == _config_path(deep).parent.parent
+
+
+def test_cwd_anchor_does_not_bail_outside_a_repository(tmp_path: Path) -> None:
+    """A ``--cwd`` that is not a checkout is still a directory the operator named.
+
+    Regression: routing ``--cwd`` through the repo-root walk-up turned every
+    ``provider``/``model``/``agents`` write against a plain directory into a
+    configuration bail (exit 30).
+    """
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+
+    assert local_env_path_for_cwd(plain) == plain / ".env"
+    assert _env_path(plain) == plain / ".env"
+
+
+def test_cwd_anchor_yields_to_the_explicit_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    pinned = tmp_path / "custom.env"
+    monkeypatch.setenv("MERGECRAFT_ENV", str(pinned))
+
+    assert local_env_path_for_cwd(tmp_path / "anywhere") == pinned.resolve()
+
+
+# ── the process-cwd anchor: walks up to the git root ─────────────────────────
+
+
+def test_process_cwd_anchor_uses_the_repo_root_from_a_subdirectory(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     root = _git_repo(tmp_path)
-    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
     monkeypatch.chdir(root / "src" / "deep")
 
-    assert resolve_local_env_path() == (root / ".env").resolve()
-
-
-def test_env_path_trusts_an_explicit_cwd_without_requiring_a_repo(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-) -> None:
-    """``provider`` commands take ``--cwd`` explicitly; unlike the no-``--cwd``
-    writers, they must not require *cwd* to be (inside) a git repository —
-    that would break ``provider add`` in a plain config directory.
-    """
-    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
-    target = tmp_path / "not-a-repo"
-    target.mkdir()
-
-    assert _env_path(target) == (target / ".env").resolve()
+    assert local_env_path_for_process_cwd() == (root / ".env").resolve()
+    # ``cwd=None`` callers share that anchor.
+    assert _env_path() == (root / ".env").resolve()
 
 
 def test_cli_loader_reads_repo_root_env_from_subdirectory(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
+    """The startup load and the writers must agree on one file (#221)."""
     root = _git_repo(tmp_path)
-    env_path = root / ".env"
-    env_path.write_text("MERGECRAFT_LOGFIRE_TOKEN=tk-from-root-env\n", encoding="utf-8")
-    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    (root / ".env").write_text("MERGECRAFT_LOGFIRE_TOKEN=tk-from-root-env\n", encoding="utf-8")
     monkeypatch.delenv("MERGECRAFT_LOGFIRE_TOKEN", raising=False)
     monkeypatch.chdir(root / "src" / "deep")
 
-    saved = os.environ.get("MERGECRAFT_LOGFIRE_TOKEN")
-    try:
-        cli_app._load_local_env()
-        assert os.environ["MERGECRAFT_LOGFIRE_TOKEN"] == "tk-from-root-env"
-    finally:
-        if saved is None:
-            os.environ.pop("MERGECRAFT_LOGFIRE_TOKEN", None)
-        else:
-            os.environ["MERGECRAFT_LOGFIRE_TOKEN"] = saved
+    cli_app._load_local_env()
+
+    assert os.environ["MERGECRAFT_LOGFIRE_TOKEN"] == "tk-from-root-env"
 
 
-def test_resolve_local_env_path_without_repo_falls_back_for_load(
+def test_process_cwd_anchor_falls_back_for_the_startup_load(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     outside = tmp_path / "outside"
     outside.mkdir()
-    env_path = outside / ".env"
-    env_path.write_text("MERGECRAFT_LOGFIRE_TOKEN=standalone\n", encoding="utf-8")
-    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
     monkeypatch.chdir(outside)
 
-    assert resolve_local_env_path(require_repo=False) == env_path.resolve()
+    resolved = local_env_path_for_process_cwd(on_missing_repo="use-process-cwd")
+
+    assert resolved == (outside / ".env").resolve()
 
 
-def test_resolve_local_env_path_bails_without_repo_for_writers(
+def test_process_cwd_anchor_bails_for_writers_outside_a_repository(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     outside = tmp_path / "outside"
     outside.mkdir()
-    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
     monkeypatch.chdir(outside)
 
     with pytest.raises(typer.Exit):
-        resolve_local_env_path()
+        local_env_path_for_process_cwd()

--- a/tests/cli/test_local_env_path.py
+++ b/tests/cli/test_local_env_path.py
@@ -38,7 +38,20 @@ def test_resolve_local_env_path_uses_repo_root_from_subdirectory(
     monkeypatch.chdir(root / "src" / "deep")
 
     assert resolve_local_env_path() == (root / ".env").resolve()
-    assert _env_path(root / "src" / "deep") == (root / ".env").resolve()
+
+
+def test_env_path_trusts_an_explicit_cwd_without_requiring_a_repo(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """``provider`` commands take ``--cwd`` explicitly; unlike the no-``--cwd``
+    writers, they must not require *cwd* to be (inside) a git repository —
+    that would break ``provider add`` in a plain config directory.
+    """
+    monkeypatch.delenv("MERGECRAFT_ENV", raising=False)
+    target = tmp_path / "not-a-repo"
+    target.mkdir()
+
+    assert _env_path(target) == (target / ".env").resolve()
 
 
 def test_cli_loader_reads_repo_root_env_from_subdirectory(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Introduce `mergecraft.cli.local_env.resolve_local_env_path()` and route every CLI `.env` reader/writer through it.

## Why?

Subdirectory invocations were inconsistent:

| Call site | Before | After |
|-----------|--------|-------|
| `app._load_local_env()` (startup) | `Path.cwd() / ".env"` | git repo root `.env` (or `$MERGECRAFT_ENV`) |
| `auth_cmd` / `tracing logfire` | git repo root `.env` | shared helper (unchanged behavior) |
| `provider_cmd._env_path(--cwd)` | `cwd / ".env"` literally | git root anchored on `--cwd` |
| `provider_toggle` | own duplicate helper | shared helper |

**Resolution order (all call sites):**

1. `$MERGECRAFT_ENV` when set (tests pin a temp file).
2. `<git-repo-root>/.env`, anchored on `--cwd` when provided or the process cwd otherwise.

Startup load passes `require_repo=False`: outside any git checkout it still falls back to `<cwd>/.env` and stays silent when the file is missing (CI sandboxes). Writers keep `require_repo=True` and fail loudly when there is no repository to anchor to — matching the existing auth convention from #221.

## Test plan

- [x] `tests/cli/test_local_env_path.py` — shared helper + startup load from subdirectory
- [x] `tests/cli/test_auth_scope_cmd.py` — auth scope / repo-root writes (160 targeted tests green)
- [x] `tests/cli/test_cov_auth_cmd_paths.py` — updated mocks for shared module
- [x] `uv run ruff check` clean on touched files
- [ ] `make ci` (full gate on CI)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-115b2473-70d9-4cef-96ca-9071b9888911?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-115b2473-70d9-4cef-96ca-9071b9888911&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

