### PR TITLE
chore(action): prepare verified image manifest 12ace767

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:960b0cc62dc15d6d0ac3df2db47e4bf5fa193749b367a6a6fbb95916f50e977b"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:12ace76753fef1bce3619069fa3057f9b3d71dd7a6b33cad22ea58ae025705ba"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Manifest commit **C** for the `S → D → C → P` cycle (#641). One line: `action.yml`'s `runs.image` digest.

| | |
| --- | --- |
| Source **S** | `5a96e11532ba6bab6b4d6da2affe875456fb98aa` (main's tip, the #606 merge) |
| Image **D** | `sha256:12ace76753fef1bce3619069fa3057f9b3d71dd7a6b33cad22ea58ae025705ba` |
| Manifest **C** | `3b149a41` — this PR |
| Consumer pin **P** | unchanged at `37e79f67`; moves in the pin PR that follows |

Closes #691 once the pin PR lands.

## Why now?

#606 landed the filtered-egress hardening and the orphan sweeper, taking the pin's freshness lag from **3 to 8** against a ceiling of 5. The staleness workflow filed #691 twenty-three seconds after that merge — the automated path working end to end, unprompted.

Until this cycle completes, the self-review Action reviews pull requests without any of #606's analyzer changes.

## Verification

`make action-images-resolve` verified D against GHCR before the manifest was cut: cosign signature, build provenance, and the tracing extra all check out, and the image reports `5a96e115` as its source revision.

`make action-candidate-check`, exactly as CI runs it:

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "3b149a41…", "source_revision": "5a96e115…",
                "image_digest": "sha256:12ace767…", "verified": true}]}
```

## Merge note

**Merge this with a merge commit, not a squash.** The pin PR must name `3b149a41`, and `verify_manifest` requires that commit to differ from its image source in `action.yml` alone. A squash orphans it and leaves nothing pinnable — the trap that made `dac17243` unusable two cycles ago (#684).

Also avoid landing other `src/mergecraft/` work between this and the pin PR; each intervening merge widens the gap between main's tip and S. **#679 in particular should wait** — it touches 18 files under that tree.

## Test plan

- [x] Diff is `action.yml` `runs.image` only.
- [x] Digest verified against signed image provenance before cutting.
- [x] `make action-candidate-check` → `verified: true`.
- [x] `make ci-static` OK.
- [ ] After merge: pin PR naming `3b149a41`, then #691 closes itself on the push-triggered staleness run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
