### PR TITLE
refactor(types): remove unused workflow permission port

### DIFF
--- a/src/mergecraft/types.py
+++ b/src/mergecraft/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 # ── agent / MCP ───────────────────────────────────────────────────────────────
 
@@ -42,38 +42,8 @@ def format_mcp_tool_ref(agent_id: AgentId, tool_name: str) -> str:
 
 # ── tool / runtime permissions ────────────────────────────────────────────────
 
-ToolPermission = Literal["disabled", "enabled"]
 ShellPermission = Literal["disabled", "restricted", "enabled"]
 PushPermission = Literal["disabled", "restricted", "enabled"]
-StatusChecksPermission = Literal["disabled", "enabled"]
-
-# ── workflow.yml GITHUB_TOKEN permissions ─────────────────────────────────────
-
-WorkflowPermissionValue = Literal["read", "write", "none"]
-WorkflowIdTokenPermissionValue = Literal["write", "none"]
-
-
-class WorkflowPermissions(BaseModel):
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-    actions: WorkflowPermissionValue | None = None
-    attestations: WorkflowPermissionValue | None = None
-    checks: WorkflowPermissionValue | None = None
-    contents: WorkflowPermissionValue | None = None
-    deployments: WorkflowPermissionValue | None = None
-    discussions: WorkflowPermissionValue | None = None
-    id_token: WorkflowIdTokenPermissionValue | None = Field(default=None, alias="id-token")
-    issues: WorkflowPermissionValue | None = None
-    models: WorkflowPermissionValue | None = None
-    packages: WorkflowPermissionValue | None = None
-    pages: WorkflowPermissionValue | None = None
-    pull_requests: WorkflowPermissionValue | None = Field(default=None, alias="pull-requests")
-    repository_projects: WorkflowPermissionValue | None = Field(
-        default=None, alias="repository-projects"
-    )
-    security_events: WorkflowPermissionValue | None = Field(default=None, alias="security-events")
-    statuses: WorkflowPermissionValue | None = None
-
 
 # GitHub permission levels: admin > write > maintain > triage > read > none
 AuthorPermission = Literal["admin", "maintain", "write", "triage", "read", "none"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Weekday audit **D8** — subtract unused TypeScript-port symbols from `src/mergecraft/types.py`.

**Finding:** `ToolPermission`, `StatusChecksPermission`, `WorkflowPermissionValue`, `WorkflowIdTokenPermissionValue`, and `WorkflowPermissions` had zero production or test importers (ripgrep confirmed; only unrelated `TestScanCalledWorkflowPermissions` test class name remains).

**Deleted:** the five symbols above, the `# ── workflow.yml GITHUB_TOKEN permissions ──` section, and the unused `Field` pydantic import.

**Kept:** `ShellPermission`, `PushPermission`, `AuthorPermission`, `XrepoConfig`, and all other symbols in `types.py`.

**Researched from:** `main` @ `153dd175cdc380984c2142aa62f1b643d67246f9`.

**Verified:** `make lint`, `make typecheck`, and `tests/test_modes.py` (34 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5fdf692-bd78-4e58-b8ad-96b911e1ea81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5fdf692-bd78-4e58-b8ad-96b911e1ea81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

