### PR TITLE
fix(broker): close failed streams and preserve loopback routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Credential broker stream failures now close the connection without inserting a
+  second HTTP response, and client disconnects release upstream responses (#595)
+- Brokered Codex runs preserve configured proxy bypass entries and always bypass
+  proxies for the loopback broker, without changing parent proxy settings (#597)
+- Removed an obsolete Codex broker auth branch that suppressed the API-key
+  authentication diagnostic; subscription authentication is unchanged (#596)
+
 - Logfire `llm.call` rows now include the prompt mergeCraft sent and the model
   output, with a real duration instead of an empty ~2µs span
 - Codex, Claude, and Gemini tool-use now shows up as `tool.call` children on

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -21,7 +21,6 @@ from mergecraft.agents.codex_broker import (
     add_broker_openai_config,
     begin_broker_session,
     broker_run_record_fields,
-    current_broker_session,
     resolve_codex_broker_posture,
     set_broker_session,
     stop_broker_session,
@@ -276,9 +275,6 @@ def _setup_codex_auth(
             CODEX_AUTH_ENV,
             OPENAI_API_KEY_ENV,
         )
-    session = current_broker_session()
-    if session is not None and session.active:
-        return
     if _has_openai_api_key():
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
 
@@ -619,6 +615,15 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
         # in build_agent_env so the real parent key never reaches the agent.
         extra[OPENAI_API_KEY_ENV] = handle.token
     env = build_agent_env("codex", extra, model=ctx.resolved_model)
+    if broker_active:
+        # Respect the filtered child env: never restore denied parent variables.
+        bypass: dict[str, str] = {}
+        for raw in (env.get("NO_PROXY", ""), env.get("no_proxy", ""), "localhost,127.0.0.1"):
+            for entry in raw.split(","):
+                entry = entry.strip()
+                if entry:
+                    bypass.setdefault(entry.casefold(), entry)
+        env["NO_PROXY"] = env["no_proxy"] = ",".join(bypass.values())
     _setup_codex_auth(ctx, codex_home=codex_home)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process
@@ -910,7 +915,7 @@ def prepare_codex_brokered_run(
     *,
     openai_api_key: str = "",
 ) -> CodexBrokeredRun:
-    """Start broker, build env, auth stub, and MCP config (plan 18 W3)."""
+    """Start broker, build env, and MCP config (plan 18 W3)."""
     from mergecraft.agents import codex_broker
 
     return codex_broker.prepare_codex_brokered_run(ctx, openai_api_key=openai_api_key)

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -462,6 +462,7 @@ def credential_broker(
             )
 
             upstream_path = _upstream_request_path(upstream_path)
+            response_committed = False
             try:
                 with shared_upstream_client.stream(
                     method,
@@ -487,6 +488,9 @@ def credential_broker(
                             continue
                         self.send_header(header, redact_broker_output(value))
                     self.send_header("Connection", "close")
+                    # Once headers start leaving the process, another status would
+                    # corrupt the response body. A failed stream must end at EOF.
+                    response_committed = True
                     self.end_headers()
 
                     for chunk in upstream_response.iter_bytes():
@@ -495,10 +499,12 @@ def credential_broker(
                         self.wfile.write(_redact_stream_chunk(chunk))
             except httpx.HTTPError as exc:
                 _broker_log("warning", "broker upstream request failed: {}", exc)
-                self._reject(HTTPStatus.BAD_GATEWAY, "upstream request failed")
-                return
-
-            self.close_connection = True
+                if not response_committed:
+                    self._reject(HTTPStatus.BAD_GATEWAY, "upstream request failed")
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+                _broker_log("debug", "broker client disconnected during response")
+            finally:
+                self.close_connection = True
 
         def do_GET(self) -> None:
             self._proxy("GET")

--- a/tests/agents/test_codex_credential_broker.py
+++ b/tests/agents/test_codex_credential_broker.py
@@ -271,3 +271,197 @@ def test_lane_b_sandbox_symbols_remain_defined_in_codex_module() -> None:
     codex_module = load_codex_module()
     for symbol in LANE_B_SANDBOX_SYMBOLS:
         assert hasattr(codex_module, symbol), f"{symbol} must remain in agents/codex.py"
+
+
+@pytest.fixture
+def allow_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Model the operator's explicit envAllowlist for proxy configuration."""
+    from mergecraft.utils import secrets as secret_utils
+
+    names = {"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"}
+    monkeypatch.setattr(secret_utils, "_user_allowlist", names | {name.lower() for name in names})
+
+
+@pytest.mark.parametrize(
+    ("upper", "lower", "expected"),
+    [
+        (None, None, "localhost,127.0.0.1"),
+        ("", "", "localhost,127.0.0.1"),
+        (
+            None,
+            ".internal.example,host.example:8443",
+            ".internal.example,host.example:8443,localhost,127.0.0.1",
+        ),
+        (
+            "CORP.example,localhost",
+            "corp.example,other.example",
+            "CORP.example,localhost,other.example,127.0.0.1",
+        ),
+        ("127.0.0.1, localhost,127.0.0.1", "localhost", "127.0.0.1,localhost"),
+        ("*", ".internal.example", "*,.internal.example,localhost,127.0.0.1"),
+    ],
+)
+def test_codex_credential_broker_unions_child_proxy_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    upper: str | None,
+    lower: str | None,
+    expected: str,
+    allow_proxy_env: None,
+) -> None:
+    """Broker bypass preserves both user spellings without changing the parent."""
+    import os
+
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    for name, value in (("NO_PROXY", upper), ("no_proxy", lower)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+    for name in ("HTTP_PROXY", "HTTPS_PROXY"):
+        monkeypatch.setenv(name, "http://proxy.example:3128")
+    with prepare_codex_brokered_run(brokered_codex_context(tmp_path)) as prepared:
+        assert prepared.agent_env["NO_PROXY"] == expected
+        assert prepared.agent_env["no_proxy"] == expected
+        for name in ("HTTP_PROXY", "HTTPS_PROXY"):
+            assert prepared.agent_env[name] == "http://proxy.example:3128"
+    assert os.environ.get("NO_PROXY") == upper
+    assert os.environ.get("no_proxy") == lower
+
+
+def test_codex_credential_broker_inactive_keeps_proxy_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    allow_proxy_env: None,
+) -> None:
+    """Non-brokered runs retain the original case-sensitive proxy settings."""
+    from mergecraft.agents import codex
+
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("NO_PROXY", "upper.example")
+    monkeypatch.setenv("no_proxy", "lower.example")
+    monkeypatch.setattr(codex, "active_broker_handle", lambda: None)
+    env = codex._build_env(brokered_codex_context(tmp_path))
+    assert env["NO_PROXY"] == "upper.example"
+    assert env["no_proxy"] == "lower.example"
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_codex_credential_broker_child_routes_loopback_direct_and_remote_via_proxy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    allow_proxy_env: None,
+) -> None:
+    """A real child process reaches its broker and retains non-loopback proxy routing."""
+    import subprocess
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    import httpx
+
+    from mergecraft.security import broker
+
+    paths: list[str] = []
+
+    class ProxyHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            paths.append(self.path)
+            body = b"via-proxy"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    proxy = ThreadingHTTPServer(("127.0.0.1", 0), ProxyHandler)
+    thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+    thread.start()
+    try:
+        proxy_url = f"http://127.0.0.1:{proxy.server_port}"
+        for name in (
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+        ):
+            monkeypatch.setenv(name, proxy_url)
+        for name in ("NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+        monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+        monkeypatch.setattr(
+            broker,
+            "_upstream_client",
+            lambda config: httpx.Client(
+                base_url="https://api.openai.com",
+                transport=httpx.MockTransport(
+                    lambda request: httpx.Response(200, text="via-broker")
+                ),
+            ),
+        )
+        with prepare_codex_brokered_run(brokered_codex_context(tmp_path)) as prepared:
+            script = (
+                "import os,sys,httpx; "
+                "client=httpx.Client(timeout=2); "
+                "local=client.get(sys.argv[1]+'/models',headers={'Authorization':'Bearer '+os.environ['OPENAI_API_KEY']}); "
+                "remote=client.get('http://remote.example.invalid/probe'); "
+                "print(local.text,remote.text); client.close()"
+            )
+            result = subprocess.run(
+                [sys.executable, "-I", "-c", script, prepared.broker_base_url],
+                env=prepared.agent_env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert result.returncode == 0, result.stderr
+            assert result.stdout.strip() == "via-broker via-proxy"
+        assert paths == ["http://remote.example.invalid/probe"]
+    finally:
+        proxy.shutdown()
+        proxy.server_close()
+        thread.join(timeout=2)
+    assert not thread.is_alive()
+
+
+def test_codex_credential_broker_auth_setup_keeps_api_key_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broker activity no longer suppresses the otherwise normal API-key auth path."""
+    from tests.security.support_agent_isolation import capture_loguru_messages
+
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    with (
+        capture_loguru_messages() as logs,
+        prepare_codex_brokered_run(brokered_codex_context(tmp_path)) as prepared,
+    ):
+        assert not (Path(prepared.agent_env["CODEX_HOME"]) / "auth.json").exists()
+    assert any("using OPENAI_API_KEY for Codex CLI authentication" in line for line in logs)
+    assert REAL_OPENAI_API_KEY_FIXTURE not in "\n".join(logs)
+
+
+def test_codex_credential_broker_does_not_restore_denied_parent_proxy_variables(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loopback repair must not circumvent the child environment allowlist."""
+    from mergecraft.utils import secrets as secret_utils
+
+    monkeypatch.setattr(secret_utils, "_user_allowlist", None)
+    monkeypatch.setenv("OPENAI_API_KEY", REAL_OPENAI_API_KEY_FIXTURE)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.setenv("all_proxy", "http://denied.example:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "also-denied.example")
+    with prepare_codex_brokered_run(brokered_codex_context(tmp_path)) as prepared:
+        assert "all_proxy" not in prepared.agent_env
+        assert prepared.agent_env["NO_PROXY"] == "localhost,127.0.0.1"
+        assert prepared.agent_env["no_proxy"] == "localhost,127.0.0.1"

--- a/tests/security/test_credential_broker.py
+++ b/tests/security/test_credential_broker.py
@@ -523,3 +523,125 @@ def test_broker_does_not_forward_hop_by_hop_headers(
         assert smuggle_marker not in (forwarded_value or ""), (
             f"smuggled marker {smuggle_marker!r} must not appear in forwarded {header_name!r}"
         )
+
+
+class _InterruptedBrokerStream(httpx.SyncByteStream):
+    """Deliver an SSE event, then fail; record deterministic response cleanup."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield b'data: {"delta":"first"}\n\n'
+        raise httpx.ReadError(f"upstream interrupted: {REAL_OPENAI_API_KEY_FIXTURE}")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _raw_broker_request(handle: Any) -> bytes:
+    """Read the actual HTTP wire to EOF with a bounded socket timeout."""
+    import socket
+
+    with socket.create_connection((handle.host, handle.port), timeout=2) as connection:
+        connection.sendall(
+            f"GET /v1/models HTTP/1.1\r\nHost: {handle.host}\r\n"
+            f"Authorization: Bearer {handle.token}\r\n\r\n".encode()
+        )
+        chunks: list[bytes] = []
+        while chunk := connection.recv(65536):
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.mark.parametrize("before_headers", [False, True])
+def test_credential_broker_failure_emits_one_status_and_closes_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    before_headers: bool,
+) -> None:
+    """A stream failure is EOF, never another HTTP response inside SSE (#595)."""
+    module = load_broker_module()
+    streams: list[_InterruptedBrokerStream] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if before_headers:
+            raise httpx.ConnectError(f"connect failed: {REAL_OPENAI_API_KEY_FIXTURE}")
+        stream = _InterruptedBrokerStream()
+        streams.append(stream)
+        return httpx.Response(200, headers={"Content-Type": "text/event-stream"}, stream=stream)
+
+    client = httpx.Client(base_url="https://api.openai.com", transport=httpx.MockTransport(respond))
+    monkeypatch.setattr(module, "_upstream_client", lambda config: client)
+    config = module.CredentialBrokerConfig(
+        upstream_base_url="https://api.openai.com",
+        api_key=REAL_OPENAI_API_KEY_FIXTURE,
+        run_upstream_hosts=frozenset({"api.openai.com"}),
+    )
+    start = time.monotonic()
+    with capture_loguru_messages() as logs, module.credential_broker(config) as handle:
+        for _ in range(3):
+            wire = _raw_broker_request(handle)
+            assert wire.count(b"HTTP/1.1 ") == 1
+            if before_headers:
+                assert wire.startswith(b"HTTP/1.1 502 ")
+                assert b'"error": "upstream request failed"' in wire
+            else:
+                assert wire.startswith(b"HTTP/1.1 200 ")
+                assert wire.split(b"\r\n\r\n", 1)[1] == b'data: {"delta":"first"}\n\n'
+                assert all(stream.closed for stream in streams)
+            assert not client.is_closed, "one failed request must not close the shared client"
+            assert_credential_absent(wire.decode())
+    assert client.is_closed
+    assert time.monotonic() - start < 5
+    assert any("upstream request failed" in line for line in logs)
+    assert_credential_absent("\n".join(logs))
+
+
+def test_credential_broker_client_disconnect_closes_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client reset during streaming releases the upstream response promptly."""
+    import socket
+    import struct
+    import threading
+
+    module = load_broker_module()
+    continue_stream = threading.Event()
+    closed = threading.Event()
+
+    class DisconnectStream(httpx.SyncByteStream):
+        def __iter__(self) -> Iterator[bytes]:
+            yield b"data: first\n\n"
+            assert continue_stream.wait(2), "client never released upstream"
+            for _ in range(128):
+                yield b"x" * 65536
+
+        def close(self) -> None:
+            closed.set()
+
+    client = httpx.Client(
+        base_url="https://api.openai.com",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=DisconnectStream())
+        ),
+    )
+    monkeypatch.setattr(module, "_upstream_client", lambda config: client)
+    config = module.CredentialBrokerConfig(
+        upstream_base_url="https://api.openai.com",
+        api_key=REAL_OPENAI_API_KEY_FIXTURE,
+        run_upstream_hosts=frozenset({"api.openai.com"}),
+    )
+    with capture_loguru_messages() as logs, module.credential_broker(config) as handle:
+        with socket.create_connection((handle.host, handle.port), timeout=2) as connection:
+            connection.sendall(
+                f"GET /v1/models HTTP/1.1\r\nHost: {handle.host}\r\n"
+                f"Authorization: Bearer {handle.token}\r\n\r\n".encode()
+            )
+            assert connection.recv(65536).startswith(b"HTTP/1.1 200 ")
+            connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        continue_stream.set()
+        assert closed.wait(2), "upstream response leaked after downstream disconnect"
+        assert not client.is_closed
+    assert client.is_closed
+    assert any("client disconnected" in line for line in logs)
+    assert_credential_absent("\n".join(logs))


### PR DESCRIPTION
## What?

Terminate broker streams cleanly after upstream failure, preserve loopback proxy bypass in broker-active Codex child environments, and remove the obsolete broker-auth early return.

## Why?

An upstream failure after response headers previously inserted a second HTTP status into the stream. Proxy settings could route the local credential broker through a proxy, and an obsolete auth branch unnecessarily suppressed the normal API-key diagnostic.

## Test plan

- [ ] `make ci` green locally: the full combined release gate was not run on this branch; focused and broader affected-area checks passed below.
- [x] Added or updated tests: real socket assertions cover a single response, prompt EOF, redacted failures and resource cleanup; a real child process proves loopback bypass while remote traffic still uses the proxy.
- [x] Focused credential checks: 91 passed. Broader Codex/security checks: 651 passed, 6 skipped, 1 expected failure.
- [x] `make lint`, `make typecheck`, `make pyright`, and commit hooks passed.
- [x] Added an Unreleased changelog entry.
- [ ] Linux-specific runtime checks: local verification ran on Darwin; Linux /proc tests and unavailable optional tools were skipped.

Subscription authentication and the child credential allowlist are preserved. The latest merge incorporates pre-0.0.1 at bb865d5c. Its only conflict was CHANGELOG.md; both sets of entries were preserved. Broker source/tests are unchanged, and 57 broker regressions passed after the merge.


## Related PR(s)/Issue(s)

Closes #595
Closes #596
Closes #597
