### PR TITLE
docs: match the staleness triggers to the workflow

### DIFF
--- a/.github/workflows/action-pin-staleness.yml
+++ b/.github/workflows/action-pin-staleness.yml
@@ -10,14 +10,19 @@
 # by that same red check. #669 deadlocked exactly this way, and the two greens
 # left in the queue were stale results from before the debt landed.
 #
-# So the rule moved here. It runs against main on a schedule and files a single
-# tracking issue that it keeps current and closes itself once the pin is bumped.
-# The PR gate keeps the rules a PR author can actually act on: rung
-# self-consistency, env parity, and freshness (`make action-pin-check`).
+# So the rule moved here. It measures on every push to main — debt is reported
+# when it lands, and the tracking issue closes when a pin bump lands — with a
+# daily cron as the backstop for a pin that goes stale because main moved under
+# it. One tracking issue, kept current rather than re-filed. The PR gate keeps
+# the rules a PR author can actually act on: rung self-consistency, env parity,
+# and freshness (`make action-pin-check`).
 #
-# Safety: this workflow never checks out or executes PR code — it runs on
-# `main` from `schedule` / `workflow_dispatch` only, and its sole write scope
-# is `issues`.
+# Safety: this workflow never checks out or executes PR code. It is reachable
+# from `push` (main only), `schedule`, and `workflow_dispatch`; the last of
+# those accepts any branch, so the job carries an explicit
+# `if: github.ref == 'refs/heads/main'` guard — see the comment on the job for
+# why a dispatch from another branch would otherwise close a live alert. Its
+# sole write scope is `issues`.
 name: Action pin staleness
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request. `action-pin-check`'s staleness rule compared `main`'s pin against
   `main`'s own tip, so it read nothing from the PR under review — one commit of
   debt on `main` froze the whole queue, including the manifest PR that was the
-  only way to clear it (#669). The rule moved to a daily
-  `action-pin-staleness.yml` run against `main` that files one tracking issue,
-  keeps it current, and closes it once the pin is bumped. The required PR check
+  only way to clear it (#669). The rule moved to `action-pin-staleness.yml`,
+  which runs on every push to `main` (with a daily cron backstop) and files one
+  tracking issue, keeps it current, and closes it once the pin is bumped. The required PR check
   keeps every rule a branch can act on: rung self-consistency, drift from
   `env.MERGECRAFT_ACTION_SHA`, and freshness against the default branch's pin.
   `make action-pin-staleness-check` runs the full set locally.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -267,16 +267,22 @@ edit, and two targets guard it (#532):
 | Target | Rules | Where it runs |
 | --- | --- | --- |
 | `make action-pin-check` | rungs disagree, a rung drifts from `env.MERGECRAFT_ACTION_SHA`, the pin diverges from the default branch's | `make ci-static` — a required PR check |
-| `make action-pin-staleness-check` | all of the above, plus the pin lagging the default branch's own tip by more than `MERGECRAFT_MAX_ACTION_PIN_PRODUCT_LAG` commits under `src/mergecraft/` | `.github/workflows/action-pin-staleness.yml`, daily against `main` |
+| `make action-pin-staleness-check` | all of the above, plus the pin lagging the default branch's own tip by more than `MERGECRAFT_MAX_ACTION_PIN_PRODUCT_LAG` commits under `src/mergecraft/` | `.github/workflows/action-pin-staleness.yml`, on every push to `main`, with a daily cron backstop |
 
 The split is deliberate. Staleness compares `main`'s pin against `main`'s tip,
 so nothing in it reads the pull request under review. While it gated PRs, one
 stale pin on `main` failed every open PR at once — and the only change that
 could clear it (repointing the pin at a manifest commit that does not exist
-until the manifest PR merges) was blocked by that same red check (#669). The
-scheduled job files a single tracking issue instead, keeps it current, and
-closes it once the pin is bumped. `make action-pin-check` still runs every rule
-a branch can actually act on.
+until the manifest PR merges) was blocked by that same red check (#669).
+
+`action-pin-staleness.yml` files a single tracking issue instead, keeps it
+current, and closes it once the pin is bumped. It measures on every push to
+`main`, so debt is reported when it lands rather than up to a day later. The
+daily cron is the backstop for a pin that goes stale because `main` moved under
+it — GitHub's scheduler is best-effort, routinely late and skipped under load,
+so it is the safety net rather than the primary trigger.
+
+`make action-pin-check` still runs every rule a branch can actually act on.
 
 Locally, plain `make action-pin-check` is the PR-scoped set; run
 `make action-pin-staleness-check` for the full picture.


### PR DESCRIPTION
## What?

Three wording fixes, no behaviour change:

- `docs/workflows.md` — the table's "where it runs" cell now reads "on every push to `main`, with a daily cron backstop" instead of "daily against `main`", and the surrounding paragraph explains which trigger is primary and why.
- `CHANGELOG.md` — same correction to the `## [Unreleased]` entry.
- `.github/workflows/action-pin-staleness.yml` — the file's own header comments claimed it "runs against main on a schedule" and was reachable "from `schedule` / `workflow_dispatch` only". Both stopped being true when `push` was added. The safety paragraph now also names the `if: github.ref == 'refs/heads/main'` guard, since that guard — not the trigger list — is what makes the main-only claim true.

Only comments change in the YAML; every key is untouched.

## Why?

Review of #670 added `push: branches: [main]` as the primary trigger so debt is reported when it lands rather than up to a day later, with the cron demoted to a backstop. The docs, changelog and the workflow's own header were all written against the cron-only version and were left saying "daily".

This is the follow-up to the two non-blocking nits on #670. It is deliberately **not** folded into #669: `verify_manifest` in `scripts/check_action_image_digest.py` rejects a manifest commit that touches anything but `action.yml` relative to its image source, so adding docs there would fail `Verify changed deployment candidates` outright — and the push would dismiss the standing approval.

## Test plan

- [x] `make docs` is a no-op beyond the edited files — the `llms-full.txt` bundle regenerated identically.
- [x] `make docs-check` passes: reference docs, README index, llms-full bundle and support matrix all match sources.
- [x] `actionlint` clean; `zizmor` clean at the gating `--min-severity high`.
- [x] 33 tests pass across `test_w18_action_pin_gate.py` and `test_action_pin_freshness.py`, including the trigger and ref-guard assertions — so the header now agrees with what the tests pin down.
- [x] No executable change: the YAML diff is comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
