### PR TITLE
chore(action): pin self-review to verified manifest 280cd0d5

### DIFF
--- a/.github/workflows/mergecraft.yml
+++ b/.github/workflows/mergecraft.yml
@@ -162,7 +162,7 @@ env:
   # Single Action SHA for all three review rungs (D10 / #532). Bump here only;
   # every `uses: alexhawat/mergeCraft@…` below must match — enforced by
   # `make action-pin-check`.
-  MERGECRAFT_ACTION_SHA: "3b149a41b095a651feab0f4021bae0e1564eebc5"
+  MERGECRAFT_ACTION_SHA: "280cd0d539152c9b398f53acf607c8d7e74bc084"
 
 concurrency:
   # pull_request_target resolves github.ref to the default branch; key on PR number
@@ -610,7 +610,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@280cd0d539152c9b398f53acf607c8d7e74bc084 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m
@@ -763,7 +763,7 @@ jobs:
         # work (#573, #536, #520). 3ed2c798 is the sync of main into
         # pre-0.0.1 before the lane A/C pin; #583 promotes that workflow to
         # main. pull_request_target still resolves from main until then.
-        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@280cd0d539152c9b398f53acf607c8d7e74bc084 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           # Must stay BELOW the job's timeout-minutes: when GitHub kills the job
@@ -892,7 +892,7 @@ jobs:
         # lockstep when bumping, and mirror to the sevn-side workflow. This rung
         # was authored against the pre-#533 pin; carried forward on each bump so
         # all three rungs run the same product code (#532). Now 3ed2c798 (#582).
-        uses: alexhawat/mergeCraft@3b149a41b095a651feab0f4021bae0e1564eebc5 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
+        uses: alexhawat/mergeCraft@280cd0d539152c9b398f53acf607c8d7e74bc084 # env.MERGECRAFT_ACTION_SHA / digest commit / pin 10
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           timeout: ${{ env.MERGECRAFT_REVIEW_ATTEMPT_TIMEOUT_MINUTES }}m


### PR DESCRIPTION
## What?

Consumer pin **P**, completing the cycle started in #700. Moves all four references in `.github/workflows/mergecraft.yml` from `3b149a41` to `280cd0d5`.

| | |
| --- | --- |
| Source **S** | `3bc4b734` |
| Image **D** | `sha256:429091af…` |
| Manifest **C** | `280cd0d5` (merged in #700) |
| Consumer pin **P** | this PR |

Closes #698.

## Why

#697 brought #679 to `main` — Action pin identity, userspace filtered egress, trust apply — taking lag to **8 of 5**. Until this merges the reviewer runs none of it, including the relay allowlist fix and the orphan sweeper.

## Prepared by hand — #699's `stage=pin` has a bug

Its first real run failed, and the failure is structural rather than transient:

```
{"analyzers_digest": "", "slim_digest": ""}
no published slim image for e2da18fc… — wait for CI/CD to finish
```

The pin stage checks out `main` and resolves the image for **main's tip**. But the image was built from `3bc4b734`, and by the pin stage `main` has advanced to `e2da18fc` — the manifest PR's own merge commit. **Main will always have moved past S by then**, so the pin stage could never have worked.

The step is also redundant: `action-pin-prepare` runs `verify_manifest(manifest_commit)` internally, which verifies the digest against GHCR for the correct source. That is visible in this PR's own output, which reports `source_revision: 3bc4b734` — resolved from the manifest commit, not from `main`.

Fix follows separately: skip image resolution for `stage=pin`.

## Verification

```json
{"state": "deployment-candidates-verified",
 "manifests": [{"manifest_commit": "280cd0d5…", "source_revision": "3bc4b734…",
                "image_digest": "sha256:429091af…", "verified": true}]}
```

- [x] `make action-pin-prepare` → `pin-change-prepared`, strict provenance verification passed.
- [x] `make action-candidate-check` → `verified: true`.
- [x] `make ci-static` OK.
- [x] `280cd0d5` confirmed on `main` and still differing from S in `action.yml` alone before cutting.
- [x] Diff is the four pin references only.
- [ ] After merge: #698 closes itself on the push-triggered staleness run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
