### PR TITLE
review: close audit-r2 lane A review-integrity findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HEAD commit's patch; the single-commit diff stays an inspection artifact, so
   admissible citations, inline anchors and blast radius remain bound to the
   whole change under review (N3)
+- Default local review includes eligible untracked additions, so a brand-new
+  source file is reviewed without knowing an alternate flag; every exclusion —
+  gitignored, oversized, binary, symlink — is surfaced as a review-coverage
+  limitation, and an all-excluded diff can no longer render as a passed review
+  with "no changes to review" (N7)
 
 - The Action-pin staleness budget counts changes rather than landings. Without
   `--no-merges`, a PR touching `src/mergecraft/` scored twice — its own commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correctness; genuine style nits are still deflated (N4)
 - Category inference no longer returns on the first maintainability pattern match
   when a security signal is present in the same message (N20)
+- Corroborating duplicates can no longer weaken a finding: clustering keeps the
+  strongest member's severity while the agent's prose stays canonical wording,
+  and semantic dedupe keeps the strongest paraphrase with the discarded members'
+  evidence — a weaker copy arriving first can no longer turn a CI blocker green
+  (N5)
 
 - The Action-pin staleness budget counts changes rather than landings. Without
   `--no-merges`, a PR touching `src/mergecraft/` scored twice — its own commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and semantic dedupe keeps the strongest paraphrase with the discarded members'
   evidence — a weaker copy arriving first can no longer turn a CI blocker green
   (N5)
+- A partial analyzer rerun no longer erases earlier blockers: results are
+  retained by covered scope, so a clean pass over a file the first pass did not
+  cover leaves the prior finding, the shared finding count and the
+  terminal-approve rejection intact (N2)
+- `get_commit_info` can no longer replace the canonical review scope with the
+  HEAD commit's patch; the single-commit diff stays an inspection artifact, so
+  admissible citations, inline anchors and blast radius remain bound to the
+  whole change under review (N3)
 
 - The Action-pin staleness budget counts changes rather than landings. Without
   `--no-merges`, a PR touching `src/mergecraft/` scored twice — its own commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `config.runtime_provider_registry`, the single credential authority across every
   `authKind`, cloud suffix and spelling — the pinned drift that dropped
   `GOOGLE_API_KEY` is gone, and `AWS_SESSION_TOKEN` is covered (N21)
+- Critical and Major security findings are no longer demoted when incidental
+  maintainability or documentation words appear in the same message; the security
+  lane takes absolute precedence and capping rules are inapplicable when impact
+  evidence supports the asserted severity (N4)
+- Security category inference now recognizes `auth`/`unauth` stems and the named
+  vulnerability classes (RCE, deserialization, pickle, path traversal, SSRF, CSRF,
+  XXE, privilege escalation, prototype pollution, open redirect, hardcoded key)
+  (N20)
 
 ### Fixed
+
+- Incidental prose such as `readme`, `comment`, `style`, `naming` or `typo` no
+  longer caps `Critical`/`Major` findings whose core impact is security or
+  correctness; genuine style nits are still deflated (N4)
+- Category inference no longer returns on the first maintainability pattern match
+  when a security signal is present in the same message (N20)
 
 - The Action-pin staleness budget counts changes rather than landings. Without
   `--no-merges`, a PR touching `src/mergecraft/` scored twice — its own commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,11 +119,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Incidental prose such as `readme`, `comment`, `style`, `naming` or `typo` no
-  longer caps `Critical`/`Major` findings whose core impact is security or
-  correctness; genuine style nits are still deflated (N4)
-- Category inference no longer returns on the first maintainability pattern match
-  when a security signal is present in the same message (N20)
 - Corroborating duplicates can no longer weaken a finding: clustering keeps the
   strongest member's severity while the agent's prose stays canonical wording,
   and semantic dedupe keeps the strongest paraphrase with the discarded members'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outbound egress stays open and ChatGPT subscription auth (`CODEX_AUTH_JSON`) is
   not brokered; clear that secret and use `OPENAI_API_KEY` when broker coverage
   matters (#553)
+- The fork-head credential invariant now rejects indexed OAuth, device-code and
+  cloud-chain credentials (`LLM_PROVIDER_<N>_CLAUDE_CODE_OAUTH_TOKEN`,
+  `_CODEX_AUTH_JSON`, `_AWS_*`, `_GOOGLE_APPLICATION_CREDENTIALS`) instead of only
+  flat names and `_API_KEY`; a fork PR can no longer carry a credential past the
+  pre-dispatch rejection boundary (N1)
+- Indexed Codex `device_code` credentials reach the isolated run home's
+  `auth.json` and the broker reports `subscription`; `_setup_codex_auth` consumes
+  the resolved child mapping instead of reading `os.environ` (N19)
+- The fork-credential allowlist and the agent-env strip set both derive from
+  `config.runtime_provider_registry`, the single credential authority across every
+  `authKind`, cloud suffix and spelling — the pinned drift that dropped
+  `GOOGLE_API_KEY` is gone, and `AWS_SESSION_TOKEN` is covered (N21)
 
 ### Fixed
 

--- a/docs/test-plans/audit-r2-p1-review-integrity.md
+++ b/docs/test-plans/audit-r2-p1-review-integrity.md
@@ -2,7 +2,8 @@
 
 Plan: [`.ignorelocal/waves/20-audit-r2-a-p1-review-integrity-wave-plan.md`](../../.ignorelocal/waves/20-audit-r2-a-p1-review-integrity-wave-plan.md)
 Owner: `test-creator`. Wave RA1 authors the entire RED suite for RA2–RA6; each
-impl wave flips its own slice from `xfail(strict=False)` to green (D13b).
+impl wave flips its own slice green (D13b). All RA1 `xfail(strict=False)`
+markers were removed in the RA7 strictness sweep — see **RA1.7** below.
 
 Baseline for every RED assertion: `origin/main @ 059634b0`, reproduced by RA0 in
 `.ignorelocal/waves/evidence/ra0-baseline.txt`.
@@ -99,7 +100,7 @@ diff runner, because the defect is in what `git diff` omits.
 
 | Test | Owning wave | Change |
 | --- | --- | --- |
-| `tests/mcp/test_reviewer_resilience_degraded_scope.py::test_get_commit_info_registers_scope_for_pr_head` → renamed `test_get_commit_info_does_not_register_scope_for_pr_head` | RA5 (N3) | The old expectation pinned `get_commit_info` registering review scope for the PR head as intended behaviour. The contract inverted: the tool is `REPOSITORY_READ` and must not advance `review_phase` or set `primary.diff_path`. Docstring rewritten; tagged `xfail(strict=False)`. |
+| `tests/mcp/test_reviewer_resilience_degraded_scope.py::test_get_commit_info_registers_scope_for_pr_head` → renamed `test_get_commit_info_does_not_register_scope_for_pr_head` | RA5 (N3) | The old expectation pinned `get_commit_info` registering review scope for the PR head as intended behaviour. The contract inverted: the tool is `REPOSITORY_READ` and must not advance `review_phase` or set `primary.diff_path`. Docstring rewritten; the temporary `xfail(strict=False)` was removed in the RA7 sweep (RA1.7). |
 
 ### Identified but not modified (lane B ownership)
 
@@ -114,3 +115,59 @@ lane B before Final — this plan does not touch the file.
 No pre-existing test pins a *first-survivor* dedupe severity: `tests/findings/test_dedup.py`
 and `tests/analyzers/test_cluster.py` assert collapse counts, not which member
 survives. That gap is why the RA1.3 survival cases are new.
+
+## RA1.7 — strictness sweep (RA7 Step 1)
+
+After RA2–RA6 all landed, every RA1 `xfail(strict=False)` marker on the
+RA1.1–RA1.5 slices was removed. The tests are ordinary passing tests; **no
+`xfail` remains in the lane**. D13b is closed: the ratchet (`tests/conftest.py`
+session hook → `scripts/check_xpass.py`) reports **0 xpassed**.
+
+| Slice | File | `pytest.mark.xfail` declarations removed |
+| --- | --- | --- |
+| RA1.1 | `tests/security/test_fork_credential_invariant.py` | 1 |
+| RA1.1 | `tests/security/test_credential_authority_drift.py` | 1 |
+| RA1.1 | `tests/agents/test_codex_auth_indexed.py` | 1 |
+| RA1.2 | `tests/findings/test_severity_impact_pairs.py` | 1 |
+| RA1.2 | `tests/findings/test_security_vocabulary.py` | 1 |
+| RA1.2 | `tests/findings/test_severity_property.py` | 1 |
+| RA1.2 | `tests/findings/test_severity_end_to_end.py` | 1 |
+| RA1.3 | `tests/analyzers/test_cluster_severity.py` | 1 |
+| RA1.3 | `tests/analyzers/test_cluster_permutation.py` | 1 |
+| RA1.3 | `tests/findings/test_dedup_severity.py` | 1 |
+| RA1.4 | `tests/mcp/test_analyzer_rerun_retention.py` | 1 |
+| RA1.4 | `tests/mcp/test_commit_info_scope.py` | 1 |
+| RA1.4 | `tests/mcp/test_reviewer_resilience_degraded_scope.py` | 1 |
+| RA1.5 | `tests/utils/test_offline_diff_untracked.py` | 1 |
+| RA1.5 | `tests/utils/test_offline_diff_coverage_limits.py` | 1 |
+
+The 15 declarations decorated 48 test functions, collecting as **54 test
+cases** (parametrization expands the RA1.1/RA1.5 rows). `import pytest` was
+dropped from the eight files that used it only for the marker; in
+`tests/agents/test_codex_auth_indexed.py` the surviving `pytest.MonkeyPatch`
+annotation moved under `TYPE_CHECKING`.
+
+### Fixture repairs in the same commit (test-owned)
+
+1. `tests/utils/test_offline_diff_coverage_limits.py::_init_repo` created the
+   repo with `repo.mkdir()`, but callers pass `tmp_path/"clean"` /
+   `tmp_path/"excluded"`, whose parents did not exist — the fixture raised during
+   setup and the D12 case xfailed without ever exercising the product.
+   `mkdir(parents=True)` fixes it. The test now asserts the distinction it was
+   written for: a clean repo returns `empty is True` with **no** coverage
+   limitations, while an all-excluded diff (`huge.py` over the byte cap) reports
+   a coverage limitation, so the two empty states are distinguishable.
+2. `tests/instructions/test_offline_review_fence.py::_make_diff_repo` initialised
+   the reviewed repository at `tmp_path` itself, and both tests wrote their prompt
+   capture files into that same directory. Under RA6's D11 behaviour the run-1
+   capture became an eligible untracked addition, so run 2's diff gained a second
+   file and the outside-fence prompt diverged — a fixture artifact, not a fence
+   regression. The repo now lives at `tmp_path/repo` and the captures at
+   `tmp_path/*.txt`, outside the reviewed tree. Both runs materialize the same
+   one-file diff and the test asserts the fenced-body-only difference it intends.
+
+### Non-lane xfails
+
+Twelve `xfail` tests elsewhere in `tests/` (tracing/evals/evidence waves) remain
+and are genuine xfails; they are outside lane A and untouched. The repo-wide
+ratchet is clean: **0 xpassed**.

--- a/docs/test-plans/audit-r2-p1-review-integrity.md
+++ b/docs/test-plans/audit-r2-p1-review-integrity.md
@@ -1,0 +1,116 @@
+# Test plan — audit-r2 lane A: P1 review integrity (RA1)
+
+Plan: [`.ignorelocal/waves/20-audit-r2-a-p1-review-integrity-wave-plan.md`](../../.ignorelocal/waves/20-audit-r2-a-p1-review-integrity-wave-plan.md)
+Owner: `test-creator`. Wave RA1 authors the entire RED suite for RA2–RA6; each
+impl wave flips its own slice from `xfail(strict=False)` to green (D13b).
+
+Baseline for every RED assertion: `origin/main @ 059634b0`, reproduced by RA0 in
+`.ignorelocal/waves/evidence/ra0-baseline.txt`.
+
+## RA1.1 — credential authority (RA2: N1 / N19 / N21)
+
+| Contract (D-row) | Test file | Cases |
+| --- | --- | --- |
+| Fork invariant rejects indexed credentials before dispatch (D3, N1) | `tests/security/test_fork_credential_invariant.py` | `test_indexed_oauth_credential_is_rejected_on_fork_head`, `test_indexed_device_code_credential_is_rejected_on_fork_head`, `test_indexed_cloud_chain_credentials_are_rejected_on_fork_head`, `test_untrusted_tier_filtering_does_not_reintroduce_the_credential` |
+| Flat spellings and same-repo events are untouched (guards) | same file | `test_flat_legacy_spellings_stay_rejected`, `test_same_repo_event_with_every_auth_kind_is_permitted` |
+| Both consumer sets derive from the provider registry (D2) | `tests/security/test_credential_authority_drift.py` | `test_fork_invariant_covers_every_registry_credential_name`, `test_agent_env_filter_covers_every_registry_credential_name`, `test_indexed_registry_credential_is_rejected_on_fork_head`, `test_google_api_key_is_present_in_both_sets` |
+| Indexed Codex credential reaches the run home's `auth.json` (D4, N19) | `tests/agents/test_codex_auth_indexed.py` | `test_indexed_codex_auth_json_writes_run_home_auth_file`, `test_flat_codex_auth_json_still_writes_auth_file` (control), `test_indexed_and_flat_conflict_resolves_to_the_registry_credential`, `test_setup_codex_auth_does_not_read_ambient_os_environ` |
+
+The drift tests derive the registry's credential names from
+`credential_env_keys_for_entry` / `_credential_suffixes_for_entry` over one
+entry per `authKind` (`api_key`, `oauth`, `device_code`, `cloud_chain` bedrock,
+`cloud_chain` vertex) and both spellings, so a provider added to one consumer
+and not the other fails with a named list.
+
+## RA1.2 — impact-based severity (RA3: N4 / N20)
+
+| Contract (D-row) | Test file | Cases |
+| --- | --- | --- |
+| Matched-paraphrase pairs agree (D15) | `tests/findings/test_severity_impact_pairs.py` | the six r2 rows (`readme`, `comment`, `style`, `naming`, `typo`, correctness-`comment`) plus `test_control_paraphrases_retain_their_asserted_severity` |
+| Auth stems and named classes infer Security (D6) | `tests/findings/test_security_vocabulary.py` | `test_auth_stems_infer_security_category`, `test_named_security_classes_infer_security_category`, `test_genuine_style_nit_is_still_capped` (deflation guard) |
+| No impact-preserving lexical change crosses a blocking boundary (property) | `tests/findings/test_severity_property.py` | `test_no_impact_preserving_lexical_change_crosses_a_blocking_boundary` |
+| Inference → cap → `BLOCKING_SEVERITIES` → `decide_approval` (D14) | `tests/findings/test_severity_end_to_end.py` | `test_critical_security_finding_reaches_decide_approval_as_blocking` |
+
+### Property tests and their corpus
+
+`tests/findings/test_severity_property.py` is the only Hypothesis property in
+this lane's slice. It draws from two fixed corpora in
+`tests/findings/fixtures/severity_pairs.py`:
+
+- `IMPACT_STATEMENTS` — eight `(severity, impact)` rows: six security impacts
+  asserted `Critical` and two correctness impacts asserted `Major`.
+- `INCIDENTAL_TOKENS` — six docs/style tokens (`see README`, `see the comment`,
+  `style`, `naming`, `typo`, `docstring`).
+
+For every sampled `(impact, incidental)` pair the test runs the paraphrased
+message through the real `infer_category_from_message` + `apply_severity_rubric`
+composition and asserts the incidental member's severity equals the control's.
+`max_examples=40`, `deadline=None`.
+
+`tests/analyzers/test_cluster_permutation.py` and
+`tests/findings/test_dedup_severity.py::test_dedupe_result_is_permutation_invariant`
+are exhaustive permutation properties (no Hypothesis) over small fixed input
+sets, because the audit's order-dependence is small-n.
+
+## RA1.3 — severity-preserving collapse (RA4: N5)
+
+| Contract (D-row) | Test file | Cases |
+| --- | --- | --- |
+| Corroboration cannot lower a blocker (D7) | `tests/analyzers/test_cluster_severity.py` | `test_major_alone_and_major_plus_minor_duplicate_gate_identically`, `test_corroboration_cannot_lower_should_verify` |
+| Wording vs severity are separate selections (D8) | same file | `test_canonical_keeps_agent_wording_but_not_a_weaker_severity` |
+| Cluster is permutation-invariant | `tests/analyzers/test_cluster_permutation.py` | `test_cluster_result_is_permutation_invariant` |
+| Semantic dedupe keeps the strongest survivor | `tests/findings/test_dedup_severity.py` | `test_semantic_dedupe_keeps_the_strongest_survivor`, `test_dedupe_result_is_permutation_invariant`, `test_evidence_from_discarded_members_is_retained`, `test_kept_indices_still_point_at_the_surviving_row` |
+
+`test_kept_indices_still_point_at_the_surviving_row` is the cross-lane contract:
+lane B's RB6 (`findings/agent_adapter._apply_row_level_precision`) realigns
+original rows on `kept_indices`, so the index must name the row actually kept.
+
+## RA1.4 — canonical scope and evidence retention (RA5: N2 / N3)
+
+| Contract (D-row) | Test file | Cases |
+| --- | --- | --- |
+| Retention by covered scope (D9) | `tests/mcp/test_analyzer_rerun_retention.py` | `test_clean_partial_rerun_does_not_erase_a_prior_blocker`, `test_same_scope_rerun_supersedes` (guard), `test_unavailable_analyzer_rerun_does_not_supersede`, `test_no_match_rerun_does_not_supersede`, `test_concurrent_overlapping_runs_do_not_lose_findings`, `test_terminal_approve_stays_rejected_after_a_partial_clean_rerun` |
+| A metadata read may not register scope (D10) | `tests/mcp/test_commit_info_scope.py` | `test_get_commit_info_does_not_change_canonical_scope`, `test_get_commit_info_still_returns_a_usable_diff_file` (control), `test_admissible_changed_files_survive_head_inspection`, `test_blast_radius_survives_head_inspection`, `test_inline_anchors_survive_head_inspection` |
+
+`test_concurrent_overlapping_runs_do_not_lose_findings` drives two overlapping
+scopes through `asyncio.gather`. The two-commit PR fixture lives in
+`tests/mcp/support_two_commit_pr.py`: commit 1 touches `security.py`, commit 2
+touches `docs.md`, and a recording SCM returns per-commit patches.
+
+## RA1.5 — untracked source in default local review (RA6: N7)
+
+| Contract (D-row) | Test file | Cases |
+| --- | --- | --- |
+| Default materialization includes eligible untracked adds (D11) | `tests/utils/test_offline_diff_untracked.py` | `test_default_materialization_includes_an_untracked_addition`, `test_mixed_tracked_and_untracked_changes_include_both`, `test_unicode_quoted_path_is_included` |
+| Staged and commit-range semantics are unchanged (guards) | same file | `test_staged_mode_semantics_are_unchanged`, `test_commit_range_semantics_are_unchanged` |
+| Every exclusion is visible | same file | `test_gitignored_file_is_excluded`, `test_oversized_untracked_file_is_excluded_and_reported`, `test_binary_untracked_file_is_excluded_and_reported`, `test_symlink_is_excluded` |
+| Empty states are distinguishable (D12) | `tests/utils/test_offline_diff_coverage_limits.py` | `test_exclusions_are_reported_as_review_coverage_limitations`, `test_empty_because_nothing_changed_is_distinguishable_from_empty_because_excluded` |
+
+All RA1.5 cases use real `git init` repositories in `tmp_path`; none mock the
+diff runner, because the defect is in what `git diff` omits.
+
+## RA1.6 — fixtures and inverted expectations
+
+- Two-commit PR fixture: `tests/mcp/support_two_commit_pr.py`.
+- Severity corpus: `tests/findings/fixtures/severity_pairs.py`.
+- `docs/test-plans/audit-r2-p1-review-integrity.md` (this file).
+
+### Pre-existing tests whose expectation was inverted
+
+| Test | Owning wave | Change |
+| --- | --- | --- |
+| `tests/mcp/test_reviewer_resilience_degraded_scope.py::test_get_commit_info_registers_scope_for_pr_head` → renamed `test_get_commit_info_does_not_register_scope_for_pr_head` | RA5 (N3) | The old expectation pinned `get_commit_info` registering review scope for the PR head as intended behaviour. The contract inverted: the tool is `REPOSITORY_READ` and must not advance `review_phase` or set `primary.diff_path`. Docstring rewritten; tagged `xfail(strict=False)`. |
+
+### Identified but not modified (lane B ownership)
+
+`tests/findings/test_agent_adapter.py::test_category_hints_match_whole_tokens_not_substrings`
+is lane B's file (Parallel contract: `tests/findings/test_agent_adapter*.py`).
+Its first assertion pins `infer_category_from_message("Update the author bio copy")`
+to `Functional Correctness`. If RA3 relaxes `\bauth\b` to `\bauth\w*\b`, that
+pattern also matches `author`, so the assertion would flip. RA3 must either
+narrow the stem (exclude `author`) or coordinate the expectation change with
+lane B before Final — this plan does not touch the file.
+
+No pre-existing test pins a *first-survivor* dedupe severity: `tests/findings/test_dedup.py`
+and `tests/analyzers/test_cluster.py` assert collapse counts, not which member
+survives. That gap is why the RA1.3 survival cases are new.

--- a/docs/test-plans/audit-r2-p1-review-integrity.md
+++ b/docs/test-plans/audit-r2-p1-review-integrity.md
@@ -29,6 +29,8 @@ and not the other fails with a named list.
 | --- | --- | --- |
 | Matched-paraphrase pairs agree (D15) | `tests/findings/test_severity_impact_pairs.py` | the six r2 rows (`readme`, `comment`, `style`, `naming`, `typo`, correctness-`comment`) plus `test_control_paraphrases_retain_their_asserted_severity` |
 | Auth stems and named classes infer Security (D6) | `tests/findings/test_security_vocabulary.py` | `test_auth_stems_infer_security_category`, `test_named_security_classes_infer_security_category`, `test_genuine_style_nit_is_still_capped` (deflation guard) |
+| Author-family prose is **not** a security signal (RA3 regression) | `tests/findings/test_security_vocabulary.py` | `test_security_auth_forms_infer_security_category` (×8), `test_unauth_forms_infer_security_category` (×2), `test_author_family_prose_does_not_infer_security_category` (×8) |
+| An author-family word does not cross a blocking boundary (D5/D15) | `tests/findings/test_severity_impact_pairs.py` | `test_author_family_pair_agrees_on_severity` (×4), `test_style_nit_with_authors_tail_is_not_raised_to_blocking`, `test_style_nit_with_authorship_in_the_core_is_not_raised_to_blocking`, `test_docs_nit_with_authoritative_tail_is_not_raised_to_blocking`, `test_correctness_impact_keeps_its_asserted_severity_with_an_authors_tail` |
 | No impact-preserving lexical change crosses a blocking boundary (property) | `tests/findings/test_severity_property.py` | `test_no_impact_preserving_lexical_change_crosses_a_blocking_boundary` |
 | Inference → cap → `BLOCKING_SEVERITIES` → `decide_approval` (D14) | `tests/findings/test_severity_end_to_end.py` | `test_critical_security_finding_reaches_decide_approval_as_blocking` |
 
@@ -40,13 +42,36 @@ this lane's slice. It draws from two fixed corpora in
 
 - `IMPACT_STATEMENTS` — eight `(severity, impact)` rows: six security impacts
   asserted `Critical` and two correctness impacts asserted `Major`.
-- `INCIDENTAL_TOKENS` — six docs/style tokens (`see README`, `see the comment`,
-  `style`, `naming`, `typo`, `docstring`).
+- `INCIDENTAL_TOKENS` — thirteen tokens: six docs/style tokens (`see README`,
+  `see the comment`, `style`, `naming`, `typo`, `docstring`) plus seven
+  author-family prose tokens (`authors`, `authoring`, `authored`, `authorship`,
+  `authoritative`, `authority`, `authorities`).
 
 For every sampled `(impact, incidental)` pair the test runs the paraphrased
 message through the real `infer_category_from_message` + `apply_severity_rubric`
 composition and asserts the incidental member's severity equals the control's.
 `max_examples=40`, `deadline=None`.
+
+### RA1.2 follow-up — author-family regression (RA3)
+
+RA3's stem relaxation (`\bauth(?!or\b)\w*`) still matched `authors`,
+`authoring`, `authored`, `authoritative`, `authority`, `authorities` and
+`authorship`, so an incidental prose word could infer `Security & Privacy` and
+— because the security lane is non-capping (D5) — keep a style/docs finding at
+`Critical`/`Major` and block approval. The follow-up narrows the lookahead to
+`\bauth(?!or(?!iz))\w*` and these tests pin the observable contract:
+
+- `tests/findings/test_security_vocabulary.py` — the eight security `auth`
+  forms still infer Security, the two `unauth` forms keep their own pattern
+  (guard), and the eight `author`-family prose forms infer the same non-security
+  category as an author-free control (the exact other category is not pinned).
+- `tests/findings/test_severity_impact_pairs.py` — matched author-family pairs
+  (`AUTHOR_FAMILY_PAIRS` in `tests/findings/fixtures/severity_pairs.py`): a
+  style nit and a docs nit with/without an incidental author word must agree on
+  a **non-blocking** severity and reach `decide_approval` as `success`, while a
+  genuine correctness impact keeps its asserted `Critical`.
+- `tests/findings/test_severity_property.py` — the property corpus now samples
+  the author-family tokens (`INCIDENTAL_TOKENS`).
 
 `tests/analyzers/test_cluster_permutation.py` and
 `tests/findings/test_dedup_severity.py::test_dedupe_result_is_permutation_invariant`
@@ -93,7 +118,9 @@ diff runner, because the defect is in what `git diff` omits.
 ## RA1.6 — fixtures and inverted expectations
 
 - Two-commit PR fixture: `tests/mcp/support_two_commit_pr.py`.
-- Severity corpus: `tests/findings/fixtures/severity_pairs.py`.
+- Severity corpus: `tests/findings/fixtures/severity_pairs.py` (`SEVERITY_PAIRS`,
+  `IMPACT_STATEMENTS`, `INCIDENTAL_TOKENS`, and the RA1.2 follow-up
+  `AUTHOR_FAMILY_PAIRS` / `AuthorFamilyPair`).
 - `docs/test-plans/audit-r2-p1-review-integrity.md` (this file).
 
 ### Pre-existing tests whose expectation was inverted
@@ -111,6 +138,9 @@ to `Functional Correctness`. If RA3 relaxes `\bauth\b` to `\bauth\w*\b`, that
 pattern also matches `author`, so the assertion would flip. RA3 must either
 narrow the stem (exclude `author`) or coordinate the expectation change with
 lane B before Final — this plan does not touch the file.
+The RA1.2 follow-up above narrows the lookahead further so the whole `author`
+family (`authors`, `authority`, `authoritative`, …) stays non-security; lane B's
+single-`author` assertion remains satisfied.
 
 No pre-existing test pins a *first-survivor* dedupe severity: `tests/findings/test_dedup.py`
 and `tests/analyzers/test_cluster.py` assert collapse counts, not which member

--- a/src/mergecraft/action/inputs.py
+++ b/src/mergecraft/action/inputs.py
@@ -21,7 +21,11 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any, Literal
 
-from mergecraft.config.settings import TraceSinkEntry, TracingSettings
+from mergecraft.config.runtime_provider_registry import (
+    provider_credential_env_names,
+    provider_credential_env_suffixes,
+)
+from mergecraft.config.settings import RepoSettings, TraceSinkEntry, TracingSettings
 from mergecraft.config.trust_policy import is_fork_pull_request
 
 if TYPE_CHECKING:
@@ -347,8 +351,6 @@ def apply_setup_overrides(settings: Any) -> Any:
     Invalid values from the action input raise before the run starts — the
     outer catch maps them to ``RunOutcome.configuration_error``.
     """
-    from mergecraft.config.settings import RepoSettings
-
     if not isinstance(settings, RepoSettings):
         return settings
 
@@ -369,41 +371,40 @@ class ForkCredentialInvariantError(RuntimeError):
     """Fork head + provider credential present — refuse before review starts (D2b)."""
 
 
-_PROVIDER_CREDENTIAL_ENV_KEYS: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "OPENAI_API_KEY",
-        "CODEX_AUTH_JSON",
-        "NOUS_API_KEY",
-        "TOKENHUB_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_GENERATIVE_AI_API_KEY",
-        "CURSOR_API_KEY",
-        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
-        "AWS_BEARER_TOKEN_BEDROCK",
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "GOOGLE_APPLICATION_CREDENTIALS",
-        "VERTEX_SERVICE_ACCOUNT_JSON",
-    }
-)
+# Derived from the one credential authority (D2). The set covers every
+# ``authKind``, every cloud suffix and both spellings; ``_provider_credential_present``
+# additionally scans for indexed names the sweep did not enumerate.
+_PROVIDER_CREDENTIAL_ENV_KEYS: frozenset[str] = provider_credential_env_names()
+_PROVIDER_CREDENTIAL_SUFFIXES: frozenset[str] = provider_credential_env_suffixes()
+_INDEXED_PROVIDER_CREDENTIAL_PREFIX = "LLM_PROVIDER_"
+_CUSTOM_PROVIDER_API_KEY_PREFIX = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_"
 
 
-def _provider_credential_present(env: Mapping[str, str]) -> bool:
-    for key in _PROVIDER_CREDENTIAL_ENV_KEYS:
+def _is_indexed_credential_key(key: str) -> bool:
+    """Return whether *key* is ``LLM_PROVIDER_<N>_<credential-suffix>`` (any N)."""
+    if not key.startswith(_INDEXED_PROVIDER_CREDENTIAL_PREFIX):
+        return False
+    return any(key.endswith(f"_{suffix}") for suffix in _PROVIDER_CREDENTIAL_SUFFIXES)
+
+
+def _provider_credential_present(
+    env: Mapping[str, str],
+    settings: RepoSettings | None = None,
+) -> bool:
+    keys = _PROVIDER_CREDENTIAL_ENV_KEYS
+    if settings is not None:
+        keys = keys | provider_credential_env_names(settings)
+    for key in keys:
         value = env.get(key)
         if isinstance(value, str) and value.strip():
             return True
     for key, value in env.items():
         if not isinstance(value, str) or not value.strip():
             continue
-        if key.startswith("MERGECRAFT_CUSTOM_PROVIDER_API_KEY_"):
+        if key.startswith(_CUSTOM_PROVIDER_API_KEY_PREFIX):
             return True
-        if key.startswith("LLM_PROVIDER_") and key.endswith("_API_KEY"):
+        if _is_indexed_credential_key(key):
             return True
-        if key.startswith("MERGECRAFT_CUSTOM_PROVIDER_BASE_URL_"):
-            continue
     return False
 
 
@@ -412,16 +413,19 @@ def validate_fork_credential_invariant(
     event: dict[str, Any],
     env: Mapping[str, str] | None = None,
     agent_sandbox_tier: str | None = None,
+    settings: RepoSettings | None = None,
 ) -> None:
     """Refuse fork-head runs that carry provider credentials (lane B D2b).
 
-    Independent of ``trust.agentSandbox`` and the consumer workflow YAML.
+    Independent of ``trust.agentSandbox`` and the consumer workflow YAML. The
+    check is on credential *presence* (D3), not on whether a running agent can
+    reach the credential; it runs before any provider is selected.
     """
     _ = agent_sandbox_tier
     if not is_fork_pull_request(event):
         return
     env_map = env if env is not None else os.environ
-    if not _provider_credential_present(env_map):
+    if not _provider_credential_present(env_map, settings):
         return
     msg = (
         "refusing fork pull request run: provider credentials are present in the "

--- a/src/mergecraft/agents/codex.py
+++ b/src/mergecraft/agents/codex.py
@@ -55,6 +55,8 @@ from mergecraft.utils.provider_failure import is_retryable_cli_failure
 from mergecraft.utils.secrets import build_agent_env
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mergecraft.tracing.tracer import Tracer
 
 CODEX_AUTH_ENV = "CODEX_AUTH_JSON"
@@ -220,8 +222,17 @@ def _setup_codex_auth(
     ctx: AgentRunContext,
     *,
     codex_home: Path,
+    credential_env: Mapping[str, str] | None = None,
 ) -> None:
-    raw = os.environ.get(CODEX_AUTH_ENV, "").strip()
+    """Write the isolated run home's ``auth.json`` from resolved credentials.
+
+    ``credential_env`` is the resolved child mapping (registry credential
+    outranks the legacy flat spelling); only when a caller omits it — the
+    direct-call contract used by the credential tests — is ``os.environ`` read.
+    Never mutates ``os.environ`` (D4).
+    """
+    source: Mapping[str, str] = credential_env if credential_env is not None else os.environ
+    raw = source.get(CODEX_AUTH_ENV, "").strip()
     if raw and subscription_auth_usable(raw):
         codex_home.mkdir(parents=True, exist_ok=True)
         auth_path = codex_home / "auth.json"
@@ -235,6 +246,29 @@ def _setup_codex_auth(
         )
     if _has_openai_api_key():
         logger.info("using {} for Codex CLI authentication", OPENAI_API_KEY_ENV)
+
+
+def _with_flat_codex_auth(env: dict[str, str]) -> dict[str, str]:
+    """Carry the legacy flat ``CODEX_AUTH_JSON`` into *env* when the registry did not.
+
+    Registry-backed credentials outrank the flat spelling (``build_agent_env``
+    maps them first); this only fills the gap so ``_setup_codex_auth`` and the
+    broker-posture selection consume one resolved mapping (D4).
+    """
+    if CODEX_AUTH_ENV not in env:
+        flat = os.environ.get(CODEX_AUTH_ENV, "").strip()
+        if flat:
+            env[CODEX_AUTH_ENV] = flat
+    return env
+
+
+def _resolved_parent_credentials(ctx: AgentRunContext) -> dict[str, str]:
+    """Return Codex's resolved parent credentials, excluding any broker token.
+
+    The per-run broker throwaway is injected later by :func:`_build_env`; posture
+    must be decided by what the parent actually holds.
+    """
+    return _with_flat_codex_auth(build_agent_env("codex", model=ctx.resolved_model))
 
 
 def _codex_mcp_tool_preamble() -> str:
@@ -573,6 +607,7 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
         # in build_agent_env so the real parent key never reaches the agent.
         extra[OPENAI_API_KEY_ENV] = handle.token
     env = build_agent_env("codex", extra, model=ctx.resolved_model)
+    _with_flat_codex_auth(env)
     if broker_active:
         # Respect the filtered child env: never restore denied parent variables.
         bypass: dict[str, str] = {}
@@ -582,7 +617,7 @@ def _build_env(ctx: AgentRunContext) -> dict[str, str]:
                 if entry:
                     bypass.setdefault(entry.casefold(), entry)
         env["NO_PROXY"] = env["no_proxy"] = ",".join(bypass.values())
-    _setup_codex_auth(ctx, codex_home=codex_home)
+    _setup_codex_auth(ctx, codex_home=codex_home, credential_env=env)
     # write_mcp_config() and _setup_codex_auth() both write into $CODEX_HOME
     # (config.toml, mergecraft-instructions.md, auth.json) while this process
     # still runs as root. wrap_agent_command()'s setpriv drops the actual
@@ -772,7 +807,11 @@ async def _run(ctx: AgentRunContext) -> AgentResult:
     except FileNotFoundError as err:
         return AgentResult(success=False, error=str(err))
 
-    initial_posture = resolve_codex_broker_posture()
+    credential_env = _resolved_parent_credentials(ctx)
+    initial_posture = resolve_codex_broker_posture(
+        codex_auth_json=credential_env.get(CODEX_AUTH_ENV, ""),
+        openai_api_key=credential_env.get(OPENAI_API_KEY_ENV, ""),
+    )
     try:
         broker_session = begin_broker_session(posture=initial_posture)
     except RuntimeError as err:

--- a/src/mergecraft/analyzers/cluster.py
+++ b/src/mergecraft/analyzers/cluster.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from mergecraft.analyzers.finding import Finding, make_finding
+from mergecraft.evidence.merge import _severity_rank
 from mergecraft.review_taxonomy import FINDING_CONFIDENCES, finding_fingerprint
 
 _CONFIDENCE_RANK = {name: index for index, name in enumerate(FINDING_CONFIDENCES)}
@@ -19,12 +20,27 @@ def _raise_confidence(confidence: str, steps: int = 1) -> str:
     return FINDING_CONFIDENCES[rank]
 
 
+def _strongest_confidence(members: list[Finding]) -> str:
+    """Return the highest-confidence member's grade (lowest rank wins)."""
+    rank = min(_CONFIDENCE_RANK.get(member.confidence, 0) for member in members)
+    return FINDING_CONFIDENCES[rank]
+
+
 def _evidence_entry(finding: Finding) -> str:
     return f"{finding.tool}:{finding.rule_id} — {finding.message}"
 
 
 def _merge_into_canonical(members: list[Finding]) -> Finding:
-    """Merge same-cluster findings into one canonical finding."""
+    """Merge same-cluster findings into one canonical finding.
+
+    Wording and severity are selected independently (D8). Canonical *wording*
+    keeps the agent-prose preference — that is why the selection below prefers
+    ``source == "agent"``. Canonical *severity* is the strongest member's, via
+    the shared ``evidence.merge._severity_rank`` helper, so a corroborating
+    duplicate can never downgrade a CI blocker behind a weaker copy. Evidence
+    from every member is retained; a discarded member's evidence is the
+    corroboration.
+    """
     agent_members = [member for member in members if member.source == "agent"]
     ci_members = [member for member in members if member.source == "ci"]
     analyzer_members = [member for member in members if member.source == "analyzer"]
@@ -35,6 +51,8 @@ def _merge_into_canonical(members: list[Finding]) -> Finding:
         canonical = ci_members[0]
     else:
         canonical = sorted(analyzer_members, key=lambda item: item.tool)[0]
+
+    strongest = min(members, key=_severity_rank)
 
     evidence: list[str] = []
     seen_evidence: set[str] = set()
@@ -50,13 +68,18 @@ def _merge_into_canonical(members: list[Finding]) -> Finding:
     confidence = canonical.confidence
     if corroboration:
         confidence = _raise_confidence(confidence, min(corroboration, 2))
+    # A weaker canonical must not drag confidence below the strongest member's:
+    # corroboration may raise confidence, never lower it.
+    floor = _strongest_confidence(members)
+    if _CONFIDENCE_RANK.get(confidence, 0) > _CONFIDENCE_RANK.get(floor, 0):
+        confidence = floor
 
     key = cluster_key(canonical)
     return make_finding(
         tool=canonical.tool,
         rule_id=canonical.rule_id,
         category=canonical.category,
-        severity=canonical.severity,
+        severity=strongest.severity,
         confidence=confidence,
         message=canonical.message,
         path=canonical.path,

--- a/src/mergecraft/config/runtime_provider_registry.py
+++ b/src/mergecraft/config/runtime_provider_registry.py
@@ -6,8 +6,6 @@ import os
 import warnings
 from typing import TYPE_CHECKING
 
-from mergecraft.config.provider_registry import BUILTIN_HARNESS_DEFAULTS
-
 if TYPE_CHECKING:
     from mergecraft.config.settings import ProviderRegistryEntry, RepoSettings
 
@@ -31,6 +29,36 @@ _BEDROCK_CLOUD_SUFFIXES: tuple[str, ...] = (
 )
 
 _VERTEX_CLOUD_SUFFIXES: tuple[str, ...] = ("GOOGLE_APPLICATION_CREDENTIALS",)
+
+# Credential-bearing cloud suffixes — a *presence* vocabulary (D3), deliberately
+# wider than ``_credential_suffixes_for_entry`` ("which single value authenticates
+# the entry"). A session token or a Bedrock bearer token is a credential in the
+# environment even though it cannot satisfy a ``cloud_chain`` entry on its own.
+_CLOUD_CREDENTIAL_SUFFIXES: tuple[str, ...] = (
+    *_BEDROCK_CLOUD_SUFFIXES,
+    "AWS_SESSION_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    *_VERTEX_CLOUD_SUFFIXES,
+    "VERTEX_SERVICE_ACCOUNT_JSON",
+)
+
+# Flat credential spellings with no indexed-suffix equivalent: legacy aliases and
+# ambient aliases the built-in harnesses accept.
+_AMBIENT_CREDENTIAL_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "NOUS_API_KEY",
+        "TOKENHUB_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
+    }
+)
+
+# Indexed credentials are swept over this range when no registry rows are
+# available, so the fork invariant still fails closed on an index the operator
+# has not configured. Registry rows extend the sweep with their own ``envIndex``.
+_DEFAULT_ENV_INDEX_SWEEP: tuple[int, ...] = tuple(range(1, 32))
+_CUSTOM_PROVIDER_API_KEY_PREFIX = "MERGECRAFT_CUSTOM_PROVIDER_API_KEY_"
 
 _BUILTIN_LABEL_TO_HARNESS_API_KEY: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
