### PR TITLE
chore: ignore local .opencode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ graphify-out/
 .ignorelocal/
 /.claude/
 /.cursor/
+/.opencode/
 CLAUDE.md
 
 # Sanitizing fetcher quarantine (github-issue-triage fetch_issue_safe.py).


### PR DESCRIPTION
## What?

Ignores the local `.opencode/` agent config directory.

## Why?

It sits with the already-ignored `.cursor/` and `.claude/` host configs. Without this, machine-local opencode agents and worktree permissions show up as untracked in every checkout.

## Test plan

- [ ] `git status` no longer reports `.opencode/`
