### PR TITLE
fix(cli): preserve review diffs and validate installed eval paths

### DIFF
--- a/.github/agents/wave-plan-executor.md
+++ b/.github/agents/wave-plan-executor.md
@@ -96,7 +96,7 @@ ask whether to skip.
   `src/mergecraft/analyzers/pipeline.py`.
 
 ## Step 4 — Execute to project standards
-- Stack is Python 3.14+, package under `src/mergecraft/`, repo config in
+- Stack is Python 3.11+, package under `src/mergecraft/`, repo config in
   `.mergecraft/config.yaml`, Action inputs in `action.yml`.
 - Loguru only; mypy strict; Pyright; Conventional Commits.
 - **Always use uv**: every Python tool invocation goes through `uv run` / `uv sync`. Never raw

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,6 +186,7 @@ jobs:
           # provider failure or timeout fails the step; --help is not acceptance.
           docker run --rm --user 10001:10001 \
             --entrypoint /opt/mergecraft/.venv/bin/python \
+            -e HOME=/home/mergecraft -e XDG_CACHE_HOME=/home/mergecraft/.cache \
             -e MERGECRAFT_E2E_LIVE_MODEL -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e GEMINI_API_KEY \
             -v "$PWD/scripts/live_image_smoke.py:/smoke.py:ro" \
             "${E2E_IMAGE}" /smoke.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -170,19 +170,22 @@ jobs:
           docker/e2e/run_in_image_adversarial.sh "${E2E_IMAGE}"
           kill "${MOCK_PID}" 2>/dev/null || true
 
-      - name: Live-provider matrix (secrets-gated)
+      - name: Live installed-harness smoke (explicit model required)
         env:
