### PR TITLE
chore: sync pre-0.0.1 into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ graphify-out/
 .ignorelocal/
 /.claude/
 /.cursor/
+/.opencode/
 CLAUDE.md
 
 # Sanitizing fetcher quarantine (github-issue-triage fetch_issue_safe.py).


### PR DESCRIPTION
## What?

Brings `main` up to `pre-0.0.1` after #706 (`chore: ignore local .opencode config`, one `.gitignore` line). Merges clean — 0 conflicts.

The branches diverged when #706 landed on `pre-0.0.1` while the #705 chain landed on `main`, so this is a real merge rather than the fast-forward the last few syncs were.

## Pin budget

`action.yml` is **identical** on both sides, so this does not change the deployed image digest and the deployment-candidate gate has nothing to verify. Lag stays at **4 of 5**.

Worth noting for anyone tracking #684: this sync does **not** exercise #705's fix, precisely because there is no digest change to reason about. That gets its first real test on a sync that crosses a manifest bump.

## Test plan

- [x] Merges clean — verified with `git merge-tree`, 0 conflicts.
- [x] `action.yml` identical between the branches; candidate gate has nothing to check.
- [x] Pin lag unchanged at 4 of 5.
- [ ] CI green on the merge result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
