### PR TITLE
fix(ci): verify release provenance before action pin promotion

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,7 +54,8 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/e2e.yml
-    secrets: inherit
+    with:
+      required-security: true
 
   build-dist:
     name: Build Python dist
@@ -79,18 +80,22 @@ jobs:
   # W8.3 — build once; push immutable SHA tags only; capture digests for promote.
   build-images:
     name: Build GHCR images (once)
+    concurrency:
+      group: image-source-${{ github.sha }}
+      cancel-in-progress: false
     needs: [verify, e2e-gate]
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/'))
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
+      attestations: read
     outputs:
-      slim_digest: ${{ steps.build-slim.outputs.digest }}
-      analyzers_digest: ${{ steps.build-analyzers.outputs.digest }}
-      slim_ref: ${{ steps.meta.outputs.slim_ref }}
-      analyzers_ref: ${{ steps.meta.outputs.analyzers_ref }}
+      slim_digest: ${{ steps.resolve.outputs.slim_digest || steps.build-slim.outputs.digest }}
+      analyzers_digest: ${{ steps.resolve.outputs.analyzers_digest || steps.build-analyzers.outputs.digest }}
+      slim_ref: ${{ env.IMAGE_SLIM }}@${{ steps.resolve.outputs.slim_digest || steps.build-slim.outputs.digest }}
+      analyzers_ref: ${{ env.IMAGE_ANALYZERS }}@${{ steps.resolve.outputs.analyzers_digest || steps.build-analyzers.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -99,28 +104,36 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Image refs
-        id: meta
-        run: |
-          set -euo pipefail
-          echo "slim_ref=${IMAGE_SLIM}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          echo "analyzers_ref=${IMAGE_ANALYZERS}:analyzers-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/bootstrap
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - name: Reuse only verified immutable images
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REVISION: ${{ github.sha }}
+        run: make action-images-resolve
       - name: Build and push slim (SHA tag only)
         id: build-slim
+        if: steps.resolve.outputs.slim_digest == ''
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
+          build-args: SOURCE_REVISION=${{ github.sha }}
+          labels: org.opencontainers.image.revision=${{ github.sha }}
           push: true
           tags: ${{ env.IMAGE_SLIM }}:${{ github.sha }}
           cache-from: type=gha,scope=mergeCraft-slim
           cache-to: type=gha,mode=max,scope=mergeCraft-slim
       - name: Build and push analyzers (SHA tag only)
         id: build-analyzers
+        if: steps.resolve.outputs.analyzers_digest == ''
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.analyzers
+          labels: org.opencontainers.image.revision=${{ github.sha }}
           push: true
           tags: ${{ env.IMAGE_ANALYZERS }}:analyzers-${{ github.sha }}
           cache-from: type=gha,scope=mergeCraft-analyzers
@@ -343,10 +356,37 @@ jobs:
             exit 1
           fi
 
+  verify-images:
+    name: Verify signed image provenance
+    needs: [build-images, sign-attest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/bootstrap
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify digest, source, signer, and SBOM
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REVISION: ${{ github.sha }}
+          SLIM_DIGEST: ${{ needs.build-images.outputs.slim_digest }}
+          ANALYZERS_DIGEST: ${{ needs.build-images.outputs.analyzers_digest }}
+        run: make action-images-verify
+
   # W8.3 — promote mutable tags by retagging the signed digests (no rebuild).
   promote:
     name: Promote digests to mutable tags
-    needs: [build-images, sign-attest]
+    needs: [build-images, sign-attest, verify-images]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      packages: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -41,6 +43,19 @@ jobs:
         env:
           # Exporter unit tests run in coverage-measure (D14 / TH8) — match ci.yml.
           MERGECRAFT_UV_EXTRAS: tracing
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Verify changed image or consumer pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_BASE: ${{ github.event.before || github.sha }}
+          CANDIDATE_HEAD: ${{ github.sha }}
+        run: make action-candidate-check
       - name: make ci
         run: make ci
 
@@ -77,12 +92,9 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  # W8.3 — build once; push immutable SHA tags only; capture digests for promote.
+  # W8.3 — build once; push attempt-specific staging tags; capture digests for verification.
   build-images:
     name: Build GHCR images (once)
-    concurrency:
-      group: image-source-${{ github.sha }}
-      cancel-in-progress: false
     needs: [verify, e2e-gate]
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
@@ -113,7 +125,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOURCE_REVISION: ${{ github.sha }}
         run: make action-images-resolve
-      - name: Build and push slim (SHA tag only)
+      - name: Build and push slim (attempt staging tag)
         id: build-slim
         if: steps.resolve.outputs.slim_digest == ''
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -123,10 +135,10 @@ jobs:
           build-args: SOURCE_REVISION=${{ github.sha }}
           labels: org.opencontainers.image.revision=${{ github.sha }}
           push: true
-          tags: ${{ env.IMAGE_SLIM }}:${{ github.sha }}
+          tags: ${{ env.IMAGE_SLIM }}:staging-${{ github.run_id }}-${{ github.run_attempt }}-slim
           cache-from: type=gha,scope=mergeCraft-slim
           cache-to: type=gha,mode=max,scope=mergeCraft-slim
-      - name: Build and push analyzers (SHA tag only)
+      - name: Build and push analyzers (attempt staging tag)
         id: build-analyzers
         if: steps.resolve.outputs.analyzers_digest == ''
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -135,7 +147,7 @@ jobs:
           file: Dockerfile.analyzers
           labels: org.opencontainers.image.revision=${{ github.sha }}
           push: true
-          tags: ${{ env.IMAGE_ANALYZERS }}:analyzers-${{ github.sha }}
+          tags: ${{ env.IMAGE_ANALYZERS }}:staging-${{ github.run_id }}-${{ github.run_attempt }}-analyzers
           cache-from: type=gha,scope=mergeCraft-analyzers
           cache-to: type=gha,mode=max,scope=mergeCraft-analyzers
 
@@ -383,10 +395,41 @@ jobs:
           ANALYZERS_DIGEST: ${{ needs.build-images.outputs.analyzers_digest }}
         run: make action-images-verify
 
+  publish-canonical:
+    name: Publish verified source tags
+    needs: [build-images, verify-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: image-source-${{ github.sha }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+      attestations: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/bootstrap
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Reverify and publish both canonical source tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REVISION: ${{ github.sha }}
+          SLIM_DIGEST: ${{ needs.build-images.outputs.slim_digest }}
+          ANALYZERS_DIGEST: ${{ needs.build-images.outputs.analyzers_digest }}
+        run: make action-images-publish-canonical
+
   # W8.3 — promote mutable tags by retagging the signed digests (no rebuild).
   promote:
     name: Promote digests to mutable tags
-    needs: [build-images, sign-attest, verify-images]
+    needs: [build-images, sign-attest, verify-images, publish-canonical]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pre-0.0.1' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -411,14 +454,14 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
+          docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_SLIM}:latest" \
             "${IMAGE_SLIM}@${{ needs.build-images.outputs.slim_digest }}"
       - name: Retag analyzers digest → :analyzers
         if: github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
+          docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_ANALYZERS}:analyzers" \
             "${IMAGE_ANALYZERS}@${{ needs.build-images.outputs.analyzers_digest }}"
       # pre-0.0.1 (the active pre-release/staging branch) gets its own mutable
@@ -428,14 +471,14 @@ jobs:
         if: github.ref == 'refs/heads/pre-0.0.1'
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
+          docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_SLIM}:rc" \
             "${IMAGE_SLIM}@${{ needs.build-images.outputs.slim_digest }}"
       - name: Retag analyzers digest → :analyzers-rc
         if: github.ref == 'refs/heads/pre-0.0.1'
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
+          docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_ANALYZERS}:analyzers-rc" \
             "${IMAGE_ANALYZERS}@${{ needs.build-images.outputs.analyzers_digest }}"
       - name: Record digests for Craft SHA→version retag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  deployment-candidate:
+    name: Verify changed deployment candidates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/bootstrap
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Verify changed image or consumer pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_BASE: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
+          CANDIDATE_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: make action-candidate-check
+
   toolchain:
     name: Verify (toolchain py${{ matrix.python }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,70 +94,8 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: make coverage-gate
 
-  action-slim-bootstrap:
-    name: Bootstrap slim GHCR image for Action SHA pin
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.base.ref == 'pre-0.0.1' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Resolve self-review Action SHA pin
-        id: pin
-        run: |
-          set -euo pipefail
-          SHA=$(grep -E '^\s*MERGECRAFT_ACTION_SHA:\s*"' .github/workflows/mergecraft.yml | head -1 | sed -E 's/.*"([0-9a-f]{40})".*/\1/')
-          test -n "${SHA}"
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check whether slim image tag already exists on GHCR
-        id: tag
-        env:
-          SHA: ${{ steps.pin.outputs.sha }}
-        run: |
-          set -euo pipefail
-          if docker manifest inspect "ghcr.io/alexhawat/mergecraft:${SHA}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Slim image tag already published — skipping bootstrap rebuild"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Slim image tag missing — will build and push"
-          fi
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.tag.outputs.exists != 'true'
-        with:
-          ref: ${{ steps.pin.outputs.sha }}
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        if: steps.tag.outputs.exists != 'true'
-      - name: Build and push slim image for pinned Action SHA
-        if: steps.tag.outputs.exists != 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ghcr.io/alexhawat/mergecraft:${{ steps.pin.outputs.sha }}
-          labels: |
-            org.opencontainers.image.revision=${{ steps.pin.outputs.sha }}
-          cache-from: type=gha,scope=mergeCraft-slim-bootstrap
-          cache-to: type=gha,mode=max,scope=mergeCraft-slim-bootstrap
-
   static:
     name: Verify (static + build py${{ matrix.python }})
-    needs: action-slim-bootstrap
-    if: >-
-      always() &&
-      (needs.action-slim-bootstrap.result == 'success' ||
-       needs.action-slim-bootstrap.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      required-security:
+        description: Run the required image security slice for a release caller
+        required: false
+        default: false
+        type: boolean
       ref:
         description: Git ref under test (defaults to the caller ref)
         required: false
@@ -52,7 +57,7 @@ env:
 jobs:
   e2e-pr:
     name: Action-image E2E (PR / security slice)
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    if: inputs.required-security || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -119,7 +124,7 @@ jobs:
 
   e2e-nightly:
     name: Action-image E2E (nightly / broad + live)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: ${{ !inputs.required-security && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release E2E now runs for reusable workflow callers, and image promotion
+  requires verified signatures, source provenance, and SBOM attestations.
+  Action pin preparation separates the built source from the manifest commit
+  consumers execute, preventing deployment of the previous image (#579, #641).
 - Logfire `llm.call` rows now include the prompt mergeCraft sent and the model
   output, with a real duration instead of an empty ~2µs span
 - Codex, Claude, and Gemini tool-use now shows up as `tool.call` children on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release verification uses compatible GitHub CLI policy flags, validates deployment
+  candidates automatically, and publishes canonical image tags only after signed
+  staging digests verify. Pin preparation safely supports repeat invocations and
+  environment-only references; Docker source validation survives optimized Python.
+
 - Release E2E now runs for reusable workflow callers, and image promotion
   requires verified signatures, source provenance, and SBOM attestations.
   Action pin preparation separates the built source from the manifest commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,13 @@ Skip entries with `#skip-changelog` or the `skip-changelog` label.
 
 ### Verify a published image
 
+For the exact consumer `uses:` pin, run `make action-image-digest-check`.
+It reads the pinned commit’s manifest and verifies its signed image against
+the built source, rather than comparing the working tree to a mutable tag.
+The two-phase preparation flow is documented in
+[Action manifest and consumer pin lifecycle](docs/release-process.md#action-manifest-and-consumer-pin-lifecycle).
+
+
 Replace `<digest>` with the digest from the CI/CD run (or `crane digest
 ghcr.io/alexhawat/mergecraft:<tag>`):
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ ARG SOURCE_DATE_EPOCH=1700000000
 FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f
 
 ARG SOURCE_DATE_EPOCH
+ARG SOURCE_REVISION=""
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+LABEL org.opencontainers.image.revision=${SOURCE_REVISION}
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.29@sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc \
     /uv /usr/local/bin/uv
@@ -107,6 +109,10 @@ RUN uv sync --frozen --no-dev --extra tracing \
         /opt/mergecraft/.venv/lib/python3.14/site-packages/merge_craft-*.dist-info/RECORD \
     && rm -rf /root/.cache/uv /tmp/* \
     && { command -v setpriv >/dev/null && getent passwd mergecraft >/dev/null || { echo "FATAL: privilege drop unavailable (setpriv or mergecraft user missing)"; exit 1; }; }
+
+# The container build has no .git directory. Stamp only the source S, never
+# the future manifest commit C or this image's own digest D.
+RUN SOURCE_REVISION="${SOURCE_REVISION}" python -c 'import os, pathlib, re; value = os.environ["SOURCE_REVISION"]; assert not value or re.fullmatch("[0-9a-f]{40}", value), "invalid source revision"; pathlib.Path("src/mergecraft/_build_metadata.py").write_text("__commit__: str | None = " + repr(value or None) + "\n")'
 
 COPY docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,18 @@ RUN uv sync --frozen --no-dev --extra tracing \
 
 # The container build has no .git directory. Stamp only the source S, never
 # the future manifest commit C or this image's own digest D.
-RUN SOURCE_REVISION="${SOURCE_REVISION}" python -c 'import os, pathlib, re; value = os.environ["SOURCE_REVISION"]; assert not value or re.fullmatch("[0-9a-f]{40}", value), "invalid source revision"; pathlib.Path("src/mergecraft/_build_metadata.py").write_text("__commit__: str | None = " + repr(value or None) + "\n")'
+RUN SOURCE_REVISION="${SOURCE_REVISION}" python - <<'PYTHON'
+import os
+import pathlib
+import re
+
+value = os.environ["SOURCE_REVISION"]
+if value and not re.fullmatch("[0-9a-f]{40}", value):
+    raise ValueError("invalid source revision")
+pathlib.Path("src/mergecraft/_build_metadata.py").write_text(
+    "__commit__: str | None = " + repr(value or None) + "\n"
+)
+PYTHON
 
 COPY docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SHELL := /bin/bash
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check mcp-server-json mcp-server-json-check reference-docs reference-docs-check bench-review eval-gate eval-replay eval-convergence \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-measure coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check
+	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check action-image-structure-check action-images-resolve action-images-verify action-manifest-prepare action-pin-prepare
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -80,7 +80,7 @@ lint: ## Ruff check + formatting + loguru-only + action-yml-hygiene + hook-pins-
 	$(UV) run python scripts/check_cli_consoles.py
 	$(MAKE) action-yml-hygiene-check
 	$(MAKE) hook-pins-check
-	$(MAKE) action-image-digest-check
+	$(MAKE) action-image-structure-check
 	$(UV) run python scripts/check_privilege_drop_chown.py
 	$(UV) run python scripts/check_type_ignores.py
 	$(UV) run python scripts/check_called_workflow_permissions.py
@@ -99,8 +99,23 @@ hook-pins-check: ## Fail when .pre-commit-config.yaml hook revs drift from pypro
 action-pin-check: ## Fail when the default branch's self-review Action pin drifts too far behind (#450)
 	$(UV) run python scripts/check_action_pin_freshness.py
 
-action-image-digest-check: ## Fail when action.yml slim digest drifts from GHCR for the Action SHA (#526)
+action-image-structure-check: ## Validate source syntax without asserting deployed provenance
+	$(UV) run python scripts/check_action_image_digest.py --structure-only
+
+action-image-digest-check: ## Verify the deployed pinned manifest against signed image provenance
 	$(UV) run python scripts/check_action_image_digest.py
+
+action-images-resolve: ## Resolve verified immutable images for release reuse
+	$(UV) run python scripts/bump_action_pin.py resolve-images
+
+action-images-verify: ## Verify both signed release digests before promotion
+	$(UV) run python scripts/bump_action_pin.py verify-images
+
+action-manifest-prepare: ## Prepare manifest C from SOURCE_REVISION and IMAGE_DIGEST
+	$(UV) run python scripts/bump_action_pin.py manifest
+
+action-pin-prepare: ## Prepare consumer pin P to an already merged MANIFEST_COMMIT
+	$(UV) run python scripts/bump_action_pin.py pin
 
 lint-ruff-advisory: ## Ruff advisory families (non-blocking CI; #146)
 	$(RUFF) check src tests scripts --select $(RUFF_ADVISORY_FAMILIES)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SHELL := /bin/bash
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check mcp-server-json mcp-server-json-check reference-docs reference-docs-check bench-review eval-gate eval-replay eval-convergence \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-measure coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check action-image-structure-check action-images-resolve action-images-verify action-manifest-prepare action-pin-prepare
+	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check action-image-structure-check action-candidate-check action-images-resolve action-images-verify action-images-publish-canonical action-manifest-prepare action-pin-prepare
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -105,11 +105,17 @@ action-image-structure-check: ## Validate source syntax without asserting deploy
 action-image-digest-check: ## Verify the deployed pinned manifest against signed image provenance
 	$(UV) run python scripts/check_action_image_digest.py
 
+action-candidate-check: ## Verify changed image and consumer pins at immutable base/head commits
+	$(UV) run python scripts/check_action_image_digest.py --candidate
+
 action-images-resolve: ## Resolve verified immutable images for release reuse
 	$(UV) run python scripts/bump_action_pin.py resolve-images
 
 action-images-verify: ## Verify both signed release digests before promotion
 	$(UV) run python scripts/bump_action_pin.py verify-images
+
+action-images-publish-canonical: ## Publish verified source tags under release job serialization
+	$(UV) run python scripts/bump_action_pin.py publish-canonical
 
 action-manifest-prepare: ## Prepare manifest C from SOURCE_REVISION and IMAGE_DIGEST
 	$(UV) run python scripts/bump_action_pin.py manifest

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ Operator runbook for the agent-owned and operator-owned boxes in
 (E2E on publish SHA, blocking Trivy on promoting refs, live-provider matrix) is
 documented in [`docs/supply-chain.md`](supply-chain.md) and the linked wave plan.
 
-## Already shipped in CI (no operator publish step)
+## CI delivery configuration (verify live execution before release)
 
 | Item | Evidence |
 |------|----------|
@@ -16,6 +16,10 @@ documented in [`docs/supply-chain.md`](supply-chain.md) and the linked wave plan
 | SLSA build-provenance attestations | `actions/attest-build-provenance` steps |
 | SPDX SBOM + SBOM attestations | `sbom-scan` + `actions/attest-sbom` |
 | Python sdist/wheel artifact | `build-dist` → `artifact-python-dist` |
+
+For Action references, follow the separate source → manifest → consumer pin
+[lifecycle](release-process.md#action-manifest-and-consumer-pin-lifecycle).
+Workflow configuration alone is not evidence that the jobs ran.
 
 Verify a published digest locally (see [CONTRIBUTING.md](../CONTRIBUTING.md#verify-a-published-image)).
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -53,3 +53,71 @@ second schema-migration system on this page.
 - [CHANGELOG.md](../CHANGELOG.md)
 - [support-matrix.md](support-matrix.md) — generated support matrix
 - [SECURITY.md](../SECURITY.md) — security-response and disclosure
+
+## Action manifest and consumer pin lifecycle
+
+A source revision and an Action reference have different roles. Let **S** be
+built source, **D** its signed image digest, **C** the later commit whose
+`action.yml` names D, and **P** the consumer workflow update that pins C.
+The deployed path is `uses@C → action.yml@C → D → S`. Pinning S immediately
+after its image builds still runs the older digest already stored at S.
+
+CI/CD explicitly requests its required security E2E slice on push and manual
+runs. Only approved main, pre-release, release-branch, or version-tag refs can
+publish. Images are scanned by digest, signed and attested, then independently
+verified before mutable-tag promotion. Existing source tags are reused only
+when the same source and trusted provenance verify; an unsigned collision or
+registry outage fails rather than overwriting an immutable tag.
+
+After an approved CI/CD run completes, prepare **two separate reviewed changes**:
+
+1. In a clean isolated worktree checked out at S, set `SOURCE_REVISION` to that
+   full commit and `IMAGE_DIGEST` to the verified slim digest, then run
+   `make action-manifest-prepare`. This verifies provenance and changes only
+   `action.yml`. Review, commit and merge this change. Record its resulting
+   manifest commit C; if squash merging, record the actual merged commit.
+2. Fetch the target branch. In a clean isolated worktree based on that branch,
+   set `MANIFEST_COMMIT` to C and `RELEASE_BASE_BRANCH` to `main` or `pre-0.0.1`,
+   then run `make action-pin-prepare`. This requires C to be in the fetched
+   target branch, verifies C's image, and updates consumer references to C.
+   Review and merge this second change P.
+3. Run `make action-image-digest-check` against the updated consumer checkout.
+   Successful output records the manifest commit, image digest and built source.
+   Observe an actual Action run at C before declaring deployment verified.
+
+Preparation never commits, pushes, creates a PR, or claims checks ran. Repeating
+an already satisfied phase reports that state without creating new changes.
+C may differ from S only in `action.yml`'s `runs.image`; changing entrypoint,
+arguments, source, dependencies or build files requires a new built source.
+Do not combine C and P into a squash-merged change that discards the referenced C.
+
+`make lint` performs a source image-syntax check and explicitly reports its
+provenance as **UNVERIFIED**. It does not depend on publishing the code being
+validated. The separate strict deployment checker fails on missing registry
+content, missing tools, invalid signatures, absent tracing, or an unverified
+source mapping. Optional offline inspection exits with an unverified status;
+it never reports cryptographic verification. Verification requires authenticated
+`gh` registry access and `cosign`, with repository, workflow, source revision,
+GitHub-hosted runner and issuer constraints.
+
+The image records S in its build metadata. C and D are reported by the external
+verifier after publication; they cannot be baked into the image that creates D.
+Local contract tests do not establish that production images have been signed
+or deployed. Required live acceptance remains a successful release run with
+E2E, build, scan, signing, attestation, verification and promotion, followed by
+an observed consumer Action run resolving C to D.
+
+### Recovery and pending pin automation
+
+An existing unsigned or partially attested source-S tag deliberately fails
+immutable-image reuse. After a failure in scan/sign/attest/verify, rerun the
+failed downstream jobs of the original run so they retain its captured digest
+outputs. Do not rerun publication to overwrite the source tag. If the original
+run cannot be recovered, prepare a new source revision and build a new tag;
+retain the failed run and digest for diagnosis.
+
+Pending PR #578 combines App identity with older pin automation. Its pin
+portion must be reconciled with this two-phase C/P lifecycle before enabling
+it: automation that pins the built source S directly would reintroduce the
+previous-image defect. App identity remains separate work; this release change
+does not register an App, install credentials, or enable that pending workflow.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,7 +65,9 @@ after its image builds still runs the older digest already stored at S.
 CI/CD explicitly requests its required security E2E slice on push and manual
 runs. Only approved main, pre-release, release-branch, or version-tag refs can
 publish. Images are scanned by digest, signed and attested, then independently
-verified before mutable-tag promotion. Existing source tags are reused only
+verified before canonical source-tag and mutable-tag promotion. New builds use
+run/attempt-specific staging tags, so failed scanning or signing leaves no
+unsigned canonical tag that blocks a fresh attempt. Existing source tags are reused only
 when the same source and trusted provenance verify; an unsigned collision or
 registry outage fails rather than overwriting an immutable tag.
 
@@ -87,13 +89,24 @@ After an approved CI/CD run completes, prepare **two separate reviewed changes**
 
 Preparation never commits, pushes, creates a PR, or claims checks ran. Repeating
 an already satisfied phase reports that state without creating new changes.
+An exact, unstaged preparation patch can be repeated; staged files, unexpected
+untracked files, and unrelated changes are rejected. An uncommitted manifest
+reports `manifest_commit: null`; an already committed manifest reports its actual C.
+Consumer preparation supports both literal `uses` references and
+`MERGECRAFT_ACTION_SHA` markers, including marker-only workflows.
 C may differ from S only in `action.yml`'s `runs.image`; changing entrypoint,
 arguments, source, dependencies or build files requires a new built source.
 Do not combine C and P into a squash-merged change that discards the referenced C.
 
 `make lint` performs a source image-syntax check and explicitly reports its
 provenance as **UNVERIFIED**. It does not depend on publishing the code being
-validated. The separate strict deployment checker fails on missing registry
+validated. Both CI and CI/CD run a read-only candidate gate over immutable base
+and head Git objects: changing `runs.image` verifies the complete new manifest;
+changing consumer references verifies every resulting C. Source-only Action
+metadata changes can build with the existing image field, but do not endorse
+that commit as a deployment manifest. Pinning such a commit still requires its
+complete runtime behavior to match the verified built source.
+The strict deployment checker fails on missing registry
 content, missing tools, invalid signatures, absent tracing, or an unverified
 source mapping. Optional offline inspection exits with an unverified status;
 it never reports cryptographic verification. Verification requires authenticated
@@ -109,12 +122,19 @@ an observed consumer Action run resolving C to D.
 
 ### Recovery and pending pin automation
 
-An existing unsigned or partially attested source-S tag deliberately fails
-immutable-image reuse. After a failure in scan/sign/attest/verify, rerun the
-failed downstream jobs of the original run so they retain its captured digest
-outputs. Do not rerun publication to overwrite the source tag. If the original
-run cannot be recovered, prepare a new source revision and build a new tag;
-retain the failed run and digest for diagnosis.
+Canonical publication serializes both image kinds by source revision, verifies
+both before writing either tag, and checks that registry readback preserves D.
+Concurrent runs producing different digests for one S fail instead of overwriting
+it. If only one tag was published before a transient failure, retrying accepts
+that identical digest and completes the other. The release tooling currently
+requires both image kinds in `ghcr.io/alexhawat/mergecraft`; differing
+`IMAGE_SLIM` or `IMAGE_ANALYZERS` repositories are explicitly rejected.
+
+For ordinary failed staging builds, rerun all jobs or the failed downstream jobs;
+canonical tags have not been written before successful scan/sign/verification.
+A legacy unsigned or partially attested canonical source-S tag still deliberately
+fails reuse. Recover its original downstream jobs with the captured digest, or
+prepare a new source revision; never overwrite it or trust its revision label.
 
 Pending PR #578 combines App identity with older pin automation. Its pin
 portion must be reconciled with this two-phase C/P lifecycle before enabling

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -51,9 +51,9 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | **W1.8** `ci.yml` non-zero on stale pin | W8 | `test_w18_action_pin_gate.py::test_ci_yml_fails_on_stale_pin_instead_of_warning_only` |
 | **W1.8** single pin, three rungs | W8 | `test_w18_action_pin_gate.py::test_mergecraft_workflow_three_rungs_share_one_pin_value` |
 | **W1.8** partial bump fails | W8 | `test_w18_action_pin_gate.py::test_partial_pin_bump_fails_action_pin_check` |
-| **W8 / #535** digest guard script | W8 | `test_action_image_digest_check.py` (pre-tracing case stubs workflow SHA when current pin lacks GHCR tag) |
+| **W8 / #535** digest guard script | W8 | `test_action_image_digest_check.py` (real Git histories and digest-bound provenance policy regressions) |
 | **W8 / #535** digest pin in `action.yml` | W8 | `test_action_image_digest_sync.py`, `test_action_yml_contract.py::test_docker_action_pulls_digest_pinned_slim_image` |
-| **W8 / #535** `action-image-digest-check` in `make lint` | W8 | `test_action_image_digest_sync.py::test_action_image_digest_check_runs_via_make_lint` |
+| **W8 / #535** source syntax in `make lint`; strict deployment candidate and promotion gates | W8 | `test_action_image_digest_sync.py::test_action_image_structure_check_runs_via_make_lint` and `test_signed_image_verification_is_required_before_promotion` |
 | **W2** `Finding.scope` on CI evidence path | W2 | `test_evidence.py::test_no_new_finding_fields_introduced` |
 | **cd6ff87c** cached packet re-finalizes on outcome | — | `test_run_packet.py::test_resolve_prepared_run_packet_refinalizes_on_outcome_change` |
 

--- a/scripts/bump_action_pin.py
+++ b/scripts/bump_action_pin.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Prepare the two reviewed commits C (manifest) then P (consumer pin).
 
-This tool never commits, pushes, creates PRs, or claims CI ran. Both phases
+Preparation never commits, pushes Git branches, creates PRs, or claims CI ran. Both phases
 require signed image verification; the pin phase requires C already merged.
-Exports: prepare_manifest, prepare_pin, resolve_images, main.
+The CI-only publish-canonical phase writes registry tags after strict verification.
+Exports: prepare_manifest, prepare_pin, resolve_images, publish_canonical, main.
 """
 
 from __future__ import annotations
@@ -17,11 +18,14 @@ from pathlib import Path
 
 from check_action_image_digest import (
     REPO,
+    SLIM_IMAGE,
     TagLookupStatus,
     VerificationError,
     _commit,
     _ghcr_digest_for_tag,
+    _ghcr_digest_for_tag_once,
     _git,
+    _run,
     verify_image,
     verify_manifest,
 )
@@ -34,19 +38,30 @@ _PIN = re.compile(r"(uses:\s*alexhawat/mergeCraft@)[0-9a-f]{40}")
 _ENV_PIN = re.compile(r'(?m)^(\s*MERGECRAFT_ACTION_SHA:\s*["\']?)[0-9a-f]{40}')
 
 
-def _clean(repo: Path) -> str:
-    if _git(repo, "status", "--porcelain").strip():
-        raise VerificationError("prepare release changes in a clean isolated worktree")
-    return _commit(_git(repo, "rev-parse", "HEAD").strip())
+def _prepared_state(repo: Path, expected: dict[str, str]) -> bool:
+    """Allow only exact unstaged prepared bytes; never absorb staged/untracked edits."""
+    if _git(repo, "diff", "--cached", "--name-only").strip():
+        raise VerificationError("staged changes must be committed or unstaged before preparation")
+    if _git(repo, "ls-files", "--others", "--exclude-standard").strip():
+        raise VerificationError("untracked files are not part of a prepared release change")
+    if _git(repo, "diff", "--summary").strip():
+        raise VerificationError("file modes and paths must not change during preparation")
+    changed = set(_git(repo, "diff", "--name-only").splitlines())
+    if not changed <= expected.keys():
+        raise VerificationError("unexpected dirty files outside the prepared release change")
+    for name in changed:
+        path = repo / name
+        if path.is_symlink() or not path.is_file() or path.read_text() != expected[name]:
+            raise VerificationError("dirty content is not the exact prepared release change")
+    return bool(changed)
 
 
-def prepare_manifest(repo: Path, source: str, digest: str) -> dict[str, str]:
-    """Change only action.yml at S; the caller reviews and merges it as C."""
+def prepare_manifest(repo: Path, source: str, digest: str) -> dict[str, str | None]:
+    """Prepare only the image patch, or recognize its exact uncommitted state."""
     source = _commit(source)
-    head = _clean(repo)
-    verify_image(repo, digest, source)
+    head = _commit(_git(repo, "rev-parse", "HEAD").strip())
     if head != source:
-        # An already merged manifest is a safe idempotent no-op, not a rebuild.
+        _prepared_state(repo, {})
         result = verify_manifest(repo, head)
         if result.source_revision != source or result.image_digest != digest:
             raise VerificationError("HEAD is not the built source or its verified manifest")
@@ -56,64 +71,83 @@ def prepare_manifest(repo: Path, source: str, digest: str) -> dict[str, str]:
             "source_revision": source,
             "image_digest": digest,
         }
-    path = repo / "action.yml"
+    baseline = _git(repo, "show", f"{source}:action.yml")
     content, count = _IMAGE_LINE.subn(
         lambda match: f"{match[1]}docker://ghcr.io/alexhawat/mergecraft@{digest}{match[2]}",
-        path.read_text(),
+        baseline,
     )
     if count != 1:
         raise VerificationError("expected exactly one digest image line")
-    path.write_text(content)
-    return {"state": "manifest-change-prepared", "source_revision": source, "image_digest": digest}
+    _prepared_state(repo, {"action.yml": content})
+    verify_image(repo, digest, source)
+    if content == baseline:
+        return {
+            "state": "manifest-already-present",
+            "manifest_commit": head,
+            "source_revision": source,
+            "image_digest": digest,
+        }
+    (repo / "action.yml").write_text(content)
+    return {
+        "state": "manifest-change-prepared",
+        "manifest_commit": None,
+        "source_revision": source,
+        "image_digest": digest,
+    }
 
 
 def prepare_pin(repo: Path, manifest: str, base_branch: str = "pre-0.0.1") -> dict[str, str]:
-    """Pin an already merged C; never point consumers at S just because it built D."""
-    head = _clean(repo)
+    """Prepare literal and environment references to merged C, accepting exact reruns."""
+    head = _commit(_git(repo, "rev-parse", "HEAD").strip())
     manifest = _commit(manifest)
     if base_branch not in ("main", "pre-0.0.1"):
         raise VerificationError("consumer pins target main or pre-0.0.1 only")
     _git(repo, "merge-base", "--is-ancestor", manifest, f"origin/{base_branch}")
     _git(repo, "merge-base", "--is-ancestor", manifest, head)
-    result = verify_manifest(repo, manifest)
-    changes: list[tuple[Path, str]] = []
+    expected: dict[str, str] = {}
+    changed = False
     consumer_pins = 0
-    for name in ("mergecraft.yml", "mergecraft-approve.yml"):
-        path = repo / ".github" / "workflows" / name
-        if not path.is_file():
-            continue
-        content = path.read_text()
-        consumer_pins += len(_PIN.findall(content))
+    candidates = [
+        f".github/workflows/{name}" for name in ("mergecraft.yml", "mergecraft-approve.yml")
+    ]
+    tracked = _git(repo, "ls-tree", "--name-only", head, "--", *candidates).splitlines()
+    for name in tracked:
+        content = _git(repo, "show", f"{head}:{name}")
+        consumer_pins += len(_PIN.findall(content)) + len(_ENV_PIN.findall(content))
         replaced = _ENV_PIN.sub(
             lambda match: match[1] + manifest, _PIN.sub(lambda match: match[1] + manifest, content)
         )
-        if replaced != content:
-            changes.append((path, replaced))
+        expected[name] = replaced
+        changed = changed or replaced != content
     if not consumer_pins:
         raise VerificationError("no self-review consumer Action references found")
-    if not changes:
-        return {
-            "state": "pin-already-present",
-            "manifest_commit": manifest,
-            "source_revision": result.source_revision,
-            "image_digest": result.image_digest,
-        }
-    for path, content in changes:
-        path.write_text(content)
+    _prepared_state(repo, expected)
+    result = verify_manifest(repo, manifest)
+    if changed:
+        for name, content in expected.items():
+            (repo / name).write_text(content)
     return {
-        "state": "pin-change-prepared",
+        "state": "pin-change-prepared" if changed else "pin-already-present",
         "manifest_commit": manifest,
         "source_revision": result.source_revision,
         "image_digest": result.image_digest,
     }
 
 
+def _shared_image_repository() -> None:
+    """Both kinds share one GHCR repository; reject configuration drift explicitly."""
+    for variable in ("IMAGE_SLIM", "IMAGE_ANALYZERS"):
+        if os.environ.get(variable, SLIM_IMAGE) != SLIM_IMAGE:
+            raise VerificationError(f"{variable} must equal the shared repository {SLIM_IMAGE}")
+
+
 def resolve_images(repo: Path, source: str) -> dict[str, str]:
     """Reuse only verified SHA tags; registry errors/unsigned collisions fail closed."""
+    _shared_image_repository()
     source = _commit(source)
     outputs: dict[str, str] = {}
     for kind, tag in (("slim", source), ("analyzers", f"analyzers-{source}")):
-        lookup = _ghcr_digest_for_tag(tag)
+        lookup = _ghcr_digest_for_tag_once(tag)
         if lookup.status is TagLookupStatus.ERROR:
             raise VerificationError("registry unavailable: cannot determine immutable tag state")
         if lookup.status is TagLookupStatus.MISSING:
@@ -126,9 +160,51 @@ def resolve_images(repo: Path, source: str) -> dict[str, str]:
     return outputs
 
 
+def publish_canonical(repo: Path, source: str, digests: dict[str, str]) -> dict[str, str]:
+    """Publish verified canonical tags while the workflow holds the source-S lock."""
+    _shared_image_repository()
+    source = _commit(source)
+    if set(digests) != {"slim", "analyzers"}:
+        raise VerificationError("both image digests are required before canonical publication")
+    pending: list[tuple[str, str]] = []
+    # Check both kinds before writing either. A resumed partial publication is
+    # valid only when the existing tag already equals the requested digest.
+    for kind, digest in digests.items():
+        verify_image(repo, digest, source, require_tracing=kind == "slim")
+        tag = source if kind == "slim" else f"analyzers-{source}"
+        current = _ghcr_digest_for_tag_once(tag)
+        if current.status is TagLookupStatus.ERROR:
+            raise VerificationError("registry unavailable during canonical publication")
+        if current.status is TagLookupStatus.FOUND:
+            if current.digest != digest:
+                raise VerificationError("canonical source tag already names a different digest")
+        else:
+            pending.append((tag, digest))
+    for tag, digest in pending:
+        _run(
+            repo,
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "create",
+                "--prefer-index=false",
+                "--tag",
+                f"{SLIM_IMAGE}:{tag}",
+                f"{SLIM_IMAGE}@{digest}",
+            ],
+        )
+        published = _ghcr_digest_for_tag(tag)
+        if published.status is not TagLookupStatus.FOUND or published.digest != digest:
+            raise VerificationError("canonical tag readback differs from verified digest")
+    return {"state": "canonical-images-published", "source_revision": source, **digests}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("phase", choices=("manifest", "pin", "resolve-images", "verify-images"))
+    parser.add_argument(
+        "phase", choices=("manifest", "pin", "resolve-images", "verify-images", "publish-canonical")
+    )
     parser.add_argument("--source", default=os.environ.get("SOURCE_REVISION"))
     parser.add_argument("--digest", default=os.environ.get("IMAGE_DIGEST"))
     parser.add_argument("--manifest", default=os.environ.get("MANIFEST_COMMIT"))
@@ -144,7 +220,17 @@ def main(argv: list[str] | None = None) -> int:
             if output := os.environ.get("GITHUB_OUTPUT"):
                 with Path(output).open("a") as stream:
                     stream.writelines(f"{key}={value}\n" for key, value in result.items())
+        elif args.phase == "publish-canonical":
+            result = publish_canonical(
+                REPO,
+                args.source or "",
+                {
+                    kind: os.environ.get(f"{kind.upper()}_DIGEST", "")
+                    for kind in ("slim", "analyzers")
+                },
+            )
         else:
+            _shared_image_repository()
             source = _commit(args.source or "")
             for kind in ("slim", "analyzers"):
                 verify_image(

--- a/scripts/bump_action_pin.py
+++ b/scripts/bump_action_pin.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Prepare the two reviewed commits C (manifest) then P (consumer pin).
+
+This tool never commits, pushes, creates PRs, or claims CI ran. Both phases
+require signed image verification; the pin phase requires C already merged.
+Exports: prepare_manifest, prepare_pin, resolve_images, main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from check_action_image_digest import (
+    REPO,
+    TagLookupStatus,
+    VerificationError,
+    _commit,
+    _ghcr_digest_for_tag,
+    _git,
+    verify_image,
+    verify_manifest,
+)
+
+_IMAGE_LINE = re.compile(
+    r"(?m)^([ \t]*image:[ \t]*[\"']?)docker://ghcr\.io/alexhawat/mergecraft@sha256:[0-9a-f]{64}([\"']?[ \t]*(?:#.*)?)$"
+)
+
+_PIN = re.compile(r"(uses:\s*alexhawat/mergeCraft@)[0-9a-f]{40}")
+_ENV_PIN = re.compile(r'(?m)^(\s*MERGECRAFT_ACTION_SHA:\s*["\']?)[0-9a-f]{40}')
+
+
+def _clean(repo: Path) -> str:
+    if _git(repo, "status", "--porcelain").strip():
+        raise VerificationError("prepare release changes in a clean isolated worktree")
+    return _commit(_git(repo, "rev-parse", "HEAD").strip())
+
+
+def prepare_manifest(repo: Path, source: str, digest: str) -> dict[str, str]:
+    """Change only action.yml at S; the caller reviews and merges it as C."""
+    source = _commit(source)
+    head = _clean(repo)
+    verify_image(repo, digest, source)
+    if head != source:
+        # An already merged manifest is a safe idempotent no-op, not a rebuild.
+        result = verify_manifest(repo, head)
+        if result.source_revision != source or result.image_digest != digest:
+            raise VerificationError("HEAD is not the built source or its verified manifest")
+        return {
+            "state": "manifest-already-present",
+            "manifest_commit": head,
+            "source_revision": source,
+            "image_digest": digest,
+        }
+    path = repo / "action.yml"
+    content, count = _IMAGE_LINE.subn(
+        lambda match: f"{match[1]}docker://ghcr.io/alexhawat/mergecraft@{digest}{match[2]}",
+        path.read_text(),
+    )
+    if count != 1:
+        raise VerificationError("expected exactly one digest image line")
+    path.write_text(content)
+    return {"state": "manifest-change-prepared", "source_revision": source, "image_digest": digest}
+
+
+def prepare_pin(repo: Path, manifest: str, base_branch: str = "pre-0.0.1") -> dict[str, str]:
+    """Pin an already merged C; never point consumers at S just because it built D."""
+    head = _clean(repo)
+    manifest = _commit(manifest)
+    if base_branch not in ("main", "pre-0.0.1"):
+        raise VerificationError("consumer pins target main or pre-0.0.1 only")
+    _git(repo, "merge-base", "--is-ancestor", manifest, f"origin/{base_branch}")
+    _git(repo, "merge-base", "--is-ancestor", manifest, head)
+    result = verify_manifest(repo, manifest)
+    changes: list[tuple[Path, str]] = []
+    consumer_pins = 0
+    for name in ("mergecraft.yml", "mergecraft-approve.yml"):
+        path = repo / ".github" / "workflows" / name
+        if not path.is_file():
+            continue
+        content = path.read_text()
+        consumer_pins += len(_PIN.findall(content))
+        replaced = _ENV_PIN.sub(
+            lambda match: match[1] + manifest, _PIN.sub(lambda match: match[1] + manifest, content)
+        )
+        if replaced != content:
+            changes.append((path, replaced))
+    if not consumer_pins:
+        raise VerificationError("no self-review consumer Action references found")
+    if not changes:
+        return {
+            "state": "pin-already-present",
+            "manifest_commit": manifest,
+            "source_revision": result.source_revision,
+            "image_digest": result.image_digest,
+        }
+    for path, content in changes:
+        path.write_text(content)
+    return {
+        "state": "pin-change-prepared",
+        "manifest_commit": manifest,
+        "source_revision": result.source_revision,
+        "image_digest": result.image_digest,
+    }
+
+
+def resolve_images(repo: Path, source: str) -> dict[str, str]:
+    """Reuse only verified SHA tags; registry errors/unsigned collisions fail closed."""
+    source = _commit(source)
+    outputs: dict[str, str] = {}
+    for kind, tag in (("slim", source), ("analyzers", f"analyzers-{source}")):
+        lookup = _ghcr_digest_for_tag(tag)
+        if lookup.status is TagLookupStatus.ERROR:
+            raise VerificationError("registry unavailable: cannot determine immutable tag state")
+        if lookup.status is TagLookupStatus.MISSING:
+            outputs[f"{kind}_digest"] = ""
+            continue
+        if lookup.digest is None:
+            raise VerificationError("registry returned an empty image digest")
+        verify_image(repo, lookup.digest, source, require_tracing=kind == "slim")
+        outputs[f"{kind}_digest"] = lookup.digest
+    return outputs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("phase", choices=("manifest", "pin", "resolve-images", "verify-images"))
+    parser.add_argument("--source", default=os.environ.get("SOURCE_REVISION"))
+    parser.add_argument("--digest", default=os.environ.get("IMAGE_DIGEST"))
+    parser.add_argument("--manifest", default=os.environ.get("MANIFEST_COMMIT"))
+    parser.add_argument("--base-branch", default=os.environ.get("RELEASE_BASE_BRANCH", "pre-0.0.1"))
+    args = parser.parse_args(argv)
+    try:
+        if args.phase == "manifest":
+            result = prepare_manifest(REPO, args.source or "", args.digest or "")
+        elif args.phase == "pin":
+            result = prepare_pin(REPO, args.manifest or "", args.base_branch)
+        elif args.phase == "resolve-images":
+            result = resolve_images(REPO, args.source or "")
+            if output := os.environ.get("GITHUB_OUTPUT"):
+                with Path(output).open("a") as stream:
+                    stream.writelines(f"{key}={value}\n" for key, value in result.items())
+        else:
+            source = _commit(args.source or "")
+            for kind in ("slim", "analyzers"):
+                verify_image(
+                    REPO,
+                    os.environ.get(f"{kind.upper()}_DIGEST", ""),
+                    source,
+                    require_tracing=kind == "slim",
+                )
+            result = {"state": "images-verified", "source_revision": source}
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (VerificationError, OSError, ValueError) as exc:
+        print(f"action-pin preparation FAILED: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_action_image_digest.py
+++ b/scripts/check_action_image_digest.py
@@ -83,7 +83,7 @@ def _ghcr_pull_token() -> str | None:
     return token if isinstance(token, str) and token else None
 
 
-# Retry a briefly missing source tag before deciding it is safe to build.
+# Retry post-publication tag visibility before accepting canonical readback.
 # Registry errors remain fatal; an unsigned existing tag is never overwritten.
 _MISSING_RETRIES = int(os.environ.get("MERGECRAFT_GHCR_MISSING_RETRIES", "3"))
 _MISSING_BACKOFF_SECONDS = float(os.environ.get("MERGECRAFT_GHCR_MISSING_BACKOFF", "3"))
@@ -278,14 +278,11 @@ _RELEASE_IDENTITY = (
 )
 
 
-def _verify_attestations(repo: Path, digest: str, source: str) -> None:
-    """Cryptographically bind D to S and the approved GitHub-hosted release workflow."""
-    image = f"{SLIM_IMAGE}@{digest}"
-    common = [
+def _attestation_policy(source: str) -> list[str]:
+    """Return compatible gh policy flags; the identity regex includes workflow and ref."""
+    return [
         "--repo",
         "alexhawat/mergeCraft",
-        "--signer-workflow",
-        "alexhawat/mergeCraft/.github/workflows/ci-cd.yml",
         "--source-digest",
         _commit(source),
         "--signer-digest",
@@ -296,6 +293,12 @@ def _verify_attestations(repo: Path, digest: str, source: str) -> None:
         "https://token.actions.githubusercontent.com",
         "--deny-self-hosted-runners",
     ]
+
+
+def _verify_attestations(repo: Path, digest: str, source: str) -> None:
+    """Cryptographically bind D to S and the approved GitHub-hosted release workflow."""
+    image = f"{SLIM_IMAGE}@{digest}"
+    common = _attestation_policy(source)
     _run(repo, ["gh", "attestation", "verify", f"oci://{image}", *common])
     _run(
         repo,
@@ -363,14 +366,84 @@ def verify_manifest(repo: Path, manifest_commit: str) -> VerifiedManifest:
     return VerifiedManifest(manifest_commit, source, digest)
 
 
+def _workflow_pins(text: str, *, strict: bool = True) -> set[str]:
+    """Parse literal Action references and exported pin markers, rejecting mutable refs."""
+    pins: set[str] = set()
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if (
+                    key == "uses"
+                    and isinstance(child, str)
+                    and child.lower().startswith("alexhawat/mergecraft@")
+                ):
+                    reference = child.split("@", 1)[1]
+                    pins.add(_commit(reference) if strict else reference)
+                elif key == "MERGECRAFT_ACTION_SHA":
+                    pins.add(_commit(str(child)) if strict else str(child))
+                else:
+                    visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(yaml.safe_load(text))
+    return pins
+
+
+def verify_candidate(repo: Path, base: str, head: str) -> dict[str, Any]:
+    """Verify deployment boundary changes without requiring source S to be published."""
+    base, head = _commit(base), _commit(head)
+    if base == "0" * 40:
+        base = _commit(_git(repo, "rev-parse", f"{head}^").strip())
+    changed = set(_git(repo, "diff", "--name-only", base, head, "--").splitlines())
+    manifests: set[str] = set()
+    if "action.yml" in changed:
+        before, after = _action_at(repo, base), _action_at(repo, head)
+        if before["runs"].get("image") != after["runs"].get("image"):
+            manifests.add(head)
+    base_paths = set(
+        _git(repo, "ls-tree", "-r", "--name-only", base, "--", ".github/workflows").splitlines()
+    )
+    head_paths = set(
+        _git(repo, "ls-tree", "-r", "--name-only", head, "--", ".github/workflows").splitlines()
+    )
+    for path in sorted(changed & (base_paths | head_paths)):
+        if not path.endswith((".yml", ".yaml")):
+            continue
+        old = (
+            _workflow_pins(_git(repo, "show", f"{base}:{path}"), strict=False)
+            if path in base_paths
+            else set()
+        )
+        new = _workflow_pins(_git(repo, "show", f"{head}:{path}")) if path in head_paths else set()
+        if old != new:
+            manifests.update(new)
+    records = [verify_manifest(repo, commit).__dict__ for commit in sorted(manifests)]
+    return {
+        "state": "deployment-candidates-verified" if records else "source-only-change",
+        "base_commit": base,
+        "head_commit": head,
+        "manifests": records,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     """Check deployed pins strictly, or explicitly report unverified source structure."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest-commit")
+    parser.add_argument("--candidate", action="store_true")
     parser.add_argument("--structure-only", action="store_true")
     parser.add_argument("--offline", action="store_true")
     args = parser.parse_args(argv or [])
     try:
+        if args.candidate:
+            result = verify_candidate(
+                REPO, os.environ.get("CANDIDATE_BASE", ""), os.environ.get("CANDIDATE_HEAD", "")
+            )
+            print(json.dumps(result, sort_keys=True))
+            return 0
         if args.structure_only:
             data = yaml.safe_load(ACTION_YML.read_text(encoding="utf-8"))
             _digest_from_action(data)

--- a/scripts/check_action_image_digest.py
+++ b/scripts/check_action_image_digest.py
@@ -1,29 +1,18 @@
 #!/usr/bin/env python3
-"""Guard: ``action.yml`` slim image digest must match GHCR for the workflow Action SHA.
+"""Verify the manifest commit actually pinned by a consumer against signed image provenance.
 
-The published Docker action must pull a digest-pinned ``ghcr.io/alexhawat/mergecraft``
-image instead of rebuilding from ``Dockerfile`` on every run (#526). When CI/CD
-has published a slim image for the self-review workflow's Action SHA pin, this
-script compares that registry digest to ``action.yml``'s ``runs.image`` pin and
-verifies the image was built with ``--extra tracing`` (#531).
-
-Registry outcomes are handled separately:
-- reachable + tag present → digest must match ``action.yml``
-- reachable + tag missing → **fail** (chicken-and-egg blocks a stale digest)
-- unreachable → skip with a notice (offline / local ``make lint``)
-
-Module: scripts.check_action_image_digest
-Depends: json, re, sys, urllib.error, urllib.request, pathlib, yaml
-
-Exports:
-    main — CLI entry; compares action.yml digest vs published GHCR slim image.
+Source validation is deliberately separate from deployed C → D → S verification.
+Only strict verification produces a verified result; offline mode exits 2.
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.error
@@ -32,6 +21,8 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 ACTION_YML = REPO / "action.yml"
@@ -71,18 +62,6 @@ def _pins_in(text: str) -> list[str]:
     return [match.group("sha") for match in _ACTION_PIN_RE.finditer(text)]
 
 
-def _read_action_image() -> str | None:
-    if not ACTION_YML.is_file():
-        return None
-    payload = ACTION_YML.read_text(encoding="utf-8")
-    data = __import__("yaml").safe_load(payload)
-    runs = data.get("runs") if isinstance(data, dict) else None
-    if not isinstance(runs, dict):
-        return None
-    image = runs.get("image")
-    return image if isinstance(image, str) else None
-
-
 def _ghcr_pull_token() -> str | None:
     """Return a registry pull token (anonymous for public packages, or via env)."""
     auth_header: str | None = None
@@ -104,14 +83,8 @@ def _ghcr_pull_token() -> str | None:
     return token if isinstance(token, str) and token else None
 
 
-def _registry_reachable() -> bool:
-    return _ghcr_pull_token() is not None
-
-
-# A tag pushed by action-slim-bootstrap is not always visible on the very next
-# read: GHCR settles a moment behind the push, and the gates start seconds after
-# it. Retry only MISSING, and only a few times — a genuinely unpublished SHA
-# must still fail rather than stall the job.
+# Retry a briefly missing source tag before deciding it is safe to build.
+# Registry errors remain fatal; an unsigned existing tag is never overwritten.
 _MISSING_RETRIES = int(os.environ.get("MERGECRAFT_GHCR_MISSING_RETRIES", "3"))
 _MISSING_BACKOFF_SECONDS = float(os.environ.get("MERGECRAFT_GHCR_MISSING_BACKOFF", "3"))
 
@@ -122,7 +95,7 @@ def _ghcr_digest_for_tag(tag: str) -> TagLookupResult:
     ``MISSING`` is retried because it is the one status that is routinely
     transient right after a push. ``ERROR`` is not: a registry fault or a bad
     token will not resolve itself inside a few seconds, and retrying it would
-    only delay a failure the caller already treats as non-fatal.
+    only delay the required failure.
     """
     result = _ghcr_digest_for_tag_once(tag)
     attempts = 0
@@ -157,60 +130,53 @@ def _ghcr_digest_for_tag_once(tag: str) -> TagLookupResult:
 
 
 def _fetch_oci_config_for_tag(tag: str) -> dict[str, Any] | None:
-    """Return the OCI image config JSON for a published slim image tag."""
+    """Read content-addressed registry objects and verify every returned byte hash."""
     token = _ghcr_pull_token()
-    if token is None:
+    if token is None or not re.fullmatch(r"sha256:[0-9a-f]{64}", tag):
         return None
-    request = urllib.request.Request(
-        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/manifests/{tag}",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": GHCR_MANIFEST_ACCEPT,
-        },
-    )
-    try:
-        index = json.loads(urllib.request.urlopen(request, timeout=30).read().decode("utf-8"))
-    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
-        return None
-    manifests = index.get("manifests")
-    if not isinstance(manifests, list) or not manifests:
-        return None
-    platform = manifests[0]
-    if not isinstance(platform, dict):
-        return None
-    manifest_digest = platform.get("digest")
-    if not isinstance(manifest_digest, str):
-        return None
-    request_manifest = urllib.request.Request(
-        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/manifests/{manifest_digest}",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": GHCR_MANIFEST_ACCEPT,
-        },
-    )
-    try:
-        manifest = json.loads(
-            urllib.request.urlopen(request_manifest, timeout=30).read().decode("utf-8")
+
+    def fetch(kind: str, digest: str) -> dict[str, Any]:
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise ValueError("registry descriptor is not a SHA256 digest")
+        request = urllib.request.Request(
+            f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/{kind}/{digest}",
+            headers={"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT},
         )
-    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
-        return None
-    config = manifest.get("config")
-    if not isinstance(config, dict):
-        return None
-    config_digest = config.get("digest")
-    if not isinstance(config_digest, str):
-        return None
-    request_config = urllib.request.Request(
-        f"https://ghcr.io/v2/{SLIM_IMAGE_REPO}/blobs/{config_digest}",
-        headers={"Authorization": f"Bearer {token}"},
-    )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read()
+        if "sha256:" + hashlib.sha256(raw).hexdigest() != digest:
+            raise ValueError("registry object does not match its digest")
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise ValueError("registry object is not a mapping")
+        return value
+
     try:
-        payload = json.loads(
-            urllib.request.urlopen(request_config, timeout=30).read().decode("utf-8")
-        )
-    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+        root = fetch("manifests", tag)
+        descriptors = root.get("manifests")
+        if isinstance(descriptors, list):
+            # BuildKit adds unknown/unknown attestation descriptors. Verify every
+            # runnable platform, not whichever descriptor happens to be first.
+            manifests = [
+                fetch("manifests", item["digest"])
+                for item in descriptors
+                if item.get("platform", {}).get("os") != "unknown"
+            ]
+        else:
+            manifests = [root]
+        configs = [fetch("blobs", item["config"]["digest"]) for item in manifests]
+        if not configs:
+            return None
+        revision = _revision_from_config(configs[0])
+        if any(
+            _revision_from_config(c) != revision
+            or _image_has_tracing_extra(c) != _image_has_tracing_extra(configs[0])
+            for c in configs
+        ):
+            return None
+        return configs[0]
+    except (OSError, ValueError, KeyError, TypeError, AttributeError):
         return None
-    return payload if isinstance(payload, dict) else None
 
 
 def _image_has_tracing_extra(config: dict[str, Any]) -> bool:
@@ -228,7 +194,10 @@ def _image_has_tracing_extra(config: dict[str, Any]) -> bool:
 
 
 def _revision_from_config(config: dict[str, Any]) -> str | None:
-    labels = config.get("config", {}).get("Labels")
+    image_config = config.get("config")
+    if not isinstance(image_config, dict):
+        return None
+    labels = image_config.get("Labels")
     if not isinstance(labels, dict):
         return None
     revision = labels.get(OCI_REVISION_LABEL)
@@ -239,144 +208,188 @@ def _self_review_action_sha() -> str | None:
     if not SELF_REVIEW_WORKFLOW.is_file():
         return None
     text = SELF_REVIEW_WORKFLOW.read_text(encoding="utf-8")
+    pins = set(_pins_in(text))
+    if len(pins) != 1:
+        return None
+    pin = next(iter(pins))
     env_match = _ENV_SHA_RE.search(text)
-    if env_match is not None:
-        return env_match.group("sha")
-    pins = _pins_in(text)
-    if not pins:
+    if env_match is not None and env_match.group("sha") != pin:
         return None
-    distinct = set(pins)
-    if len(distinct) != 1:
-        return None
-    return pins[0]
+    return pin
 
 
-def main() -> int:
-    """Validate action.yml image contract and GHCR parity."""
-    image = _read_action_image()
-    if image is None:
-        print("action-image-digest-check: action.yml missing runs.image", file=sys.stderr)
-        return 1
+class VerificationError(ValueError):
+    """The deployment cannot be proven against the trusted release policy."""
 
-    if image == "Dockerfile" or image.endswith("/Dockerfile"):
-        print(
-            "action-image-digest-check FAILED: action.yml still builds from Dockerfile — "
-            "pin docker://ghcr.io/alexhawat/mergecraft@sha256:<digest> (#526)",
-            file=sys.stderr,
+
+@dataclass(frozen=True)
+class VerifiedManifest:
+    manifest_commit: str
+    source_revision: str
+    image_digest: str
+    verified: bool = True
+
+
+def _run(repo: Path, argv: list[str]) -> str:
+    """Run a bounded verifier without shell interpolation or credential output."""
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env.update({"GIT_TERMINAL_PROMPT": "0", "GIT_CONFIG_NOSYSTEM": "1"})
+    try:
+        result = subprocess.run(
+            argv, cwd=repo, env=env, capture_output=True, text=True, timeout=120, check=False
         )
-        return 1
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise VerificationError(f"verification tool unavailable: {argv[0]}") from exc
+    if result.returncode:
+        raise VerificationError(f"{argv[0]} verification failed (exit {result.returncode})")
+    return result.stdout
 
-    match = _DIGEST_IMAGE_RE.match(image)
-    if match is None:
-        print(
-            f"action-image-digest-check FAILED: runs.image must be digest-pinned slim image "
-            f"docker://{SLIM_IMAGE}@sha256:<64-hex> — got {image!r}",
-            file=sys.stderr,
-        )
-        return 1
 
-    pinned = f"sha256:{match.group(1)}"
-    if "analyzers" in image:
-        print(
-            "action-image-digest-check FAILED: Action must use the slim image, not analyzers",
-            file=sys.stderr,
-        )
-        return 1
-
-    if not _registry_reachable():
-        print(
-            "action-image-digest-check: skipped GHCR parity — registry unreachable "
-            f"(action.yml pins {pinned[:19]}…)"
-        )
-        return 0
-
-    action_sha = _self_review_action_sha()
-    if action_sha is None:
-        print(
-            "action-image-digest-check OK: digest-pinned slim image "
-            f"({pinned[:19]}…) — no self-review Action SHA to compare"
-        )
-        return 0
-
-    lookup = _ghcr_digest_for_tag(action_sha)
-    if lookup.status is TagLookupStatus.ERROR:
-        print(
-            "action-image-digest-check: skipped GHCR parity — registry error while "
-            f"resolving {SLIM_IMAGE}:{action_sha[:12]} (action.yml pins {pinned[:19]}…)"
-        )
-        return 0
-
-    if lookup.status is TagLookupStatus.MISSING:
-        if not __import__("os").environ.get("GITHUB_ACTIONS"):
-            print(
-                "action-image-digest-check: skipped GHCR parity — slim image tag "
-                f"{SLIM_IMAGE}:{action_sha} not published yet (action.yml pins "
-                f"{pinned[:19]}…). The action-slim-bootstrap job or ci-cd "
-                "build-images must publish it first."
-            )
-            return 0
-        print("action-image-digest-check FAILED:", file=sys.stderr)
-        print(
-            f"  no published slim image for Action SHA {action_sha} "
-            f"(expected tag {SLIM_IMAGE}:{action_sha})",
-            file=sys.stderr,
-        )
-        print(
-            f"  action.yml pins {pinned} — run ci-cd build-images on pre-0.0.1, "
-            "then bump runs.image to that digest",
-            file=sys.stderr,
-        )
-        return 1
-
-    published = lookup.digest
-    assert published is not None
-    if published != pinned:
-        print("action-image-digest-check FAILED:", file=sys.stderr)
-        print(f"  action.yml pins {pinned}", file=sys.stderr)
-        print(f"  GHCR {SLIM_IMAGE}:{action_sha[:12]} publishes {published}", file=sys.stderr)
-        print(
-            "  Update action.yml runs.image to the published slim digest for this Action SHA.",
-            file=sys.stderr,
-        )
-        return 1
-
-    published_config = _fetch_oci_config_for_tag(action_sha)
-    if published_config is None:
-        print(
-            "action-image-digest-check FAILED: could not read OCI config for "
-            f"{SLIM_IMAGE}:{action_sha}",
-            file=sys.stderr,
-        )
-        return 1
-
-    if not _image_has_tracing_extra(published_config):
-        print(
-            "action-image-digest-check FAILED: published slim image was built without "
-            "`uv sync --extra tracing` — Logfire/OTEL sinks degrade to NullSink (#531). "
-            f"Do not pin pre-#531 digests such as {pinned[:19]}…",
-            file=sys.stderr,
-        )
-        return 1
-
-    published_revision = _revision_from_config(published_config)
-    if published_revision is not None and published_revision != action_sha:
-        print("action-image-digest-check FAILED:", file=sys.stderr)
-        print(
-            f"  GHCR tag {action_sha} ({OCI_REVISION_LABEL}={published_revision})",
-            file=sys.stderr,
-        )
-        print(
-            f"  mergecraft.yml Action SHA is {action_sha}",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(
-        f"action-image-digest-check OK: action.yml matches GHCR slim digest for "
-        f"Action SHA {action_sha[:12]} (tracing extra present)"
+def _git(repo: Path, *args: str) -> str:
+    return _run(
+        repo, ["git", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null", *args]
     )
-    return 0
+
+
+def _commit(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise VerificationError("expected an immutable 40-hex Git commit")
+    return value
+
+
+def _action_at(repo: Path, commit: str) -> dict[str, Any]:
+    data = yaml.safe_load(_git(repo, "show", f"{_commit(commit)}:action.yml"))
+    if not isinstance(data, dict) or not isinstance(data.get("runs"), dict):
+        raise VerificationError("pinned action.yml lacks a runs mapping")
+    return data
+
+
+def _digest_from_action(data: dict[str, Any]) -> str:
+    image = data["runs"].get("image", "")
+    match = _DIGEST_IMAGE_RE.fullmatch(image) if isinstance(image, str) else None
+    if match is None:
+        raise VerificationError("action must name the slim image by SHA256 digest")
+    return "sha256:" + match.group(1)
+
+
+_RELEASE_IDENTITY = (
+    r"^https://github\.com/alexhawat/mergeCraft/\.github/workflows/ci-cd\.yml@"
+    r"refs/(heads/(main|pre-0\.0\.1|release/[^ ]+)|tags/v[^ ]+)$"
+)
+
+
+def _verify_attestations(repo: Path, digest: str, source: str) -> None:
+    """Cryptographically bind D to S and the approved GitHub-hosted release workflow."""
+    image = f"{SLIM_IMAGE}@{digest}"
+    common = [
+        "--repo",
+        "alexhawat/mergeCraft",
+        "--signer-workflow",
+        "alexhawat/mergeCraft/.github/workflows/ci-cd.yml",
+        "--source-digest",
+        _commit(source),
+        "--signer-digest",
+        source,
+        "--cert-identity-regex",
+        _RELEASE_IDENTITY,
+        "--cert-oidc-issuer",
+        "https://token.actions.githubusercontent.com",
+        "--deny-self-hosted-runners",
+    ]
+    _run(repo, ["gh", "attestation", "verify", f"oci://{image}", *common])
+    _run(
+        repo,
+        [
+            "gh",
+            "attestation",
+            "verify",
+            f"oci://{image}",
+            *common,
+            "--predicate-type",
+            "https://spdx.dev/Document",
+        ],
+    )
+    _run(
+        repo,
+        [
+            "cosign",
+            "verify",
+            "--certificate-identity-regexp",
+            _RELEASE_IDENTITY,
+            "--certificate-oidc-issuer",
+            "https://token.actions.githubusercontent.com",
+            image,
+        ],
+    )
+
+
+def verify_image(
+    repo: Path, digest: str, expected_source: str | None = None, *, require_tracing: bool = True
+) -> str:
+    """Return S only after digest-addressed content and external attestations verify."""
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise VerificationError("expected an immutable image digest")
+    config = _fetch_oci_config_for_tag(digest)
+    if config is None:
+        raise VerificationError("registry content unavailable or invalid")
+    source = _revision_from_config(config)
+    if source is None:
+        raise VerificationError("image lacks its source revision")
+    _commit(source)
+    if expected_source is not None and source != _commit(expected_source):
+        raise VerificationError("image source differs from the requested source")
+    if require_tracing and not _image_has_tracing_extra(config):
+        raise VerificationError("image was built without the tracing extra")
+    _verify_attestations(repo, digest, source)
+    return source
+
+
+def verify_manifest(repo: Path, manifest_commit: str) -> VerifiedManifest:
+    """Verify C→D→S; C may differ from S only in the action's image field."""
+    manifest_commit = _commit(manifest_commit)
+    action = _action_at(repo, manifest_commit)
+    digest = _digest_from_action(action)
+    source = verify_image(repo, digest)
+    changed = _git(repo, "diff", "--name-only", source, manifest_commit, "--").splitlines()
+    if any(path != "action.yml" for path in changed):
+        raise VerificationError(
+            "manifest commit changes files beyond action.yml relative to image source"
+        )
+    source_action = _action_at(repo, source)
+    action["runs"].pop("image", None)
+    source_action["runs"].pop("image", None)
+    if action != source_action:
+        raise VerificationError("manifest commit changes Action behavior beyond runs.image")
+    return VerifiedManifest(manifest_commit, source, digest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check deployed pins strictly, or explicitly report unverified source structure."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest-commit")
+    parser.add_argument("--structure-only", action="store_true")
+    parser.add_argument("--offline", action="store_true")
+    args = parser.parse_args(argv or [])
+    try:
+        if args.structure_only:
+            data = yaml.safe_load(ACTION_YML.read_text(encoding="utf-8"))
+            _digest_from_action(data)
+            print("UNVERIFIED: source Action image syntax valid; deployed provenance not checked")
+            return 0
+        commit = args.manifest_commit or _self_review_action_sha()
+        if commit is None:
+            raise VerificationError("self-review Action pin missing or ambiguous")
+        if args.offline:
+            _digest_from_action(_action_at(REPO, commit))
+            print("UNVERIFIED: pinned manifest syntax valid; offline verification requested")
+            return 2
+        result = verify_manifest(REPO, commit)
+        print(json.dumps(result.__dict__, sort_keys=True))
+        return 0
+    except (VerificationError, OSError, ValueError, TypeError, KeyError) as exc:
+        print(f"action-image-digest-check FAILED: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/action/test_release_build_metadata.py
+++ b/tests/action/test_release_build_metadata.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -12,19 +11,20 @@ import pytest
 from tests.ci.workflow_support import REPO_ROOT
 
 
+def _stamp_source() -> str:
+    text = (REPO_ROOT / "Dockerfile").read_text()
+    return text.split("python - <<'PYTHON'\n", 1)[1].split("\nPYTHON", 1)[0]
+
+
 @pytest.mark.parametrize("revision", ["a" * 40, ""])
-def test_docker_source_stamp_records_only_valid_source(tmp_path: Path, revision: str) -> None:
-    line = next(
-        line
-        for line in (REPO_ROOT / "Dockerfile").read_text().splitlines()
-        if line.startswith("RUN SOURCE_REVISION=")
-    )
-    argv = shlex.split(line)
-    source = argv[argv.index("-c") + 1]
+@pytest.mark.parametrize("optimized", [False, True])
+def test_docker_source_stamp_records_only_valid_source(
+    tmp_path: Path, revision: str, optimized: bool
+) -> None:
     metadata = tmp_path / "src/mergecraft/_build_metadata.py"
     metadata.parent.mkdir(parents=True)
     subprocess.run(
-        [sys.executable, "-c", source],
+        [sys.executable, *(["-O"] if optimized else []), "-c", _stamp_source()],
         cwd=tmp_path,
         env={**os.environ, "SOURCE_REVISION": revision},
         check=True,
@@ -33,20 +33,18 @@ def test_docker_source_stamp_records_only_valid_source(tmp_path: Path, revision:
     assert metadata.read_text() == f"__commit__: str | None = {revision or None!r}\n"
 
 
-def test_docker_source_stamp_rejects_untrusted_non_sha_value(tmp_path: Path) -> None:
-    line = next(
-        line
-        for line in (REPO_ROOT / "Dockerfile").read_text().splitlines()
-        if line.startswith("RUN SOURCE_REVISION=")
-    )
-    argv = shlex.split(line)
+@pytest.mark.parametrize("optimized", [False, True])
+def test_docker_source_stamp_rejects_untrusted_non_sha_value(
+    tmp_path: Path, optimized: bool
+) -> None:
     result = subprocess.run(
-        [sys.executable, "-c", argv[argv.index("-c") + 1]],
+        [sys.executable, *(["-O"] if optimized else []), "-c", _stamp_source()],
         cwd=tmp_path,
-        env={**os.environ, "SOURCE_REVISION": "not-a-commit"},
+        env={**os.environ, "SOURCE_REVISION": "not-a-commit", "PYTHONOPTIMIZE": "1"},
         capture_output=True,
         check=False,
         timeout=10,
     )
     assert result.returncode != 0
+    assert b"invalid source revision" in result.stderr
     assert not (tmp_path / "src/mergecraft/_build_metadata.py").exists()

--- a/tests/action/test_release_build_metadata.py
+++ b/tests/action/test_release_build_metadata.py
@@ -1,0 +1,52 @@
+"""Image build source stamping must not invent its future digest or manifest SHA."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from tests.ci.workflow_support import REPO_ROOT
+
+
+@pytest.mark.parametrize("revision", ["a" * 40, ""])
+def test_docker_source_stamp_records_only_valid_source(tmp_path: Path, revision: str) -> None:
+    line = next(
+        line
+        for line in (REPO_ROOT / "Dockerfile").read_text().splitlines()
+        if line.startswith("RUN SOURCE_REVISION=")
+    )
+    argv = shlex.split(line)
+    source = argv[argv.index("-c") + 1]
+    metadata = tmp_path / "src/mergecraft/_build_metadata.py"
+    metadata.parent.mkdir(parents=True)
+    subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=tmp_path,
+        env={**os.environ, "SOURCE_REVISION": revision},
+        check=True,
+        timeout=10,
+    )
+    assert metadata.read_text() == f"__commit__: str | None = {revision or None!r}\n"
+
+
+def test_docker_source_stamp_rejects_untrusted_non_sha_value(tmp_path: Path) -> None:
+    line = next(
+        line
+        for line in (REPO_ROOT / "Dockerfile").read_text().splitlines()
+        if line.startswith("RUN SOURCE_REVISION=")
+    )
+    argv = shlex.split(line)
+    result = subprocess.run(
+        [sys.executable, "-c", argv[argv.index("-c") + 1]],
+        cwd=tmp_path,
+        env={**os.environ, "SOURCE_REVISION": "not-a-commit"},
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode != 0
+    assert not (tmp_path / "src/mergecraft/_build_metadata.py").exists()

--- a/tests/ci/test_action_image_digest_check.py
+++ b/tests/ci/test_action_image_digest_check.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import urllib.error
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
+
+import pytest
 
 from tests.ci.workflow_support import REPO_ROOT
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def _load_module() -> Any:
@@ -158,44 +158,216 @@ class TestGhcrDigestLookup:
         assert module._image_has_tracing_extra(config) is False
 
 
-class TestMain:
-    def test_fails_when_image_is_dockerfile(self, tmp_path: Path) -> None:
-        module = _load_module()
-        action = tmp_path / "action.yml"
-        action.write_text("runs:\n  using: docker\n  image: Dockerfile\n", encoding="utf-8")
-        module.ACTION_YML = action
-        assert module.main() != 0
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, timeout=30, check=True
+    )
+    return result.stdout.strip()
 
-    def test_fails_on_mutable_tag(self, tmp_path: Path) -> None:
-        module = _load_module()
-        action = tmp_path / "action.yml"
-        action.write_text(
-            "runs:\n  using: docker\n  image: docker://ghcr.io/alexhawat/mergecraft:latest\n",
-            encoding="utf-8",
-        )
-        module.ACTION_YML = action
-        assert module.main() != 0
 
-    def test_fails_on_pre_tracing_digest(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Pinned pre-#531 digests must not pass the tracing-extra contract."""
-        module = _load_module()
-        action = tmp_path / "action.yml"
-        action.write_text(
-            "runs:\n  using: docker\n  image: "
-            "docker://ghcr.io/alexhawat/mergecraft@"
-            "sha256:955510ad23e1aa23d564475c2220ec0988236838a914a2a7472ea38220cb1f90\n",
-            encoding="utf-8",
-        )
-        module.ACTION_YML = action
-        monkeypatch.setattr(
-            module,
-            "_self_review_action_sha",
-            lambda: "cfdf38dcd062779aac3e141c51f134213d395b67",
-        )
-        assert module.main() != 0
+def _history(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "fixture@example.invalid")
+    _git(repo, "config", "user.name", "Release Fixture")
+    action = repo / "action.yml"
+    action.write_text(
+        "runs:\n  using: docker\n  image: docker://ghcr.io/alexhawat/mergecraft@sha256:"
+        + "a" * 64
+        + "\n"
+    )
+    (repo / "runtime.py").write_text("VALUE = 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: source fixture")
+    source = _git(repo, "rev-parse", "HEAD")
+    action.write_text(action.read_text().replace("a" * 64, "b" * 64))
+    _git(repo, "commit", "-am", "test: manifest fixture")
+    return repo, source, _git(repo, "rev-parse", "HEAD")
 
-    def test_passes_on_repo_action_yml(self) -> None:
-        module = _load_module()
-        assert module.main() == 0
+
+def _config(source: str) -> dict[str, Any]:
+    return {
+        "config": {"Labels": {"org.opencontainers.image.revision": source}},
+        "history": [{"created_by": "RUN uv sync --extra tracing"}],
+    }
+
+
+def test_manifest_only_commit_verifies_actual_pinned_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    repo, source, manifest = _history(tmp_path)
+    seen: list[str] = []
+    monkeypatch.setattr(
+        module, "_fetch_oci_config_for_tag", lambda digest: seen.append(digest) or _config(source)
+    )
+    monkeypatch.setattr(module, "_verify_attestations", lambda *args: None)
+    # Uncommitted working-tree bytes must never change what uses@C executes.
+    (repo / "action.yml").write_text("runs:\n  image: Dockerfile\n")
+    result = module.verify_manifest(repo, manifest)
+    assert result.source_revision == source
+    assert result.manifest_commit == manifest
+    assert result.image_digest == "sha256:" + "b" * 64
+    assert seen == [result.image_digest]
+
+
+def test_correct_worktree_cannot_rescue_old_pinned_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    repo, source, _manifest = _history(tmp_path)
+    monkeypatch.setattr(
+        module,
+        "_fetch_oci_config_for_tag",
+        lambda digest: _config(source) if digest.endswith("b" * 64) else None,
+    )
+    with pytest.raises(module.VerificationError, match="registry"):
+        module.verify_manifest(repo, source)
+
+
+@pytest.mark.parametrize("change", ["runtime", "entrypoint", "args", "workflow"])
+def test_manifest_must_not_change_runtime_or_build_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, change: str
+) -> None:
+    module = _load_module()
+    repo, source, _manifest = _history(tmp_path)
+    if change == "runtime":
+        (repo / "runtime.py").write_text("VALUE = 2\n")
+    elif change == "workflow":
+        (repo / "release.yml").write_text("unreviewed workflow\n")
+    else:
+        with (repo / "action.yml").open("a") as stream:
+            stream.write(f"  {change}: changed\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: changed behavior")
+    monkeypatch.setattr(module, "_fetch_oci_config_for_tag", lambda _: _config(source))
+    monkeypatch.setattr(module, "_verify_attestations", lambda *args: None)
+    with pytest.raises(module.VerificationError, match="changes"):
+        module.verify_manifest(repo, _git(repo, "rev-parse", "HEAD"))
+
+
+@pytest.mark.parametrize(
+    "failure", ["missing-revision", "wrong-revision", "missing-tracing", "registry", "attestation"]
+)
+def test_image_claims_do_not_bypass_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    module = _load_module()
+    config = _config("a" * 40)
+    if failure == "missing-revision":
+        config["config"]["Labels"] = {}
+    elif failure == "wrong-revision":
+        config["config"]["Labels"][module.OCI_REVISION_LABEL] = "b" * 40
+    elif failure == "missing-tracing":
+        config["history"] = [{"created_by": "RUN uv sync"}]
+    monkeypatch.setattr(
+        module, "_fetch_oci_config_for_tag", lambda _: None if failure == "registry" else config
+    )
+
+    def deny(*args: object) -> None:
+        raise module.VerificationError("attestation rejected")
+
+    monkeypatch.setattr(module, "_verify_attestations", deny)
+    with pytest.raises(module.VerificationError):
+        module.verify_image(tmp_path, "sha256:" + "d" * 64, "a" * 40)
+
+
+def test_attestation_commands_bind_digest_source_and_trusted_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    calls: list[list[str]] = []
+    monkeypatch.setattr(module, "_run", lambda repo, argv: calls.append(argv) or "")
+    digest, source = "sha256:" + "b" * 64, "a" * 40
+    module._verify_attestations(tmp_path, digest, source)
+    assert len(calls) == 3
+    for argv in calls[:2]:
+        assert argv[:4] == ["gh", "attestation", "verify", f"oci://{module.SLIM_IMAGE}@{digest}"]
+        assert argv[argv.index("--source-digest") + 1] == source
+        assert argv[argv.index("--signer-digest") + 1] == source
+        assert (
+            argv[argv.index("--signer-workflow") + 1]
+            == "alexhawat/mergeCraft/.github/workflows/ci-cd.yml"
+        )
+        assert argv[argv.index("--repo") + 1] == "alexhawat/mergeCraft"
+        assert "--deny-self-hosted-runners" in argv
+        identity = argv[argv.index("--cert-identity-regex") + 1]
+        assert module.re.fullmatch(
+            identity,
+            "https://github.com/alexhawat/mergeCraft/.github/workflows/ci-cd.yml@refs/heads/main",
+        )
+        assert not module.re.fullmatch(
+            identity,
+            "https://github.com/alexhawat/mergeCraft/.github/workflows/ci-cd.yml@refs/pull/42/merge",
+        )
+    assert calls[1][-2:] == ["--predicate-type", "https://spdx.dev/Document"]
+    assert calls[2][-1] == f"{module.SLIM_IMAGE}@{digest}"
+    assert "--certificate-oidc-issuer" in calls[2]
+
+
+def test_offline_is_explicitly_unverified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_module()
+    repo, _source, manifest = _history(tmp_path)
+    monkeypatch.setattr(module, "REPO", repo)
+    assert module.main(["--offline", "--manifest-commit", manifest]) == 2
+    assert "UNVERIFIED" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("image", ["Dockerfile", "docker://ghcr.io/alexhawat/mergecraft:latest"])
+def test_source_structure_rejects_unpinned_image(tmp_path: Path, image: str) -> None:
+    module = _load_module()
+    action = tmp_path / "action.yml"
+    action.write_text(f"runs:\n  image: {image}\n")
+    module.ACTION_YML = action
+    assert module.main(["--structure-only"]) == 1
+
+
+@pytest.mark.parametrize("tamper", [False, True])
+def test_registry_config_is_bound_to_immutable_descriptor_hashes(
+    monkeypatch: pytest.MonkeyPatch, tamper: bool
+) -> None:
+    import hashlib
+    import json
+
+    module = _load_module()
+    objects: dict[str, bytes] = {}
+
+    def store(value: dict[str, Any]) -> str:
+        raw = json.dumps(value).encode()
+        digest = "sha256:" + hashlib.sha256(raw).hexdigest()
+        objects[digest] = raw
+        return digest
+
+    config = _config("a" * 40)
+    config_digest = store(config)
+    manifest = store({"config": {"digest": config_digest}})
+    index = store(
+        {"manifests": [{"digest": manifest, "platform": {"os": "linux", "architecture": "amd64"}}]}
+    )
+    if tamper:
+        objects[config_digest] = json.dumps(_config("b" * 40)).encode()
+    monkeypatch.setattr(module, "_ghcr_pull_token", lambda: "public-fixture")
+
+    class Response:
+        def __init__(self, data: bytes) -> None:
+            self.data = data
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self.data
+
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda request, timeout: Response(objects[request.full_url.rsplit("/", 1)[1]]),
+    )
+    result = module._fetch_oci_config_for_tag(index)
+    assert result == (None if tamper else config)

--- a/tests/ci/test_action_image_digest_check.py
+++ b/tests/ci/test_action_image_digest_check.py
@@ -286,10 +286,7 @@ def test_attestation_commands_bind_digest_source_and_trusted_identity(
         assert argv[:4] == ["gh", "attestation", "verify", f"oci://{module.SLIM_IMAGE}@{digest}"]
         assert argv[argv.index("--source-digest") + 1] == source
         assert argv[argv.index("--signer-digest") + 1] == source
-        assert (
-            argv[argv.index("--signer-workflow") + 1]
-            == "alexhawat/mergeCraft/.github/workflows/ci-cd.yml"
-        )
+        assert "--signer-workflow" not in argv
         assert argv[argv.index("--repo") + 1] == "alexhawat/mergeCraft"
         assert "--deny-self-hosted-runners" in argv
         identity = argv[argv.index("--cert-identity-regex") + 1]
@@ -371,3 +368,103 @@ def test_registry_config_is_bound_to_immutable_descriptor_hashes(
     )
     result = module._fetch_oci_config_for_tag(index)
     assert result == (None if tamper else config)
+
+
+def test_real_gh_accepts_attestation_policy_before_offline_bundle_failure(tmp_path: Path) -> None:
+    """Exercise gh's real argument parser without registry access or mocked execution."""
+    import os
+    import shutil
+
+    gh = shutil.which("gh")
+    if gh is None:
+        pytest.skip("gh CLI required for real attestation argument compatibility")
+    module = _load_module()
+    artifact = tmp_path / "artifact"
+    artifact.write_text("public parser fixture\n")
+    missing = tmp_path / "missing-bundle.jsonl"
+    result = subprocess.run(
+        [
+            gh,
+            "attestation",
+            "verify",
+            str(artifact),
+            "--bundle",
+            str(missing),
+            *module._attestation_policy("a" * 40),
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "GH_TOKEN": "public-parser-fixture",
+            "HTTPS_PROXY": "http://127.0.0.1:1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert result.returncode != 0
+    downstream_error = (
+        "missing-bundle.jsonl" in result.stderr
+        and "no such file or directory" in result.stderr.lower()
+    ) or "no valid Sigstore verifiers could be initialized" in result.stderr
+    assert downstream_error, result.stderr
+    assert "were all set" not in result.stderr
+    assert "unknown flag" not in result.stderr
+
+
+def test_candidate_image_change_verifies_full_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    repo, source, manifest = _history(tmp_path)
+    monkeypatch.setattr(module, "verify_image", lambda *_args: source)
+    result = module.verify_candidate(repo, source, manifest)
+    assert result["manifests"][0]["manifest_commit"] == manifest
+    action = repo / "action.yml"
+    action.write_text(action.read_text() + "  entrypoint: malicious\n")
+    _git(repo, "commit", "-am", "test: incompatible manifest")
+    with pytest.raises(module.VerificationError, match="behavior"):
+        module.verify_candidate(repo, source, _git(repo, "rev-parse", "HEAD"))
+
+
+def test_source_metadata_can_build_but_cannot_be_pinned_without_matching_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    repo, source, manifest = _history(tmp_path)
+    monkeypatch.setattr(module, "verify_image", lambda *_args: source)
+    action = repo / "action.yml"
+    action.write_text(action.read_text() + "  args: [changed]\n")
+    _git(repo, "commit", "-am", "test: source metadata")
+    changed = _git(repo, "rev-parse", "HEAD")
+    assert module.verify_candidate(repo, manifest, changed)["state"] == "source-only-change"
+    workflow = repo / ".github/workflows/review.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(f"jobs:\n  review:\n    uses: alexhawat/mergeCraft@{changed}\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: deploy incompatible candidate")
+    with pytest.raises(module.VerificationError, match="behavior"):
+        module.verify_candidate(repo, changed, _git(repo, "rev-parse", "HEAD"))
+
+
+def test_candidate_rejects_mutable_new_pin_but_allows_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    repo, source, manifest = _history(tmp_path)
+    monkeypatch.setattr(module, "verify_image", lambda *_args: source)
+    workflow = repo / ".github/workflows/review.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("jobs:\n  review:\n    uses: alexhawat/mergeCraft@main\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: mutable reference")
+    mutable = _git(repo, "rev-parse", "HEAD")
+    with pytest.raises(module.VerificationError):
+        module.verify_candidate(repo, manifest, mutable)
+    workflow.write_text(f"env:\n  MERGECRAFT_ACTION_SHA: {manifest}\n")
+    _git(repo, "commit", "-am", "test: repair mutable reference")
+    result = module.verify_candidate(repo, mutable, _git(repo, "rev-parse", "HEAD"))
+    assert result["manifests"][0]["manifest_commit"] == manifest
+    with pytest.raises(module.VerificationError):
+        module.verify_candidate(repo, "main", manifest)

--- a/tests/ci/test_bump_action_pin.py
+++ b/tests/ci/test_bump_action_pin.py
@@ -1,0 +1,131 @@
+"""Real-history coverage for source→manifest→consumer pin preparation."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.ci.test_action_image_digest_check import _git, _history
+from tests.ci.workflow_support import REPO_ROOT
+
+
+def _module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
+    return importlib.import_module("bump_action_pin")
+
+
+def test_manifest_preparation_changes_only_image_after_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, _manifest = _history(tmp_path)
+    _git(repo, "checkout", "--detach", source)
+    seen: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        module, "verify_image", lambda repo, digest, sha: seen.append((digest, sha))
+    )
+    digest = "sha256:" + "b" * 64
+    result = module.prepare_manifest(repo, source, digest)
+    assert result["state"] == "manifest-change-prepared"
+    assert seen == [(digest, source)]
+    assert _git(repo, "diff", "--name-only") == "action.yml"
+    assert digest in (repo / "action.yml").read_text()
+    assert _git(repo, "rev-parse", "HEAD") == source
+
+
+def test_failed_attestation_cannot_prepare_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, _manifest = _history(tmp_path)
+    _git(repo, "checkout", "--detach", source)
+
+    def deny(*args: object) -> None:
+        raise module.VerificationError("signature rejected")
+
+    monkeypatch.setattr(module, "verify_image", deny)
+    with pytest.raises(module.VerificationError):
+        module.prepare_manifest(repo, source, "sha256:" + "b" * 64)
+    assert not _git(repo, "status", "--porcelain")
+
+
+def test_pin_requires_manifest_already_in_target_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, manifest = _history(tmp_path)
+    _git(repo, "update-ref", "refs/remotes/origin/pre-0.0.1", source)
+    with pytest.raises(module.VerificationError):
+        module.prepare_pin(repo, manifest)
+    assert not _git(repo, "status", "--porcelain")
+
+
+def test_consumer_pin_uses_c_and_never_built_source_s(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, manifest = _history(tmp_path)
+    workflows = repo / ".github/workflows"
+    workflows.mkdir(parents=True)
+    path = workflows / "mergecraft.yml"
+    path.write_text(
+        f'env:\n  MERGECRAFT_ACTION_SHA: "{source}"\njobs:\n  review:\n    steps:\n      - uses: alexhawat/mergeCraft@{source}\n'
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: consumer fixture")
+    _git(repo, "update-ref", "refs/remotes/origin/pre-0.0.1", manifest)
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        module,
+        "verify_manifest",
+        lambda repo, commit: SimpleNamespace(
+            source_revision=source, image_digest="sha256:" + "b" * 64
+        ),
+    )
+    result = module.prepare_pin(repo, manifest)
+    assert result["state"] == "pin-change-prepared"
+    assert source not in path.read_text()
+    assert path.read_text().count(manifest) == 2
+    _git(repo, "commit", "-am", "test: pin fixture")
+    assert module.prepare_pin(repo, manifest)["state"] == "pin-already-present"
+
+
+def test_existing_unsigned_tag_is_not_rebuilt_or_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        module,
+        "_ghcr_digest_for_tag",
+        lambda tag: SimpleNamespace(
+            status=module.TagLookupStatus.FOUND, digest="sha256:" + "d" * 64
+        ),
+    )
+
+    def deny(*args: object, **kwargs: object) -> None:
+        raise module.VerificationError("unsigned tag")
+
+    monkeypatch.setattr(module, "verify_image", deny)
+    with pytest.raises(module.VerificationError, match="unsigned"):
+        module.resolve_images(tmp_path, "a" * 40)
+
+
+def test_registry_error_does_not_mean_missing_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        module,
+        "_ghcr_digest_for_tag",
+        lambda tag: SimpleNamespace(status=module.TagLookupStatus.ERROR),
+    )
+    with pytest.raises(module.VerificationError, match="unavailable"):
+        module.resolve_images(tmp_path, "a" * 40)

--- a/tests/ci/test_bump_action_pin.py
+++ b/tests/ci/test_bump_action_pin.py
@@ -34,6 +34,8 @@ def test_manifest_preparation_changes_only_image_after_verification(
     assert _git(repo, "diff", "--name-only") == "action.yml"
     assert digest in (repo / "action.yml").read_text()
     assert _git(repo, "rev-parse", "HEAD") == source
+    assert result["manifest_commit"] is None
+    assert module.prepare_manifest(repo, source, digest) == result
 
 
 def test_failed_attestation_cannot_prepare_manifest(
@@ -90,6 +92,7 @@ def test_consumer_pin_uses_c_and_never_built_source_s(
     assert result["state"] == "pin-change-prepared"
     assert source not in path.read_text()
     assert path.read_text().count(manifest) == 2
+    assert module.prepare_pin(repo, manifest) == result
     _git(repo, "commit", "-am", "test: pin fixture")
     assert module.prepare_pin(repo, manifest)["state"] == "pin-already-present"
 
@@ -102,7 +105,7 @@ def test_existing_unsigned_tag_is_not_rebuilt_or_reused(
 
     monkeypatch.setattr(
         module,
-        "_ghcr_digest_for_tag",
+        "_ghcr_digest_for_tag_once",
         lambda tag: SimpleNamespace(
             status=module.TagLookupStatus.FOUND, digest="sha256:" + "d" * 64
         ),
@@ -124,8 +127,188 @@ def test_registry_error_does_not_mean_missing_tag(
 
     monkeypatch.setattr(
         module,
-        "_ghcr_digest_for_tag",
+        "_ghcr_digest_for_tag_once",
         lambda tag: SimpleNamespace(status=module.TagLookupStatus.ERROR),
     )
     with pytest.raises(module.VerificationError, match="unavailable"):
         module.resolve_images(tmp_path, "a" * 40)
+
+
+@pytest.mark.parametrize("dirty", ["staged", "untracked", "runtime", "wrong-image", "mode"])
+def test_prepared_manifest_rejects_unrelated_or_staged_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, dirty: str
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, _manifest = _history(tmp_path)
+    _git(repo, "checkout", "--detach", source)
+    monkeypatch.setattr(module, "verify_image", lambda *args: None)
+    digest = "sha256:" + "b" * 64
+    module.prepare_manifest(repo, source, digest)
+    if dirty == "staged":
+        _git(repo, "add", "action.yml")
+    elif dirty == "untracked":
+        (repo / "untracked").write_text("unexpected")
+    elif dirty == "runtime":
+        (repo / "runtime.py").write_text("VALUE = 2\n")
+    elif dirty == "wrong-image":
+        path = repo / "action.yml"
+        path.write_text(path.read_text().replace("b" * 64, "c" * 64))
+    else:
+        (repo / "action.yml").chmod(0o755)
+    with pytest.raises(module.VerificationError):
+        module.prepare_manifest(repo, source, digest)
+
+
+def test_already_present_manifest_reports_existing_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    repo, source, _manifest = _history(tmp_path)
+    _git(repo, "checkout", "--detach", source)
+    monkeypatch.setattr(module, "verify_image", lambda *args: None)
+    result = module.prepare_manifest(repo, source, "sha256:" + "a" * 64)
+    assert result["state"] == "manifest-already-present"
+    assert result["manifest_commit"] == source
+    assert not _git(repo, "status", "--porcelain")
+
+
+def test_env_only_consumer_is_supported_and_prepared_rerun_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from types import SimpleNamespace
+
+    module = _module(monkeypatch)
+    repo, source, manifest = _history(tmp_path)
+    path = repo / ".github/workflows/mergecraft.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(f'env:\n  MERGECRAFT_ACTION_SHA: "{source}"\n')
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "test: env-only consumer")
+    _git(repo, "update-ref", "refs/remotes/origin/pre-0.0.1", manifest)
+    monkeypatch.setattr(
+        module,
+        "verify_manifest",
+        lambda *args: SimpleNamespace(source_revision=source, image_digest="sha256:" + "b" * 64),
+    )
+    first = module.prepare_pin(repo, manifest)
+    assert first["state"] == "pin-change-prepared"
+    assert manifest in path.read_text()
+    assert module.prepare_pin(repo, manifest) == first
+    _git(repo, "add", ".")
+    with pytest.raises(module.VerificationError, match="staged"):
+        module.prepare_pin(repo, manifest)
+
+
+def test_shared_repository_drift_fails_before_registry_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module(monkeypatch)
+    monkeypatch.setenv("IMAGE_ANALYZERS", "ghcr.io/alexhawat/other-package")
+
+    def unexpected(*args: object) -> None:
+        pytest.fail("registry access must not occur for unsupported repository configuration")
+
+    monkeypatch.setattr(module, "_ghcr_digest_for_tag_once", unexpected)
+    with pytest.raises(module.VerificationError, match="shared repository"):
+        module.resolve_images(tmp_path, "a" * 40)
+
+
+def test_failed_staging_attempt_can_restart_without_unsigned_canonical_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from types import SimpleNamespace
+
+    module = _module(monkeypatch)
+    source = "a" * 40
+    tags: dict[str, str] = {}
+    verified: set[str] = set()
+    attempts: list[tuple[str, str]] = []
+
+    def lookup(tag: str) -> Any:
+        return SimpleNamespace(
+            status=module.TagLookupStatus.FOUND if tag in tags else module.TagLookupStatus.MISSING,
+            digest=tags.get(tag),
+        )
+
+    def verify(repo: Path, digest: str, sha: str, **kwargs: object) -> str:
+        assert sha == source
+        if digest not in verified:
+            raise module.VerificationError("signature absent")
+        return source
+
+    def run(repo: Path, argv: list[str]) -> str:
+        assert argv[:5] == ["docker", "buildx", "imagetools", "create", "--prefer-index=false"]
+        tag = argv[argv.index("--tag") + 1].split(":")[-1]
+        digest = argv[-1].split("@")[-1]
+        attempts.append((tag, digest))
+        tags[tag] = digest
+        return ""
+
+    monkeypatch.setattr(module, "_ghcr_digest_for_tag_once", lookup)
+    monkeypatch.setattr(module, "_ghcr_digest_for_tag", lookup)
+    monkeypatch.setattr(module, "verify_image", verify)
+    monkeypatch.setattr(module, "_run", run)
+    assert module.resolve_images(tmp_path, source) == {"slim_digest": "", "analyzers_digest": ""}
+    tags["staging-42-1-slim"] = "sha256:" + "b" * 64
+    # Failed scan/sign left staging only. Re-run-all starts without trusting it.
+    assert module.resolve_images(tmp_path, source) == {"slim_digest": "", "analyzers_digest": ""}
+    digests = {"slim": "sha256:" + "c" * 64, "analyzers": "sha256:" + "d" * 64}
+    with pytest.raises(module.VerificationError, match="signature"):
+        module.publish_canonical(tmp_path, source, digests)
+    assert not attempts
+    verified.update(digests.values())
+    # A conflict in the SECOND kind must not publish the first one.
+    tags[f"analyzers-{source}"] = "sha256:" + "f" * 64
+    with pytest.raises(module.VerificationError, match="different digest"):
+        module.publish_canonical(tmp_path, source, digests)
+    assert not attempts
+    del tags[f"analyzers-{source}"]
+    # Simulate interruption after only slim was published; retry finishes analyzers.
+    tags[source] = digests["slim"]
+    module.publish_canonical(tmp_path, source, digests)
+    assert attempts == [(f"analyzers-{source}", digests["analyzers"])]
+    tags.clear()
+    attempts.clear()
+    module.publish_canonical(tmp_path, source, digests)
+    assert tags[source] == digests["slim"]
+    assert tags[f"analyzers-{source}"] == digests["analyzers"]
+    assert len(attempts) == 2
+    module.publish_canonical(tmp_path, source, digests)
+    assert len(attempts) == 2
+    different = {**digests, "slim": "sha256:" + "e" * 64}
+    verified.add(different["slim"])
+    with pytest.raises(module.VerificationError, match="different digest"):
+        module.publish_canonical(tmp_path, source, different)
+    assert len(attempts) == 2
+
+
+@pytest.mark.parametrize("readback", ["wrong-digest", "missing", "error"])
+def test_canonical_publication_rejects_unverified_readback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, readback: str
+) -> None:
+    from types import SimpleNamespace
+
+    module = _module(monkeypatch)
+    monkeypatch.setattr(module, "verify_image", lambda *_args, **_kwargs: "a" * 40)
+    monkeypatch.setattr(
+        module,
+        "_ghcr_digest_for_tag_once",
+        lambda _tag: SimpleNamespace(status=module.TagLookupStatus.MISSING),
+    )
+    writes: list[list[str]] = []
+    monkeypatch.setattr(module, "_run", lambda _repo, argv: writes.append(argv))
+    statuses = {
+        "wrong-digest": module.TagLookupStatus.FOUND,
+        "missing": module.TagLookupStatus.MISSING,
+        "error": module.TagLookupStatus.ERROR,
+    }
+    monkeypatch.setattr(
+        module,
+        "_ghcr_digest_for_tag",
+        lambda _tag: SimpleNamespace(status=statuses[readback], digest="sha256:" + "f" * 64),
+    )
+    with pytest.raises(module.VerificationError, match="readback"):
+        module.publish_canonical(
+            tmp_path, "a" * 40, {"slim": "sha256:" + "b" * 64, "analyzers": "sha256:" + "c" * 64}
+        )
+    assert len(writes) == 1

--- a/tests/ci/test_e2e_release_gate.py
+++ b/tests/ci/test_e2e_release_gate.py
@@ -35,18 +35,11 @@ def test_ci_cd_has_e2e_gate_job() -> None:
     assert uses == "./.github/workflows/e2e.yml", f"e2e-gate uses: {uses!r}"
 
 
-def test_e2e_gate_passes_secrets_not_as_inputs() -> None:
-    """Convention 3 — secrets travel via ``secrets:``, never ``with:`` / inputs."""
+def test_required_e2e_gate_has_no_live_provider_credentials() -> None:
+    """The release gate uses fake providers and never inherits live provider keys."""
     gate = job(load_workflow("ci-cd.yml"), "e2e-gate")
-    secrets = gate.get("secrets")
-    assert secrets == "inherit" or isinstance(secrets, dict), (
-        f"e2e-gate must set secrets: inherit or named secrets:, got {secrets!r}"
-    )
-    with_block = gate.get("with") or {}
-    secretish = [
-        key for key in with_block if "secret" in str(key).lower() or "key" in str(key).lower()
-    ]
-    assert not secretish, f"secrets must not appear as workflow inputs: {secretish}"
+    assert "secrets" not in gate
+    assert gate["with"] == {"required-security": True}
 
 
 def test_build_images_needs_e2e_gate() -> None:
@@ -74,3 +67,149 @@ def test_build_dist_does_not_need_e2e_gate() -> None:
 def test_touched_workflows_third_party_uses_are_sha_pinned(workflow: str) -> None:
     """Convention 2 — every third-party ``uses:`` stays 40-hex SHA-pinned."""
     assert_third_party_uses_sha_pinned(workflow)
+
+
+def _condition(expression: str, context: dict[str, object]) -> bool:
+    """Interpret the small Actions expression subset used by these release jobs.
+
+    No Python eval: unsupported syntax fails the test instead of becoming true.
+    """
+    import re
+
+    text = expression.removeprefix("${{").removesuffix("}}").strip()
+    token_re = re.compile(r"\s*(\|\||&&|==|!=|!|\(|\)|,|'[^']*'|[A-Za-z_][A-Za-z0-9_.-]*)")
+    tokens: list[str] = []
+    while text:
+        match = token_re.match(text)
+        assert match is not None, f"unsupported release expression: {text!r}"
+        tokens.append(match[1])
+        text = text[match.end() :]
+    index = 0
+
+    def atom() -> object:
+        nonlocal index
+        token = tokens[index]
+        index += 1
+        if token == "!":
+            return not atom()
+        if token == "(":
+            result = disjunction()
+            assert tokens[index] == ")"
+            index += 1
+            return result
+        if token == "startsWith":
+            assert tokens[index] == "("
+            index += 1
+            value = atom()
+            assert tokens[index] == ","
+            index += 1
+            prefix = atom()
+            assert tokens[index] == ")"
+            index += 1
+            return str(value).startswith(str(prefix))
+        if token.startswith("'"):
+            return token[1:-1]
+        if token in ("true", "false"):
+            return token == "true"
+        assert token in context, f"unrecognized release expression identifier {token}"
+        return context[token]
+
+    def equality() -> object:
+        nonlocal index
+        left = atom()
+        if index < len(tokens) and tokens[index] in ("==", "!="):
+            op = tokens[index]
+            index += 1
+            right = atom()
+            return left == right if op == "==" else left != right
+        return left
+
+    def conjunction() -> bool:
+        nonlocal index
+        result = bool(equality())
+        while index < len(tokens) and tokens[index] == "&&":
+            index += 1
+            right = bool(equality())
+            result = result and right
+        return result
+
+    def disjunction() -> bool:
+        nonlocal index
+        result = conjunction()
+        while index < len(tokens) and tokens[index] == "||":
+            index += 1
+            right = conjunction()
+            result = result or right
+        return result
+
+    result = disjunction()
+    assert index == len(tokens)
+    return result
+
+
+@pytest.mark.parametrize("event", ["push", "workflow_dispatch", "pull_request"])
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "refs/heads/main",
+        "refs/heads/pre-0.0.1",
+        "refs/heads/release/1.0",
+        "refs/tags/v1.0",
+        "refs/heads/feature",
+        "refs/pull/42/merge",
+    ],
+)
+def test_release_graph_executes_required_e2e_for_allowed_events(event: str, ref: str) -> None:
+    """Evaluate actual workflow predicates with the caller's event retained."""
+    ci = load_workflow("ci-cd.yml")
+    gate = job(ci, "e2e-gate")
+    context: dict[str, object] = {
+        "github.event_name": event,
+        "github.ref": ref,
+        "inputs.required-security": gate["with"]["required-security"],
+    }
+    e2e = job(load_workflow("e2e.yml"), "e2e-pr")
+    assert _condition(e2e["if"], context)
+    build = job(ci, "build-images")
+    expected = event in ("push", "workflow_dispatch") and ref in (
+        "refs/heads/main",
+        "refs/heads/pre-0.0.1",
+        "refs/heads/release/1.0",
+        "refs/tags/v1.0",
+    )
+    assert _condition(build["if"], context) == expected
+    assert not _condition(job(load_workflow("e2e.yml"), "e2e-nightly")["if"], context)
+
+
+@pytest.mark.parametrize("failure", ["failure", "cancelled", "skipped"])
+@pytest.mark.parametrize(
+    "failed_job",
+    ["verify", "e2e-gate", "build-images", "sbom-scan", "sign-attest", "verify-images"],
+)
+def test_release_graph_never_promotes_after_unsuccessful_prerequisite(
+    failure: str, failed_job: str
+) -> None:
+    """Simulate Actions' implicit success gate across the real needs DAG."""
+    ci = load_workflow("ci-cd.yml")
+    context: dict[str, object] = {"github.event_name": "push", "github.ref": "refs/heads/main"}
+    results: dict[str, str] = {}
+    for name in (
+        "verify",
+        "e2e-gate",
+        "build-images",
+        "sbom-scan",
+        "sign-attest",
+        "verify-images",
+        "promote",
+    ):
+        spec = job(ci, name)
+        if name == failed_job:
+            results[name] = failure
+            continue
+        assert "always(" not in str(spec.get("if", "")), (
+            "publishing cannot bypass failed dependencies"
+        )
+        success = all(results[parent] == "success" for parent in as_list(spec.get("needs")))
+        eligible = _condition(spec["if"], context) if spec.get("if") else True
+        results[name] = "success" if success and eligible else "skipped"
+    assert results["promote"] == "skipped"

--- a/tests/ci/test_e2e_release_gate.py
+++ b/tests/ci/test_e2e_release_gate.py
@@ -184,7 +184,15 @@ def test_release_graph_executes_required_e2e_for_allowed_events(event: str, ref:
 @pytest.mark.parametrize("failure", ["failure", "cancelled", "skipped"])
 @pytest.mark.parametrize(
     "failed_job",
-    ["verify", "e2e-gate", "build-images", "sbom-scan", "sign-attest", "verify-images"],
+    [
+        "verify",
+        "e2e-gate",
+        "build-images",
+        "sbom-scan",
+        "sign-attest",
+        "verify-images",
+        "publish-canonical",
+    ],
 )
 def test_release_graph_never_promotes_after_unsuccessful_prerequisite(
     failure: str, failed_job: str
@@ -200,6 +208,7 @@ def test_release_graph_never_promotes_after_unsuccessful_prerequisite(
         "sbom-scan",
         "sign-attest",
         "verify-images",
+        "publish-canonical",
         "promote",
     ):
         spec = job(ci, name)
@@ -213,3 +222,34 @@ def test_release_graph_never_promotes_after_unsuccessful_prerequisite(
         eligible = _condition(spec["if"], context) if spec.get("if") else True
         results[name] = "success" if success and eligible else "skipped"
     assert results["promote"] == "skipped"
+
+
+def test_canonical_publication_serializes_both_images_after_verification() -> None:
+    ci = load_workflow("ci-cd.yml")
+    publication = job(ci, "publish-canonical")
+    assert publication["concurrency"] == {
+        "group": "image-source-${{ github.sha }}",
+        "cancel-in-progress": False,
+    }
+    assert "verify-images" in as_list(publication["needs"])
+    assert any(
+        step.get("run") == "make action-images-publish-canonical" for step in publication["steps"]
+    )
+    build = job(ci, "build-images")
+    tags = [
+        step["with"]["tags"]
+        for step in build["steps"]
+        if step.get("id") in {"build-slim", "build-analyzers"}
+    ]
+    assert len(tags) == 2
+    assert all("staging-${{ github.run_id }}-${{ github.run_attempt }}-" in tag for tag in tags)
+
+
+def test_deployment_candidate_gate_is_read_only_and_required_in_both_workflows() -> None:
+    for filename, name in (("ci.yml", "deployment-candidate"), ("ci-cd.yml", "verify")):
+        gate = job(load_workflow(filename), name)
+        assert all(value == "read" for value in gate["permissions"].values())
+        steps = [step for step in gate["steps"] if step.get("run") == "make action-candidate-check"]
+        assert len(steps) == 1
+        assert "if" not in steps[0]
+        assert {"CANDIDATE_BASE", "CANDIDATE_HEAD"} <= steps[0]["env"].keys()

--- a/tests/pins/test_action_image_digest_sync.py
+++ b/tests/pins/test_action_image_digest_sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.ci.workflow_support import REPO_ROOT, as_list, job, load_workflow, read_text
 from tests.docs.support import ci_steps
 
 _TARGET = "action-image-digest-check"
@@ -37,14 +37,33 @@ def test_make_action_image_digest_check_target_exists() -> None:
     assert re.search(rf"^{re.escape(_TARGET)}:", makefile, re.MULTILINE)
 
 
-def test_action_image_digest_check_runs_via_make_lint() -> None:
+def test_action_image_structure_check_runs_via_make_lint() -> None:
+    """Source validation must not require publishing the source under validation."""
     makefile = read_text("Makefile")
     lint_body = makefile.split("lint:", maxsplit=1)[1].split("\n\n", maxsplit=1)[0]
-    assert f"$(MAKE) {_TARGET}" in lint_body, (
-        "make lint must invoke action-image-digest-check (#526)"
+    assert "$(MAKE) action-image-structure-check" in lint_body
+    structure_body = makefile.split("action-image-structure-check:", maxsplit=1)[1].split(
+        "\n\n", maxsplit=1
+    )[0]
+    assert "check_action_image_digest.py --structure-only" in structure_body
+
+
+def test_signed_image_verification_is_required_before_promotion() -> None:
+    """Separating source lint preserves the strict release verification gate."""
+    workflow = load_workflow("ci-cd.yml")
+    verify = job(workflow, "verify-images")
+    assert set(as_list(verify.get("needs"))) == {"build-images", "sign-attest"}
+    assert not verify.get("if")
+    assert not verify.get("continue-on-error")
+    execution = next(
+        step for step in verify["steps"] if step.get("run") == "make action-images-verify"
     )
+    assert not execution.get("if")
+    assert not execution.get("continue-on-error")
+    assert "verify-images" in as_list(job(workflow, "promote").get("needs"))
+    assert "always(" not in str(job(workflow, "promote").get("if", ""))
 
 
 def test_action_image_digest_check_not_in_ci_steps_as_duplicate() -> None:
-    """Covered by the lint step — avoid a second CI_STEPS entry that re-runs it."""
+    """Remote deployment verification belongs in the release graph, not source CI."""
     assert _TARGET not in ci_steps()


### PR DESCRIPTION
## What?

Run the required security E2E slice for release callers and require verified image provenance before publication. New builds use attempt-specific staging tags; canonical source tags are published under a shared source lock only after both images verify. Existing conflicting or unsigned canonical tags fail closed.

Verify the consumer's manifest commit against its exact image digest and built source. CI checks changed image digests and consumer pins automatically, while ordinary source changes remain buildable. Prepare the manifest and consumer pin as separate reviewed commits, with repeatable preparation and explicit state reporting.

## Why?

The old reusable-workflow event condition skipped required release work, and the old checker inspected working-tree action.yml rather than the manifest consumers execute. The initial implementation also combined mutually exclusive gh verification flags and published canonical tags before signing, which blocked retries after downstream failures. Compatible verification flags and delayed canonical publication fix those failures without trusting unsigned revision labels.

Related to #579 and #641. Live release and consumer execution evidence remains required before closing these issues. Pending #578 must adopt the manifest-first lifecycle.

## Test plan

- [x] Final `make ci PYTEST='uv run pytest -n 2'` passed: 8,273 passed, 15 skipped, 12 expected failures; coverage 82.75%, ratchet and floors passed. The run emitted 14 warnings and a non-failing asynchronous Loguru closed-capture diagnostic during a simulated tool failure.
- [x] Regression coverage includes real Git histories, actual gh argument parsing, optimized Python validation, prepared-state reruns, environment-only pins, conflicting and partial canonical publication, and changed deployment candidates.
- [x] Native workflow lint: actionlint 1.7.12 and zizmor 1.28.0 (offline audit mode) pass.
- [x] Added Unreleased changelog entries and updated release/review-check documentation.
- [ ] Live release acceptance: observe E2E, build, scan, sign, attest, verification and promotion, then prove the consumer pin resolves the intended image. Local tests do not establish cryptographic verification of a production image; no release dispatch or production pin change was performed.
