### PR TITLE
chore(action): prepare verified image manifest 429091af

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
   # Slim image published by ci-cd.yml (SHA tag + digest retag). Pin by digest, never
   # :latest / :rc. Bump with scripts/check_action_image_digest.py after each
   # build-images push for the workflow Action SHA (#526).
-  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:12ace76753fef1bce3619069fa3057f9b3d71dd7a6b33cad22ea58ae025705ba"
+  image: "docker://ghcr.io/alexhawat/mergecraft@sha256:429091afb4fb1975ca915c5014e4f42753500917c50aee0ba989c0d311138f53"
   entrypoint: "/entrypoint.sh"
   args:
     - "gha"


### PR DESCRIPTION
## What?

Manifest commit **C** for the `S → D → C → P` cycle (#641). One line: `action.yml`'s `runs.image` digest.

| | |
| --- | --- |
| Source **S** | `3bc4b734f08a1a1a105e59f84c0d22356169fd5b` (main's tip, the #697 sync) |
| Image **D** | `sha256:429091afb4fb1975ca915c5014e4f42753500917c50aee0ba989c0d311138f53` |
| Manifest **C** | `280cd0d5` — this PR |
| Consumer pin **P** | unchanged at `3b149a41`; moves in the pin PR that follows |

Closes #698 once the pin lands.

## Why now?

#697 brought #679 to `main` — Action pin identity, userspace filtered egress, trust apply — touching **18** files under `src/mergecraft/` and taking the pin's freshness lag to **8 against a ceiling of 5**. The staleness workflow filed #698 on that merge push.

Until this cycle completes the reviewer runs none of #679's code, including the userspace egress backend and the relay allowlist fix.

## Verification

`make action-images-resolve` verified D against GHCR before the manifest was cut: cosign signature, build provenance, and the tracing extra all check out, and the image reports `3bc4b734` as its source revision.

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "280cd0d5…", "source_revision": "3bc4b734…",
                "image_digest": "sha256:429091af…", "verified": true}]}
```

## Merge note

**Merge with a merge commit, not a squash.** The pin PR must name `280cd0d5`, and `verify_manifest` requires that commit to differ from its image source in `action.yml` alone. A squash orphans it — the trap that made `dac17243` unpinnable (#684).

Avoid landing other `src/mergecraft/` work between this and the pin PR.

## Test plan

- [x] Diff is `action.yml` `runs.image` only.
- [x] Digest verified against signed image provenance before cutting.
- [x] `make action-candidate-check` → `verified: true`.
- [x] `make ci-static` OK.
- [ ] After merge: pin PR naming `280cd0d5`, then #698 closes itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
