### PR TITLE
chore(action): pin self-review to verified manifest 492684ed

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -162,7 +162,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec"
+  MERGECRAFT_ACTION_SHA: "492684edcadd06aa99c3d15a12d162a15828ee38"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -610,7 +610,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -763,7 +763,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -892,7 +892,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@78bfbeb247b1ddb4cbf851e2821c08c1a6c595ec # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Consumer pin **P** for the `S → D → C → P` cycle (#641). Moves all four references in `.github/workflows/mergecraft.yml` — `env.MERGECRAFT_ACTION_SHA` plus the three review rungs — from `78bfbeb247b1` to manifest commit `492684ed`.

## Why this SHA, and not the #669 merge commit

#669's review said to pin the commit #669 *landed as*, warning against `492684ed`. That guidance assumed a squash merge, which would have orphaned the branch commit. **#669 landed as a merge**, so `492684ed` is itself an ancestor of `main` — and it is the only candidate that satisfies the manifest invariant.

`verify_manifest` requires the manifest commit to differ from the image's source tree in `action.yml` alone:

| Candidate | `git diff --name-only 5a30b000 <c>` | Verdict |
| --- | --- | --- |
| `dac17243` (#669 merge commit) | **10 files** — `Makefile`, `ci.yml`, `action-pin-staleness.yml`, `check_action_pin_freshness.py`, tests, docs, `CHANGELOG.md`, `action.yml` | rejected |
| `492684ed` (manifest commit) | `action.yml` | **verified** |

`dac17243` fails because #670 and #678 merged between the image being built from `5a30b000` and #669 landing. Pinning it is not a style preference — `make action-pin-prepare` refuses it.

`492684ed` still carries current product code: the only `src/mergecraft/` commit between it and `main` is the #668 merge itself, so measured product lag is effectively zero.

## Test plan

- [x] `MANIFEST_COMMIT=492684ed… RELEASE_BASE_BRANCH=main make action-pin-prepare` → `pin-change-prepared`, passing strict provenance verification (digest `sha256:61662cda…`, source `5a30b000`, cosign signature).
- [x] `make action-candidate-check` with CI's `CANDIDATE_BASE`/`CANDIDATE_HEAD` → `"verified": true`, `deployment-candidates-verified`.
- [x] `make action-pin-check` (PR scope) OK.
- [x] **`--scope all` OK** — staleness passes for the first time since the pin fell 23 product commits behind.
- [x] `make ci-static` OK.
- [ ] After merge: [#677](https://github.com/alexhawat/mergeCraft/issues/677) closes itself on the push-triggered staleness run, and the next Action run boots at this pin.

Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
