### PR TITLE
chore: sync pre-0.0.1 into main

### DIFF
--- a/.github/workflows/mergecraft-approve.yml
+++ b/.github/workflows/mergecraft-approve.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Mint distinct approval App token
         if: env.HAS_APP == 'true'
         id: app_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.MERGECRAFT_APPROVAL_APP_ID }}
           private-key: ${{ secrets.MERGECRAFT_APPROVAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -508,7 +508,7 @@ jobs:
         if: env.HAS_APP == 'true' && env.HAS_NOUS == 'true'
         id: app_token_nous
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.MERGECRAFT_APP_ID }}
           private-key: ${{ secrets.MERGECRAFT_APP_PRIVATE_KEY }}
@@ -694,7 +694,7 @@ jobs:
           )
         id: app_token_codex
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.MERGECRAFT_APP_ID }}
           private-key: ${{ secrets.MERGECRAFT_APP_PRIVATE_KEY }}
@@ -862,7 +862,7 @@ jobs:
           )
         id: app_token_claude
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.MERGECRAFT_APP_ID }}
           private-key: ${{ secrets.MERGECRAFT_APP_PRIVATE_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE_DATE_EPOCH=1700000000
 
 # Build the upstream gh release with its remaining vulnerable Go module patched.
 # The archive, Go toolchain and dependency checksums are immutable inputs.
-FROM --platform=$BUILDPLATFORM golang:1.26.8-bookworm@sha256:9fdc884aacc3bec89b20ffc69f4bb369c78210e3e4f600387b5128b12c199f81 AS gh-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b AS gh-builder
 ARG TARGETARCH
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 ADD --checksum=sha256:e16749bc0d99dc0633a3d5ebadf48ffff1c24beb1ce83e8f6a71bb64ce477e9a \

--- a/Dockerfile.analyzers
+++ b/Dockerfile.analyzers
@@ -11,7 +11,7 @@ ARG SOURCE_DATE_EPOCH=1700000000
 
 # Build the upstream gh release with its remaining vulnerable Go module patched.
 # The archive, Go toolchain and dependency checksums are immutable inputs.
-FROM --platform=$BUILDPLATFORM golang:1.26.8-bookworm@sha256:9fdc884aacc3bec89b20ffc69f4bb369c78210e3e4f600387b5128b12c199f81 AS gh-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b AS gh-builder
 ARG TARGETARCH
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 ADD --checksum=sha256:e16749bc0d99dc0633a3d5ebadf48ffff1c24beb1ce83e8f6a71bb64ce477e9a \
@@ -25,7 +25,7 @@ RUN tar -xzf /tmp/gh-source.tar.gz --strip-components=1 -C /src/gh \
         -o /out/gh ./cmd/gh
 
 # Preserve actionlint 1.7.12 source/dependencies, replacing its vulnerable Go runtime.
-FROM --platform=$BUILDPLATFORM golang:1.26.8-bookworm@sha256:9fdc884aacc3bec89b20ffc69f4bb369c78210e3e4f600387b5128b12c199f81 AS actionlint-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b AS actionlint-builder
 ARG TARGETARCH
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 ADD --checksum=sha256:30a9b942aa2a9c5246d8434d3ad9ff010969d1d4510281c4d395e18665192e6e \

--- a/docker/agent-clis/package-lock.json
+++ b/docker/agent-clis/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "name": "mergecraft-agent-clis",
       "dependencies": {
-        "@anthropic-ai/claude-code": "2.1.251",
-        "@google/gemini-cli": "0.57.0",
-        "@openai/codex": "0.151.0",
-        "opencode-ai": "1.18.25"
+        "@anthropic-ai/claude-code": "2.1.263",
+        "@google/gemini-cli": "0.58.0",
+        "@openai/codex": "0.153.4",
+        "opencode-ai": "1.18.29"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.251.tgz",
-      "integrity": "sha512-eG+ZPPpW2Dbmnntf1Fz9/T9ewS8I8SKfc1tcU2PqSwmftfjRPP7BXPaCyLuZ8kvgTdiPnJi/2/JnTvTRieneEQ==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.263.tgz",
+      "integrity": "sha512-kvvBK6/69iTRYnq0TKVyxVZs1CxYCJGojshQSP+2qaDb66A2xtI4zbCuqkZUWLkFGmHSRqhFf/ATpzH2UNKcwg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -25,20 +25,20 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.251",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.251",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.251",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.251",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.251",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.251",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.251",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.251"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.263",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.263",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.263"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.251.tgz",
-      "integrity": "sha512-Qr5oMGVrOUyatsMlK0361OSnr3C785QBFIDoaiHMpaJ/nu/Ji2ccwI7nv0o54q3v3Y+zU9xbtEmcGxPRcR9ptA==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.263.tgz",
+      "integrity": "sha512-yLv8MtgulGMGCWTwDUSmlEL0+94sxKP3vJm0SAXZX+0qVQ09PrjVSRC0ibtVeW7xymyhvP1JaUimOyp+t2wO5g==",
       "cpu": [
         "arm64"
       ],
@@ -49,9 +49,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.251.tgz",
-      "integrity": "sha512-wDMj6uELqU/uUeXH3E+32R9Gyx6pxdffBmjCbP8CoGGN0VufEd88vXhIGK2P0XIsksSh3fJZdxS00EaQSpHYPw==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.263.tgz",
+      "integrity": "sha512-55AHarRoo10yV8qLRrtZiNfum0uLQ6FKtwQEGuahzXHUnBDDrQ56ejLZB/FSs+q2Nx3IFWEq9J/rNVfuX7oZ6w==",
       "cpu": [
         "x64"
       ],
@@ -62,9 +62,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.251.tgz",
-      "integrity": "sha512-h4EXRyV25yJfez40cTIoBlJptJqccP8nIDPdDMO9TDPUzZ6e5Y3OO9AgrfdMRAgccaTRsKfJenh7lA2D40nzdw==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.263.tgz",
+      "integrity": "sha512-RlJtLbl8xqFMf2zUdOKD4o5FkNhcgGjlS3Un8PNfSbv1fLQg3SqBQgEJhNEtSeKlEsOs26RnCG/jVk4yah8Udw==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.251.tgz",
-      "integrity": "sha512-VJAZGuGTaRQINdUS35qhkgZoK8R+0MciPHMG6KMTFHjLC8GKtxj47RmiWcCUAu+fJpEOsko0FLEBqvAbdOpkJg==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.263.tgz",
+      "integrity": "sha512-RxeDl9uWmj7FtghdtRImpWsGEEe8l05VoS9wt5vJAFVZFP6ZmyanS7b+1+STXW6F6QsEbVqbKF5R/HPz3dzW4g==",
       "cpu": [
         "arm64"
       ],
@@ -94,9 +94,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.251.tgz",
-      "integrity": "sha512-HJyCY1ynzlsBk+N02IJeBNNZmzyd43lMuff49IXtbUDGHlf2XFHcxwYJEWCwIW51J3Hl4MvrqM6Ye8PGpJRIiA==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.263.tgz",
+      "integrity": "sha512-0IrvpLd/0FP0acQw59T4Cvx/r4nwAXKBrW0WyhIXymzYWurPCLztB+Icu9MkeewAUI+p3PTXsSfmilv/n6XlAQ==",
       "cpu": [
         "x64"
       ],
@@ -110,9 +110,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.251.tgz",
-      "integrity": "sha512-fuELyER/KyDie/iPimqHgZauPINBb+mWoYG7dXKxaxXlqCSmSI9YHzDVQ/1zSfiUnAU3FhbT1p9GNBqwJPikqA==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.263.tgz",
+      "integrity": "sha512-R6gtwGcW+sxoyANhikfUKPsat+mysEoLhl5rBUSaSHsey7x4oe/0zrWV2vbWw3t5X9XDsh0Bcl/n4/1Jgyc4vw==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +126,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.251.tgz",
-      "integrity": "sha512-6hkf7WoAk74WJuQ/epE+GKy5SJ7RU7kcpy3PRFHt6E1tiYNscihfZY1TMQ+AMQsDo1iFQFHbGITR95+vr3at+w==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.263.tgz",
+      "integrity": "sha512-koscGNDJ0qMXQIAse9zqeQ70EL8qoMkDnMSrAbW8ussrLCyTvfgNny+N9GFic382XegSAIhcInF+oqJnaBSyxA==",
       "cpu": [
         "arm64"
       ],
@@ -139,9 +139,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.251",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.251.tgz",
-      "integrity": "sha512-fVXAvS2lCMJWD/lcyzzai5pcDQnlldGl8pwyGQ2vBxcuF8LS/7nVDqLOqTZsoAJ+VDKnlkPlPOJytDQEhTHHMQ==",
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.263.tgz",
+      "integrity": "sha512-P1LnudAWj2ptyE0IZzCZKAe7nU7LxqlkcLdBfp8FsHlH5dp75Og4JJ6TClvfjanHn3shYW4CYN6oI1vSqZlkHw==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@google/gemini-cli": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.57.0.tgz",
-      "integrity": "sha512-I0V03d3k0J0ZN2m9u54XhN3VcMG+VjyPzoy7E9QV8lhzd39C6UgaZGLZNsOgODOtDhK8YMijHJWJn+Qxop2umw==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.58.0.tgz",
+      "integrity": "sha512-++LtUYMcLE8dVxMcuwv6kIp8+h6z+std/7iVE+vSunkrwNDaWMFkWw/psv2RSySWjr2A1SsEEIGCK0xULWY2sA==",
       "license": "Apache-2.0",
       "bin": {
         "gemini": "bundle/gemini.js"
@@ -278,9 +278,9 @@
       ]
     },
     "node_modules/@openai/codex": {
-      "version": "0.151.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0.tgz",
-      "integrity": "sha512-mhtWmOZRdmWD1jPbLDnQb59BsaVP/V+lXe/OFNR9ZcLZU0UCiBwn98Fcav1ss7sDIlHkuqj6nWd44IPeXoOhJA==",
+      "version": "0.153.4",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4.tgz",
+      "integrity": "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -289,19 +289,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.151.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.151.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.151.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.151.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.151.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.151.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.151.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-darwin-arm64.tgz",
-      "integrity": "sha512-g7YzpaCZGCw19R/gly3vRPjnLqaW7JcBAu2WQQ6e8PIlvBPmS/gMplIUURMgNO6gi8LsPzdlQtLqkwoeOOlIdg==",
+      "version": "0.153.4-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-arm64.tgz",
+      "integrity": "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==",
       "cpu": [
         "arm64"
       ],
@@ -316,9 +316,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.151.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-darwin-x64.tgz",
-      "integrity": "sha512-0y+g8TVpP+Fn10mjoKYXER6qYjn29w7xBUsbPXJ6Accu/FoM4Qp4WbKXQPmE0G0yUACTQVZRjzTSsdWUezNgkg==",
+      "version": "0.153.4-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-x64.tgz",
+      "integrity": "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +333,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.151.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-linux-arm64.tgz",
-      "integrity": "sha512-CsLgFeX4TQ6I2Gdrxd2r5UbgIbDLCdtcLAlnMYjr06bCL057MTNGec7Ewb3+Z2DBiMuXCljdTBGqLOePkMV0sQ==",
+      "version": "0.153.4-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-arm64.tgz",
+      "integrity": "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==",
       "cpu": [
         "arm64"
       ],
@@ -350,9 +350,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.151.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-linux-x64.tgz",
-      "integrity": "sha512-xcVyY1FtwvVYhh2JBmz8fX8CQqFAxO/lxJ2IXsh8x5uwxZVHVl5fZHFHf8JdRaOGG0vpkYmu/DKKVoLd56/DDQ==",
+      "version": "0.153.4-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-x64.tgz",
+      "integrity": "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==",
       "cpu": [
         "x64"
       ],
@@ -367,9 +367,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.151.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-win32-arm64.tgz",
-      "integrity": "sha512-zDWzOoh9wHm+Om1Nhn7os47rAVeSGPh0SnM3YOttdq6iPJz2zn4vBnbGUZjeih1qW/3mvNF3Oyd4owlaHmphmg==",
+      "version": "0.153.4-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-arm64.tgz",
+      "integrity": "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==",
       "cpu": [
         "arm64"
       ],
@@ -384,9 +384,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.151.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.151.0-win32-x64.tgz",
-      "integrity": "sha512-sLT7xvID3jhU6tkzcwRPnMEclKRwUPbpo0mtfxIF9KpdZH3VJV7sM2/kXWXyvUM7Zt/YeyOaeATTEysbRz8Yog==",
+      "version": "0.153.4-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-x64.tgz",
+      "integrity": "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ==",
       "cpu": [
         "x64"
       ],
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/opencode-ai": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.25.tgz",
-      "integrity": "sha512-pS4RKJ9eKwU7Dp5G5pdj1rhMnpG5APixXzfTKNoFqv9aFVI36Rnza2jESvKifxyPZlsA65MQB03WCArY0EK6mg==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.29.tgz",
+      "integrity": "sha512-syIDVwlrYTgTOXzZe9SkInJWethbq6l3SNC762UeXyO0a9V0wGfd+U4yACvppwNBnhIsl0j2QPYYCyLpNaSomg==",
       "cpu": [
         "arm64",
         "x64"
@@ -446,24 +446,24 @@
         "opencode": "bin/opencode.exe"
       },
       "optionalDependencies": {
-        "opencode-darwin-arm64": "1.18.25",
-        "opencode-darwin-x64": "1.18.25",
-        "opencode-darwin-x64-baseline": "1.18.25",
-        "opencode-linux-arm64": "1.18.25",
-        "opencode-linux-arm64-musl": "1.18.25",
-        "opencode-linux-x64": "1.18.25",
-        "opencode-linux-x64-baseline": "1.18.25",
-        "opencode-linux-x64-baseline-musl": "1.18.25",
-        "opencode-linux-x64-musl": "1.18.25",
-        "opencode-windows-arm64": "1.18.25",
-        "opencode-windows-x64": "1.18.25",
-        "opencode-windows-x64-baseline": "1.18.25"
+        "opencode-darwin-arm64": "1.18.29",
+        "opencode-darwin-x64": "1.18.29",
+        "opencode-darwin-x64-baseline": "1.18.29",
+        "opencode-linux-arm64": "1.18.29",
+        "opencode-linux-arm64-musl": "1.18.29",
+        "opencode-linux-x64": "1.18.29",
+        "opencode-linux-x64-baseline": "1.18.29",
+        "opencode-linux-x64-baseline-musl": "1.18.29",
+        "opencode-linux-x64-musl": "1.18.29",
+        "opencode-windows-arm64": "1.18.29",
+        "opencode-windows-x64": "1.18.29",
+        "opencode-windows-x64-baseline": "1.18.29"
       }
     },
     "node_modules/opencode-darwin-arm64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.25.tgz",
-      "integrity": "sha512-W4dyMFtHBglWZ1SEooh3Ke9v1M9lv945Y58atb8e1yKII8YykJ8LknOFyKipYC028oPDO4IZc3GYGKbg9PCg2w==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.29.tgz",
+      "integrity": "sha512-EU0qma5GPJXcDp5rENvedSfqJjqxatQW/Qzjs71pR2YdbrSh7YmBwtvnIb2/KIvfQr0DErX4ST14sbBQI2mQdg==",
       "cpu": [
         "arm64"
       ],
@@ -473,9 +473,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.25.tgz",
-      "integrity": "sha512-YYKrfeUSJhD7hZl+yNmayS51sDwxiE9o5XwrfgYSSie6sOyHFc9Ei13VBkVU6T+IJHhFhTahOFAwSDxggrAnGA==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.29.tgz",
+      "integrity": "sha512-Soyw5WI5kRI3Wbk5eeuSkMw4x+ScXi3SqzITMsi6rnVX0hsAbFCOmKOieYcd8BKJ1aUTrrG0Vv556CFzekk5Bw==",
       "cpu": [
         "x64"
       ],
@@ -485,9 +485,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64-baseline": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.25.tgz",
-      "integrity": "sha512-rRgTaoTeIN2diL1e1HGZ48Zh4ynMDEB1jYjD76LaFUVzMwakEY1i7NvG8e/rbjRMDkgXIr6TwzCtIMcMOpLQMA==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.29.tgz",
+      "integrity": "sha512-LJAQWZd4Tixo/IYCM3qYDk+h+OydkcZY6ywL99K67acJzfiAmfzqDKUi7WuQkMrlTCSPoOxkyz3yTPd0GzVeXw==",
       "cpu": [
         "x64"
       ],
@@ -497,9 +497,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.25.tgz",
-      "integrity": "sha512-PMvcpFpha3yAhaVCC0QbegHPxsEZ0FuQf+52PXvqQut1r3w1l1Pilor9tUA7TyCRa4UokACI90nTmKmtMnQBag==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.29.tgz",
+      "integrity": "sha512-Lr7XXik5wPJZBV5RW+aR6Uogf1n5GogpB565m+D/jiO/vRXr9LhvCpixgAr1tiwuH1ZfMsqOOlbFQz5jgH3Tqg==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +509,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64-musl": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.25.tgz",
-      "integrity": "sha512-IwIPKmNwIjLshlSgjoRLKFwxxiLpZ5Y0zjv6r456RQtJKK62IbYGXkCm3AiSZ/lqGsu3XF+xn/Xza29ivgpgcg==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.29.tgz",
+      "integrity": "sha512-9lNhNvW3FdwbI+BDy/y+0bwIQkbz36u/RVQoZH2tYvWjHkOaf8D+mSuDKbKcFqpLFIbbQona01oYSQZzncZIcQ==",
       "cpu": [
         "arm64"
       ],
@@ -524,9 +524,9 @@
       ]
     },
     "node_modules/opencode-linux-x64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.25.tgz",
