### PR TITLE
docs: align READMEs with init workflow and CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,10 @@ Use this when asked to add AI PR review to another repository.
    that step to the human when interactive auth is required.
 5. **Commit only** `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`
    on a new branch. Do not commit secrets.
-6. **Trigger a review** — open a pull request, comment `@mergecraft review`, or
-   run the workflow via `workflow_dispatch`. Local/offline review uses
+6. **Trigger a review** — open a pull request or run the workflow via
+   `workflow_dispatch`. The default `mergecraft init` workflow does **not**
+   listen for `@mergecraft review` comments (comment triggers are opt-in; see
+   [`docs/workflows.md`](docs/workflows.md)). Local/offline review uses
    **`mergecraft review`** (not `diff-review`, which is a deprecated alias that
    emits one stderr warning per invocation).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Landing README Example 1 matches the `mergecraft init` / `examples/workflows/`
+  scaffold (PR types, `status_checks`, `checks: write`); default trigger copy no
+  longer teaches `@mergecraft review` comments, which the scaffold omits
+- `evals/README.md` Harbor install pin is `v0.1.0a1`, and live detection is
+  documented as `mergecraft review` (Harbor still calls the hidden
+  `diff-review` alias)
+- AGENTS.md and the consumer skill match the default workflow triggers
+
 - The self-review Action pin on all three review rungs moves to `93a7897c`,
   pin 5 — GitHub Action Logfire honors `MERGECRAFT_TRACING_REGION` (#607)
 - Self-review Codex fallback uses `openai/gpt-terra` (GPT 5.6 Terra) instead of

--- a/README.md
+++ b/README.md
@@ -434,7 +434,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: alexhawat/mergeCraft@v0.1.0a1
         with:
-          prompt: Review this pull request.
+          # Event-aware: a pull_request run reviews the PR, a manual dispatch
+          # uses the prompt the operator typed. Hardcoding the text here would
+          # silently ignore the required `prompt` input declared above.
+          prompt: >
+            ${{ github.event_name == 'pull_request'
+                && 'Review this pull request.'
+                || github.event.inputs.prompt }}
           model: anthropic/claude-sonnet
           status_checks: enabled
         env:

--- a/README.md
+++ b/README.md
@@ -438,6 +438,9 @@ jobs:
           model: anthropic/claude-sonnet
           status_checks: enabled
         env:
+          # Keep equal to the `uses:` ref above — the container cannot read it,
+          # so this is the only way the run records which pin it is running.
+          MERGECRAFT_ACTION_SHA: v0.1.0a1
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,18 +72,20 @@ Do all of this yourself, without asking me, except where step 4 says STOP:
    read docs/authentication.md and set up the custom-provider env pair instead.
    Each command stores a GitHub Actions secret for me via `gh secret set`.
 
-5. After I confirm the credential is stored, set `models:` in
-   .mergecraft/config.yaml to a fallback chain whose first entry matches the
-   provider I authenticated. Then run `mergecraft doctor` and fix anything it
-   reports that is not the credential itself.
+5. After I confirm the credential is stored, run `mergecraft doctor` and fix
+   anything it reports that is not the credential itself. The first
+   `provider auth` after `init` seeds `agents.reviewer` and `models:` — only
+   edit `models:` if you want a fallback chain.
 
-6. Commit ONLY .mergecraft/config.yaml, .mergecraft/learnings.md, and
-   .github/workflows/mergecraft.yml on a new branch. Never commit secrets.
+6. Commit ONLY .mergecraft/config.yaml, .mergecraft/learnings.md,
+   .github/workflows/mergecraft.yml, and any `.gitignore` lines `init` added.
+   Never commit secrets.
    Open a pull request titled "ci: add mergeCraft AI PR review".
 
 7. That PR is the first review target. Tell me to watch the `mergecraft-approval`
-   check on it, and that I can re-run a review any time by commenting
-   `@mergecraft review`.
+   check on it. Re-run by pushing a commit (`synchronize`) or using
+   `workflow_dispatch`. The default `mergecraft init` workflow does not listen
+   for `@mergecraft review` comments.
 
 Finally, print a short summary: provider chosen, files added, PR link, and the
 exact command I still need to run (if any).
@@ -240,8 +242,8 @@ Constraints:
     Never fabricate, log, or commit a credential.
   - `mergecraft review --agent` streams versioned JSONL on stdout — use that,
     not screen-scraping, if you want to consume review results.
-  - Exit codes are contractual: 0 pass, 10 findings, 11 blocking, 20
-    inconclusive, 30 config error, 40 provider/infra, 50 timeout.
+  - Exit codes are contractual: 0 pass, 10 findings, 11 blocking, 12 failed,
+    20 inconclusive, 30 config error, 40 provider/infra, 50 timeout, 2 usage.
     See docs/EXIT-CODES.md.
 
 Produce a plan, execute it, then open a PR and report the escalation you need.
@@ -386,8 +388,10 @@ The credential is stored as a GitHub Actions secret via `gh secret set`. Add
 More providers, custom gateways and model chains:
 [`docs/authentication.md`](docs/authentication.md).
 
-3. **Trigger a review** — open a pull request, comment `@mergecraft review`, or
-   run the workflow via `workflow_dispatch`.
+3. **Trigger a review** — open a pull request, or run the workflow via
+   `workflow_dispatch`. The default scaffold does not listen for
+   `@mergecraft review` comments (comment triggers are an opt-in pattern in
+   [`docs/workflows.md`](docs/workflows.md)).
 
 ```bash
 mergecraft doctor   # optional: verify git, providers, analyzers, auth, config, MCP
@@ -396,24 +400,36 @@ mergecraft doctor   # optional: verify git, providers, analyzers, auth, config, 
 ### Example 1 — auto-review every PR
 
 ```yaml
-# .github/workflows/mergecraft.yml
+# .github/workflows/mergecraft.yml  — matches `mergecraft init` / examples/workflows/
 name: mergeCraft
 on:
   pull_request:
+    types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
+  checks: write
+  actions: read
   id-token: write
 
 jobs:
-  review:
+  mergecraft:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: alexhawat/mergeCraft@v0.1.0a1
+        with:
+          prompt: Review this pull request.
+          model: anthropic/claude-sonnet
+          status_checks: enabled
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -13,7 +13,7 @@ The one binary still missing is the demo capture for the landing README **Visual
 
 | File | Purpose |
 |------|---------|
-| `assets/demo.mp4` | Preferred ~30s screen capture: open PR → `@mergecraft review` → inline findings → approval check |
+| `assets/demo.mp4` | Preferred ~30s screen capture: open PR → review runs → inline findings → approval check |
 | `assets/demo.gif` | GIF fallback when MP4 is unavailable — same capture, shorter loop |
 
 Do not invent a placeholder GIF or MP4 in CI — ship the real capture under `assets/`

--- a/evals/README.md
+++ b/evals/README.md
@@ -115,7 +115,7 @@ different questions and are never conflated:
 |---|---|---|
 | Question | *Did the gate make the right decision?* | *Did the review find the right lines?* |
 | Ground truth | `recorded_findings` + `expected_decision`, no patch | a patch + `baseline.json` (`{"closed_world": bool, "issues": [...]}`) |
-| Cost | free, keyless — `replay_case()` recomputes the verdict | needs a live provider — runs `diff-review` for real |
+| Cost | free, keyless — `replay_case()` recomputes the verdict | needs a live provider — runs `mergecraft review` for real |
 | Consumer | `mergecraft eval replay-bank`, the `gate_matrix` fields | `mergecraft eval bench`, the `detection` section |
 
 A bank case cannot answer a detection question (no patch to review) and a
@@ -131,9 +131,10 @@ make bench-detect
 ```
 
 Joins the keyless structural replay above with a live run against
-`evals/bench/mergecraft/`: each case's patch is reviewed via `diff-review`,
-scored against its `baseline.json` with `score_findings()`, and folded into
-the `detection` section of the published result set (`evals/live_run.py`).
+`evals/bench/mergecraft/`: each case's patch is reviewed via the same offline
+engine as `mergecraft review`, scored against its `baseline.json` with
+`score_findings()`, and folded into the `detection` section of the published
+result set (`evals/live_run.py`).
 The structural section always populates; `detection` is `None` with a typed
 `skipped_reason` — `"no live credential"` or `"no patch-bearing cases"` — when
 it cannot run, never a fabricated zero. B4 seeded the detection corpus (43
@@ -160,7 +161,7 @@ tripll ReviewBench corpus described earlier in this document; caveat it
 separately when publishing (B7).
 
 Provider set defaults to **Claude + OpenAI**; estimate ~10–30 tokens per case for
-a minimal live probe. Full diff-review runs are operator-triggered, not PR CI.
+a minimal live probe. Full live `mergecraft review` runs are operator-triggered, not PR CI.
 
 ## Harbor agent
 
@@ -173,11 +174,13 @@ harbor run -d "<dataset>" --agent mergecraft.harbor.agent:MergecraftReviewAgent
 ```
 
 The agent installs mergecraft with `uv tool install git+https://github.com/alexhawat/mergeCraft@<ref>`
-(default ref `v0.1.0`; override with `MERGECRAFT_INSTALL_REF`) and runs
-`mergecraft diff-review --json` inside each task environment.
+(default ref `v0.1.0a1`, the same pin as README Example 1; override with
+`MERGECRAFT_INSTALL_REF`) and runs `mergecraft diff-review --json` inside each
+task environment — that is the hidden deprecated alias of `mergecraft review`
+(one stderr warning per invocation).
 
-Structured JSON output requires Batch A (`--json` on `diff-review`) — see
-[mergeCraft#30](https://github.com/alexhawat/mergeCraft/issues/30).
+Structured JSON output is `--json` on `mergecraft review` (the Harbor agent still
+calls the hidden alias).
 
 ## See also
 

--- a/examples/cli/01-review-local-diff/README.md
+++ b/examples/cli/01-review-local-diff/README.md
@@ -6,7 +6,7 @@ the uncommitted edit that `run.sh` applies before invoking mergeCraft.
 
 ## Live command
 
-From this directory (after `mergecraft auth …`):
+From this directory (after `mergecraft provider auth …`):
 
 ```bash
 mergecraft review

--- a/examples/workflows/mergecraft-hardened.yml
+++ b/examples/workflows/mergecraft-hardened.yml
@@ -367,6 +367,11 @@ jobs:
           # upload is logged rather than failing the review.
           # sarif_upload: enabled
         env:
+          # The pin this job runs (#641). The container cannot read the
+          # `uses:` line above, so it learns the pin only from here — omit it and
+          # the run records an empty Action pin and cannot report a pin/image
+          # mismatch. Keep it equal to the `uses:` ref.
+          MERGECRAFT_ACTION_SHA: REPLACE_WITH_FULL_COMMIT_SHA
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # Add a second provider's credentials here to extend the chain —

--- a/examples/workflows/mergecraft.yml
+++ b/examples/workflows/mergecraft.yml
@@ -59,6 +59,11 @@ jobs:
           status_checks: enabled
           # token: ${{ steps.token.outputs.token }}
         env:
+          # The pin this job runs (#641). The container cannot read the
+          # `uses:` line above, so it learns the pin only from here — omit it and
+          # the run records an empty Action pin and cannot report a pin/image
+          # mismatch. Keep it equal to the `uses:` ref.
+          MERGECRAFT_ACTION_SHA: v0.1.0a1
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -442,6 +442,9 @@ jobs:
           model: anthropic/claude-sonnet
           status_checks: enabled
         env:
+          # Keep equal to the `uses:` ref above — the container cannot read it,
+          # so this is the only way the run records which pin it is running.
+          MERGECRAFT_ACTION_SHA: v0.1.0a1
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -76,18 +76,20 @@ Do all of this yourself, without asking me, except where step 4 says STOP:
    read docs/authentication.md and set up the custom-provider env pair instead.
    Each command stores a GitHub Actions secret for me via `gh secret set`.
 
-5. After I confirm the credential is stored, set `models:` in
-   .mergecraft/config.yaml to a fallback chain whose first entry matches the
-   provider I authenticated. Then run `mergecraft doctor` and fix anything it
-   reports that is not the credential itself.
+5. After I confirm the credential is stored, run `mergecraft doctor` and fix
+   anything it reports that is not the credential itself. The first
+   `provider auth` after `init` seeds `agents.reviewer` and `models:` — only
+   edit `models:` if you want a fallback chain.
 
-6. Commit ONLY .mergecraft/config.yaml, .mergecraft/learnings.md, and
-   .github/workflows/mergecraft.yml on a new branch. Never commit secrets.
+6. Commit ONLY .mergecraft/config.yaml, .mergecraft/learnings.md,
+   .github/workflows/mergecraft.yml, and any `.gitignore` lines `init` added.
+   Never commit secrets.
    Open a pull request titled "ci: add mergeCraft AI PR review".
 
 7. That PR is the first review target. Tell me to watch the `mergecraft-approval`
-   check on it, and that I can re-run a review any time by commenting
-   `@mergecraft review`.
+   check on it. Re-run by pushing a commit (`synchronize`) or using
+   `workflow_dispatch`. The default `mergecraft init` workflow does not listen
+   for `@mergecraft review` comments.
 
 Finally, print a short summary: provider chosen, files added, PR link, and the
 exact command I still need to run (if any).
@@ -244,8 +246,8 @@ Constraints:
     Never fabricate, log, or commit a credential.
   - `mergecraft review --agent` streams versioned JSONL on stdout — use that,
     not screen-scraping, if you want to consume review results.
-  - Exit codes are contractual: 0 pass, 10 findings, 11 blocking, 20
-    inconclusive, 30 config error, 40 provider/infra, 50 timeout.
+  - Exit codes are contractual: 0 pass, 10 findings, 11 blocking, 12 failed,
+    20 inconclusive, 30 config error, 40 provider/infra, 50 timeout, 2 usage.
     See docs/EXIT-CODES.md.
 
 Produce a plan, execute it, then open a PR and report the escalation you need.
@@ -390,8 +392,10 @@ The credential is stored as a GitHub Actions secret via `gh secret set`. Add
 More providers, custom gateways and model chains:
 [`docs/authentication.md`](docs/authentication.md).
 
-3. **Trigger a review** — open a pull request, comment `@mergecraft review`, or
-   run the workflow via `workflow_dispatch`.
+3. **Trigger a review** — open a pull request, or run the workflow via
+   `workflow_dispatch`. The default scaffold does not listen for
+   `@mergecraft review` comments (comment triggers are an opt-in pattern in
+   [`docs/workflows.md`](docs/workflows.md)).
 
 ```bash
 mergecraft doctor   # optional: verify git, providers, analyzers, auth, config, MCP
@@ -400,24 +404,36 @@ mergecraft doctor   # optional: verify git, providers, analyzers, auth, config, 
 ### Example 1 — auto-review every PR
 
 ```yaml
-# .github/workflows/mergecraft.yml
+# .github/workflows/mergecraft.yml  — matches `mergecraft init` / examples/workflows/
 name: mergeCraft
 on:
   pull_request:
+    types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
+    inputs:
+      prompt:
+        description: Prompt for the agent
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
+  checks: write
+  actions: read
   id-token: write
 
 jobs:
-  review:
+  mergecraft:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: alexhawat/mergeCraft@v0.1.0a1
+        with:
+          prompt: Review this pull request.
+          model: anthropic/claude-sonnet
+          status_checks: enabled
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -547,8 +563,10 @@ Use this when asked to add AI PR review to another repository.
    that step to the human when interactive auth is required.
 5. **Commit only** `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`
    on a new branch. Do not commit secrets.
-6. **Trigger a review** — open a pull request, comment `@mergecraft review`, or
-   run the workflow via `workflow_dispatch`. Local/offline review uses
+6. **Trigger a review** — open a pull request or run the workflow via
+   `workflow_dispatch`. The default `mergecraft init` workflow does **not**
+   listen for `@mergecraft review` comments (comment triggers are opt-in; see
+   [`docs/workflows.md`](docs/workflows.md)). Local/offline review uses
    **`mergecraft review`** (not `diff-review`, which is a deprecated alias that
    emits one stderr warning per invocation).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -438,7 +438,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: alexhawat/mergeCraft@v0.1.0a1
         with:
-          prompt: Review this pull request.
+          # Event-aware: a pull_request run reviews the PR, a manual dispatch
+          # uses the prompt the operator typed. Hardcoding the text here would
+          # silently ignore the required `prompt` input declared above.
+          prompt: >
+            ${{ github.event_name == 'pull_request'
+                && 'Review this pull request.'
+                || github.event.inputs.prompt }}
           model: anthropic/claude-sonnet
           status_checks: enabled
         env:

--- a/scripts/example_workflows/hardened.yml.tpl
+++ b/scripts/example_workflows/hardened.yml.tpl
@@ -367,6 +367,11 @@ jobs:
           # upload is logged rather than failing the review.
           # sarif_upload: enabled
         env:
+          # The pin this job runs (#641). The container cannot read the
+          # `uses:` line above, so it learns the pin only from here — omit it and
+          # the run records an empty Action pin and cannot report a pin/image
+          # mismatch. Keep it equal to the `uses:` ref.
+          MERGECRAFT_ACTION_SHA: __ACTION_PIN__
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # Add a second provider's credentials here to extend the chain —

--- a/scripts/example_workflows/minimal.yml.tpl
+++ b/scripts/example_workflows/minimal.yml.tpl
@@ -59,6 +59,11 @@ jobs:
           status_checks: enabled
           # token: ${{ steps.token.outputs.token }}
         env:
+          # The pin this job runs (#641). The container cannot read the
+          # `uses:` line above, so it learns the pin only from here — omit it and
+          # the run records an empty Action pin and cannot report a pin/image
+          # mismatch. Keep it equal to the `uses:` ref.
+          MERGECRAFT_ACTION_SHA: __ACTION_PIN__
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -41,55 +41,55 @@
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/mergecraft/SKILL.md",
-      "computedHash": "d741ddd1578225ffea44efb1e41b74202cda4c1c2f1136f2f6701f4dae9f878d"
+      "computedHash": "b0e5bb842b866495d2c628784eff60fcdb78891093eafb69134cfd49b0f0b2d3"
     },
     "mergecraft-codex": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/codex/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-cursor": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/cursor/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-opencode": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/opencode/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-gemini-cli": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/gemini-cli/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-openclaw": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/openclaw/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-hermes": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/hermes/mergecraft/SKILL.md",
-      "computedHash": "cd20d7b7a08c78b5b3018406d5c837f9b92619cc63d9f9ec8be240bad2dbb407"
+      "computedHash": "ac45533db5d3ea84825f595d78677e387e8b8e40bfec925cbc8a0b6075d4f425"
     },
     "mergecraft-claude-code": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/claude-code/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     },
     "mergecraft-grok-bot": {
       "source": "alexhawat/mergeCraft",
       "sourceType": "local",
       "skillPath": "skills/grok-bot/mergecraft/SKILL.md",
-      "computedHash": "80ebab59ab646405bbca2a706d670b773c5bf5c36257b4315dba2b69e73e1566"
+      "computedHash": "a3b32bce0a179ee9d0f4a3e82aaaf096e868fca31d864242d310c71e06c9a8b3"
     }
   }
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,7 +27,7 @@ over each generated directory.
 Copying to `.claude/skills/` is a common mistake and will not work.
 
 **Hermes** is a [Nous Research](https://nousresearch.com/) agent. mergeCraft already
-ships a Nous provider (`mergecraft auth nous`, `nous/deepseek/deepseek-v4-flash`), so a
+ships a Nous provider (`mergecraft provider auth nous`, `nous/deepseek/deepseek-v4-flash`), so a
 Hermes user can run mergeCraft entirely on Nous credentials when configured. The Hermes
 package declares `required_environment_variables` in frontmatter so Hermes prompts for
 provider credentials securely — never paste secrets into the skill body.

--- a/skills/claude-code/mergecraft/SKILL.md
+++ b/skills/claude-code/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/codex/mergecraft/SKILL.md
+++ b/skills/codex/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/cursor/mergecraft/SKILL.md
+++ b/skills/cursor/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/gemini-cli/mergecraft/SKILL.md
+++ b/skills/gemini-cli/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/grok-bot/mergecraft/SKILL.md
+++ b/skills/grok-bot/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/hermes/mergecraft/SKILL.md
+++ b/skills/hermes/mergecraft/SKILL.md
@@ -56,8 +56,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/mergecraft/SKILL.md
+++ b/skills/mergecraft/SKILL.md
@@ -35,8 +35,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/openclaw/mergecraft/SKILL.md
+++ b/skills/openclaw/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/skills/opencode/mergecraft/SKILL.md
+++ b/skills/opencode/mergecraft/SKILL.md
@@ -38,8 +38,10 @@ a read-only verifier; typed findings drive inline comments and the
    Never handle raw credentials; never commit secrets. GitHub scope checks the exact
    target repository before collecting credentials and stores Actions secrets.
    Local scope writes only the displayed `.env` file and never calls GitHub.
-4. Commit only `.mergecraft/config.yaml` and `.github/workflows/mergecraft.yml`,
-   push, open a PR (or comment `@mergecraft review`).
+4. Commit `.mergecraft/config.yaml`, `.mergecraft/learnings.md`,
+   `.github/workflows/mergecraft.yml`, and any `.gitignore` lines `init` added;
+   push; open a PR or run `workflow_dispatch`. The default workflow does not
+   listen for `@mergecraft review` comments.
 
 ## Standalone installation links
 

--- a/tests/ci/test_checkout_credential_persistence.py
+++ b/tests/ci/test_checkout_credential_persistence.py
@@ -100,3 +100,31 @@ def test_shipped_examples_export_the_pin_they_run(relative: str) -> None:
         f"{relative} exports {exported} but runs {uses}; "
         "the recorded pin would not be the code that ran"
     )
+
+
+def _readme_workflow_examples() -> list[str]:
+    """Fenced yaml blocks in README that configure the action."""
+    import re
+
+    text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    blocks = re.findall(r"```ya?ml\n(.*?)```", text, re.S)
+    return [block for block in blocks if "alexhawat/mergeCraft@" in block]
+
+
+def test_readme_examples_honour_a_dispatch_prompt_they_declare() -> None:
+    """An example that advertises `workflow_dispatch` must actually use it.
+
+    README declared a required `prompt` input and then passed a hardcoded
+    string to the action, so a manually dispatched run silently ignored what
+    the operator typed — unlike the workflow `mergecraft init` generates and
+    unlike both shipped example templates, which resolve it event-aware.
+    """
+    examples = _readme_workflow_examples()
+    assert examples, "no action example found in README"
+    for block in examples:
+        if "workflow_dispatch" not in block or "inputs:" not in block:
+            continue
+        assert "github.event.inputs.prompt" in block or "inputs.prompt" in block, (
+            "README example declares a workflow_dispatch prompt input but never "
+            "passes it to the action; a dispatched run would ignore it"
+        )

--- a/tests/ci/test_checkout_credential_persistence.py
+++ b/tests/ci/test_checkout_credential_persistence.py
@@ -71,3 +71,32 @@ def test_checkout_does_not_persist_credentials(relpath: str) -> None:
             "extraheader collides with mergeCraft's own Authorization header and "
             "GitHub rejects the fetch with 400 Duplicate header"
         )
+
+
+_PIN_EXAMPLES = (
+    "examples/workflows/mergecraft.yml",
+    "examples/workflows/mergecraft-hardened.yml",
+)
+
+
+@pytest.mark.parametrize("relative", _PIN_EXAMPLES)
+def test_shipped_examples_export_the_pin_they_run(relative: str) -> None:
+    """A consumer copying an example must record the pin it runs (#641).
+
+    `resolve_action_pin_sha()` reads `MERGECRAFT_ACTION_SHA` and nothing else,
+    and the container cannot see the workflow's `uses:` line. An example that
+    omits it hands every copier an empty Action pin and no pin/image mismatch
+    detection — the same gap `mergecraft init` had before #679.
+    """
+    import re
+
+    text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+    uses = re.findall(r"uses:\s*alexhawat/mergeCraft@(\S+)", text)
+    exported = re.findall(r"MERGECRAFT_ACTION_SHA:\s*(\S+)", text)
+
+    assert uses, f"{relative} no longer references the action"
+    assert exported, f"{relative} does not export MERGECRAFT_ACTION_SHA"
+    assert set(exported) == set(uses), (
+        f"{relative} exports {exported} but runs {uses}; "
+        "the recorded pin would not be the code that ran"
+    )


### PR DESCRIPTION
## Summary
- Align the landing README Example 1 and install/agent prompts with what `mergecraft init` actually writes: PR event types, `status_checks`, `checks: write`, first-auth roster seeding, and no comment trigger on the default workflow.
- Correct `evals/README.md` so the Harbor install pin is `v0.1.0a1` and live detection is described as `mergecraft review` (Harbor still invokes the hidden `diff-review` alias).
- Keep AGENTS.md and the generated consumer skills in sync so agents are not re-taught `@mergecraft review` as the default re-run path.

## Test plan
- [x] `make docs-check`
- [x] `make agent-packages-check`
- [x] `uv run pytest` on landing README, agent surfaces, docs gate, init pin vs Example 1, and eval live-run skip-reason tests
