### PR TITLE
chore(action): pin self-review to verified manifest 3b149a41

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -162,7 +162,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "37e79f6771e3e7b092615ed15b7829d036f9479a"
+  MERGECRAFT_ACTION_SHA: "3b149a41b095a651feab0f4021bae0e1564eebc5"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -610,7 +610,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -763,7 +763,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -892,7 +892,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@37e79f6771e3e7b092615ed15b7829d036f9479a # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Consumer pin **P**, completing the cycle started in #692. Moves all four references in `.github/workflows/mergecraft.yml` — `env.MERGECRAFT_ACTION_SHA` plus the three review rungs — from `37e79f67` to `3b149a41`.

| | |
| --- | --- |
| Source **S** | `5a96e115` (the #606 merge) |
| Image **D** | `sha256:12ace767…` |
| Manifest **C** | `3b149a41` (merged in #692) |
| Consumer pin **P** | this PR |

Closes #691.

## Why

#606 landed the filtered-egress hardening and the orphan sweeper, taking the lag to **8 against a ceiling of 5**. Until this merges, the reviewer runs without any of that analyzer code — including the sweeper whose malformed `iptables -D` was caught in review.

**Lag with this pin: 0 of 5.**

## Verification

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "3b149a41…", "source_revision": "5a96e115…",
                "image_digest": "sha256:12ace767…", "verified": true}]}
```

- [x] `make action-pin-prepare` → `pin-change-prepared`, strict provenance verification passed.
- [x] `make action-candidate-check` (CI's env) → `verified: true`.
- [x] `make ci-static` OK; `action-pin-check` and `--scope all` both OK.
- [x] `#692` landed as a merge, so `3b149a41` is an ancestor of main and still differs from S in `action.yml` alone — checked explicitly before cutting this.
- [x] Diff is the four pin references only.
- [ ] After merge: #691 closes itself on the push-triggered staleness run.

## After this

#679 is safe to land once this merges — it touches 18 `src/mergecraft/` files, which is why it was held during the cycle. Expect it to consume most of the fresh budget on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