-      "integrity": "sha512-bdRSJ6gbK/EnLNWxROOQYXFXiUeqeFxGz8DIO8LCqnii99A2OWFAyZ3Da5gpvfT1Yrp9/lYL55n/tM3ale5smg==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.29.tgz",
+      "integrity": "sha512-X8/wS/8mzL7Ko0zYYF6RzKax39KkxXDRoimhmzXuo0gPrZX4DQjqBNpPAByBwUjFapk73ZGSVsjDGvoNapBa1Q==",
       "cpu": [
         "x64"
       ],
@@ -536,9 +536,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.25.tgz",
-      "integrity": "sha512-+b0w7XyHx0XPQWHBk2JymXbXnyZQ2PjIPuu4a4QJgSUqGuGz1L2flA3wgpZVAWFUhrEIr9DFhBk3AkKKNgMuRw==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.29.tgz",
+      "integrity": "sha512-AnPvoVjeLC6qBYSeDwmj8fIVeJxspkrh1xAPow5NMSdH7IZZd0auiI2PHIW+0/3B+xfar1Zx1a6yvDd4Wd74Wg==",
       "cpu": [
         "x64"
       ],
@@ -548,9 +548,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.25.tgz",
-      "integrity": "sha512-E2JUeOOSXPbG1cNOzxnqjqkd0a3+oFmwkbJe6bZ308CFgLWBFfVh0fF42HTCEqfK+yYbidpEkQuEkUgxq/11IA==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.29.tgz",
+      "integrity": "sha512-A60ew2Xu0gXPwjPYbXoYtkzpUYaLKpgp8dVU5RJpGhT2NBMWBaEyY8O/pcZJFvhPOoEFP9IYmcF2k8Pj4mjDfA==",
       "cpu": [
         "x64"
       ],
