### PR TITLE
refactor(enterprise): remove unused Starlette /healthz app

### DIFF
--- a/docs/test-plans/open-issues-sweep-2026-08-20d-b-runtime.md
+++ b/docs/test-plans/open-issues-sweep-2026-08-20d-b-runtime.md
@@ -75,7 +75,7 @@ GREEN (no xfail) — must stay passing through impl:
 | `src/mergecraft/enterprise/offline.py` | `offline_install_plan`, `OfflineInstallError` |
 | `src/mergecraft/enterprise/telemetry.py` | `TelemetryMode`, `resolve_telemetry_mode`, `is_telemetry_export_enabled` |
 | `src/mergecraft/enterprise/residency.py` | `DataResidencyPolicy`, `enforce_data_residency` |
-| `src/mergecraft/enterprise/health.py` | `HEALTHZ_PATH` (`/healthz`), `health_payload`, `build_health_app` |
+| `src/mergecraft/enterprise/health.py` | `health_payload` (CLI JSON via `mergecraft health`) |
 | `src/mergecraft/enterprise/audit.py` | `export_audit_log`, `export_usage`, `explain_blocking_decision` |
 | `src/mergecraft/enterprise/support_bundle.py` | `write_support_bundle` |
 | `src/mergecraft/enterprise/policy_distribution.py` | `distribute_org_policy` (wraps `mergecraft.policy`) |
@@ -120,7 +120,7 @@ Do not hand-edit `docs/compatibility-matrix.md` into the six-axis matrix.
 | DB381c | Offline install | unit | happy/error | `test_offline_install_plan_uses_python_311_floor`, `test_offline_install_rejects_standalone_binary_request` |
 | DB381d | Telemetry on/opt-out/off | unit | happy/edge/error | `tests/enterprise/test_telemetry.py` |
 | DB381e | Data residency | unit | happy/edge/error | `tests/enterprise/test_residency.py` |
-| DB381f | `/healthz` JSON | unit + integration | happy/error | `tests/enterprise/test_health.py` |
+| DB381f | CLI health JSON (`health_payload`) | unit | happy | `tests/enterprise/test_health.py` |
 | DB381g | Audit + usage JSON | unit | happy/edge/error | `tests/enterprise/test_audit.py` |
 | DB381h | Support bundle redaction | unit | happy/edge/error | `tests/enterprise/test_support_bundle.py` |
 | DB381i | Policy/memory without dashboard | integration | happy/error | `tests/enterprise/test_policy_memory_distribution.py` |

--- a/src/mergecraft/enterprise/health.py
+++ b/src/mergecraft/enterprise/health.py
@@ -1,31 +1,18 @@
-"""Machine-readable health endpoint for enterprise / server deployments (#381).
+"""Machine-readable health payload for enterprise / server deployments (#381).
 
 Distinct from the MCP FastAPI ``/health`` probe.
 
 Exports:
-    HEALTHZ_PATH: The canonical enterprise health path (``/healthz``).
     health_payload: Return a JSON-serialisable dict with a ``status`` field.
-    build_health_app: Build a minimal Starlette ASGI app serving ``/healthz``.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from starlette.applications import Starlette
-from starlette.responses import JSONResponse, Response
-from starlette.routing import Route
-
-if TYPE_CHECKING:
-    from starlette.requests import Request
+from typing import Any
 
 __all__ = [
-    "HEALTHZ_PATH",
-    "build_health_app",
     "health_payload",
 ]
-
-HEALTHZ_PATH: str = "/healthz"
 
 
 def health_payload() -> dict[str, Any]:
@@ -56,24 +43,3 @@ def health_payload() -> dict[str, Any]:
         },
     }
     return {"status": "ok", "checks": checks}
-
-
-async def _healthz(request: Request) -> Response:
-    return JSONResponse(health_payload())
-
-
-async def _not_found(request: Request, exc: Exception) -> Response:
-    return JSONResponse({"detail": "not found"}, status_code=404)
-
-
-def build_health_app() -> Starlette:
-    """Build a minimal Starlette ASGI app that answers ``GET /healthz``.
-
-    Returns:
-        A Starlette application with a single ``/healthz`` route.
-        All other paths return 404.
-    """
-    return Starlette(
-        routes=[Route(HEALTHZ_PATH, _healthz, methods=["GET"])],
-        exception_handlers={404: _not_found},
-    )

--- a/tests/enterprise/test_health.py
+++ b/tests/enterprise/test_health.py
@@ -1,18 +1,10 @@
-"""W7.1 — machine-readable health endpoint for server deployments (#381).
+"""W7.1 — machine-readable health payload for server deployments (#381).
 
 Intended public API (W7.2): ``mergecraft.enterprise.health``.
 Distinct from the MCP FastAPI ``/health`` probe.
 """
 
 from __future__ import annotations
-
-
-def test_healthz_path_is_not_mcp_health() -> None:
-    """Happy: enterprise health is ``/healthz``, not the MCP ``/health`` route."""
-    from mergecraft.enterprise.health import HEALTHZ_PATH
-
-    assert HEALTHZ_PATH == "/healthz"
-    assert HEALTHZ_PATH != "/health"
 
 
 def test_health_payload_is_machine_readable() -> None:
@@ -27,27 +19,3 @@ def test_health_payload_is_machine_readable() -> None:
     assert isinstance(checks, dict)
     assert "python" in checks
     assert "telemetry" in checks
-
-
-def test_health_app_serves_healthz() -> None:
-    """Integration: the health ASGI app answers GET /healthz with JSON."""
-    from starlette.testclient import TestClient
-
-    from mergecraft.enterprise.health import build_health_app
-
-    client = TestClient(build_health_app())
-    response = client.get("/healthz")
-    assert response.status_code == 200
-    payload = response.json()
-    assert str(payload.get("status", "")).casefold() in {"ok", "healthy"}
-
-
-def test_health_app_unknown_path_is_not_ok() -> None:
-    """Error: a missing path is not reported as healthy."""
-    from starlette.testclient import TestClient
-
-    from mergecraft.enterprise.health import build_health_app
-
-    client = TestClient(build_health_app())
-    response = client.get("/not-a-health-route")
-    assert response.status_code >= 400


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Starlette ASGI health server (`build_health_app`, `GET /healthz`) was never wired into production code — zero `src/` importers. Live operator health is already `mergecraft health` → `health_payload()` only.

Verified 2026-09-10 (read-only research agent bc-0682b918). No open PR covers this (#683 is public_comments only).

## Changes

- **`src/mergecraft/enterprise/health.py`** — removed `HEALTHZ_PATH`, `_healthz`, `_not_found`, `build_health_app`, and Starlette imports; kept `health_payload()` unchanged
- **`tests/enterprise/test_health.py`** — removed ASGI integration tests and `HEALTHZ_PATH` assertion; kept `test_health_payload_is_machine_readable`
- **`docs/test-plans/open-issues-sweep-2026-08-20d-b-runtime.md`** — updated DB381f to reflect CLI JSON via `health_payload`, not ASGI `/healthz`

## Not touched

- MCP `/health` probe
- `health_cmd.py` or `health_payload()` behavior

## Verification

```bash
pytest tests/enterprise/test_health.py tests/enterprise/test_cli_verbs.py -q
ruff check src/mergecraft/enterprise/health.py tests/enterprise/test_health.py
ruff format --check src/mergecraft/enterprise/health.py tests/enterprise/test_health.py
```

Results: **7 passed**, ruff check clean, format check clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18eb6df0-782e-46e7-b412-bc216997425e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18eb6df0-782e-46e7-b412-bc216997425e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

