### PR TITLE
chore(action): pin self-review to verified manifest 37e79f67

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -162,7 +162,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "492684edcadd06aa99c3d15a12d162a15828ee38"
+  MERGECRAFT_ACTION_SHA: "37e79f6771e3e7b092615ed15b7829d036f9479a"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -610,7 +610,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -763,7 +763,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -892,7 +892,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@492684edcadd06aa99c3d15a12d162a15828ee38 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Consumer pin **P**, completing the cycle started in #688. Moves all four references in `.github/workflows/mergecraft.yml` — `env.MERGECRAFT_ACTION_SHA` plus the three review rungs — from `492684ed` to `37e79f67`.

| | |
| --- | --- |
| Source **S** | `4bb4f886` |
| Image **D** | `sha256:960b0cc6…` |
| Manifest **C** | `37e79f67` (merged in #688) |
| Consumer pin **P** | this PR |

## Why

The previous pin `492684ed` was cut from `5a30b000`. Everything merged since — #665, #670, #673, #675, #678, #680, #686 — was absent from every review the Action performed, and lag sat at the **5-of-5 ceiling**.

## The squash-vs-merge point, resolved

#688 landed as a **merge**, so `37e79f67` is itself an ancestor of `main` and still differs from its image source in `action.yml` alone — the invariant `verify_manifest` enforces. A squash would have orphaned it and left nothing pinnable, which is what nearly happened last cycle with `dac17243` (#684 tracks the underlying gap).

## Verification

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "37e79f67…", "source_revision": "4bb4f886…",
                "image_digest": "sha256:960b0cc6…", "verified": true}]}
```

- [x] `make action-pin-prepare` → `pin-change-prepared`, strict provenance verification passed.
- [x] `make action-candidate-check` (CI's env) → `verified: true`.
- [x] `make action-pin-check` and `--scope all` both OK.
- [x] `make ci-static` OK.
- [x] Diff is the four pin references only.
- [ ] After merge: confirm an Action run boots at `37e79f67`.

## Related

#684 — the pin PR must name the manifest commit rather than the merge commit, because `verify_candidate` has no notion of an inherited digest. Still open.

Separately, `fix/staleness-no-merges` corrects the lag metric to count changes rather than landings; with it, today's lag reads 2 instead of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