+          MERGECRAFT_E2E_LIVE_MODEL: ${{ vars.MERGECRAFT_E2E_LIVE_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          # D6 — live LLMs are scheduled-only and secrets-gated. Documented
-          # skip (not a silent pass) when no provider secret is present.
-          if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" && -z "${GEMINI_API_KEY:-}" ]]; then
-            echo "skipped: no live credential — nightly live-provider matrix requires ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY"
+          set -euo pipefail
+          if [[ -z "${MERGECRAFT_E2E_LIVE_MODEL:-}" ]]; then
+            echo "skipped: set MERGECRAFT_E2E_LIVE_MODEL to enable the bounded real-harness smoke"
             exit 0
           fi
-          echo "Live-provider matrix: at least one provider secret is present."
-          echo "Broad live cells are operator-expanded against docs/compatibility-matrix.md;"
-          echo "security slice above already proved the shipped image with D6 shims."
-          docker run --rm "${E2E_IMAGE}" --help
+          # The helper requires a real accepted terminal review. Missing credentials,
+          # provider failure or timeout fails the step; --help is not acceptance.
+          docker run --rm --user 10001:10001 \
+            --entrypoint /opt/mergecraft/.venv/bin/python \
+            -e MERGECRAFT_E2E_LIVE_MODEL -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e GEMINI_API_KEY \
+            -v "$PWD/scripts/live_image_smoke.py:/smoke.py:ro" \
+            "${E2E_IMAGE}" /smoke.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,11 +182,21 @@ jobs:
             echo "skipped: set MERGECRAFT_E2E_LIVE_MODEL to enable the bounded real-harness smoke"
             exit 0
           fi
+          case "${MERGECRAFT_E2E_LIVE_MODEL}" in
+            openai/*) credential_name=OPENAI_API_KEY ;;
+            anthropic/*) credential_name=ANTHROPIC_API_KEY ;;
+            google/*|gemini/*) credential_name=GEMINI_API_KEY ;;
+            *) echo "unsupported live-smoke provider" >&2; exit 2 ;;
+          esac
+          if [[ -z "${!credential_name:-}" ]]; then
+            echo "missing credential for the selected live-smoke provider" >&2
+            exit 2
+          fi
           # The helper requires a real accepted terminal review. Missing credentials,
           # provider failure or timeout fails the step; --help is not acceptance.
           docker run --rm --user 10001:10001 \
             --entrypoint /opt/mergecraft/.venv/bin/python \
             -e HOME=/home/mergecraft -e XDG_CACHE_HOME=/home/mergecraft/.cache \
-            -e MERGECRAFT_E2E_LIVE_MODEL -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e GEMINI_API_KEY \
+            -e MERGECRAFT_E2E_LIVE_MODEL -e "${credential_name}" \
             -v "$PWD/scripts/live_image_smoke.py:/smoke.py:ro" \
             "${E2E_IMAGE}" /smoke.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local base-only reviews retain working-tree changes; remote comparisons deepen
   bounded shared history and fail explicitly rather than substitute endpoint diffs.
   Untracked text additions produce valid patches, including special filenames
-  and missing final newlines.
+  and missing final newlines. Binary and non-UTF-8 untracked files are skipped
+  with a diagnostic rather than producing a lossy patch or crashing.
 - Installed convergence evaluations include their recall corpus. Example drift
   checks run in disposable copies and no longer rewrite tracked outputs.
 - Redaction preserves closing assignment brackets and ordinary source paths while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bring the GitLab review-support matrix correction from main to the prerelease branch.
+
+- Local base-only reviews retain working-tree changes; remote comparisons deepen
+  bounded shared history and fail explicitly rather than substitute endpoint diffs.
+  Untracked text additions produce valid patches, including special filenames
+  and missing final newlines.
+- Installed convergence evaluations include their recall corpus. Example drift
+  checks run in disposable copies and no longer rewrite tracked outputs.
+- Redaction preserves closing assignment brackets and ordinary source paths while
+  retaining secret-pattern and high-entropy controls.
+- Optional image live checks require an actual terminal review rather than CLI help.
+
 - Local review honors configured model chains, explicit/environment precedence,
   fallback restrictions, and cumulative budgets; a process without a terminal
   verdict is inconclusive (#592).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contributor setup, make targets, and PR expectations for mergeCraft itself.
 make setup
 ```
 
-Requires Python 3.14 and [uv](https://docs.astral.sh/uv/).
+Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 
 `make setup` and all Makefile targets use a dedicated project virtualenv at
 `.venv-dev` (via `UV_PROJECT_ENVIRONMENT` in the Makefile). This keeps the dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ WORKDIR /opt/mergecraft
 
 COPY pyproject.toml uv.lock README.md hatch_build.py ./
 COPY src/mergecraft ./src/mergecraft
+COPY evals/corpora/recall_pass_corpus.json ./evals/corpora/recall_pass_corpus.json
 
 # ``--extra tracing`` installs logfire + the OpenTelemetry SDK/exporter. Without
 # it the sink factory degrades a ``logfire`` / ``otel`` sink to ``NullSink``

--- a/Dockerfile.analyzers
+++ b/Dockerfile.analyzers
@@ -110,6 +110,7 @@ WORKDIR /opt/mergecraft
 
 COPY pyproject.toml uv.lock README.md hatch_build.py ./
 COPY src/mergecraft ./src/mergecraft
+COPY evals/corpora/recall_pass_corpus.json ./evals/corpora/recall_pass_corpus.json
 
 RUN uv sync --frozen --no-dev \
     && useradd -m -u 10001 -s /bin/bash mergecraft \

--- a/Makefile
+++ b/Makefile
@@ -312,14 +312,15 @@ bench-review: ## Run ReviewBench via Harbor (set REVIEWBENCH_DIR to an external 
 eval-gate: ## Check eval-bank integrity (structural; see 'mergecraft eval gate --help')
 	$(UV) run mergecraft eval gate
 
-eval-replay: ## Replay eval bank; write versioned result set (operator-triggered; needs live keys for F1)
+eval-replay: ## Replay structural eval-bank integrity; keyless, not live detection scores
 	$(UV) run mergecraft eval replay-bank
 
 eval-convergence: ## Score multi-round convergence metric; write result set (RC6)
 	$(UV) run mergecraft eval convergence
 
+BENCH_DETECT_ARGS ?=
 bench-detect: ## Join structural replay + live finding-location detection (#140, B3; needs live keys)
-	$(UV) run mergecraft eval bench
+	$(UV) run mergecraft eval bench $(BENCH_DETECT_ARGS)
 
 docker-build: ## Build action Docker image
 	docker build -t mergeCraft:local -f Dockerfile .
@@ -334,3 +335,7 @@ test-filtered-egress: ## Real production firewall tests, disposable Linux only
 	@test -x /usr/bin/python3 || { echo "Integration probes require readable system Python"; exit 1; }
 	/usr/bin/python3 --version
 	unshare --mount --net --pid --fork --mount-proc bash -ec 'mount --make-rprivate /; sysctl -q -w net.ipv4.ip_forward=1; export MERGECRAFT_FILTERED_EGRESS_ISOLATED_RUNTIME=1; exec "$(CURDIR)/.venv-dev/bin/python" -m pytest tests/analyzers/test_filtered_egress.py -v --tb=short --strict-markers -m integration -p no:cacheprovider'
+
+.PHONY: test-wheel-corpus
+test-wheel-corpus: build ## Verify installed convergence corpus outside the checkout
+	UV="$(UV)" $(UV) run python scripts/check_wheel_corpus.py dist/merge_craft-*.whl

--- a/docs/_standards/coding-standards.md
+++ b/docs/_standards/coding-standards.md
@@ -31,7 +31,7 @@ Standards and conventions for all code written in mergeCraft. Follow these consi
 
 ## Language & Runtime
 
-- **Python 3.14+** — use modern syntax (match/case, `X | Y` unions, PEP 695 type params where they help)
+- **Python 3.11+** — keep runtime syntax compatible with the supported floor; CI also tests Python 3.14
 - **Package manager:** uv (not pip directly)
 - **Build system:** hatchling
 - **Source layout:** `src/mergecraft/` (src layout, not flat)

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -80,3 +80,39 @@ run", not "no contribution".
 - Put scores on `README.md`.
 - Claim a ranking against other tools without a number on the same line as
   the claim, backed by a recorded result set.
+
+## Reproducible live campaign
+
+`make eval-gate` and `make eval-replay` check structural case integrity and
+replay expected decisions without a provider. They do not measure live detection.
+Use `make bench-detect BENCH_DETECT_ARGS='--model PROVIDER/MODEL --detection-corpus PATH --results-dir PATH --json'`
+once per chosen model against the same frozen, patch-bearing corpus. Record its
+Git tree SHA, exact model, rubric/source pins, expected case count, executed
+case count, errors, latency and cost alongside each result. A missing detection
+section or zero executed cases is not benchmark acceptance. Failures must remain
+visible, not be scored as clean reviews.
+
+Start with a small corpus containing a labelled defect and a clean case. Obtain
+a spend ceiling and provider/model choices before expanding to the full bank.
+`MERGECRAFT_RUN_TIMEOUT_S`, `MERGECRAFT_COST_BUDGET_USD`, and
+`MERGECRAFT_TOKEN_BUDGET` bound each review; the operator must also cap total
+campaign size. Preserve raw case results for adjudication. Unmatched findings
+remain unadjudicated when the reference labels are incomplete. Publish measured
+results here or under `evals/results`, with a README link rather than unsupported
+landing-page scores; reconcile #140's publication contract before closure.
+
+`make test-wheel-corpus` installs the built wheel in a temporary target and
+runs convergence outside the source checkout. This verifies packaging only.
+The E2E workflow's optional real-harness smoke requires the trusted repository
+variable `MERGECRAFT_E2E_LIVE_MODEL` and that model's credential. It permits one
+180-second review with a 12,000-token, 30-tool-call and $1 reported-cost budget.
+It runs the actual installed image harness and requires a terminal verdict;
+it is not a quality score or a substitute for the two-provider campaign.
+
+The initial two-case smoke selection is frozen in
+`evals/bench/smoke-manifest.json` with SHA-256 hashes of each patch and label file.
+Copy only those named case directories into the campaign corpus directory.
+It contains one seeded boundary defect and one clean documentation change.
+These are agent-seeded labels, not independent ground truth; independent
+adjudication and model/rubric pins remain prerequisites for comparison claims.
+No provider, spend authorization, or measured result is implied by this manifest.

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -116,3 +116,7 @@ It contains one seeded boundary defect and one clean documentation change.
 These are agent-seeded labels, not independent ground truth; independent
 adjudication and model/rubric pins remain prerequisites for comparison claims.
 No provider, spend authorization, or measured result is implied by this manifest.
+
+The live image smoke accepts `openai/`, `anthropic/`, `google/` or `gemini/`
+model prefixes and passes only the selected provider credential into the container.
+Unknown providers or a missing selected credential fail before starting Docker.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -21,7 +21,7 @@ notes stay in [compatibility-matrix.md](compatibility-matrix.md).
 | SCM | Role | Status |
 |------|------|------|
 | `github` | Webhook + review ingress | Supported |
-| `gitlab` | Webhook + review ingress | Supported |
+| `gitlab` | Webhook + review ingress | Not supported yet |
 | `bitbucket` | Webhook ingress | Not supported |
 
 ## Languages

--- a/evals/bench/smoke-manifest.json
+++ b/evals/bench/smoke-manifest.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "purpose": "Offline-frozen smoke selection; not a measured quality result",
+  "source_commit": "d78dd487227b0fdd2f7f3854a1d94023a9da0893",
+  "corpus_directory": "evals/bench/mergecraft",
+  "expected_case_count": 2,
+  "expected_clean_case_count": 1,
+  "label_status": "Agent-seeded labels; independent adjudication required before a comparative campaign",
+  "model_configurations": [],
+  "campaign_budget_usd": null,
+  "publication_status": "Not run; operator model, budget, and publication decisions pending",
+  "cases": [
+    {
+      "case_id": "bench-adversarial-clean-diff",
+      "files": {
+        "task.patch": "3c84182357ba656547e665e125dbdeb2bc6bfd0b8fca0c605f3db63a0dbf1c00",
+        "baseline.json": "b352e2fe08c01cacdeae9b514755e48e28830f785726a3bf29e3fbabff47520d"
+      },
+      "expected_reference_issues": 0
+    },
+    {
+      "case_id": "bench-correctness-boundary",
+      "files": {
+        "task.patch": "ba398c8149c2f5815d768000773e3b59e4161573d88071ed44c14ed85556deba",
+        "baseline.json": "0e7aa77568bdc573e0b85e50fa6f0006f473938e5bb066c4f97b242628f1035e"
+      },
+      "expected_reference_issues": 1
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,11 @@ artifacts = [
     "src/mergecraft/data/**/*.yaml",
 ]
 
+[tool.hatch.build.targets.wheel.force-include]
+"evals/corpora/recall_pass_corpus.json" = "mergecraft/evals/fixtures/recall_pass_corpus.json"
+
 [tool.hatch.build.targets.sdist]
-include = ["src/mergecraft", "tests", "README.md", "pyproject.toml", "hatch_build.py"]
+include = ["src/mergecraft", "tests", "README.md", "pyproject.toml", "hatch_build.py", "evals/corpora/recall_pass_corpus.json"]
 
 [tool.ruff]
 target-version = "py311"

--- a/scripts/check_cli_examples.py
+++ b/scripts/check_cli_examples.py
@@ -11,9 +11,11 @@ Exports:
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -30,7 +32,9 @@ def example_dirs() -> list[Path]:
     )
 
 
