### PR TITLE
refactor(tracing): drop unused INPUT_TRACING_REGION Action branch

### DIFF
--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -85,8 +85,6 @@ US one:
 | Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
 | Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`). The Action applies that env onto the logfire sink even when tracing is enabled via the `tracing` input rather than `MERGECRAFT_TRACING` |
 
-There is no `tracing-region` Action input, so GitHub never injects `INPUT_TRACING_REGION`. If both `INPUT_TRACING_REGION` and `MERGECRAFT_TRACING_REGION` are set, the Action input wins — it is more specific than the job `env:`.
-
 Both paths converge on the same precedence layer
 (`cli/tracing_precedence.py`) and the same resolver
 (`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1853,8 +1853,6 @@ US one:
 | Local   | `mergecraft tracing logfire enable --region eu` (writes `MERGECRAFT_TRACING_REGION` to `.env`) |
 | Action  | `mergecraft tracing logfire wire-workflow --region eu --apply` (writes it to the step's `env:`). The Action applies that env onto the logfire sink even when tracing is enabled via the `tracing` input rather than `MERGECRAFT_TRACING` |
 
-There is no `tracing-region` Action input, so GitHub never injects `INPUT_TRACING_REGION`. If both `INPUT_TRACING_REGION` and `MERGECRAFT_TRACING_REGION` are set, the Action input wins — it is more specific than the job `env:`.
-
 Both paths converge on the same precedence layer
 (`cli/tracing_precedence.py`) and the same resolver
 (`tracing/resolve.py`), so the local `.env` shape and the workflow `env:`

--- a/src/mergecraft/action/inputs.py
+++ b/src/mergecraft/action/inputs.py
@@ -60,21 +60,18 @@ def _read_input(name: str) -> str | None:
 
 
 def _read_logfire_region() -> Literal["us", "eu"] | None:
-    """Return a valid Logfire region from Action input or ``MERGECRAFT_TRACING_REGION``.
+    """Return a valid Logfire region from ``MERGECRAFT_TRACING_REGION``.
 
-    ``INPUT_TRACING_REGION`` (if a consumer sets it) beats
-    ``MERGECRAFT_TRACING_REGION``. Invalid or unset values return ``None`` so
-    the sink keeps the US default.
+    Invalid or unset values return ``None`` so the sink keeps the US default.
     """
-    for name in ("INPUT_TRACING_REGION", "MERGECRAFT_TRACING_REGION"):
-        raw = os.environ.get(name)
-        if raw is None or raw == "":
-            continue
-        region = raw.strip().lower()
-        if region == "us":
-            return "us"
-        if region == "eu":
-            return "eu"
+    raw = os.environ.get("MERGECRAFT_TRACING_REGION")
+    if raw is None or raw == "":
+        return None
+    region = raw.strip().lower()
+    if region == "us":
+        return "us"
+    if region == "eu":
+        return "eu"
     return None
 
 

--- a/src/mergecraft/cli/tracing_precedence.py
+++ b/src/mergecraft/cli/tracing_precedence.py
@@ -145,13 +145,6 @@ def _resolve_env_layer(env: dict[str, str]) -> dict[str, Any]:
         region = env["MERGECRAFT_TRACING_REGION"].strip().lower()
         if region in {"us", "eu"}:
             out["region"] = region
-    # Action input is more specific than job ``env:``. There is currently no
-    # ``tracing-region`` Action input, so GitHub never injects this var; if
-    # both are set, ``INPUT_TRACING_REGION`` still wins.
-    if "INPUT_TRACING_REGION" in env:
-        region = env["INPUT_TRACING_REGION"].strip().lower()
-        if region in {"us", "eu"}:
-            out["region"] = region
     if "MERGECRAFT_TRACING_CONTENT" in env:
         content = env["MERGECRAFT_TRACING_CONTENT"].strip()
         if content:

--- a/src/mergecraft/tracing/resolve.py
+++ b/src/mergecraft/tracing/resolve.py
@@ -81,10 +81,9 @@ def _overlay_logfire_region(
 ) -> list[TraceSinkEntry]:
     """Apply the resolved ``region`` onto adopted logfire sinks, if present.
 
-    ``merged["region"]`` already encodes CLI ``--region`` over the env layer,
-    and the env layer already prefers ``INPUT_TRACING_REGION`` over
-    ``MERGECRAFT_TRACING_REGION``. Re-reading the Action input here would
-    invert that stack when ``cli_args`` set ``--region``.
+    ``merged["region"]`` already encodes CLI ``--region`` over
+    ``MERGECRAFT_TRACING_REGION``. Re-reading env here would invert that
+    stack when ``cli_args`` set ``--region``.
     """
     raw_region = merged.get("region")
     if raw_region not in ("us", "eu"):
@@ -161,8 +160,7 @@ def resolve_active_tracing(
         # so ``MERGECRAFT_TRACING`` is often unset even when tracing is on.
         # Overlay the resolved region onto logfire sinks so an EU write
         # token is not posted to the US OTLP host. ``merged["region"]``
-        # already prefers ``INPUT_TRACING_REGION`` over job env, and CLI
-        # ``--region`` over both.
+        # already prefers CLI ``--region`` over ``MERGECRAFT_TRACING_REGION``.
         return TracingSettings(
             enabled=bool(config.enabled),
             sinks=_overlay_logfire_region(list(config.sinks), merged),

--- a/tests/tracing/exporters/test_action_inputs.py
+++ b/tests/tracing/exporters/test_action_inputs.py
@@ -205,7 +205,6 @@ def _clear_action_tracing_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in (
         "INPUT_TRACING",
         "INPUT_TRACING_TO",
-        "INPUT_TRACING_REGION",
         "INPUT_TRACING_CONTENT",
         "INPUT_TRACING_EXPORT_UNTRUSTED_CONTENT",
         "INPUT_LOGFIRE_TOKEN",
@@ -231,22 +230,6 @@ def test_action_logfire_shorthand_honors_tracing_region_env(
     resolved = resolve_tracing_from_action_inputs()
     assert resolved["sinks"][0]["type"] == "logfire"
     assert resolved["sinks"][0]["region"] == "eu"
-    assert resolved["settings"].sinks[0].region == "eu"
-
-
-def test_action_logfire_shorthand_honors_tracing_region_input(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``INPUT_TRACING_REGION`` wins over ``MERGECRAFT_TRACING_REGION``."""
-    _clear_action_tracing_env(monkeypatch)
-    monkeypatch.setenv("INPUT_TRACING", "true")
-    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
-    monkeypatch.setenv("INPUT_TRACING_REGION", "eu")
-    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "us")
-
-    from mergecraft.action.inputs import resolve_tracing_from_action_inputs
-
-    resolved = resolve_tracing_from_action_inputs()
     assert resolved["settings"].sinks[0].region == "eu"
 
 