@@ -563,9 +563,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-musl": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.25.tgz",
-      "integrity": "sha512-W15qTNDz1fsTzs1SkE6bB/gpIDBF3rwDbewUKdbyXD3dVs6umyugOql1T4u9n/gqWa/Z/VDURbn39VsejeSdbQ==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.29.tgz",
+      "integrity": "sha512-bGAZ9NFzNOzrXVN9oczd1H+vzLH1aGyYg1ZZNtuZiszxKr8+vTjLnNcjzGJIuc6jtjvlWbfp8l+S5fxCVuQo2A==",
       "cpu": [
         "x64"
       ],
@@ -578,9 +578,9 @@
       ]
     },
     "node_modules/opencode-windows-arm64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.25.tgz",
-      "integrity": "sha512-GFp74pProoPwqktHMf+9wQ8fza1RvFt0RG0iRtTQnJ4VWVY62qEeVuJkH6ki9QXS270HXyqtxvF8AuHQzuVZlA==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.29.tgz",
+      "integrity": "sha512-LwDli4EeZIGNnq8vJ9/uLIvsxAY0zLi6+54KsmOk8E1w7121axXpJ/5TpCg4LvmsNXwRKenKJgWzqoDBhy/2mw==",
       "cpu": [
         "arm64"
       ],
