### PR TITLE
chore(action): prepare verified image manifest 960b0cc6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:61662cdab01769659f8e506c162757feb6c61413b7148d7e9d411ab5b2bbff37"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:960b0cc62dc15d6d0ac3df2db47e4bf5fa193749b367a6a6fbb95916f50e977b"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Manifest commit **C** for the `S → D → C → P` cycle (#641). One line: `action.yml`'s `runs.image` digest.

| | |
| --- | --- |
| Source **S** | `4bb4f8869633ad08d378e6252e403a0f233312a6` (main's tip, the #686 sync) |
| Image **D** | `sha256:960b0cc62dc15d6d0ac3df2db47e4bf5fa193749b367a6a6fbb95916f50e977b` |
| Manifest **C** | this PR |
| Consumer pin **P** | unchanged at `492684ed` — moves in the separate pin PR after this merges |

## Why now?

The self-review pin's freshness lag hit **5 of 5** — the ceiling. The check still passes at exactly 5, so #677 has not reopened, but there is no headroom: the next `src/mergecraft/` merge opens it.

The current pin `492684ed` was cut from `5a30b000`. Everything merged since — #665, #670, #673, #675, #678, #680, #686 — is absent from every review the Action performs. This cycle closes that gap.

## Verification

`make action-images-resolve` verified D against GHCR before the manifest was cut: cosign signature, build provenance, and the tracing extra all check out, and the image reports `4bb4f886` as its source revision.

`make action-candidate-check`, exactly as CI runs it:

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "37e79f67…", "source_revision": "4bb4f886…",
                "image_digest": "sha256:960b0cc6…", "verified": true}]}
```

## Merge note — please read

`verify_manifest` requires C to differ from its image source in `action.yml` **alone**. That holds for `37e79f67`, but **not** for whatever merge commit lands on main, once anything else merges alongside it. This is exactly why `dac17243` was unpinnable in the last cycle and the pin had to name the branch commit `492684ed`.

So:

- **Merge this with a merge commit, not a squash.** A squash orphans `37e79f67` and there is then no pinnable commit at all.
- **Avoid merging other work into main between this and the pin PR.** Every merge in between widens the gap between main's tip and S.
- The pin PR will name `37e79f67` — the manifest commit — not this PR's merge commit. That is deliberate, and #684 tracks the checker gap that forces it.

## Test plan

- [x] Diff is `action.yml` `runs.image` only — no entrypoint, argument, workflow or source change.
- [x] Digest verified against signed image provenance before cutting.
- [x] `make action-candidate-check` → `verified: true`.
- [x] `make ci-static` OK.
- [ ] After merge: pin PR naming `37e79f67`, then confirm an Action run boots at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