-def run_example(example_dir: Path) -> subprocess.CompletedProcess[str]:
+def run_example(
+    example_dir: Path, *, project_root: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     run_sh = example_dir / "run.sh"
     if not run_sh.is_file():
         msg = f"missing {run_sh.relative_to(REPO)}"
@@ -38,6 +42,7 @@ def run_example(example_dir: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(run_sh)],
         cwd=example_dir,
+        env={**os.environ, "MERGECRAFT_EXAMPLE_PROJECT_ROOT": str(project_root or REPO)},
         capture_output=True,
         text=True,
         check=False,
@@ -66,8 +71,21 @@ def expected_fixtures(example_dir: Path) -> list[Path]:
 
 
 def check_example(example_dir: Path) -> list[str]:
+    """Run checks in a copied fixture tree, leaving tracked outputs untouched."""
+    with tempfile.TemporaryDirectory(prefix="mergecraft-examples-") as temporary:
+        root = Path(temporary)
+        copied = root / "examples" / "cli" / example_dir.name
+        shutil.copytree(example_dir, copied)
+        shutil.copytree(REPO / "scripts" / "cli_example_lib", root / "scripts" / "cli_example_lib")
+        # Delete prior outputs so a script that stops producing one cannot pass.
+        for fixture in expected_fixtures(copied):
+            (copied / fixture.name).unlink(missing_ok=True)
+        return _check_copied_example(copied)
+
+
+def _check_copied_example(example_dir: Path) -> list[str]:
     errors: list[str] = []
-    proc = run_example(example_dir)
+    proc = run_example(example_dir, project_root=REPO)
     if proc.returncode != 0:
         errors.append(
             f"{example_dir.name}/run.sh exited {proc.returncode}: {proc.stderr or proc.stdout}"

--- a/scripts/check_wheel_corpus.py
+++ b/scripts/check_wheel_corpus.py
@@ -1,0 +1,45 @@
+"""Install a built wheel in isolation and run convergence outside the checkout."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> None:
+    """Fail if a built distribution cannot run its bundled convergence corpus."""
+    wheel = Path(sys.argv[1]).resolve()
+    with tempfile.TemporaryDirectory(prefix="mergecraft-wheel-") as temporary:
+        root = Path(temporary)
+        target = root / "installed"
+        subprocess.run(
+            [
+                os.environ.get("UV", "uv"),
+                "pip",
+                "install",
+                "--target",
+                str(target),
+                "--no-deps",
+                str(wheel),
+            ],
+            check=True,
+        )
+        code = """import json, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+import mergecraft
+assert Path(mergecraft.__file__).is_relative_to(Path(sys.argv[1]))
+from mergecraft.evals.convergence_benchmark import replay_convergence
+result, path = replay_convergence(results_dir=Path('results'))
+assert result.convergence is not None and result.convergence.cases_total > 0
+assert path.is_file()
+print('installed wheel convergence passed')
+"""
+        subprocess.run([sys.executable, "-I", "-c", code, str(target)], cwd=root, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cli_example_lib/mergecraft_root.sh
+++ b/scripts/cli_example_lib/mergecraft_root.sh
@@ -2,7 +2,11 @@
 # Resolve the mergeCraft repo root from any examples/cli/<name>/ run.sh.
 mergecraft_repo_root() {
   local here="${1:?}"
-  (cd "${here}/../../.." && pwd)
+  if [[ -n "${MERGECRAFT_EXAMPLE_PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$MERGECRAFT_EXAMPLE_PROJECT_ROOT"
+  else
+    (cd "${here}/../../.." && pwd)
+  fi
 }
 
 mergecraft_invoke() {

--- a/scripts/gen_support_matrix.py
+++ b/scripts/gen_support_matrix.py
@@ -3,7 +3,7 @@
 
 Module: scripts.gen_support_matrix
 Depends: argparse, difflib, pathlib, sys,
-    mergecraft.analyzers.registry, mergecraft.models, mergecraft.scm.webhooks
+    mergecraft.analyzers.registry, mergecraft.models
 
 Builds OS, SCM, language, analyzer, provider, and model tables from live
 catalogs so ``make docs-check`` fails when those sources drift. File 8 RV4
@@ -24,7 +24,6 @@ from pathlib import Path
 
 from mergecraft.analyzers.registry import load_catalog
 from mergecraft.models import PROVIDERS
-from mergecraft.scm.webhooks import SUPPORTED_WEBHOOK_PROVIDERS
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_PATH = REPO_ROOT / "docs" / "support-matrix.md"
@@ -80,11 +79,13 @@ def gen_support_matrix() -> str:
             notes = "preferred" if defn.preferred else "—"
             model_rows.append((f"`{provider_key}/{model_id}`", f"`{provider_key}`", notes))
 
+    # Review operations are GitHub-only. Webhook signature support alone
+    # does not implement a GitLab review adapter.
     scm_rows = [
-        (f"`{name}`", "Webhook + review ingress", "Supported")
-        for name in sorted(SUPPORTED_WEBHOOK_PROVIDERS)
+        ("`github`", "Webhook + review ingress", "Supported"),
+        ("`gitlab`", "Webhook + review ingress", "Not supported yet"),
+        ("`bitbucket`", "Webhook ingress", "Not supported"),
     ]
-    scm_rows.append(("`bitbucket`", "Webhook ingress", "Not supported"))
 
     language_rows = [(lang, "Analyzer catalog `languages:`") for lang in languages]
 

--- a/scripts/live_image_smoke.py
+++ b/scripts/live_image_smoke.py
@@ -1,0 +1,56 @@
+"""Run one bounded, real review through the installed image's provider harness.
+
+Requires MERGECRAFT_E2E_LIVE_MODEL and the selected provider's credential.
+This checks terminal protocol, not defect-detection quality.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mergecraft.offline_review import run_offline_diff_review
+from mergecraft.run_outcome import RunOutcome
+from mergecraft.utils.git_hardening import git_argv
+
+
+async def main() -> None:
+    """Reject dry runs, missing credentials and nonterminal provider completions."""
+    model = os.environ["MERGECRAFT_E2E_LIVE_MODEL"]
+    if not model.strip():
+        raise ValueError("an explicit live model is required")
+    os.environ["MERGECRAFT_RUN_TIMEOUT_S"] = "180"
+    os.environ["MERGECRAFT_TOKEN_BUDGET"] = "12000"
+    os.environ["MERGECRAFT_TOOL_CALL_BUDGET"] = "30"
+    os.environ["MERGECRAFT_COST_BUDGET_USD"] = "1"
+    with tempfile.TemporaryDirectory(prefix="mergecraft-live-smoke-") as temporary:
+        root = Path(temporary)
+        await asyncio.to_thread(subprocess.run, git_argv(["init", "-q", str(root)]), check=True)
+        (root / "sample.py").write_text("def add(left, right):\n    return left + right\n")
+        patch = root / "review.patch"
+        patch.write_text(
+            "diff --git a/sample.py b/sample.py\n--- a/sample.py\n+++ b/sample.py\n"
+            "@@ -1,2 +1,2 @@\n def add(left, right):\n-    return left + right - 1\n+    return left + right\n"
+        )
+        result = await run_offline_diff_review(
+            cwd=root, diff_file=patch, model=model, use_cache=False
+        )
+        if (
+            not result.success
+            or result.outcome != RunOutcome.passed
+            or not result.structured_output
+        ):
+            raise RuntimeError("live image smoke did not produce an accepted terminal review")
+        print(
+            json.dumps(
+                {"requested_model": model, "terminal_review": True, "outcome": result.outcome.value}
+            )
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/mergecraft/analyzers/redact.py
+++ b/src/mergecraft/analyzers/redact.py
@@ -22,7 +22,12 @@ _SECRET_PATTERNS: tuple[Pattern[str], ...] = (
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\b(?:xox[baprs]-)[A-Za-z0-9-]{10,}\b"),
-    re.compile(r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?([^\s'\"\]})]{8,})", re.I),
+    re.compile(
+        r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*"
+        r"""(?:"(?:\\.|[^"\\]){8,}"|'(?:\\.|[^'\\]){8,}'|"""
+        r"[^\s'\"]{8,}?(?=[\]})]*(?:\s|$)))",
+        re.I,
+    ),
     re.compile(r"Basic [A-Za-z0-9+/=]{16,}"),
 )
 

--- a/src/mergecraft/analyzers/redact.py
+++ b/src/mergecraft/analyzers/redact.py
@@ -17,17 +17,19 @@ from mergecraft.redaction_structured import redact_structured_value
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+_ASSIGNMENT_SECRET_PATTERN: Pattern[str] = re.compile(
+    r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*"
+    r"""(?:"(?:\\.|[^"\\]){8,}"|'(?:\\.|[^'\\]){8,}'|"""
+    r"(?P<unquoted>[^\s'\"]{8,}))",
+    re.I,
+)
+
 _SECRET_PATTERNS: tuple[Pattern[str], ...] = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\b(?:xox[baprs]-)[A-Za-z0-9-]{10,}\b"),
-    re.compile(
-        r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*"
-        r"""(?:"(?:\\.|[^"\\]){8,}"|'(?:\\.|[^'\\]){8,}'|"""
-        r"[^\s'\"]{8,}?(?=[\]})]*(?:\s|$)))",
-        re.I,
-    ),
+    _ASSIGNMENT_SECRET_PATTERN,
     re.compile(r"Basic [A-Za-z0-9+/=]{16,}"),
 )
 
@@ -201,10 +203,20 @@ def _entropy_redact(text: str) -> str:
     return _ENTROPY_TOKEN_RE.sub(replacer, text)
 
 
+def _redact_assignment(match: re.Match[str]) -> str:
+    """Preserve trailing delimiters after matching the complete assignment value."""
+    value = match.group("unquoted") or ""
+    suffix_start = len(value.rstrip("]})"))
+    return REDACTION_SENTINEL + value[suffix_start:]
+
+
 def _pattern_redact(text: str) -> str:
     redacted = text
     for pattern in _SECRET_PATTERNS:
-        redacted = pattern.sub(REDACTION_SENTINEL, redacted)
+        replacement = (
+            _redact_assignment if pattern is _ASSIGNMENT_SECRET_PATTERN else REDACTION_SENTINEL
+        )
+        redacted = pattern.sub(replacement, redacted)
     return redacted
 
 

--- a/src/mergecraft/analyzers/redact.py
+++ b/src/mergecraft/analyzers/redact.py
@@ -22,7 +22,7 @@ _SECRET_PATTERNS: tuple[Pattern[str], ...] = (
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\b(?:xox[baprs]-)[A-Za-z0-9-]{10,}\b"),
-    re.compile(r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?([^\s'\"]{8,})", re.I),
+    re.compile(r"\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?([^\s'\"\]})]{8,})", re.I),
     re.compile(r"Basic [A-Za-z0-9+/=]{16,}"),
 )
 
@@ -158,6 +158,15 @@ def _looks_like_repo_path_token(token: str) -> bool:
 def _entropy_redact(text: str) -> str:
     def replacer(match: re.Match[str]) -> str:
         token = match.group(0)
+        # The entropy alphabet excludes dots, so inspect a bounded filename
+        # suffix before classifying a normal path prefix as a dense token.
+        suffix = re.match(
+            r"\.(?:py|js|ts|md|json|yaml|yml|toml|sh|txt)(?![\w.])", text[match.end() :]
+        )
+        if suffix and "/" in token:
+            segments = token.split("/")
+            if all(re.fullmatch(r"[a-z_][a-z0-9_-]{0,14}", part) for part in segments):
+                return token
         if _looks_like_repo_path_token(token):
             return token
         if len(token) < _MIN_ENTROPY_LENGTH:

--- a/src/mergecraft/evals/convergence_benchmark.py
+++ b/src/mergecraft/evals/convergence_benchmark.py
@@ -79,6 +79,9 @@ def _resolved_recall_pass_corpus_path() -> Path:
     checkout = _REPO_ROOT / RECALL_PASS_CORPUS_PATH
     if checkout.is_file():
         return checkout
+    packaged = Path(__file__).parent / "fixtures" / "recall_pass_corpus.json"
+    if packaged.is_file():
+        return packaged
     msg = f"recall pass corpus does not exist: {RECALL_PASS_CORPUS_PATH}"
     raise FileNotFoundError(msg)
 

--- a/src/mergecraft/utils/offline_diff.py
+++ b/src/mergecraft/utils/offline_diff.py
@@ -104,14 +104,6 @@ def git_merge_base_diff(
 
     result = _run_git(["diff", "--merge-base", base], cwd=cwd)
     if result.returncode != 0:
-        # Fallback: three-dot committed-only range.
-        logger.warning(
-            "git diff --merge-base {} failed ({}); trying three-dot range",
-            base,
-            result.stderr.strip() or result.returncode,
-        )
-        result = _run_git(["diff", f"{base}...HEAD"], cwd=cwd)
-    if result.returncode != 0:
         msg = f"failed to compute diff against {base!r}: {result.stderr.strip()}"
         raise RuntimeError(msg)
     return result.stdout
@@ -134,10 +126,11 @@ def git_ref_diff(
         if origin_probe.returncode == 0:
             resolved_base = candidate
     result = _run_git(["diff", f"{resolved_base}...{head}"], cwd=cwd)
-    if result.returncode != 0 and "no merge base" in (result.stderr or "").lower():
-        result = _run_git(["diff", f"{resolved_base}..{head}"], cwd=cwd)
     if result.returncode != 0:
-        msg = f"failed to compute diff {base!r}...{head!r}: {result.stderr.strip()}"
+        msg = (
+            f"failed to compute diff {base!r}...{head!r}: {result.stderr.strip()}. "
+            "Fetch sufficient shared history before retrying; endpoint comparison is not equivalent."
+        )
         raise RuntimeError(msg)
     return result.stdout
 
@@ -167,7 +160,7 @@ def git_unstaged_diff(*, cwd: Path) -> str:
             if not rel:
                 continue
             path = cwd / rel
-            if not path.is_file():
+            if path.is_symlink() or not path.is_file():
                 continue
             try:
                 raw = path.read_bytes()
@@ -179,14 +172,11 @@ def git_unstaged_diff(*, cwd: Path) -> str:
             if b"\0" in raw:
                 logger.info("skipped binary untracked file in unstaged diff: {}", rel)
                 continue
-            contents = raw.decode("utf-8", errors="replace")
-            text += (
-                f"diff --git a/{rel} b/{rel}\nnew file mode 100644\n--- /dev/null\n+++ b/{rel}\n"
-            )
-            for line in contents.splitlines():
-                text += f"+{line}\n"
-            if contents and not contents.endswith("\n"):
-                text += "\n"
+            patch = _run_git(["diff", "--no-index", "--", "/dev/null", rel], cwd=cwd)
+            if patch.returncode not in (0, 1):
+                msg = f"failed to compute untracked diff for {rel!r}: {patch.stderr.strip()}"
+                raise RuntimeError(msg)
+            text += patch.stdout
     return text
 
 

--- a/src/mergecraft/utils/offline_diff.py
+++ b/src/mergecraft/utils/offline_diff.py
@@ -172,6 +172,11 @@ def git_unstaged_diff(*, cwd: Path) -> str:
             if b"\0" in raw:
                 logger.info("skipped binary untracked file in unstaged diff: {}", rel)
                 continue
+            try:
+                raw.decode("utf-8")
+            except UnicodeDecodeError:
+                logger.info("skipped non-UTF-8 untracked file in unstaged diff: {}", rel)
+                continue
             patch = _run_git(["diff", "--no-index", "--", "/dev/null", rel], cwd=cwd)
             if patch.returncode not in (0, 1):
                 msg = f"failed to compute untracked diff for {rel!r}: {patch.stderr.strip()}"

--- a/src/mergecraft/utils/source_resolve.py
+++ b/src/mergecraft/utils/source_resolve.py
@@ -447,6 +447,22 @@ def _fetch_remote_ref(
     )
 
 
+def _ensure_shared_history(*, cwd: Path, head_ref: str, base_ref: str, env: dict[str, str]) -> None:
+    """Deepen both tips within a fixed budget; never substitute endpoint semantics."""
+    for depth in (0, 50, 200):
+        if depth:
+            _fetch_remote_ref(ref=head_ref, cwd=cwd, env=env, depth=depth)
+            _fetch_remote_ref(ref=base_ref, cwd=cwd, env=env, depth=depth)
+            _enforce_limits(cwd, max_bytes=DEFAULT_MAX_BYTES, max_files=DEFAULT_MAX_FILES)
+        try:
+            _run_git(["merge-base", "HEAD", f"origin/{base_ref}"], cwd=str(cwd))
+            return
+        except RuntimeError:
+            continue
+    msg = "shared history unavailable within the 200-commit acquisition budget; provide a local checkout with sufficient history"
+    raise SourceResolveError(msg)
+
+
 def resolve_workspace(spec: SourceResolverSpec) -> ResolvedWorkspace:
     """Resolve ``--repo`` / ``--cwd`` into a review workspace."""
     if spec.repo is None:
@@ -468,17 +484,28 @@ def resolve_workspace(spec: SourceResolverSpec) -> ResolvedWorkspace:
             dest=temp_dir,
         )
         auth_env = _credential_env(auth.token)
+        comparison_base: str | None = None
         if spec.base and spec.base != ref:
             _fetch_remote_ref(ref=spec.base, cwd=acquired.path, env=auth_env)
+            comparison_base = spec.base
         elif spec.head and spec.base is None and ref not in {"main", "master"}:
             for candidate in ("main", "master"):
                 if candidate == ref:
                     continue
                 try:
                     _fetch_remote_ref(ref=candidate, cwd=acquired.path, env=auth_env)
+                    comparison_base = candidate
                     break
                 except RuntimeError:
                     continue
+        if comparison_base:
+            try:
+                _ensure_shared_history(
+                    cwd=acquired.path, head_ref=ref, base_ref=comparison_base, env=auth_env
+                )
+            except (RuntimeError, SourceResolveError):
+                shutil.rmtree(temp_dir, ignore_errors=True)
+                raise
         return ResolvedWorkspace(
             cwd=acquired.path,
             git_common_dir=resolve_git_common_dir(acquired.path),
@@ -534,6 +561,10 @@ def materialize_resolved_diff(
         parse_commit_range(spec.commit_range)
         text = git_range_diff(cwd=workspace.cwd, range_spec=spec.commit_range)
         base_ref = spec.commit_range
+    elif spec.base and not spec.head and not workspace.cloned:
+        return materialize_diff(
+            cwd=workspace.cwd, out_dir=out_dir, base=spec.base, git_dir=workspace.git_common_dir
+        )
     elif spec.head or spec.base:
         if spec.base:
             base_ref = spec.base

--- a/tests/analyzers/test_redaction_boundaries.py
+++ b/tests/analyzers/test_redaction_boundaries.py
@@ -1,0 +1,22 @@
+"""Independent punctuation and source-path redaction regressions."""
+
+from mergecraft.analyzers.redact import redact_secrets
+
+
+def test_assignment_preserves_closing_bracket() -> None:
+    output = redact_secrets("found [password=public-fixture-value] here")
+    assert "public-fixture-value" not in output
+    assert output.endswith("] here")
+
+
+def test_source_path_remains_readable() -> None:
+    path = "src/mergecraft/analyzers/redact.py"
+    assert redact_secrets(path) == path
+    assert redact_secrets(f"changed {path} today") == f"changed {path} today"
+
+
+def test_secret_inside_source_path_is_still_redacted() -> None:
+    secret = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"
+    assert secret not in redact_secrets(f"src/{secret}/redact.py")
+    dense = "Q8nV4zK7pR2wX6mJ9sT3bF5h"
+    assert dense not in redact_secrets(f"src/{dense}/redact.py")

--- a/tests/analyzers/test_redaction_boundaries.py
+++ b/tests/analyzers/test_redaction_boundaries.py
@@ -1,11 +1,21 @@
 """Independent punctuation and source-path redaction regressions."""
 
+import pytest
+
 from mergecraft.analyzers.redact import redact_secrets
 
 
 def test_assignment_preserves_closing_bracket() -> None:
     output = redact_secrets("found [password=public-fixture-value] here")
     assert "public-fixture-value" not in output
+    assert output.endswith("] here")
+
+
+@pytest.mark.parametrize("quote", ["", "'", '"'])
+def test_assignment_does_not_expose_secret_after_interior_bracket(quote: str) -> None:
+    output = redact_secrets(f"found [password={quote}abcdefgh]private_tail{quote}] here")
+    assert "abcdefgh" not in output
+    assert "private_tail" not in output
     assert output.endswith("] here")
 
 

--- a/tests/ci/test_cli_examples_isolation.py
+++ b/tests/ci/test_cli_examples_isolation.py
@@ -1,0 +1,26 @@
+"""Example drift checks must not rewrite tracked outputs."""
+
+from pathlib import Path
+
+from scripts import check_cli_examples as examples
+
+
+def test_check_runs_in_copy_and_preserves_original(tmp_path: Path) -> None:
+    fixture = tmp_path / "example"
+    fixture.mkdir()
+    (fixture / "expected").mkdir()
+    (fixture / "expected" / "result.txt").write_text("new\n")
+    (fixture / "result.txt").write_text("old tracked output\n")
+    (fixture / "run.sh").write_text("#!/bin/bash\nprintf 'new\\n' > result.txt\n")
+    assert examples.check_example(fixture) == []
+    assert (fixture / "result.txt").read_text() == "old tracked output\n"
+
+
+def test_existing_output_cannot_hide_a_missing_generated_file(tmp_path: Path) -> None:
+    fixture = tmp_path / "example"
+    fixture.mkdir()
+    (fixture / "expected").mkdir()
+    (fixture / "expected" / "result.txt").write_text("old\n")
+    (fixture / "result.txt").write_text("old\n")
+    (fixture / "run.sh").write_text("#!/bin/bash\nexit 0\n")
+    assert "missing output" in examples.check_example(fixture)[0]

--- a/tests/ci/test_live_image_smoke.py
+++ b/tests/ci/test_live_image_smoke.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import os
+import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from mergecraft.review.offline_result import OfflineReviewResult
 from mergecraft.run_outcome import RunOutcome
@@ -58,3 +61,57 @@ async def test_live_smoke_reports_accepted_terminal(
     monkeypatch.setattr(live_image_smoke, "run_offline_diff_review", review)
     await live_image_smoke.main()
     assert '"terminal_review": true' in capsys.readouterr().out
+
+
+@pytest.fixture
+def live_step_script() -> str:
+    workflow = yaml.safe_load(
+        (Path(__file__).resolve().parents[2] / ".github/workflows/e2e.yml").read_text()
+    )
+    return next(
+        step["run"]
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("name") == "Live installed-harness smoke (explicit model required)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_key"),
+    [
+        ("openai/test", "OPENAI_API_KEY"),
+        ("anthropic/test", "ANTHROPIC_API_KEY"),
+        ("google/test", "GEMINI_API_KEY"),
+        ("unknown/test", None),
+        ("openai/test-missing", None),
+    ],
+)
+def test_live_container_gets_only_its_selected_credential(
+    tmp_path: Path, live_step_script: str, model: str, expected_key: str | None
+) -> None:
+    docker = tmp_path / "docker"
+    arguments = tmp_path / "arguments"
+    docker.write_text('#!/bin/bash\nprintf "%s\\n" "$@" > "$SMOKE_DOCKER_ARGS"\n')
+    docker.chmod(0o700)
+    keys = {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"}
+    environment = {
+        **os.environ,
+        **dict.fromkeys(keys, "nonsecret-fixture"),
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "SMOKE_DOCKER_ARGS": str(arguments),
+        "E2E_IMAGE": "test-image",
+        "MERGECRAFT_E2E_LIVE_MODEL": model,
+    }
+    if model.endswith("-missing"):
+        environment["OPENAI_API_KEY"] = ""
+    result = subprocess.run(
+        ["bash", "-c", live_step_script], env=environment, capture_output=True, text=True
+    )
+    if expected_key is None:
+        assert result.returncode != 0
+        assert not arguments.exists()
+    else:
+        assert result.returncode == 0, result.stderr
+        passed = set(arguments.read_text().splitlines())
+        assert passed.intersection(keys) == {expected_key}
+        assert "nonsecret-fixture" not in passed

--- a/tests/ci/test_live_image_smoke.py
+++ b/tests/ci/test_live_image_smoke.py
@@ -1,0 +1,60 @@
+"""The image live gate must require real terminal-review acceptance."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from mergecraft.review.offline_result import OfflineReviewResult
+from mergecraft.run_outcome import RunOutcome
+from scripts import live_image_smoke
+
+
+@pytest.fixture(autouse=True)
+def restore_smoke_budget_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "MERGECRAFT_RUN_TIMEOUT_S",
+        "MERGECRAFT_TOKEN_BUDGET",
+        "MERGECRAFT_TOOL_CALL_BUDGET",
+        "MERGECRAFT_COST_BUDGET_USD",
+    ):
+        monkeypatch.setenv(key, "1")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        OfflineReviewResult(success=False, outcome=RunOutcome.configuration_error),
+        OfflineReviewResult(success=True, outcome=RunOutcome.passed),
+        OfflineReviewResult(success=True, structured_output="{}"),
+    ],
+)
+async def test_live_smoke_rejects_nonterminal_results(
+    monkeypatch: pytest.MonkeyPatch, result: OfflineReviewResult
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_E2E_LIVE_MODEL", "openai/test")
+
+    async def review(**kwargs: Any) -> OfflineReviewResult:
+        assert kwargs["use_cache"] is False
+        assert kwargs["diff_file"].is_file()
+        assert os.environ["MERGECRAFT_RUN_TIMEOUT_S"] == "180"
+        return result
+
+    monkeypatch.setattr(live_image_smoke, "run_offline_diff_review", review)
+    with pytest.raises(RuntimeError, match="accepted terminal"):
+        await live_image_smoke.main()
+
+
+async def test_live_smoke_reports_accepted_terminal(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("MERGECRAFT_E2E_LIVE_MODEL", "openai/test")
+
+    async def review(**kwargs: Any) -> OfflineReviewResult:
+        return OfflineReviewResult(success=True, outcome=RunOutcome.passed, structured_output="{}")
+
+    monkeypatch.setattr(live_image_smoke, "run_offline_diff_review", review)
+    await live_image_smoke.main()
+    assert '"terminal_review": true' in capsys.readouterr().out

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -108,13 +108,11 @@ def test_doctor_rejects_unknown_schema_version_via_migrate_config(
 
     output = _plain(result.stdout + result.stderr)
     assert result.exit_code != 0, output
-    if output.strip():
-        assert "schema" in output.lower() or "validation" in output.lower()
-    else:
-        from mergecraft.cli.doctor_cmd import _config_probe
-
-        detail = _config_probe(tmp_path).detail.lower()
-        assert "schema" in detail or "validation" in detail, detail
+    # Startup config validation may raise before the doctor command renders.
+    # Assert the diagnostic from this invocation, not a second direct probe;
+    # unrelated background stderr must not decide which assertion runs.
+    diagnostic = f"{output}\n{result.exception or ''}".lower()
+    assert "schema" in diagnostic or "validation" in diagnostic, diagnostic
 
 
 def test_never_prints_a_credential_value(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/utils/test_offline_diff.py
+++ b/tests/utils/test_offline_diff.py
@@ -103,3 +103,9 @@ def test_missing_common_history_never_substitutes_endpoint_diff(git_repo: Path) 
     _git(git_repo, "commit", "-m", "unrelated root")
     with pytest.raises(RuntimeError, match="shared history"):
         git_ref_diff(cwd=git_repo, base="main", head="HEAD")
+
+
+def test_untracked_non_utf8_does_not_crash_or_emit_a_lossy_patch(git_repo: Path) -> None:
+    (git_repo / "legacy.txt").write_bytes(b"caf\xe9\n")
+    text = git_unstaged_diff(cwd=git_repo)
+    assert "legacy.txt" not in text

--- a/tests/utils/test_offline_diff.py
+++ b/tests/utils/test_offline_diff.py
@@ -57,3 +57,49 @@ def test_unstaged_diff_skips_binary_untracked_files(git_repo: Path) -> None:
     (git_repo / "binary.bin").write_bytes(b"\x00\x01\x02")
     text = git_unstaged_diff(cwd=git_repo)
     assert "binary.bin" not in text
+
+
+@pytest.mark.parametrize("name", ["new.txt", "with space.txt", "with\ttab.txt"])
+@pytest.mark.parametrize("contents", ["first\nsecond\n", "no newline", ""])
+def test_untracked_patch_is_accepted_by_git(git_repo: Path, name: str, contents: str) -> None:
+    path = git_repo / name
+    path.write_text(contents)
+    patch = git_unstaged_diff(cwd=git_repo)
+    path.unlink()
+    _git(git_repo, "checkout", "--", "a.txt")
+    result = subprocess.run(
+        ["git", "apply", "-"], cwd=git_repo, input=patch, text=True, capture_output=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert path.read_text() == contents
+
+
+def test_explicit_local_base_preserves_staged_and_unstaged_changes(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    from mergecraft.utils.source_resolve import (
+        ResolvedWorkspace,
+        SourceResolverSpec,
+        materialize_resolved_diff,
+    )
+
+    (git_repo / "a.txt").write_text("staged\n")
+    _git(git_repo, "add", "a.txt")
+    (git_repo / "a.txt").write_text("staged\nunstaged\n")
+    result = materialize_resolved_diff(
+        ResolvedWorkspace(cwd=git_repo, git_common_dir=None, cloned=False),
+        spec=SourceResolverSpec(cwd=git_repo, base="main"),
+        out_dir=tmp_path / "result",
+    )
+    assert "+staged" in result.path.read_text()
+    assert "+unstaged" in result.path.read_text()
+
+
+def test_missing_common_history_never_substitutes_endpoint_diff(git_repo: Path) -> None:
+    from mergecraft.utils.offline_diff import git_ref_diff
+
+    _git(git_repo, "checkout", "--orphan", "unrelated")
+    _git(git_repo, "add", ".")
+    _git(git_repo, "commit", "-m", "unrelated root")
+    with pytest.raises(RuntimeError, match="shared history"):
+        git_ref_diff(cwd=git_repo, base="main", head="HEAD")


### PR DESCRIPTION
## What?

Preserve staged and unstaged changes when reviewing a local explicit base; deepen shallow remote histories within a fixed bound and fail when no common history is found. Generate valid untracked-file patches, including empty files and quoted names.

Ship the convergence corpus in the wheel and verify an installed wheel outside the checkout. Run example checks in disposable copies. Preserve benign paths and closing brackets during redaction while retaining secret controls. Bring the existing GitLab support-matrix correction from main to this prerelease branch.

Replace the optional image `--help` smoke with a bounded real review that requires a terminal verdict. Document and freeze a two-case benchmark smoke selection; no quality measurements are claimed.

## Why?

The previous local diff path silently dropped working-tree changes, and endpoint fallback changed the meaning of remote PR diffs. Source-checkout tests hid a missing wheel fixture, while example checks could overwrite tracked outputs. These changes complete the general correctness portion of Plan 007.

Related: #140. Live two-provider measurements, independent label adjudication and publication acceptance remain outstanding, so this PR does not close that issue. The live smoke requires an explicitly configured model and credential.

## Test plan

- [x] Real Git tests cover staged/unstaged input, unrelated histories, shallow clones and applying untracked patches.
- [x] Installed-wheel convergence and isolated CLI example checks passed.
- [x] 325 focused redaction/evaluation tests passed; 71 benchmark/live-smoke tests passed (optional skips and one existing expected failure).
- [x] Structural evaluation gate passed with 49 loaded cases; this is not a live detection score.
- [x] Latest lint, mypy, Pyright and generated docs checks passed; latest 340 public regression tests passed.
- [x] Full `make ci` on the combined audit checkout passed: 8,509 tests, 55 skips, 12 expected failures; coverage 82.37%. The public PR head also passed hosted static/build, unit/coverage and root/image E2E checks. The separate long integration job is still running.
- [ ] Live image review and two-provider benchmark need operator configuration and budget.

Latest follow-ups (`918ebb1b`, `1ca57019`): handle non-UTF-8 untracked files with an explicit skip diagnostic and pass only the selected provider credential into the live image. All 33 affected tests, lint/mypy, generated docs checks and native workflow linters passed. Hosted checks are refreshing on the latest head.

Final redaction cleanup: `564cfc27` matches complete assignment values before preserving trailing delimiters. All 311 focused redaction tests, lint, mypy, and normal commit/push hooks passed.

Cross-plan integration verification: full `make ci` passed with 8,549 tests, 55 skips, 12 expected failures and 82.37% coverage. Supplemental Pyright completed with zero errors (45 warnings). This complements the focused tests on the individual PR head; it does not constitute live deployment acceptance.

Merged-base update: `28f863d9` incorporates merged #664 and resolves the CHANGELOG conflict while preserving both entries. Dockerfile/Makefile merges were inspected. Ten affected image/corpus/live-smoke tests and native actionlint/zizmor passed; normal hooks passed.