@@ -590,9 +590,9 @@
       ]
     },
     "node_modules/opencode-windows-x64": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.25.tgz",
-      "integrity": "sha512-xW5wtSxWYbI7DcmQWMlNWIiDBdMJON1vDiEmVWo88R9tT/PaahOhWKgp7FoWDqJKf89jS3ZIzkqnkU3F2dio7A==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.29.tgz",
+      "integrity": "sha512-xtWiZNMiwFtBl7q9yMG+XK/BTYGfgFoHLDx4ruWVYCoxjV0NYwjJi6rB9B3xIVbTclzu81YLKNFcT3kNBEG9Yw==",
       "cpu": [
         "x64"
       ],
@@ -602,9 +602,9 @@
       ]
     },
     "node_modules/opencode-windows-x64-baseline": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.25.tgz",
-      "integrity": "sha512-/28bGRQwT+2JdGbtGaNr95tstgysiULEXtcvgNg7yLDxitqmSVgd8V8XRGS0UWDdfiWWMND9A9T5EAsbF1/xDQ==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.29.tgz",
+      "integrity": "sha512-rUqqp8zbHq5bc3yWPymQxCHgS2Fax07GoEq/KX1R+FE4XNDgL6R+Q1PFqqVDneLd3l0h5qPb+qqsiiWGGEORlA==",
       "cpu": [
         "x64"
       ],