@@ -278,6 +306,49 @@ def _harness_env_name_for_suffix(label: str, suffix: str) -> str | None:
     return None
 
 
+def provider_credential_env_suffixes() -> frozenset[str]:
+    """Every credential-bearing env suffix the registry can consume."""
+    return frozenset((*_AUTH_KIND_PRIMARY_SUFFIX.values(), *_CLOUD_CREDENTIAL_SUFFIXES))
+
+
+def _credential_env_indices(settings: RepoSettings | None) -> tuple[int, ...]:
+    indices = set(_DEFAULT_ENV_INDEX_SWEEP)
+    if settings is not None:
+        indices.update(entry.env_index for entry in settings.providers)
+    return tuple(sorted(indices))
+
+
+def provider_credential_env_names(settings: RepoSettings | None = None) -> frozenset[str]:
+    """Return every env name the registry can consume as a provider credential (D2).
+
+    Covers every ``authKind`` (``api_key``, ``oauth``, ``device_code``,
+    ``cloud_chain``), every cloud suffix, and both the flat and
+    ``LLM_PROVIDER_<N>_<SUFFIX>`` spellings — plus the indexed
+    ``MERGECRAFT_CUSTOM_PROVIDER_API_KEY_<N>`` workflow secret. *settings*
+    extends the indexed sweep with the operator's configured ``envIndex`` values.
+
+    This is the sole authority for "is this env var a provider credential?".
+    ``action.inputs`` and ``utils.secrets`` derive from it; the drift test fails
+    when a consumer stops deriving.
+    """
+    names: set[str] = set(_AMBIENT_CREDENTIAL_ENV_NAMES)
+    names.update(_BUILTIN_LABEL_TO_HARNESS_API_KEY.values())
+    names.update(_CLOUD_CREDENTIAL_SUFFIXES)
+    names.update(_AUTH_KIND_PRIMARY_SUFFIX.values())
+    if settings is not None:
+        for entry in settings.providers:
+            for suffix in _credential_suffixes_for_entry(entry):
+                harness_name = _harness_env_name_for_suffix(entry.label, suffix)
+                if harness_name is not None:
+                    names.add(harness_name)
+    suffixes = provider_credential_env_suffixes()
+    for index in _credential_env_indices(settings):
+        names.add(f"{_CUSTOM_PROVIDER_API_KEY_PREFIX}{index}")
+        for suffix in suffixes:
+            names.add(indexed_env_key(index, suffix))
+    return frozenset(names)
+
+
 def _read_indexed_credential_value(entry: ProviderRegistryEntry, suffix: str) -> str | None:
     value = _read_env_value(indexed_env_key(entry.env_index, suffix))
     if value:
