### PR TITLE
fix(ci): move Action-pin staleness off the required PR gate

### DIFF
--- a/.github/workflows/action-pin-staleness.yml
+++ b/.github/workflows/action-pin-staleness.yml
@@ -21,9 +21,15 @@
 name: Action pin staleness
 
 on:
+  push:
+    # Debt lands on main at merge time, so measure then rather than leaving the
+    # queue un-flagged until the next cron. This also closes the tracking issue
+    # as soon as a pin bump lands, instead of up to a day later.
+    branches: [main]
   schedule:
-    # Daily, after the usual merge window, so a filed issue reports the day's
-    # settled lag rather than a mid-merge snapshot.
+    # Backstop for the push path: catches a pin that goes stale because main
+    # moved under it. GitHub's cron is best-effort — routinely late and skipped
+    # under load — so it is the safety net, not the primary trigger.
     - cron: "0 7 * * *"
   workflow_dispatch:
 
@@ -41,6 +47,13 @@ env:
 
 jobs:
   staleness:
+    # workflow_dispatch accepts any branch, and this job reads the pin from the
+    # tree it checks out. Dispatched from a pin-bump branch, that pin is ahead
+    # of main rather than behind it, `_check_staleness` returns clean for the
+    # "bumped here, not yet promoted" case, and the close step would resolve the
+    # tracking issue while main is still stale — silently retiring a live alert.
+    # This job only ever speaks for main, so it only ever runs on main.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/action-pin-staleness.yml
+++ b/.github/workflows/action-pin-staleness.yml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# Staleness of the self-review Action pin is a property of `main`, not of any
+# one pull request.
+#
+# `scripts/check_action_pin_freshness.py`'s staleness rule compares main's pin
+# against main's own tip; nothing in that computation reads a PR's diff. While
+# it ran as a required PR check, one commit of debt on main failed every open
+# PR at once — and the only change that could clear it (repointing the pin at a
+# manifest commit that does not exist until the manifest PR merges) was blocked
+# by that same red check. #669 deadlocked exactly this way, and the two greens
+# left in the queue were stale results from before the debt landed.
+#
+# So the rule moved here. It runs against main on a schedule and files a single
+# tracking issue that it keeps current and closes itself once the pin is bumped.
+# The PR gate keeps the rules a PR author can actually act on: rung
+# self-consistency, env parity, and freshness (`make action-pin-check`).
+#
+# Safety: this workflow never checks out or executes PR code — it runs on
+# `main` from `schedule` / `workflow_dispatch` only, and its sole write scope
+# is `issues`.
+name: Action pin staleness
+
+on:
+  schedule:
+    # Daily, after the usual merge window, so a filed issue reports the day's
+    # settled lag rather than a mid-merge snapshot.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: action-pin-staleness
+  cancel-in-progress: false
+
+env:
+  # One tracking issue, matched by exact title, edited in place rather than
+  # re-filed — a daily comment thread would train everyone to mute it.
+  ISSUE_TITLE: "Self-review Action pin on main is stale"
+
+jobs:
+  staleness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/bootstrap
+        with:
+          python-version: "3.14"
+
+      - name: Measure pin staleness against main
+        id: measure
+        run: |
+          # No --depth. A depth-limited fetch marks origin/main as a shallow
+          # boundary, so rev-list stops at the graft and the lag under-reports
+          # (measured on this repo: 5 commits -> 1), silently defanging the only
+          # job that now enforces this rule. The checkout above is fetch-depth: 0,
+          # so the objects are already local and a full fetch is near-free.
+          git fetch --no-tags origin main:refs/remotes/origin/main || true
+          if make action-pin-staleness-check > staleness.log 2>&1; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+          cat staleness.log
+
+      - name: File or refresh the tracking issue
+        if: steps.measure.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "\`make action-pin-staleness-check\` is failing on \`main\`:"
+            echo
+            echo '```'
+            cat staleness.log
+            echo '```'
+            echo
+            echo "While this is open, the self-review Action is reviewing pull"
+            echo "requests with product code older than \`main\`. Reviews still run;"
+            echo "they just do not exercise anything merged after the pin."
+            echo
+            echo "### How to clear it"
+            echo
+            echo "The pin can only name a commit whose \`action.yml\` carries a"
+            echo "verified image digest, so this takes the documented two-commit"
+            echo "flow (S -> D -> C -> P, #641):"
+            echo
+            echo "1. Land manifest commit C — \`make action-manifest-prepare\`, which"
+            echo "   updates only \`action.yml\`'s \`runs.image\` digest."
+            echo "2. Land consumer pin P against the SHA C actually landed as:"
+            echo "   \`MANIFEST_COMMIT=<sha> RELEASE_BASE_BRANCH=main make action-pin-prepare\`."
+            echo
+            echo "Do not collapse the two into one PR — P has to reference a commit"
+            echo "that exists, and C's SHA is not known until it merges."
+            echo
+            echo "---"
+            echo "_Filed and kept current by [\`action-pin-staleness.yml\`]($RUN_URL). It closes"
+            echo "itself once the pin is back within budget._"
+          } > issue-body.md
+
+          existing=$(gh issue list --state open --search "$ISSUE_TITLE in:title" \
+            --json number,title \
+            --jq 'map(select(.title == env.ISSUE_TITLE)) | .[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file issue-body.md
+            echo "refreshed issue #$existing"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body-file issue-body.md
+          fi
+
+      - name: Close the tracking issue once the pin is fresh
+        if: steps.measure.outputs.stale == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --state open --search "$ISSUE_TITLE in:title" \
+            --json number,title \
+            --jq 'map(select(.title == env.ISSUE_TITLE)) | .[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Pin is back within the freshness budget ([run]($RUN_URL))."
+            echo "closed issue #$existing"
+          else
+            echo "pin is fresh and no tracking issue is open; nothing to do"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,15 @@ jobs:
       - name: Action pin freshness
         if: matrix.python == '3.14'
         run: |
-          # No --depth here. A depth-limited fetch marks origin/main as a
-          # shallow boundary, so rev-list stops at the graft and the staleness
-          # check under-reports the product lag (measured on this repo: 5
-          # commits -> 1), silently defanging the guard in the only job that
-          # runs it. The checkout above is fetch-depth: 0, so the objects are
-          # already local and a full fetch is near-free.
+          # PR-scoped rules only: rung self-consistency, env parity, and
+          # freshness. Staleness (main's pin vs main's tip) reads nothing from
+          # this diff, so gating PRs on it froze the whole queue behind one
+          # commit of debt on main (#669); it now runs on a schedule in
+          # action-pin-staleness.yml. Freshness still needs origin/main present
+          # to read the base workflow's pin, or it skips with a notice — hence
+          # the fetch. No --depth: a depth-limited fetch marks origin/main as a
+          # shallow boundary and rev-list stops at the graft. The checkout above
+          # is fetch-depth: 0, so the objects are local and this is near-free.
           git fetch --no-tags origin main:refs/remotes/origin/main || true
           make action-pin-check
       # First-wave CI SARIF for mergeCraft ingest (#464 / D8). Upload even when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A stale self-review Action pin on `main` no longer fails every open pull
+  request. `action-pin-check`'s staleness rule compared `main`'s pin against
+  `main`'s own tip, so it read nothing from the PR under review — one commit of
+  debt on `main` froze the whole queue, including the manifest PR that was the
+  only way to clear it (#669). The rule moved to a daily
+  `action-pin-staleness.yml` run against `main` that files one tracking issue,
+  keeps it current, and closes it once the pin is bumped. The required PR check
+  keeps every rule a branch can act on: rung self-consistency, drift from
+  `env.MERGECRAFT_ACTION_SHA`, and freshness against the default branch's pin.
+  `make action-pin-staleness-check` runs the full set locally.
+
 - Consolidated integration CI retains Python 3.11 and 3.14 coverage after
   prerelease/main reconciliation; the coverage ratchet runs once on 3.14.
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SHELL := /bin/bash
 	examples example-workflows-check agent-packages agent-packages-check cli-examples cli-examples-check docs docs-check llms llms-check mcp-server-json mcp-server-json-check reference-docs reference-docs-check bench-review eval-gate eval-replay eval-convergence \
 	bench-detect diagrams diagrams-check \
 	test-integration test-integration-live test-otlp-collector coverage-measure coverage-gate npm-audit workflow-lint \
-	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-image-digest-check action-image-structure-check action-candidate-check action-images-resolve action-images-verify action-images-publish-canonical action-manifest-prepare action-pin-prepare
+	lint-ruff-advisory hook-pins-check pins-check action-pin-check action-pin-staleness-check action-image-digest-check action-image-structure-check action-candidate-check action-images-resolve action-images-verify action-images-publish-canonical action-manifest-prepare action-pin-prepare
 
 PIPELINE_D2 := docs/diagrams/pipeline.d2
 PIPELINE_LIGHT := assets/diagrams/pipeline-light.svg
@@ -96,8 +96,11 @@ action-yml-hygiene-check: ## Fail when an action.yml description embeds a litera
 hook-pins-check: ## Fail when .pre-commit-config.yaml hook revs drift from pyproject.toml pins
 	$(UV) run python scripts/check_hook_pins.py
 
-action-pin-check: ## Fail when the default branch's self-review Action pin drifts too far behind (#450)
-	$(UV) run python scripts/check_action_pin_freshness.py
+action-pin-check: ## Fail on Action-pin defects a PR can fix: rung disagreement, env drift, freshness (#450)
+	$(UV) run python scripts/check_action_pin_freshness.py --scope pr
+
+action-pin-staleness-check: ## Fail when main's own pin lags main; scheduled, never a required PR check (#450)
+	$(UV) run python scripts/check_action_pin_freshness.py --scope all
 
 action-image-structure-check: ## Validate source syntax without asserting deployed provenance
 	$(UV) run python scripts/check_action_image_digest.py --structure-only

--- a/docs/test-plans/12-review-record-integrity.md
+++ b/docs/test-plans/12-review-record-integrity.md
@@ -48,7 +48,10 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | **W1.7** `evidence_packet` output | W7 | `test_w17_packet_artifact_summary.py::test_evidence_packet_output_nonempty_for_pr_run` |
 | **W1.7** workflow artifact via `env:` | W7 | `test_w17_packet_artifact_summary.py::test_mergecraft_workflow_persists_packet_via_env_not_inline_interpolation` |
 | **W1.8** `action-pin-check` in `ci-static` | W8 | `test_w18_action_pin_gate.py::test_make_ci_static_invokes_action_pin_check` |
-| **W1.8** `ci.yml` non-zero on stale pin | W8 | `test_w18_action_pin_gate.py::test_ci_yml_fails_on_stale_pin_instead_of_warning_only` |
+| **W1.8** `ci.yml` non-zero on pin defects | W8 | `test_w18_action_pin_gate.py::test_ci_yml_fails_on_pin_defects_instead_of_warning_only` |
+| **W1.8** stale pin reported, not warned | W8 | `test_w18_action_pin_gate.py::test_the_staleness_workflow_reports_a_stale_pin_instead_of_warning_only` |
+| **W1.8** staleness scoped off the PR gate (#669) | W8 | `test_w18_action_pin_gate.py::test_the_required_gate_carries_no_rule_a_pull_request_cannot_satisfy` |
+| **W1.8** staleness job is main-only | W8 | `test_w18_action_pin_gate.py::test_the_staleness_job_only_ever_speaks_for_main` |
 | **W1.8** single pin, three rungs | W8 | `test_w18_action_pin_gate.py::test_mergecraft_workflow_three_rungs_share_one_pin_value` |
 | **W1.8** partial bump fails | W8 | `test_w18_action_pin_gate.py::test_partial_pin_bump_fails_action_pin_check` |
 | **W8 / #535** digest guard script | W8 | `test_action_image_digest_check.py` (real Git histories and digest-bound provenance policy regressions) |
@@ -75,6 +78,7 @@ Authoring wave: **W1** (`test-creator`). Implementation: **W2–W8**.
 | `render_step_summary` / `append_step_summary` | `utils/step_summary.py` | `test_w17_packet_artifact_summary.py` |
 | workflow packet `env:` artifact steps | `.github/workflows/mergecraft.yml` | `test_w17_packet_artifact_summary.py` |
 | `action-pin-check` in `ci-static` / `CI_STEPS` | `Makefile` | `test_w18_action_pin_gate.py` |
+| `action-pin-staleness-check` on a schedule | `Makefile`, `.github/workflows/action-pin-staleness.yml` | `test_w18_action_pin_gate.py` |
 | `action-image-digest-check` / `check_action_image_digest.py` | `scripts/`, `Makefile` | `test_action_image_digest_check.py`, `test_action_image_digest_sync.py` |
 
 ## Fixtures

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -262,8 +262,24 @@ env:
 
 All three review rungs (`uses: alexhawat/mergeCraft@…`) derive from that value,
 with a `# env.MERGECRAFT_ACTION_SHA` comment suffix on each line. A bump is one
-edit; `make action-pin-check` (wired into `make ci-static`) fails when the pin
-drifts from the default branch or when the three rungs disagree (#532).
+edit, and two targets guard it (#532):
+
+| Target | Rules | Where it runs |
+| --- | --- | --- |
+| `make action-pin-check` | rungs disagree, a rung drifts from `env.MERGECRAFT_ACTION_SHA`, the pin diverges from the default branch's | `make ci-static` — a required PR check |
+| `make action-pin-staleness-check` | all of the above, plus the pin lagging the default branch's own tip by more than `MERGECRAFT_MAX_ACTION_PIN_PRODUCT_LAG` commits under `src/mergecraft/` | `.github/workflows/action-pin-staleness.yml`, daily against `main` |
+
+The split is deliberate. Staleness compares `main`'s pin against `main`'s tip,
+so nothing in it reads the pull request under review. While it gated PRs, one
+stale pin on `main` failed every open PR at once — and the only change that
+could clear it (repointing the pin at a manifest commit that does not exist
+until the manifest PR merges) was blocked by that same red check (#669). The
+scheduled job files a single tracking issue instead, keeps it current, and
+closes it once the pin is bumped. `make action-pin-check` still runs every rule
+a branch can actually act on.
+
+Locally, plain `make action-pin-check` is the PR-scoped set; run
+`make action-pin-staleness-check` for the full picture.
 
 After each review rung, the workflow persists the `evidence_packet` action output
 to disk and uploads it as an artifact (`if: always()`):

--- a/scripts/check_action_pin_freshness.py
+++ b/scripts/check_action_pin_freshness.py
@@ -12,26 +12,45 @@ Nothing detected that skew, and it reached 687 commits: PR #443 timed out on a
 branch's own workflow pins the fixed SHA, and CI still exercises the old code
 (#450).
 
-Three checks:
+Four rules, split across two scopes by ``--scope``.
+
+``--scope pr`` — the rules whose subject is the diff under review. Wired into
+``make ci-static``, so they gate every PR.
 
 1. **Self-consistency** (offline, always runs). Every ``uses:`` pin of this
    action inside a workflow file must be the same SHA. The workflow header
    warns that a one-sided bump is a footgun; this makes it an error.
-2. **Freshness** (needs the default-branch ref). The default branch's pin must
+2. **Env parity** (offline, always runs). Every rung pin must equal the hoisted
+   ``env.MERGECRAFT_ACTION_SHA``, so a bump cannot land half-applied.
+3. **Freshness** (needs the default-branch ref). The default branch's pin must
    be an ancestor of this branch's pin and within ``MAX_DRIFT`` commits of it.
    Skips with a notice when the ref is not fetched, so a local ``make lint``
-   in a shallow or offline checkout does not fail on it.
-3. **Staleness** (needs the default-branch ref). The pin must not lag the
+   in a shallow or offline checkout does not fail on it. It is a no-op unless
+   the branch actually moves the pin, which is what keeps it a PR rule.
+
+``--scope all`` (the default) — adds the rule whose subject is the default
+branch itself. Run on a schedule against ``main`` by
+``.github/workflows/action-pin-staleness.yml``, never as a required PR check.
+
+4. **Staleness** (needs the default-branch ref). The pin must not lag the
    default branch's own tip by more than ``MAX_PRODUCT_LAG`` commits touching
-   ``src/mergecraft/``. Check 2 compares the two branches' pins only to each
+   ``src/mergecraft/``. Rule 3 compares the two branches' pins only to each
    other, so it passes when *both* are equally stale: after PR #457 merged,
    both branches pinned the same SHA and the check reported OK while the
    reviewer ran none of the fixes that had just landed. Measuring against the
    default branch's tip rather than HEAD keeps this stable, since unmerged
    feature commits are not something a pin could reference yet.
 
+Why rule 4 is not a PR gate: nothing in its computation reads the PR's diff, so
+one stale pin on ``main`` failed *every* open PR at once, while the only change
+that could clear it — repointing the pin at a manifest commit that does not
+exist until the manifest PR merges — was itself blocked by the same red check
+(#669). Enforcing a default-branch invariant per-PR turns one commit of debt
+into a repo-wide merge freeze no PR author can lift. The schedule files an
+issue against ``main`` instead, where the debt actually lives.
+
 Module: scripts.check_action_pin_freshness
-Depends: os, re, subprocess, sys, pathlib
+Depends: argparse, os, re, subprocess, sys, pathlib
 
 Exports:
     main — CLI entry; compares self-review Action pins for drift.
@@ -39,11 +58,16 @@ Exports:
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO / ".github" / "workflows"
@@ -56,6 +80,15 @@ _ENV_SHA_RE = re.compile(
 )
 
 DEFAULT_BRANCH = os.environ.get("MERGECRAFT_DEFAULT_BRANCH", "main")
+
+# Rule scopes. ``PR_SCOPE`` holds only assertions a PR author can act on from
+# the branch they are on; ``ALL_SCOPE`` adds the default-branch invariant.
+PR_SCOPE = "pr"
+ALL_SCOPE = "all"
+
+# Where rule 4 is enforced now that it is off the PR gate. Named in the
+# scope-pr success line so an operator reading a green log knows it still runs.
+STALENESS_WORKFLOW = ".github/workflows/action-pin-staleness.yml"
 
 # Chosen to catch a genuinely stale reviewer, not routine lag: a pin a few
 # merges behind still runs substantially current code, while hundreds of
@@ -205,8 +238,45 @@ def _check_staleness(rel_path: str, head_sha: str) -> list[str]:
     ]
 
 
-def main() -> int:
-    """Report Action-pin drift; return 1 when a check fails."""
+def _rules_for_scope(
+    rel_path: str,
+    text: str,
+    pins: list[tuple[int, str]],
+    scope: str,
+) -> list[str]:
+    """Run the rules belonging to ``scope`` over one workflow file."""
+    failures = [
+        *_check_self_consistency(rel_path, pins),
+        *_check_env_parity(rel_path, text, pins),
+        *_check_freshness(rel_path, pins[0][1]),
+    ]
+    if scope == ALL_SCOPE:
+        failures.extend(_check_staleness(rel_path, pins[0][1]))
+    return failures
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    """Parse the scope selector; default to every rule for local and cron use."""
+    parser = argparse.ArgumentParser(
+        description="Compare self-review Action pins for drift (#450, #532).",
+    )
+    parser.add_argument(
+        "--scope",
+        choices=(PR_SCOPE, ALL_SCOPE),
+        default=ALL_SCOPE,
+        help=(
+            "'pr' runs only the rules a PR author can act on: self-consistency, "
+            "env parity and freshness. 'all' (default) adds staleness, whose "
+            "subject is the default branch and which no PR can fix."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Report Action-pin drift; return 1 when a rule in the chosen scope fails."""
+    args = _parse_args(argv)
+
     if not WORKFLOW_DIR.is_dir():
         print("action-pin-check: no .github/workflows directory; nothing to check")
         return 0
@@ -220,16 +290,21 @@ def main() -> int:
             continue
         checked += 1
         rel_path = path.relative_to(REPO).as_posix()
-        failures.extend(_check_self_consistency(rel_path, pins))
-        failures.extend(_check_env_parity(rel_path, text, pins))
-        failures.extend(_check_freshness(rel_path, pins[0][1]))
-        failures.extend(_check_staleness(rel_path, pins[0][1]))
+        failures.extend(_rules_for_scope(rel_path, text, pins, args.scope))
 
     if failures:
         print("action-pin-check FAILED:", file=sys.stderr)
         for failure in failures:
             print(f"  - {failure}", file=sys.stderr)
         return 1
+
+    if args.scope == PR_SCOPE:
+        print(
+            f"action-pin-check OK (scope=pr): {checked} workflow(s) pin this action. "
+            f"Staleness against '{DEFAULT_BRANCH}' is measured on a schedule by "
+            f"{STALENESS_WORKFLOW}."
+        )
+        return 0
 
     print(f"action-pin-check OK: {checked} workflow(s) pin this action")
     return 0

--- a/tests/pins/test_action_pin_freshness.py
+++ b/tests/pins/test_action_pin_freshness.py
@@ -5,11 +5,14 @@ resolves its ``uses:`` pin from the default branch. When that pin lags, the
 reviewer executes old code while the branch under review holds the fix — the
 skew that made PR #443 time out on an already-fixed 600s ceiling.
 
-Covers the three guards in ``scripts/check_action_pin_freshness.py``: pins
-inside one workflow file must agree, the default branch's pin must stay within
-``MAX_DRIFT`` commits of this branch's, and the pin must not lag the default
-branch's own tip by more than ``MAX_PRODUCT_LAG`` commits touching
-``src/mergecraft/``.
+Covers the guards in ``scripts/check_action_pin_freshness.py``: pins inside one
+workflow file must agree, every rung must match ``env.MERGECRAFT_ACTION_SHA``,
+the default branch's pin must stay within ``MAX_DRIFT`` commits of this
+branch's, and the pin must not lag the default branch's own tip by more than
+``MAX_PRODUCT_LAG`` commits touching ``src/mergecraft/``.
+
+The last of those is scoped out of the PR gate — see ``_rules_for_scope`` and
+the scope tests at the foot of this module.
 """
 
 from __future__ import annotations
@@ -166,15 +169,14 @@ def test_the_live_workflow_pins_are_self_consistent() -> None:
 
 
 def test_the_pin_check_ci_step_does_not_shallow_fetch_the_default_branch() -> None:
-    """A depth-limited fetch silently defangs the staleness guard.
+    """The PR gate still needs ``origin/main`` present, or freshness skips.
 
-    ``--depth=1`` marks ``origin/main`` as a shallow boundary, so
-    ``_check_staleness``'s ``rev-list --count <pin>..origin/main`` stops at the
-    graft and under-reports the product lag — measured on this repo, 5 commits
-    read as 1. The guard exists for the #450 case freshness cannot see (both
-    branches pinning the same stale SHA), so a silent under-count is the one
-    failure that makes it useless while still reporting OK. The ``static`` job
-    checks out ``fetch-depth: 0``, so a full fetch costs nothing here.
+    ``_check_freshness`` reads the base workflow with ``git show
+    origin/main:<path>``; without the ref it prints a skip notice and returns
+    clean, so the rung-bump guard silently stops guarding. Staleness moved to
+    ``action-pin-staleness.yml`` (#669), which is where a shallow fetch would
+    now under-report the lag — asserted separately over there. The ``static``
+    job checks out ``fetch-depth: 0``, so a full fetch costs nothing here.
     """
     static = job(load_workflow("ci.yml"), "static")
     steps = [s for s in static["steps"] if "pin freshness" in str(s.get("name", "")).lower()]
@@ -281,3 +283,63 @@ def test_matching_pins_that_both_lag_the_tip_are_still_caught(
     # Staleness measures against the branch tip and catches it.
     failures = _staleness_with(module, monkeypatch, product_lag="8")
     assert len(failures) == 1
+
+
+def test_the_pr_scope_omits_the_rule_no_pull_request_can_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Staleness compares main's pin to main's tip and never reads the diff.
+
+    Left on the required PR check it failed every open PR at once over one
+    commit of debt on main, while the change that would clear it could not
+    merge through the same red check (#669).
+    """
+    module = _load()
+    monkeypatch.setattr(module, "_check_self_consistency", lambda *_a: [])
+    monkeypatch.setattr(module, "_check_env_parity", lambda *_a: [])
+    monkeypatch.setattr(module, "_check_freshness", lambda *_a: [])
+    monkeypatch.setattr(module, "_check_staleness", lambda *_a: ["stale pin"])
+
+    text = _workflow_text(_SHA_NEW)
+    pins = module._pins_in(text)
+
+    assert module._rules_for_scope(_WORKFLOW, text, pins, module.PR_SCOPE) == []
+    assert module._rules_for_scope(_WORKFLOW, text, pins, module.ALL_SCOPE) == ["stale pin"]
+
+
+def test_the_pr_scope_still_fails_a_defect_the_branch_owns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Narrowing the scope must not disarm the rules that are about the diff."""
+    module = _load()
+    monkeypatch.setattr(module, "_check_freshness", lambda *_a: [])
+
+    text = _workflow_text(_SHA_NEW, _SHA_OLD)
+    pins = module._pins_in(text)
+
+    failures = module._rules_for_scope(_WORKFLOW, text, pins, module.PR_SCOPE)
+    assert len(failures) == 1
+    assert "different Action pins" in failures[0]
+
+
+def test_the_default_scope_keeps_every_rule() -> None:
+    """`make lint` and the cron both want the whole picture; only CI narrows it."""
+    module = _load()
+    assert module._parse_args([]).scope == module.ALL_SCOPE
+    assert module._parse_args(["--scope", "pr"]).scope == module.PR_SCOPE
+    assert module._parse_args(["--scope", "all"]).scope == module.ALL_SCOPE
+
+
+def test_a_green_pr_scope_run_says_where_staleness_is_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A narrowed gate that does not say what it dropped invites the old bug back."""
+    module = _load()
+    monkeypatch.setattr(module, "_check_freshness", lambda *_a: [])
+    monkeypatch.setattr(module, "_check_staleness", lambda *_a: ["stale pin"])
+
+    assert module.main(["--scope", "pr"]) == 0
+    out = capsys.readouterr().out
+    assert module.STALENESS_WORKFLOW in out
+    assert (REPO_ROOT / module.STALENESS_WORKFLOW).is_file()

--- a/tests/review_record/test_w18_action_pin_gate.py
+++ b/tests/review_record/test_w18_action_pin_gate.py
@@ -98,11 +98,57 @@ def test_the_staleness_workflow_does_not_shallow_fetch_the_default_branch() -> N
         assert "--shallow-since" not in line, f"shallow fetch defeats the staleness guard: {line}"
 
 
-def test_ci_yml_fails_on_stale_pin_instead_of_warning_only() -> None:
+def test_ci_yml_fails_on_pin_defects_instead_of_warning_only() -> None:
+    """The PR gate must break the build, not emit a ``::warning`` nobody reads.
+
+    Renamed from ``..._on_stale_pin_...``: ci.yml no longer runs the staleness
+    rule at all (#669), so a name promising that was a lie about coverage. The
+    property being guarded is unchanged and still real — the rules ci.yml *does*
+    run are hard failures. Staleness gets the same treatment one test down, in
+    the job that now owns it.
+    """
     ci_yml = read_text(".github/workflows/ci.yml")
     assert 'echo "::warning title=mergecraft action pin drift::' not in ci_yml
     assert "make action-pin-check" in ci_yml
     assert "exit 1" in ci_yml or "exit $?" in ci_yml
+
+
+def test_the_staleness_workflow_reports_a_stale_pin_instead_of_warning_only() -> None:
+    """Moving the rule must not downgrade it to a log line in a job nobody opens."""
+    text = read_text(f".github/workflows/{_STALENESS_WORKFLOW}")
+    assert "::warning" not in text, "a scheduled job's warning annotation reaches nobody"
+
+    steps = job(load_workflow(_STALENESS_WORKFLOW), "staleness")["steps"]
+    filing = [step for step in steps if "gh issue create" in str(step.get("run", ""))]
+    assert filing, "a stale pin produces no durable report"
+    assert "stale == 'true'" in str(filing[0].get("if", "")), (
+        "the reporting step must be gated on the measurement, not run unconditionally"
+    )
+
+
+def test_the_staleness_job_only_ever_speaks_for_main() -> None:
+    """``workflow_dispatch`` accepts any branch; this job must not believe one.
+
+    It reads the pin from the tree it checks out. Dispatched from a pin-bump
+    branch, that pin is *ahead* of main, ``_check_staleness`` returns clean for
+    the "bumped here, not yet promoted" case, and the close step would resolve
+    the tracking issue while main is still stale — silently retiring a live
+    alert.
+    """
+    staleness = job(load_workflow(_STALENESS_WORKFLOW), "staleness")
+    assert staleness.get("if") == "github.ref == 'refs/heads/main'"
+
+
+def test_staleness_is_measured_when_debt_lands_not_only_once_a_day() -> None:
+    """Cron alone leaves the queue un-flagged for up to a day after a merge.
+
+    GitHub's scheduler is best-effort — routinely late, skipped entirely under
+    load — so a push trigger on main is what makes this timely; the cron is the
+    backstop for a pin that goes stale because main moved under it.
+    """
+    triggers = workflow_on(load_workflow(_STALENESS_WORKFLOW))
+    assert "push" in triggers, "debt is not reported until the next cron"
+    assert triggers["push"]["branches"] == ["main"]
 
 
 def test_mergecraft_workflow_three_rungs_share_one_pin_value() -> None:

--- a/tests/review_record/test_w18_action_pin_gate.py
+++ b/tests/review_record/test_w18_action_pin_gate.py
@@ -8,16 +8,29 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
-from tests.ci.workflow_support import REPO_ROOT, read_text
+from tests.ci.workflow_support import REPO_ROOT, job, load_workflow, read_text, workflow_on
 from tests.pins.test_action_pin_freshness import _load, _workflow_text
 
 _SHA_A = "0592d72828797005fdc5af1da9e413b0a98bd8a0"
 _SHA_B = "cfa36704cf6c58a6abe895e539a377c4599fa4bd"
 _WORKFLOW = ".github/workflows/mergecraft.yml"
+_STALENESS_WORKFLOW = "action-pin-staleness.yml"
 
 
 def _makefile_text() -> str:
     return (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+
+def _recipe(target: str) -> str:
+    """Return the tab-indented recipe body for one Makefile target."""
+    lines = _makefile_text().splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"{target}:"))
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if not line.startswith("\t"):
+            break
+        body.append(line)
+    return "\n".join(body)
 
 
 def test_make_ci_static_invokes_action_pin_check() -> None:
@@ -26,6 +39,63 @@ def test_make_ci_static_invokes_action_pin_check() -> None:
     assert "action-pin-check" in ci_static_line
     ci_steps = next(line for line in makefile.splitlines() if line.startswith("CI_STEPS :="))
     assert "action-pin-check" in ci_steps
+
+
+def test_the_required_gate_carries_no_rule_a_pull_request_cannot_satisfy() -> None:
+    """#669: staleness on the PR gate froze the whole queue behind main's debt.
+
+    ``action-pin-staleness-check`` must stay out of the tiers wired to the
+    required ``Verify (static + build)`` check, or one stale pin on main fails
+    every open PR again — including the manifest PR that would fix it.
+    """
+    makefile = _makefile_text()
+    ci_static_line = next(line for line in makefile.splitlines() if line.startswith("ci-static:"))
+    ci_steps = next(line for line in makefile.splitlines() if line.startswith("CI_STEPS :="))
+    assert "action-pin-staleness-check" not in ci_static_line
+    assert "action-pin-staleness-check" not in ci_steps
+
+
+def test_the_two_targets_select_the_scopes_they_claim() -> None:
+    assert "--scope pr" in _recipe("action-pin-check")
+    assert "--scope all" in _recipe("action-pin-staleness-check")
+
+
+def test_staleness_runs_on_a_schedule_never_on_a_pull_request() -> None:
+    triggers = workflow_on(load_workflow(_STALENESS_WORKFLOW))
+    assert "schedule" in triggers, "staleness has no owner if nothing schedules it"
+    assert "workflow_dispatch" in triggers, "an operator must be able to re-check on demand"
+    assert "pull_request" not in triggers
+    assert "pull_request_target" not in triggers
+
+
+def test_the_staleness_workflow_runs_the_full_scope_and_can_file_an_issue() -> None:
+    """Moving a rule off the PR gate only works if something still reports it."""
+    text = read_text(f".github/workflows/{_STALENESS_WORKFLOW}")
+    assert "make action-pin-staleness-check" in text
+
+    staleness = job(load_workflow(_STALENESS_WORKFLOW), "staleness")
+    permissions = staleness["permissions"]
+    assert permissions["issues"] == "write", "cannot report a stale pin without issues: write"
+    assert permissions["contents"] == "read", "the reporter never needs write access to the tree"
+
+
+def test_the_staleness_workflow_does_not_shallow_fetch_the_default_branch() -> None:
+    """A depth-limited fetch silently defangs the staleness guard.
+
+    ``--depth=1`` marks ``origin/main`` as a shallow boundary, so
+    ``_check_staleness``'s ``rev-list --count <pin>..origin/main`` stops at the
+    graft and under-reports the product lag — measured on this repo, 5 commits
+    read as 1. This job is now the only place that rule runs, so a silent
+    under-count is the one failure that makes it useless while still reporting
+    OK.
+    """
+    staleness = job(load_workflow(_STALENESS_WORKFLOW), "staleness")
+    runs = "\n".join(str(step.get("run", "")) for step in staleness["steps"])
+    fetches = [line.strip() for line in runs.splitlines() if line.strip().startswith("git fetch")]
+    assert fetches, f"staleness job no longer fetches the default branch:\n{runs}"
+    for line in fetches:
+        assert "--depth" not in line, f"depth-limited fetch defeats the staleness guard: {line}"
+        assert "--shallow-since" not in line, f"shallow fetch defeats the staleness guard: {line}"
 
 
 def test_ci_yml_fails_on_stale_pin_instead_of_warning_only() -> None:


### PR DESCRIPTION
## What?

Split `scripts/check_action_pin_freshness.py` by `--scope`:

| Scope | Rules | Where it runs |
| --- | --- | --- |
| `pr` | rung self-consistency, drift from `env.MERGECRAFT_ACTION_SHA`, freshness against the default branch's pin | `make action-pin-check` → `make ci-static` → the required `Verify (static + build)` check |
| `all` (default) | all of the above **plus** staleness | `make action-pin-staleness-check` → new `action-pin-staleness.yml`, daily against `main` |

The new workflow files a single tracking issue when the pin goes stale, edits it in place on later runs, and closes it once the pin is bumped.

## Why?

Staleness compares `main`'s pin against `main`'s own tip. Nothing in that computation reads the pull request under review, so as a required check it converted one commit of debt on `main` into a repo-wide merge freeze — every open PR went red at once, for a defect none of them introduced and none could fix.

#669 is the deadlock in its sharpest form: the only change that clears the lag is repointing the pin at a manifest commit that does not exist until the manifest PR merges, and that PR was blocked by the same red check. `main` itself has been failing `CI/CD` for the same reason since #668. The two greens left in the queue (#665, #606) are stale results from before the debt landed — re-running either would have failed.

Enforcing a default-branch invariant per-PR is the category error. The rule is sound; its subject was wrong. It now reports against `main`, where the debt actually lives.

**Nothing is relaxed.** `MAX_DRIFT` and `MAX_PRODUCT_LAG` keep their values, every rule still runs, and the nine required contexts in the `require-ci-on-main` ruleset are unchanged.

## Test plan

- [x] `make ci-static` passes, including `action-pin-check OK (scope=pr)` — the exact gate that was red.
- [x] `make action-pin-staleness-check` still fails on the current stale pin, so the rule was moved, not weakened.
- [x] 1047 passed / 5 skipped across `tests/ci`, `tests/security`, `tests/pins`, `tests/review_record`; skips are pre-existing environment gates.
- [x] New tests assert the split is deliberate: staleness is absent from `ci-static` and `CI_STEPS`, each target selects the scope it claims, the scheduled workflow never triggers on a pull request, and it holds `issues: write` with a full-depth fetch.
- [x] `actionlint` clean; `zizmor` clean at the gating `--min-severity high`.
- [x] Executed the issue-body shell block against a simulated failure log — renders valid Markdown with the real error embedded.
- [x] Verified the `gh issue list --jq 'map(select(.title == env.ISSUE_TITLE))'` idempotency lookup against the live API with a positive control.
- [ ] After merge: confirm the daily run files the tracking issue, then re-run #669's checks.

### Follow-up

This does not by itself unblock #669 — that PR's checks ran against the old `ci-static` and need a re-run once this is on `main`. The pin PR then follows the documented S → D → C → P flow (#641).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