--- a/docker/agent-clis/package.json
+++ b/docker/agent-clis/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "description": "Pinned agent CLI dependencies for mergeCraft Docker images (W7 / D7).",
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.251",
-    "@openai/codex": "0.151.0",
-    "@google/gemini-cli": "0.57.0",
-    "opencode-ai": "1.18.25"
+    "@anthropic-ai/claude-code": "2.1.263",
+    "@openai/codex": "0.153.4",
+    "@google/gemini-cli": "0.58.0",
+    "opencode-ai": "1.18.29"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "pyright==1.1.411",
     "basedpyright==1.39.9",
     "pytest-cov==7.1.0",
-    "pytest-randomly==4.1.0",
+    "pytest-randomly==5.0.0",
     "pytest-split==0.11.0",
     "types-aiofiles==25.1.0.20251011",
     # Pinned to the version in analyzers/catalog/ast-grep.yaml so dev/test


### PR DESCRIPTION
## What?

Brings `main` up to `pre-0.0.1` after the Dependabot merges. `main` is a strict ancestor of `pre-0.0.1`, so this is a clean fast-forward-shaped sync with no conflicts and no hand edits.

Eight commits, four merged PRs:

| PR | |
| --- | --- |
| #671 | golang 1.26.8-bookworm → 1.27.1-bookworm |
| #672 | agent-clis patch/minor group (4 updates) |
| #674 | pytest-randomly 4.1.0 → 5.0.0 |
| #676 | actions/create-github-app-token 2.2.2 → 3.2.0 |

## Why?

The two branches diverged when those four landed on `pre-0.0.1`. A stale `pre-0.0.1` is what kept eight PRs frozen on `action-pin-check` earlier today, so the branches are worth keeping converged rather than letting the gap grow.

## Pin budget

This sync contains **0 commits touching `src/mergecraft/`**, so it costs nothing against the self-review pin's freshness budget — lag stays at 1 of 5 (`MERGECRAFT_MAX_ACTION_PIN_PRODUCT_LAG`). Only product-code commits reaching `main` consume it.

It also does not change `action.yml`'s image digest relative to `main`, so it does not trip #684 — the reason the earlier forward-port PR (#681) failed `Verify changed deployment candidates`.

## Test plan

- [x] `main` is a strict ancestor of `pre-0.0.1` — no conflicts possible.
- [x] Sync touches no `src/mergecraft/` files; pin lag unchanged.
- [x] No `action.yml` digest change relative to base, so the deployment-candidate gate sees nothing to verify.
- [ ] CI green on the merge result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