--- a/tests/tracing/test_tracing_resolution.py
+++ b/tests/tracing/test_tracing_resolution.py
@@ -35,7 +35,6 @@ _LOG_KEYS = (
     "MERGECRAFT_TRACING_REGION",
     "INPUT_TRACING",
     "INPUT_TRACING_TO",
-    "INPUT_TRACING_REGION",
     "INPUT_TRACING_CONTENT",
     "INPUT_TRACING_EXPORT_UNTRUSTED_CONTENT",
 )
@@ -230,41 +229,13 @@ def test_action_enablement_without_tracing_env_defaults_region_us(
     assert active.sinks[0].region == "us"
 
 
-def test_action_input_region_wins_over_conflicting_env_region(
+def test_cli_region_wins_over_env_on_adopt_config_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``INPUT_TRACING_REGION`` beats ``MERGECRAFT_TRACING_REGION`` end to end.
+    """CLI ``--region`` beats ``MERGECRAFT_TRACING_REGION`` when overlaying config sinks.
 
-    ``apply_tracing_overrides`` stamps Action shorthand sinks onto
-    ``RepoSettings``; ``resolve_active_tracing`` then overlays region. When
-    both vars are set to conflicting values, the Action input wins — it is
-    more specific than job env. GitHub does not declare a ``tracing-region``
-    input today, so this is the contract if ``INPUT_TRACING_REGION`` is set.
-    """
-    _clear_tracing_env(monkeypatch)
-    monkeypatch.setenv("INPUT_TRACING", "true")
-    monkeypatch.setenv("INPUT_TRACING_TO", "logfire")
-    monkeypatch.setenv("INPUT_TRACING_REGION", "eu")
-    monkeypatch.setenv("MERGECRAFT_TRACING_REGION", "us")
-
-    from mergecraft.action.inputs import apply_tracing_overrides
-    from mergecraft.config.settings import RepoSettings
-    from mergecraft.tracing.resolve import resolve_active_tracing
-
-    settings = apply_tracing_overrides(RepoSettings())
-    active = resolve_active_tracing(config=settings.tracing)
-    assert active.enabled is True
-    assert active.sinks[0].type == "logfire"
-    assert active.sinks[0].region == "eu"
-
-
-def test_cli_region_wins_over_action_input_on_adopt_config_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """CLI ``--region`` beats ``INPUT_TRACING_REGION`` when overlaying config sinks.
-
-    The adopt-config path used to re-read the Action input from the env dict
-    and invert the documented CLI > env stack. Overlay must use the already
+    The adopt-config path used to re-read env vars from the env dict and
+    invert the documented CLI > env stack. Overlay must use the already
     merged region so ``--region`` still wins.
     """
     _clear_tracing_env(monkeypatch)
@@ -278,7 +249,7 @@ def test_cli_region_wins_over_action_input_on_adopt_config_path(
     )
     active = resolve_active_tracing(
         cli_args=["--region", "eu"],
-        env={"INPUT_TRACING_REGION": "us"},
+        env={"MERGECRAFT_TRACING_REGION": "us"},
         config=config,
     )
     assert active.enabled is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`action.yml` has no `tracing-region` input, so GitHub never injects `INPUT_TRACING_REGION`. Code in `action/inputs.py` and `cli/tracing_precedence.py` still treated it as a higher-precedence override that cannot be set through the Action contract. The live EU Logfire path already works via `MERGECRAFT_TRACING_REGION` in job/step `env:` (dogfood + `mergecraft tracing logfire wire-workflow`).

## Changes

- **`src/mergecraft/action/inputs.py`**: `_read_logfire_region` reads `MERGECRAFT_TRACING_REGION` only.
- **`src/mergecraft/cli/tracing_precedence.py`**: removed the phantom `INPUT_TRACING_REGION` env-layer block.
- **`src/mergecraft/tracing/resolve.py`**: updated comments to match reality.
- **`docs/TRACING.md`** + regenerated **`llms-full.txt`**: removed phantom-input precedence note.
- **Tests**: dropped/adjusted `INPUT_TRACING_REGION` precedence cases; kept `MERGECRAFT_TRACING_REGION` coverage.

No change to `action.yml` (no new input).

## Verify

```bash
uv run --extra dev pytest tests/tracing/exporters/test_action_inputs.py -k region -v
uv run --extra dev pytest tests/tracing/test_tracing_resolution.py -k region -v
uv run --extra dev pytest tests/cli/test_tracing_region_env.py -v
make llms-check
```

All of the above pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14b0a53d-1e72-4571-ae1d-7a8e38410958?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14b0a53d-1e72-4571-ae1d-7a8e38410958&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

