### PR TITLE
fix(action): prepare verified audit image manifest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:43fca0bdd4bc629285a75c7126bc4e653149fa041fede688a97a523298e4b6b1"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:61662cdab01769659f8e506c162757feb6c61413b7148d7e9d411ab5b2bbff37"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Change only `action.yml`'s image digest to `sha256:61662cdab01769659f8e506c162757feb6c61413b7148d7e9d411ab5b2bbff37`, built from `5a30b000ed301b8378651a3ec0483e097e9ced09`. That source tree is identical to main's #668 merge (`fbec41c8`).

## Why?

This is manifest commit C in the documented source S → image D → manifest C → consumer pin P lifecycle. The self-review workflow still pins `78bfbeb2`; it will not use the new image until the separate consumer-pin PR references this PR's actual merged manifest commit. References #641; deployment acceptance is not complete yet.

Release evidence: https://github.com/alexhawat/mergeCraft/actions/runs/34248091224 passed required E2E, both image builds/scans, signing, attestations, provenance verification and promotion. Local `make action-manifest-prepare` independently verified this digest, source revision, tracing extra, build/SBOM attestations and cosign signature.

## Test plan

- [x] Source tree matches merged main exactly before the image-only change.
- [x] `make action-manifest-prepare` passed strict remote provenance verification.
- [x] Only the immutable image digest changes; no entrypoint, argument, source or workflow changes.
- [x] Local `make action-candidate-check` passed for committed manifest `492684ed`, with `verified: true`.
- [x] Hosted deployment-candidate verification passed for 492684ed; both image scans, security E2E, unit-test shards, coverage and both integration runtime checks also passed. Only the documented stale-pin failures remain.
- [ ] After merge, prepare the separate consumer-pin PR against the actual merged manifest SHA, then observe an Action run at that pin.

### Transitional stale-pin check

`action-pin-check` currently fails on main because the old consumer pin lags by 23 product commits. This manifest-only PR intentionally leaves that pin unchanged, so the same freshness failure is expected here. It cannot be fixed in this PR without violating the required image-only manifest invariant. No freshness thresholds or security checks are relaxed. Review the strict deployment-candidate result separately; the subsequent pin PR removes the stale-pin failure. Record the actual merged SHA if squash merging.