@@ -342,6 +413,11 @@ def infer_harness_for_slug(
     if registry_harness is not None:
         return registry_harness
 
+    # Imported lazily: ``config.provider_registry`` pulls in ``utils.agent_resolve``
+    # which imports this module back. A top-level import would make this module
+    # unusable as the credential authority for ``utils.secrets``.
+    from mergecraft.config.provider_registry import BUILTIN_HARNESS_DEFAULTS
+
     builtin = BUILTIN_HARNESS_DEFAULTS.get(provider)
     if builtin is not None:
         return builtin
@@ -370,6 +446,8 @@ __all__ = [
     "legacy_opencode_harness_for_unregistered_provider",
     "lookup_registry_entry",
     "lookup_registry_entry_by_env_index",
+    "provider_credential_env_names",
+    "provider_credential_env_suffixes",
     "registry_harness_for_provider",
     "resolve_legacy_nous_gateway_endpoint",
     "resolve_registry_gateway_endpoint",

--- a/src/mergecraft/evidence/merge.py
+++ b/src/mergecraft/evidence/merge.py
@@ -131,6 +131,7 @@ def merge_findings(*groups: list[Finding]) -> list[Finding]:
 
 
 __all__ = [
+    "_severity_rank",
     "finding_dedupe_key",
     "merge_findings",
     "typed_findings_from_rows",

--- a/src/mergecraft/findings/dedup.py
+++ b/src/mergecraft/findings/dedup.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import TYPE_CHECKING
 
+from mergecraft.evidence.merge import _severity_rank
 from mergecraft.review_policy.paths import normalize_repo_path
 from mergecraft.review_policy.security_tokens import DOMAIN_HINT_GROUPS
 
@@ -203,8 +204,42 @@ def _location_key(finding: Finding) -> tuple[str, int | None, int | None, str]:
     )
 
 
+def _strongest_member(cluster: list[tuple[int, Finding]]) -> tuple[int, Finding]:
+    """Select the most severe member of a semantic cluster (N5, D7).
+
+    Dedup must not let a weaker paraphrase arriving first hide a blocker. The
+    survivor is the strongest member by the shared ``evidence.merge`` ranking,
+    and its original index is returned alongside it so ``kept_indices`` points
+    at the row actually kept (lane B's RB6 realigns on those indices).
+    """
+    return min(cluster, key=lambda item: (_severity_rank(item[1]), item[0]))
+
+
+def _merge_member_evidence(survivor: Finding, cluster: list[tuple[int, Finding]]) -> None:
+    """Fold every discarded member's evidence into the survivor, in place.
+
+    The survivor object is returned as-is (not copied) so identity is
+    preserved; its evidence list is the one field this helper may change.
+    """
+    merged = list(survivor.evidence)
+    seen = set(merged)
+    for _, member in cluster:
+        if member is survivor:
+            continue
+        for entry in member.evidence:
+            if entry not in seen:
+                merged.append(entry)
+                seen.add(entry)
+    survivor.evidence = merged
+
+
 def dedupe_findings_with_indices(findings: list[Finding]) -> DedupeResult:
-    """Return deduped findings and the input indices that survived."""
+    """Return deduped findings and the input indices that survived.
+
+    Within a semantic cluster the survivor is the **strongest** member, not the
+    first: corroborating paraphrases augment evidence, they do not dilute
+    severity. ``kept_indices`` names the row actually kept.
+    """
     if not findings:
         return DedupeResult(findings=[], kept_indices=[])
 
@@ -227,7 +262,8 @@ def dedupe_findings_with_indices(findings: list[Finding]) -> DedupeResult:
             if not placed:
                 clusters.append([(index, finding)])
         for cluster in clusters:
-            survivor_index, survivor = cluster[0]
+            survivor_index, survivor = _strongest_member(cluster)
+            _merge_member_evidence(survivor, cluster)
             deduped.append(survivor)
             kept_indices.append(survivor_index)
     return DedupeResult(findings=deduped, kept_indices=kept_indices)

--- a/src/mergecraft/findings/severity_rubric.py
+++ b/src/mergecraft/findings/severity_rubric.py
@@ -47,10 +47,64 @@ SEVERITY_RUBRIC: Final[tuple[_RubricRule, ...]] = (
     },
 )
 
-_COMPILED: Final[tuple[tuple[_RubricRule, tuple[re.Pattern[str], ...]], ...]] = tuple(
-    (rule, tuple(re.compile(pattern, re.IGNORECASE) for pattern in rule["patterns"]))
+_SECURITY_RULE_ID: Final[str] = "security-signal"
+_ASSERTED_BLOCKING_SEVERITIES: Final[frozenset[str]] = frozenset({"Critical", "Major"})
+
+_RULES_BY_ID: Final[dict[str, _RubricRule]] = {str(rule["id"]): rule for rule in SEVERITY_RUBRIC}
+_SECURITY_RULE: Final[_RubricRule] = _RULES_BY_ID[_SECURITY_RULE_ID]
+
+
+def _compile_patterns(rule: _RubricRule) -> tuple[re.Pattern[str], ...]:
+    return tuple(re.compile(pattern, re.IGNORECASE) for pattern in rule["patterns"])
+
+
+_SECURITY_PATTERNS: Final[tuple[re.Pattern[str], ...]] = _compile_patterns(_SECURITY_RULE)
+#: Every category rule except the security lane. Security is handled explicitly
+#: first (D5), so its position in ``SEVERITY_RUBRIC`` is no longer load-bearing.
+_NON_SECURITY_RULES: Final[tuple[tuple[_RubricRule, tuple[re.Pattern[str], ...]], ...]] = tuple(
+    (rule, _compile_patterns(rule))
     for rule in SEVERITY_RUBRIC
+    if str(rule["id"]) != _SECURITY_RULE_ID
 )
+
+
+def _matches_any(message: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    return any(pattern.search(message) for pattern in patterns)
+
+
+def _matches_security_signal(message: str) -> bool:
+    return _matches_any(message, _SECURITY_PATTERNS)
+
+
+def _core_impact_message(message: str) -> str:
+    """Return the asserted impact, excluding incidental prose after a semicolon.
+
+    Reviewers append incidental notes (``; see README``, ``; typo``) after the
+    impact they are describing. The core is what carries the claim, so the
+    capping vocabulary is evaluated against it, not against the whole message.
+    """
+    return message.split(";", maxsplit=1)[0].strip()
+
+
+def _core_is_genuine_style_or_docs_nit(message: str) -> bool:
+    """Whether the asserted impact itself is a maintainability/docs nit."""
+    core = _core_impact_message(message)
+    return any(_matches_any(core, patterns) for _, patterns in _NON_SECURITY_RULES)
+
+
+def _cap_inapplicable(message: str, asserted_severity: str) -> bool:
+    """Whether D5 forbids deflating this finding.
+
+    A security signal anywhere makes every capping rule inapplicable (the
+    security lane is non-capping in both directions). Otherwise, a
+    Critical/Major assertion with a non-nit core impact is impact evidence and
+    is not lowered by a stray maintainability or docs word.
+    """
+    if _matches_security_signal(message):
+        return True
+    if asserted_severity not in _ASSERTED_BLOCKING_SEVERITIES:
+        return False
+    return not _core_is_genuine_style_or_docs_nit(message)
 
 
 def _cap_severity(current: str, maximum: str) -> str:
@@ -74,11 +128,15 @@ def apply_severity_rubric(
     """Normalize inflated model severity using the code-defined rubric."""
     severity = model_assigned_severity or finding.severity
     message = finding.message
-    for rule, patterns in _COMPILED:
+    if _cap_inapplicable(message, severity):
+        if severity == finding.severity:
+            return finding
+        return finding.model_copy(update={"severity": severity})
+    for rule, patterns in _NON_SECURITY_RULES:
         categories = rule.get("categories")
         if categories and finding.category not in categories:
             continue
-        if any(pattern.search(message) for pattern in patterns):
+        if _matches_any(message, patterns):
             max_severity = rule.get("max_severity")
             if max_severity is not None:
                 severity = _cap_severity(severity, str(max_severity))
@@ -88,12 +146,20 @@ def apply_severity_rubric(
 
 
 def infer_category_from_message(body: str) -> str:
-    """Infer a taxonomy category from message text using rubric patterns."""
-    for rule, patterns in _COMPILED:
+    """Infer a taxonomy category from message text using rubric patterns.
+
+    The security lane is checked first as a deliberate precedent (D5), not by
+    virtue of its position in ``SEVERITY_RUBRIC``.
+    """
+    if _matches_security_signal(body):
+        categories = _SECURITY_RULE.get("categories")
+        if categories:
+            return str(categories[0])
+    for rule, patterns in _NON_SECURITY_RULES:
         categories = rule.get("categories")
         if not categories:
             continue
-        if any(pattern.search(body) for pattern in patterns):
+        if _matches_any(body, patterns):
             return str(categories[0])
     return "Functional Correctness"
 

--- a/src/mergecraft/main.py
+++ b/src/mergecraft/main.py
@@ -753,7 +753,7 @@ async def _resolve_credentials(ctx: RunContext) -> RunContext:
     repo_root = Path.cwd()
     gh_event = ctx.gh_event or {}
     try:
-        validate_fork_credential_invariant(event=gh_event, env=os.environ)
+        validate_fork_credential_invariant(event=gh_event, env=os.environ, settings=ctx.settings)
     except ForkCredentialInvariantError as exc:
         raise _ConfigurationError(str(exc)) from exc
 

--- a/src/mergecraft/mcp/analyzers.py
+++ b/src/mergecraft/mcp/analyzers.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from mergecraft.mcp.shared import ToolClass, execute, tool
-from mergecraft.mcp.tool_state import AnalyzerRunState, analyzer_run_key, primary_repo_state
+from mergecraft.mcp.tool_state import (
+    AnalyzerRunKey,
+    AnalyzerRunState,
+    AnalyzerStatusRow,
+    analyzer_run_key,
+    primary_repo_state,
+)
 from mergecraft.modes._api_only_scope import API_ONLY_SCOPE, API_ONLY_SCOPE_GUIDANCE
 
 if TYPE_CHECKING:
@@ -25,17 +31,124 @@ def _resolve_tier(ctx: ToolContext) -> str:
     return ctx.trust_tier
 
 
+def _merge_analyzer_segments(
+    segments: dict[AnalyzerRunKey | None, AnalyzerRunState],
+    *,
+    latest: AnalyzerRunState,
+) -> AnalyzerRunState:
+    """Return one ``AnalyzerRunState`` carrying every retained segment's evidence.
+
+    N2 / D9 — analyzer findings are additive across scopes. A rerun over a
+    different covered-file selection must not erase a finding produced for a
+    file it never looked at, so the merged view is the union of every retained
+    segment. Rows are de-duplicated on fingerprint (an overlapping scope cannot
+    double-count a finding); descriptive fields take the most recent non-empty
+    value, since they describe the latest run rather than the union.
+    """
+    if len(segments) == 1:
+        return next(iter(segments.values()))
+    findings: list[dict[str, Any]] = []
+    inline: list[dict[str, Any]] = []
+    deferred: list[dict[str, Any]] = []
+    analyzers: list[AnalyzerStatusRow] = []
+    verified: set[str] = set()
+    seen_findings: set[str] = set()
+    seen_deferred: set[str] = set()
+    seen_inline: set[str] = set()
+    seen_analyzers: set[str] = set()
+    mechanical_section: str | None = None
+    deferred_section: str | None = None
+    pre_merge_summary: str | None = None
+    lockfile_digest: str | None = None
+    for segment in segments.values():
+        for row in segment.findings:
+            fingerprint = str(row.get("fingerprint") or "")
+            if fingerprint and fingerprint in seen_findings:
+                continue
+            if fingerprint:
+                seen_findings.add(fingerprint)
+            findings.append(row)
+        for row in segment.inline:
+            fingerprint = str((row.get("finding") or {}).get("fingerprint") or "")
+            if fingerprint and fingerprint in seen_inline:
+                continue
+            if fingerprint:
+                seen_inline.add(fingerprint)
+            inline.append(row)
+        for row in segment.deferred_findings:
+            fingerprint = str(row.get("fingerprint") or "")
+            if fingerprint and fingerprint in seen_deferred:
+                continue
+            if fingerprint:
+                seen_deferred.add(fingerprint)
+            deferred.append(row)
+        for status_row in segment.analyzers:
+            if status_row.id in seen_analyzers:
+                continue
+            seen_analyzers.add(status_row.id)
+            analyzers.append(status_row)
+        verified |= set(segment.verified_ids)
+        mechanical_section = segment.mechanical_section or mechanical_section
+        deferred_section = segment.deferred_section or deferred_section
+        pre_merge_summary = segment.pre_merge_summary or pre_merge_summary
+        lockfile_digest = segment.lockfile_digest or lockfile_digest
+    scope = latest.covered_scope or latest.key
+    return AnalyzerRunState(
+        ran=any(segment.ran for segment in segments.values()),
+        reason=latest.reason,
+        analyzers=analyzers,
+        findings=findings,
+        inline=inline,
+        mechanical_section=mechanical_section,
+        deferred_section=deferred_section,
+        deferred_findings=deferred,
+        pre_merge_summary=pre_merge_summary,
+        lockfile_digest=lockfile_digest,
+        verified_ids=verified,
+        key=scope,
+        covered_scope=scope,
+    )
+
+
 def _store_run_state(ctx: ToolContext, state: AnalyzerRunState) -> None:
+    """Retain a run's evidence by covered scope (N2 / D9).
+
+    ``verified_ids`` has always been additive across calls; findings are made
+    equally additive here. A rerun supersedes only the segment(s) whose covered
+    scope is equivalent to this run's, and an unavailable run supersedes
+    nothing. ``analyzer_run`` is then rebuilt as the merged view so every
+    downstream consumer (the gate, the packet, ``analyzer_findings``) reads the
+    retained set rather than the last write.
+    """
     from mergecraft.findings.ledger import record_deferred_from_analyzer_run
 
-    session_ids = set(ctx.tool_state.verified_ids)
-    prior = ctx.tool_state.analyzer_run
+    tool_state = ctx.tool_state
+    session_ids = set(tool_state.verified_ids)
+    prior = tool_state.analyzer_run
     if prior is not None:
         session_ids |= set(prior.verified_ids)
     state.verified_ids = set(state.verified_ids) | session_ids
-    ctx.tool_state.analyzer_run = state
-    ctx.tool_state.verified_ids = session_ids | set(state.verified_ids)
-    record_deferred_from_analyzer_run(ctx.tool_state, state)
+    tool_state.verified_ids = session_ids | set(state.verified_ids)
+
+    scope = state.covered_scope or state.key
+    segments = tool_state.analyzer_evidence
+    if prior is not None and state is prior and scope in segments:
+        # The reuse fast-path handed back the already-retained view; there is
+        # nothing new to merge.
+        record_deferred_from_analyzer_run(tool_state, state)
+        return
+    if state.ran:
+        # Equivalent covered scope — supersede it. Any other scope's evidence
+        # survives (D9).
+        segments.pop(scope, None)
+        segments[scope] = state
+    else:
+        # An unavailable run produced no evidence for its scope, so it may not
+        # replace a segment that did. It is recorded only where no evidence
+        # exists yet.
+        segments.setdefault(scope, state)
+    tool_state.analyzer_run = _merge_analyzer_segments(segments, latest=state)
+    record_deferred_from_analyzer_run(tool_state, state)
 
 
 def run_analyzers_tool(ctx: ToolContext):
@@ -95,6 +208,9 @@ def run_analyzers_tool(ctx: ToolContext):
                 mode=ctx.analyzers_mode,
                 self_review_level=str(ctx.tool_state.trust_self_review_level or "off"),
             )
+            # N2 / D9 — record the covered selection this run is evidence for so
+            # a later partial rerun supersedes only an equivalent scope.
+            run_state.covered_scope = request_key
         _store_run_state(ctx, run_state)
 
         payload: dict[str, Any] = {
@@ -219,9 +335,11 @@ def analyzer_findings_tool(ctx: ToolContext):
         name="analyzer_findings",
         tool_class=ToolClass.ANALYSIS,
         description=(
-            "Retrieve the scoped, clustered, budgeted analyzer finding set from the most recent "
-            "run_analyzers call — inline bodies include tool/rule citations and confidence tags. "
-            "Use this for placement instead of re-deriving findings from raw tool output."
+            "Retrieve the scoped, clustered, budgeted analyzer finding set retained across "
+            "every run_analyzers call this session — a later partial rerun does not drop "
+            "findings for files it did not cover. Inline bodies include tool/rule citations "
+            "and confidence tags. Use this for placement instead of re-deriving findings "
+            "from raw tool output."
         ),
         input_schema={
             "type": "object",

--- a/src/mergecraft/mcp/commit_info.py
+++ b/src/mergecraft/mcp/commit_info.py
@@ -30,18 +30,21 @@ def get_commit_info_tool(ctx: ToolContext):
         diff_file = str(Path(temp) / f"commit-{sha[:7]}.diff")
         Path(diff_file).write_text(content, encoding="utf-8")
         logger.debug("wrote commit diff to {} ({} bytes)", diff_file, len(content))
+        # N3 / D10 — ``get_commit_info`` is a REPOSITORY_READ. The patch above is
+        # an *inspection artifact*: it is written to disk and returned as
+        # ``diffFile``, but it must never become the canonical review scope.
+        # Registering it used to overwrite ``primary.diff_path`` with the HEAD
+        # commit's patch, silently shrinking a whole-PR review to its last
+        # commit and corrupting admissible citations, inline anchors and blast
+        # radius downstream. Validate the artifact still (head binding + shape)
+        # but leave scope registration to the paths that legitimately own it
+        # (``checkout`` / ``api`` / ``local-diff``).
         primary = primary_repo_state(ctx.tool_state)
         pr_head = (primary.checkout_sha or "").strip().lower()
         if pr_head and sha.strip().lower() == pr_head:
-            from mergecraft.mcp.verdict import register_review_scope, validate_review_scope_evidence
+            from mergecraft.mcp.verdict import validate_review_scope_evidence
 
             await validate_review_scope_evidence(ctx, diff_path=diff_file, head_sha=sha)
-            register_review_scope(
-                ctx.tool_state,
-                diff_path=diff_file,
-                provenance="commit-info",
-                review_scope=ctx.tool_state.review_scope,
-            )
         stats = data.get("stats") or {}
         return {
             "sha": data.get("sha"),

--- a/src/mergecraft/mcp/tool_state.py
+++ b/src/mergecraft/mcp/tool_state.py
@@ -274,6 +274,12 @@ class AnalyzerRunState:
     # else — including on the GitHub Action path, which has no pre-pass — so an
     # unkeyed run is never reused by ``run_analyzers``.
     key: AnalyzerRunKey | None = None
+    # N2 / D9 — the covered file selection this run's evidence belongs to.
+    # ``run_analyzers`` stamps it from the request key; the offline pre-pass
+    # leaves it ``None`` and records the same identity in ``key``. Evidence is
+    # retained per covered scope, so a partial rerun cannot erase a finding
+    # produced for a file it did not cover.
+    covered_scope: AnalyzerRunKey | None = None
 
     def all_rows(self) -> list[dict[str, Any]]:
         """Return every dict-shaped finding row held on this analyzer run."""
@@ -439,8 +445,16 @@ class ToolState:
     agent_diagnostic: Any = None
     browser_daemon: Any = None
     analyzer_run: AnalyzerRunState | None = None
-    # Session-scoped verifier confirms. ``run_analyzers`` replaces
-    # ``analyzer_run`` wholesale, so confirmations must not live only there.
+    # N2 / D9 — analyzer evidence retained per covered scope. ``analyzer_run``
+    # is the merged view over these segments; a rerun supersedes only the
+    # segment(s) whose covered scope is equivalent to the request, so evidence
+    # for files the rerun did not cover survives. The key is the analyzer
+    # request key (immutable run inputs + covered file selection), or ``None``
+    # for a run that recorded no scope.
+    analyzer_evidence: dict[AnalyzerRunKey | None, AnalyzerRunState] = field(default_factory=dict)
+    # Session-scoped verifier confirms. ``analyzer_run`` is rebuilt from the
+    # retained segments on every ``run_analyzers`` call, so confirmations must
+    # not live only there.
     verified_ids: set[str] = field(default_factory=set)
     # Fingerprints a verifier ``drop`` retired during this run. This set is
     # authoritative within the run — only canonical fingerprints survive the
@@ -461,8 +475,10 @@ class ToolState:
     # ref is not checked out locally; ``None`` means full local scope.
     review_scope: str | None = None
     # How review scope was established (``checkout_pr`` api fallback,
-    # ``establish_review_scope``, or ``get_commit_info`` at PR head).
-    scope_provenance: Literal["api", "checkout", "local-diff", "commit-info"] | None = None
+    # ``establish_review_scope``, or the offline ``local-diff`` path).
+    # ``get_commit_info`` is deliberately not a value (N3 / D10): a metadata
+    # read may not register canonical scope.
+    scope_provenance: Literal["api", "checkout", "local-diff"] | None = None
     # Memoized ``git show <rev>:<path>`` output paths keyed ``rev\\0path``.
     git_show_cache: dict[str, str] = field(default_factory=dict)
     confirmed_findings: list[dict[str, Any]] = field(default_factory=list)

--- a/src/mergecraft/mcp/verdict.py
+++ b/src/mergecraft/mcp/verdict.py
@@ -40,7 +40,11 @@ _ALLOWED_VERDICTS = frozenset({"approve", "request_changes"})
 _ALLOWED_TOP_LEVEL_KEYS = frozenset({"verdict", "summary", "findings"})
 _REQUIRED_TOP_LEVEL_KEYS = frozenset({"verdict", "summary"})
 _REVIEW_MODES = frozenset({"Review", "IncrementalReview"})
-_SCOPE_PROVENANCE = frozenset({"api", "checkout", "local-diff", "commit-info"})
+# N3 / D10 — ``commit-info`` is deliberately absent. ``get_commit_info`` is a
+# REPOSITORY_READ and may not register review scope, so no caller can name that
+# provenance. The three remaining values are the paths that legitimately
+# materialize a canonical review diff.
+_SCOPE_PROVENANCE = frozenset({"api", "checkout", "local-diff"})
 _UNIFIED_DIFF_MARKERS = ("diff --git", "--- a/", "+++ b/")
 
 REJECTION_INVALID_VERDICT = "invalid_verdict"
@@ -207,7 +211,7 @@ def register_review_scope(
     tool_state: ToolState,
     *,
     diff_path: str,
-    provenance: Literal["api", "checkout", "local-diff", "commit-info"],
+    provenance: Literal["api", "checkout", "local-diff"],
     review_scope: str | None = None,
 ) -> None:
     """Record evidence-backed review scope and advance past ``INIT`` (D4)."""
@@ -315,8 +319,9 @@ def ensure_review_scope_for_terminal(tool_state: ToolState, tool_name: str) -> N
     """Raise when a Review-mode terminal tool runs before review scope exists (D10).
 
     Scope is evidence-backed (D4) and may be established by ``checkout_pr``,
-    :func:`establish_review_scope`, :func:`establish_offline_review_scope`, or
-    ``get_commit_info`` when its SHA equals the PR head.
+    :func:`establish_review_scope`, or :func:`establish_offline_review_scope`.
+    ``get_commit_info`` may not establish scope (N3 / D10) — it is a
+    ``REPOSITORY_READ`` and its patch is an inspection artifact only.
     """
     mode = tool_state.selected_mode
     if mode not in _REVIEW_MODES or _current_review_phase(tool_state) != ReviewPhase.INIT:

--- a/src/mergecraft/offline_review.py
+++ b/src/mergecraft/offline_review.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
 from mergecraft.analyzers.finding import (
     STRUCTURED_OUTPUT_REQUIRED_MSG,
     Finding,
@@ -522,6 +524,7 @@ class _OfflineDiffReviewRun:
                     base_ref=built.base_ref,
                     line_count=0 if not filtered.strip() else filtered.count("\n"),
                     empty=not filtered.strip(),
+                    coverage_limitations=built.coverage_limitations,
                 )
         diff_text = built.path.read_text(encoding="utf-8")
         reduced_text, self.scope_reduction = apply_diff_line_budget(
@@ -535,6 +538,7 @@ class _OfflineDiffReviewRun:
                 base_ref=built.base_ref,
                 line_count=self.scope_reduction.kept_lines,
                 empty=not reduced_text.strip(),
+                coverage_limitations=built.coverage_limitations,
             )
         self.materialization = built
         return built
@@ -555,7 +559,26 @@ class _OfflineDiffReviewRun:
 
     async def review(self) -> OfflineReviewResult:
         assert self.materialization is not None
+        limitations = self.materialization.coverage_limitations
         if self.materialization.empty:
+            if limitations:
+                # "empty because we did not look" must not masquerade as
+                # "empty because there is nothing" (D12). Name every excluded
+                # path and refuse to report a pass.
+                detail = "; ".join(limitations)
+                message = (
+                    "no changes to review: every change was excluded from coverage "
+                    f"({detail}); this is not a clean pass."
+                )
+                return OfflineReviewResult(
+                    success=False,
+                    error=message,
+                    output=message,
+                    diff_path=str(self.materialization.path),
+                    empty_diff=True,
+                    outcome=RunOutcome.inconclusive,
+                    scope_reduction=self.scope_reduction,
+                )
             if self.json_path is not None:
                 try:
                     write_findings_json(self.json_path, [])
@@ -571,6 +594,13 @@ class _OfflineDiffReviewRun:
                 empty_diff=True,
                 outcome=outcome_with_scope_reduction(RunOutcome.passed, self.scope_reduction),
                 scope_reduction=self.scope_reduction,
+            )
+
+        if limitations:
+            logger.warning(
+                "review coverage limited: {} path(s) excluded — {}",
+                len(limitations),
+                "; ".join(limitations),
             )
 
         output_schema = findings_output_schema() if self.json_path is not None else None

--- a/src/mergecraft/review_policy/security_tokens.py
+++ b/src/mergecraft/review_policy/security_tokens.py
@@ -15,17 +15,18 @@ DOMAIN_HINT_GROUPS: Final[tuple[frozenset[str], ...]] = (
 )
 
 # ``auth`` must relax to a stem without swallowing the ``author`` word family
-# (lane B's whole-token test). The negative lookahead matches ``auth``,
-# ``authentication``, ``authorization`` and ``authorize`` but not ``author``;
-# ``unauth\w*`` covers the ``unauthenticated``/``unauthorized`` forms, which
-# have no word boundary before ``auth``.
+# (lane B's whole-token test). The lookahead excludes words starting ``author``
+# unless followed by ``iz``: ``auth``, ``authentication``, ``authorize`` and
+# ``authorization`` match, while ``author``/``authors``/``authoritative``/
+# ``authority`` do not. ``unauth\w*`` covers the ``unauthenticated``/
+# ``unauthorized`` forms, which have no word boundary before ``auth``.
 SECURITY_MESSAGE_PATTERNS: Final[tuple[str, ...]] = (
     r"\bsecret\b",
     r"\btoken\b",
     r"\bcredential\b",
     r"\bpassword\b",
     r"\binjection\b",
-    r"\bauth(?!or\b)\w*",
+    r"\bauth(?!or(?!iz))\w*",
     r"\bunauth\w*\b",
     r"\bsql\b",
     r"\bxss\b",

--- a/src/mergecraft/review_policy/security_tokens.py
+++ b/src/mergecraft/review_policy/security_tokens.py
@@ -7,18 +7,39 @@ from typing import Final
 DOMAIN_HINT_GROUPS: Final[tuple[frozenset[str], ...]] = (
     frozenset({"sql", "query", "injection", "unsanitized", "binding"}),
     frozenset({"timeout", "retry", "loop"}),
-    frozenset({"secret", "token", "credential", "password"}),
+    frozenset({"secret", "token", "credential", "password", "hardcoded", "key"}),
+    frozenset({"deserializ", "pickle", "unpickle"}),
+    frozenset({"traversal", "ssrf", "csrf", "xxe"}),
+    frozenset({"privilege", "escalation", "pollution", "redirect"}),
+    frozenset({"execution", "rce", "eval", "unsafe"}),
 )
 
+# ``auth`` must relax to a stem without swallowing the ``author`` word family
+# (lane B's whole-token test). The negative lookahead matches ``auth``,
+# ``authentication``, ``authorization`` and ``authorize`` but not ``author``;
+# ``unauth\w*`` covers the ``unauthenticated``/``unauthorized`` forms, which
+# have no word boundary before ``auth``.
 SECURITY_MESSAGE_PATTERNS: Final[tuple[str, ...]] = (
     r"\bsecret\b",
     r"\btoken\b",
     r"\bcredential\b",
     r"\bpassword\b",
     r"\binjection\b",
-    r"\bauth\b",
+    r"\bauth(?!or\b)\w*",
+    r"\bunauth\w*\b",
     r"\bsql\b",
     r"\bxss\b",
+    r"\b(?:remote code execution|rce)\b",
+    r"\bdeserializ\w*\b",
+    r"\bpickle\b",
+    r"\bpath traversal\b",
+    r"\bssrf\b",
+    r"\bcsrf\b",
+    r"\bxxe\b",
+    r"\bprivilege escalation\b",
+    r"\bprototype pollution\b",
+    r"\bopen redirect\b",
+    r"\bhardcoded key\b",
 )
 
 __all__ = ["DOMAIN_HINT_GROUPS", "SECURITY_MESSAGE_PATTERNS"]

--- a/src/mergecraft/security/broker.py
+++ b/src/mergecraft/security/broker.py
@@ -163,9 +163,18 @@ def subscription_auth_usable(raw: str) -> bool:
 _subscription_auth_usable = subscription_auth_usable
 
 
-def resolve_codex_broker_posture(*, openai_api_key: str = "") -> CodexBrokerPosture:
-    """Return whether the broker is active for the current Codex auth mode (D3a)."""
-    subscription_raw = os.environ.get("CODEX_AUTH_JSON", "").strip()
+def resolve_codex_broker_posture(
+    *,
+    openai_api_key: str = "",
+    codex_auth_json: str = "",
+) -> CodexBrokerPosture:
+    """Return whether the broker is active for the current Codex auth mode (D3a).
+
+    Callers that hold the already resolved credential mapping pass it in
+    (``codex_auth_json`` / ``openai_api_key``) rather than relying on the
+    ambient environment (D4). When omitted, the process environment is read.
+    """
+    subscription_raw = (codex_auth_json or os.environ.get("CODEX_AUTH_JSON", "")).strip()
     if subscription_raw and subscription_auth_usable(subscription_raw):
         return CodexBrokerPosture(
             active=False,

--- a/src/mergecraft/utils/offline_diff.py
+++ b/src/mergecraft/utils/offline_diff.py
@@ -22,6 +22,11 @@ class DiffMaterialization:
     base_ref: str | None
     line_count: int
     empty: bool
+    #: Working-tree paths the default materialization deliberately left out
+    #: (gitignored, oversized, binary, symlink, non-UTF-8). Carried on the
+    #: result so an empty diff can never silently read as "nothing to review"
+    #: (D11/D12) — the exclusion is visible, not just a log line.
+    coverage_limitations: tuple[str, ...] = ()
 
 
 def _run_git(
@@ -144,45 +149,95 @@ def git_staged_diff(*, cwd: Path) -> str:
     return result.stdout
 
 
+def _nul_paths(data: str) -> list[str]:
+    """Split a NUL-delimited ``git ls-files -z`` listing into paths."""
+    return [item for item in data.split("\0") if item]
+
+
+def _ignored_limitations(cwd: Path, *, already_seen: set[str]) -> list[str]:
+    """Return limitations for gitignored working-tree paths.
+
+    ``--exclude-standard`` hides ignored files from the eligible listing, so
+    they would otherwise disappear without a trace. ``--directory`` collapses
+    a fully-ignored directory (e.g. ``.venv/``) to one entry so the report
+    stays readable in a large checkout.
+    """
+    ignored = _run_git(
+        ["ls-files", "--others", "--ignored", "--exclude-standard", "--directory", "-z"],
+        cwd=cwd,
+    )
+    if ignored.returncode != 0:
+        return []
+    return [
+        f"gitignored path not reviewed: {rel}"
+        for rel in _nul_paths(ignored.stdout)
+        if rel not in already_seen
+    ]
+
+
+def _discover_untracked_additions(
+    cwd: Path,
+    *,
+    report_ignored: bool = False,
+) -> tuple[str, tuple[str, ...]]:
+    """Return unified patches for eligible untracked files and their exclusions.
+
+    This is the discovery half of :func:`git_unstaged_diff`, reused by the
+    default ``--merge-base`` materialization (D11). A file that is skipped —
+    symlink, oversized, binary, non-UTF-8 — is returned as a coverage
+    limitation as well as logged; gitignored paths are reported when
+    ``report_ignored`` is set (they never reach the eligible listing).
+    """
+    listing = _run_git(["ls-files", "--others", "--exclude-standard", "-z"], cwd=cwd)
+    patches: list[str] = []
+    limitations: list[str] = []
+    eligible: set[str] = set()
+    if listing.returncode == 0:
+        for rel in _nul_paths(listing.stdout):
+            eligible.add(rel)
+            path = cwd / rel
+            if path.is_symlink():
+                limitations.append(f"symlink not reviewed: {rel}")
+                continue
+            if not path.is_file():
+                continue
+            try:
+                raw = path.read_bytes()
+            except OSError:
+                limitations.append(f"unreadable file not reviewed: {rel}")
+                continue
+            if len(raw) > _MAX_UNTRACKED_FILE_BYTES:
+                logger.info("skipped oversized untracked file in unstaged diff: {}", rel)
+                limitations.append(f"oversized file not reviewed: {rel}")
+                continue
+            if b"\0" in raw:
+                logger.info("skipped binary untracked file in unstaged diff: {}", rel)
+                limitations.append(f"binary file not reviewed: {rel}")
+                continue
+            try:
+                raw.decode("utf-8")
+            except UnicodeDecodeError:
+                logger.info("skipped non-UTF-8 untracked file in unstaged diff: {}", rel)
+                limitations.append(f"non-UTF-8 file not reviewed: {rel}")
+                continue
+            patch = _run_git(["diff", "--no-index", "--", "/dev/null", rel], cwd=cwd)
+            if patch.returncode not in (0, 1):
+                msg = f"failed to compute untracked diff for {rel!r}: {patch.stderr.strip()}"
+                raise RuntimeError(msg)
+            patches.append(patch.stdout)
+    if report_ignored:
+        limitations.extend(_ignored_limitations(cwd, already_seen=eligible))
+    return "".join(patches), tuple(limitations)
+
+
 def git_unstaged_diff(*, cwd: Path) -> str:
     """Return unstaged working-tree diff (tracked edits plus untracked adds)."""
     result = _run_git(["diff"], cwd=cwd)
     if result.returncode != 0:
         msg = f"failed to compute unstaged diff: {result.stderr.strip()}"
         raise RuntimeError(msg)
-    untracked = _run_git(
-        ["ls-files", "--others", "--exclude-standard", "-z"],
-        cwd=cwd,
-    )
-    text = result.stdout
-    if untracked.returncode == 0 and untracked.stdout.strip("\0"):
-        for rel in untracked.stdout.strip("\0").split("\0"):
-            if not rel:
-                continue
-            path = cwd / rel
-            if path.is_symlink() or not path.is_file():
-                continue
-            try:
-                raw = path.read_bytes()
-            except OSError:
-                continue
-            if len(raw) > _MAX_UNTRACKED_FILE_BYTES:
-                logger.info("skipped oversized untracked file in unstaged diff: {}", rel)
-                continue
-            if b"\0" in raw:
-                logger.info("skipped binary untracked file in unstaged diff: {}", rel)
-                continue
-            try:
-                raw.decode("utf-8")
-            except UnicodeDecodeError:
-                logger.info("skipped non-UTF-8 untracked file in unstaged diff: {}", rel)
-                continue
-            patch = _run_git(["diff", "--no-index", "--", "/dev/null", rel], cwd=cwd)
-            if patch.returncode not in (0, 1):
-                msg = f"failed to compute untracked diff for {rel!r}: {patch.stderr.strip()}"
-                raise RuntimeError(msg)
-            text += patch.stdout
-    return text
+    untracked_text, _ = _discover_untracked_additions(cwd)
+    return result.stdout + untracked_text
 
 
 def git_range_diff(*, cwd: Path, range_spec: str) -> str:
@@ -206,6 +261,7 @@ def materialize_diff(
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / "review.diff"
     base_ref: str | None = None
+    coverage_limitations: tuple[str, ...] = ()
 
     if diff_file is not None:
         text = diff_file.read_text(encoding="utf-8")
@@ -213,6 +269,15 @@ def materialize_diff(
     else:
         base_ref = base or detect_default_base(cwd, git_dir=git_dir)
         text = git_merge_base_diff(cwd=cwd, base=base_ref, git_dir=git_dir)
+        # ``--merge-base`` never lists untracked files by construction, so a new
+        # source file would otherwise be invisible to the default review (N7/D11).
+        if text and not text.endswith("\n"):
+            text = f"{text}\n"
+        untracked_text, coverage_limitations = _discover_untracked_additions(
+            cwd,
+            report_ignored=True,
+        )
+        text += untracked_text
 
     # Normalize trailing newline for stable line counts.
     if text and not text.endswith("\n"):
@@ -221,12 +286,19 @@ def materialize_diff(
     line_count = 0 if not text.strip() else text.count("\n")
     empty = not text.strip()
     logger.info(
-        "» offline diff ready ({} lines{}) → {}",
+        "» offline diff ready ({} lines{}{}) → {}",
         line_count,
         f", base={base_ref}" if base_ref else "",
+        f", {len(coverage_limitations)} coverage limitation(s)" if coverage_limitations else "",
         path,
     )
-    return DiffMaterialization(path=path, base_ref=base_ref, line_count=line_count, empty=empty)
+    return DiffMaterialization(
+        path=path,
+        base_ref=base_ref,
+        line_count=line_count,
+        empty=empty,
+        coverage_limitations=coverage_limitations,
+    )
 
 
 def summarize_diff(text: str) -> str:

--- a/src/mergecraft/utils/secrets.py
+++ b/src/mergecraft/utils/secrets.py
@@ -7,6 +7,8 @@ import re
 
 from loguru import logger
 
+from mergecraft.config.runtime_provider_registry import provider_credential_env_names
+
 # Patterns for sensitive env var names (used by normalize_env / redaction).
 SENSITIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"_KEY$", re.IGNORECASE),
@@ -150,22 +152,10 @@ ALWAYS_STRIP_FROM_AGENT_ENV: frozenset[str] = frozenset(
     }
 )
 
-# Provider credential env vars — only the active agent's key is re-injected.
-PROVIDER_KEY_ENV_VARS: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "OPENAI_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
-        "GOOGLE_GENERATIVE_AI_API_KEY",
-        "CURSOR_API_KEY",
-        "NOUS_API_KEY",
-        "TOKENHUB_API_KEY",
-        "MERGECRAFT_CUSTOM_PROVIDER_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "CODEX_AUTH_JSON",
-    }
-)
+# Provider credential env vars — derived from the one credential authority
+# (``config.runtime_provider_registry``, D2), so this set and the fork invariant
+# cannot drift. Only the active agent's key is re-injected below.
+PROVIDER_KEY_ENV_VARS: frozenset[str] = provider_credential_env_names()
 
 ACTIVE_PROVIDER_KEY_BY_AGENT: dict[str, str | None] = {
     "claude": "ANTHROPIC_API_KEY",

--- a/tests/agents/test_codex_auth_indexed.py
+++ b/tests/agents/test_codex_auth_indexed.py
@@ -1,0 +1,142 @@
+"""Indexed Codex credentials reach the isolated run home's ``auth.json`` (RA1.1, N19/D4).
+
+An indexed-only ``device_code`` setup maps ``LLM_PROVIDER_1_CODEX_AUTH_JSON``
+into the resolved child environment, but the baseline ``_setup_codex_auth``
+reads ``os.environ`` instead — so the file is never written. The observable is
+the file on disk in the isolated run home, not the child env.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from tests.agents.conftest import make_agent_run_context
+from tests.cli.support_provider_registry import (
+    scaffold_mergecraft_home,
+    write_registry_provider_row,
+)
+
+_RA2_XFAIL = pytest.mark.xfail(
+    reason="green after RA2: resolved credential mapping reaches _setup_codex_auth",
+    strict=False,
+)
+
+_INDEXED_AUTH = json.dumps(
+    {"tokens": {"access_token": "indexed-access", "refresh_token": "indexed-refresh"}}
+)
+_FLAT_AUTH = json.dumps(
+    {"tokens": {"access_token": "flat-access", "refresh_token": "flat-refresh"}}
+)
+
+
+def _codex() -> Any:
+    import importlib
+
+    return importlib.import_module("mergecraft.agents.codex")
+
+
+def _ctx(tmp_path: Any) -> Any:
+    return make_agent_run_context(tmp_path, resolved_model="openai/gpt-5.3-codex")
+
+
+def _register_indexed_device_code(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    scaffold_mergecraft_home(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_registry_provider_row(
+        tmp_path,
+        label="openai",
+        harness="codex",
+        env_index=1,
+        auth_kind="device_code",
+    )
+
+
+def _auth_path(codex: Any, ctx: Any) -> Any:
+    return codex._codex_home(ctx) / "auth.json"
+
+
+@_RA2_XFAIL
+def test_indexed_codex_auth_json_writes_run_home_auth_file(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    codex = _codex()
+    _register_indexed_device_code(tmp_path, monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER_1_CODEX_AUTH_JSON", _INDEXED_AUTH)
+    monkeypatch.delenv("CODEX_AUTH_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    ctx = _ctx(tmp_path)
+
+    codex._build_env(ctx)
+
+    auth_path = _auth_path(codex, ctx)
+    assert auth_path.is_file(), "indexed device_code credential wrote no auth.json"
+    assert auth_path.read_text(encoding="utf-8") == _INDEXED_AUTH
+
+
+def test_flat_codex_auth_json_still_writes_auth_file(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control — the ambient flat spelling keeps working."""
+    codex = _codex()
+    monkeypatch.setenv("CODEX_AUTH_JSON", _FLAT_AUTH)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    ctx = _ctx(tmp_path)
+
+    codex._build_env(ctx)
+
+    auth_path = _auth_path(codex, ctx)
+    assert auth_path.is_file()
+    assert auth_path.read_text(encoding="utf-8") == _FLAT_AUTH
+
+
+@_RA2_XFAIL
+def test_indexed_and_flat_conflict_resolves_to_the_registry_credential(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    codex = _codex()
+    _register_indexed_device_code(tmp_path, monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER_1_CODEX_AUTH_JSON", _INDEXED_AUTH)
+    monkeypatch.setenv("CODEX_AUTH_JSON", _FLAT_AUTH)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    ctx = _ctx(tmp_path)
+
+    codex._build_env(ctx)
+
+    auth_path = _auth_path(codex, ctx)
+    assert auth_path.is_file()
+    assert auth_path.read_text(encoding="utf-8") == _INDEXED_AUTH
+
+
+@_RA2_XFAIL
+def test_setup_codex_auth_does_not_read_ambient_os_environ(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D4 — patch the real seam: the resolved mapping is what was consumed."""
+    codex = _codex()
+    _register_indexed_device_code(tmp_path, monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER_1_CODEX_AUTH_JSON", _INDEXED_AUTH)
+    monkeypatch.setenv("CODEX_AUTH_JSON", _FLAT_AUTH)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def _spy(ctx: Any, *args: Any, **kwargs: Any) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(codex, "_setup_codex_auth", _spy)
+    ctx = _ctx(tmp_path)
+
+    codex._build_env(ctx)
+
+    values = [*captured.get("args", ()), *captured.get("kwargs", {}).values()]
+    candidates = [value for value in values if isinstance(value, Mapping)]
+    assert any(mapping.get("CODEX_AUTH_JSON") == _INDEXED_AUTH for mapping in candidates), (
+        "the resolved credential mapping was not threaded into _setup_codex_auth"
+    )
+    assert all(mapping.get("CODEX_AUTH_JSON") != _FLAT_AUTH for mapping in candidates), (
+        "the ambient flat credential was consumed instead of the resolved mapping"
+    )

--- a/tests/agents/test_codex_auth_indexed.py
+++ b/tests/agents/test_codex_auth_indexed.py
@@ -10,19 +10,16 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import pytest
 from tests.agents.conftest import make_agent_run_context
 from tests.cli.support_provider_registry import (
     scaffold_mergecraft_home,
     write_registry_provider_row,
 )
 
-_RA2_XFAIL = pytest.mark.xfail(
-    reason="green after RA2: resolved credential mapping reaches _setup_codex_auth",
-    strict=False,
-)
+if TYPE_CHECKING:
+    import pytest
 
 _INDEXED_AUTH = json.dumps(
     {"tokens": {"access_token": "indexed-access", "refresh_token": "indexed-refresh"}}
@@ -58,7 +55,6 @@ def _auth_path(codex: Any, ctx: Any) -> Any:
     return codex._codex_home(ctx) / "auth.json"
 
 
-@_RA2_XFAIL
 def test_indexed_codex_auth_json_writes_run_home_auth_file(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -92,7 +88,6 @@ def test_flat_codex_auth_json_still_writes_auth_file(
     assert auth_path.read_text(encoding="utf-8") == _FLAT_AUTH
 
 
-@_RA2_XFAIL
 def test_indexed_and_flat_conflict_resolves_to_the_registry_credential(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -110,7 +105,6 @@ def test_indexed_and_flat_conflict_resolves_to_the_registry_credential(
     assert auth_path.read_text(encoding="utf-8") == _INDEXED_AUTH
 
 
-@_RA2_XFAIL
 def test_setup_codex_auth_does_not_read_ambient_os_environ(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/analyzers/test_cluster_permutation.py
+++ b/tests/analyzers/test_cluster_permutation.py
@@ -10,14 +10,7 @@ from __future__ import annotations
 import itertools
 from typing import Any
 
-import pytest
-
 from tests.findings.support import make_finding
-
-_RA4_XFAIL = pytest.mark.xfail(
-    reason="green after RA4: cluster result is invariant under input ordering",
-    strict=False,
-)
 
 _MESSAGE = "same defect, same location"
 
@@ -37,7 +30,6 @@ def _finding(tool: str, severity: str, *, source: str = "analyzer") -> Any:
     )
 
 
-@_RA4_XFAIL
 def test_cluster_result_is_permutation_invariant() -> None:
     """Every ordering of the same input set yields the same severities."""
     from mergecraft.analyzers.cluster import cluster_findings

--- a/tests/analyzers/test_cluster_permutation.py
+++ b/tests/analyzers/test_cluster_permutation.py
@@ -1,0 +1,60 @@
+"""Clustering is permutation-invariant (RA1.3, D15).
+
+The audit reproduced order-dependence: the canonical member was picked by input
+order, so the same input set clustered to different severities. A fixed
+two-element case passes on the wrong fix; this property checks every ordering.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import pytest
+
+from tests.findings.support import make_finding
+
+_RA4_XFAIL = pytest.mark.xfail(
+    reason="green after RA4: cluster result is invariant under input ordering",
+    strict=False,
+)
+
+_MESSAGE = "same defect, same location"
+
+
+def _finding(tool: str, severity: str, *, source: str = "analyzer") -> Any:
+    return make_finding(
+        tool=tool,
+        rule_id=f"{tool}-rule",
+        category="Security & Privacy",
+        severity=severity,
+        confidence="likely",
+        message=_MESSAGE,
+        path="src/app.py",
+        start_line=10,
+        end_line=10,
+        source=source,
+    )
+
+
+@_RA4_XFAIL
+def test_cluster_result_is_permutation_invariant() -> None:
+    """Every ordering of the same input set yields the same severities."""
+    from mergecraft.analyzers.cluster import cluster_findings
+
+    members = [
+        _finding("agent-a", "Minor", source="agent"),
+        _finding("agent-b", "Major", source="agent"),
+        _finding("z-scanner", "Critical"),
+    ]
+
+    reference: tuple[str, ...] | None = None
+    for ordering in itertools.permutations(members):
+        result = cluster_findings(list(ordering))
+        severities = tuple(sorted(finding.severity for finding in result))
+        if reference is None:
+            reference = severities
+        else:
+            assert severities == reference, (
+                f"ordering {[f.tool for f in ordering]} produced {severities!r} != {reference!r}"
+            )

--- a/tests/analyzers/test_cluster_severity.py
+++ b/tests/analyzers/test_cluster_severity.py
@@ -10,14 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from tests.findings.support import make_finding
-
-_RA4_XFAIL = pytest.mark.xfail(
-    reason="green after RA4: cluster canonicalization keeps the strongest severity",
-    strict=False,
-)
 
 _MESSAGE = "duplicate defect at the same location"
 
@@ -43,7 +36,6 @@ def _finding(
     )
 
 
-@_RA4_XFAIL
 def test_major_alone_and_major_plus_minor_duplicate_gate_identically() -> None:
     """The audit's reproduction: [Major z] vs [Major z, Minor a]."""
     from mergecraft.agents.gates import decide_approval
@@ -62,7 +54,6 @@ def test_major_alone_and_major_plus_minor_duplicate_gate_identically() -> None:
     assert decide_approval(both, run_succeeded=True, tier="trusted") == "failure"
 
 
-@_RA4_XFAIL
 def test_canonical_keeps_agent_wording_but_not_a_weaker_severity() -> None:
     """D8 — split wording from severity: agent prose wins, the Major survives."""
     from mergecraft.analyzers.cluster import cluster_findings
@@ -77,7 +68,6 @@ def test_canonical_keeps_agent_wording_but_not_a_weaker_severity() -> None:
     assert canonical[0].severity == "Major"
 
 
-@_RA4_XFAIL
 def test_corroboration_cannot_lower_should_verify() -> None:
     """A weaker duplicate must not clear the verification gate."""
     from mergecraft.agents.verifier import should_verify

--- a/tests/analyzers/test_cluster_severity.py
+++ b/tests/analyzers/test_cluster_severity.py
@@ -1,0 +1,93 @@
+"""Cluster canonicalization must not let corroboration lower a severity (RA1.3, D8).
+
+The audit's exact reproduction: a Major ``z-scanner`` finding alone gates the
+run; adding an identical Minor ``a-scanner`` finding at the same location must
+not weaken the canonical row. Canonical *wording* may keep the agent's prose;
+canonical *severity* is the strongest member's.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.findings.support import make_finding
+
+_RA4_XFAIL = pytest.mark.xfail(
+    reason="green after RA4: cluster canonicalization keeps the strongest severity",
+    strict=False,
+)
+
+_MESSAGE = "duplicate defect at the same location"
+
+
+def _finding(
+    tool: str,
+    severity: str,
+    *,
+    source: str = "analyzer",
+    message: str = _MESSAGE,
+) -> Any:
+    return make_finding(
+        tool=tool,
+        rule_id=f"{tool}-rule",
+        category="Security & Privacy",
+        severity=severity,
+        confidence="likely",
+        message=message,
+        path="src/app.py",
+        start_line=10,
+        end_line=10,
+        source=source,
+    )
+
+
+@_RA4_XFAIL
+def test_major_alone_and_major_plus_minor_duplicate_gate_identically() -> None:
+    """The audit's reproduction: [Major z] vs [Major z, Minor a]."""
+    from mergecraft.agents.gates import decide_approval
+    from mergecraft.analyzers.cluster import cluster_findings
+
+    major = _finding("z-scanner", "Major")
+    minor = _finding("a-scanner", "Minor")
+
+    alone = cluster_findings([major])
+    both = cluster_findings([major, minor])
+
+    assert len(alone) == 1
+    assert len(both) == 1
+    assert alone[0].severity == both[0].severity == "Major"
+    assert decide_approval(alone, run_succeeded=True, tier="trusted") == "failure"
+    assert decide_approval(both, run_succeeded=True, tier="trusted") == "failure"
+
+
+@_RA4_XFAIL
+def test_canonical_keeps_agent_wording_but_not_a_weaker_severity() -> None:
+    """D8 — split wording from severity: agent prose wins, the Major survives."""
+    from mergecraft.analyzers.cluster import cluster_findings
+
+    agent = _finding("agent", "Minor", source="agent", message="Canonical agent prose")
+    analyzer = _finding("z-scanner", "Major", source="analyzer", message="Canonical agent prose")
+
+    canonical = cluster_findings([analyzer, agent])
+
+    assert len(canonical) == 1
+    assert canonical[0].message == "Canonical agent prose"
+    assert canonical[0].severity == "Major"
+
+
+@_RA4_XFAIL
+def test_corroboration_cannot_lower_should_verify() -> None:
+    """A weaker duplicate must not clear the verification gate."""
+    from mergecraft.agents.verifier import should_verify
+    from mergecraft.analyzers.cluster import cluster_findings
+
+    major = _finding("z-scanner", "Major")
+    minor = _finding("a-scanner", "Minor")
+
+    alone = cluster_findings([major])[0]
+    corroborated = cluster_findings([major, minor])[0]
+
+    assert should_verify(alone) is True
+    assert should_verify(corroborated) == should_verify(alone)

--- a/tests/findings/fixtures/__init__.py
+++ b/tests/findings/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for shared findings fixtures."""

--- a/tests/findings/fixtures/severity_pairs.py
+++ b/tests/findings/fixtures/severity_pairs.py
@@ -78,6 +78,60 @@ SEVERITY_PAIRS: Final[tuple[SeverityPair, ...]] = (
 #: The six incidental rows only (the seven controls are ``impact_message``).
 INCIDENTAL_PAIRS: Final[tuple[SeverityPair, ...]] = SEVERITY_PAIRS
 
+
+# ---------------------------------------------------------------------------
+# Author-family corpus (RA3 regression): a prose word that begins with ``auth``
+# must not be read as a security signal. An incidental ``authors`` /
+# ``authoritative`` in a style or docs finding must not lift it across a
+# blocking boundary; a genuine correctness impact must keep its asserted grade.
+# ---------------------------------------------------------------------------
+
+STYLE_NIT_IMPACT: Final[str] = "Prefer f-string over percent formatting"
+DOCS_NIT_IMPACT: Final[str] = "Update the comment in this module"
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorFamilyPair:
+    """A prose finding with and without an incidental author-family word.
+
+    ``control_message`` omits the word; ``incidental_message`` carries it. The
+    word does not change the asserted impact, so the pair must agree on the
+    severity that reaches the gate.
+    """
+
+    case_id: str
+    asserted_severity: str
+    control_message: str
+    incidental_message: str
+
+
+AUTHOR_FAMILY_PAIRS: Final[tuple[AuthorFamilyPair, ...]] = (
+    AuthorFamilyPair(
+        case_id="critical-style-authors-tail",
+        asserted_severity="Critical",
+        control_message=STYLE_NIT_IMPACT,
+        incidental_message=f"{STYLE_NIT_IMPACT}; the authors guide documents this",
+    ),
+    AuthorFamilyPair(
+        case_id="critical-style-authorship-core",
+        asserted_severity="Critical",
+        control_message=STYLE_NIT_IMPACT,
+        incidental_message="The authorship rules say prefer f-string over percent formatting",
+    ),
+    AuthorFamilyPair(
+        case_id="critical-docs-authoritative-tail",
+        asserted_severity="Critical",
+        control_message=DOCS_NIT_IMPACT,
+        incidental_message=f"{DOCS_NIT_IMPACT}; this is authoritative",
+    ),
+    AuthorFamilyPair(
+        case_id="critical-correctness-authors-tail",
+        asserted_severity="Critical",
+        control_message=CORRECTNESS_IMPACT,
+        incidental_message=f"{CORRECTNESS_IMPACT}; the authors guide documents this",
+    ),
+)
+
 # ---------------------------------------------------------------------------
 # Property-test corpus (RA1.2): impact statements x incidental tokens.
 # ---------------------------------------------------------------------------
@@ -94,7 +148,9 @@ IMPACT_STATEMENTS: Final[tuple[tuple[str, str], ...]] = (
     ("Major", "Missing validation on the request body"),
 )
 
-#: Incidental tokens that belong to the docs / style vocabulary.
+#: Incidental tokens that belong to the docs / style vocabulary, plus the
+#: ``author`` word family — ordinary prose that must not read as a security
+#: signal (RA3 regression).
 INCIDENTAL_TOKENS: Final[tuple[str, ...]] = (
     "see README",
     "see the comment",
@@ -102,6 +158,13 @@ INCIDENTAL_TOKENS: Final[tuple[str, ...]] = (
     "naming",
     "typo",
     "docstring",
+    "authors",
+    "authoring",
+    "authored",
+    "authorship",
+    "authoritative",
+    "authority",
+    "authorities",
 )
 
 
@@ -111,12 +174,16 @@ def incidental_message(impact: str, incidental: str) -> str:
 
 
 __all__ = [
+    "AUTHOR_FAMILY_PAIRS",
     "CORRECTNESS_IMPACT",
+    "DOCS_NIT_IMPACT",
     "IMPACT_STATEMENTS",
     "INCIDENTAL_PAIRS",
     "INCIDENTAL_TOKENS",
     "SECURITY_IMPACT",
     "SEVERITY_PAIRS",
+    "STYLE_NIT_IMPACT",
+    "AuthorFamilyPair",
     "SeverityPair",
     "incidental_message",
 ]

--- a/tests/findings/fixtures/severity_pairs.py
+++ b/tests/findings/fixtures/severity_pairs.py
@@ -1,0 +1,122 @@
+"""Matched-paraphrase severity corpus (RA1.6, D15).
+
+The r2 audit earned its N4 escalation with *pairs*: the same asserted impact
+with and without an incidental word. The claim under test is that the pair
+agrees, so the corpus lives here as data rather than as inline strings
+duplicated across test modules.
+
+``impact_message`` carries the asserted impact and the severity the reviewing
+model assigned. ``incidental_message`` is the same impact wearing a word that
+belongs to the maintainability/docs vocabulary (``readme``, ``comment``,
+``style``, ``naming``, ``typo``). The cap is only reachable when the inferred
+category lands on ``Maintainability & Code Quality``, which is exactly the
+lexical inference N4/N20 exploit.
+
+Source of truth: ``plans/audit-2026-09-10-r2.md`` §4, reproduced verbatim in
+``.ignorelocal/waves/evidence/ra0-baseline.txt``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class SeverityPair:
+    """One asserted impact and the same impact with an incidental word."""
+
+    case_id: str
+    asserted_severity: str
+    impact_message: str
+    incidental_message: str
+
+
+SECURITY_IMPACT: Final[str] = "Authentication bypass in the session check"
+CORRECTNESS_IMPACT: Final[str] = "The retry loop never sets a timeout"
+
+#: The seven r2 rows: six incidental cases and their controls.
+SEVERITY_PAIRS: Final[tuple[SeverityPair, ...]] = (
+    SeverityPair(
+        case_id="critical-security-readme",
+        asserted_severity="Critical",
+        impact_message=SECURITY_IMPACT,
+        incidental_message=f"{SECURITY_IMPACT}; see README",
+    ),
+    SeverityPair(
+        case_id="critical-security-comment",
+        asserted_severity="Critical",
+        impact_message=SECURITY_IMPACT,
+        incidental_message=f"{SECURITY_IMPACT}; see the comment",
+    ),
+    SeverityPair(
+        case_id="critical-security-style",
+        asserted_severity="Critical",
+        impact_message=SECURITY_IMPACT,
+        incidental_message=f"{SECURITY_IMPACT}; style",
+    ),
+    SeverityPair(
+        case_id="critical-security-naming",
+        asserted_severity="Critical",
+        impact_message=SECURITY_IMPACT,
+        incidental_message=f"{SECURITY_IMPACT}; naming",
+    ),
+    SeverityPair(
+        case_id="critical-security-typo",
+        asserted_severity="Critical",
+        impact_message=SECURITY_IMPACT,
+        incidental_message=f"{SECURITY_IMPACT}; typo",
+    ),
+    SeverityPair(
+        case_id="major-correctness-comment",
+        asserted_severity="Major",
+        impact_message=CORRECTNESS_IMPACT,
+        incidental_message=f"{CORRECTNESS_IMPACT}; see the comment",
+    ),
+)
+
+#: The six incidental rows only (the seven controls are ``impact_message``).
+INCIDENTAL_PAIRS: Final[tuple[SeverityPair, ...]] = SEVERITY_PAIRS
+
+# ---------------------------------------------------------------------------
+# Property-test corpus (RA1.2): impact statements x incidental tokens.
+# ---------------------------------------------------------------------------
+
+#: Asserted impacts, each paired with the severity the model assigned.
+IMPACT_STATEMENTS: Final[tuple[tuple[str, str], ...]] = (
+    ("Critical", "Authentication bypass in the session check"),
+    ("Critical", "Authorization check missing on the admin route"),
+    ("Critical", "Unauthenticated users can reach the admin endpoint"),
+    ("Critical", "Hardcoded secret committed in the settings module"),
+    ("Critical", "SQL injection in the query builder"),
+    ("Critical", "Server-side request forgery via a user-supplied URL"),
+    ("Major", "The retry loop never sets a timeout"),
+    ("Major", "Missing validation on the request body"),
+)
+
+#: Incidental tokens that belong to the docs / style vocabulary.
+INCIDENTAL_TOKENS: Final[tuple[str, ...]] = (
+    "see README",
+    "see the comment",
+    "style",
+    "naming",
+    "typo",
+    "docstring",
+)
+
+
+def incidental_message(impact: str, incidental: str) -> str:
+    """Append one incidental token to an asserted impact statement."""
+    return f"{impact}; {incidental}"
+
+
+__all__ = [
+    "CORRECTNESS_IMPACT",
+    "IMPACT_STATEMENTS",
+    "INCIDENTAL_PAIRS",
+    "INCIDENTAL_TOKENS",
+    "SECURITY_IMPACT",
+    "SEVERITY_PAIRS",
+    "SeverityPair",
+    "incidental_message",
+]

--- a/tests/findings/test_dedup_severity.py
+++ b/tests/findings/test_dedup_severity.py
@@ -12,14 +12,7 @@ from __future__ import annotations
 import itertools
 from typing import Any
 
-import pytest
-
 from tests.findings.support import make_finding
-
-_RA4_XFAIL = pytest.mark.xfail(
-    reason="green after RA4: semantic dedupe keeps the strongest survivor",
-    strict=False,
-)
 
 
 def _finding(severity: str, message: str, *, evidence: list[str] | None = None) -> Any:
@@ -46,7 +39,6 @@ def _major() -> Any:
     return _finding("Major", "The retry loop never sets a timeout", evidence=["major-evidence"])
 
 
-@_RA4_XFAIL
 def test_semantic_dedupe_keeps_the_strongest_survivor() -> None:
     """The paraphrased retry-loop-timeout pair collapses to the Major row."""
     from mergecraft.findings.dedup import dedupe_findings_with_indices
@@ -57,7 +49,6 @@ def test_semantic_dedupe_keeps_the_strongest_survivor() -> None:
     assert result.findings[0].severity == "Major"
 
 
-@_RA4_XFAIL
 def test_dedupe_result_is_permutation_invariant() -> None:
     """Both orderings of the same pair produce the same survivor severity."""
     from mergecraft.findings.dedup import dedupe_findings_with_indices
@@ -72,7 +63,6 @@ def test_dedupe_result_is_permutation_invariant() -> None:
             assert severities == reference, f"ordering produced {severities!r} != {reference!r}"
 
 
-@_RA4_XFAIL
 def test_evidence_from_discarded_members_is_retained() -> None:
     """A discarded paraphrase's evidence survives on the survivor."""
     from mergecraft.findings.dedup import dedupe_findings_with_indices
@@ -85,7 +75,6 @@ def test_evidence_from_discarded_members_is_retained() -> None:
     assert "major-evidence" in evidence
 
 
-@_RA4_XFAIL
 def test_kept_indices_still_point_at_the_surviving_row() -> None:
     """The cross-lane contract RB6 depends on: indices name the row actually kept."""
     from mergecraft.findings.dedup import dedupe_findings_with_indices

--- a/tests/findings/test_dedup_severity.py
+++ b/tests/findings/test_dedup_severity.py
@@ -1,0 +1,99 @@
+"""Semantic dedupe keeps the strongest survivor (RA1.3, D7/D8).
+
+``findings/dedup.py`` runs before ``evidence/merge.merge_findings`` and used to
+keep ``cluster[0]`` unconditionally, so a weaker paraphrase arriving first could
+turn a blocker green. The survivor must be the strongest member, its evidence
+must unite the discarded members, and ``kept_indices`` must point at the row
+actually kept (lane B's RB6 realigns on those indices).
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import pytest
+
+from tests.findings.support import make_finding
+
+_RA4_XFAIL = pytest.mark.xfail(
+    reason="green after RA4: semantic dedupe keeps the strongest survivor",
+    strict=False,
+)
+
+
+def _finding(severity: str, message: str, *, evidence: list[str] | None = None) -> Any:
+    return make_finding(
+        tool="agent",
+        rule_id="agent:retry-timeout",
+        category="Functional Correctness",
+        severity=severity,
+        confidence="likely",
+        message=message,
+        path="src/app.py",
+        start_line=42,
+        end_line=42,
+        source="agent",
+        evidence=evidence or [],
+    )
+
+
+def _minor() -> Any:
+    return _finding("Minor", "Missing timeout on the retry loop", evidence=["minor-evidence"])
+
+
+def _major() -> Any:
+    return _finding("Major", "The retry loop never sets a timeout", evidence=["major-evidence"])
+
+
+@_RA4_XFAIL
+def test_semantic_dedupe_keeps_the_strongest_survivor() -> None:
+    """The paraphrased retry-loop-timeout pair collapses to the Major row."""
+    from mergecraft.findings.dedup import dedupe_findings_with_indices
+
+    result = dedupe_findings_with_indices([_minor(), _major()])
+
+    assert len(result.findings) == 1
+    assert result.findings[0].severity == "Major"
+
+
+@_RA4_XFAIL
+def test_dedupe_result_is_permutation_invariant() -> None:
+    """Both orderings of the same pair produce the same survivor severity."""
+    from mergecraft.findings.dedup import dedupe_findings_with_indices
+
+    reference: tuple[str, ...] | None = None
+    for ordering in itertools.permutations([_minor(), _major()]):
+        result = dedupe_findings_with_indices(list(ordering))
+        severities = tuple(sorted(finding.severity for finding in result.findings))
+        if reference is None:
+            reference = severities
+        else:
+            assert severities == reference, f"ordering produced {severities!r} != {reference!r}"
+
+
+@_RA4_XFAIL
+def test_evidence_from_discarded_members_is_retained() -> None:
+    """A discarded paraphrase's evidence survives on the survivor."""
+    from mergecraft.findings.dedup import dedupe_findings_with_indices
+
+    result = dedupe_findings_with_indices([_minor(), _major()])
+
+    assert len(result.findings) == 1
+    evidence = " ".join(result.findings[0].evidence)
+    assert "minor-evidence" in evidence
+    assert "major-evidence" in evidence
+
+
+@_RA4_XFAIL
+def test_kept_indices_still_point_at_the_surviving_row() -> None:
+    """The cross-lane contract RB6 depends on: indices name the row actually kept."""
+    from mergecraft.findings.dedup import dedupe_findings_with_indices
+
+    source = [_minor(), _major()]
+    result = dedupe_findings_with_indices(source)
+
+    assert len(result.kept_indices) == len(result.findings) == 1
+    survivor = source[result.kept_indices[0]]
+    assert survivor is result.findings[0]
+    assert survivor.severity == "Major"

--- a/tests/findings/test_security_vocabulary.py
+++ b/tests/findings/test_security_vocabulary.py
@@ -9,9 +9,43 @@ on the stem relaxation for no reason).
 
 from __future__ import annotations
 
+import pytest
+
 from tests.findings.support import make_finding
 
 _AUTH_STEMS = ("auth", "authentication", "authorization", "unauthenticated", "authorize")
+
+#: ``auth`` forms that name a security concern and must infer Security.
+_SECURITY_AUTH_FORMS = (
+    "auth",
+    "authentication",
+    "authenticate",
+    "authorize",
+    "authorization",
+    "authorized",
+    "authorizer",
+    "authorizing",
+)
+
+#: ``unauth``-prefixed forms have no word boundary before ``auth``; the separate
+#: ``unauth`` pattern covers them, and it must keep doing so.
+_UNAUTH_FORMS = ("unauthenticated", "unauthorized")
+
+#: Ordinary prose that merely begins with ``auth`` — the ``author`` word family.
+_AUTHOR_PROSE_FORMS = (
+    "author",
+    "authors",
+    "authoring",
+    "authored",
+    "authorship",
+    "authoritative",
+    "authority",
+    "authorities",
+)
+
+#: Control text with no security or docs vocabulary. Its inferred category is
+#: the non-security category the prose forms must land on (not pinned by name).
+_AUTHOR_PROSE_CONTROL = "The section is out of date"
 
 _NAMED_SECURITY_CLASSES = (
     "Remote code execution via unsafe eval",
@@ -66,3 +100,35 @@ def test_genuine_style_nit_is_still_capped() -> None:
     normalized = apply_severity_rubric(finding, model_assigned_severity="Critical")
 
     assert normalized.severity not in {"Critical", "Major"}
+
+
+@pytest.mark.parametrize("form", _SECURITY_AUTH_FORMS)
+def test_security_auth_forms_infer_security_category(form: str) -> None:
+    """Every security ``auth`` form infers Security — not just the literal token."""
+    from mergecraft.findings.severity_rubric import infer_category_from_message
+
+    assert infer_category_from_message(f"The {form} path is wrong") == "Security & Privacy", (
+        f"{form!r} did not infer Security & Privacy"
+    )
+
+
+@pytest.mark.parametrize("form", _UNAUTH_FORMS)
+def test_unauth_forms_infer_security_category(form: str) -> None:
+    """``unauth`` forms are covered by their own pattern, not the relaxed stem."""
+    from mergecraft.findings.severity_rubric import infer_category_from_message
+
+    assert infer_category_from_message(f"The {form} path is wrong") == "Security & Privacy", (
+        f"{form!r} did not infer Security & Privacy"
+    )
+
+
+@pytest.mark.parametrize("word", _AUTHOR_PROSE_FORMS)
+def test_author_family_prose_does_not_infer_security_category(word: str) -> None:
+    """The ``author`` word family is ordinary prose, never a security signal."""
+    from mergecraft.findings.severity_rubric import infer_category_from_message
+
+    inferred = infer_category_from_message(f"The {word} section is out of date")
+    assert inferred != "Security & Privacy", f"{word!r} wrongly inferred Security & Privacy"
+    assert inferred == infer_category_from_message(_AUTHOR_PROSE_CONTROL), (
+        f"{word!r} did not match the non-security control category"
+    )

--- a/tests/findings/test_security_vocabulary.py
+++ b/tests/findings/test_security_vocabulary.py
@@ -9,14 +9,7 @@ on the stem relaxation for no reason).
 
 from __future__ import annotations
 
-import pytest
-
 from tests.findings.support import make_finding
-
-_RA3_XFAIL = pytest.mark.xfail(
-    reason="green after RA3: widened security vocabulary and auth stem",
-    strict=False,
-)
 
 _AUTH_STEMS = ("auth", "authentication", "authorization", "unauthenticated", "authorize")
 
@@ -36,7 +29,6 @@ _NAMED_SECURITY_CLASSES = (
 )
 
 
-@_RA3_XFAIL
 def test_auth_stems_infer_security_category() -> None:
     """Every ``auth`` stem infers Security — not just the literal token."""
     from mergecraft.findings.severity_rubric import infer_category_from_message
@@ -48,7 +40,6 @@ def test_auth_stems_infer_security_category() -> None:
         )
 
 
-@_RA3_XFAIL
 def test_named_security_classes_infer_security_category() -> None:
     """Named vulnerability classes the eight-pattern vocabulary misses."""
     from mergecraft.findings.severity_rubric import infer_category_from_message

--- a/tests/findings/test_security_vocabulary.py
+++ b/tests/findings/test_security_vocabulary.py
@@ -1,0 +1,77 @@
+"""Security vocabulary: stems and named classes, plus the deflation guard (RA1.2).
+
+N20 has two halves (D6): the eight-pattern vocabulary misses whole classes, and
+``\\bauth\\b`` only matches the literal token. This module pins the vocabulary
+half through ``infer_category_from_message`` — not by asserting a pattern string
+appears in ``SECURITY_MESSAGE_PATTERNS`` (that would pin today's list and fail
+on the stem relaxation for no reason).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.findings.support import make_finding
+
+_RA3_XFAIL = pytest.mark.xfail(
+    reason="green after RA3: widened security vocabulary and auth stem",
+    strict=False,
+)
+
+_AUTH_STEMS = ("auth", "authentication", "authorization", "unauthenticated", "authorize")
+
+_NAMED_SECURITY_CLASSES = (
+    "Remote code execution via unsafe eval",
+    "RCE in the template renderer",
+    "Unsafe deserialization of a session payload",
+    "Pickle load of untrusted bytes",
+    "Path traversal in the static file handler",
+    "SSRF through a user-controlled callback URL",
+    "CSRF token is not validated",
+    "XXE expansion in the XML parser",
+    "Privilege escalation via a misordered check",
+    "Prototype pollution in the config merge",
+    "Open redirect on the login callback",
+    "Hardcoded key committed in the source",
+)
+
+
+@_RA3_XFAIL
+def test_auth_stems_infer_security_category() -> None:
+    """Every ``auth`` stem infers Security — not just the literal token."""
+    from mergecraft.findings.severity_rubric import infer_category_from_message
+
+    for stem in _AUTH_STEMS:
+        message = f"The {stem} path is wrong"
+        assert infer_category_from_message(message) == "Security & Privacy", (
+            f"{stem!r} did not infer Security & Privacy"
+        )
+
+
+@_RA3_XFAIL
+def test_named_security_classes_infer_security_category() -> None:
+    """Named vulnerability classes the eight-pattern vocabulary misses."""
+    from mergecraft.findings.severity_rubric import infer_category_from_message
+
+    for message in _NAMED_SECURITY_CLASSES:
+        assert infer_category_from_message(message) == "Security & Privacy", (
+            f"{message!r} did not infer Security & Privacy"
+        )
+
+
+def test_genuine_style_nit_is_still_capped() -> None:
+    """The deflation job survives the repair: a real style nit still caps."""
+    from mergecraft.findings.severity_rubric import apply_severity_rubric
+
+    finding = make_finding(
+        category="Maintainability & Code Quality",
+        severity="Critical",
+        message="Prefer f-string over percent formatting",
+        path="src/util.py",
+        start_line=3,
+        end_line=3,
+    )
+
+    normalized = apply_severity_rubric(finding, model_assigned_severity="Critical")
+
+    assert normalized.severity not in {"Critical", "Major"}

--- a/tests/findings/test_severity_end_to_end.py
+++ b/tests/findings/test_severity_end_to_end.py
@@ -1,0 +1,52 @@
+"""Severity composition end to end: inference -> cap -> gate (RA1.2, D5/D14).
+
+The audit's point is the composition, not any one unit. A ``Critical`` security
+finding whose prose names a README must reach ``decide_approval`` as a blocker
+and veto the run. Asserting the rubric in isolation would prove nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.findings.support import make_finding
+
+_RA3_XFAIL = pytest.mark.xfail(
+    reason="green after RA3: inference + cap leave a Critical security finding blocking",
+    strict=False,
+)
+
+_MESSAGE = (
+    "Authentication bypass lets an unauthenticated attacker reach the admin endpoint; see README"
+)
+
+
+@_RA3_XFAIL
+def test_critical_security_finding_reaches_decide_approval_as_blocking() -> None:
+    """Inference -> cap -> BLOCKING_SEVERITIES -> decide_approval is non-success."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+    from mergecraft.findings.severity_rubric import (
+        apply_severity_rubric,
+        infer_category_from_message,
+    )
+
+    category = infer_category_from_message(_MESSAGE)
+    finding = make_finding(
+        category=category,
+        severity="Critical",
+        message=_MESSAGE,
+        path="src/session.py",
+        start_line=12,
+        end_line=12,
+        source="agent",
+    )
+    normalized = apply_severity_rubric(finding, model_assigned_severity="Critical")
+
+    assert normalized.severity in BLOCKING_SEVERITIES, (
+        f"inference produced category {category!r} and capped the finding to "
+        f"{normalized.severity!r}"
+    )
+    conclusion = decide_approval([normalized], run_succeeded=True, tier="trusted")
+    assert conclusion != "success", (
+        f"a blocking Critical security finding produced approval {conclusion!r}"
+    )

--- a/tests/findings/test_severity_end_to_end.py
+++ b/tests/findings/test_severity_end_to_end.py
@@ -7,21 +7,13 @@ and veto the run. Asserting the rubric in isolation would prove nothing.
 
 from __future__ import annotations
 
-import pytest
-
 from tests.findings.support import make_finding
-
-_RA3_XFAIL = pytest.mark.xfail(
-    reason="green after RA3: inference + cap leave a Critical security finding blocking",
-    strict=False,
-)
 
 _MESSAGE = (
     "Authentication bypass lets an unauthenticated attacker reach the admin endpoint; see README"
 )
 
 
-@_RA3_XFAIL
 def test_critical_security_finding_reaches_decide_approval_as_blocking() -> None:
     """Inference -> cap -> BLOCKING_SEVERITIES -> decide_approval is non-success."""
     from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval

--- a/tests/findings/test_severity_impact_pairs.py
+++ b/tests/findings/test_severity_impact_pairs.py
@@ -1,0 +1,105 @@
+"""Impact-based severity: matched-paraphrase pairs (RA1.2, D15).
+
+Each case runs the *same asserted impact* twice through the real composition —
+``infer_category_from_message`` then ``apply_severity_rubric`` — once with an
+incidental word and once without. The claim is that the pair agrees. A single
+assertion on one member would pass on a vocabulary change that merely moves
+which word demotes the finding (N4/N20).
+
+Every incidental case is expected to fail until RA3 lands: incidentals must not
+lower a severity across a blocking boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.findings.fixtures.severity_pairs import SEVERITY_PAIRS, SeverityPair
+from tests.findings.support import make_finding
+
+_RA3_XFAIL = pytest.mark.xfail(
+    reason="green after RA3: impact decides severity, incidental prose does not",
+    strict=False,
+)
+
+
+def _by_case(case_id: str) -> SeverityPair:
+    for pair in SEVERITY_PAIRS:
+        if pair.case_id == case_id:
+            return pair
+    msg = f"unknown severity pair: {case_id}"
+    raise KeyError(msg)
+
+
+def _normalized(message: str, severity: str) -> Any:
+    """Drive inference -> cap over one message and return the normalized finding."""
+    from mergecraft.findings.severity_rubric import (
+        apply_severity_rubric,
+        infer_category_from_message,
+    )
+
+    category = infer_category_from_message(message)
+    finding = make_finding(
+        category=category,
+        severity=severity,
+        message=message,
+        path="src/session.py",
+        start_line=12,
+        end_line=12,
+        source="agent",
+    )
+    return apply_severity_rubric(finding, model_assigned_severity=severity)
+
+
+def _assert_pair_agrees(pair: SeverityPair) -> None:
+    incidental = _normalized(pair.incidental_message, pair.asserted_severity)
+    control = _normalized(pair.impact_message, pair.asserted_severity)
+    assert incidental.severity == control.severity, (
+        f"{pair.case_id}: incidental prose changed the severity "
+        f"({incidental.severity!r} vs control {control.severity!r})"
+    )
+    assert control.severity == pair.asserted_severity, (
+        f"{pair.case_id}: control lost its asserted severity "
+        f"({control.severity!r} != {pair.asserted_severity!r})"
+    )
+
+
+@_RA3_XFAIL
+def test_critical_security_survives_incidental_readme() -> None:
+    _assert_pair_agrees(_by_case("critical-security-readme"))
+
+
+@_RA3_XFAIL
+def test_critical_security_survives_incidental_comment() -> None:
+    _assert_pair_agrees(_by_case("critical-security-comment"))
+
+
+@_RA3_XFAIL
+def test_critical_security_survives_incidental_style() -> None:
+    _assert_pair_agrees(_by_case("critical-security-style"))
+
+
+@_RA3_XFAIL
+def test_critical_security_survives_incidental_naming() -> None:
+    _assert_pair_agrees(_by_case("critical-security-naming"))
+
+
+@_RA3_XFAIL
+def test_critical_security_survives_incidental_typo() -> None:
+    _assert_pair_agrees(_by_case("critical-security-typo"))
+
+
+@_RA3_XFAIL
+def test_major_correctness_survives_incidental_comment() -> None:
+    _assert_pair_agrees(_by_case("major-correctness-comment"))
+
+
+def test_control_paraphrases_retain_their_asserted_severity() -> None:
+    """Every control keeps its asserted severity — the no-incidental guard."""
+    for pair in SEVERITY_PAIRS:
+        control = _normalized(pair.impact_message, pair.asserted_severity)
+        assert control.severity == pair.asserted_severity, (
+            f"{pair.case_id}: control was capped without an incidental word"
+        )

--- a/tests/findings/test_severity_impact_pairs.py
+++ b/tests/findings/test_severity_impact_pairs.py
@@ -14,7 +14,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from tests.findings.fixtures.severity_pairs import SEVERITY_PAIRS, SeverityPair
+import pytest
+
+from tests.findings.fixtures.severity_pairs import (
+    AUTHOR_FAMILY_PAIRS,
+    SEVERITY_PAIRS,
+    AuthorFamilyPair,
+    SeverityPair,
+)
 from tests.findings.support import make_finding
 
 
@@ -23,6 +30,14 @@ def _by_case(case_id: str) -> SeverityPair:
         if pair.case_id == case_id:
             return pair
     msg = f"unknown severity pair: {case_id}"
+    raise KeyError(msg)
+
+
+def _author_pair(case_id: str) -> AuthorFamilyPair:
+    for pair in AUTHOR_FAMILY_PAIRS:
+        if pair.case_id == case_id:
+            return pair
+    msg = f"unknown author-family pair: {case_id}"
     raise KeyError(msg)
 
 
@@ -90,3 +105,79 @@ def test_control_paraphrases_retain_their_asserted_severity() -> None:
         assert control.severity == pair.asserted_severity, (
             f"{pair.case_id}: control was capped without an incidental word"
         )
+
+
+# ---------------------------------------------------------------------------
+# Author-family pairs (RA3 regression): prose that begins with ``auth`` is not a
+# security signal, so it must not lift a style/docs finding across a blocking
+# boundary — and it must not lower a genuine correctness impact.
+# ---------------------------------------------------------------------------
+
+
+def _assert_author_pair_agrees(pair: AuthorFamilyPair) -> tuple[Any, Any]:
+    incidental = _normalized(pair.incidental_message, pair.asserted_severity)
+    control = _normalized(pair.control_message, pair.asserted_severity)
+    assert incidental.severity == control.severity, (
+        f"{pair.case_id}: author-family prose changed the severity "
+        f"({incidental.severity!r} vs control {control.severity!r})"
+    )
+    return incidental, control
+
+
+@pytest.mark.parametrize("case_id", [pair.case_id for pair in AUTHOR_FAMILY_PAIRS])
+def test_author_family_pair_agrees_on_severity(case_id: str) -> None:
+    _assert_author_pair_agrees(_author_pair(case_id))
+
+
+def test_style_nit_with_authors_tail_is_not_raised_to_blocking() -> None:
+    """An incidental ``authors`` must not keep a style nit at a blocking grade."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+
+    pair = _author_pair("critical-style-authors-tail")
+    incidental, control = _assert_author_pair_agrees(pair)
+
+    assert control.severity not in BLOCKING_SEVERITIES
+    assert incidental.severity not in BLOCKING_SEVERITIES, (
+        f"incidental 'authors' lifted a style nit to {incidental.severity!r}"
+    )
+    assert decide_approval([incidental], run_succeeded=True, tier="trusted") == "success", (
+        "an incidental author-family word blocked approval of a style nit"
+    )
+
+
+def test_style_nit_with_authorship_in_the_core_is_not_raised_to_blocking() -> None:
+    """The author word in the asserted impact itself must not read as security."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES
+
+    pair = _author_pair("critical-style-authorship-core")
+    incidental, control = _assert_author_pair_agrees(pair)
+
+    assert control.severity not in BLOCKING_SEVERITIES
+    assert incidental.severity not in BLOCKING_SEVERITIES, (
+        f"'authorship' in the core lifted a style nit to {incidental.severity!r}"
+    )
+
+
+def test_docs_nit_with_authoritative_tail_is_not_raised_to_blocking() -> None:
+    """An incidental ``authoritative`` must not keep a docs nit at a blocking grade."""
+    from mergecraft.agents.gates import BLOCKING_SEVERITIES, decide_approval
+
+    pair = _author_pair("critical-docs-authoritative-tail")
+    incidental, control = _assert_author_pair_agrees(pair)
+
+    assert control.severity not in BLOCKING_SEVERITIES
+    assert incidental.severity not in BLOCKING_SEVERITIES, (
+        f"incidental 'authoritative' lifted a docs nit to {incidental.severity!r}"
+    )
+    assert decide_approval([incidental], run_succeeded=True, tier="trusted") == "success", (
+        "an incidental author-family word blocked approval of a docs nit"
+    )
+
+
+def test_correctness_impact_keeps_its_asserted_severity_with_an_authors_tail() -> None:
+    """An author-family word must not lower a genuine correctness impact either."""
+    pair = _author_pair("critical-correctness-authors-tail")
+    incidental, control = _assert_author_pair_agrees(pair)
+
+    assert control.severity == pair.asserted_severity
+    assert incidental.severity == pair.asserted_severity

--- a/tests/findings/test_severity_impact_pairs.py
+++ b/tests/findings/test_severity_impact_pairs.py
@@ -6,23 +6,16 @@ incidental word and once without. The claim is that the pair agrees. A single
 assertion on one member would pass on a vocabulary change that merely moves
 which word demotes the finding (N4/N20).
 
-Every incidental case is expected to fail until RA3 lands: incidentals must not
-lower a severity across a blocking boundary.
+Incidental prose must not lower a severity across a blocking boundary; RA3 has
+landed, so these cases pin the enforced contract as ordinary passing tests.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from tests.findings.fixtures.severity_pairs import SEVERITY_PAIRS, SeverityPair
 from tests.findings.support import make_finding
-
-_RA3_XFAIL = pytest.mark.xfail(
-    reason="green after RA3: impact decides severity, incidental prose does not",
-    strict=False,
-)
 
 
 def _by_case(case_id: str) -> SeverityPair:
@@ -66,32 +59,26 @@ def _assert_pair_agrees(pair: SeverityPair) -> None:
     )
 
 
-@_RA3_XFAIL
 def test_critical_security_survives_incidental_readme() -> None:
     _assert_pair_agrees(_by_case("critical-security-readme"))
 
 
-@_RA3_XFAIL
 def test_critical_security_survives_incidental_comment() -> None:
     _assert_pair_agrees(_by_case("critical-security-comment"))
 
 
-@_RA3_XFAIL
 def test_critical_security_survives_incidental_style() -> None:
     _assert_pair_agrees(_by_case("critical-security-style"))
 
 
-@_RA3_XFAIL
 def test_critical_security_survives_incidental_naming() -> None:
     _assert_pair_agrees(_by_case("critical-security-naming"))
 
 
-@_RA3_XFAIL
 def test_critical_security_survives_incidental_typo() -> None:
     _assert_pair_agrees(_by_case("critical-security-typo"))
 
 
-@_RA3_XFAIL
 def test_major_correctness_survives_incidental_comment() -> None:
     _assert_pair_agrees(_by_case("major-correctness-comment"))
 

--- a/tests/findings/test_severity_property.py
+++ b/tests/findings/test_severity_property.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -22,11 +21,6 @@ from tests.findings.fixtures.severity_pairs import (
     incidental_message,
 )
 from tests.findings.support import make_finding
-
-_RA3_XFAIL = pytest.mark.xfail(
-    reason="green after RA3: no impact-preserving lexical change crosses a blocking boundary",
-    strict=False,
-)
 
 
 def _normalized(message: str, severity: str) -> Any:
@@ -48,7 +42,6 @@ def _normalized(message: str, severity: str) -> Any:
     return apply_severity_rubric(finding, model_assigned_severity=severity)
 
 
-@_RA3_XFAIL
 @settings(
     max_examples=40,
     deadline=None,

--- a/tests/findings/test_severity_property.py
+++ b/tests/findings/test_severity_property.py
@@ -1,0 +1,72 @@
+"""The property N20 is judged by (RA1.2, D15).
+
+No lexical transformation of a finding's prose that preserves its asserted
+impact may lower its severity across a blocking boundary. The corpus is a fixed
+set of impact statements (security and correctness) crossed with incidental
+tokens; the property compares the incidental paraphrase against the same impact
+without the token. A fixed two-element case would pass on the wrong fix, so the
+property is Hypothesis-driven over the corpus.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from tests.findings.fixtures.severity_pairs import (
+    IMPACT_STATEMENTS,
+    INCIDENTAL_TOKENS,
+    incidental_message,
+)
+from tests.findings.support import make_finding
+
+_RA3_XFAIL = pytest.mark.xfail(
+    reason="green after RA3: no impact-preserving lexical change crosses a blocking boundary",
+    strict=False,
+)
+
+
+def _normalized(message: str, severity: str) -> Any:
+    from mergecraft.findings.severity_rubric import (
+        apply_severity_rubric,
+        infer_category_from_message,
+    )
+
+    category = infer_category_from_message(message)
+    finding = make_finding(
+        category=category,
+        severity=severity,
+        message=message,
+        path="src/session.py",
+        start_line=42,
+        end_line=42,
+        source="agent",
+    )
+    return apply_severity_rubric(finding, model_assigned_severity=severity)
+
+
+@_RA3_XFAIL
+@settings(
+    max_examples=40,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    impact=st.sampled_from(IMPACT_STATEMENTS),
+    incidental=st.sampled_from(INCIDENTAL_TOKENS),
+)
+def test_no_impact_preserving_lexical_change_crosses_a_blocking_boundary(
+    impact: tuple[str, str],
+    incidental: str,
+) -> None:
+    severity, impact_message = impact
+    control = _normalized(impact_message, severity)
+    paraphrased = _normalized(incidental_message(impact_message, incidental), severity)
+
+    assert paraphrased.severity == control.severity, (
+        f"incidental {incidental!r} changed {impact_message!r} from "
+        f"{control.severity!r} to {paraphrased.severity!r}"
+    )

--- a/tests/instructions/test_offline_review_fence.py
+++ b/tests/instructions/test_offline_review_fence.py
@@ -7,9 +7,8 @@ twice — once with a benign operator-supplied "PR body" via
 are identical. The agent is stubbed in-process so the test proves the
 *prompt* is fenced, not that a live model resists.
 
-Pending tests are `@pytest.mark.xfail(strict=True)` — W4 will land the
-fence; these tests fail-strict until the implementation arrives. They pin
-the public outcome, not the impl signature.
+The fence has landed (W4), so these tests run for real. They pin the
+public outcome, not the impl signature.
 """
 
 from __future__ import annotations
@@ -49,23 +48,31 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
 
-def _make_diff_repo(tmp_path: Path) -> Path:
+def _make_diff_repo(root: Path) -> Path:
     """One fixture diff, identical across both runs of W3.1 — the diff
     content must not change between the benign and the injected body;
     only the body (carried in `prompt_extra`) varies. Mirrors the
-    setup in `tests/utils/test_offline_diff.py::test_materialize_on_feature_branch`."""
-    _git(tmp_path, "init")
-    _git(tmp_path, "config", "user.email", "test@example.com")
-    _git(tmp_path, "config", "user.name", "Test")
-    (tmp_path / "a.txt").write_text("one\n", encoding="utf-8")
-    _git(tmp_path, "add", "a.txt")
-    _git(tmp_path, "commit", "-m", "init")
-    _git(tmp_path, "branch", "-M", "main")
-    _git(tmp_path, "checkout", "-b", "feature")
-    (tmp_path / "a.txt").write_text("one\ntwo\n", encoding="utf-8")
-    _git(tmp_path, "add", "a.txt")
-    _git(tmp_path, "commit", "-m", "feature change")
-    return tmp_path
+    setup in `tests/utils/test_offline_diff.py::test_materialize_on_feature_branch`.
+
+    The reviewed repository lives in ``root/repo`` so that any capture
+    artifact written under ``root`` is never part of the reviewed tree.
+    RA6's default materialization includes eligible untracked adds (D11),
+    so a capture file written inside the repo would itself change the
+    second run's diff — and the finding set — for the wrong reason."""
+    repo = root / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "a.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "a.txt").write_text("one\ntwo\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-m", "feature change")
+    return repo
 
 
 def _build_stub_agent(monkeypatch: MonkeyPatch, capture_path: Path) -> None:
@@ -135,7 +142,10 @@ def test_injected_pr_body_does_not_change_findings(
     captures' structure (ignoring the fenced body bytes) to prove the
     injection only changed the fenced section.
 
-    W4 will land the fence; until then this test is xfail.
+    The capture files live outside the reviewed repository (``tmp_path``
+    while the repo is ``tmp_path/repo``): a capture written inside the
+    tree would count as an untracked addition under RA6 and change the
+    second run's diff for the wrong reason.
     """
     _require_fence()
     repo = _make_diff_repo(tmp_path)

--- a/tests/mcp/support_two_commit_pr.py
+++ b/tests/mcp/support_two_commit_pr.py
@@ -1,0 +1,101 @@
+"""Recording two-commit PR fixture for commit-info scope tests (RA1.6).
+
+Commit 1 touches ``security.py``; commit 2 touches ``docs.md``. The full PR
+diff covers both files; each ``get_commit`` returns only its own commit's patch.
+The recording SCM lets a test prove which commit the inspection tool saw without
+touching the network.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+_FIRST_SHA = "1" * 40
+_HEAD_SHA = "2" * 40
+
+_FIRST_HUNK = "@@ -1,3 +1,4 @@\n def check(user):\n+    assert user is not None\n     return user\n"
+_HEAD_HUNK = "@@ -1 +1,2 @@\n # Docs\n+new line\n"
+
+
+@dataclass
+class RecordingScm:
+    """Minimal SCM stub recording every ``get_commit`` / ``get_pull`` call."""
+
+    pulls: dict[int, dict[str, Any]]
+    commits: dict[str, dict[str, Any]]
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def get_commit(self, owner: str, repo: str, sha: str) -> dict[str, Any]:
+        self.calls.append(("get_commit", sha))
+        return copy.deepcopy(self.commits[sha])
+
+    async def get_pull(self, owner: str, repo: str, pull_number: int) -> dict[str, Any]:
+        self.calls.append(("get_pull", str(pull_number)))
+        return copy.deepcopy(self.pulls[pull_number])
+
+
+@dataclass
+class TwoCommitPR:
+    """Fixture bundle for one two-commit pull request."""
+
+    root: Any
+    pr_diff_path: Any
+    first_sha: str
+    head_sha: str
+    scm: RecordingScm
+    pr_number: int = 1
+
+    def pr_diff_text(self) -> str:
+        return self.pr_diff_path.read_text(encoding="utf-8")
+
+
+def _commit_payload(sha: str, filename: str, hunk: str) -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "commit": {"message": f"change {filename}", "author": {"date": "2026-09-01T00:00:00Z"}},
+        "author": {"login": "dev"},
+        "committer": {"login": "dev"},
+        "html_url": f"https://example.test/commit/{sha}",
+        "parents": [],
+        "stats": {"additions": 1, "deletions": 0, "total": 1},
+        "files": [{"filename": filename, "patch": hunk}],
+    }
+
+
+def _diff_header(filename: str, hunk: str) -> str:
+    return f"diff --git a/{filename} b/{filename}\n--- a/{filename}\n+++ b/{filename}\n{hunk}"
+
+
+def build_two_commit_pr(tmp_path: Any) -> TwoCommitPR:
+    """Build a disposable two-commit PR with a recording SCM."""
+    pr_diff_path = tmp_path / "pr.diff"
+    pr_diff_path.write_text(
+        _diff_header("security.py", _FIRST_HUNK) + _diff_header("docs.md", _HEAD_HUNK),
+        encoding="utf-8",
+    )
+    scm = RecordingScm(
+        pulls={
+            1: {
+                "head": {"ref": "feature", "sha": _HEAD_SHA},
+                "base": {"ref": "main", "sha": _FIRST_SHA},
+                "title": "Two-commit change",
+                "html_url": "https://example.test/pull/1",
+            }
+        },
+        commits={
+            _FIRST_SHA: _commit_payload(_FIRST_SHA, "security.py", _FIRST_HUNK),
+            _HEAD_SHA: _commit_payload(_HEAD_SHA, "docs.md", _HEAD_HUNK),
+        },
+    )
+    return TwoCommitPR(
+        root=tmp_path,
+        pr_diff_path=pr_diff_path,
+        first_sha=_FIRST_SHA,
+        head_sha=_HEAD_SHA,
+        scm=scm,
+    )
+
+
+__all__ = ["RecordingScm", "TwoCommitPR", "build_two_commit_pr"]

--- a/tests/mcp/test_analyzer_rerun_retention.py
+++ b/tests/mcp/test_analyzer_rerun_retention.py
@@ -24,11 +24,6 @@ from mergecraft.utils.github import GitHubClient
 if TYPE_CHECKING:
     from pathlib import Path
 
-_RA5_XFAIL = pytest.mark.xfail(
-    reason="green after RA5: retain analyzer evidence by covered scope",
-    strict=False,
-)
-
 
 def _ctx(tmp_path: Path) -> ToolContext:
     return ToolContext(
@@ -115,7 +110,6 @@ async def _retained_fingerprints(ctx: ToolContext) -> set[str]:
 
 
 @pytest.mark.asyncio
-@_RA5_XFAIL
 async def test_clean_partial_rerun_does_not_erase_a_prior_blocker(
     tmp_path: Path, pipeline: dict[str, Any]
 ) -> None:
@@ -143,7 +137,6 @@ async def test_same_scope_rerun_supersedes(tmp_path: Path, pipeline: dict[str, A
 
 
 @pytest.mark.asyncio
-@_RA5_XFAIL
 async def test_unavailable_analyzer_rerun_does_not_supersede(
     tmp_path: Path, pipeline: dict[str, Any]
 ) -> None:
@@ -157,7 +150,6 @@ async def test_unavailable_analyzer_rerun_does_not_supersede(
 
 
 @pytest.mark.asyncio
-@_RA5_XFAIL
 async def test_no_match_rerun_does_not_supersede(tmp_path: Path, pipeline: dict[str, Any]) -> None:
     ctx = _ctx(tmp_path)
     await _run(ctx, changed_files=["bug.py"])
@@ -168,7 +160,6 @@ async def test_no_match_rerun_does_not_supersede(tmp_path: Path, pipeline: dict[
 
 
 @pytest.mark.asyncio
-@_RA5_XFAIL
 async def test_terminal_approve_stays_rejected_after_a_partial_clean_rerun(
     tmp_path: Path, pipeline: dict[str, Any]
 ) -> None:
@@ -192,7 +183,6 @@ async def test_terminal_approve_stays_rejected_after_a_partial_clean_rerun(
 
 
 @pytest.mark.asyncio
-@_RA5_XFAIL
 async def test_concurrent_overlapping_runs_do_not_lose_findings(
     tmp_path: Path, pipeline: dict[str, Any]
 ) -> None:

--- a/tests/mcp/test_analyzer_rerun_retention.py
+++ b/tests/mcp/test_analyzer_rerun_retention.py
@@ -1,0 +1,207 @@
+"""Partial analyzer reruns must not erase earlier blockers (RA1.4, N2/D9).
+
+``_store_run_state`` replaces the whole ``AnalyzerRunState`` on every call, so a
+clean re-run over a *different* covered scope discards findings the previous
+pass produced for files it never looked at. Retention is keyed by
+(immutable snapshot, analyzer, covered scope); a rerun supersedes only for an
+equivalent covered scope. The terminal-approve guard is the consequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.findings.support import make_finding
+
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import AnalyzerRunState, init_tool_state
+from mergecraft.modes import compute_modes
+from mergecraft.utils.github import GitHubClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_RA5_XFAIL = pytest.mark.xfail(
+    reason="green after RA5: retain analyzer evidence by covered scope",
+    strict=False,
+)
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(
+            event=PayloadEvent(trigger="unknown"),
+            shell="restricted",
+        ),
+        github=GitHubClient(token=""),
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=init_tool_state(owner="acme", name="demo", dir=str(tmp_path)),
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+        analyzers_settings_enabled=True,
+        analyzers_mode="auto",
+        trust_tier="trusted",
+    )
+
+
+def _row(fingerprint: str, severity: str) -> dict[str, Any]:
+    return make_finding(
+        tool="bandit",
+        rule_id=f"rule-{fingerprint}",
+        category="Security & Privacy",
+        severity=severity,
+        confidence="certain",
+        message=f"finding {fingerprint}",
+        path="bug.py",
+        start_line=10,
+        end_line=10,
+        source="analyzer",
+        fingerprint=fingerprint,
+        introduced_by_pr="true",
+    ).model_dump()
+
+
+def _state(*fingerprints: tuple[str, str], ran: bool = True, reason: str | None = None) -> Any:
+    return AnalyzerRunState(
+        ran=ran,
+        reason=reason,
+        findings=[_row(fingerprint, severity) for fingerprint, severity in fingerprints],
+    )
+
+
+@pytest.fixture
+def pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Route every covered scope to a configured state; record the bug call count."""
+    calls: dict[str, int] = {"bug": 0}
+    controls: dict[str, Any] = {"docs": _state(), "unavailable": _state(ran=False, reason="none")}
+
+    def _fake(**kwargs: Any) -> Any:
+        changed = set(kwargs.get("changed_files") or [])
+        if "bug.py" in changed:
+            calls["bug"] += 1
+            return _state(("major-bug", "Major")) if calls["bug"] == 1 else _state()
+        if "docs.md" in changed:
+            return controls["docs"]
+        if "a.py" in changed:
+            return _state(("fp-a", "Major"))
+        if "b.py" in changed:
+            return _state(("fp-b", "Major"))
+        return _state(ran=False, reason="no analyzers matched")
+
+    monkeypatch.setattr("mergecraft.analyzers.pipeline.run_analyzer_pipeline", _fake)
+    return controls
+
+
+async def _run(ctx: ToolContext, **params: Any) -> dict[str, Any]:
+    from mergecraft.mcp.analyzers import run_analyzers_tool
+
+    result = await run_analyzers_tool(ctx).execute(params)
+    return json.loads(result.content[0]["text"])
+
+
+async def _retained_fingerprints(ctx: ToolContext) -> set[str]:
+    from mergecraft.mcp.analyzers import analyzer_findings_tool
+
+    payload = json.loads((await analyzer_findings_tool(ctx).execute({})).content[0]["text"])
+    return {row.get("fingerprint") for row in payload["findings"]}
+
+
+@pytest.mark.asyncio
+@_RA5_XFAIL
+async def test_clean_partial_rerun_does_not_erase_a_prior_blocker(
+    tmp_path: Path, pipeline: dict[str, Any]
+) -> None:
+    ctx = _ctx(tmp_path)
+    await _run(ctx, changed_files=["bug.py"])
+    assert await _retained_fingerprints(ctx) == {"major-bug"}
+
+    await _run(ctx, changed_files=["docs.md"])
+
+    assert "major-bug" in await _retained_fingerprints(ctx)
+
+
+@pytest.mark.asyncio
+async def test_same_scope_rerun_supersedes(tmp_path: Path, pipeline: dict[str, Any]) -> None:
+    """A genuine rerun over the same covered scope replaces the earlier result."""
+    ctx = _ctx(tmp_path)
+    await _run(ctx, changed_files=["bug.py"])
+    stored = ctx.tool_state.analyzer_run
+    assert stored is not None
+    stored.key = None  # force a fresh run rather than the reuse fast-path
+
+    await _run(ctx, changed_files=["bug.py"])
+
+    assert await _retained_fingerprints(ctx) == set()
+
+
+@pytest.mark.asyncio
+@_RA5_XFAIL
+async def test_unavailable_analyzer_rerun_does_not_supersede(
+    tmp_path: Path, pipeline: dict[str, Any]
+) -> None:
+    ctx = _ctx(tmp_path)
+    await _run(ctx, changed_files=["bug.py"])
+    pipeline["docs"] = pipeline["unavailable"]
+
+    await _run(ctx, changed_files=["docs.md"])
+
+    assert "major-bug" in await _retained_fingerprints(ctx)
+
+
+@pytest.mark.asyncio
+@_RA5_XFAIL
+async def test_no_match_rerun_does_not_supersede(tmp_path: Path, pipeline: dict[str, Any]) -> None:
+    ctx = _ctx(tmp_path)
+    await _run(ctx, changed_files=["bug.py"])
+
+    await _run(ctx, changed_files=["docs.md"])
+
+    assert "major-bug" in await _retained_fingerprints(ctx)
+
+
+@pytest.mark.asyncio
+@_RA5_XFAIL
+async def test_terminal_approve_stays_rejected_after_a_partial_clean_rerun(
+    tmp_path: Path, pipeline: dict[str, Any]
+) -> None:
+    from mergecraft.mcp.verdict import validate_submission, validation_state_from_tool_state
+
+    ctx = _ctx(tmp_path)
+    await _run(ctx, changed_files=["bug.py"])
+    blocking = validate_submission(
+        {"verdict": "approve", "summary": "ok", "findings": []},
+        state=validation_state_from_tool_state(ctx.tool_state),
+    )
+    assert blocking.accepted is False
+
+    await _run(ctx, changed_files=["docs.md"])
+
+    still = validate_submission(
+        {"verdict": "approve", "summary": "ok", "findings": []},
+        state=validation_state_from_tool_state(ctx.tool_state),
+    )
+    assert still.accepted is False, "a partial clean rerun cleared a prior blocker"
+
+
+@pytest.mark.asyncio
+@_RA5_XFAIL
+async def test_concurrent_overlapping_runs_do_not_lose_findings(
+    tmp_path: Path, pipeline: dict[str, Any]
+) -> None:
+    ctx = _ctx(tmp_path)
+
+    await asyncio.gather(
+        _run(ctx, changed_files=["a.py"]),
+        _run(ctx, changed_files=["b.py"]),
+    )
+
+    fingerprints = await _retained_fingerprints(ctx)
+    assert {"fp-a", "fp-b"} <= fingerprints

--- a/tests/mcp/test_commit_info_scope.py
+++ b/tests/mcp/test_commit_info_scope.py
@@ -1,0 +1,140 @@
+"""``get_commit_info`` must not register review scope (RA1.4, N3/D10).
+
+The tool legitimately writes and returns a single-commit patch, but it is a
+``REPOSITORY_READ``. Registering that patch as the canonical scope silently
+replaces the whole-PR review scope with the last commit's diff, which corrupts
+admissible citations, inline anchors and blast radius downstream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.mcp.support_two_commit_pr import build_two_commit_pr
+
+from mergecraft.mcp.commit_info import get_commit_info_tool
+from mergecraft.mcp.context import PayloadEvent, RepoIdentity, ResolvedPayload, ToolContext
+from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
+from mergecraft.mcp.verdict import ReviewPhase, register_review_scope
+from mergecraft.modes import compute_modes
+
+_RA5_XFAIL = pytest.mark.xfail(
+    reason="green after RA5: a metadata read may not register review scope",
+    strict=False,
+)
+
+
+def _ctx(pr: Any, tmp_path: Path) -> ToolContext:
+    state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
+    ctx = ToolContext(
+        agent_id="claude",
+        repo=RepoIdentity(owner="acme", name="demo"),
+        payload=ResolvedPayload(event=PayloadEvent(trigger="pull_request")),
+        scm=pr.scm,
+        github_installation_token="",
+        git_token="",
+        api_token="",
+        modes=compute_modes("claude"),
+        tool_state=state,
+        mcp_server_url="",
+        tmpdir=str(tmp_path),
+    )
+    ctx.tool_state.pr_number = pr.pr_number
+    primary = primary_repo_state(state)
+    primary.checkout_sha = pr.head_sha
+    register_review_scope(state, diff_path=str(pr.pr_diff_path), provenance="checkout")
+    return ctx
+
+
+async def _inspect_head(ctx: ToolContext, head_sha: str) -> dict[str, Any]:
+    result = await get_commit_info_tool(ctx).execute({"sha": head_sha})
+    assert result.is_error is False, result.content[0]["text"]
+    import json
+
+    return json.loads(result.content[0]["text"])
+
+
+def _read_text(path: str) -> str:
+    """Sync helper — keeps blocking FS reads out of async test bodies."""
+    return Path(path).read_text(encoding="utf-8")
+
+
+@_RA5_XFAIL
+@pytest.mark.asyncio
+async def test_get_commit_info_does_not_change_canonical_scope(tmp_path: Path) -> None:
+    pr = build_two_commit_pr(tmp_path)
+    ctx = _ctx(pr, tmp_path)
+    primary = primary_repo_state(ctx.tool_state)
+
+    await _inspect_head(ctx, pr.head_sha)
+
+    assert primary.diff_path == str(pr.pr_diff_path)
+    assert ctx.tool_state.scope_provenance == "checkout"
+    assert ctx.tool_state.review_phase == ReviewPhase.ESTABLISH_SCOPE.value
+
+
+@pytest.mark.asyncio
+async def test_get_commit_info_still_returns_a_usable_diff_file(tmp_path: Path) -> None:
+    """The tool keeps working: it still writes and returns the commit patch."""
+    pr = build_two_commit_pr(tmp_path)
+    ctx = _ctx(pr, tmp_path)
+
+    payload = await _inspect_head(ctx, pr.head_sha)
+
+    diff_file = payload.get("diffFile")
+    assert diff_file
+    text = _read_text(diff_file)
+    assert "docs.md" in text
+
+
+@_RA5_XFAIL
+@pytest.mark.asyncio
+async def test_admissible_changed_files_survive_head_inspection(tmp_path: Path) -> None:
+    from mergecraft.utils.diff_paths import changed_paths_from_diff
+
+    pr = build_two_commit_pr(tmp_path)
+    ctx = _ctx(pr, tmp_path)
+
+    await _inspect_head(ctx, pr.head_sha)
+
+    primary = primary_repo_state(ctx.tool_state)
+    assert primary.diff_path is not None
+    paths = set(changed_paths_from_diff(_read_text(primary.diff_path)))
+    assert {"security.py", "docs.md"} <= paths
+
+
+@_RA5_XFAIL
+@pytest.mark.asyncio
+async def test_blast_radius_survives_head_inspection(tmp_path: Path) -> None:
+    from mergecraft.evidence.run_packet import classify_run_blast_radius
+
+    pr = build_two_commit_pr(tmp_path)
+    ctx = _ctx(pr, tmp_path)
+    primary = primary_repo_state(ctx.tool_state)
+    before = classify_run_blast_radius(pr.pr_diff_text())
+
+    await _inspect_head(ctx, pr.head_sha)
+
+    assert primary.diff_path is not None
+    after = classify_run_blast_radius(_read_text(primary.diff_path))
+    assert before is not None
+    assert after is not None
+    assert after.lane == before.lane
+
+
+@_RA5_XFAIL
+@pytest.mark.asyncio
+async def test_inline_anchors_survive_head_inspection(tmp_path: Path) -> None:
+    from mergecraft.mcp.inline_anchors import build_inline_anchor_index
+
+    pr = build_two_commit_pr(tmp_path)
+    ctx = _ctx(pr, tmp_path)
+
+    await _inspect_head(ctx, pr.head_sha)
+
+    primary = primary_repo_state(ctx.tool_state)
+    assert primary.diff_path is not None
+    index = build_inline_anchor_index(_read_text(primary.diff_path))
+    assert any(path == "security.py" for path, _line, _side in index.anchors)

--- a/tests/mcp/test_commit_info_scope.py
+++ b/tests/mcp/test_commit_info_scope.py
@@ -20,11 +20,6 @@ from mergecraft.mcp.tool_state import init_tool_state, primary_repo_state
 from mergecraft.mcp.verdict import ReviewPhase, register_review_scope
 from mergecraft.modes import compute_modes
 
-_RA5_XFAIL = pytest.mark.xfail(
-    reason="green after RA5: a metadata read may not register review scope",
-    strict=False,
-)
-
 
 def _ctx(pr: Any, tmp_path: Path) -> ToolContext:
     state = init_tool_state(owner="acme", name="demo", dir=str(tmp_path))
@@ -61,7 +56,6 @@ def _read_text(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-@_RA5_XFAIL
 @pytest.mark.asyncio
 async def test_get_commit_info_does_not_change_canonical_scope(tmp_path: Path) -> None:
     pr = build_two_commit_pr(tmp_path)
@@ -89,7 +83,6 @@ async def test_get_commit_info_still_returns_a_usable_diff_file(tmp_path: Path) 
     assert "docs.md" in text
 
 
-@_RA5_XFAIL
 @pytest.mark.asyncio
 async def test_admissible_changed_files_survive_head_inspection(tmp_path: Path) -> None:
     from mergecraft.utils.diff_paths import changed_paths_from_diff
@@ -105,7 +98,6 @@ async def test_admissible_changed_files_survive_head_inspection(tmp_path: Path) 
     assert {"security.py", "docs.md"} <= paths
 
 
-@_RA5_XFAIL
 @pytest.mark.asyncio
 async def test_blast_radius_survives_head_inspection(tmp_path: Path) -> None:
     from mergecraft.evidence.run_packet import classify_run_blast_radius
@@ -124,7 +116,6 @@ async def test_blast_radius_survives_head_inspection(tmp_path: Path) -> None:
     assert after.lane == before.lane
 
 
-@_RA5_XFAIL
 @pytest.mark.asyncio
 async def test_inline_anchors_survive_head_inspection(tmp_path: Path) -> None:
     from mergecraft.mcp.inline_anchors import build_inline_anchor_index

--- a/tests/mcp/test_reviewer_resilience_degraded_scope.py
+++ b/tests/mcp/test_reviewer_resilience_degraded_scope.py
@@ -326,8 +326,18 @@ async def test_successful_checkout_pr_sets_scope_provenance_checkout(tmp_path: P
     assert ctx.tool_state.review_phase == ReviewPhase.ESTABLISH_SCOPE.value
 
 
+@pytest.mark.xfail(
+    reason="green after RA5: get_commit_info is REPOSITORY_READ and must not register scope",
+    strict=False,
+)
 @pytest.mark.asyncio
-async def test_get_commit_info_registers_scope_for_pr_head(tmp_path: Path) -> None:
+async def test_get_commit_info_does_not_register_scope_for_pr_head(tmp_path: Path) -> None:
+    """N3 / D10 — a metadata read must not replace the canonical review scope.
+
+    The tool still writes and returns its single-commit patch; it must not
+    advance ``review_phase`` or set ``primary.diff_path``. Before RA5 this test
+    pinned the opposite behaviour as intended — that expectation is the defect.
+    """
     head_sha = "5" * 40
     ctx = _ctx(tmp_path, _StubGitHub(head_sha=head_sha))
     ctx.tool_state.pr_number = 1
@@ -336,8 +346,8 @@ async def test_get_commit_info_registers_scope_for_pr_head(tmp_path: Path) -> No
 
     result = await get_commit_info_tool(ctx).execute({"sha": head_sha})
     assert result.is_error is False, result.content[0]["text"]
-    assert ctx.tool_state.review_phase == ReviewPhase.ESTABLISH_SCOPE.value
-    assert primary.diff_path
+    assert ctx.tool_state.review_phase != ReviewPhase.ESTABLISH_SCOPE.value
+    assert primary.diff_path is None
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_reviewer_resilience_degraded_scope.py
+++ b/tests/mcp/test_reviewer_resilience_degraded_scope.py
@@ -326,10 +326,6 @@ async def test_successful_checkout_pr_sets_scope_provenance_checkout(tmp_path: P
     assert ctx.tool_state.review_phase == ReviewPhase.ESTABLISH_SCOPE.value
 
 
-@pytest.mark.xfail(
-    reason="green after RA5: get_commit_info is REPOSITORY_READ and must not register scope",
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_get_commit_info_does_not_register_scope_for_pr_head(tmp_path: Path) -> None:
     """N3 / D10 — a metadata read must not replace the canonical review scope.

--- a/tests/security/test_credential_authority_drift.py
+++ b/tests/security/test_credential_authority_drift.py
@@ -1,0 +1,132 @@
+"""One credential authority: the fork invariant and the agent-env filter (RA1.1, D2/N21).
+
+``action/inputs._PROVIDER_CREDENTIAL_ENV_KEYS`` and
+``utils/secrets.PROVIDER_KEY_ENV_VARS`` are two hand-maintained literals that
+disagree with each other and with the provider registry. These tests derive the
+registry's credential names from the registry itself, so adding a provider to
+one consumer and not the other fails here rather than re-drifting silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from mergecraft.config.runtime_provider_registry import (
+    _credential_suffixes_for_entry,
+    _harness_env_name_for_suffix,
+    indexed_env_key,
+)
+from mergecraft.config.settings import ProviderRegistryEntry
+from mergecraft.utils.secrets import (
+    PROVIDER_KEY_ENV_VARS,
+    build_agent_env,
+)
+from tests.analyzers.support import FORK_PULL_REQUEST_EVENT
+from tests.trust_credentials.support import import_action_symbol
+
+_RA2_XFAIL = pytest.mark.xfail(
+    reason="green after RA2: both credential sets derive from the provider registry",
+    strict=False,
+)
+
+_ENTRIES: tuple[ProviderRegistryEntry, ...] = tuple(
+    ProviderRegistryEntry.model_validate(row)
+    for row in (
+        {"label": "anthropic", "harness": "claude", "envIndex": 1, "authKind": "oauth"},
+        {"label": "openai", "harness": "codex", "envIndex": 2, "authKind": "device_code"},
+        {"label": "bedrock", "harness": "claude", "envIndex": 3, "authKind": "cloud_chain"},
+        {"label": "vertex", "harness": "claude", "envIndex": 4, "authKind": "cloud_chain"},
+        {"label": "google", "harness": "gemini", "envIndex": 5, "authKind": "api_key"},
+        {"label": "cursor", "harness": "cursor", "envIndex": 6, "authKind": "api_key"},
+    )
+)
+
+
+def _indexed_names() -> frozenset[str]:
+    names: set[str] = set()
+    for entry in _ENTRIES:
+        for suffix in _credential_suffixes_for_entry(entry):
+            names.add(indexed_env_key(entry.env_index, suffix))
+    return frozenset(names)
+
+
+def _flat_names() -> frozenset[str]:
+    names: set[str] = set()
+    for entry in _ENTRIES:
+        for suffix in _credential_suffixes_for_entry(entry):
+            harness_name = _harness_env_name_for_suffix(entry.label, suffix)
+            if harness_name is not None:
+                names.add(harness_name)
+    return frozenset(names)
+
+
+def _registry_names() -> frozenset[str]:
+    return _indexed_names() | _flat_names()
+
+
+def _invariant_rejects(name: str) -> bool:
+    validate = import_action_symbol("validate_fork_credential_invariant")
+    from mergecraft.action.inputs import ForkCredentialInvariantError
+
+    try:
+        validate(event=FORK_PULL_REQUEST_EVENT, env={name: "planted-credential"})
+    except ForkCredentialInvariantError:
+        return True
+    return False
+
+
+@_RA2_XFAIL
+def test_fork_invariant_covers_every_registry_credential_name() -> None:
+    """Every registry credential name — indexed and flat — fires the invariant."""
+    missing = sorted(name for name in _registry_names() if not _invariant_rejects(name))
+    assert not missing, f"fork invariant misses registry credential names: {missing}"
+
+
+@_RA2_XFAIL
+def test_agent_env_filter_covers_every_registry_credential_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The declared strip set names every registry credential, and strips it."""
+    flat = _flat_names()
+    missing = sorted(flat - PROVIDER_KEY_ENV_VARS)
+    assert not missing, f"agent-env strip set is missing registry credentials: {missing}"
+
+    for name in sorted(flat):
+        monkeypatch.setenv(name, "planted-credential")
+    env = build_agent_env("opencode")
+    leaked = sorted(name for name in flat if name in env)
+    assert not leaked, f"build_agent_env kept registry credentials: {leaked}"
+
+
+@_RA2_XFAIL
+def test_google_api_key_is_present_in_both_sets() -> None:
+    """N21's named drift, pinned: ``GOOGLE_API_KEY`` is a credential in both sets."""
+    from mergecraft.action.inputs import _PROVIDER_CREDENTIAL_ENV_KEYS
+
+    assert "GOOGLE_API_KEY" in _PROVIDER_CREDENTIAL_ENV_KEYS
+    assert "GOOGLE_API_KEY" in PROVIDER_KEY_ENV_VARS
+
+
+def _validate_fork(env: Mapping[str, str]) -> None:
+    validate = import_action_symbol("validate_fork_credential_invariant")
+    validate(event=FORK_PULL_REQUEST_EVENT, env=dict(env))
+
+
+@_RA2_XFAIL
+@pytest.mark.parametrize(
+    "env_key",
+    [
+        "LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN",
+        "LLM_PROVIDER_2_CODEX_AUTH_JSON",
+        "LLM_PROVIDER_3_AWS_ACCESS_KEY_ID",
+        "LLM_PROVIDER_3_AWS_SECRET_ACCESS_KEY",
+        "LLM_PROVIDER_4_GOOGLE_APPLICATION_CREDENTIALS",
+    ],
+)
+def test_indexed_registry_credential_is_rejected_on_fork_head(env_key: str) -> None:
+    from mergecraft.action.inputs import ForkCredentialInvariantError
+
+    with pytest.raises(ForkCredentialInvariantError):
+        _validate_fork({env_key: "planted-credential"})

--- a/tests/security/test_credential_authority_drift.py
+++ b/tests/security/test_credential_authority_drift.py
@@ -26,11 +26,6 @@ from mergecraft.utils.secrets import (
 from tests.analyzers.support import FORK_PULL_REQUEST_EVENT
 from tests.trust_credentials.support import import_action_symbol
 
-_RA2_XFAIL = pytest.mark.xfail(
-    reason="green after RA2: both credential sets derive from the provider registry",
-    strict=False,
-)
-
 _ENTRIES: tuple[ProviderRegistryEntry, ...] = tuple(
     ProviderRegistryEntry.model_validate(row)
     for row in (
@@ -77,14 +72,12 @@ def _invariant_rejects(name: str) -> bool:
     return False
 
 
-@_RA2_XFAIL
 def test_fork_invariant_covers_every_registry_credential_name() -> None:
     """Every registry credential name — indexed and flat — fires the invariant."""
     missing = sorted(name for name in _registry_names() if not _invariant_rejects(name))
     assert not missing, f"fork invariant misses registry credential names: {missing}"
 
 
-@_RA2_XFAIL
 def test_agent_env_filter_covers_every_registry_credential_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -100,7 +93,6 @@ def test_agent_env_filter_covers_every_registry_credential_name(
     assert not leaked, f"build_agent_env kept registry credentials: {leaked}"
 
 
-@_RA2_XFAIL
 def test_google_api_key_is_present_in_both_sets() -> None:
     """N21's named drift, pinned: ``GOOGLE_API_KEY`` is a credential in both sets."""
     from mergecraft.action.inputs import _PROVIDER_CREDENTIAL_ENV_KEYS
@@ -114,7 +106,6 @@ def _validate_fork(env: Mapping[str, str]) -> None:
     validate(event=FORK_PULL_REQUEST_EVENT, env=dict(env))
 
 
-@_RA2_XFAIL
 @pytest.mark.parametrize(
     "env_key",
     [

--- a/tests/security/test_fork_credential_invariant.py
+++ b/tests/security/test_fork_credential_invariant.py
@@ -17,11 +17,6 @@ from mergecraft.utils.secrets import filter_env
 from tests.analyzers.support import FORK_PULL_REQUEST_EVENT, SAME_REPO_PULL_REQUEST_EVENT
 from tests.trust_credentials.support import import_action_symbol
 
-_RA2_XFAIL = pytest.mark.xfail(
-    reason="green after RA2: fork invariant derives from the one credential registry",
-    strict=False,
-)
-
 _FORK = FORK_PULL_REQUEST_EVENT
 _SAME_REPO = SAME_REPO_PULL_REQUEST_EVENT
 
@@ -38,12 +33,10 @@ def _assert_rejected(env: Mapping[str, str]) -> None:
         _validate(env)
 
 
-@_RA2_XFAIL
 def test_indexed_oauth_credential_is_rejected_on_fork_head() -> None:
     _assert_rejected({"LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-indexed-oauth"})
 
 
-@_RA2_XFAIL
 def test_indexed_device_code_credential_is_rejected_on_fork_head() -> None:
     _assert_rejected({"LLM_PROVIDER_1_CODEX_AUTH_JSON": '{"tokens": {"access_token": "x"}}'})
 
@@ -56,7 +49,6 @@ def test_indexed_device_code_credential_is_rejected_on_fork_head() -> None:
         ("LLM_PROVIDER_1_GOOGLE_APPLICATION_CREDENTIALS", "/run/vertex/indexed.json"),
     ],
 )
-@_RA2_XFAIL
 def test_indexed_cloud_chain_credentials_are_rejected_on_fork_head(
     env_key: str, value: str
 ) -> None:
@@ -102,7 +94,6 @@ def test_same_repo_event_with_every_auth_kind_is_permitted() -> None:
     validate(event=_SAME_REPO, env=env)
 
 
-@_RA2_XFAIL
 def test_untrusted_tier_filtering_does_not_reintroduce_the_credential() -> None:
     """The audit's reproduction path: agent-env filtering must not be the guard.
 

--- a/tests/security/test_fork_credential_invariant.py
+++ b/tests/security/test_fork_credential_invariant.py
@@ -1,0 +1,122 @@
+"""Fork-head credential invariant: every auth kind, both spellings (RA1.1, N1/N21).
+
+The invariant is a **presence** check before dispatch (D3). The baseline only
+recognises the flat spellings plus the ``LLM_PROVIDER_*_API_KEY`` suffix rule,
+so indexed OAuth, device-code and cloud-chain credentials sail past a fork
+event. Each case here drives the real ``validate_fork_credential_invariant``
+entry point with a genuine fork payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from mergecraft.utils.secrets import filter_env
+from tests.analyzers.support import FORK_PULL_REQUEST_EVENT, SAME_REPO_PULL_REQUEST_EVENT
+from tests.trust_credentials.support import import_action_symbol
+
+_RA2_XFAIL = pytest.mark.xfail(
+    reason="green after RA2: fork invariant derives from the one credential registry",
+    strict=False,
+)
+
+_FORK = FORK_PULL_REQUEST_EVENT
+_SAME_REPO = SAME_REPO_PULL_REQUEST_EVENT
+
+
+def _validate(env: Mapping[str, str]) -> None:
+    validate = import_action_symbol("validate_fork_credential_invariant")
+    validate(event=_FORK, env=dict(env))
+
+
+def _assert_rejected(env: Mapping[str, str]) -> None:
+    from mergecraft.action.inputs import ForkCredentialInvariantError
+
+    with pytest.raises(ForkCredentialInvariantError):
+        _validate(env)
+
+
+@_RA2_XFAIL
+def test_indexed_oauth_credential_is_rejected_on_fork_head() -> None:
+    _assert_rejected({"LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-indexed-oauth"})
+
+
+@_RA2_XFAIL
+def test_indexed_device_code_credential_is_rejected_on_fork_head() -> None:
+    _assert_rejected({"LLM_PROVIDER_1_CODEX_AUTH_JSON": '{"tokens": {"access_token": "x"}}'})
+
+
+@pytest.mark.parametrize(
+    ("env_key", "value"),
+    [
+        ("LLM_PROVIDER_1_AWS_ACCESS_KEY_ID", "AKIA-INDEXED"),
+        ("LLM_PROVIDER_1_AWS_SECRET_ACCESS_KEY", "indexed-secret"),
+        ("LLM_PROVIDER_1_GOOGLE_APPLICATION_CREDENTIALS", "/run/vertex/indexed.json"),
+    ],
+)
+@_RA2_XFAIL
+def test_indexed_cloud_chain_credentials_are_rejected_on_fork_head(
+    env_key: str, value: str
+) -> None:
+    _assert_rejected({env_key: value})
+
+
+@pytest.mark.parametrize(
+    "env_key",
+    [
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CODEX_AUTH_JSON",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "NOUS_API_KEY",
+        "CURSOR_API_KEY",
+    ],
+)
+def test_flat_legacy_spellings_stay_rejected(env_key: str) -> None:
+    """Guard — the flat spellings already fire on trunk and must not regress."""
+    _assert_rejected({env_key: "planted-credential"})
+
+
+def test_same_repo_event_with_every_auth_kind_is_permitted() -> None:
+    """The fail-closed rule must not become fail-always."""
+    validate = import_action_symbol("validate_fork_credential_invariant")
+    env = {
+        "ANTHROPIC_API_KEY": "sk-ant",
+        "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oauth",
+        "OPENAI_API_KEY": "sk-openai",
+        "CODEX_AUTH_JSON": '{"tokens": {"access_token": "x"}}',
+        "GEMINI_API_KEY": "gemini",
+        "CURSOR_API_KEY": "cursor",
+        "AWS_ACCESS_KEY_ID": "AKIA",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/run/vertex/sa.json",
+        "LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-indexed-oauth",
+        "LLM_PROVIDER_2_CODEX_AUTH_JSON": '{"tokens": {"access_token": "x"}}',
+        "LLM_PROVIDER_3_AWS_ACCESS_KEY_ID": "AKIA-INDEXED",
+    }
+
+    validate(event=_SAME_REPO, env=env)
+
+
+@_RA2_XFAIL
+def test_untrusted_tier_filtering_does_not_reintroduce_the_credential() -> None:
+    """The audit's reproduction path: agent-env filtering must not be the guard.
+
+    ``filter_env`` drops the indexed credential from the *child* environment,
+    but the invariant runs before dispatch on the process environment. If the
+    filter were the protection, the credential would be invisible to the
+    invariant and the fork run would start.
+    """
+    raw = {"PATH": "/usr/bin", "LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-indexed"}
+    filtered = filter_env(raw)
+    assert "LLM_PROVIDER_1_CLAUDE_CODE_OAUTH_TOKEN" not in filtered
+
+    validate = import_action_symbol("validate_fork_credential_invariant")
+    from mergecraft.action.inputs import ForkCredentialInvariantError
+
+    with pytest.raises(ForkCredentialInvariantError):
+        validate(event=_FORK, env=raw, agent_sandbox_tier="never")

--- a/tests/utils/test_offline_diff_coverage_limits.py
+++ b/tests/utils/test_offline_diff_coverage_limits.py
@@ -12,14 +12,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from mergecraft.utils.offline_diff import materialize_diff
-
-_RA6_XFAIL = pytest.mark.xfail(
-    reason="green after RA6: exclusions are reported, empty states are distinguishable",
-    strict=False,
-)
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -35,7 +28,7 @@ def _git(cwd: Path, *args: str) -> str:
 
 def _init_repo(tmp_path: Path, *, gitignore: str | None = None) -> Path:
     repo = tmp_path / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
     _git(repo, "init", "-b", "main")
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test")
@@ -56,7 +49,6 @@ def _reports(limitations: Any, needle: str) -> bool:
     return any(needle in str(item) for item in (limitations or ()))
 
 
-@_RA6_XFAIL
 def test_exclusions_are_reported_as_review_coverage_limitations(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, gitignore="ignored.py\n")
     (repo / "ignored.py").write_text("x = 1\n", encoding="utf-8")
@@ -71,7 +63,6 @@ def test_exclusions_are_reported_as_review_coverage_limitations(tmp_path: Path) 
         assert _reports(limitations, name), f"{name} was silently excluded"
 
 
-@_RA6_XFAIL
 def test_empty_because_nothing_changed_is_distinguishable_from_empty_because_excluded(
     tmp_path: Path,
 ) -> None:

--- a/tests/utils/test_offline_diff_coverage_limits.py
+++ b/tests/utils/test_offline_diff_coverage_limits.py
@@ -1,0 +1,89 @@
+"""Exclusions become visible review-coverage limitations (RA1.5, D11/D12).
+
+Every skip — gitignored, oversized, binary, symlink — must be reported on the
+result, never a silent omission. And "empty because nothing changed" must be
+distinguishable from "empty because everything was excluded", so an excluded
+run cannot render as a passed review with "no changes to review".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mergecraft.utils.offline_diff import materialize_diff
+
+_RA6_XFAIL = pytest.mark.xfail(
+    reason="green after RA6: exclusions are reported, empty states are distinguishable",
+    strict=False,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _init_repo(tmp_path: Path, *, gitignore: str | None = None) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "existing.py").write_text("def existing():\n    return 1\n", encoding="utf-8")
+    if gitignore is not None:
+        (repo / ".gitignore").write_text(gitignore, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "checkout", "-b", "feature")
+    return repo
+
+
+def _limitations(result: Any) -> Any:
+    return getattr(result, "coverage_limitations", None)
+
+
+def _reports(limitations: Any, needle: str) -> bool:
+    return any(needle in str(item) for item in (limitations or ()))
+
+
+@_RA6_XFAIL
+def test_exclusions_are_reported_as_review_coverage_limitations(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, gitignore="ignored.py\n")
+    (repo / "ignored.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "huge.py").write_bytes(b"x = 1\n" + b"# pad\n" * 60_000)
+    (repo / "blob.bin").write_bytes(b"\x00\x01\x02\x03")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    limitations = _limitations(result)
+    assert limitations, "excluded files were not reported as coverage limitations"
+    for name in ("ignored.py", "huge.py", "blob.bin"):
+        assert _reports(limitations, name), f"{name} was silently excluded"
+
+
+@_RA6_XFAIL
+def test_empty_because_nothing_changed_is_distinguishable_from_empty_because_excluded(
+    tmp_path: Path,
+) -> None:
+    clean = _init_repo(tmp_path / "clean")
+    clean_result = materialize_diff(cwd=clean, out_dir=tmp_path / "clean-out", base="main")
+
+    excluded = _init_repo(tmp_path / "excluded")
+    (excluded / "huge.py").write_bytes(b"x = 1\n" + b"# pad\n" * 60_000)
+    excluded_result = materialize_diff(cwd=excluded, out_dir=tmp_path / "excluded-out", base="main")
+
+    assert clean_result.empty is True
+    assert not _limitations(clean_result), "a clean repo reported coverage limitations"
+    assert _limitations(excluded_result), (
+        "an all-excluded diff is indistinguishable from a clean one"
+    )

--- a/tests/utils/test_offline_diff_untracked.py
+++ b/tests/utils/test_offline_diff_untracked.py
@@ -12,17 +12,10 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from mergecraft.utils.offline_diff import (
     git_range_diff,
     git_staged_diff,
     materialize_diff,
-)
-
-_RA6_XFAIL = pytest.mark.xfail(
-    reason="green after RA6: default materialization includes untracked source",
-    strict=False,
 )
 
 
@@ -60,7 +53,6 @@ def _reports(limitations: Any, needle: str) -> bool:
     return any(needle in str(item) for item in (limitations or ()))
 
 
-@_RA6_XFAIL
 def test_default_materialization_includes_an_untracked_addition(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     (repo / "new_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
@@ -72,7 +64,6 @@ def test_default_materialization_includes_an_untracked_addition(tmp_path: Path) 
     assert result.empty is False
 
 
-@_RA6_XFAIL
 def test_mixed_tracked_and_untracked_changes_include_both(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     (repo / "existing.py").write_text("def existing():\n    return 2\n", encoding="utf-8")
@@ -114,7 +105,6 @@ def test_commit_range_semantics_are_unchanged(tmp_path: Path) -> None:
     assert "new_bug.py" not in text
 
 
-@_RA6_XFAIL
 def test_gitignored_file_is_excluded(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path, gitignore="ignored.py\n")
     (repo / "ignored.py").write_text("def ignored():\n    return 1 / 0\n", encoding="utf-8")
@@ -125,7 +115,6 @@ def test_gitignored_file_is_excluded(tmp_path: Path) -> None:
     assert _reports(_limitations(result), "ignored.py")
 
 
-@_RA6_XFAIL
 def test_oversized_untracked_file_is_excluded_and_reported(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     (repo / "huge.py").write_bytes(b"x = 1\n" + b"# pad\n" * 60_000)
@@ -136,7 +125,6 @@ def test_oversized_untracked_file_is_excluded_and_reported(tmp_path: Path) -> No
     assert _reports(_limitations(result), "huge.py")
 
 
-@_RA6_XFAIL
 def test_binary_untracked_file_is_excluded_and_reported(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     (repo / "blob.bin").write_bytes(b"\x00\x01\x02\x03")
@@ -147,7 +135,6 @@ def test_binary_untracked_file_is_excluded_and_reported(tmp_path: Path) -> None:
     assert _reports(_limitations(result), "blob.bin")
 
 
-@_RA6_XFAIL
 def test_symlink_is_excluded(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     (repo / "target.py").write_text("x = 1\n", encoding="utf-8")
@@ -159,7 +146,6 @@ def test_symlink_is_excluded(tmp_path: Path) -> None:
     assert _reports(_limitations(result), "link.py")
 
 
-@_RA6_XFAIL
 def test_unicode_quoted_path_is_included(tmp_path: Path) -> None:
     """The path round-trips into the materialized diff (adjacent to residual R5)."""
     repo = _init_repo(tmp_path)

--- a/tests/utils/test_offline_diff_untracked.py
+++ b/tests/utils/test_offline_diff_untracked.py
@@ -1,0 +1,171 @@
+"""Default local review includes eligible untracked additions (RA1.5, N7/D11).
+
+A repository with a committed ``existing.py`` and an untracked ``new_bug.py``
+produced ``empty=True`` under default materialization, and the offline review
+mapped that to a passed review. These tests use real Git in disposable repos —
+a mocked runner returning a canned diff cannot see what ``git diff`` omits.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mergecraft.utils.offline_diff import (
+    git_range_diff,
+    git_staged_diff,
+    materialize_diff,
+)
+
+_RA6_XFAIL = pytest.mark.xfail(
+    reason="green after RA6: default materialization includes untracked source",
+    strict=False,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _init_repo(tmp_path: Path, *, gitignore: str | None = None) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "existing.py").write_text("def existing():\n    return 1\n", encoding="utf-8")
+    if gitignore is not None:
+        (repo / ".gitignore").write_text(gitignore, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "checkout", "-b", "feature")
+    return repo
+
+
+def _limitations(result: Any) -> Any:
+    return getattr(result, "coverage_limitations", None)
+
+
+def _reports(limitations: Any, needle: str) -> bool:
+    return any(needle in str(item) for item in (limitations or ()))
+
+
+@_RA6_XFAIL
+def test_default_materialization_includes_an_untracked_addition(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "new_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    text = result.path.read_text(encoding="utf-8")
+    assert "new_bug.py" in text
+    assert result.empty is False
+
+
+@_RA6_XFAIL
+def test_mixed_tracked_and_untracked_changes_include_both(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "existing.py").write_text("def existing():\n    return 2\n", encoding="utf-8")
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-m", "tracked change")
+    (repo / "new_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    text = result.path.read_text(encoding="utf-8")
+    assert "existing.py" in text
+    assert "new_bug.py" in text
+
+
+def test_staged_mode_semantics_are_unchanged(tmp_path: Path) -> None:
+    """Guard — staged mode has a defined meaning and untracked files are not in it."""
+    repo = _init_repo(tmp_path)
+    (repo / "existing.py").write_text("def existing():\n    return 3\n", encoding="utf-8")
+    _git(repo, "add", "existing.py")
+    (repo / "new_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
+
+    text = git_staged_diff(cwd=repo)
+
+    assert "existing.py" in text
+    assert "new_bug.py" not in text
+
+
+def test_commit_range_semantics_are_unchanged(tmp_path: Path) -> None:
+    """Guard — a committed range never picks up untracked working-tree files."""
+    repo = _init_repo(tmp_path)
+    (repo / "existing.py").write_text("def existing():\n    return 4\n", encoding="utf-8")
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-m", "tracked change")
+    (repo / "new_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
+
+    text = git_range_diff(cwd=repo, range_spec="main..feature")
+
+    assert "existing.py" in text
+    assert "new_bug.py" not in text
+
+
+@_RA6_XFAIL
+def test_gitignored_file_is_excluded(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, gitignore="ignored.py\n")
+    (repo / "ignored.py").write_text("def ignored():\n    return 1 / 0\n", encoding="utf-8")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    assert "ignored.py" not in result.path.read_text(encoding="utf-8")
+    assert _reports(_limitations(result), "ignored.py")
+
+
+@_RA6_XFAIL
+def test_oversized_untracked_file_is_excluded_and_reported(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "huge.py").write_bytes(b"x = 1\n" + b"# pad\n" * 60_000)
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    assert "huge.py" not in result.path.read_text(encoding="utf-8")
+    assert _reports(_limitations(result), "huge.py")
+
+
+@_RA6_XFAIL
+def test_binary_untracked_file_is_excluded_and_reported(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "blob.bin").write_bytes(b"\x00\x01\x02\x03")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    assert "blob.bin" not in result.path.read_text(encoding="utf-8")
+    assert _reports(_limitations(result), "blob.bin")
+
+
+@_RA6_XFAIL
+def test_symlink_is_excluded(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "target.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "link.py").symlink_to(repo / "target.py")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    assert "link.py" not in result.path.read_text(encoding="utf-8")
+    assert _reports(_limitations(result), "link.py")
+
+
+@_RA6_XFAIL
+def test_unicode_quoted_path_is_included(tmp_path: Path) -> None:
+    """The path round-trips into the materialized diff (adjacent to residual R5)."""
+    repo = _init_repo(tmp_path)
+    _git(repo, "config", "core.quotepath", "false")
+    (repo / "ünïcode_bug.py").write_text("def bug():\n    return 1 / 0\n", encoding="utf-8")
+
+    result = materialize_diff(cwd=repo, out_dir=tmp_path / "out", base="main")
+
+    assert "ünïcode_bug.py" in result.path.read_text(encoding="utf-8")


### PR DESCRIPTION
## What?

Closes the eight P1 review-integrity findings and N21 from the 2026-09-10 audit r2. The approval gate was already sound; every defect was a corrupted input arriving at it.

- A Critical or Major security or correctness finding keeps its blocking severity when its prose also mentions a README, comment, style, naming, or typo. An asserted Critical can no longer be reclassified as a maintenance nit that lets the run report success.
- Security category inference recognizes auth stems and the common vulnerability classes instead of the eight-word vocabulary that missed them.
- A weaker corroborating duplicate can no longer lower a severity, flip a gate, or clear should-verify. Both collapse points keep the strongest member and return indices that point at the row actually kept.
- A partial analyzer rerun over an uncovered scope can no longer erase an earlier blocker, and terminal approve stays rejected.
- Inspecting a final commit no longer replaces the canonical review scope with that commit's patch, so admissible citations, inline anchors, and blast radius stay bound to the whole change.
- Default local review reviews new files that were never committed. Exclusions are reported as coverage limitations instead of silently shrinking the diff to "no changes to review."
- Indexed OAuth, device-code, and cloud-chain credentials are rejected on fork heads, and an indexed-only Codex device-code setup writes its auth file into the isolated run home and reports subscription auth mode.

## Why?

A review that reports success while a Critical authentication bypass sits in the diff is worse than a review that never ran, because it is trusted. Each of these defects let a real finding arrive at the gate already demoted, overwritten, or replaced by a weaker copy, and the gate faithfully approved what it was handed.

The same three idioms recur: a regex over prose deciding a finding's category (and therefore its cap), a mutable "current" value replacing an immutable snapshot, and a hand-maintained allowlist drifting from its authority. The repairs target the idiom at its seam rather than widening a keyword list or adding a guard at one call site.

## Findings

| ID | Priority | Audit r2 verification | Repair |
| --- | --- | --- | --- |
| N1 | P1 | Source-confirmed | The fork-head credential invariant derives from the provider registry and rejects indexed OAuth / device-code / cloud-chain names, not just flat names and `_API_KEY`. |
| N19 | P1 | Source-confirmed | `_setup_codex_auth` consumes the resolved child credential mapping instead of reading `os.environ`, so an indexed-only `device_code` setup writes `auth.json` and the broker reports `subscription`. |
| N21 | P2 | Reproduced | The fork invariant and the agent-env strip set both derive from `config.runtime_provider_registry`; a drift test fails if a name is added to one and not the other. `GOOGLE_API_KEY` and `AWS_SESSION_TOKEN` are covered. |
| N4 | P1 | Reproduced | Impact decides severity. The security lane takes absolute precedence and capping rules are inapplicable when correctness or security evidence supports the asserted severity. Genuine style nits are still deflated. |
| N20 | P1 | Reproduced | Security precedence in category inference, plus the widened vocabulary. A property test asserts no impact-preserving lexical change crosses a blocking boundary. |
| N5 | P1 | Reproduced | Clustering and semantic dedupe keep the strongest member's severity while retaining the agent's canonical wording and every discarded member's evidence. |
| N2 | P1 | Source-confirmed | Analyzer results are retained by covered scope; a rerun supersedes only for equivalent scope or an explicit withdrawal. |
| N3 | P1 | Source-confirmed | `get_commit_info` no longer registers review scope; its single-commit patch is an inspection artifact. |
| N7 | P1 | Reproduced | Default local review includes eligible untracked additions; exclusions are surfaced as review-coverage limitations, and an all-excluded diff is not a clean pass. |

## Note

- **D19 — CI evidence boundary.** Lane B's acceptance repairs (an E2E checker, an integration gate, and mutation scoring) merge separately. Until that PR lands, green CI here proves these repairs against the current harness, not that the harness itself is trustworthy. Do not read this branch's CI as validating lane B's acceptance work.
- **N1 bounding.** The indexed-credential rejection closes a bypass of mergeCraft's own pre-dispatch fork rejection. It does not claim every fork PR receives secrets; a consumer workflow that deliberately wires an indexed secret into a fork event is the trigger, and GitHub's ordinary fork-secret withholding is an independent protection.
- **Named, not fixed.** `apply_causality_policy` downgrades a blocking finding whose `introduced_by_pr` is `false` to Minor, and for agent-sourced findings that field is model-supplied. It is documented policy and deliberately left out of this branch; it is a second lexical-to-structural path into the gate for whoever scopes it next.

## Test plan

- `make ci` on a clean tree (run as `make ci-resume`; all 16 steps passed, 8606 tests, coverage 82.24%).
- `make lint` and `make typecheck`.
- The retained audit probe inverted against the branch tip: the seven incidental security rows and the correctness rows retain their asserted severity, the auth stems infer Security, both collapse points are order-invariant, and every indexed credential is rejected on a fork head.

Evidence transcripts live under `.ignorelocal/waves/evidence/` (`ra0-baseline.txt`, `ra1-red.txt`, `ra1-strict.txt`, `ra2-credential-registry.txt`, `ra3-impact-severity.txt`, `ra4-collapse.txt`, `ra5-scope.txt`, `ra6-untracked.txt`, `ra7-make-ci.txt`, `ra7-probe-inverted.txt`).

## Related PR(s)/Issue(s)

Source: 2026-09-10 audit r2, lane A (review integrity). Sibling lane: `wave/audit-r2-b-p2-reliability` (out of scope here).
