### PR TITLE
fix(ci): do not resolve the image from main's tip in the pin stage

### DIFF
--- a/.github/workflows/bump-action-pin.yml
+++ b/.github/workflows/bump-action-pin.yml
@@ -71,8 +71,15 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
+      # stage=manifest only. The pin stage must not resolve from main's tip: by
+      # then main has advanced to the manifest PR's own merge commit, which is
+      # never the source the image was built from, so this always resolved an
+      # empty digest and failed. It is redundant there anyway —
+      # `action-pin-prepare` runs verify_manifest(manifest_commit) internally,
+      # which verifies the digest against GHCR for the correct source.
       - name: Resolve and verify the published image
         id: image
+        if: inputs.stage == 'manifest'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -101,6 +108,8 @@ jobs:
           SOURCE_REVISION: ${{ steps.image.outputs.source }}
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
           SHORT: ${{ steps.image.outputs.short }}
+          # Empty for stage=pin, where the source is derived from the manifest
+          # commit by action-pin-prepare rather than from main's tip.
         run: |
           set -euo pipefail
           if [ "$STAGE" = "manifest" ]; then
@@ -140,6 +149,7 @@ jobs:
           BRANCH: ${{ steps.prepare.outputs.branch }}
           TITLE: ${{ steps.prepare.outputs.title }}
           STAGE: ${{ inputs.stage }}
+          MANIFEST_COMMIT: ${{ inputs.manifest_commit }}
           SOURCE_REVISION: ${{ steps.image.outputs.source }}
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
@@ -149,8 +159,12 @@ jobs:
             echo "| | |"
             echo "| --- | --- |"
             echo "| stage | \`$STAGE\` |"
-            echo "| source S | \`$SOURCE_REVISION\` |"
-            echo "| image D | \`$IMAGE_DIGEST\` |"
+            if [ -n "$SOURCE_REVISION" ]; then
+              echo "| source S | \`$SOURCE_REVISION\` |"
+              echo "| image D | \`$IMAGE_DIGEST\` |"
+            else
+              echo "| manifest C | \`$MANIFEST_COMMIT\` |"
+            fi
             echo
             echo "Open the PR yourself — a GITHUB_TOKEN-opened PR carries no required checks:"
             echo

--- a/tests/review_record/test_w18_action_pin_gate.py
+++ b/tests/review_record/test_w18_action_pin_gate.py
@@ -214,3 +214,34 @@ def test_the_pin_bump_workflow_warns_against_squashing_the_manifest() -> None:
     """Squashing C orphans it and leaves nothing for P to name (#684)."""
     text = read_text(f".github/workflows/{_BUMP_WORKFLOW}")
     assert "squash" in text.lower(), "no squash warning for the manifest stage"
+
+
+def test_the_pin_stage_does_not_resolve_the_image_from_mains_tip() -> None:
+    """By the pin stage, main's tip is never the source the image was built from.
+
+    The manifest PR's own merge advances main, so `stage=pin` resolving from
+    HEAD asked GHCR for a digest tagged with the merge commit and always got
+    nothing:
+
+        {"analyzers_digest": "", "slim_digest": ""}
+        no published slim image for e2da18fc… — wait for CI/CD to finish
+
+    It is redundant as well as wrong: `action-pin-prepare` runs
+    `verify_manifest(manifest_commit)` internally, which verifies the digest
+    against GHCR for the correct source.
+    """
+    steps = job(load_workflow(_BUMP_WORKFLOW), "prepare")["steps"]
+    resolve = [step for step in steps if "action-images-resolve" in str(step.get("run", ""))]
+    assert len(resolve) == 1, "expected exactly one image-resolve step"
+    guard = str(resolve[0].get("if", ""))
+    assert "manifest" in guard, (
+        f"image resolution is not restricted to the manifest stage: {guard!r}"
+    )
+
+
+def test_the_pin_stage_names_its_branch_from_the_manifest_commit() -> None:
+    """The pin branch must not depend on the skipped resolve step's outputs."""
+    text = read_text(f".github/workflows/{_BUMP_WORKFLOW}")
+    assert "chore/action-pin-${MANIFEST_COMMIT" in text, (
+        "pin branch name derives from a step that does not run in this stage"
+    )


### PR DESCRIPTION
## What?

Guards #699's image-resolve step to `stage=manifest`. Found by running `stage=pin` on a real cycle — [run 34477928043](https://github.com/alexhawat/mergeCraft/actions/runs/34477928043).

## The bug

```
{"analyzers_digest": "", "slim_digest": ""}
no published slim image for e2da18fc… — wait for CI/CD to finish
```

`stage=pin` checked out `main` and resolved the image for **main's tip**. But by the pin stage `main` has advanced to the manifest PR's own merge commit, which is never the source the image was built from:

| | |
| --- | --- |
| image built from | `3bc4b734` |
| main's tip at pin time | `e2da18fc` (the #700 merge) |

So it asked GHCR for a digest tagged with the merge commit, got nothing, and failed closed. **The pin stage could never have worked** — this wasn't a transient.

## It was redundant too

`action-pin-prepare` runs `verify_manifest(manifest_commit)` internally, which verifies the digest against GHCR for the correct source. Visible in the manual run that replaced this one (#702): it reported `source_revision: 3bc4b734` while sitting on `e2da18fc`, having derived the source from the manifest commit rather than from `main`.

So the correct verification was already happening; the extra step only added a wrong one.

## Fix

- Image resolution is `if: inputs.stage == 'manifest'`.
- The job summary reports the manifest commit rather than S/D for the pin stage.
- The pin branch name already derived from `MANIFEST_COMMIT`, so it does not depend on the skipped step.

## Test plan

- [x] `test_the_pin_stage_does_not_resolve_the_image_from_mains_tip` — verified it fails against the previous workflow: `image resolution is not restricted to the manifest stage: ''`.
- [x] `test_the_pin_stage_names_its_branch_from_the_manifest_commit`.
- [x] 18 tests pass in `test_w18_action_pin_gate.py`; `actionlint` and `zizmor` clean; `make ci-static` OK.
- [ ] After merge: re-run `stage=pin` on the next cycle to confirm end to end.

## Note

This is why #699's trial ran on a live cycle rather than waiting: the failure is one that only appears when `main` has moved between the two stages, which no dry run would have produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
