### PR TITLE
ci: bump the reviewer action pin to 78bfbeb2 (pin 10)

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -160,7 +160,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "e3a0cc27f8212c7abe4060847d5810d2fba31f9d"
+  MERGECRAFT_ACTION_SHA: "78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -596,7 +596,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
+        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -740,7 +740,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
+        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -845,7 +845,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@e3a0cc27f8212c7abe4060847d5810d2fba31f9d # env.MERGECRAFT_ACTION_SHA / digest commit / pin 9
+        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:d7ed9a04f22072934ca7adb07e0b53b243c931c36a5bdd797ed1484960193cfa"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:43fca0bdd4bc629285a75c7126bc4e653149fa041fede688a97a523298e4b6b1"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Bump the self-review Action pin from `e3a0cc27` to `78bfbeb2` (main's own tip), and match `action.yml`'s `runs.image` to that image's GHCR digest.

## Why?

`main` is currently **red** on `action-pin-check`:

> `.github/workflows/mergecraft.yml`: pin `e3a0cc27f821` lags main by 6 commits touching `src/mergecraft/` (max 5). The reviewer is not running the product code on main, so anything merged since the pin is absent from every review.

Because `mergecraft.yml` triggers on `pull_request_target`, GitHub resolves its `uses:` pin from the **default branch** — so this failure is inherited by every branch cut from main, not just one PR. It surfaced on #654, which is otherwise green.

Same two-part shape as pin 9 (#648): the SHA in `MERGECRAFT_ACTION_SHA` plus all three review rungs, and the digest in `action.yml`.

## Test plan

Verified against the repo's own guards:

- [x] `scripts/check_action_pin_freshness.py` — OK. `e3a0cc27` is an ancestor of `78bfbeb2`, drift 21 (max 100), product lag **0** (max 5).
- [x] `scripts/check_action_image_digest.py` — OK. `action.yml` matches the GHCR slim digest for `78bfbeb2`, tracing extra present.
- [x] `make ci-static` — OK end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)